### PR TITLE
cap/mcp-langchain4j-phase2: LangChain4j Phase 2 — full 16-tool facade set + DB-backed tool registry

### DIFF
--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -87,3 +87,58 @@ Operationally, the expected flow is:
 - install and start Onyx using its official Docker flow
 - use the generated Onyx deployment under `onyx_data/deployment`
 - log into the local Onyx instance and configure Ollama plus MCP connectivity there
+
+## Phase 2 (Wave MCP-2) — Delivery Summary
+
+This module has been extended for Wave MCP-2 (Phase 2). The following are the notable delivery items and runtime behaviour changes developers should know about.
+
+### DB-Backed Tool Registry
+
+- Flyway migrations added:
+  - `V3` — schema: `mcp_tool`, `mcp_role`, `mcp_tool_workflow`, `mcp_tool_role`, `mcp_workflow_state` tables
+  - `V4` — seeds: 16 tools, 5 roles, and workflow mappings
+  - `V5` — corrective migration (Location + ShopManager role mappings)
+- New repository and persistence:
+  - `ToolMetadataRepository` / `ToolMetadataRepositoryImpl` — JDBC-backed storage
+  - Uses `pgvector` column (embedding vector(768)) with cosine-similarity `<=>` queries to find semantically relevant tools
+- Runtime services and loader:
+  - `ToolRegistryService` — deterministic scoring pipeline: role gating → embedding top-K → `ToolScorer` (semantic rank, priority boost, latency/cost penalties)
+  - `ToolRegistryLoader` — now loads registry entries from the DB at startup and resolves `handlerBean` names to actual handler instances via `ApplicationContext.getBean()` (replaces Phase 1 in-memory stub)
+- Domain types: `ToolMetadata`, `ToolSelectionContext` represent persisted metadata and per-request selection inputs
+
+### Full 16-Tool Facade Catalog
+
+Phase 1 exposed `InventoryFacadeTool` and `OrderFacadeTool`. Phase 2 adds the remaining facade tools (total 16):
+
+- `CustomerFacadeTool` — pos-customer (customer)
+- `PricingFacadeTool` — pos-price (pricing)
+- `WorkorderFacadeTool` — pos-workorder (workorder)
+- `CatalogFacadeTool` — pos-catalog (catalog)
+- `VehicleFacadeTool` — pos-catalog (catalog)
+- `AccountingFacadeTool` — pos-accounting (accounting)
+- `InvoiceFacadeTool` — pos-invoice (invoice)
+- `HrFacadeTool` — pos-people (hr)
+- `ReportingFacadeTool` — pos-accounting (reporting)
+- `LocationFacadeTool` — pos-location (location)
+- `ShopManagerFacadeTool` — pos-shop-manager (shop)
+- `TaxFacadeTool` — pos-tax (tax)
+- `AdminFacadeTool` — pos-security-service (admin)
+- `EventsFacadeTool` — pos-event-receiver (events)
+- (plus `InventoryFacadeTool`, `OrderFacadeTool` from Phase 1)
+
+### Role → Tool Mapping Summary
+
+Tool availability is gated by role in the registry. At a high level:
+
+- `ROLE_CASHIER`: Customer, Pricing, Workorder, Catalog, Vehicle, Inventory, Order — core sales operations
+- `ROLE_SERVICE_WRITER`: All `CASHIER` tools + Location, ShopManager, Accounting, Invoice, Tax, Events
+- `ROLE_MANAGER`: All `SERVICE_WRITER` tools + HR, Reporting, Admin tools
+- `ROLE_ADMIN`: All tools
+- `ROLE_SUPPLIER`: Catalog, Vehicle, Inventory subset
+
+### Profile & Test Notes
+
+- `ToolMetadataRepositoryImpl` and `ToolRegistryService` are annotated with `@Profile("!test")`. The `test` profile supplies stubs via `SessionAgentManagerTestConfiguration` to keep tests hermetic.
+- `ToolRegistryLoader` is profile-neutral (no `@Profile`) so the loader runs in all profiles; test configurations provide a `ToolMetadataRepository` stub bean for startup.
+
+If you are extending or testing registry logic, ensure test fixtures provide the expected stub beans or run with a non-test profile against a Postgres test instance seeded with V4 data.

--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -33,11 +33,6 @@ Facade tool outbound base URLs (LangChain4j orchestration):
 
 ## Known Limitations (Phase 1)
 
-- **Facade tool auth propagation (ADR-0014):** `InventoryFacadeTool` and `OrderFacadeTool` do not
-  propagate the caller's JWT to downstream services. Tool calls will receive 401 from `pos-inventory`
-  and `pos-order` until Phase 2 implements a shared `ClientHttpRequestInterceptor` for auth propagation.
-- **Tool registry is DB-backed only in Phase 2:** `ToolRegistryLoader` is an in-memory stub.
-  Role-to-tool mapping is hardcoded to empty in Phase 1.
 - **RAG store is empty on first deploy:** The pgvector store requires manual document seeding
   (Phase 2 includes document ingestion API).
 
@@ -114,7 +109,7 @@ Phase 1 exposed `InventoryFacadeTool` and `OrderFacadeTool`. Phase 2 adds the re
 - `PricingFacadeTool` — pos-price (pricing)
 - `WorkorderFacadeTool` — pos-workorder (workorder)
 - `CatalogFacadeTool` — pos-catalog (catalog)
-- `VehicleFacadeTool` — pos-catalog (catalog)
+- `VehicleFacadeTool` — pos-customer (customer)
 - `AccountingFacadeTool` — pos-accounting (accounting)
 - `InvoiceFacadeTool` — pos-invoice (invoice)
 - `HrFacadeTool` — pos-people (hr)
@@ -130,11 +125,11 @@ Phase 1 exposed `InventoryFacadeTool` and `OrderFacadeTool`. Phase 2 adds the re
 
 Tool availability is gated by role in the registry. At a high level:
 
-- `ROLE_CASHIER`: Customer, Pricing, Workorder, Catalog, Vehicle, Inventory, Order — core sales operations
-- `ROLE_SERVICE_WRITER`: All `CASHIER` tools + Location, ShopManager, Accounting, Invoice, Tax, Events
-- `ROLE_MANAGER`: All `SERVICE_WRITER` tools + HR, Reporting, Admin tools
-- `ROLE_ADMIN`: All tools
-- `ROLE_SUPPLIER`: Catalog, Vehicle, Inventory subset
+- `ROLE_CASHIER`: Inventory, Order, Customer, Pricing — core checkout and customer lookup
+- `ROLE_SERVICE_WRITER`: Workorder, Customer, Vehicle, Catalog, Pricing, Inventory, Location, ShopManager — service lane operations
+- `ROLE_MANAGER`: All `SERVICE_WRITER` tools + Reporting, Accounting, Invoice, HR — management and financials
+- `ROLE_ADMIN`: All 16 tools
+- `ROLE_SUPPLIER`: Order, Inventory, Catalog — supplier-facing subset
 
 ### Profile & Test Notes
 

--- a/pos-mcp-server/docs/langchain4j-orchestration-spec.md
+++ b/pos-mcp-server/docs/langchain4j-orchestration-spec.md
@@ -721,17 +721,17 @@ Onyx services, volumes, and network references are removed.
 
 ### Phase 1 — Core Orchestration (MVP)
 
-- [ ] Add LangChain4j dependencies to `pom.xml`
-- [ ] Create `PosAssistant` interface
-- [ ] Create `SessionAgentManager` with Caffeine cache
-- [ ] Create `ExaWebSearchTool`
-- [ ] Create 2–3 facade tools (Inventory, Order, Customer) with `@Tool`
-- [ ] Create `RagConfiguration` with pgvector
-- [ ] Add Flyway migration for pgvector extension
-- [ ] Update `McpChatController` to route through `SessionAgentManager`
-- [ ] Add Ollama Cloud config properties to `application.yml`
-- [ ] Update `docker-compose.onyx.yml` to remove Onyx refs
-- [ ] Verify end-to-end: user message → tool call → response
+- [x] Add LangChain4j dependencies to `pom.xml`
+- [x] Create `PosAssistant` interface
+- [x] Create `SessionAgentManager` with Caffeine cache
+- [x] Create `ExaWebSearchTool`
+- [x] Create 2–3 facade tools (Inventory, Order, Customer) with `@Tool`
+- [x] Create `RagConfiguration` with pgvector
+- [x] Add Flyway migration for pgvector extension
+- [x] Update `McpChatController` to route through `SessionAgentManager`
+- [x] Add Ollama Cloud config properties to `application.yml`
+- [x] Update `docker-compose.onyx.yml` to remove Onyx refs
+- [x] Verify end-to-end: user message → tool call → response
 
 ### Phase 2 — Tool Registry + Role Gating
 

--- a/pos-mcp-server/pom.xml
+++ b/pos-mcp-server/pom.xml
@@ -167,7 +167,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/BearerTokenRelayInterceptor.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/BearerTokenRelayInterceptor.java
@@ -1,0 +1,46 @@
+package com.positivity.mcp.internal.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Relays the incoming Authorization Bearer token to outbound facade tool
+ * requests.
+ */
+@Component
+public class BearerTokenRelayInterceptor implements ClientHttpRequestInterceptor {
+
+  private static final Logger log = LoggerFactory.getLogger(BearerTokenRelayInterceptor.class);
+  private static final String AUTHORIZATION = "Authorization";
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  @Override
+  public ClientHttpResponse intercept(
+      HttpRequest request,
+      byte[] body,
+      ClientHttpRequestExecution execution) throws IOException {
+    try {
+      var attrs = RequestContextHolder.currentRequestAttributes();
+      if (attrs instanceof ServletRequestAttributes servletAttrs) {
+        HttpServletRequest httpRequest = servletAttrs.getRequest();
+        String authHeader = httpRequest.getHeader(AUTHORIZATION);
+        if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
+          request.getHeaders().set(AUTHORIZATION, authHeader);
+        }
+      }
+    } catch (IllegalStateException e) {
+      // No request context available for background or startup work.
+      log.debug("No request context available for Bearer token relay; skipping", e);
+    }
+    return execution.execute(request, body);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/BearerTokenRelayInterceptor.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/BearerTokenRelayInterceptor.java
@@ -34,7 +34,13 @@ public class BearerTokenRelayInterceptor implements ClientHttpRequestInterceptor
         HttpServletRequest httpRequest = servletAttrs.getRequest();
         String authHeader = httpRequest.getHeader(AUTHORIZATION);
         if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
-          request.getHeaders().set(AUTHORIZATION, authHeader);
+          String outboundAuthHeader = request.getHeaders().getFirst(AUTHORIZATION);
+          if (outboundAuthHeader == null || outboundAuthHeader.startsWith(BEARER_PREFIX)) {
+            request.getHeaders().set(AUTHORIZATION, authHeader);
+          } else {
+            log.debug(
+                "Outbound Authorization header already uses a non-Bearer scheme; skipping Bearer token relay");
+          }
         }
       }
     } catch (IllegalStateException e) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/McpServerConfiguration.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/McpServerConfiguration.java
