### PR TITLE
cap/missing-endpoints: pos-customer GET /v1/crm/billing-terms

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmBillingTermsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmBillingTermsController.java
@@ -35,7 +35,11 @@ public class CrmBillingTermsController {
   @Operation(summary = "List billing terms", description = "Returns the reference list of all available billing terms. "
       + "This is a static reference endpoint; it does not vary per party or account.")
   @ApiResponse(responseCode = "200", description = "Billing terms retrieved successfully")
+  @ApiResponse(responseCode = "401", description = "Authentication required")
+  @ApiResponse(responseCode = "403", description = "Forbidden - missing authority " + CrmPermissionRegistry.PARTY_VIEW)
   @GetMapping("/billing-terms")
+  @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+      CrmPermissionRegistry.PARTY_VIEW })
   @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
   public ResponseEntity<List<BillingTermsRef>> listBillingTerms() {
     return ResponseEntity.ok(BILLING_TERMS);

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmBillingTermsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmBillingTermsController.java
@@ -1,0 +1,43 @@
+package com.positivity.customer.internal.controller;
+
+import com.positivity.customer.internal.dto.BillingTermsRef;
+import com.positivity.customer.internal.security.CrmPermissionRegistry;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes the reference list of available billing term options.
+ *
+ * <p>
+ * This is a static reference endpoint intended to populate billing-term
+ * dropdowns when creating or editing a commercial account. The list is stable
+ * and does not vary per party or caller.
+ */
+@Tag(name = "CRM Accounts", description = "Account tier management, party creation, search, merge, contacts, preferences, and vehicle operations")
+@RestController
+@RequestMapping("/v1/crm")
+public class CrmBillingTermsController {
+
+  private static final List<BillingTermsRef> BILLING_TERMS = List.of(
+      BillingTermsRef.builder().code("NET_30").label("Net 30").netDays(30).build(),
+      BillingTermsRef.builder().code("NET_60").label("Net 60").netDays(60).build(),
+      BillingTermsRef.builder().code("NET_90").label("Net 90").netDays(90).build(),
+      BillingTermsRef.builder().code("COD").label("Cash on Delivery").netDays(0).build(),
+      BillingTermsRef.builder().code("PREPAID").label("Prepaid").netDays(-1).build());
+
+  @Operation(summary = "List billing terms", description = "Returns the reference list of all available billing terms. "
+      + "This is a static reference endpoint; it does not vary per party or account.")
+  @ApiResponse(responseCode = "200", description = "Billing terms retrieved successfully")
+  @GetMapping("/billing-terms")
+  @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
+  public ResponseEntity<List<BillingTermsRef>> listBillingTerms() {
+    return ResponseEntity.ok(BILLING_TERMS);
+  }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/BillingTermsRef.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/BillingTermsRef.java
@@ -1,0 +1,31 @@
+package com.positivity.customer.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Reference entry for a billing term option.
+ *
+ * <p>
+ * Used in the {@code GET /v1/crm/billing-terms} response to populate
+ * billing-term dropdowns on the frontend without hardcoding values.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Billing term reference entry")
+public class BillingTermsRef {
+
+  @Schema(description = "Billing term code identifier", example = "NET_30")
+  private String code;
+
+  @Schema(description = "Human-readable label", example = "Net 30")
+  private String label;
+
+  @Schema(description = "Net payment days. Negative values indicate prepayment is required.", example = "30")
+  private int netDays;
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmBillingTermsControllerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmBillingTermsControllerTest.java
@@ -1,0 +1,70 @@
+package com.positivity.customer.internal.controller;
+
+import static org.mockito.Mockito.lenient;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.customer.config.WebMvcTestSecurityConfig;
+import com.positivity.customer.internal.config.CrmExceptionHandler;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CrmBillingTermsController.class)
+@Import({ WebMvcTestSecurityConfig.class, CrmExceptionHandler.class })
+@ActiveProfiles("test")
+@SuppressWarnings({ "java:S6813", "java:S100", "java:S1192" })
+class CrmBillingTermsControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @MockitoBean
+  java.time.Clock clock;
+
+  @BeforeEach
+  void setUpClock() {
+    lenient().when(clock.instant()).thenReturn(Instant.EPOCH);
+    lenient().when(clock.getZone()).thenReturn(java.time.ZoneOffset.UTC);
+  }
+
+  // ─── GET /v1/crm/billing-terms — 200 OK ──────────────────────────────────
+
+  @Test
+  void listBillingTerms_withPartyViewAuthority_returns200WithAllTerms() throws Exception {
+    mockMvc.perform(get("/v1/crm/billing-terms")
+        .header("X-Authorities", "crm:party:view"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(5))
+        .andExpect(jsonPath("$[0].code").value("NET_30"))
+        .andExpect(jsonPath("$[0].label").value("Net 30"))
+        .andExpect(jsonPath("$[0].netDays").value(30));
+  }
+
+  @Test
+  void listBillingTerms_includesCodAndPrepaidTerms() throws Exception {
+    mockMvc.perform(get("/v1/crm/billing-terms")
+        .header("X-Authorities", "crm:party:view"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[3].code").value("COD"))
+        .andExpect(jsonPath("$[3].netDays").value(0))
+        .andExpect(jsonPath("$[4].code").value("PREPAID"))
+        .andExpect(jsonPath("$[4].netDays").value(-1));
+  }
+
+  // ─── GET /v1/crm/billing-terms — 403 Forbidden ───────────────────────────
+
+  @Test
+  void listBillingTerms_withoutPartyViewAuthority_returns403() throws Exception {
+    mockMvc.perform(get("/v1/crm/billing-terms")
+        .header("X-Authorities", "crm:party:create"))
+        .andExpect(status().isForbidden());
+  }
+}


### PR DESCRIPTION
## Objective
Add `GET /v1/crm/billing-terms` reference endpoint to `pos-customer` as required by the SDK migration PRD.

## Scope
- Module: `pos-customer`
- Branch: `feat/api-customer-billing-terms`
- Linked spec: `durion-positivity-backend/docs/PRD-missing-backend-endpoints.md`

## Changes
- `pos-customer/.../dto/BillingTermsRef.java` — new DTO (code, label, netDays)
- `pos-customer/.../controller/CrmBillingTermsController.java` — new controller, `GET /v1/crm/billing-terms`, `crm:party:view` authority required
- `pos-customer/.../controller/CrmBillingTermsControllerTest.java` — 3 WebMvcTest tests (200×2, 403×1)

## Verification
- `mvnw -pl pos-customer verify` — BUILD SUCCESS (99 unit + 47 contract tests, 0 failures)
- Lint gate — 60 rules, 3 files, 0 findings — PASS

## Notes
- Static reference data; no service layer, no DB, no events required (read-only)
- Uses `X-Authorities` header in tests to set per-test authority context
