### PR TITLE
cap/320 pos-bulk-loader: register BULK_LOADER_JOB_RETRY and BULK_LOADER_CORRECTION_SUBMIT event types

### DIFF
--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/config/BulkLoaderEventTypes.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/config/BulkLoaderEventTypes.java
@@ -5,23 +5,37 @@ import java.util.List;
 
 public final class BulkLoaderEventTypes {
 
-    private BulkLoaderEventTypes() {}
+        private BulkLoaderEventTypes() {
+        }
 
-    public static List<EventTypeRegistration> all() {
-        return List.of(
-                EventTypeRegistration.write("BULK_LOADER_JOB_CREATE", "Create a new bulk load job")
-                        .build(),
-                EventTypeRegistration.write("BULK_LOADER_JOB_START", "Start processing a bulk load job")
-                        .build(),
-                EventTypeRegistration.approval("BULK_LOADER_JOB_COMPLETE", "Bulk load job completed successfully")
-                        .build(),
-                EventTypeRegistration.write("BULK_LOADER_JOB_CANCEL", "Cancel a bulk load job")
-                        .build(),
-                EventTypeRegistration.write("BULK_LOADER_FILE_UPLOAD", "File uploaded for bulk load job")
-                        .build(),
-                EventTypeRegistration.approval("BULK_LOADER_MAPPING_APPROVE", "Column mappings approved by operator")
-                        .build(),
-                EventTypeRegistration.write("BULK_LOADER_TUS_UPLOAD_COMPLETE", "TUS resumable upload completed")
-                        .build());
-    }
+        public static List<EventTypeRegistration> all() {
+                return List.of(
+                                EventTypeRegistration.write("BULK_LOADER_JOB_CREATE", "Create a new bulk load job")
+                                                .build(),
+                                EventTypeRegistration.write("BULK_LOADER_JOB_START", "Start processing a bulk load job")
+                                                .build(),
+                                EventTypeRegistration
+                                                .approval("BULK_LOADER_JOB_COMPLETE",
+                                                                "Bulk load job completed successfully")
+                                                .build(),
+                                EventTypeRegistration.write("BULK_LOADER_JOB_CANCEL", "Cancel a bulk load job")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("BULK_LOADER_FILE_UPLOAD", "File uploaded for bulk load job")
+                                                .build(),
+                                EventTypeRegistration
+                                                .approval("BULK_LOADER_MAPPING_APPROVE",
+                                                                "Column mappings approved by operator")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("BULK_LOADER_TUS_UPLOAD_COMPLETE",
+                                                                "TUS resumable upload completed")
+                                                .build(),
+                                EventTypeRegistration.write("BULK_LOADER_JOB_RETRY", "Retry a failed bulk load job")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("BULK_LOADER_CORRECTION_SUBMIT",
+                                                                "Submit corrected records for a bulk load job")
+                                                .build());
+        }
 }


### PR DESCRIPTION
## Objective

Wave 2 — `pos-bulk-loader` contract parity for PRD issue 320 (B-4 / B-5 blocker groups).

Registers the two missing event types that were annotated on controllers but absent from
the startup event registry, closing the event audit gap for both new write operations.

## Specification Sources

- `durion-positivity-backend/docs/PRD-missing-backend-endpoints.md` — Section 4 (Bulk Loader Job Retry) and Section 5 (Bulk Loader Correction Submission)
- `durion/Durion-Processing.md` — Wave 2 execution tracking

## Modules / Files Changed

| File | Change |
|---|---|
| `pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/config/BulkLoaderEventTypes.java` | Added `BULK_LOADER_JOB_RETRY` and `BULK_LOADER_CORRECTION_SUBMIT` event type registrations |

**Pre-existing (no change required):**
- `BulkLoadJobController.retryJob` — fully annotated with `@EmitEvent`, `@Operation`, `@ApiResponse`, `@Parameter`, `@SecurityRequirement`, `@PreAuthorize` ✓
- `ReviewQueueController.submitCorrections` — fully annotated ✓
- All correction DTOs with `@Schema` ✓
- `BulkLoadJobService.retryJob` interface + implementation ✓
- `ReviewQueueService.submitCorrections` interface + implementation ✓
- Controller and service tests (happy-path + all 4xx) ✓
- `pos-bulk-loader/openapi.yaml` already contains both paths ✓

## Verification Evidence

### Module verify gate
```
./mvnw -pl pos-bulk-loader -am -DskipTests=false verify
Tests run: 155, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS (exit 0)
```

### Lint gate
```
./.github/hooks/lint-run-hook.sh --repo .../durion-positivity-backend --module pos-bulk-loader
Ran 60 rules on 1 file: 0 findings.
Lint run PASS
```

### Code review
`Code Review Agent` — Verdict: PASS, no findings

## Blocker / Risk Notes

None. Both operations had complete controller, service, DTO, and test implementations
already merged. Only the event registry was missing the two new IDs.

## Follow-ups

Pre-existing: `BULK_LOADER_JOB_COMPLETE` and `BULK_LOADER_TUS_UPLOAD_COMPLETE` are
registered but have no matching `@EmitEvent` controller annotation. Likely emitted by
service/infrastructure code. Warrants a separate story to confirm or clean up.