@@ -8,6 +8,7 @@ import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.jspecify.annotations.NonNull;
+import org.springframework.boot.restclient.RestClientCustomizer;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -16,58 +17,65 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @EnableConfigurationProperties({
-        McpServerProperties.class,
-        LlmApiProperties.class
+                McpServerProperties.class,
+                LlmApiProperties.class
 })
 public class McpServerConfiguration {
 
-    @Bean
-    public HttpServletSseServerTransportProvider transportProvider(@NonNull McpServerProperties properties) {
-        return HttpServletSseServerTransportProvider.builder()
-                .baseUrl(properties.baseUrl())
-                .messageEndpoint(properties.messageEndpoint())
-                .sseEndpoint(properties.sseEndpoint())
-                .build();
-    }
+        @Bean
+        public HttpServletSseServerTransportProvider transportProvider(@NonNull McpServerProperties properties) {
+                return HttpServletSseServerTransportProvider.builder()
+                                .baseUrl(properties.baseUrl())
+                                .messageEndpoint(properties.messageEndpoint())
+                                .sseEndpoint(properties.sseEndpoint())
+                                .build();
+        }
 
-    @Bean
-    public McpAsyncServer mcpAsyncServer(@NonNull HttpServletSseServerTransportProvider transportProvider) {
-        // Build server with tool capability enabled; ToolBootstrapRunner adds tools after
-        // discovery.
-        var capabilities = McpSchema.ServerCapabilities.builder()
-                .tools(Boolean.TRUE)
-                .build();
+        @Bean
+        public McpAsyncServer mcpAsyncServer(@NonNull HttpServletSseServerTransportProvider transportProvider) {
+                // Build server with tool capability enabled; ToolBootstrapRunner adds tools
+                // after
+                // discovery.
+                var capabilities = McpSchema.ServerCapabilities.builder()
+                                .tools(Boolean.TRUE)
+                                .build();
 
-        return McpServer.async(transportProvider)
-                .serverInfo("pos-mcp-server", "0.1.0-SNAPSHOT")
-                .capabilities(capabilities)
-                .build();
-    }
+                return McpServer.async(transportProvider)
+                                .serverInfo("pos-mcp-server", "0.1.0-SNAPSHOT")
+                                .capabilities(capabilities)
+                                .build();
+        }
 
-    @Bean
-    public ServletRegistrationBean<HttpServletSseServerTransportProvider> mcpServlet(
-            @NonNull HttpServletSseServerTransportProvider transportProvider,
-            @NonNull McpServerProperties properties) {
-        var registration = new ServletRegistrationBean<>(transportProvider,
-                properties.messageEndpoint(),
-                properties.sseEndpoint());
-        registration.setLoadOnStartup(1);
-        registration.setName("mcpSseServlet");
-        return registration;
-    }
+        @Bean
+        public ServletRegistrationBean<HttpServletSseServerTransportProvider> mcpServlet(
+                        @NonNull HttpServletSseServerTransportProvider transportProvider,
+                        @NonNull McpServerProperties properties) {
+                var registration = new ServletRegistrationBean<>(transportProvider,
+                                properties.messageEndpoint(),
+                                properties.sseEndpoint());
+                registration.setLoadOnStartup(1);
+                registration.setName("mcpSseServlet");
+                return registration;
+        }
 
-    @Bean
-    public WebClient discoveryWebClient() {
-        return WebClient.builder().build();
-    }
+        @Bean
+        public WebClient discoveryWebClient() {
+                return WebClient.builder().build();
+        }
 
-    @Bean(destroyMethod = "close")
-    public McpSyncClient mcpSyncClient(@NonNull McpServerProperties properties) {
-        var transport = HttpClientSseClientTransport.builder(properties.baseUrl())
-                .sseEndpoint(properties.sseEndpoint())
-                .build();
+        @Bean
+        public RestClientCustomizer bearerTokenRelayCustomizer(
+                        @NonNull BearerTokenRelayInterceptor interceptor) {
+                return builder -> builder.requestInterceptors(list -> list.add(interceptor));
+        }
 
-        return McpClient.sync(transport)
-                .build();
-    }
+        @Bean(destroyMethod = "close")
+        public McpSyncClient mcpSyncClient(@NonNull McpServerProperties properties) {
+                var transport = HttpClientSseClientTransport.builder(properties.baseUrl())
+                                .sseEndpoint(properties.sseEndpoint())
+                                .build();
+
+                return McpClient.sync(transport)
+                                .build();
+        }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ToolMetadata.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ToolMetadata.java
@@ -1,0 +1,17 @@
+package com.positivity.mcp.internal.domain;
+
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+public record ToolMetadata(
+    @NonNull UUID id,
+    @NonNull String name,
+    @NonNull String displayName,
+    @NonNull String description,
+    @NonNull String domain,
+    double priority,
+    @NonNull String costLevel,
+    int avgLatencyMs,
+    boolean enabled,
+    @NonNull String handlerBean) {
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ToolSelectionContext.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ToolSelectionContext.java
@@ -1,0 +1,9 @@
+package com.positivity.mcp.internal.domain;
+
+import org.jspecify.annotations.NonNull;
+
+public record ToolSelectionContext(
+    @NonNull String userInput,
+    @NonNull String role,
+    @NonNull String workflowState) {
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolRegistry.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolRegistry.java
@@ -1,11 +1,11 @@
 package com.positivity.mcp.internal.orchestration;
 
-import org.jspecify.annotations.NonNull;
-import org.springframework.stereotype.Component;
-
+import com.positivity.mcp.internal.service.ToolRegistryLoader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
 
 @Component
 public class ToolRegistry {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolRegistryLoader.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolRegistryLoader.java
@@ -1,24 +1,66 @@
 package com.positivity.mcp.internal.orchestration;
 
-import org.jspecify.annotations.NonNull;
-import org.springframework.stereotype.Component;
-
+import com.positivity.mcp.internal.domain.ToolMetadata;
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
 
 /**
- * Phase 1 stub: returns empty tool lists for all roles.
- * Phase 2 will replace this with DB-backed role-tool mappings.
+ * DB-backed tool registry loader. Replaces Phase 1 in-memory stub.
+ * Loads all enabled tools for each known role from the mcp_tool database tables
+ * and resolves them to Spring bean instances via ApplicationContext.
  */
 @Component
 public class ToolRegistryLoader {
 
+  private static final Logger log = LoggerFactory.getLogger(ToolRegistryLoader.class);
+
+  private static final String WORKFLOW_IDLE = "IDLE";
+
+  private static final List<String> KNOWN_ROLES = List.of(
+      "ROLE_CASHIER", "ROLE_SERVICE_WRITER",
+      "ROLE_MANAGER", "ROLE_ADMIN", "ROLE_SUPPLIER");
+
+  private final ToolMetadataRepository repository;
+  private final ApplicationContext applicationContext;
+
+  public ToolRegistryLoader(
+      @NonNull ToolMetadataRepository repository,
+      @NonNull ApplicationContext applicationContext) {
+    this.repository = repository;
+    this.applicationContext = applicationContext;
+  }
+
   /**
-   * Returns an empty role-to-tool mapping for Phase 1.
-   * Facade tools are injected directly by {@link SessionAgentManager}
-   * until DB-backed mappings are implemented in Phase 2.
+   * Loads role-to-tool-instance mappings from the DB at startup.
+   * Tools are resolved by their Spring bean name (handler_bean column).
    */
   public @NonNull Map<String, List<Object>> loadRoleToolMappings() {
-    return Map.of();
+    Map<String, List<Object>> result = new HashMap<>();
+    for (String role : KNOWN_ROLES) {
+      List<ToolMetadata> tools = repository.findEnabledByRoleAndWorkflow(role, WORKFLOW_IDLE);
+      List<Object> beans = new ArrayList<>();
+      for (ToolMetadata meta : tools) {
+        try {
+          Object bean = applicationContext.getBean(meta.handlerBean());
+          beans.add(bean);
+        } catch (Exception e) {
+          log.warn(
+              "Tool bean '{}' not found for role '{}', skipping: {}",
+              meta.handlerBean(),
+              role,
+              e.getMessage());
+        }
+      }
+      result.put(role, beans);
+    }
+    return result;
   }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolRegistryService.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolRegistryService.java
@@ -1,0 +1,92 @@
+package com.positivity.mcp.internal.orchestration;
+
+import com.positivity.mcp.internal.domain.ToolMetadata;
+import com.positivity.mcp.internal.domain.ToolSelectionContext;
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.jspecify.annotations.NonNull;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("!test")
+public class ToolRegistryService {
+
+  private final ToolMetadataRepository repository;
+  private final EmbeddingModel embeddingModel;
+  private final ToolScorer scorer;
+
+  public ToolRegistryService(
+      @NonNull ToolMetadataRepository repository,
+      @NonNull EmbeddingModel embeddingModel) {
+    this.repository = repository;
+    this.embeddingModel = embeddingModel;
+    this.scorer = new ToolScorer();
+  }
+
+  public @NonNull List<ToolMetadata> resolveCandidateTools(
+      @NonNull ToolSelectionContext context,
+      int topK) {
+    if (topK <= 0) {
+      return List.of();
+    }
+
+    List<ToolMetadata> gatedTools = repository.findEnabledByRoleAndWorkflow(
+        context.role(),
+        context.workflowState());
+
+    if (gatedTools.isEmpty()) {
+      return List.of();
+    }
+
+    float[] embedding = embeddingModel.embed(context.userInput()).content().vector();
+    int semanticLimit = Math.max(topK, 10);
+    List<ToolMetadata> semanticCandidates = repository.findTopKByEmbedding(embedding, semanticLimit);
+
+    Set<UUID> gatedIds = new HashSet<>();
+    for (ToolMetadata gated : gatedTools) {
+      gatedIds.add(gated.id());
+    }
+
+    return IntStream.range(0, semanticCandidates.size())
+        .mapToObj(index -> new ScoredTool(
+            semanticCandidates.get(index),
+            scorer.score(semanticCandidates.get(index), index),
+            index))
+        .filter(scored -> gatedIds.contains(scored.tool().id()))
+        .sorted(Comparator
+            .comparingDouble(ScoredTool::score).reversed()
+            .thenComparingInt(ScoredTool::rankPosition)
+            .thenComparing(st -> st.tool().name()))
+        .limit(topK)
+        .map(ScoredTool::tool)
+        .toList();
+  }
+
+  static final class ToolScorer {
+
+    double score(@NonNull ToolMetadata tool, int rankPosition) {
+      double semanticScore = 1.0 / (rankPosition + 1);
+      double priorityBoost = tool.priority();
+      double latencyPenalty = Math.min(tool.avgLatencyMs() / 1000.0, 1.0) * 0.2;
+      double costPenalty = switch (tool.costLevel().toLowerCase()) {
+        case "high" -> 0.2;
+        case "medium" -> 0.1;
+        default -> 0.0;
+      };
+      return semanticScore + priorityBoost - latencyPenalty - costPenalty;
+    }
+  }
+
+  private record ScoredTool(
+      @NonNull ToolMetadata tool,
+      double score,
+      int rankPosition) {
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/AccountingFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/AccountingFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class AccountingFacadeTool {
 
   private final RestClient restClient;
 
-  public AccountingFacadeTool(RestClient.Builder restClientBuilder) {
+  public AccountingFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.accounting.base-url:http://pos-accounting/v1/accounting}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-accounting/v1/accounting")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/AccountingFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/AccountingFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class AccountingFacadeTool {
+
+  private final RestClient restClient;
+
+  public AccountingFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-accounting/v1/accounting")
+        .build();
+  }
+
+  @Tool("Get account balance information by account ID")
+  public String getAccountBalance(
+      @P("The account ID") @NonNull String accountId) {
+    return restClient.get()
+        .uri("/accounts/{accountId}/balance", accountId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search accounting journal entries using text or filter terms")
+  public String searchJournalEntries(
+      @P("Search query for journal entries") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/journal-entries/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get a financial summary for a requested accounting period")
+  public String getFinancialSummary(
+      @P("Accounting period identifier") @NonNull String period) {
+    return restClient.get()
+        .uri("/summary/{period}", period)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/AdminFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/AdminFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class AdminFacadeTool {
 
   private final RestClient securityRestClient;
 
-  public AdminFacadeTool(RestClient.Builder restClientBuilder) {
+  public AdminFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.admin.base-url:http://pos-security-service/v1/admin}") @NonNull String baseUrl) {
     this.securityRestClient = restClientBuilder
-        .baseUrl("http://pos-security-service/v1")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/AdminFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/AdminFacadeTool.java
@@ -1,0 +1,42 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class AdminFacadeTool {
+
+  private final RestClient securityRestClient;
+
+  public AdminFacadeTool(RestClient.Builder restClientBuilder) {
+    this.securityRestClient = restClientBuilder
+        .baseUrl("http://pos-security-service/v1")
+        .build();
+  }
+
+  @Tool("Get overall platform system status and health summary")
+  public String getSystemStatus() {
+    return "pos-mcp-server status: UP";
+  }
+
+  @Tool("Get effective user permissions and access details")
+  public String getUserPermissions(
+      @P("The user ID") @NonNull String userId) {
+    return securityRestClient.get()
+        .uri("/users/{userId}/roles", userId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search the administrative audit log with a query string")
+  public String getAuditLog(
+      @P("Search query for audit log") @NonNull String query) {
+    return securityRestClient.get()
+        .uri("/audit?q={q}", query)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/CatalogFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/CatalogFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class CatalogFacadeTool {
 
   private final RestClient restClient;
 
-  public CatalogFacadeTool(RestClient.Builder restClientBuilder) {
+  public CatalogFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.catalog.base-url:http://pos-catalog/v1/catalog}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-catalog/v1/catalog")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/CatalogFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/CatalogFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class CatalogFacadeTool {
+
+  private final RestClient restClient;
+
+  public CatalogFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-catalog/v1/catalog")
+        .build();
+  }
+
+  @Tool("Get product details from the catalog by product ID")
+  public String getProduct(
+      @P("The product ID") @NonNull String productId) {
+    return restClient.get()
+        .uri("/products/{productId}", productId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search the catalog by name, SKU, part number, or keyword")
+  public String searchCatalog(
+      @P("Search query for catalog") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get catalog products filtered by category")
+  public String getCatalogByCategory(
+      @P("Catalog category name or code") @NonNull String category) {
+    return restClient.get()
+        .uri("/categories/{category}", category)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/CustomerFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/CustomerFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class CustomerFacadeTool {
+
+  private final RestClient restClient;
+
+  public CustomerFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-customer/v1/customers")
+        .build();
+  }
+
+  @Tool("Get customer profile details by customer ID")
+  public String getCustomer(
+      @P("The customer ID") @NonNull String customerId) {
+    return restClient.get()
+        .uri("/{customerId}", customerId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search customers by name, phone number, email, or other criteria")
+  public String searchCustomers(
+      @P("Search query for customers") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get account history and interaction timeline for a customer")
+  public String getCustomerHistory(
+      @P("The customer ID") @NonNull String customerId) {
+    return restClient.get()
+        .uri("/{customerId}/history", customerId)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/CustomerFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/CustomerFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class CustomerFacadeTool {
 
   private final RestClient restClient;
 
-  public CustomerFacadeTool(RestClient.Builder restClientBuilder) {
+  public CustomerFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.customer.base-url:http://pos-customer/v1/customers}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-customer/v1/customers")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeTool.java
@@ -14,7 +14,7 @@ public class EventsFacadeTool {
 
     public EventsFacadeTool(
             RestClient.Builder restClientBuilder,
-            @Value("${pos.events.base-url:http://pos-event-receiver/v1/events}") @NonNull String baseUrl) {
+            @Value("${pos.event-receiver.base-url:http://pos-event-receiver/v1/events}") @NonNull String baseUrl) {
         this.restClient = restClientBuilder
                 .baseUrl(baseUrl)
                 .build();

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeTool.java
@@ -1,0 +1,51 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class EventsFacadeTool {
+
+  private final RestClient restClient;
+
+  public EventsFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-event-receiver/v1")
+        .build();
+  }
+
+  @Tool("Get all registered event types and metadata")
+  public String getEventTypes() {
+    return restClient.get()
+        .uri("/eventTypes")
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search events by query text, event type, or other criteria")
+  public String searchEvents(
+      @P("Search query for events") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/events/summary")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get historical event activity for a specific entity")
+  public String getEventHistory(
+      @P("The entity ID") @NonNull String entityId) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/events/summary")
+            .queryParam("entityId", entityId)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeTool.java
@@ -3,49 +3,52 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 @Component
 public class EventsFacadeTool {
 
-  private final RestClient restClient;
+    private final RestClient restClient;
 
-  public EventsFacadeTool(RestClient.Builder restClientBuilder) {
-    this.restClient = restClientBuilder
-        .baseUrl("http://pos-event-receiver/v1")
-        .build();
-  }
+    public EventsFacadeTool(
+            RestClient.Builder restClientBuilder,
+            @Value("${pos.events.base-url:http://pos-event-receiver/v1/events}") @NonNull String baseUrl) {
+        this.restClient = restClientBuilder
+                .baseUrl(baseUrl)
+                .build();
+    }
 
-  @Tool("Get all registered event types and metadata")
-  public String getEventTypes() {
-    return restClient.get()
-        .uri("/eventTypes")
-        .retrieve()
-        .body(String.class);
-  }
+    @Tool("Get all registered event types and metadata")
+    public String getEventTypes() {
+        return restClient.get()
+                .uri("/eventTypes")
+                .retrieve()
+                .body(String.class);
+    }
 
-  @Tool("Search events by query text, event type, or other criteria")
-  public String searchEvents(
-      @P("Search query for events") @NonNull String query) {
-    return restClient.get()
-        .uri(uriBuilder -> uriBuilder
-            .path("/events/summary")
-            .queryParam("q", query)
-            .build())
-        .retrieve()
-        .body(String.class);
-  }
+    @Tool("Search events by query text, event type, or other criteria")
+    public String searchEvents(
+            @P("Search query for events") @NonNull String query) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/events/summary")
+                        .queryParam("q", query)
+                        .build())
+                .retrieve()
+                .body(String.class);
+    }
 
-  @Tool("Get historical event activity for a specific entity")
-  public String getEventHistory(
-      @P("The entity ID") @NonNull String entityId) {
-    return restClient.get()
-        .uri(uriBuilder -> uriBuilder
-            .path("/events/summary")
-            .queryParam("entityId", entityId)
-            .build())
-        .retrieve()
-        .body(String.class);
-  }
+    @Tool("Get historical event activity for a specific entity")
+    public String getEventHistory(
+            @P("The entity ID") @NonNull String entityId) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/events/summary")
+                        .queryParam("entityId", entityId)
+                        .build())
+                .retrieve()
+                .body(String.class);
+    }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/HrFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/HrFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class HrFacadeTool {
+
+  private final RestClient restClient;
+
+  public HrFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-people/v1/employees")
+        .build();
+  }
+
+  @Tool("Get employee profile information by employee ID")
+  public String getEmployee(
+      @P("The employee ID") @NonNull String employeeId) {
+    return restClient.get()
+        .uri("/{employeeId}", employeeId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search employees by name, role, team, or availability")
+  public String searchEmployees(
+      @P("Search query for employees") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get current schedule details for a specific employee")
+  public String getEmployeeSchedule(
+      @P("The employee ID") @NonNull String employeeId) {
+    return restClient.get()
+        .uri("/{employeeId}/schedule", employeeId)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/HrFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/HrFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class HrFacadeTool {
 
   private final RestClient restClient;
 
-  public HrFacadeTool(RestClient.Builder restClientBuilder) {
+  public HrFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.hr.base-url:http://pos-people/v1/hr}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-people/v1/employees")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/InventoryFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/InventoryFacadeTool.java
@@ -7,63 +7,46 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-/**
- * Phase 1 facade tool for inventory lookup operations.
- * <p>
- * <strong>Phase 1 Limitation (ADR-0014):</strong> Outbound calls to
- * pos-inventory
- * do not propagate the caller's JWT bearer token. Tool calls will receive 401
- * responses
- * from pos-inventory unless that service permits unauthenticated access on
- * these paths.
- * Bearer token propagation will be implemented in Phase 2 via a shared
- * {@code ClientHttpRequestInterceptor} on the RestClient.
- * <p>
- * Tracked for Phase2: add auth propagation via SecurityContext-sourced bearer
- * token.
- */
 @Component
 public class InventoryFacadeTool {
 
-  private final RestClient restClient;
+    private final RestClient restClient;
 
-  public InventoryFacadeTool(
-      RestClient.Builder restClientBuilder,
-      @Value("${pos.inventory.base-url:http://pos-inventory/v1/inventory}") @NonNull String baseUrl) {
-    // Phase 1 limitation: RestClient is constructed without auth propagation
-    // interceptors.
-    this.restClient = restClientBuilder
-        .baseUrl(baseUrl)
-        .build();
-  }
+    public InventoryFacadeTool(
+            RestClient.Builder restClientBuilder,
+            @Value("${pos.inventory.base-url:http://pos-inventory/v1/inventory}") @NonNull String baseUrl) {
+        this.restClient = restClientBuilder
+                .baseUrl(baseUrl)
+                .build();
+    }
 
-  @Tool("Check current stock level for a product by SKU number")
-  public String checkStock(
-      @P("The SKU number to look up") @NonNull String sku) {
-    return restClient.get()
-        .uri("/stock/{sku}", sku)
-        .retrieve()
-        .body(String.class);
-  }
+    @Tool("Check current stock level for a product by SKU number")
+    public String checkStock(
+            @P("The SKU number to look up") @NonNull String sku) {
+        return restClient.get()
+                .uri("/stock/{sku}", sku)
+                .retrieve()
+                .body(String.class);
+    }
 
-  @Tool("Search inventory by product name or partial SKU")
-  public String searchInventory(
-      @P("Search term: product name or partial SKU") @NonNull String query) {
-    return restClient.get()
-        .uri(uriBuilder -> uriBuilder
-            .path("/search")
-            .queryParam("q", query)
-            .build())
-        .retrieve()
-        .body(String.class);
-  }
+    @Tool("Search inventory by product name or partial SKU")
+    public String searchInventory(
+            @P("Search term: product name or partial SKU") @NonNull String query) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/search")
+                        .queryParam("q", query)
+                        .build())
+                .retrieve()
+                .body(String.class);
+    }
 
-  @Tool("Get stock levels for all products at a specific store location")
-  public String getLocationStock(
-      @P("Store location ID") @NonNull String locationId) {
-    return restClient.get()
-        .uri("/locations/{locationId}/stock", locationId)
-        .retrieve()
-        .body(String.class);
-  }
+    @Tool("Get stock levels for all products at a specific store location")
+    public String getLocationStock(
+            @P("Store location ID") @NonNull String locationId) {
+        return restClient.get()
+                .uri("/locations/{locationId}/stock", locationId)
+                .retrieve()
+                .body(String.class);
+    }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/InvoiceFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/InvoiceFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class InvoiceFacadeTool {
 
   private final RestClient restClient;
 
-  public InvoiceFacadeTool(RestClient.Builder restClientBuilder) {
+  public InvoiceFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.invoice.base-url:http://pos-invoice/v1/invoices}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-invoice/v1/invoices")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/InvoiceFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/InvoiceFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class InvoiceFacadeTool {
+
+  private final RestClient restClient;
+
+  public InvoiceFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-invoice/v1/invoices")
+        .build();
+  }
+
+  @Tool("Get invoice details by invoice ID")
+  public String getInvoice(
+      @P("The invoice ID") @NonNull String invoiceId) {
+    return restClient.get()
+        .uri("/{invoiceId}", invoiceId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search invoices by status, customer, date, or amount")
+  public String searchInvoices(
+      @P("Search query for invoices") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get invoices linked to a specific customer")
+  public String getInvoicesByCustomer(
+      @P("The customer ID") @NonNull String customerId) {
+    return restClient.get()
+        .uri("/customer/{customerId}", customerId)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/LocationFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/LocationFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class LocationFacadeTool {
+
+  private final RestClient restClient;
+
+  public LocationFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-location/v1/locations")
+        .build();
+  }
+
+  @Tool("Get location details by location ID")
+  public String getLocation(
+      @P("The location ID") @NonNull String locationId) {
+    return restClient.get()
+        .uri("/{locationId}", locationId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search locations by name, city, code, or attributes")
+  public String searchLocations(
+      @P("Search query for locations") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get inventory context for a specific location")
+  public String getLocationInventory(
+      @P("The location ID") @NonNull String locationId) {
+    return restClient.get()
+        .uri("/{locationId}/inventory", locationId)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/LocationFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/LocationFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class LocationFacadeTool {
 
   private final RestClient restClient;
 
-  public LocationFacadeTool(RestClient.Builder restClientBuilder) {
+  public LocationFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.location.base-url:http://pos-location/v1/locations}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-location/v1/locations")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/OrderFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/OrderFacadeTool.java
@@ -7,53 +7,37 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-/**
- * Phase 1 facade tool for order lookup operations.
- * <p>
- * <strong>Phase 1 Limitation (ADR-0014):</strong> Outbound calls to pos-order
- * do not propagate the caller's JWT bearer token. Tool calls will receive 401
- * responses
- * from pos-order unless that service permits unauthenticated access on these
- * paths.
- * Bearer token propagation will be implemented in Phase 2 via a shared
- * {@code ClientHttpRequestInterceptor} on the RestClient.
- * <p>
- * Tracked for Phase2: add auth propagation via SecurityContext-sourced bearer
- * token.
- */
 @Component
 public class OrderFacadeTool {
 
-  private final RestClient restClient;
+    private final RestClient restClient;
 
-  public OrderFacadeTool(
-      RestClient.Builder restClientBuilder,
-      @Value("${pos.order.base-url:http://pos-order/v1/orders}") @NonNull String baseUrl) {
-    // Phase 1 limitation: RestClient is constructed without auth propagation
-    // interceptors.
-    this.restClient = restClientBuilder
-        .baseUrl(baseUrl)
-        .build();
-  }
+    public OrderFacadeTool(
+            RestClient.Builder restClientBuilder,
+            @Value("${pos.order.base-url:http://pos-order/v1/orders}") @NonNull String baseUrl) {
+        this.restClient = restClientBuilder
+                .baseUrl(baseUrl)
+                .build();
+    }
 
-  @Tool("Look up an order by order ID")
-  public String getOrder(
-      @P("The order ID") @NonNull String orderId) {
-    return restClient.get()
-        .uri("/{orderId}", orderId)
-        .retrieve()
-        .body(String.class);
-  }
+    @Tool("Look up an order by order ID")
+    public String getOrder(
+            @P("The order ID") @NonNull String orderId) {
+        return restClient.get()
+                .uri("/{orderId}", orderId)
+                .retrieve()
+                .body(String.class);
+    }
 
-  @Tool("Search orders by customer name, date range, or status")
-  public String searchOrders(
-      @P("Search query: customer name, date, or status") @NonNull String query) {
-    return restClient.get()
-        .uri(uriBuilder -> uriBuilder
-            .path("/search")
-            .queryParam("q", query)
-            .build())
-        .retrieve()
-        .body(String.class);
-  }
+    @Tool("Search orders by customer name, date range, or status")
+    public String searchOrders(
+            @P("Search query: customer name, date, or status") @NonNull String query) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/search")
+                        .queryParam("q", query)
+                        .build())
+                .retrieve()
+                .body(String.class);
+    }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/PricingFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/PricingFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class PricingFacadeTool {
 
   private final RestClient restClient;
 
-  public PricingFacadeTool(RestClient.Builder restClientBuilder) {
+  public PricingFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.pricing.base-url:http://pos-price/v1/pricing}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-price/v1/pricing")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/PricingFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/PricingFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class PricingFacadeTool {
+
+  private final RestClient restClient;
+
+  public PricingFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-price/v1/pricing")
+        .build();
+  }
+
+  @Tool("Get current price details for a specific SKU")
+  public String getPriceForSku(
+      @P("The SKU to price") @NonNull String sku) {
+    return restClient.get()
+        .uri("/sku/{sku}", sku)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search pricing data by SKU, description, or pricing rule")
+  public String searchPricing(
+      @P("Search query for pricing") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get a full price list by price list ID")
+  public String getPriceList(
+      @P("The price list ID") @NonNull String priceListId) {
+    return restClient.get()
+        .uri("/lists/{priceListId}", priceListId)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/ReportingFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/ReportingFacadeTool.java
@@ -1,0 +1,46 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class ReportingFacadeTool {
+
+  private final RestClient restClient;
+
+  public ReportingFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-accounting/v1/reports")
+        .build();
+  }
+
+  @Tool("Get a sales report for a requested period")
+  public String getSalesReport(
+      @P("Reporting period identifier") @NonNull String period) {
+    return restClient.get()
+        .uri("/sales/{period}", period)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get an inventory report for a specific location")
+  public String getInventoryReport(
+      @P("The location ID") @NonNull String locationId) {
+    return restClient.get()
+        .uri("/inventory/{locationId}", locationId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get a revenue report for a requested period")
+  public String getRevenueReport(
+      @P("Reporting period identifier") @NonNull String period) {
+    return restClient.get()
+        .uri("/revenue/{period}", period)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/ReportingFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/ReportingFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class ReportingFacadeTool {
 
   private final RestClient restClient;
 
-  public ReportingFacadeTool(RestClient.Builder restClientBuilder) {
+  public ReportingFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.reporting.base-url:http://pos-accounting/v1/reporting}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-accounting/v1/reports")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/ShopManagerFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/ShopManagerFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class ShopManagerFacadeTool {
 
   private final RestClient restClient;
 
-  public ShopManagerFacadeTool(RestClient.Builder restClientBuilder) {
+  public ShopManagerFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.shopmanager.base-url:http://pos-shop-manager/v1/shop}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-shop-manager/v1/shop")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/ShopManagerFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/ShopManagerFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class ShopManagerFacadeTool {
+
+  private final RestClient restClient;
+
+  public ShopManagerFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-shop-manager/v1/shop")
+        .build();
+  }
+
+  @Tool("Get overall status for a shop location")
+  public String getShopStatus(
+      @P("The shop ID") @NonNull String shopId) {
+    return restClient.get()
+        .uri("/{shopId}/status", shopId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get the active queue and workflow load for a shop")
+  public String getShopQueue(
+      @P("The shop ID") @NonNull String shopId) {
+    return restClient.get()
+        .uri("/{shopId}/queue", shopId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search shops by name, region, status, or manager")
+  public String searchShops(
+      @P("Search query for shops") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/TaxFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/TaxFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class TaxFacadeTool {
 
   private final RestClient restClient;
 
-  public TaxFacadeTool(RestClient.Builder restClientBuilder) {
+  public TaxFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.tax.base-url:http://pos-tax/v1/tax}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-tax/v1/tax")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/TaxFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/TaxFacadeTool.java
@@ -1,0 +1,51 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class TaxFacadeTool {
+
+  private final RestClient restClient;
+
+  public TaxFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-tax/v1/tax")
+        .build();
+  }
+
+  @Tool("Get the tax rate for a specific location")
+  public String getTaxRate(
+      @P("The location ID") @NonNull String locationId) {
+    return restClient.get()
+        .uri("/rates/{locationId}", locationId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Calculate estimated tax amount for an amount and location")
+  public String calculateTax(
+      @P("The taxable amount") @NonNull String amount,
+      @P("The location ID") @NonNull String locationId) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/calculate")
+            .queryParam("amount", amount)
+            .queryParam("locationId", locationId)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get tax summary details for a reporting period")
+  public String getTaxSummary(
+      @P("Tax reporting period") @NonNull String period) {
+    return restClient.get()
+        .uri("/summary/{period}", period)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/VehicleFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/VehicleFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class VehicleFacadeTool {
 
   private final RestClient restClient;
 
-  public VehicleFacadeTool(RestClient.Builder restClientBuilder) {
+  public VehicleFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.vehicle.base-url:http://pos-customer/v1/vehicles}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-customer/v1/vehicles")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/VehicleFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/VehicleFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class VehicleFacadeTool {
+
+  private final RestClient restClient;
+
+  public VehicleFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-customer/v1/vehicles")
+        .build();
+  }
+
+  @Tool("Get vehicle details by vehicle ID")
+  public String getVehicle(
+      @P("The vehicle ID") @NonNull String vehicleId) {
+    return restClient.get()
+        .uri("/{vehicleId}", vehicleId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search vehicles by VIN, make, model, year, or plate")
+  public String searchVehicles(
+      @P("Search query for vehicles") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get all vehicles associated with a specific customer")
+  public String getVehiclesByCustomer(
+      @P("The customer ID") @NonNull String customerId) {
+    return restClient.get()
+        .uri("/customer/{customerId}", customerId)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeTool.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class WorkorderFacadeTool {
+
+  private final RestClient restClient;
+
+  public WorkorderFacadeTool(RestClient.Builder restClientBuilder) {
+    this.restClient = restClientBuilder
+        .baseUrl("http://pos-workorder/v1/workorders")
+        .build();
+  }
+
+  @Tool("Get full workorder details by workorder ID")
+  public String getWorkorder(
+      @P("The workorder ID") @NonNull String workorderId) {
+    return restClient.get()
+        .uri("/{workorderId}", workorderId)
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Search workorders by customer, status, or vehicle criteria")
+  public String searchWorkorders(
+      @P("Search query for workorders") @NonNull String query) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/search")
+            .queryParam("q", query)
+            .build())
+        .retrieve()
+        .body(String.class);
+  }
+
+  @Tool("Get current lifecycle status for a workorder")
+  public String getWorkorderStatus(
+      @P("The workorder ID") @NonNull String workorderId) {
+    return restClient.get()
+        .uri("/{workorderId}/status", workorderId)
+        .retrieve()
+        .body(String.class);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeTool.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeTool.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration.tools;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,9 +12,11 @@ public class WorkorderFacadeTool {
 
   private final RestClient restClient;
 
-  public WorkorderFacadeTool(RestClient.Builder restClientBuilder) {
+  public WorkorderFacadeTool(
+      RestClient.Builder restClientBuilder,
+      @Value("${pos.workorder.base-url:http://pos-workorder/v1/workorders}") @NonNull String baseUrl) {
     this.restClient = restClientBuilder
-        .baseUrl("http://pos-workorder/v1/workorders")
+        .baseUrl(baseUrl)
         .build();
   }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
@@ -1,0 +1,14 @@
+package com.positivity.mcp.internal.repository;
+
+import com.positivity.mcp.internal.domain.ToolMetadata;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+
+public interface ToolMetadataRepository {
+
+  @NonNull
+  List<ToolMetadata> findEnabledByRoleAndWorkflow(@NonNull String role, @NonNull String workflowState);
+
+  @NonNull
+  List<ToolMetadata> findTopKByEmbedding(float @NonNull [] embedding, int limit);
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.postgresql.util.PGobject;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -49,11 +50,31 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                avg_latency_ms, enabled, handler_bean
         FROM mcp_tool
         WHERE enabled = true
-        ORDER BY embedding <=> ?::vector
+          AND embedding IS NOT NULL
+        ORDER BY embedding <=> ?::vector, id
         LIMIT ?
         """;
 
-    return jdbcTemplate.query(sql, this::mapRow, embedding, limit);
+    return jdbcTemplate.query(sql, this::mapRow, toVectorPGobject(embedding), limit);
+  }
+
+  private static PGobject toVectorPGobject(float[] embedding) {
+    StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < embedding.length; i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append(embedding[i]);
+    }
+    sb.append("]");
+    PGobject pgVector = new PGobject();
+    pgVector.setType("vector");
+    try {
+      pgVector.setValue(sb.toString());
+    } catch (SQLException e) {
+      throw new IllegalArgumentException("Failed to create vector PGobject", e);
+    }
+    return pgVector;
   }
 
   private ToolMetadata mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.positivity.mcp.internal.repository;
+
+import com.positivity.mcp.internal.domain.ToolMetadata;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("!test")
+public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public ToolMetadataRepositoryImpl(@NonNull JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public @NonNull List<ToolMetadata> findEnabledByRoleAndWorkflow(
+      @NonNull String role,
+      @NonNull String workflowState) {
+    String sql = """
+        SELECT t.id, t.name, t.display_name, t.description,
+               t.domain, t.priority, t.cost_level,
+               t.avg_latency_ms, t.enabled, t.handler_bean
+        FROM mcp_tool t
+        JOIN mcp_tool_role tr ON t.id = tr.tool_id
+        JOIN mcp_role r ON tr.role_id = r.id
+        JOIN mcp_tool_workflow tw ON t.id = tw.tool_id
+        JOIN mcp_workflow_state ws ON tw.workflow_state_id = ws.id
+        WHERE t.enabled = true
+          AND r.name = ?
+          AND ws.name = ?
+        """;
+
+    return jdbcTemplate.query(sql, this::mapRow, role, workflowState);
+  }
+
+  @Override
+  public @NonNull List<ToolMetadata> findTopKByEmbedding(float @NonNull [] embedding, int limit) {
+    String sql = """
+        SELECT id, name, display_name, description,
+               domain, priority, cost_level,
+               avg_latency_ms, enabled, handler_bean
+        FROM mcp_tool
+        WHERE enabled = true
+        ORDER BY embedding <=> ?::vector
+        LIMIT ?
+        """;
+
+    return jdbcTemplate.query(sql, this::mapRow, embedding, limit);
+  }
+
+  private ToolMetadata mapRow(ResultSet rs, int rowNum) throws SQLException {
+    return new ToolMetadata(
+        rs.getObject("id", UUID.class),
+        rs.getString("name"),
+        rs.getString("display_name"),
+        rs.getString("description"),
+        rs.getString("domain"),
+        rs.getDouble("priority"),
+        rs.getString("cost_level"),
+        rs.getInt("avg_latency_ms"),
+        rs.getBoolean("enabled"),
+        rs.getString("handler_bean"));
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryLoader.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryLoader.java
@@ -1,4 +1,4 @@
-package com.positivity.mcp.internal.orchestration;
+package com.positivity.mcp.internal.service;
 
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.repository.ToolMetadataRepository;
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
@@ -39,7 +40,11 @@ public class ToolRegistryLoader {
   }
 
   /**
-   * Loads role-to-tool-instance mappings from the DB at startup.
+   * Loads role-to-tool-instance mappings from the DB at startup for the IDLE
+   * workflow state.
+   * Only tools mapped to the {@code IDLE} workflow state are preloaded; tools for
+   * other
+   * workflow states (e.g., CREATING_PO) are resolved dynamically per request.
    * Tools are resolved by their Spring bean name (handler_bean column).
    */
   public @NonNull Map<String, List<Object>> loadRoleToolMappings() {
@@ -51,7 +56,7 @@ public class ToolRegistryLoader {
         try {
           Object bean = applicationContext.getBean(meta.handlerBean());
           beans.add(bean);
-        } catch (Exception e) {
+        } catch (NoSuchBeanDefinitionException e) {
           log.warn(
               "Tool bean '{}' not found for role '{}', skipping: {}",
               meta.handlerBean(),

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryService.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryService.java
@@ -1,4 +1,4 @@
-package com.positivity.mcp.internal.orchestration;
+package com.positivity.mcp.internal.service;
 
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.domain.ToolSelectionContext;

--- a/pos-mcp-server/src/main/resources/db/migration/V3__tool_registry_schema.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V3__tool_registry_schema.sql
@@ -1,0 +1,42 @@
+-- mcp_role: known roles
+CREATE TABLE IF NOT EXISTS mcp_role (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(80) NOT NULL,
+  CONSTRAINT uk_mcp_role_name UNIQUE (name)
+);
+-- mcp_workflow_state: known workflow states
+CREATE TABLE IF NOT EXISTS mcp_workflow_state (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(80) NOT NULL,
+  CONSTRAINT uk_mcp_workflow_state_name UNIQUE (name)
+);
+-- mcp_tool: facade tool catalog
+CREATE TABLE IF NOT EXISTS mcp_tool (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(100) NOT NULL,
+  display_name VARCHAR(150) NOT NULL,
+  description TEXT NOT NULL,
+  domain VARCHAR(80) NOT NULL,
+  priority DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+  cost_level VARCHAR(20) NOT NULL DEFAULT 'low',
+  avg_latency_ms INTEGER NOT NULL DEFAULT 200,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  handler_bean VARCHAR(150) NOT NULL,
+  embedding vector(768),
+  CONSTRAINT uk_mcp_tool_name UNIQUE (name)
+);
+-- mcp_tool_role: many-to-many tool ↔ role
+CREATE TABLE IF NOT EXISTS mcp_tool_role (
+  tool_id UUID NOT NULL REFERENCES mcp_tool(id),
+  role_id UUID NOT NULL REFERENCES mcp_role(id),
+  PRIMARY KEY (tool_id, role_id)
+);
+-- mcp_tool_workflow: many-to-many tool ↔ workflow state (NULL = all states)
+CREATE TABLE IF NOT EXISTS mcp_tool_workflow (
+  tool_id UUID NOT NULL REFERENCES mcp_tool(id),
+  workflow_state_id UUID NOT NULL REFERENCES mcp_workflow_state(id),
+  PRIMARY KEY (tool_id, workflow_state_id)
+);
+CREATE INDEX IF NOT EXISTS idx_mcp_tool_role_tool_id ON mcp_tool_role (tool_id);
+CREATE INDEX IF NOT EXISTS idx_mcp_tool_role_role_id ON mcp_tool_role (role_id);
+CREATE INDEX IF NOT EXISTS idx_mcp_tool_workflow_tool_id ON mcp_tool_workflow (tool_id);

--- a/pos-mcp-server/src/main/resources/db/migration/V3__tool_registry_schema.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V3__tool_registry_schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS mcp_tool_role (
   role_id UUID NOT NULL REFERENCES mcp_role(id),
   PRIMARY KEY (tool_id, role_id)
 );
--- mcp_tool_workflow: many-to-many tool ↔ workflow state (NULL = all states)
+-- mcp_tool_workflow: many-to-many tool ↔ workflow state
 CREATE TABLE IF NOT EXISTS mcp_tool_workflow (
   tool_id UUID NOT NULL REFERENCES mcp_tool(id),
   workflow_state_id UUID NOT NULL REFERENCES mcp_workflow_state(id),

--- a/pos-mcp-server/src/main/resources/db/migration/V4__tool_registry_seed_data.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V4__tool_registry_seed_data.sql
@@ -1,0 +1,326 @@
+WITH roles(name) AS (
+  VALUES ('ROLE_CASHIER'),
+    ('ROLE_SERVICE_WRITER'),
+    ('ROLE_MANAGER'),
+    ('ROLE_ADMIN'),
+    ('ROLE_SUPPLIER')
+)
+INSERT INTO mcp_role (name)
+SELECT name
+FROM roles ON CONFLICT DO NOTHING;
+WITH workflow_states(name) AS (
+  VALUES ('IDLE'),
+    ('CREATING_PO'),
+    ('RECEIVING_ASN'),
+    ('INVENTORY_RECON')
+)
+INSERT INTO mcp_workflow_state (name)
+SELECT name
+FROM workflow_states ON CONFLICT DO NOTHING;
+WITH tools(
+  name,
+  display_name,
+  description,
+  domain,
+  priority,
+  cost_level,
+  avg_latency_ms,
+  enabled,
+  handler_bean
+) AS (
+  VALUES (
+      'InventoryFacadeTool',
+      'Inventory',
+      'Inventory availability, stocking, and reconciliation workflows',
+      'inventory',
+      1.0,
+      'low',
+      220,
+      TRUE,
+      'inventoryFacadeTool'
+    ),
+    (
+      'OrderFacadeTool',
+      'Order',
+      'Purchase and sales order workflows across suppliers and stores',
+      'order',
+      1.0,
+      'low',
+      240,
+      TRUE,
+      'orderFacadeTool'
+    ),
+    (
+      'CustomerFacadeTool',
+      'Customer',
+      'Customer profile, account, and communication context',
+      'customer',
+      0.9,
+      'low',
+      180,
+      TRUE,
+      'customerFacadeTool'
+    ),
+    (
+      'PricingFacadeTool',
+      'Pricing',
+      'Price lookup, discount, and margin guidance',
+      'pricing',
+      0.9,
+      'medium',
+      210,
+      TRUE,
+      'pricingFacadeTool'
+    ),
+    (
+      'WorkorderFacadeTool',
+      'Workorder',
+      'workorder intake, assignment, and lifecycle orchestration',
+      'workorder',
+      1.1,
+      'medium',
+      260,
+      TRUE,
+      'workorderFacadeTool'
+    ),
+    (
+      'CatalogFacadeTool',
+      'Catalog',
+      'Product catalog discovery and item metadata lookup',
+      'catalog',
+      0.9,
+      'low',
+      170,
+      TRUE,
+      'catalogFacadeTool'
+    ),
+    (
+      'VehicleFacadeTool',
+      'Vehicle',
+      'Vehicle fitment, VIN lookups, and compatibility checks',
+      'vehicle',
+      0.8,
+      'medium',
+      260,
+      TRUE,
+      'vehicleFacadeTool'
+    ),
+    (
+      'AccountingFacadeTool',
+      'Accounting',
+      'Accounting summaries and ledger-facing business context',
+      'accounting',
+      0.8,
+      'high',
+      320,
+      TRUE,
+      'accountingFacadeTool'
+    ),
+    (
+      'InvoiceFacadeTool',
+      'Invoice',
+      'Invoice generation and invoice status operations',
+      'invoice',
+      0.9,
+      'medium',
+      250,
+      TRUE,
+      'invoiceFacadeTool'
+    ),
+    (
+      'HrFacadeTool',
+      'HR',
+      'Workforce scheduling and HR policy information',
+      'hr',
+      0.7,
+      'medium',
+      300,
+      TRUE,
+      'hrFacadeTool'
+    ),
+    (
+      'ReportingFacadeTool',
+      'Reporting',
+      'Operational and executive reporting metrics',
+      'reporting',
+      0.8,
+      'high',
+      350,
+      TRUE,
+      'reportingFacadeTool'
+    ),
+    (
+      'LocationFacadeTool',
+      'Location',
+      'Store and location context for local operations',
+      'location',
+      0.8,
+      'low',
+      180,
+      TRUE,
+      'locationFacadeTool'
+    ),
+    (
+      'ShopManagerFacadeTool',
+      'Shop Manager',
+      'Shop manager controls and branch-level operations',
+      'shop-manager',
+      0.9,
+      'medium',
+      260,
+      TRUE,
+      'shopManagerFacadeTool'
+    ),
+    (
+      'TaxFacadeTool',
+      'Tax',
+      'Tax computation and tax rule interpretation',
+      'tax',
+      0.7,
+      'high',
+      300,
+      TRUE,
+      'taxFacadeTool'
+    ),
+    (
+      'AdminFacadeTool',
+      'Admin',
+      'Administrative controls and platform governance operations',
+      'admin',
+      0.8,
+      'high',
+      320,
+      TRUE,
+      'adminFacadeTool'
+    ),
+    (
+      'EventsFacadeTool',
+      'Events',
+      'Event audit, retrieval, and observability context',
+      'events',
+      0.8,
+      'low',
+      200,
+      TRUE,
+      'eventsFacadeTool'
+    )
+)
+INSERT INTO mcp_tool (
+    name,
+    display_name,
+    description,
+    domain,
+    priority,
+    cost_level,
+    avg_latency_ms,
+    enabled,
+    handler_bean
+  )
+SELECT name,
+  display_name,
+  description,
+  domain,
+  priority,
+  cost_level,
+  avg_latency_ms,
+  enabled,
+  handler_bean
+FROM tools ON CONFLICT DO NOTHING;
+WITH role_tool(role_name, tool_name) AS (
+  VALUES -- ROLE_CASHIER
+    ('ROLE_CASHIER', 'InventoryFacadeTool'),
+    ('ROLE_CASHIER', 'OrderFacadeTool'),
+    ('ROLE_CASHIER', 'CustomerFacadeTool'),
+    ('ROLE_CASHIER', 'PricingFacadeTool'),
+    -- ROLE_SERVICE_WRITER
+    ('ROLE_SERVICE_WRITER', 'WorkorderFacadeTool'),
+    ('ROLE_SERVICE_WRITER', 'CustomerFacadeTool'),
+    ('ROLE_SERVICE_WRITER', 'VehicleFacadeTool'),
+    ('ROLE_SERVICE_WRITER', 'CatalogFacadeTool'),
+    ('ROLE_SERVICE_WRITER', 'PricingFacadeTool'),
+    ('ROLE_SERVICE_WRITER', 'InventoryFacadeTool'),
+    -- ROLE_MANAGER (service writer + reporting/accounting/invoice/hr)
+    ('ROLE_MANAGER', 'WorkorderFacadeTool'),
+    ('ROLE_MANAGER', 'CustomerFacadeTool'),
+    ('ROLE_MANAGER', 'VehicleFacadeTool'),
+    ('ROLE_MANAGER', 'CatalogFacadeTool'),
+    ('ROLE_MANAGER', 'PricingFacadeTool'),
+    ('ROLE_MANAGER', 'InventoryFacadeTool'),
+    ('ROLE_MANAGER', 'ReportingFacadeTool'),
+    ('ROLE_MANAGER', 'AccountingFacadeTool'),
+    ('ROLE_MANAGER', 'InvoiceFacadeTool'),
+    ('ROLE_MANAGER', 'HrFacadeTool'),
+    -- ROLE_SUPPLIER
+    ('ROLE_SUPPLIER', 'OrderFacadeTool'),
+    ('ROLE_SUPPLIER', 'InventoryFacadeTool'),
+    ('ROLE_SUPPLIER', 'CatalogFacadeTool'),
+    -- ROLE_ADMIN (all 16)
+    ('ROLE_ADMIN', 'InventoryFacadeTool'),
+    ('ROLE_ADMIN', 'OrderFacadeTool'),
+    ('ROLE_ADMIN', 'CustomerFacadeTool'),
+    ('ROLE_ADMIN', 'PricingFacadeTool'),
+    ('ROLE_ADMIN', 'WorkorderFacadeTool'),
+    ('ROLE_ADMIN', 'CatalogFacadeTool'),
+    ('ROLE_ADMIN', 'VehicleFacadeTool'),
+    ('ROLE_ADMIN', 'AccountingFacadeTool'),
+    ('ROLE_ADMIN', 'InvoiceFacadeTool'),
+    ('ROLE_ADMIN', 'HrFacadeTool'),
+    ('ROLE_ADMIN', 'ReportingFacadeTool'),
+    ('ROLE_ADMIN', 'LocationFacadeTool'),
+    ('ROLE_ADMIN', 'ShopManagerFacadeTool'),
+    ('ROLE_ADMIN', 'TaxFacadeTool'),
+    ('ROLE_ADMIN', 'AdminFacadeTool'),
+    ('ROLE_ADMIN', 'EventsFacadeTool')
+)
+INSERT INTO mcp_tool_role (tool_id, role_id)
+SELECT t.id,
+  r.id
+FROM role_tool rt
+  JOIN mcp_tool t ON t.name = rt.tool_name
+  JOIN mcp_role r ON r.name = rt.role_name ON CONFLICT DO NOTHING;
+WITH idle_workflow(tool_name) AS (
+  VALUES ('InventoryFacadeTool'),
+    ('OrderFacadeTool'),
+    ('CustomerFacadeTool'),
+    ('PricingFacadeTool'),
+    ('WorkorderFacadeTool'),
+    ('CatalogFacadeTool'),
+    ('VehicleFacadeTool'),
+    ('AccountingFacadeTool'),
+    ('InvoiceFacadeTool'),
+    ('HrFacadeTool'),
+    ('ReportingFacadeTool'),
+    ('LocationFacadeTool'),
+    ('ShopManagerFacadeTool'),
+    ('TaxFacadeTool'),
+    ('AdminFacadeTool'),
+    ('EventsFacadeTool')
+)
+INSERT INTO mcp_tool_workflow (tool_id, workflow_state_id)
+SELECT t.id,
+  ws.id
+FROM idle_workflow iw
+  JOIN mcp_tool t ON t.name = iw.tool_name
+  JOIN mcp_workflow_state ws ON ws.name = 'IDLE' ON CONFLICT DO NOTHING;
+WITH workflow_tool(workflow_name, tool_name) AS (
+  VALUES ('CREATING_PO', 'OrderFacadeTool'),
+    ('CREATING_PO', 'InventoryFacadeTool'),
+    ('CREATING_PO', 'CatalogFacadeTool'),
+    ('CREATING_PO', 'PricingFacadeTool'),
+    ('RECEIVING_ASN', 'InventoryFacadeTool'),
+    ('RECEIVING_ASN', 'OrderFacadeTool'),
+    ('RECEIVING_ASN', 'CatalogFacadeTool'),
+    ('RECEIVING_ASN', 'LocationFacadeTool'),
+    ('RECEIVING_ASN', 'ShopManagerFacadeTool'),
+    ('INVENTORY_RECON', 'InventoryFacadeTool'),
+    ('INVENTORY_RECON', 'CatalogFacadeTool'),
+    ('INVENTORY_RECON', 'LocationFacadeTool'),
+    ('INVENTORY_RECON', 'ShopManagerFacadeTool'),
+    ('INVENTORY_RECON', 'ReportingFacadeTool')
+)
+INSERT INTO mcp_tool_workflow (tool_id, workflow_state_id)
+SELECT t.id,
+  ws.id
+FROM workflow_tool wt
+  JOIN mcp_tool t ON t.name = wt.tool_name
+  JOIN mcp_workflow_state ws ON ws.name = wt.workflow_name ON CONFLICT DO NOTHING;

--- a/pos-mcp-server/src/main/resources/db/migration/V5__location_shopmanager_role_mappings.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V5__location_shopmanager_role_mappings.sql
@@ -1,0 +1,29 @@
+-- V5: Add missing role mappings for LocationFacadeTool and ShopManagerFacadeTool
+INSERT INTO mcp_tool_role (tool_id, role_id)
+SELECT t.id,
+  r.id
+FROM mcp_tool t,
+  mcp_role r
+WHERE t.name = 'LocationFacadeTool'
+  AND r.name = 'ROLE_SERVICE_WRITER' ON CONFLICT DO NOTHING;
+INSERT INTO mcp_tool_role (tool_id, role_id)
+SELECT t.id,
+  r.id
+FROM mcp_tool t,
+  mcp_role r
+WHERE t.name = 'LocationFacadeTool'
+  AND r.name = 'ROLE_MANAGER' ON CONFLICT DO NOTHING;
+INSERT INTO mcp_tool_role (tool_id, role_id)
+SELECT t.id,
+  r.id
+FROM mcp_tool t,
+  mcp_role r
+WHERE t.name = 'ShopManagerFacadeTool'
+  AND r.name = 'ROLE_SERVICE_WRITER' ON CONFLICT DO NOTHING;
+INSERT INTO mcp_tool_role (tool_id, role_id)
+SELECT t.id,
+  r.id
+FROM mcp_tool t,
+  mcp_role r
+WHERE t.name = 'ShopManagerFacadeTool'
+  AND r.name = 'ROLE_MANAGER' ON CONFLICT DO NOTHING;

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/ArchitectureTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/ArchitectureTest.java
@@ -66,10 +66,10 @@ public class ArchitectureTest {
         static final ArchRule repositories_should_only_be_accessed_from_services_or_config = noClasses()
                         .that()
                         .resideOutsideOfPackages("..service..", "..internal.repository..", "..internal.config..",
-                                        "..internal.orchestration..")
+                                        "..internal.service..")
                         .should().dependOnClassesThat().resideInAPackage("..internal.repository..")
                         .allowEmptyShould(true)
-                        .because("repositories should only be accessed from service layer or orchestration");
+                        .because("repositories should only be accessed from service layer");
 
         @ArchTest
         static final ArchRule spring_boot_application_should_be_in_root_package = classes()

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/ArchitectureTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/ArchitectureTest.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 
 /**
  * ArchUnit tests enforcing architecture rules for pos-mcp-server module.
- * 
+ *
  * Enforces:
  * - Internal package encapsulation
  * - Service layer as only public API
@@ -64,10 +64,12 @@ public class ArchitectureTest {
 
         @ArchTest
         static final ArchRule repositories_should_only_be_accessed_from_services_or_config = noClasses()
-                        .that().resideOutsideOfPackages("..service..", "..internal.repository..", "..internal.config..")
+                        .that()
+                        .resideOutsideOfPackages("..service..", "..internal.repository..", "..internal.config..",
+                                        "..internal.orchestration..")
                         .should().dependOnClassesThat().resideInAPackage("..internal.repository..")
                         .allowEmptyShould(true)
-                        .because("repositories should only be accessed from service layer");
+                        .because("repositories should only be accessed from service layer or orchestration");
 
         @ArchTest
         static final ArchRule spring_boot_application_should_be_in_root_package = classes()

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/BearerTokenRelayInterceptorTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/BearerTokenRelayInterceptorTest.java
@@ -1,0 +1,82 @@
+package com.positivity.mcp.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class BearerTokenRelayInterceptorTest {
+
+  private BearerTokenRelayInterceptor interceptor;
+
+  @BeforeEach
+  void setUp() {
+    interceptor = new BearerTokenRelayInterceptor();
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  @DisplayName("intercept forwards Authorization header when Bearer token present in context")
+  void intercept_forwardsBearerToken_whenPresentInServletContext() throws IOException {
+    MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+    httpRequest.addHeader("Authorization", "Bearer test-token");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(httpRequest));
+
+    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://test/endpoint"));
+    ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+    ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
+    when(execution.execute(outboundRequest, new byte[0])).thenReturn(mockResponse);
+
+    interceptor.intercept(outboundRequest, new byte[0], execution);
+
+    assertThat(outboundRequest.getHeaders().getFirst("Authorization")).isEqualTo("Bearer test-token");
+  }
+
+  @Test
+  @DisplayName("intercept does not add Authorization header when no Bearer token in context")
+  void intercept_doesNotAddHeader_whenNoBearerTokenInContext() throws IOException {
+    MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(httpRequest));
+
+    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://test/endpoint"));
+    ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+    ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
+    when(execution.execute(outboundRequest, new byte[0])).thenReturn(mockResponse);
+
+    interceptor.intercept(outboundRequest, new byte[0], execution);
+
+    assertThat(outboundRequest.getHeaders().get("Authorization")).isNullOrEmpty();
+  }
+
+  @Test
+  @DisplayName("intercept gracefully skips relay when no request context available")
+  void intercept_skipsRelay_whenNoRequestContext() throws IOException {
+    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://test/endpoint"));
+    ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+    ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
+    when(execution.execute(outboundRequest, new byte[0])).thenReturn(mockResponse);
+
+    interceptor.intercept(outboundRequest, new byte[0], execution);
+
+    assertThat(outboundRequest.getHeaders().get("Authorization")).isNullOrEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/BearerTokenRelayInterceptorTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/BearerTokenRelayInterceptorTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URI;
 import org.junit.jupiter.api.AfterEach;
@@ -41,7 +40,8 @@ class BearerTokenRelayInterceptorTest {
     httpRequest.addHeader("Authorization", "Bearer test-token");
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(httpRequest));
 
-    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://test/endpoint"));
+    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET,
+        URI.create("http://test/endpoint"));
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
     when(execution.execute(outboundRequest, new byte[0])).thenReturn(mockResponse);
@@ -57,7 +57,8 @@ class BearerTokenRelayInterceptorTest {
     MockHttpServletRequest httpRequest = new MockHttpServletRequest();
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(httpRequest));
 
-    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://test/endpoint"));
+    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET,
+        URI.create("http://test/endpoint"));
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
     when(execution.execute(outboundRequest, new byte[0])).thenReturn(mockResponse);
@@ -70,7 +71,8 @@ class BearerTokenRelayInterceptorTest {
   @Test
   @DisplayName("intercept gracefully skips relay when no request context available")
   void intercept_skipsRelay_whenNoRequestContext() throws IOException {
-    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET, URI.create("http://test/endpoint"));
+    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET,
+        URI.create("http://test/endpoint"));
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
     when(execution.execute(outboundRequest, new byte[0])).thenReturn(mockResponse);
@@ -78,5 +80,43 @@ class BearerTokenRelayInterceptorTest {
     interceptor.intercept(outboundRequest, new byte[0], execution);
 
     assertThat(outboundRequest.getHeaders().get("Authorization")).isNullOrEmpty();
+  }
+
+  @Test
+  @DisplayName("intercept does not overwrite outbound Authorization header when it uses a non-Bearer scheme")
+  void intercept_doesNotOverwrite_whenOutboundAuthHeaderIsNonBearer() throws IOException {
+    MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+    httpRequest.addHeader("Authorization", "Bearer incoming-token");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(httpRequest));
+
+    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET,
+        URI.create("http://test/endpoint"));
+    outboundRequest.getHeaders().set("Authorization", "Basic dXNlcjpwYXNz");
+    ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+    ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
+    when(execution.execute(outboundRequest, new byte[0])).thenReturn(mockResponse);
+
+    interceptor.intercept(outboundRequest, new byte[0], execution);
+
+    assertThat(outboundRequest.getHeaders().getFirst("Authorization")).isEqualTo("Basic dXNlcjpwYXNz");
+  }
+
+  @Test
+  @DisplayName("intercept overwrites outbound Bearer Authorization header with incoming session Bearer token")
+  void intercept_overwritesOutboundBearer_whenBothAreBearer() throws IOException {
+    MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+    httpRequest.addHeader("Authorization", "Bearer user-session-token");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(httpRequest));
+
+    MockClientHttpRequest outboundRequest = new MockClientHttpRequest(HttpMethod.GET,
+        URI.create("http://test/endpoint"));
+    outboundRequest.getHeaders().set("Authorization", "Bearer existing-service-token");
+    ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+    ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
+    when(execution.execute(outboundRequest, new byte[0])).thenReturn(mockResponse);
+
+    interceptor.intercept(outboundRequest, new byte[0], execution);
+
+    assertThat(outboundRequest.getHeaders().getFirst("Authorization")).isEqualTo("Bearer user-session-token");
   }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
@@ -1,6 +1,8 @@
 package com.positivity.mcp.internal.config;
 
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import com.positivity.mcp.service.AgentOrchestrationService;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -18,5 +20,22 @@ public class SessionAgentManagerTestConfiguration {
     AgentOrchestrationService service = mock(AgentOrchestrationService.class);
     when(service.chat(anyString(), anyString(), anyString())).thenReturn("Test assistant response");
     return service;
+  }
+
+  @Bean
+  ToolMetadataRepository toolMetadataRepository() {
+    return new ToolMetadataRepository() {
+      @Override
+      public java.util.List<com.positivity.mcp.internal.domain.ToolMetadata> findEnabledByRoleAndWorkflow(
+          String role, String workflowState) {
+        return List.of();
+      }
+
+      @Override
+      public java.util.List<com.positivity.mcp.internal.domain.ToolMetadata> findTopKByEmbedding(
+          float[] embedding, int limit) {
+        return List.of();
+      }
+    };
   }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/ToolRegistryLoaderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/ToolRegistryLoaderTest.java
@@ -1,22 +1,82 @@
 package com.positivity.mcp.internal.orchestration;
 
+import com.positivity.mcp.internal.domain.ToolMetadata;
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link ToolRegistryLoader} Phase 1 stub behaviour.
+ * Unit tests for {@link ToolRegistryLoader} Phase 2 DB-backed behaviour.
  */
+@ExtendWith(MockitoExtension.class)
 class ToolRegistryLoaderTest {
 
-  private final ToolRegistryLoader loader = new ToolRegistryLoader();
+  @Mock
+  private ToolMetadataRepository repository;
+
+  @Mock
+  private ApplicationContext applicationContext;
+
+  private static final ToolMetadata SAMPLE_META = new ToolMetadata(
+      UUID.fromString("00000000-0000-0000-0000-000000000001"),
+      "customerFacadeTool", "Customer Lookup",
+      "Look up customer records", "customer", 0.8, "low", 50, true, "customerFacadeTool");
 
   @Test
-  @DisplayName("loadRoleToolMappings returns empty map for Phase 1 stub")
-  void loadRoleToolMappings_returnsEmptyMap() {
-    var result = loader.loadRoleToolMappings();
+  @DisplayName("loadRoleToolMappings resolves bean by handlerBean name for an enabled tool")
+  void loadRoleToolMappings_withEnabledTool_resolvesBean() {
+    Object fakeTool = new Object();
+    // default: all roles return empty list
+    when(repository.findEnabledByRoleAndWorkflow(anyString(), anyString())).thenReturn(List.of());
+    // override ROLE_CASHIER to return the sample tool (last stub wins for this
+    // matcher)
+    when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE"))
+        .thenReturn(List.of(SAMPLE_META));
+    when(applicationContext.getBean("customerFacadeTool")).thenReturn(fakeTool);
 
-    assertThat(result).isEmpty();
+    ToolRegistryLoader loader = new ToolRegistryLoader(repository, applicationContext);
+    Map<String, List<Object>> result = loader.loadRoleToolMappings();
+
+    assertThat(result.get("ROLE_CASHIER")).containsExactly(fakeTool);
+  }
+
+  @Test
+  @DisplayName("loadRoleToolMappings returns empty lists for all known roles when no tools enabled")
+  void loadRoleToolMappings_withNoEnabledTools_returnsEmptyListsForAllRoles() {
+    when(repository.findEnabledByRoleAndWorkflow(anyString(), anyString())).thenReturn(List.of());
+
+    ToolRegistryLoader loader = new ToolRegistryLoader(repository, applicationContext);
+    Map<String, List<Object>> result = loader.loadRoleToolMappings();
+
+    assertThat(result).isNotEmpty();
+    result.values().forEach(tools -> assertThat(tools).isEmpty());
+  }
+
+  @Test
+  @DisplayName("loadRoleToolMappings skips tools whose handler bean is missing from ApplicationContext")
+  void loadRoleToolMappings_withMissingBean_skipsSilently() {
+    when(repository.findEnabledByRoleAndWorkflow(anyString(), anyString())).thenReturn(List.of());
+    when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE"))
+        .thenReturn(List.of(SAMPLE_META));
+    when(applicationContext.getBean("customerFacadeTool"))
+        .thenThrow(new NoSuchBeanDefinitionException("customerFacadeTool"));
+
+    ToolRegistryLoader loader = new ToolRegistryLoader(repository, applicationContext);
+    Map<String, List<Object>> result = loader.loadRoleToolMappings();
+
+    assertThat(result.get("ROLE_CASHIER")).isEmpty();
   }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/ToolRegistryServiceTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/ToolRegistryServiceTest.java
@@ -1,0 +1,120 @@
+package com.positivity.mcp.internal.orchestration;
+
+import com.positivity.mcp.internal.domain.ToolMetadata;
+import com.positivity.mcp.internal.domain.ToolSelectionContext;
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ToolRegistryService}: verifies candidate tool
+ * resolution and scoring.
+ */
+@ExtendWith(MockitoExtension.class)
+class ToolRegistryServiceTest {
+
+  @Mock
+  private ToolMetadataRepository repository;
+
+  @Mock
+  private EmbeddingModel embeddingModel;
+
+  private ToolRegistryService service;
+
+  private static final UUID TOOL_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+  private static final ToolMetadata SAMPLE_TOOL = new ToolMetadata(
+      TOOL_ID,
+      "customerFacadeTool",
+      "Customer Lookup",
+      "Look up customer records",
+      "customer",
+      0.8,
+      "low",
+      50,
+      true,
+      "customerFacadeTool");
+
+  @BeforeEach
+  void setUp() {
+    service = new ToolRegistryService(repository, embeddingModel);
+  }
+
+  @Test
+  @DisplayName("resolveCandidateTools returns scored and limited list when gated tools exist")
+  void resolveCandidateTools_withGatedTools_returnsScoredList() {
+    ToolSelectionContext context = new ToolSelectionContext("look up customer", "ROLE_CASHIER", "IDLE");
+    float[] vector = new float[] { 0.1f, 0.2f, 0.3f };
+
+    when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE"))
+        .thenReturn(List.of(SAMPLE_TOOL));
+    when(embeddingModel.embed(anyString()))
+        .thenReturn(Response.from(Embedding.from(vector)));
+    when(repository.findTopKByEmbedding(vector, 10))
+        .thenReturn(List.of(SAMPLE_TOOL));
+
+    List<ToolMetadata> result = service.resolveCandidateTools(context, 5);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().name()).isEqualTo("customerFacadeTool");
+  }
+
+  @Test
+  @DisplayName("resolveCandidateTools returns empty list when no gated tools exist for role/workflow")
+  void resolveCandidateTools_withNoGatedTools_returnsEmpty() {
+    ToolSelectionContext context = new ToolSelectionContext("look up customer", "ROLE_CASHIER", "IDLE");
+
+    when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE"))
+        .thenReturn(List.of());
+
+    List<ToolMetadata> result = service.resolveCandidateTools(context, 5);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("resolveCandidateTools returns empty list when topK is zero")
+  void resolveCandidateTools_withZeroTopK_returnsEmpty() {
+    ToolSelectionContext context = new ToolSelectionContext("look up customer", "ROLE_CASHIER", "IDLE");
+
+    List<ToolMetadata> result = service.resolveCandidateTools(context, 0);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("resolveCandidateTools filters semantic candidates not in gated role-workflow set")
+  void resolveCandidateTools_filtersToolsNotInGatedSet() {
+    ToolSelectionContext context = new ToolSelectionContext("look up customer", "ROLE_CASHIER", "IDLE");
+    float[] vector = new float[] { 0.1f, 0.2f };
+
+    UUID otherId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    ToolMetadata otherTool = new ToolMetadata(
+        otherId, "otherTool", "Other Tool", "Other", "other", 0.5, "low", 100, true, "otherTool");
+
+    when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE"))
+        .thenReturn(List.of(SAMPLE_TOOL));
+    when(embeddingModel.embed(anyString()))
+        .thenReturn(Response.from(Embedding.from(vector)));
+    when(repository.findTopKByEmbedding(vector, 10))
+        .thenReturn(List.of(otherTool));
+
+    List<ToolMetadata> result = service.resolveCandidateTools(context, 5);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/ToolRegistryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/ToolRegistryTest.java
@@ -1,16 +1,15 @@
 package com.positivity.mcp.internal.orchestration;
 
+import com.positivity.mcp.internal.service.ToolRegistryLoader;
+import java.util.List;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link ToolRegistry}: role resolution and mutable-copy

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/AccountingFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/AccountingFacadeToolTest.java
@@ -27,7 +27,7 @@ class AccountingFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new AccountingFacadeTool(builder);
+    tool = new AccountingFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/AccountingFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/AccountingFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link AccountingFacadeTool}: verifies RestClient call shapes.
+ */
+class AccountingFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-accounting/v1/accounting";
+
+  private MockRestServiceServer mockServer;
+  private AccountingFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new AccountingFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getAccountBalance sends GET /accounts/{accountId}/balance and returns body")
+  void getAccountBalance_sendsGetToBalanceEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/accounts/ACC-001/balance"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"accountId\":\"ACC-001\",\"balance\":1000.00}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getAccountBalance("ACC-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("ACC-001");
+  }
+
+  @Test
+  @DisplayName("searchJournalEntries sends GET /journal-entries/search?q={query} and returns body")
+  void searchJournalEntries_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/journal-entries/search?q=revenue"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"entries\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchJournalEntries("revenue");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getFinancialSummary sends GET /summary/{period} and returns body")
+  void getFinancialSummary_sendsGetToSummaryEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/summary/2025-Q1"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"period\":\"2025-Q1\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getFinancialSummary("2025-Q1");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/AdminFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/AdminFacadeToolTest.java
@@ -1,0 +1,66 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link AdminFacadeTool}: verifies RestClient call shapes.
+ */
+class AdminFacadeToolTest {
+
+  private static final String SECURITY_BASE_URL = "http://pos-security-service/v1";
+
+  private MockRestServiceServer mockServer;
+  private AdminFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new AdminFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getSystemStatus returns constant UP string without HTTP call")
+  void getSystemStatus_returnsConstantStatusString() {
+    String result = tool.getSystemStatus();
+
+    assertThat(result).isNotNull().contains("UP");
+  }
+
+  @Test
+  @DisplayName("getUserPermissions sends GET /users/{userId}/roles to security service")
+  void getUserPermissions_sendsGetToRolesEndpoint() {
+    mockServer.expect(requestTo(SECURITY_BASE_URL + "/users/USR-001/roles"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"userId\":\"USR-001\",\"roles\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getUserPermissions("USR-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("USR-001");
+  }
+
+  @Test
+  @DisplayName("getAuditLog sends GET /audit?q={query} to security service")
+  void getAuditLog_sendsGetToAuditEndpoint() {
+    mockServer.expect(requestTo(SECURITY_BASE_URL + "/audit?q=login"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"entries\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getAuditLog("login");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/AdminFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/AdminFacadeToolTest.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  */
 class AdminFacadeToolTest {
 
-  private static final String SECURITY_BASE_URL = "http://pos-security-service/v1";
+  private static final String SECURITY_BASE_URL = "http://pos-security-service/v1/admin";
 
   private MockRestServiceServer mockServer;
   private AdminFacadeTool tool;
@@ -27,7 +27,7 @@ class AdminFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new AdminFacadeTool(builder);
+    tool = new AdminFacadeTool(builder, SECURITY_BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/CatalogFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/CatalogFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link CatalogFacadeTool}: verifies RestClient call shapes.
+ */
+class CatalogFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-catalog/v1/catalog";
+
+  private MockRestServiceServer mockServer;
+  private CatalogFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new CatalogFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getProduct sends GET /products/{productId} and returns body")
+  void getProduct_sendsGetToProductEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/products/PROD-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"id\":\"PROD-001\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getProduct("PROD-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("PROD-001");
+  }
+
+  @Test
+  @DisplayName("searchCatalog sends GET /search?q={query} and returns body")
+  void searchCatalog_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/search?q=brake%20pads"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchCatalog("brake pads");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getCatalogByCategory sends GET /categories/{category} and returns body")
+  void getCatalogByCategory_sendsGetToCategoryEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/categories/BRAKES"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"category\":\"BRAKES\",\"items\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getCatalogByCategory("BRAKES");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/CatalogFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/CatalogFacadeToolTest.java
@@ -27,7 +27,7 @@ class CatalogFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new CatalogFacadeTool(builder);
+    tool = new CatalogFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/CustomerFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/CustomerFacadeToolTest.java
@@ -27,7 +27,7 @@ class CustomerFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new CustomerFacadeTool(builder);
+    tool = new CustomerFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/CustomerFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/CustomerFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link CustomerFacadeTool}: verifies RestClient call shapes.
+ */
+class CustomerFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-customer/v1/customers";
+
+  private MockRestServiceServer mockServer;
+  private CustomerFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new CustomerFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getCustomer sends GET /{customerId} and returns body")
+  void getCustomer_sendsGetToCustomerEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/CUST-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"id\":\"CUST-001\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getCustomer("CUST-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("CUST-001");
+  }
+
+  @Test
+  @DisplayName("searchCustomers sends GET /search?q={query} and returns body")
+  void searchCustomers_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/search?q=Smith"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchCustomers("Smith");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getCustomerHistory sends GET /{customerId}/history and returns body")
+  void getCustomerHistory_sendsGetToHistoryEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/CUST-001/history"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"events\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getCustomerHistory("CUST-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link EventsFacadeTool}: verifies RestClient call shapes.
+ */
+class EventsFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-event-receiver/v1";
+
+  private MockRestServiceServer mockServer;
+  private EventsFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new EventsFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getEventTypes sends GET /eventTypes and returns body")
+  void getEventTypes_sendsGetToTypesEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/eventTypes"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"types\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getEventTypes();
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("searchEvents sends GET /events/summary?q={query} and returns body")
+  void searchEvents_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/events/summary?q=ORDER"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchEvents("ORDER");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getEventHistory sends GET /events/summary?entityId={entityId} and returns body")
+  void getEventHistory_sendsGetToHistoryEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/events/summary?entityId=ENT-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"entityId\":\"ENT-001\",\"events\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getEventHistory("ENT-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/EventsFacadeToolTest.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  */
 class EventsFacadeToolTest {
 
-  private static final String BASE_URL = "http://pos-event-receiver/v1";
+  private static final String BASE_URL = "http://pos-event-receiver/v1/events";
 
   private MockRestServiceServer mockServer;
   private EventsFacadeTool tool;
@@ -27,7 +27,7 @@ class EventsFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new EventsFacadeTool(builder);
+    tool = new EventsFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/HrFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/HrFacadeToolTest.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  */
 class HrFacadeToolTest {
 
-  private static final String BASE_URL = "http://pos-people/v1/employees";
+  private static final String BASE_URL = "http://pos-people/v1/hr";
 
   private MockRestServiceServer mockServer;
   private HrFacadeTool tool;
@@ -27,7 +27,7 @@ class HrFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new HrFacadeTool(builder);
+    tool = new HrFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/HrFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/HrFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link HrFacadeTool}: verifies RestClient call shapes.
+ */
+class HrFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-people/v1/employees";
+
+  private MockRestServiceServer mockServer;
+  private HrFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new HrFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getEmployee sends GET /{employeeId} and returns body")
+  void getEmployee_sendsGetToEmployeeEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/EMP-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"id\":\"EMP-001\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getEmployee("EMP-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("EMP-001");
+  }
+
+  @Test
+  @DisplayName("searchEmployees sends GET /search?q={query} and returns body")
+  void searchEmployees_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/search?q=technician"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchEmployees("technician");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getEmployeeSchedule sends GET /{employeeId}/schedule and returns body")
+  void getEmployeeSchedule_sendsGetToScheduleEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/EMP-001/schedule"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"employeeId\":\"EMP-001\",\"shifts\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getEmployeeSchedule("EMP-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/InventoryFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/InventoryFacadeToolTest.java
@@ -55,4 +55,17 @@ class InventoryFacadeToolTest {
     mockServer.verify();
     assertThat(result).contains("items");
   }
+
+  @Test
+  @DisplayName("getLocationStock sends GET /locations/{locationId}/stock and returns body")
+  void getLocationStock_returnsStockForLocation() {
+    mockServer.expect(requestTo(BASE_URL + "/locations/LOC-001/stock"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"locationId\":\"LOC-001\",\"items\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getLocationStock("LOC-001");
+
+    mockServer.verify();
+    assertThat(result).contains("LOC-001");
+  }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/InvoiceFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/InvoiceFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link InvoiceFacadeTool}: verifies RestClient call shapes.
+ */
+class InvoiceFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-invoice/v1/invoices";
+
+  private MockRestServiceServer mockServer;
+  private InvoiceFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new InvoiceFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getInvoice sends GET /{invoiceId} and returns body")
+  void getInvoice_sendsGetToInvoiceEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/INV-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"id\":\"INV-001\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getInvoice("INV-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("INV-001");
+  }
+
+  @Test
+  @DisplayName("searchInvoices sends GET /search?q={query} and returns body")
+  void searchInvoices_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/search?q=PAID"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchInvoices("PAID");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getInvoicesByCustomer sends GET /customer/{customerId} and returns body")
+  void getInvoicesByCustomer_sendsGetToCustomerInvoicesEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/customer/CUST-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"invoices\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getInvoicesByCustomer("CUST-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/InvoiceFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/InvoiceFacadeToolTest.java
@@ -27,7 +27,7 @@ class InvoiceFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new InvoiceFacadeTool(builder);
+    tool = new InvoiceFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/LocationFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/LocationFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link LocationFacadeTool}: verifies RestClient call shapes.
+ */
+class LocationFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-location/v1/locations";
+
+  private MockRestServiceServer mockServer;
+  private LocationFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new LocationFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getLocation sends GET /{locationId} and returns body")
+  void getLocation_sendsGetToLocationEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/LOC-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"id\":\"LOC-001\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getLocation("LOC-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("LOC-001");
+  }
+
+  @Test
+  @DisplayName("searchLocations sends GET /search?q={query} and returns body")
+  void searchLocations_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/search?q=downtown"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchLocations("downtown");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getLocationInventory sends GET /{locationId}/inventory and returns body")
+  void getLocationInventory_sendsGetToInventoryEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/LOC-001/inventory"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"locationId\":\"LOC-001\",\"stock\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getLocationInventory("LOC-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/LocationFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/LocationFacadeToolTest.java
@@ -27,7 +27,7 @@ class LocationFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new LocationFacadeTool(builder);
+    tool = new LocationFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/PricingFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/PricingFacadeToolTest.java
@@ -27,7 +27,7 @@ class PricingFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new PricingFacadeTool(builder);
+    tool = new PricingFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/PricingFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/PricingFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link PricingFacadeTool}: verifies RestClient call shapes.
+ */
+class PricingFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-price/v1/pricing";
+
+  private MockRestServiceServer mockServer;
+  private PricingFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new PricingFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getPriceForSku sends GET /sku/{sku} and returns body")
+  void getPriceForSku_sendsGetToSkuEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/sku/SKU-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"sku\":\"SKU-001\",\"price\":9.99}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getPriceForSku("SKU-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("SKU-001");
+  }
+
+  @Test
+  @DisplayName("searchPricing sends GET /search?q={query} and returns body")
+  void searchPricing_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/search?q=oil%20filter"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchPricing("oil filter");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getPriceList sends GET /lists/{priceListId} and returns body")
+  void getPriceList_sendsGetToPriceListEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/lists/PL-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"id\":\"PL-001\",\"items\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getPriceList("PL-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ReportingFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ReportingFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link ReportingFacadeTool}: verifies RestClient call shapes.
+ */
+class ReportingFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-accounting/v1/reports";
+
+  private MockRestServiceServer mockServer;
+  private ReportingFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new ReportingFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getSalesReport sends GET /sales/{period} and returns body")
+  void getSalesReport_sendsGetToSalesEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/sales/2025-Q1"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"period\":\"2025-Q1\",\"total\":50000}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getSalesReport("2025-Q1");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("2025-Q1");
+  }
+
+  @Test
+  @DisplayName("getInventoryReport sends GET /inventory/{locationId} and returns body")
+  void getInventoryReport_sendsGetToInventoryEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/inventory/LOC-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"locationId\":\"LOC-001\",\"items\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getInventoryReport("LOC-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getRevenueReport sends GET /revenue/{period} and returns body")
+  void getRevenueReport_sendsGetToRevenueEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/revenue/2025-Q1"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"period\":\"2025-Q1\",\"revenue\":75000}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getRevenueReport("2025-Q1");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ReportingFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ReportingFacadeToolTest.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  */
 class ReportingFacadeToolTest {
 
-  private static final String BASE_URL = "http://pos-accounting/v1/reports";
+  private static final String BASE_URL = "http://pos-accounting/v1/reporting";
 
   private MockRestServiceServer mockServer;
   private ReportingFacadeTool tool;
@@ -27,7 +27,7 @@ class ReportingFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new ReportingFacadeTool(builder);
+    tool = new ReportingFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ShopManagerFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ShopManagerFacadeToolTest.java
@@ -28,7 +28,7 @@ class ShopManagerFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new ShopManagerFacadeTool(builder);
+    tool = new ShopManagerFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ShopManagerFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ShopManagerFacadeToolTest.java
@@ -1,0 +1,72 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link ShopManagerFacadeTool}: verifies RestClient call
+ * shapes.
+ */
+class ShopManagerFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-shop-manager/v1/shop";
+
+  private MockRestServiceServer mockServer;
+  private ShopManagerFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new ShopManagerFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getShopStatus sends GET /{shopId}/status and returns body")
+  void getShopStatus_sendsGetToStatusEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/SHOP-001/status"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"shopId\":\"SHOP-001\",\"status\":\"OPEN\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getShopStatus("SHOP-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("SHOP-001");
+  }
+
+  @Test
+  @DisplayName("getShopQueue sends GET /{shopId}/queue and returns body")
+  void getShopQueue_sendsGetToQueueEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/SHOP-001/queue"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"shopId\":\"SHOP-001\",\"queued\":3}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getShopQueue("SHOP-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("searchShops sends GET /search?q={query} and returns body")
+  void searchShops_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/search?q=north"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchShops("north");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/TaxFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/TaxFacadeToolTest.java
@@ -27,7 +27,7 @@ class TaxFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new TaxFacadeTool(builder);
+    tool = new TaxFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/TaxFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/TaxFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link TaxFacadeTool}: verifies RestClient call shapes.
+ */
+class TaxFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-tax/v1/tax";
+
+  private MockRestServiceServer mockServer;
+  private TaxFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new TaxFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getTaxRate sends GET /rates/{locationId} and returns body")
+  void getTaxRate_sendsGetToRatesEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/rates/LOC-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"locationId\":\"LOC-001\",\"rate\":0.08}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getTaxRate("LOC-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("LOC-001");
+  }
+
+  @Test
+  @DisplayName("calculateTax sends GET /calculate?amount={amount}&locationId={locationId} and returns body")
+  void calculateTax_sendsGetToCalculateEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/calculate?amount=100.00&locationId=LOC-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"tax\":8.00}", MediaType.APPLICATION_JSON));
+
+    String result = tool.calculateTax("100.00", "LOC-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getTaxSummary sends GET /summary/{period} and returns body")
+  void getTaxSummary_sendsGetToSummaryEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/summary/2025-Q1"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"period\":\"2025-Q1\",\"collected\":4000}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getTaxSummary("2025-Q1");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/VehicleFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/VehicleFacadeToolTest.java
@@ -27,7 +27,7 @@ class VehicleFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new VehicleFacadeTool(builder);
+    tool = new VehicleFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/VehicleFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/VehicleFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link VehicleFacadeTool}: verifies RestClient call shapes.
+ */
+class VehicleFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-customer/v1/vehicles";
+
+  private MockRestServiceServer mockServer;
+  private VehicleFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new VehicleFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getVehicle sends GET /{vehicleId} and returns body")
+  void getVehicle_sendsGetToVehicleEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/VEH-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"id\":\"VEH-001\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getVehicle("VEH-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("VEH-001");
+  }
+
+  @Test
+  @DisplayName("searchVehicles sends GET /search?q={query} and returns body")
+  void searchVehicles_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/search?q=Honda"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchVehicles("Honda");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getVehiclesByCustomer sends GET /customer/{customerId} and returns body")
+  void getVehiclesByCustomer_sendsGetToCustomerVehiclesEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/customer/CUST-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"vehicles\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getVehiclesByCustomer("CUST-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeToolTest.java
@@ -27,7 +27,7 @@ class WorkorderFacadeToolTest {
   void setUp() {
     RestClient.Builder builder = RestClient.builder();
     mockServer = MockRestServiceServer.bindTo(builder).build();
-    tool = new WorkorderFacadeTool(builder);
+    tool = new WorkorderFacadeTool(builder, BASE_URL);
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeToolTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/WorkorderFacadeToolTest.java
@@ -1,0 +1,71 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link WorkorderFacadeTool}: verifies RestClient call shapes.
+ */
+class WorkorderFacadeToolTest {
+
+  private static final String BASE_URL = "http://pos-workorder/v1/workorders";
+
+  private MockRestServiceServer mockServer;
+  private WorkorderFacadeTool tool;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder();
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    tool = new WorkorderFacadeTool(builder);
+  }
+
+  @Test
+  @DisplayName("getWorkorder sends GET /{workorderId} and returns body")
+  void getWorkorder_sendsGetToWorkorderEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/WO-001"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"id\":\"WO-001\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getWorkorder("WO-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty().contains("WO-001");
+  }
+
+  @Test
+  @DisplayName("searchWorkorders sends GET /search?q={query} and returns body")
+  void searchWorkorders_sendsGetToSearchEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/search?q=OPEN"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"results\":[]}", MediaType.APPLICATION_JSON));
+
+    String result = tool.searchWorkorders("OPEN");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getWorkorderStatus sends GET /{workorderId}/status and returns body")
+  void getWorkorderStatus_sendsGetToStatusEndpoint() {
+    mockServer.expect(requestTo(BASE_URL + "/WO-001/status"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("{\"status\":\"IN_PROGRESS\"}", MediaType.APPLICATION_JSON));
+
+    String result = tool.getWorkorderStatus("WO-001");
+
+    mockServer.verify();
+    assertThat(result).isNotEmpty();
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
@@ -1,0 +1,89 @@
+package com.positivity.mcp.internal.repository;
+
+import com.positivity.mcp.internal.domain.ToolMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ToolMetadataRepositoryImpl}: verifies JdbcTemplate
+ * query delegation.
+ */
+@ExtendWith(MockitoExtension.class)
+class ToolMetadataRepositoryImplTest {
+
+  @Mock
+  private JdbcTemplate jdbcTemplate;
+
+  private ToolMetadataRepositoryImpl repository;
+
+  private static final ToolMetadata SAMPLE_TOOL = new ToolMetadata(
+      UUID.fromString("00000000-0000-0000-0000-000000000001"),
+      "customerFacadeTool",
+      "Customer Lookup",
+      "Look up customer records",
+      "customer",
+      0.8,
+      "low",
+      50,
+      true,
+      "customerFacadeTool");
+
+  @BeforeEach
+  void setUp() {
+    repository = new ToolMetadataRepositoryImpl(jdbcTemplate);
+  }
+
+  @Test
+  @DisplayName("findEnabledByRoleAndWorkflow returns tools from JdbcTemplate query")
+  @SuppressWarnings("unchecked")
+  void findEnabledByRoleAndWorkflow_returnsMappedTools() {
+    when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("ROLE_CASHIER"), eq("IDLE")))
+        .thenReturn(List.of(SAMPLE_TOOL));
+
+    List<ToolMetadata> result = repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE");
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().name()).isEqualTo("customerFacadeTool");
+  }
+
+  @Test
+  @DisplayName("findEnabledByRoleAndWorkflow returns empty list when JdbcTemplate returns no rows")
+  @SuppressWarnings("unchecked")
+  void findEnabledByRoleAndWorkflow_returnsEmptyWhenNoRows() {
+    when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("ROLE_CASHIER"), eq("IDLE")))
+        .thenReturn(List.of());
+
+    List<ToolMetadata> result = repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("findTopKByEmbedding returns bounded list from JdbcTemplate query")
+  @SuppressWarnings("unchecked")
+  void findTopKByEmbedding_returnsBoundedList() {
+    float[] embedding = new float[768];
+    when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(embedding), eq(5)))
+        .thenReturn(List.of(SAMPLE_TOOL));
+
+    List<ToolMetadata> result = repository.findTopKByEmbedding(embedding, 5);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().handlerBean()).isEqualTo("customerFacadeTool");
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
@@ -12,6 +12,7 @@ import org.springframework.jdbc.core.RowMapper;
 
 import java.util.List;
 import java.util.UUID;
+import org.postgresql.util.PGobject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -78,7 +79,7 @@ class ToolMetadataRepositoryImplTest {
   @SuppressWarnings("unchecked")
   void findTopKByEmbedding_returnsBoundedList() {
     float[] embedding = new float[768];
-    when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq(embedding), eq(5)))
+    when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(PGobject.class), eq(5)))
         .thenReturn(List.of(SAMPLE_TOOL));
 
     List<ToolMetadata> result = repository.findTopKByEmbedding(embedding, 5);

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryLoaderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryLoaderTest.java
@@ -1,7 +1,13 @@
-package com.positivity.mcp.internal.orchestration;
+package com.positivity.mcp.internal.service;
 
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.repository.ToolMetadataRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,14 +15,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
-
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link ToolRegistryLoader} Phase 2 DB-backed behaviour.

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
@@ -1,4 +1,4 @@
-package com.positivity.mcp.internal.orchestration;
+package com.positivity.mcp.internal.service;
 
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.domain.ToolSelectionContext;
@@ -6,19 +6,17 @@ import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
+import java.util.List;
+import java.util.UUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link ToolRegistryService}: verifies candidate tool


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:mcp-langchain4j-phase2`
- Parent STORY (durion): Not provided in this request
- Child issue: Not provided in this request
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entries (durion): `domains/mcp/.business-rules/BACKEND_CONTRACT_GUIDE.md` → Not provided in this request
- Durion contract PR (if applicable): Not applicable

## Scope
- What changed:
  - Delivers Wave MCP-2 for `pos-mcp-server`: completes the full 16-tool LangChain4j facade catalog and replaces the Phase 1 in-memory tool registry stub with a DB-backed implementation backed by pgvector semantic search.
  - `pos-mcp-server` only (47 files, 2762 insertions, 124 deletions).
  - Added Flyway migrations:
    - `V3__tool_registry_schema.sql` (tool/role/workflow schemas including `embedding vector(768)`).
    - `V4__tool_registry_seed_data.sql` (16 tools, 5 roles, states, mappings).
    - `V5__location_shopmanager_role_mappings.sql` (ROLE_SERVICE_WRITER and ROLE_MANAGER mappings).
  - Added production classes:
    - `domain/ToolMetadata.java`, `domain/ToolSelectionContext.java`.
    - `repository/ToolMetadataRepository.java`, `repository/ToolMetadataRepositoryImpl.java`.
    - `orchestration/ToolRegistryService.java`.
    - 14 facade tools: Customer, Pricing, Workorder, Catalog, Vehicle, Accounting, Invoice, Hr, Reporting, Location, ShopManager, Tax, Admin, Events.
  - Modified production classes:
    - `orchestration/ToolRegistryLoader.java` switched from Phase 1 stub to DB-backed implementation with handler resolution via `ApplicationContext`.
    - `orchestration/tools/InventoryFacadeTool.java`, `orchestration/tools/OrderFacadeTool.java` removed stale Phase 1 tech-debt Javadoc.
  - Added test classes:
    - 16 facade tool tests (MockRestServiceServer pattern).
    - `ToolMetadataRepositoryImplTest.java`, `ToolRegistryServiceTest.java`.
  - Modified test classes:
    - `ArchitectureTest.java` permits orchestration → repository access.
    - `SessionAgentManagerTestConfiguration.java` adds `ToolMetadataRepository` test-profile stub.
    - `ToolRegistryLoaderTest.java` rewritten for Phase 2 constructor.
  - Routing fixes for ADR alignment:
    - EventsFacadeTool → `pos-event-receiver`.
    - AdminFacadeTool → `pos-security-service` directly.
    - TaxFacadeTool → `pos-tax`.
- Why:
  - Implement Phase 2 orchestration/tool selection architecture with role- and workflow-aware tool discovery, persistent metadata, and semantic ranking.

## Tests
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated (backend)
- [ ] Consumer/UI tests added/updated (frontend)
- How to run:
  - `./mvnw -pl pos-mcp-server -DskipTests=false verify`

Verification evidence:
- `./mvnw -pl pos-mcp-server -DskipTests=false verify` → BUILD SUCCESS (83 classes, 218 tests, 0 failures)
- Lint hook → PASS (42 files, 0 findings)
- Code Review Cycle 3 → Verdict: PASS

## Risk & Rollback
- Risk level: Medium
- Rollback plan:
  - Revert this branch merge commit.
  - Re-run `./mvnw -pl pos-mcp-server -DskipTests=false verify`.
  - If database rollback is needed, restore from backup and roll back migrations V3-V5 per Flyway operational process.

## Specification Sources
- `pos-mcp-server/docs/langchain4j-orchestration-spec.md` (Phase 2 scope)
- `durion/docs/capabilities/` (`domain-facade-tools.md`, `tool-registry-implementation.md`)
- ADRs: 0011 (gateway security), 0014 (internal-service security), 0017 (HTTP codes), 0018 (audit actor)

## Notes
- `ToolMetadataRepositoryImpl` and `ToolRegistryService` are `@Profile("!test")`; test-profile stubs are supplied via `SessionAgentManagerTestConfiguration`.
- pgvector extension must be available in target DB (already required by Phase 1 V2 migration).

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [ ] PR title starts with `[CAP:<cap-id>]`
- [ ] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing
