### PR TITLE
cap/missing-endpoints: pos-bulk-loader retry and corrections endpoints

### DIFF
--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/BulkLoadJobController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/BulkLoadJobController.java
@@ -81,6 +81,20 @@ public class BulkLoadJobController {
         return ResponseEntity.ok(bulkLoadJobService.cancelJob(jobId, operatorId));
     }
 
+    @PostMapping("/{jobId}/retry")
+    @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
+    @EmitEvent(id = "BULK_LOADER_JOB_RETRY", apiVersion = "1")
+    @Operation(summary = "Retry a failed bulk load job", description = "Retries a bulk load job that has reached the FAILED state, resetting it to CREATED and re-queuing it for processing. The operator can only retry their own jobs. Returns 409 if the job is not in FAILED state.")
+    @ApiResponse(responseCode = "200", description = "Job reset and re-queued for retry")
+    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
+    @ApiResponse(responseCode = "404", description = "Job not found")
+    @ApiResponse(responseCode = "409", description = "Job is not in FAILED state")
+    public ResponseEntity<BulkLoadJobResponse> retryJob(
+            @io.swagger.v3.oas.annotations.Parameter(description = "ID of the failed bulk load job to retry", required = true) @PathVariable @NonNull UUID jobId) {
+        String operatorId = currentOperatorId();
+        return ResponseEntity.ok(bulkLoadJobService.retryJob(jobId, operatorId));
+    }
+
     private String currentOperatorId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ReviewQueueController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ReviewQueueController.java
@@ -70,7 +70,7 @@ public class ReviewQueueController {
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_CORRECTION_SUBMIT", apiVersion = "1")
     @Operation(summary = "Submit corrected records for a bulk load job", description = "Submits corrected data for one or more error records from a bulk import audit. The job must be in FAILED state to accept corrections. Returns 409 if the job is not in a correctable state.")
-    @ApiResponse(responseCode = "202", description = "Corrections accepted for processing")
+    @ApiResponse(responseCode = "201", description = "Corrections submitted successfully")
     @ApiResponse(responseCode = "400", description = "Invalid correction request")
     @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
     @ApiResponse(responseCode = "404", description = "Job not found")
@@ -78,7 +78,7 @@ public class ReviewQueueController {
     public ResponseEntity<BulkCorrectionResponse> submitCorrections(
             @PathVariable @NonNull UUID jobId,
             @Valid @RequestBody @NonNull BulkCorrectionRequest request) {
-        return ResponseEntity.status(HttpStatus.ACCEPTED)
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body(reviewQueueService.submitCorrections(jobId, request, currentOperatorId()));
     }
 

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ReviewQueueController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ReviewQueueController.java
@@ -1,11 +1,15 @@
 package com.positivity.bulkloader.internal.controller;
 
 import com.positivity.bulkloader.internal.dto.AuditRecordResponse;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionRequest;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionResponse;
 import com.positivity.bulkloader.service.BulkLoadJobService;
 import com.positivity.bulkloader.service.ReviewQueueService;
+import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,6 +25,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -57,6 +64,22 @@ public class ReviewQueueController {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"error-report-" + jobId + ".csv\"")
                 .contentType(MediaType.parseMediaType("text/csv"))
                 .body(report);
+    }
+
+    @PostMapping("/{jobId}/corrections")
+    @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
+    @EmitEvent(id = "BULK_LOADER_CORRECTION_SUBMIT", apiVersion = "1")
+    @Operation(summary = "Submit corrected records for a bulk load job", description = "Submits corrected data for one or more error records from a bulk import audit. The job must be in FAILED state to accept corrections. Returns 409 if the job is not in a correctable state.")
+    @ApiResponse(responseCode = "202", description = "Corrections accepted for processing")
+    @ApiResponse(responseCode = "400", description = "Invalid correction request")
+    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
+    @ApiResponse(responseCode = "404", description = "Job not found")
+    @ApiResponse(responseCode = "409", description = "Job is not in a state that accepts corrections")
+    public ResponseEntity<BulkCorrectionResponse> submitCorrections(
+            @PathVariable @NonNull UUID jobId,
+            @Valid @RequestBody @NonNull BulkCorrectionRequest request) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(reviewQueueService.submitCorrections(jobId, request, currentOperatorId()));
     }
 
     private String currentOperatorId() {

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/dto/BulkCorrectionItem.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/dto/BulkCorrectionItem.java
@@ -1,0 +1,26 @@
+package com.positivity.bulkloader.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "A single corrected data record for a failed audit entry")
+public class BulkCorrectionItem {
+
+  @NotNull
+  @Schema(description = "ID of the audit record being corrected", example = "00000000-0000-0000-0000-000000000001", requiredMode = io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED)
+  private UUID auditRecordId;
+
+  @NotNull
+  @Schema(description = "Map of field names to their corrected values", example = "{\"sku\": \"PROD-001\", \"price\": \"19.99\"}", requiredMode = io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED)
+  private Map<String, String> correctedData;
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/dto/BulkCorrectionRequest.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/dto/BulkCorrectionRequest.java
@@ -1,0 +1,23 @@
+package com.positivity.bulkloader.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to submit corrected data records for a failed bulk load job")
+public class BulkCorrectionRequest {
+
+  @Valid
+  @NotEmpty
+  @Schema(description = "List of correction items, one per audit record to correct", requiredMode = io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED)
+  private List<BulkCorrectionItem> corrections;
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/dto/BulkCorrectionResponse.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/dto/BulkCorrectionResponse.java
@@ -1,0 +1,32 @@
+package com.positivity.bulkloader.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Result of a bulk correction submission")
+public class BulkCorrectionResponse {
+
+  @Schema(description = "The bulk load job ID", example = "00000000-0000-0000-0000-000000000001")
+  private UUID jobId;
+
+  @Schema(description = "Total number of corrections submitted", example = "5")
+  private int submittedCount;
+
+  @Schema(description = "Number of corrections accepted for processing", example = "5")
+  private int acceptedCount;
+
+  @Schema(description = "Number of corrections rejected", example = "0")
+  private int rejectedCount;
+
+  @Schema(description = "Rejection detail messages for each rejected correction, if any")
+  private List<String> rejections;
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/BulkLoadJobServiceImpl.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/BulkLoadJobServiceImpl.java
@@ -116,6 +116,24 @@ public class BulkLoadJobServiceImpl implements BulkLoadJobService {
 
     @Override
     @Transactional
+    public BulkLoadJobResponse retryJob(@NonNull UUID jobId, @NonNull String operatorId) {
+        BulkLoadJob job = findOrThrow(jobId);
+        if (!job.getOperatorId().equals(operatorId)) {
+            throw new JobOwnershipViolationException(jobId.toString());
+        }
+        if (job.getStatus() != JobStatus.FAILED) {
+            throw new IllegalStateException(
+                    "Job can only be retried from FAILED state, current state: " + job.getStatus());
+        }
+
+        job.setStatus(JobStatus.CREATED);
+        job.setStartedAt(null);
+        job.setCompletedAt(null);
+        return toResponse(jobRepository.save(job));
+    }
+
+    @Override
+    @Transactional
     public void startProcessing(@NonNull UUID jobId, @NonNull String operatorId, @Nullable String authorizationHeader) {
         BulkLoadJob job = findOrThrow(jobId);
         if (!job.getOperatorId().equals(operatorId)) {

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/BulkLoadJobServiceImpl.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/BulkLoadJobServiceImpl.java
@@ -126,9 +126,18 @@ public class BulkLoadJobServiceImpl implements BulkLoadJobService {
                     "Job can only be retried from FAILED state, current state: " + job.getStatus());
         }
 
+        long activeCount = jobRepository.countByOperatorIdAndStatusIn(operatorId, ACTIVE_STATUSES);
+        if (activeCount > 0) {
+            throw new IllegalStateException("Operator already has an active bulk load job in progress");
+        }
+
         job.setStatus(JobStatus.CREATED);
         job.setStartedAt(null);
         job.setCompletedAt(null);
+        job.setProcessedRows(0L);
+        job.setSuccessCount(0L);
+        job.setFailureCount(0L);
+        job.setTotalRows(null);
         return toResponse(jobRepository.save(job));
     }
 

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/ReviewQueueServiceImpl.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/ReviewQueueServiceImpl.java
@@ -1,10 +1,12 @@
 package com.positivity.bulkloader.internal.service;
 
 import com.positivity.bulkloader.internal.dto.AuditRecordResponse;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionItem;
 import com.positivity.bulkloader.internal.dto.BulkCorrectionRequest;
 import com.positivity.bulkloader.internal.dto.BulkCorrectionResponse;
 import com.positivity.bulkloader.internal.entity.BulkLoadRecordAudit;
 import com.positivity.bulkloader.internal.enums.JobStatus;
+import com.positivity.bulkloader.internal.enums.ReviewStatus;
 import com.positivity.bulkloader.internal.exception.JobOwnershipViolationException;
 import com.positivity.bulkloader.internal.repository.BulkLoadJobRepository;
 import com.positivity.bulkloader.internal.repository.BulkLoadRecordAuditRepository;
@@ -14,7 +16,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -24,6 +26,7 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +34,7 @@ public class ReviewQueueServiceImpl implements ReviewQueueService {
 
     private final BulkLoadRecordAuditRepository auditRepository;
     private final BulkLoadJobRepository jobRepository;
+    private final ObjectMapper objectMapper;
 
     @Override
     @Transactional(readOnly = true)
@@ -99,13 +103,44 @@ public class ReviewQueueServiceImpl implements ReviewQueueService {
                     "Corrections can only be submitted for jobs in FAILED state, current state: " + job.getStatus());
         }
 
-        int submittedCount = request.getCorrections().size();
+        int acceptedCount = 0;
+        int rejectedCount = 0;
+        List<String> rejections = new ArrayList<>();
+
+        for (BulkCorrectionItem item : request.getCorrections()) {
+            var auditOpt = auditRepository.findById(item.getAuditRecordId());
+            if (auditOpt.isEmpty() || !auditOpt.get().getJobId().equals(jobId)) {
+                rejectedCount++;
+                rejections.add("Audit record not found or does not belong to this job: " + item.getAuditRecordId());
+            } else {
+                var audit = auditOpt.get();
+                String serialized = trySerialize(item.getCorrectedData());
+                if (serialized == null) {
+                    rejectedCount++;
+                    rejections.add("Failed to serialize corrected values for record: " + item.getAuditRecordId());
+                } else {
+                    audit.setCorrectedValues(serialized);
+                    audit.setReviewStatus(ReviewStatus.CORRECTED);
+                    auditRepository.save(audit);
+                    acceptedCount++;
+                }
+            }
+        }
+
         return BulkCorrectionResponse.builder()
                 .jobId(jobId)
-                .submittedCount(submittedCount)
-                .acceptedCount(submittedCount)
-                .rejectedCount(0)
-                .rejections(Collections.emptyList())
+                .submittedCount(request.getCorrections().size())
+                .acceptedCount(acceptedCount)
+                .rejectedCount(rejectedCount)
+                .rejections(rejections)
                 .build();
+    }
+
+    private String trySerialize(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (Exception _) {
+            return null;
+        }
     }
 }

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/ReviewQueueServiceImpl.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/ReviewQueueServiceImpl.java
@@ -1,7 +1,12 @@
 package com.positivity.bulkloader.internal.service;
 
 import com.positivity.bulkloader.internal.dto.AuditRecordResponse;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionRequest;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionResponse;
 import com.positivity.bulkloader.internal.entity.BulkLoadRecordAudit;
+import com.positivity.bulkloader.internal.enums.JobStatus;
+import com.positivity.bulkloader.internal.exception.JobOwnershipViolationException;
+import com.positivity.bulkloader.internal.repository.BulkLoadJobRepository;
 import com.positivity.bulkloader.internal.repository.BulkLoadRecordAuditRepository;
 import com.positivity.bulkloader.service.ReviewQueueService;
 import java.io.ByteArrayOutputStream;
@@ -9,7 +14,9 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
@@ -23,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewQueueServiceImpl implements ReviewQueueService {
 
     private final BulkLoadRecordAuditRepository auditRepository;
+    private final BulkLoadJobRepository jobRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -73,6 +81,31 @@ public class ReviewQueueServiceImpl implements ReviewQueueService {
                 .reasonCodes(audit.getReasonCodes())
                 .originalValues(audit.getOriginalValues())
                 .createdAt(audit.getCreatedAt())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public BulkCorrectionResponse submitCorrections(
+            @NonNull UUID jobId, @NonNull BulkCorrectionRequest request, @NonNull String operatorId) {
+        var job = jobRepository
+                .findById(jobId)
+                .orElseThrow(() -> new NoSuchElementException("BulkLoadJob not found: " + jobId));
+        if (!job.getOperatorId().equals(operatorId)) {
+            throw new JobOwnershipViolationException(jobId.toString());
+        }
+        if (job.getStatus() != JobStatus.FAILED) {
+            throw new IllegalStateException(
+                    "Corrections can only be submitted for jobs in FAILED state, current state: " + job.getStatus());
+        }
+
+        int submittedCount = request.getCorrections().size();
+        return BulkCorrectionResponse.builder()
+                .jobId(jobId)
+                .submittedCount(submittedCount)
+                .acceptedCount(submittedCount)
+                .rejectedCount(0)
+                .rejections(Collections.emptyList())
                 .build();
     }
 }

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/service/BulkLoadJobService.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/service/BulkLoadJobService.java
@@ -20,5 +20,7 @@ public interface BulkLoadJobService {
 
     BulkLoadJobResponse cancelJob(@NonNull UUID jobId, @NonNull String operatorId);
 
+    BulkLoadJobResponse retryJob(@NonNull UUID jobId, @NonNull String operatorId);
+
     void startProcessing(@NonNull UUID jobId, @NonNull String operatorId, @Nullable String authorizationHeader);
 }

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/service/ReviewQueueService.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/service/ReviewQueueService.java
@@ -1,6 +1,8 @@
 package com.positivity.bulkloader.service;
 
 import com.positivity.bulkloader.internal.dto.AuditRecordResponse;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionRequest;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionResponse;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -11,4 +13,7 @@ public interface ReviewQueueService {
     List<AuditRecordResponse> getAuditRecords(@NonNull UUID jobId);
 
     Resource generateErrorReport(@NonNull UUID jobId);
+
+    BulkCorrectionResponse submitCorrections(
+            @NonNull UUID jobId, @NonNull BulkCorrectionRequest request, @NonNull String operatorId);
 }

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/BulkLoadJobControllerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/BulkLoadJobControllerTest.java
@@ -176,4 +176,40 @@ class BulkLoadJobControllerTest {
                                 .header("X-Authorities", "bulkImport:upload:execute"))
                                 .andExpect(status().isForbidden());
         }
+
+        // ─── POST /v1/bulk-jobs/{jobId}/retry ────────────────────────────────────
+
+        @Test
+        @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+        void retryJob_whenFailed_returns200() throws Exception {
+                BulkLoadJobResponse response = BulkLoadJobResponse.builder()
+                                .id(JOB_ID)
+                                .operatorId("test-operator")
+                                .status(JobStatus.CREATED)
+                                .build();
+
+                when(bulkLoadJobService.retryJob(JOB_ID, "test-operator")).thenReturn(response);
+
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/retry", JOB_ID))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.id").value(JOB_ID.toString()))
+                                .andExpect(jsonPath("$.status").value("CREATED"));
+        }
+
+        @Test
+        @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+        void retryJob_whenNotFailed_returns409() throws Exception {
+                when(bulkLoadJobService.retryJob(JOB_ID, "test-operator"))
+                                .thenThrow(new IllegalStateException("Job can only be retried from FAILED state"));
+
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/retry", JOB_ID))
+                                .andExpect(status().isConflict());
+        }
+
+        @Test
+        void retryJob_withoutExecuteAuthority_returns403() throws Exception {
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/retry", JOB_ID)
+                                .header("X-Authorities", "bulkImport:status:read"))
+                                .andExpect(status().isForbidden());
+        }
 }

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/BulkLoadJobControllerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/BulkLoadJobControllerTest.java
@@ -212,4 +212,25 @@ class BulkLoadJobControllerTest {
                                 .header("X-Authorities", "bulkImport:status:read"))
                                 .andExpect(status().isForbidden());
         }
+
+        @Test
+        @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+        void retryJob_whenNotFound_returns404() throws Exception {
+                when(bulkLoadJobService.retryJob(JOB_ID, "test-operator"))
+                                .thenThrow(new NoSuchElementException("BulkLoadJob not found: " + JOB_ID));
+
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/retry", JOB_ID))
+                                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void retryJob_whenNotOwner_returns403() throws Exception {
+                when(bulkLoadJobService.retryJob(JOB_ID, "other-operator"))
+                                .thenThrow(new JobOwnershipViolationException(JOB_ID.toString()));
+
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/retry", JOB_ID)
+                                .header("X-User", "other-operator")
+                                .header("X-Authorities", "bulkImport:upload:execute"))
+                                .andExpect(status().isForbidden());
+        }
 }

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/ReviewQueueControllerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/ReviewQueueControllerTest.java
@@ -16,6 +16,7 @@ import com.positivity.bulkloader.internal.dto.BulkCorrectionItem;
 import com.positivity.bulkloader.internal.dto.BulkCorrectionRequest;
 import com.positivity.bulkloader.internal.dto.BulkCorrectionResponse;
 import com.positivity.bulkloader.internal.enums.ReviewStatus;
+import com.positivity.bulkloader.internal.exception.JobOwnershipViolationException;
 import com.positivity.bulkloader.service.BulkLoadJobService;
 import com.positivity.bulkloader.service.ReviewQueueService;
 import java.util.Collections;
@@ -110,7 +111,7 @@ class ReviewQueueControllerTest {
 
         @Test
         @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
-        void submitCorrections_whenValid_returns202() throws Exception {
+        void submitCorrections_whenValid_returns201() throws Exception {
                 BulkCorrectionItem item = BulkCorrectionItem.builder()
                                 .auditRecordId(AUDIT_ID)
                                 .correctedData(Map.of("sku", "PROD-001"))
@@ -132,7 +133,7 @@ class ReviewQueueControllerTest {
                 mockMvc.perform(post("/v1/bulk-jobs/{jobId}/corrections", JOB_ID)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
-                                .andExpect(status().isAccepted())
+                                .andExpect(status().isCreated())
                                 .andExpect(jsonPath("$.jobId").value(JOB_ID.toString()))
                                 .andExpect(jsonPath("$.submittedCount").value(1))
                                 .andExpect(jsonPath("$.acceptedCount").value(1));
@@ -194,5 +195,26 @@ class ReviewQueueControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                                 .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void submitCorrections_whenNotOwner_returns403() throws Exception {
+                BulkCorrectionItem item = BulkCorrectionItem.builder()
+                                .auditRecordId(AUDIT_ID)
+                                .correctedData(Map.of("sku", "PROD-001"))
+                                .build();
+                BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                                .corrections(List.of(item))
+                                .build();
+
+                when(reviewQueueService.submitCorrections(eq(JOB_ID), any(), eq("other-operator")))
+                                .thenThrow(new JobOwnershipViolationException(JOB_ID.toString()));
+
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/corrections", JOB_ID)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("X-User", "other-operator")
+                                .header("X-Authorities", "bulkImport:upload:execute")
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isForbidden());
         }
 }

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/ReviewQueueControllerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/ReviewQueueControllerTest.java
@@ -198,6 +198,19 @@ class ReviewQueueControllerTest {
         }
 
         @Test
+        @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+        void submitCorrections_withEmptyCorrections_returns400() throws Exception {
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/corrections", JOB_ID)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                                {
+                                                  "corrections": []
+                                                }
+                                                """))
+                                .andExpect(status().isBadRequest());
+        }
+
+        @Test
         void submitCorrections_whenNotOwner_returns403() throws Exception {
                 BulkCorrectionItem item = BulkCorrectionItem.builder()
                                 .auditRecordId(AUDIT_ID)

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/ReviewQueueControllerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/ReviewQueueControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.positivity.bulkloader.config.TestSecurityConfig;
 import com.positivity.bulkloader.internal.dto.AuditRecordResponse;
 import com.positivity.bulkloader.internal.dto.BulkCorrectionItem;

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/ReviewQueueControllerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/ReviewQueueControllerTest.java
@@ -1,23 +1,34 @@
 package com.positivity.bulkloader.internal.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.positivity.bulkloader.config.TestSecurityConfig;
 import com.positivity.bulkloader.internal.dto.AuditRecordResponse;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionItem;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionRequest;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionResponse;
 import com.positivity.bulkloader.internal.enums.ReviewStatus;
 import com.positivity.bulkloader.service.BulkLoadJobService;
 import com.positivity.bulkloader.service.ReviewQueueService;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -34,6 +45,9 @@ class ReviewQueueControllerTest {
 
         @Autowired
         MockMvc mockMvc;
+
+        @Autowired
+        ObjectMapper objectMapper;
 
         @MockitoBean
         BulkLoadJobService bulkLoadJobService;
@@ -90,5 +104,95 @@ class ReviewQueueControllerTest {
                 mockMvc.perform(get("/v1/bulk-jobs/{jobId}/error-report", JOB_ID)
                                 .header("X-Authorities", "bulkImport:upload:execute")) // READ required
                                 .andExpect(status().isForbidden());
+        }
+
+        // ─── POST /v1/bulk-jobs/{jobId}/corrections ───────────────────────────────
+
+        @Test
+        @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+        void submitCorrections_whenValid_returns202() throws Exception {
+                BulkCorrectionItem item = BulkCorrectionItem.builder()
+                                .auditRecordId(AUDIT_ID)
+                                .correctedData(Map.of("sku", "PROD-001"))
+                                .build();
+                BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                                .corrections(List.of(item))
+                                .build();
+                BulkCorrectionResponse response = BulkCorrectionResponse.builder()
+                                .jobId(JOB_ID)
+                                .submittedCount(1)
+                                .acceptedCount(1)
+                                .rejectedCount(0)
+                                .rejections(Collections.emptyList())
+                                .build();
+
+                when(reviewQueueService.submitCorrections(eq(JOB_ID), any(), eq("test-operator")))
+                                .thenReturn(response);
+
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/corrections", JOB_ID)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isAccepted())
+                                .andExpect(jsonPath("$.jobId").value(JOB_ID.toString()))
+                                .andExpect(jsonPath("$.submittedCount").value(1))
+                                .andExpect(jsonPath("$.acceptedCount").value(1));
+        }
+
+        @Test
+        @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+        void submitCorrections_whenJobInWrongState_returns409() throws Exception {
+                BulkCorrectionItem item = BulkCorrectionItem.builder()
+                                .auditRecordId(AUDIT_ID)
+                                .correctedData(Map.of("sku", "PROD-001"))
+                                .build();
+                BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                                .corrections(List.of(item))
+                                .build();
+
+                when(reviewQueueService.submitCorrections(eq(JOB_ID), any(), eq("test-operator")))
+                                .thenThrow(new IllegalStateException(
+                                                "Corrections can only be submitted for jobs in FAILED state"));
+
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/corrections", JOB_ID)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isConflict());
+        }
+
+        @Test
+        void submitCorrections_withoutExecuteAuthority_returns403() throws Exception {
+                BulkCorrectionItem item = BulkCorrectionItem.builder()
+                                .auditRecordId(AUDIT_ID)
+                                .correctedData(Map.of("sku", "PROD-001"))
+                                .build();
+                BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                                .corrections(List.of(item))
+                                .build();
+
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/corrections", JOB_ID)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("X-Authorities", "bulkImport:status:read") // EXECUTE required
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+        void submitCorrections_whenJobNotFound_returns404() throws Exception {
+                BulkCorrectionItem item = BulkCorrectionItem.builder()
+                                .auditRecordId(AUDIT_ID)
+                                .correctedData(Map.of("sku", "PROD-001"))
+                                .build();
+                BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                                .corrections(List.of(item))
+                                .build();
+
+                when(reviewQueueService.submitCorrections(eq(JOB_ID), any(), eq("test-operator")))
+                                .thenThrow(new NoSuchElementException("BulkLoadJob not found: " + JOB_ID));
+
+                mockMvc.perform(post("/v1/bulk-jobs/{jobId}/corrections", JOB_ID)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isNotFound());
         }
 }

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/BulkLoadJobServiceImplTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/BulkLoadJobServiceImplTest.java
@@ -11,6 +11,7 @@ import com.positivity.bulkloader.internal.dto.BulkLoadJobResponse;
 import com.positivity.bulkloader.internal.entity.BulkLoadJob;
 import com.positivity.bulkloader.internal.enums.DomainType;
 import com.positivity.bulkloader.internal.enums.JobStatus;
+import com.positivity.bulkloader.internal.exception.JobOwnershipViolationException;
 import com.positivity.bulkloader.internal.repository.BulkLoadJobRepository;
 import com.positivity.bulkloader.service.BulkLoadBatchLauncher;
 import java.util.NoSuchElementException;
@@ -161,6 +162,61 @@ class BulkLoadJobServiceImplTest {
         assertThatThrownBy(() -> service.cancelJob(JOB_ID, OPERATOR_ID))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("terminal state");
+    }
+
+    // ─── retryJob ────────────────────────────────────────────────────────────
+
+    @Test
+    void retryJob_happyPath_resetsCountersAndSetsCreated() {
+        BulkLoadJob job = savedJob(JOB_ID, OPERATOR_ID, JobStatus.FAILED);
+        BulkLoadJob saved = savedJob(JOB_ID, OPERATOR_ID, JobStatus.CREATED);
+
+        when(jobRepository.findById(JOB_ID)).thenReturn(Optional.of(job));
+        when(jobRepository.countByOperatorIdAndStatusIn(any(), any())).thenReturn(0L);
+        when(jobRepository.save(any(BulkLoadJob.class))).thenReturn(saved);
+
+        BulkLoadJobResponse response = service.retryJob(JOB_ID, OPERATOR_ID);
+
+        assertThat(response.getStatus()).isEqualTo(JobStatus.CREATED);
+        assertThat(job.getStatus()).isEqualTo(JobStatus.CREATED);
+        assertThat(job.getProcessedRows()).isZero();
+        assertThat(job.getSuccessCount()).isZero();
+        assertThat(job.getFailureCount()).isZero();
+        assertThat(job.getTotalRows()).isNull();
+        verify(jobRepository).save(job);
+    }
+
+    @Test
+    void retryJob_whenJobNotOwned_throwsOwnershipViolation() {
+        BulkLoadJob job = savedJob(JOB_ID, "other-operator", JobStatus.FAILED);
+
+        when(jobRepository.findById(JOB_ID)).thenReturn(Optional.of(job));
+
+        assertThatThrownBy(() -> service.retryJob(JOB_ID, OPERATOR_ID))
+                .isInstanceOf(JobOwnershipViolationException.class);
+    }
+
+    @Test
+    void retryJob_whenJobNotFailed_throwsIllegalState() {
+        BulkLoadJob job = savedJob(JOB_ID, OPERATOR_ID, JobStatus.PROCESSING);
+
+        when(jobRepository.findById(JOB_ID)).thenReturn(Optional.of(job));
+
+        assertThatThrownBy(() -> service.retryJob(JOB_ID, OPERATOR_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("FAILED state");
+    }
+
+    @Test
+    void retryJob_whenOperatorHasActiveJob_throwsIllegalState() {
+        BulkLoadJob job = savedJob(JOB_ID, OPERATOR_ID, JobStatus.FAILED);
+
+        when(jobRepository.findById(JOB_ID)).thenReturn(Optional.of(job));
+        when(jobRepository.countByOperatorIdAndStatusIn(any(), any())).thenReturn(1L);
+
+        assertThatThrownBy(() -> service.retryJob(JOB_ID, OPERATOR_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("active bulk load job");
     }
 
     // ─── getJob ──────────────────────────────────────────────────────────────

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/ReviewQueueServiceImplTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/ReviewQueueServiceImplTest.java
@@ -1,20 +1,35 @@
 package com.positivity.bulkloader.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.bulkloader.internal.dto.AuditRecordResponse;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionItem;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionRequest;
+import com.positivity.bulkloader.internal.dto.BulkCorrectionResponse;
+import com.positivity.bulkloader.internal.entity.BulkLoadJob;
 import com.positivity.bulkloader.internal.entity.BulkLoadRecordAudit;
+import com.positivity.bulkloader.internal.enums.DomainType;
+import com.positivity.bulkloader.internal.enums.JobStatus;
 import com.positivity.bulkloader.internal.enums.ReviewStatus;
+import com.positivity.bulkloader.internal.exception.JobOwnershipViolationException;
+import com.positivity.bulkloader.internal.repository.BulkLoadJobRepository;
 import com.positivity.bulkloader.internal.repository.BulkLoadRecordAuditRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.Resource;
+import tools.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings({ "java:S100", "java:S1192" })
@@ -22,9 +37,16 @@ class ReviewQueueServiceImplTest {
 
     private static final UUID JOB_ID = UUID.fromString("00000000-0000-0000-0000-000000000004");
     private static final UUID AUDIT_ID = UUID.fromString("00000000-0000-0000-0000-000000000005");
+    private static final String OPERATOR_ID = "op-001";
 
     @Mock
     BulkLoadRecordAuditRepository auditRepository;
+
+    @Mock
+    BulkLoadJobRepository jobRepository;
+
+    @Spy
+    ObjectMapper objectMapper = new ObjectMapper();
 
     @InjectMocks
     ReviewQueueServiceImpl service;
@@ -88,6 +110,118 @@ class ReviewQueueServiceImplTest {
 
         String content = new String(report.getContentAsByteArray());
         assertThat(content).contains("PRODUCT").contains("PENDING");
+    }
+
+    // ─── submitCorrections ────────────────────────────────────────────────────
+
+    @Test
+    void submitCorrections_happyPath_acceptsAllValidItems() {
+        BulkLoadJob job = bulkLoadJob(JOB_ID, OPERATOR_ID, JobStatus.FAILED);
+        BulkLoadRecordAudit audit = auditRecord(AUDIT_ID, JOB_ID);
+        BulkCorrectionItem item = BulkCorrectionItem.builder()
+                .auditRecordId(AUDIT_ID)
+                .correctedData(Map.of("sku", "PROD-001"))
+                .build();
+        BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                .corrections(List.of(item))
+                .build();
+
+        when(jobRepository.findById(JOB_ID)).thenReturn(Optional.of(job));
+        when(auditRepository.findById(AUDIT_ID)).thenReturn(Optional.of(audit));
+        when(auditRepository.save(any(BulkLoadRecordAudit.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        BulkCorrectionResponse response = service.submitCorrections(JOB_ID, request, OPERATOR_ID);
+
+        assertThat(response.getJobId()).isEqualTo(JOB_ID);
+        assertThat(response.getSubmittedCount()).isEqualTo(1);
+        assertThat(response.getAcceptedCount()).isEqualTo(1);
+        assertThat(response.getRejectedCount()).isZero();
+        assertThat(audit.getReviewStatus()).isEqualTo(ReviewStatus.CORRECTED);
+        assertThat(audit.getCorrectedValues()).contains("sku");
+        verify(auditRepository).save(audit);
+    }
+
+    @Test
+    void submitCorrections_whenAuditRecordBelongsToDifferentJob_rejectsItem() {
+        UUID otherJobId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+        BulkLoadJob job = bulkLoadJob(JOB_ID, OPERATOR_ID, JobStatus.FAILED);
+        BulkLoadRecordAudit audit = auditRecord(AUDIT_ID, otherJobId);
+        BulkCorrectionItem item = BulkCorrectionItem.builder()
+                .auditRecordId(AUDIT_ID)
+                .correctedData(Map.of("sku", "PROD-001"))
+                .build();
+        BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                .corrections(List.of(item))
+                .build();
+
+        when(jobRepository.findById(JOB_ID)).thenReturn(Optional.of(job));
+        when(auditRepository.findById(AUDIT_ID)).thenReturn(Optional.of(audit));
+
+        BulkCorrectionResponse response = service.submitCorrections(JOB_ID, request, OPERATOR_ID);
+
+        assertThat(response.getAcceptedCount()).isZero();
+        assertThat(response.getRejectedCount()).isEqualTo(1);
+        assertThat(response.getRejections()).hasSize(1).first().asString().contains(AUDIT_ID.toString());
+    }
+
+    @Test
+    void submitCorrections_whenAuditRecordNotFound_rejectsItem() {
+        BulkLoadJob job = bulkLoadJob(JOB_ID, OPERATOR_ID, JobStatus.FAILED);
+        BulkCorrectionItem item = BulkCorrectionItem.builder()
+                .auditRecordId(AUDIT_ID)
+                .correctedData(Map.of("sku", "PROD-001"))
+                .build();
+        BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                .corrections(List.of(item))
+                .build();
+
+        when(jobRepository.findById(JOB_ID)).thenReturn(Optional.of(job));
+        when(auditRepository.findById(AUDIT_ID)).thenReturn(Optional.empty());
+
+        BulkCorrectionResponse response = service.submitCorrections(JOB_ID, request, OPERATOR_ID);
+
+        assertThat(response.getAcceptedCount()).isZero();
+        assertThat(response.getRejectedCount()).isEqualTo(1);
+    }
+
+    @Test
+    void submitCorrections_whenJobNotInFailedState_throwsIllegalState() {
+        BulkLoadJob job = bulkLoadJob(JOB_ID, OPERATOR_ID, JobStatus.PROCESSING);
+        BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                .corrections(List.of())
+                .build();
+
+        when(jobRepository.findById(JOB_ID)).thenReturn(Optional.of(job));
+
+        assertThatThrownBy(() -> service.submitCorrections(JOB_ID, request, OPERATOR_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("FAILED state");
+    }
+
+    @Test
+    void submitCorrections_whenNotOwner_throwsOwnershipViolation() {
+        BulkLoadJob job = bulkLoadJob(JOB_ID, "other-operator", JobStatus.FAILED);
+        BulkCorrectionRequest request = BulkCorrectionRequest.builder()
+                .corrections(List.of())
+                .build();
+
+        when(jobRepository.findById(JOB_ID)).thenReturn(Optional.of(job));
+
+        assertThatThrownBy(() -> service.submitCorrections(JOB_ID, request, OPERATOR_ID))
+                .isInstanceOf(JobOwnershipViolationException.class);
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private BulkLoadJob bulkLoadJob(UUID id, String operatorId, JobStatus status) {
+        BulkLoadJob job = new BulkLoadJob();
+        job.setId(id);
+        job.setOperatorId(operatorId);
+        job.setLocationId(UUID.fromString("00000000-0000-0000-0000-000000000003"));
+        job.setFileName("products.csv");
+        job.setDomainType(DomainType.CATALOG_PRODUCT);
+        job.setStatus(status);
+        return job;
     }
 
     // ─── helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Objective
Add `POST /v1/bulk-jobs/{jobId}/retry` and `POST /v1/bulk-jobs/{jobId}/corrections` endpoints to `pos-bulk-loader` as required by the SDK migration PRD.

## Scope
- Module: `pos-bulk-loader`
- Branch: `feat/api-bulk-loader-retry-correction`

## Changes
- `BulkLoadJobService` + `BulkLoadJobServiceImpl`: `retryJob()` — resets FAILED job to CREATED status, validates ownership and status
- `BulkLoadJobController`: `POST /{jobId}/retry` — 200 OK, 403, 404, 409
- `ReviewQueueService` + `ReviewQueueServiceImpl`: `submitCorrections()` — ownership + state validation, returns correction summary
- `ReviewQueueController`: `POST /{jobId}/corrections` — 202 Accepted, 400, 403, 404, 409
- New DTOs: `BulkCorrectionItem`, `BulkCorrectionRequest`, `BulkCorrectionResponse`
- Tests: 3 retry tests in `BulkLoadJobControllerTest`, 4 corrections tests in `ReviewQueueControllerTest`

## Specification
- PRD: `docs/PRD-missing-backend-endpoints.md`

## Verification
- `./mvnw -pl pos-bulk-loader -DskipTests=false verify`: **BUILD SUCCESS (142 tests, 0 failures, 0 errors)**
- Lint (Semgrep p/java, 60 rules, 11 files): **0 findings**
