### PR TITLE
cap/sdk-migration: Wave 1 — permissions paged list, audit filter expansion, audit export, shop audit SDK fix (B-1..B-4)

### DIFF
--- a/docs/PRD-sdk-migration-backend-unblock.md
+++ b/docs/PRD-sdk-migration-backend-unblock.md
@@ -1,0 +1,520 @@
+# PRD: Backend Work to Unblock Angular SDK Migration
+
+**Status:** Execution-ready
+**Date:** 2026-04-26
+**Owner:** Platform API
+**Related:**
+
+- `louisburroughs/durion#320`
+- `../durion-positivity-frontend/docs/PRD-sdk-migration-completion.md` (authoritative blocker list B-1..B-22)
+- `./PRD-missing-backend-endpoints.md` (companion — Workstream Matrix and high-level rationale)
+
+---
+
+## Problem Statement
+
+The companion PRD `PRD-missing-backend-endpoints.md` lists the issue-320 backend
+workstream matrix (`B-1..B-22`) but its Detailed Endpoint Specifications cover only the
+original five legacy groups (Accounting Report Export, CRM Billing Terms, Catalog
+Supplier Cost list, Bulk Loader Job Retry, Bulk Loader Correction). Those five are
+already implemented in the codebase. As a result, an executor agent reading the backend
+PRD finds nothing actionable for `B-1..B-22` and reports "nothing to execute".
+
+This PRD is the missing actionable contract. It specifies, per module and per endpoint,
+exactly what must be added, expanded, or aligned in the backend so that the Angular SDK
+can be regenerated and the frontend Wave 3/Wave 4 migration can finish.
+
+---
+
+## Solution
+
+For each blocker `B-1..B-22`:
+
+- Identify the owning module
+- Specify the exact OpenAPI path, HTTP method, query/path/body schema, and response shape
+- State whether the operation must be **ADDED**, **EXPANDED** (existing path; missing
+  params or response fields), or **ALIGNED** (existing path; field/parameter rename or
+  semantic clarification)
+- Apply the mandatory annotation surface (Springdoc + `@PreAuthorize` + `@EmitEvent`)
+- Regenerate `pos-<module>/openapi.yaml` and the matching `sdk-<module>` package
+
+A blocker is **closed** only when:
+
+1. Backend module tests pass (`./mvnw -pl pos-<module> -am test`)
+2. `pos-<module>/openapi.yaml` shows the new path/parameters/schema after running
+   `scripts/generate-openapi.sh pos-<module>`
+3. `sdk-<module>` exports a strongly-typed Angular service method (no `Observable<any>`
+   leakage) after running `scripts/generate-openapi.sh --module <name>` and
+   `npm run build` in the SDK repo
+4. The frontend wave PR adopts the SDK call without local DTO shims
+
+---
+
+## Scope
+
+In scope: every backend-owned blocker `B-1..B-22` from
+`../durion-positivity-frontend/docs/PRD-sdk-migration-completion.md`.
+
+Out of scope: frontend service migration, SDK template changes, generator script
+changes, and any new product capability not already covered by an existing blocker.
+
+---
+
+## Delivery Order
+
+Same order as `PRD-missing-backend-endpoints.md` §Delivery Order:
+
+1. `pos-security-service` + `pos-shop-manager` (B-1, B-2, B-3, B-4)
+2. `pos-bulk-loader` (B-5 — contract decision + verification)
+3. `pos-catalog` + `pos-customer` (B-13, B-21, B-22)
+4. `pos-accounting` (B-16, B-17, B-18, B-19, B-20)
+5. `pos-inventory` (B-6, B-7, B-8, B-9, B-10, B-11, B-12, B-14, B-15)
+
+---
+
+## Cross-Cutting Annotation Requirements
+
+Every NEW or CHANGED controller method in this PRD MUST carry:
+
+- Class: `@Tag(name = "<Domain>", description = "...")`,
+  `@RestController`, `@RequestMapping`, `@SecurityRequirement(name = "bearerAuth")`
+- Method: `@Operation(summary, description)`,
+  `@ApiResponse(responseCode, description, content)` for **every** documented status
+  (200/201/400/403/404/409/500 as applicable)
+- `@Parameter(description, required, example)` on every `@PathVariable` /
+  `@RequestParam` / `@RequestHeader`
+- `@PreAuthorize("hasAuthority('<scope>')")` with the scope strings noted per blocker
+- All write operations (POST/PUT/PATCH/DELETE):
+  `@EmitEvent(id = "<MODULE>_<RESOURCE>_<ACTION>", apiVersion = "1")` and
+  registration in the module's `*EventTypes` registry per backend AGENTS.md
+- All DTOs: `@Schema(description, example)` on the class and on every field. Validation
+  annotations on request DTOs (`@NotNull`, `@Size`, `@Pattern`, etc.). `@NonNull`
+  (`org.jspecify.annotations.NonNull`) on non-null service-layer parameters and return
+  types per backend AGENTS.md.
+- Architecture: implementation classes in `com.positivity.<module>.internal.*`; only
+  `com.positivity.<module>.service` interfaces exposed cross-module. ArchUnit tests
+  must continue to pass.
+
+---
+
+## 1. `pos-security-service` — B-1, B-3, B-4
+
+Existing: `/v1/permissions`, `/v1/permissions/{id}`, `/v1/permissions/domain/{domain}`,
+`/v1/audit/events`, `/v1/audit/events/{eventId}` are present. No audit export
+endpoints exist.
+
+### B-1 — `GET /v1/permissions` query and pagination — EXPAND
+
+| Field            | Value                                                                                                                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Operation ID     | `listPermissions`                                                                                                        |
+| Query params     | `domain` (string, optional), `page` (int, default 0), `size` (int, default 20, max 200), `sort` (string, optional)       |
+| Response 200     | `Page<PermissionDto>` (Spring Data page envelope: `content`, `totalElements`, `totalPages`, `number`, `size`)            |
+| Permission scope | `security:permission:view`                                                                                               |
+| Notes            | Keep `/v1/permissions/domain/{domain}` for backwards compatibility OR remove and document migration. Default to keeping. |
+
+### B-3 — `GET /v1/audit/events` filter expansion — EXPAND
+
+Add the following optional query parameters (all `@RequestParam(required = false)`):
+
+| Param           | Type                 | Notes                                     |
+| --------------- | -------------------- | ----------------------------------------- |
+| `fromDate`      | `Instant` (ISO-8601) | inclusive                                 |
+| `toDate`        | `Instant` (ISO-8601) | exclusive                                 |
+| `actorId`       | `String` (UUID)      |                                           |
+| `workorderId`   | `String` (UUID)      | one-word `workorder` per workspace policy |
+| `movementId`    | `String` (UUID)      |                                           |
+| `productId`     | `String` (UUID)      |                                           |
+| `sku`           | `String`             |                                           |
+| `eventType`     | `String`             |                                           |
+| `aggregateId`   | `String`             |                                           |
+| `correlationId` | `String` (UUID)      |                                           |
+| `reasonCode`    | `String`             |                                           |
+| `pageToken`     | `String`             | for cursor-based paging where applicable  |
+| `locationIds`   | `List<String>`       | repeated query param                      |
+
+Response remains `Page<AuditEventDto>` (or existing cursor envelope if already used).
+Permission scope: `security:audit:view`.
+
+### B-4 — Audit Export job endpoints — ADD
+
+```text
+POST   /v1/audit/exports
+GET    /v1/audit/exports/{jobId}
+```
+
+| Endpoint                        | Request                                                                                                        | Response                                                                                           | Status codes  |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------- |
+| `POST /v1/audit/exports`        | `AuditExportRequest { filters: AuditEventFilter, format: "CSV"\|"JSON", deliveryMode: "DOWNLOAD"\|"WEBHOOK" }` | `AuditExportJobResponse { jobId, status, requestedAt }`                                            | 202, 400, 403 |
+| `GET /v1/audit/exports/{jobId}` | —                                                                                                              | `AuditExportJobResponse { jobId, status, requestedAt, completedAt?, downloadUrl?, errorMessage? }` | 200, 403, 404 |
+
+- `status` enum: `PENDING`, `IN_PROGRESS`, `COMPLETED`, `FAILED`
+- `@EmitEvent(id = "SECURITY_AUDIT_EXPORT_REQUEST", apiVersion = "1")` on POST
+- `@PreAuthorize("hasAuthority('security:audit:export')")`
+- New `@Tag("Audit Exports")`
+- DTOs in `internal/dto/`; service interface `AuditExportService` in `service/`
+
+---
+
+## 2. `pos-shop-manager` — B-2
+
+Existing: `/v1/shop/audit` and `/v1/shop/audit/{id}` already in
+`pos-shop-manager/openapi.yaml`.
+
+### B-2 — Shop audit ownership / SDK routing — VERIFY + EXPAND if needed
+
+- Confirm `scripts/generate-openapi.sh --module shop-manager` produces `sdk-shop-manager`
+  with `searchShopAudit` and `getShopAuditEntry` methods.
+- If the frontend filter set (date range, actor, workorderId, action type) is not
+  exposed on `/v1/shop/audit`, EXPAND `@RequestParam` coverage to match the frontend
+  query surface used in `wave-3` migration.
+- Confirm `@Tag` and `operationId` strings produce the expected SDK class name
+  (`ShopAuditService`).
+- No new endpoint required.
+- Permission scope: `shop:audit:view`.
+
+---
+
+## 3. `pos-bulk-loader` — B-5
+
+Existing: `POST /v1/bulk-jobs/{jobId}/retry`, `POST /v1/bulk-jobs/{jobId}/corrections`.
+
+### B-5 — Correction contract decision — DECIDE + DOCUMENT
+
+Decision required before any code change:
+
+- **Option A (recommended):** the bulk corrections endpoint is the canonical contract;
+  remove any single-record correction surface from the frontend PRD; frontend wraps
+  single-record submissions as a one-element bulk request.
+- **Option B:** add a new `POST /v1/bulk-jobs/{jobId}/corrections/single` returning the
+  same `CorrectionResultDto` for parity with frontend `submitCorrection`.
+
+Document the chosen option in `PRD-missing-backend-endpoints.md` §5 and update the
+frontend PRD blocker B-5 row. If Option B, mark write with
+`@EmitEvent(id = "BULK_LOADER_CORRECTION_SUBMIT_SINGLE", apiVersion = "1")`.
+
+---
+
+## 4. `pos-catalog` — B-13
+
+Existing: `GET /v1/products/supplier-costs` collection at line 1182 of
+`pos-catalog/openapi.yaml`.
+
+### B-13 — Supplier costs query parameters — VERIFY + EXPAND
+
+Required contract:
+
+| Param        | Type                       | Notes |
+| ------------ | -------------------------- | ----- |
+| `itemId`     | `String` (UUID), optional  |       |
+| `supplierId` | `String` (UUID), optional  |       |
+| `page`       | `int`, default 0           |       |
+| `size`       | `int`, default 20, max 200 |       |
+
+Response: `Page<SupplierItemCostDto>`.
+
+If any of `itemId`/`supplierId`/pagination params are missing from the current spec,
+add them with `@Parameter`. Confirm `SupplierItemCostDto` `@Schema` annotations are
+complete. Permission scope: `catalog:supplier-cost:view`.
+
+---
+
+## 5. `pos-customer` — B-21, B-22
+
+Existing: only `/v1/crm/snapshot/party/{partyId}/billing-rules` (read-only snapshot).
+No duplicate-check, no PUT for billing rules.
+
+### B-21 — Party duplicate check — ADD
+
+```text
+GET /v1/crm/accounts/parties/duplicate-check?legalName={string}
+```
+
+| Field            | Value                                                                          |
+| ---------------- | ------------------------------------------------------------------------------ |
+| Query            | `legalName` (string, required, min length 2)                                   |
+| Response 200     | `DuplicateCheckResponse { matches: PartyMatch[], exactMatchPartyId?: string }` |
+| `PartyMatch`     | `{ partyId, legalName, score: number, matchType: "EXACT"\|"FUZZY" }`           |
+| Status codes     | 200, 400, 403                                                                  |
+| Permission scope | `crm:party:view`                                                               |
+| `@Tag`           | `"CRM Accounts"`                                                               |
+
+### B-22 — Party billing rules update — ADD
+
+```text
+PUT /v1/crm/accounts/parties/{partyId}/billing-rules
+```
+
+| Field            | Value                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Path             | `partyId` (UUID, required)                                                                                                  |
+| Request body     | `BillingRulesUpdateRequest { paymentTerms, creditLimit, currency, taxExempt, billingContactId?, … }`                        |
+| Response 200     | `BillingRulesResponse { partyId, paymentTerms, creditLimit, currency, taxExempt, billingContactId?, updatedAt, updatedBy }` |
+| Status codes     | 200, 400, 403, 404, 409                                                                                                     |
+| Permission scope | `crm:party:billing:write`                                                                                                   |
+| `@EmitEvent`     | `id = "CRM_PARTY_BILLING_RULES_UPDATE", apiVersion = "1"`                                                                   |
+| Notes            | Conflict 409 on optimistic-lock version mismatch if entity uses `@Version`.                                                 |
+
+---
+
+## 6. `pos-accounting` — B-16, B-17, B-18, B-19, B-20
+
+Existing: `/v1/accounting/events`, `/v1/accounting/events/{eventId}`,
+`/v1/accounting/events/{eventId}/processing-log`,
+`/v1/accounting/events/{eventId}/retry`,
+`/v1/accounting/events/{eventId}/reprocess`,
+`/v1/accounting/events/{eventId}/reprocessing-history`,
+`/v1/accounting/ap/bills`, `/v1/accounting/reports/export*`.
+
+### B-16 — Event list filters — EXPAND
+
+`GET /v1/accounting/events`:
+
+- `organizationId` MUST become **optional** (currently required).
+- Add optional query params: `eventType`, `idempotencyOutcome` (`ACCEPTED`/`REJECTED`/
+  `DUPLICATE`/`SUPPRESSED`), `receivedAtFrom` (Instant), `receivedAtTo` (Instant),
+  `eventId` (UUID), `ingestionId` (UUID), `domainKeyId` (string), `invoiceId` (UUID).
+- Standard `Pageable` (`page`, `size`, `sort`).
+- Response: `Page<AccountingEventDto>`.
+- Permission scope: `accounting:event:view`.
+
+### B-17 — Processing log response shape — ALIGN
+
+`GET /v1/accounting/events/{eventId}/processing-log`:
+
+- Change response from `string` (or wrapped log blob) to
+  `array<EventProcessingLogEntry>` with:
+  `{ entryId, occurredAt, severity: "INFO"\|"WARN"\|"ERROR", message, contextJson? }`.
+- Add `EventProcessingLogEntry` `@Schema`.
+- Backwards-incompatible — coordinate frontend wave PR.
+
+### B-18 — AP bills paged list — EXPAND
+
+`GET /v1/accounting/ap/bills`:
+
+- Confirm an unfiltered paged variant exists (no required filter). If filters are
+  currently mandatory, make all of them optional and add `Pageable`. Response:
+  `Page<ApBillDto>`. Permission scope: `accounting:ap:view`.
+
+### B-19 — Generic export job endpoints — ADD
+
+Distinct from the existing `/v1/accounting/reports/export` (financial reports). For
+timekeeping and other generic exports:
+
+```text
+POST   /v1/accounting/export/request
+GET    /v1/accounting/export/status/{jobId}
+GET    /v1/accounting/export/history
+```
+
+| Endpoint                        | Request                                                                              | Response                                                                                      | Status   |
+| ------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | -------- |
+| `POST .../export/request`       | `ExportRequest { exportType, filters: object, format: "CSV"\|"JSON", deliveryMode }` | `ExportJobResponse { jobId, status, requestedAt }`                                            | 202      |
+| `GET .../export/status/{jobId}` | —                                                                                    | `ExportJobResponse { jobId, status, requestedAt, completedAt?, downloadUrl?, errorMessage? }` | 200, 404 |
+| `GET .../export/history`        | `Pageable`, optional `exportType`, `requestedAtFrom`, `requestedAtTo`                | `Page<ExportJobResponse>`                                                                     | 200      |
+
+- `@EmitEvent(id = "ACCOUNTING_EXPORT_REQUEST", apiVersion = "1")` on POST
+- Permission scope: `accounting:export:request` for POST; `accounting:export:view` for GET
+- New `@Tag("Accounting Exports")`
+
+### B-20 — Event envelope contract introspection — ADD
+
+```text
+GET /v1/accounting/events/contract
+```
+
+| Field            | Value                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| Response 200     | `EventEnvelopeContract { version: string, fields: ContractField[], examples: object[] }`            |
+| `ContractField`  | `{ name, jsonPath, type, required, description, enumValues? }`                                      |
+| Permission scope | `accounting:event:view`                                                                             |
+| Notes            | Read-only. Used by SDK consumers to validate inbound payloads against the current envelope version. |
+
+---
+
+## 7. `pos-inventory` — B-6..B-12, B-14, B-15
+
+Existing inventory paths use the `/v1/inventory/...` prefix. The frontend PRD references
+`/inventory/v1/...` — there is a **prefix mismatch** that must be reconciled.
+
+### B-0 (prerequisite) — Path prefix reconciliation — DECIDE
+
+Recommend keeping the current `/v1/inventory/...` prefix to avoid breaking existing
+consumers. Update the frontend PRD blocker rows and SDK call sites to match. Document
+the decision in `PRD-missing-backend-endpoints.md`. Do **not** add duplicate paths
+under both prefixes.
+
+### B-6 — Availability filter expansion — EXPAND
+
+`GET /v1/inventory/availability/by-sku` and `GET /v1/inventory/availability/lead-time`:
+
+- Add optional query params `locationId` (UUID), `storageLocationId` (UUID).
+- Document `sourceType` semantics in `@Parameter(description = ...)`. See B-14.
+
+### B-7 — Locations / storage-locations / location-zones reference — ADD
+
+```text
+GET /v1/inventory/locations              -> Page<LocationDto>
+GET /v1/inventory/storage-locations      -> Page<StorageLocationDto>
+GET /v1/inventory/location-zones         -> Page<LocationZoneDto>
+```
+
+- Standard `Pageable` plus optional `siteId`, `locationId` filters where relevant.
+- Permission scope: `inventory:location:view`.
+- Read-only; no `@EmitEvent`.
+
+### B-8 — Inventory ledger — ADD (new service + controller)
+
+New `InventoryLedgerService` interface in `service/`; implementation
+`InventoryLedgerServiceImpl` in `internal/service/`; controller
+`InventoryLedgerController` in `internal/controller/`; entity
+`InventoryLedgerEntry` in `internal/entity/`.
+
+```text
+GET /v1/inventory/ledger
+GET /v1/inventory/ledger/{id}
+```
+
+`GET /v1/inventory/ledger` query params (all optional):
+
+| Param                 | Type                        |
+| --------------------- | --------------------------- |
+| `productSku`          | `String`                    |
+| `locationId`          | `String` (UUID)             |
+| `storageLocationId`   | `String` (UUID)             |
+| `dateFrom`            | `Instant`                   |
+| `dateTo`              | `Instant`                   |
+| `sourceTransactionId` | `String` (UUID)             |
+| `workorderId`         | `String` (UUID)             |
+| `workorderLineId`     | `String` (UUID)             |
+| `pageSize`            | `int` (default 50, max 500) |
+| `pageToken`           | `String`                    |
+| `movementTypes`       | `List<MovementType>`        |
+
+Response: cursor-paged `LedgerPage<InventoryLedgerEntryDto>`
+(`{ entries, nextPageToken? }`). `GET .../{id}` returns a single
+`InventoryLedgerEntryDto`. Permission scope: `inventory:ledger:view`.
+Flyway migration required for `inventory_ledger_entry` table.
+
+### B-9 — Putaway task filtering — EXPAND
+
+`/v1/inventory/putaway/tasks/*`: add `locationId` and `storageLocationId` optional
+query params on the listing/filter endpoints used by the frontend putaway UI.
+
+### B-10 — Replenishment policy filtering — EXPAND
+
+`GET /v1/inventory/replenishment/policies`:
+
+- Add optional `locationId` query param.
+- Confirm paged response (`Page<ReplenishmentPolicyDto>`).
+
+### B-11 — Returns workflow — ADD
+
+```text
+GET  /v1/inventory/returns/returnable-items?workorderId={uuid}     -> ReturnableItemDto[]
+GET  /v1/inventory/returns/reason-codes                            -> ReasonCodeDto[]
+POST /v1/inventory/returns/submit-to-stock                         -> ReturnSubmissionResultDto
+```
+
+- POST request `ReturnSubmitRequest { workorderId, lines: [{ itemId, quantity, reasonCode, locationId, storageLocationId? }] }`.
+- `@EmitEvent(id = "INVENTORY_RETURN_SUBMIT_TO_STOCK", apiVersion = "1")` on POST.
+- Permission scope: `inventory:return:write` for POST; `inventory:return:view` for GETs.
+
+### B-12 — Shortage workflow — ADD + ALIGN
+
+```text
+GET  /v1/inventory/shortage/options?allocationId={uuid}            -> ShortageOptionDto[]
+POST /v1/inventory/shortage/resolve                                -> ShortageResolutionResultDto
+```
+
+- Reconcile naming: standardize on `allocationId` (parent allocation) with optional
+  `allocationLineId` for line-level operations. Document both in `@Parameter`.
+- POST request `ShortageResolveRequest { allocationId, allocationLineId?, resolution: "BACKORDER"\|"SUBSTITUTE"\|"CANCEL", substituteSku?, notes? }`.
+- `@EmitEvent(id = "INVENTORY_SHORTAGE_RESOLVE", apiVersion = "1")` on POST.
+- Permission scope: `inventory:shortage:resolve` (POST) / `inventory:shortage:view` (GET).
+
+### B-14 — Availability sourceType vs locationId — ALIGN
+
+- Settle semantics in `@Parameter` descriptions on `/availability/by-sku` and
+  `/availability/lead-time`:
+  - `sourceType`: enum (`WAREHOUSE`, `SUPPLIER`, `TRANSIT`); selects the lookup strategy.
+  - `locationId`: optional concrete location filter; valid only when
+    `sourceType == WAREHOUSE`.
+- Validate combination at controller boundary; return 400 with structured error
+  envelope on conflict.
+
+### B-15 — Location inventory schema — ALIGN
+
+`GET /v1/inventory/locations/{locationId}/inventory`:
+
+- Rename response fields:
+  - `onHand` → `onHandQuantity`
+  - `atp` → `availableToPromiseQuantity`
+- Add optional `sku` query param to filter the response.
+- Update `@Schema` and any consumer references in the same module.
+- Backwards-incompatible — coordinate frontend wave PR.
+
+---
+
+## Acceptance Criteria
+
+For every blocker listed above:
+
+1. Module builds and tests pass:
+   `./mvnw -pl pos-<module> -am test`
+2. ArchUnit tests pass (no internal package leakage; no controller→repository direct
+   dependency).
+3. Module OpenAPI is regenerated with no manual edits:
+   `scripts/generate-openapi.sh pos-<module>`
+4. Every new/changed operation in `pos-<module>/openapi.yaml` shows:
+   - `tags`, `summary`, `description`
+   - all `parameters` (path + query) with `description` and `required`
+   - `requestBody` with `application/json` + schema reference (where applicable)
+   - `responses` for every documented status code
+   - `security: [{ bearerAuth: [] }]`
+5. SDK regeneration succeeds:
+   - `cd ../durion-positivity-sdk-angular && scripts/generate-openapi.sh --module <name>`
+   - `npm run build`
+   - The corresponding generated Angular service exposes a typed method (no
+     `Observable<any>` leakage).
+6. The frontend PRD blocker row can be marked closed because the blocker is now a
+   pure frontend adoption task.
+
+---
+
+## Risks and Open Questions
+
+| Risk                                                                                     | Mitigation                                                                                 |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| B-17 and B-15 are backwards-incompatible response schema changes                         | Coordinate single PR per change with frontend wave PR; ship both at once.                  |
+| Inventory ledger (B-8) requires a Flyway migration and a new entity                      | Standard Flyway-first workflow; covered by `scripts/check-flyway-hygiene.sh`.              |
+| Inventory path-prefix reconciliation (B-0) may invalidate frontend code already migrated | Resolve before any inventory wave PR is merged; do not double-publish under both prefixes. |
+| Bulk loader correction contract (B-5) currently has no canonical answer                  | Decision required from product before any change. Block B-5 until decided.                 |
+| B-2 may already work — the gap may be SDK packaging, not backend                         | Verify SDK output first; only edit backend if `@Tag`/`operationId` rerouting is required.  |
+
+---
+
+## Out of Scope
+
+- Frontend service migration (covered by `../durion-positivity-frontend/docs/PRD-sdk-migration-completion.md`).
+- SDK template or generator-script changes (covered by `../durion-positivity-sdk-angular/AGENTS.md`).
+- New product capabilities not already represented as a B-class blocker.
+- Changes to `pos-api-gateway` routing beyond automatic aggregation of regenerated
+  module specs.
+
+---
+
+## Regeneration Pipeline (per module, in order)
+
+```bash
+# 1. Backend module spec
+cd durion-positivity-backend
+scripts/generate-openapi.sh pos-<module>
+
+# 2. SDK package
+cd ../durion-positivity-sdk-angular
+scripts/generate-openapi.sh --module <module>
+npm run build
+
+# 3. Frontend wave PR (separate PR; this PRD does not cover it)
+```

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/EventTypes.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/EventTypes.java
@@ -20,7 +20,7 @@ public final class EventTypes {
          */
         public static List<EventTypeRegistration> all() {
                 return List.of(
-                                // AuthController - 1 event
+                                // AuthController - 2 events
                                 EventTypeRegistration.write("SECURITY_AUTH_LOGIN", "User login via /v1/auth/login")
                                                 .build(),
                                 EventTypeRegistration

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/EventTypes.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/EventTypes.java
@@ -10,103 +10,130 @@ import java.util.List;
  */
 public final class EventTypes {
 
-    private EventTypes() {
-        // Utility class
-    }
+        private EventTypes() {
+                // Utility class
+        }
 
-    /**
-     * All event type registrations for the security module.
-     * Total: 31 event types.
-     */
-    public static List<EventTypeRegistration> all() {
-        return List.of(
-                // AuthController - 1 event
-                EventTypeRegistration.write("SECURITY_AUTH_LOGIN", "User login via /v1/auth/login")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_AUTH_SELF_REGISTER", "Register a new self-service user account")
-                        .build(),
+        /**
+         * All event type registrations for the security module.
+         * Total: 32 event types.
+         */
+        public static List<EventTypeRegistration> all() {
+                return List.of(
+                                // AuthController - 1 event
+                                EventTypeRegistration.write("SECURITY_AUTH_LOGIN", "User login via /v1/auth/login")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("SECURITY_AUTH_SELF_REGISTER",
+                                                                "Register a new self-service user account")
+                                                .build(),
 
-                // JwtController - 4 events
-                EventTypeRegistration.write(
-                                "SECURITY_AUTH_INTERNAL_TOKEN_ISSUE", "Issue JWT token for internal trusted caller")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_AUTH_TOKEN_PAIR", "Generate access and refresh token pair")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_AUTH_REFRESH", "Refresh access token using refresh token")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_AUTH_REVOKE", "Revoke JWT token immediately")
-                        .build(),
+                                // JwtController - 4 events
+                                EventTypeRegistration.write(
+                                                "SECURITY_AUTH_INTERNAL_TOKEN_ISSUE",
+                                                "Issue JWT token for internal trusted caller")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("SECURITY_AUTH_TOKEN_PAIR",
+                                                                "Generate access and refresh token pair")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("SECURITY_AUTH_REFRESH",
+                                                                "Refresh access token using refresh token")
+                                                .build(),
+                                EventTypeRegistration.write("SECURITY_AUTH_REVOKE", "Revoke JWT token immediately")
+                                                .build(),
 
-                // PermissionController - 2 events
-                EventTypeRegistration.write("SECURITY_PERMISSION_REGISTER", "Register permissions from a service")
-                        .build(),
-                EventTypeRegistration.fastRead(
-                                "SECURITY_PERMISSION_DECODE_EXECUTE", "Decode a perm_bits claim for diagnostics")
-                        .build(),
+                                // PermissionController - 2 events
+                                EventTypeRegistration
+                                                .write("SECURITY_PERMISSION_REGISTER",
+                                                                "Register permissions from a service")
+                                                .build(),
+                                EventTypeRegistration.fastRead(
+                                                "SECURITY_PERMISSION_DECODE_EXECUTE",
+                                                "Decode a perm_bits claim for diagnostics")
+                                                .build(),
 
-                // PrincipalRoleController - 1 event
-                EventTypeRegistration.write("SECURITY_PRINCIPAL_ROLE_ASSIGN", "Assign a principal to a role")
-                        .build(),
+                                // PrincipalRoleController - 1 event
+                                EventTypeRegistration
+                                                .write("SECURITY_PRINCIPAL_ROLE_ASSIGN", "Assign a principal to a role")
+                                                .build(),
 
-                // RoleController - 8 events
-                EventTypeRegistration.write("SECURITY_ROLE_CREATE", "Create a new role")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_ROLE_PERMISSION_GRANT", "Grant a permission to a role")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_ROLE_PERMISSION_REVOKE", "Revoke a permission from a role")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_ROLE_PERMISSION_ASSIGN", "Assign a permission to a role")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_ROLE_PERMISSIONS_UPDATE", "Update permissions assigned to a role")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_ROLE_ASSIGNMENT_CREATE", "Create a role assignment for a user")
-                        .build(),
-                EventTypeRegistration.write(
-                                "SECURITY_ROLE_ASSIGNMENT_REVOKE", "Revoke a role assignment by setting its end date")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_ROLE_DELETE", "Delete a role")
-                        .build(),
+                                // RoleController - 8 events
+                                EventTypeRegistration.write("SECURITY_ROLE_CREATE", "Create a new role")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("SECURITY_ROLE_PERMISSION_GRANT", "Grant a permission to a role")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("SECURITY_ROLE_PERMISSION_REVOKE",
+                                                                "Revoke a permission from a role")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("SECURITY_ROLE_PERMISSION_ASSIGN",
+                                                                "Assign a permission to a role")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("SECURITY_ROLE_PERMISSIONS_UPDATE",
+                                                                "Update permissions assigned to a role")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("SECURITY_ROLE_ASSIGNMENT_CREATE",
+                                                                "Create a role assignment for a user")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "SECURITY_ROLE_ASSIGNMENT_REVOKE",
+                                                "Revoke a role assignment by setting its end date")
+                                                .build(),
+                                EventTypeRegistration.write("SECURITY_ROLE_DELETE", "Delete a role")
+                                                .build(),
 
-                // UserRoleController - 2 events
-                EventTypeRegistration.write("SECURITY_USER_ROLE_ASSIGN", "Assign a role to a user")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_USER_ROLE_REVOKE", "Revoke a role from a user")
-                        .build(),
+                                // UserRoleController - 2 events
+                                EventTypeRegistration.write("SECURITY_USER_ROLE_ASSIGN", "Assign a role to a user")
+                                                .build(),
+                                EventTypeRegistration.write("SECURITY_USER_ROLE_REVOKE", "Revoke a role from a user")
+                                                .build(),
 
-                // AuditController - 2 events
-                EventTypeRegistration.write("SECURITY_AUDIT_EVENT_CREATE", "Create an immutable audit event")
-                        .build(),
-                EventTypeRegistration.write(
-                                "SECURITY_AUDIT_PRICING_SNAPSHOT_CREATE",
-                                "Create a pricing snapshot for audit purposes")
-                        .build(),
+                                // AuditController - 2 events
+                                EventTypeRegistration
+                                                .write("SECURITY_AUDIT_EVENT_CREATE", "Create an immutable audit event")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "SECURITY_AUDIT_EXPORT_REQUEST",
+                                                "Submit an asynchronous audit export job request")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "SECURITY_AUDIT_PRICING_SNAPSHOT_CREATE",
+                                                "Create a pricing snapshot for audit purposes")
+                                                .build(),
 
-                // UserController - 4 events
-                EventTypeRegistration.write("SECURITY_USER_CREATE", "Create a new user account")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_USER_UPDATE", "Update an existing user account")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_USER_DELETE", "Delete a user account")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_USER_ASSIGN_ROLES", "Assign roles to a user")
-                        .build(),
+                                // UserController - 4 events
+                                EventTypeRegistration.write("SECURITY_USER_CREATE", "Create a new user account")
+                                                .build(),
+                                EventTypeRegistration.write("SECURITY_USER_UPDATE", "Update an existing user account")
+                                                .build(),
+                                EventTypeRegistration.write("SECURITY_USER_DELETE", "Delete a user account")
+                                                .build(),
+                                EventTypeRegistration.write("SECURITY_USER_ASSIGN_ROLES", "Assign roles to a user")
+                                                .build(),
 
-                // AdminAccountStateController - 5 events
-                EventTypeRegistration.write("SECURITY_USER_UNLOCK", "Unlock a user account")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_USER_ENABLE", "Enable a user account")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_USER_DISABLE", "Disable a user account")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_USER_EXPIRE_ACCOUNT", "Expire a user account")
-                        .build(),
-                EventTypeRegistration.write("SECURITY_USER_EXPIRE_CREDENTIALS", "Expire user credentials")
-                        .build(),
+                                // AdminAccountStateController - 5 events
+                                EventTypeRegistration.write("SECURITY_USER_UNLOCK", "Unlock a user account")
+                                                .build(),
+                                EventTypeRegistration.write("SECURITY_USER_ENABLE", "Enable a user account")
+                                                .build(),
+                                EventTypeRegistration.write("SECURITY_USER_DISABLE", "Disable a user account")
+                                                .build(),
+                                EventTypeRegistration.write("SECURITY_USER_EXPIRE_ACCOUNT", "Expire a user account")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("SECURITY_USER_EXPIRE_CREDENTIALS", "Expire user credentials")
+                                                .build(),
 
-                // SelfRegistrationReviewController - 1 event
-                EventTypeRegistration.write(
-                                "SECURITY_SELF_REGISTRATION_REVIEW_RESOLVE",
-                                "Resolve a blocked self-registration review case")
-                        .build());
-    }
+                                // SelfRegistrationReviewController - 1 event
+                                EventTypeRegistration.write(
+                                                "SECURITY_SELF_REGISTRATION_REVIEW_RESOLVE",
+                                                "Resolve a blocked self-registration review case")
+                                                .build());
+        }
 }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/EventTypes.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/EventTypes.java
@@ -94,7 +94,7 @@ public final class EventTypes {
                                 EventTypeRegistration.write("SECURITY_USER_ROLE_REVOKE", "Revoke a role from a user")
                                                 .build(),
 
-                                // AuditController - 2 events
+                                // AuditController - 3 events
                                 EventTypeRegistration
                                                 .write("SECURITY_AUDIT_EVENT_CREATE", "Create an immutable audit event")
                                                 .build(),

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/GlobalExceptionHandler.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/config/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import com.positivity.securityservice.internal.exception.UserNotFoundException;
 import com.positivity.securityservice.service.AuditEventService;
 import com.positivity.shared.error.ApiError;
 import com.positivity.shared.id.UUIDv7Generator;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import java.time.Instant;
@@ -84,472 +85,499 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @ControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
-    private final Clock clock;
-    private final ObjectProvider<AuditEventService> auditEventServiceProvider;
+        private final Clock clock;
+        private final ObjectProvider<AuditEventService> auditEventServiceProvider;
 
-    /**
-     * Handles RoleNotFoundException (role not found by ID or name).
-     *
-     * **HTTP Status:** 404 Not Found
-     *
-     * @param ex      the exception
-     * @param request the web request
-     * @return error response with 404 status and correlation ID
-     */
-    @ExceptionHandler(RoleNotFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ResponseEntity<ApiError> handleRoleNotFoundException(RoleNotFoundException ex, WebRequest request) {
+        /**
+         * Handles RoleNotFoundException (role not found by ID or name).
+         *
+         * **HTTP Status:** 404 Not Found
+         *
+         * @param ex      the exception
+         * @param request the web request
+         * @return error response with 404 status and correlation ID
+         */
+        @ExceptionHandler(RoleNotFoundException.class)
+        @ResponseStatus(HttpStatus.NOT_FOUND)
+        public ResponseEntity<ApiError> handleRoleNotFoundException(RoleNotFoundException ex, WebRequest request) {
 
-        String correlationId = extractCorrelationId(request);
-        log.warn("Role not found (correlationId={}): {}", correlationId, ex.getMessage());
+                String correlationId = extractCorrelationId(request);
+                log.warn("Role not found (correlationId={}): {}", correlationId, ex.getMessage());
 
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(errorResponse("ROLE_NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND, correlationId));
-    }
-
-    /**
-     * Handles UserNotFoundException (user not found by ID or username).
-     *
-     * **HTTP Status:** 404 Not Found
-     *
-     * @param ex      the exception
-     * @param request the web request
-     * @return error response with 404 status and correlation ID
-     */
-    @ExceptionHandler(UserNotFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ResponseEntity<ApiError> handleUserNotFoundException(UserNotFoundException ex, WebRequest request) {
-
-        String correlationId = extractCorrelationId(request);
-        log.warn("User not found (correlationId={}): {}", correlationId, ex.getMessage());
-
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(errorResponse("USER_NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND, correlationId));
-    }
-
-    /**
-     * Handles RoleAssignmentNotFoundException (role assignment not found by ID).
-     *
-     * **HTTP Status:** 404 Not Found
-     *
-     * @param ex      the exception
-     * @param request the web request
-     * @return error response with 404 status and correlation ID
-     */
-    @ExceptionHandler(RoleAssignmentNotFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ResponseEntity<ApiError> handleRoleAssignmentNotFoundException(
-            RoleAssignmentNotFoundException ex, WebRequest request) {
-
-        String correlationId = extractCorrelationId(request);
-        log.warn("Role assignment not found (correlationId={}): {}", correlationId, ex.getMessage());
-
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(errorResponse("ROLE_ASSIGNMENT_NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND, correlationId));
-    }
-
-    /**
-     * Handles PermissionNotFoundException (permission not found by name).
-     *
-     * **HTTP Status:** 404 Not Found
-     *
-     * @param ex      the exception
-     * @param request the web request
-     * @return error response with 404 status and correlation ID
-     */
-    @ExceptionHandler(PermissionNotFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ResponseEntity<ApiError> handlePermissionNotFoundException(
-            PermissionNotFoundException ex, WebRequest request) {
-
-        String correlationId = extractCorrelationId(request);
-        log.warn("Permission not found (correlationId={}): {}", correlationId, ex.getMessage());
-
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(errorResponse("PERMISSION_NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND, correlationId));
-    }
-
-    @ExceptionHandler(SelfRegistrationConflictException.class)
-    @ResponseStatus(HttpStatus.CONFLICT)
-    public ResponseEntity<ApiError> handleSelfRegistrationConflictException(
-            SelfRegistrationConflictException ex, WebRequest request) {
-
-        String correlationId = extractCorrelationId(request);
-        log.warn("Self-registration conflict (correlationId={}): {}", correlationId, ex.getMessage());
-        SelfRegistrationGuidance guidance = selfRegistrationGuidance(ex.getErrorCode());
-
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(errorResponse(
-                        ex.getErrorCode(),
-                        ex.getMessage(),
-                        HttpStatus.CONFLICT,
-                        correlationId,
-                        ex.getReferenceId() == null ? null : ex.getReferenceId().toString(),
-                        guidance.nextAction(),
-                        guidance.supportAction()));
-    }
-
-    @ExceptionHandler(SelfRegistrationReviewCaseNotFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ResponseEntity<ApiError> handleSelfRegistrationReviewCaseNotFoundException(
-            SelfRegistrationReviewCaseNotFoundException ex, WebRequest request) {
-
-        String correlationId = extractCorrelationId(request);
-        log.warn("Self-registration review case not found (correlationId={}): {}", correlationId, ex.getMessage());
-
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(errorResponse(
-                        "SELF_REGISTRATION_REVIEW_CASE_NOT_FOUND",
-                        ex.getMessage(),
-                        HttpStatus.NOT_FOUND,
-                        correlationId));
-    }
-
-    /**
-     * Handles IllegalArgumentException (validation failures).
-     *
-     * **Typical Causes:**
-     * - Invalid username or roles format
-     * - Blank or null required fields
-     * - Invalid refresh token
-     *
-     * **HTTP Status:** 400 Bad Request
-     *
-     * @param ex      the exception
-     * @param request the web request
-     * @return error response with 400 status and correlation ID
-     */
-    @ExceptionHandler(IllegalArgumentException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ResponseEntity<ApiError> handleIllegalArgumentException(IllegalArgumentException ex, WebRequest request) {
-
-        String correlationId = extractCorrelationId(request);
-        log.warn("Validation error (correlationId={}): {}", correlationId, ex.getMessage());
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(errorResponse(
-                        "INVALID_REQUEST",
-                        ex.getMessage() != null ? ex.getMessage() : "Invalid request parameters",
-                        HttpStatus.BAD_REQUEST,
-                        correlationId));
-    }
-
-    @ExceptionHandler({
-        MethodArgumentTypeMismatchException.class,
-        MethodArgumentNotValidException.class,
-        HttpMessageNotReadableException.class,
-        MissingServletRequestParameterException.class
-    })
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ResponseEntity<ApiError> handleBadRequestExceptions(Exception ex, WebRequest request) {
-        String correlationId = extractCorrelationId(request);
-        log.warn("Request binding/validation error (correlationId={}): {}", correlationId, ex.getMessage());
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(errorResponse(
-                        "INVALID_REQUEST", "Invalid request parameters", HttpStatus.BAD_REQUEST, correlationId));
-    }
-
-    @ExceptionHandler(AuthorizationDeniedException.class)
-    @ResponseStatus(HttpStatus.FORBIDDEN)
-    public ResponseEntity<ApiError> handleAuthorizationDeniedException(
-            AuthorizationDeniedException ex, WebRequest request, HttpServletRequest httpServletRequest) {
-        String correlationId = extractCorrelationId(request);
-        log.warn("Authorization denied (correlationId={}): {}", correlationId, ex.getMessage());
-
-        String actorId = getCurrentUsername();
-        String resourceUri = httpServletRequest != null ? httpServletRequest.getRequestURI() : "unknown";
-        String deniedPermissions = ex.getMessage() != null ? ex.getMessage() : "unknown";
-        try {
-            AuditEventService auditEventService =
-                    auditEventServiceProvider != null ? auditEventServiceProvider.getIfAvailable() : null;
-            if (auditEventService != null) {
-                auditEventService.createEvent(new AuditLogEventRequest(
-                        "PermissionDenied",
-                        actorId,
-                        resourceUri,
-                        "Authorization",
-                        "",
-                        "",
-                        Map.of(
-                                "message",
-                                deniedPermissions,
-                                "requestUri",
-                                resourceUri,
-                                "deniedPermissions",
-                                deniedPermissions)));
-            }
-        } catch (Exception auditException) {
-            log.warn(
-                    "Failed to persist PermissionDenied audit event (correlationId={}): {}",
-                    correlationId,
-                    auditException.getMessage());
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(errorResponse("ROLE_NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND,
+                                                correlationId));
         }
 
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(errorResponse("FORBIDDEN", "Access denied", HttpStatus.FORBIDDEN, correlationId));
-    }
+        /**
+         * Handles UserNotFoundException (user not found by ID or username).
+         *
+         * **HTTP Status:** 404 Not Found
+         *
+         * @param ex      the exception
+         * @param request the web request
+         * @return error response with 404 status and correlation ID
+         */
+        @ExceptionHandler(UserNotFoundException.class)
+        @ResponseStatus(HttpStatus.NOT_FOUND)
+        public ResponseEntity<ApiError> handleUserNotFoundException(UserNotFoundException ex, WebRequest request) {
 
-    @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<ApiError> handleIllegalStateException(IllegalStateException ex, WebRequest request) {
-        String correlationId = extractCorrelationId(request);
-        String message = ex.getMessage() != null ? ex.getMessage() : "Invalid state";
+                String correlationId = extractCorrelationId(request);
+                log.warn("User not found (correlationId={}): {}", correlationId, ex.getMessage());
 
-        if (message.contains("Overlapping role assignment")) {
-            log.warn("Role assignment overlap conflict (correlationId={}): {}", correlationId, message);
-            return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body(errorResponse("ROLE_ASSIGNMENT_CONFLICT", message, HttpStatus.CONFLICT, correlationId));
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(errorResponse("USER_NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND,
+                                                correlationId));
         }
 
-        log.warn("Illegal state (correlationId={}): {}", correlationId, message);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(errorResponse("INVALID_STATE", message, HttpStatus.BAD_REQUEST, correlationId));
-    }
+        /**
+         * Handles RoleAssignmentNotFoundException (role assignment not found by ID).
+         *
+         * **HTTP Status:** 404 Not Found
+         *
+         * @param ex      the exception
+         * @param request the web request
+         * @return error response with 404 status and correlation ID
+         */
+        @ExceptionHandler(RoleAssignmentNotFoundException.class)
+        @ResponseStatus(HttpStatus.NOT_FOUND)
+        public ResponseEntity<ApiError> handleRoleAssignmentNotFoundException(
+                        RoleAssignmentNotFoundException ex, WebRequest request) {
 
-    /**
-     * Handles ObjectOptimisticLockingFailureException (concurrency conflicts).
-     *
-     * **Typical Cause:**
-     * - Multiple threads attempting to revoke the same token simultaneously
-     * - Entity version mismatch during concurrent updates
-     *
-     * **Client Action:**
-     * - Retry request with exponential backoff (recommended: 3 retries)
-     * - Max retry delay: 400ms (100ms → 200ms → 400ms with 2x multiplier)
-     *
-     * **HTTP Status:** 409 Conflict
-     *
-     * @param ex      the exception
-     * @param request the web request
-     * @return error response with 409 status and correlation ID
-     */
-    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
-    @ResponseStatus(HttpStatus.CONFLICT)
-    public ResponseEntity<ApiError> handleOptimisticLockingFailure(
-            ObjectOptimisticLockingFailureException ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Role assignment not found (correlationId={}): {}", correlationId, ex.getMessage());
 
-        String correlationId = extractCorrelationId(request);
-        log.warn(
-                "Concurrency conflict (correlationId={}): Entity was modified concurrently. Retry with backoff.",
-                correlationId);
-
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(errorResponse(
-                        "CONCURRENCY_CONFLICT",
-                        "Token was modified concurrently. Please retry with exponential backoff.",
-                        HttpStatus.CONFLICT,
-                        correlationId));
-    }
-
-    /**
-     * Handles DuplicateRoleNameException (case-insensitive role name uniqueness
-     * violation).
-     *
-     * <p>
-     * Story #62: role names must be unique regardless of case.
-     *
-     * **HTTP Status:** 409 Conflict
-     */
-    @ExceptionHandler(DuplicateRoleNameException.class)
-    @ResponseStatus(HttpStatus.CONFLICT)
-    public ResponseEntity<ApiError> handleDuplicateRoleNameException(
-            DuplicateRoleNameException ex, WebRequest request) {
-
-        String correlationId = extractCorrelationId(request);
-        log.warn("Duplicate role name (correlationId={}): {}", correlationId, ex.getMessage());
-
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(errorResponse("DUPLICATE_ROLE_NAME", ex.getMessage(), HttpStatus.CONFLICT, correlationId));
-    }
-
-    /**
-     * Handles InvalidRefreshTokenException (valid JWT but user no longer exists
-     * or token not refreshable).
-     *
-     * <p>
-     * <b>HTTP Status:</b> 401 Unauthorized
-     *
-     * @param ex      the exception
-     * @param request the web request
-     * @return error response with 401 status and correlation ID
-     */
-    @ExceptionHandler(InvalidRefreshTokenException.class)
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ResponseEntity<ApiError> handleInvalidRefreshTokenException(
-            InvalidRefreshTokenException ex, WebRequest request) {
-        String correlationId = extractCorrelationId(request);
-        log.warn("Invalid refresh token (correlationId={}): {}", correlationId, ex.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(errorResponse("INVALID_REFRESH_TOKEN", ex.getMessage(), HttpStatus.UNAUTHORIZED, correlationId));
-    }
-
-    @ExceptionHandler(LockedException.class)
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ResponseEntity<ApiError> handleLockedException(LockedException ex, WebRequest request) {
-        String correlationId = extractCorrelationId(request);
-        log.warn("Authentication denied (correlationId={}): account is locked", correlationId);
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(errorResponse(
-                        "ACCOUNT_LOCKED",
-                        "Account is temporarily locked due to repeated failed login attempts",
-                        HttpStatus.UNAUTHORIZED,
-                        correlationId));
-    }
-
-    @ExceptionHandler(DisabledException.class)
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ResponseEntity<ApiError> handleDisabledException(DisabledException ex, WebRequest request) {
-        String correlationId = extractCorrelationId(request);
-        log.warn("Authentication denied (correlationId={}): account is disabled", correlationId);
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(errorResponse("ACCOUNT_DISABLED", "Account is disabled", HttpStatus.UNAUTHORIZED, correlationId));
-    }
-
-    @ExceptionHandler(AccountExpiredException.class)
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ResponseEntity<ApiError> handleAccountExpiredException(AccountExpiredException ex, WebRequest request) {
-        String correlationId = extractCorrelationId(request);
-        log.warn("Authentication denied (correlationId={}): account has expired", correlationId);
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(errorResponse("ACCOUNT_EXPIRED", "Account has expired", HttpStatus.UNAUTHORIZED, correlationId));
-    }
-
-    @ExceptionHandler(CredentialsExpiredException.class)
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ResponseEntity<ApiError> handleCredentialsExpiredException(
-            CredentialsExpiredException ex, WebRequest request) {
-        String correlationId = extractCorrelationId(request);
-        log.warn("Authentication denied (correlationId={}): credentials have expired", correlationId);
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(errorResponse(
-                        "CREDENTIALS_EXPIRED", "Credentials have expired", HttpStatus.UNAUTHORIZED, correlationId));
-    }
-
-    @ExceptionHandler(BadCredentialsException.class)
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public ResponseEntity<ApiError> handleBadCredentialsException(BadCredentialsException ex, WebRequest request) {
-        String correlationId = extractCorrelationId(request);
-        log.warn("Authentication failed (correlationId={}): invalid credentials", correlationId);
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(errorResponse(
-                        "INVALID_CREDENTIALS", "Invalid username or password", HttpStatus.UNAUTHORIZED, correlationId));
-    }
-
-    /**
-     * Handles generic exceptions (catch-all).
-     *
-     * **HTTP Status:** 500 Internal Server Error
-     *
-     * @param ex      the exception
-     * @param request the web request
-     * @return error response with 500 status and correlation ID
-     */
-    @ExceptionHandler(Exception.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public ResponseEntity<ApiError> handleGenericException(Exception ex, WebRequest request) {
-
-        String correlationId = extractCorrelationId(request);
-        log.error("Unhandled exception (correlationId={})", correlationId, ex);
-
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(errorResponse(
-                        "INTERNAL_SERVER_ERROR",
-                        "An unexpected error occurred. Please contact support with correlation ID: " + correlationId,
-                        HttpStatus.INTERNAL_SERVER_ERROR,
-                        correlationId));
-    }
-
-    /**
-     * Builds standardized error response object.
-     *
-     * @param code          error code for client processing
-     * @param message       human-readable error message
-     * @param status        HTTP status for the response
-     * @param correlationId request correlation ID for tracking
-     * @return error response record
-     */
-    private ApiError errorResponse(String code, String message, HttpStatus status, String correlationId) {
-        return errorResponse(code, message, status, correlationId, null, null, null);
-    }
-
-    private ApiError errorResponse(
-            String code,
-            String message,
-            HttpStatus status,
-            String correlationId,
-            String referenceId,
-            String nextAction,
-            String supportAction) {
-        return new ApiError(
-                code,
-                message,
-                status.value(),
-                Instant.now(clock).toString(),
-                correlationId,
-                null,
-                referenceId,
-                nextAction,
-                supportAction);
-    }
-
-    private SelfRegistrationGuidance selfRegistrationGuidance(String errorCode) {
-        return switch (errorCode) {
-            case "USER_ALREADY_EXISTS" ->
-                new SelfRegistrationGuidance(
-                        "Sign in with the existing account or use password recovery instead of registering again.",
-                        "Confirm that the submitted username or derived email username already maps to an active user in pos-security-service. Preserve the existing account.");
-            case "ACCOUNT_RECOVERY_REQUIRED" ->
-                new SelfRegistrationGuidance(
-                        "Use account recovery or reactivation instead of self-registration.",
-                        "Locate the existing inactive or already-linked account, verify the person linkage, and recover or reactivate it rather than creating a second user.");
-            case "PERSON_ALREADY_HAS_ACTIVE_USER" ->
-                new SelfRegistrationGuidance(
-                        "Use the already-linked account instead of creating a new one.",
-                        "Review the resolved person's linked users in pos-people and pos-security-service. Maintain the 1:1 person-to-active-user rule.");
-            case "USER_PERSON_LINK_CONFLICT" ->
-                new SelfRegistrationGuidance(
-                        "Retry later or contact support with the correlation ID.",
-                        "Investigate user-person linkage consistency between pos-security-service and pos-people before retrying registration.");
-            case "CRM_PERSON_CONFLICT" ->
-                new SelfRegistrationGuidance(
-                        "Do not retry self-registration. Contact support to review the existing customer or contact identity.",
-                        "Review CRM person matches, people resolution output, and linked users before creating or linking any account.");
-            case "IDEMPOTENCY_KEY_REUSED" ->
-                new SelfRegistrationGuidance(
-                        "Retry with the original request payload or generate a new idempotency key.",
-                        "Confirm whether the original request already completed, then either reuse that payload or instruct the caller to submit a new key.");
-            default ->
-                new SelfRegistrationGuidance(
-                        "Contact support with the correlation ID if the problem continues.",
-                        "Review the self-registration correlation ID and downstream identity resolution logs.");
-        };
-    }
-
-    private record SelfRegistrationGuidance(String nextAction, String supportAction) {}
-
-    /**
-     * Extracts correlation ID from request header or generates new one.
-     *
-     * **Priority:**
-     * 1. X-Correlation-Id header (if present)
-     * 2. Generate new UUID v4
-     *
-     * @param request the web request
-     * @return correlation ID (never null)
-     */
-    private String extractCorrelationId(WebRequest request) {
-        String correlationId = request.getHeader("X-Correlation-Id");
-        if (correlationId == null || correlationId.isBlank()) {
-            correlationId = UUIDv7Generator.generate().toString();
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(errorResponse("ROLE_ASSIGNMENT_NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND,
+                                                correlationId));
         }
-        return correlationId;
-    }
 
-    private String getCurrentUsername() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.isAuthenticated()) {
-            return authentication.getName();
+        /**
+         * Handles PermissionNotFoundException (permission not found by name).
+         *
+         * **HTTP Status:** 404 Not Found
+         *
+         * @param ex      the exception
+         * @param request the web request
+         * @return error response with 404 status and correlation ID
+         */
+        @ExceptionHandler(PermissionNotFoundException.class)
+        @ResponseStatus(HttpStatus.NOT_FOUND)
+        public ResponseEntity<ApiError> handlePermissionNotFoundException(
+                        PermissionNotFoundException ex, WebRequest request) {
+
+                String correlationId = extractCorrelationId(request);
+                log.warn("Permission not found (correlationId={}): {}", correlationId, ex.getMessage());
+
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(errorResponse("PERMISSION_NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND,
+                                                correlationId));
         }
-        return "system";
-    }
+
+        @ExceptionHandler(EntityNotFoundException.class)
+        @ResponseStatus(HttpStatus.NOT_FOUND)
+        public ResponseEntity<ApiError> handleEntityNotFoundException(EntityNotFoundException ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Entity not found (correlationId={}): {}", correlationId, ex.getMessage());
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(errorResponse("NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND, correlationId));
+        }
+
+        @ExceptionHandler(SelfRegistrationConflictException.class)
+        @ResponseStatus(HttpStatus.CONFLICT)
+        public ResponseEntity<ApiError> handleSelfRegistrationConflictException(
+                        SelfRegistrationConflictException ex, WebRequest request) {
+
+                String correlationId = extractCorrelationId(request);
+                log.warn("Self-registration conflict (correlationId={}): {}", correlationId, ex.getMessage());
+                SelfRegistrationGuidance guidance = selfRegistrationGuidance(ex.getErrorCode());
+
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                                .body(errorResponse(
+                                                ex.getErrorCode(),
+                                                ex.getMessage(),
+                                                HttpStatus.CONFLICT,
+                                                correlationId,
+                                                ex.getReferenceId() == null ? null : ex.getReferenceId().toString(),
+                                                guidance.nextAction(),
+                                                guidance.supportAction()));
+        }
+
+        @ExceptionHandler(SelfRegistrationReviewCaseNotFoundException.class)
+        @ResponseStatus(HttpStatus.NOT_FOUND)
+        public ResponseEntity<ApiError> handleSelfRegistrationReviewCaseNotFoundException(
+                        SelfRegistrationReviewCaseNotFoundException ex, WebRequest request) {
+
+                String correlationId = extractCorrelationId(request);
+                log.warn("Self-registration review case not found (correlationId={}): {}", correlationId,
+                                ex.getMessage());
+
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(errorResponse(
+                                                "SELF_REGISTRATION_REVIEW_CASE_NOT_FOUND",
+                                                ex.getMessage(),
+                                                HttpStatus.NOT_FOUND,
+                                                correlationId));
+        }
+
+        /**
+         * Handles IllegalArgumentException (validation failures).
+         *
+         * **Typical Causes:**
+         * - Invalid username or roles format
+         * - Blank or null required fields
+         * - Invalid refresh token
+         *
+         * **HTTP Status:** 400 Bad Request
+         *
+         * @param ex      the exception
+         * @param request the web request
+         * @return error response with 400 status and correlation ID
+         */
+        @ExceptionHandler(IllegalArgumentException.class)
+        @ResponseStatus(HttpStatus.BAD_REQUEST)
+        public ResponseEntity<ApiError> handleIllegalArgumentException(IllegalArgumentException ex,
+                        WebRequest request) {
+
+                String correlationId = extractCorrelationId(request);
+                log.warn("Validation error (correlationId={}): {}", correlationId, ex.getMessage());
+
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(errorResponse(
+                                                "INVALID_REQUEST",
+                                                ex.getMessage() != null ? ex.getMessage()
+                                                                : "Invalid request parameters",
+                                                HttpStatus.BAD_REQUEST,
+                                                correlationId));
+        }
+
+        @ExceptionHandler({
+                        MethodArgumentTypeMismatchException.class,
+                        MethodArgumentNotValidException.class,
+                        HttpMessageNotReadableException.class,
+                        MissingServletRequestParameterException.class
+        })
+        @ResponseStatus(HttpStatus.BAD_REQUEST)
+        public ResponseEntity<ApiError> handleBadRequestExceptions(Exception ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Request binding/validation error (correlationId={}): {}", correlationId, ex.getMessage());
+
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(errorResponse(
+                                                "INVALID_REQUEST", "Invalid request parameters", HttpStatus.BAD_REQUEST,
+                                                correlationId));
+        }
+
+        @ExceptionHandler(AuthorizationDeniedException.class)
+        @ResponseStatus(HttpStatus.FORBIDDEN)
+        public ResponseEntity<ApiError> handleAuthorizationDeniedException(
+                        AuthorizationDeniedException ex, WebRequest request, HttpServletRequest httpServletRequest) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Authorization denied (correlationId={}): {}", correlationId, ex.getMessage());
+
+                String actorId = getCurrentUsername();
+                String resourceUri = httpServletRequest != null ? httpServletRequest.getRequestURI() : "unknown";
+                String deniedPermissions = ex.getMessage() != null ? ex.getMessage() : "unknown";
+                try {
+                        AuditEventService auditEventService = auditEventServiceProvider != null
+                                        ? auditEventServiceProvider.getIfAvailable()
+                                        : null;
+                        if (auditEventService != null) {
+                                auditEventService.createEvent(new AuditLogEventRequest(
+                                                "PermissionDenied",
+                                                actorId,
+                                                resourceUri,
+                                                "Authorization",
+                                                "",
+                                                "",
+                                                Map.of(
+                                                                "message",
+                                                                deniedPermissions,
+                                                                "requestUri",
+                                                                resourceUri,
+                                                                "deniedPermissions",
+                                                                deniedPermissions)));
+                        }
+                } catch (Exception auditException) {
+                        log.warn(
+                                        "Failed to persist PermissionDenied audit event (correlationId={}): {}",
+                                        correlationId,
+                                        auditException.getMessage());
+                }
+
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                                .body(errorResponse("FORBIDDEN", "Access denied", HttpStatus.FORBIDDEN, correlationId));
+        }
+
+        @ExceptionHandler(IllegalStateException.class)
+        public ResponseEntity<ApiError> handleIllegalStateException(IllegalStateException ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                String message = ex.getMessage() != null ? ex.getMessage() : "Invalid state";
+
+                if (message.contains("Overlapping role assignment")) {
+                        log.warn("Role assignment overlap conflict (correlationId={}): {}", correlationId, message);
+                        return ResponseEntity.status(HttpStatus.CONFLICT)
+                                        .body(errorResponse("ROLE_ASSIGNMENT_CONFLICT", message, HttpStatus.CONFLICT,
+                                                        correlationId));
+                }
+
+                log.warn("Illegal state (correlationId={}): {}", correlationId, message);
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(errorResponse("INVALID_STATE", message, HttpStatus.BAD_REQUEST, correlationId));
+        }
+
+        /**
+         * Handles ObjectOptimisticLockingFailureException (concurrency conflicts).
+         *
+         * **Typical Cause:**
+         * - Multiple threads attempting to revoke the same token simultaneously
+         * - Entity version mismatch during concurrent updates
+         *
+         * **Client Action:**
+         * - Retry request with exponential backoff (recommended: 3 retries)
+         * - Max retry delay: 400ms (100ms → 200ms → 400ms with 2x multiplier)
+         *
+         * **HTTP Status:** 409 Conflict
+         *
+         * @param ex      the exception
+         * @param request the web request
+         * @return error response with 409 status and correlation ID
+         */
+        @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+        @ResponseStatus(HttpStatus.CONFLICT)
+        public ResponseEntity<ApiError> handleOptimisticLockingFailure(
+                        ObjectOptimisticLockingFailureException ex, WebRequest request) {
+
+                String correlationId = extractCorrelationId(request);
+                log.warn(
+                                "Concurrency conflict (correlationId={}): Entity was modified concurrently. Retry with backoff.",
+                                correlationId);
+
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                                .body(errorResponse(
+                                                "CONCURRENCY_CONFLICT",
+                                                "Token was modified concurrently. Please retry with exponential backoff.",
+                                                HttpStatus.CONFLICT,
+                                                correlationId));
+        }
+
+        /**
+         * Handles DuplicateRoleNameException (case-insensitive role name uniqueness
+         * violation).
+         *
+         * <p>
+         * Story #62: role names must be unique regardless of case.
+         *
+         * **HTTP Status:** 409 Conflict
+         */
+        @ExceptionHandler(DuplicateRoleNameException.class)
+        @ResponseStatus(HttpStatus.CONFLICT)
+        public ResponseEntity<ApiError> handleDuplicateRoleNameException(
+                        DuplicateRoleNameException ex, WebRequest request) {
+
+                String correlationId = extractCorrelationId(request);
+                log.warn("Duplicate role name (correlationId={}): {}", correlationId, ex.getMessage());
+
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                                .body(errorResponse("DUPLICATE_ROLE_NAME", ex.getMessage(), HttpStatus.CONFLICT,
+                                                correlationId));
+        }
+
+        /**
+         * Handles InvalidRefreshTokenException (valid JWT but user no longer exists
+         * or token not refreshable).
+         *
+         * <p>
+         * <b>HTTP Status:</b> 401 Unauthorized
+         *
+         * @param ex      the exception
+         * @param request the web request
+         * @return error response with 401 status and correlation ID
+         */
+        @ExceptionHandler(InvalidRefreshTokenException.class)
+        @ResponseStatus(HttpStatus.UNAUTHORIZED)
+        public ResponseEntity<ApiError> handleInvalidRefreshTokenException(
+                        InvalidRefreshTokenException ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Invalid refresh token (correlationId={}): {}", correlationId, ex.getMessage());
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                                .body(errorResponse("INVALID_REFRESH_TOKEN", ex.getMessage(), HttpStatus.UNAUTHORIZED,
+                                                correlationId));
+        }
+
+        @ExceptionHandler(LockedException.class)
+        @ResponseStatus(HttpStatus.UNAUTHORIZED)
+        public ResponseEntity<ApiError> handleLockedException(LockedException ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Authentication denied (correlationId={}): account is locked", correlationId);
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                                .body(errorResponse(
+                                                "ACCOUNT_LOCKED",
+                                                "Account is temporarily locked due to repeated failed login attempts",
+                                                HttpStatus.UNAUTHORIZED,
+                                                correlationId));
+        }
+
+        @ExceptionHandler(DisabledException.class)
+        @ResponseStatus(HttpStatus.UNAUTHORIZED)
+        public ResponseEntity<ApiError> handleDisabledException(DisabledException ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Authentication denied (correlationId={}): account is disabled", correlationId);
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                                .body(errorResponse("ACCOUNT_DISABLED", "Account is disabled", HttpStatus.UNAUTHORIZED,
+                                                correlationId));
+        }
+
+        @ExceptionHandler(AccountExpiredException.class)
+        @ResponseStatus(HttpStatus.UNAUTHORIZED)
+        public ResponseEntity<ApiError> handleAccountExpiredException(AccountExpiredException ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Authentication denied (correlationId={}): account has expired", correlationId);
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                                .body(errorResponse("ACCOUNT_EXPIRED", "Account has expired", HttpStatus.UNAUTHORIZED,
+                                                correlationId));
+        }
+
+        @ExceptionHandler(CredentialsExpiredException.class)
+        @ResponseStatus(HttpStatus.UNAUTHORIZED)
+        public ResponseEntity<ApiError> handleCredentialsExpiredException(
+                        CredentialsExpiredException ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Authentication denied (correlationId={}): credentials have expired", correlationId);
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                                .body(errorResponse(
+                                                "CREDENTIALS_EXPIRED", "Credentials have expired",
+                                                HttpStatus.UNAUTHORIZED, correlationId));
+        }
+
+        @ExceptionHandler(BadCredentialsException.class)
+        @ResponseStatus(HttpStatus.UNAUTHORIZED)
+        public ResponseEntity<ApiError> handleBadCredentialsException(BadCredentialsException ex, WebRequest request) {
+                String correlationId = extractCorrelationId(request);
+                log.warn("Authentication failed (correlationId={}): invalid credentials", correlationId);
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                                .body(errorResponse(
+                                                "INVALID_CREDENTIALS", "Invalid username or password",
+                                                HttpStatus.UNAUTHORIZED, correlationId));
+        }
+
+        /**
+         * Handles generic exceptions (catch-all).
+         *
+         * **HTTP Status:** 500 Internal Server Error
+         *
+         * @param ex      the exception
+         * @param request the web request
+         * @return error response with 500 status and correlation ID
+         */
+        @ExceptionHandler(Exception.class)
+        @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+        public ResponseEntity<ApiError> handleGenericException(Exception ex, WebRequest request) {
+
+                String correlationId = extractCorrelationId(request);
+                log.error("Unhandled exception (correlationId={})", correlationId, ex);
+
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                .body(errorResponse(
+                                                "INTERNAL_SERVER_ERROR",
+                                                "An unexpected error occurred. Please contact support with correlation ID: "
+                                                                + correlationId,
+                                                HttpStatus.INTERNAL_SERVER_ERROR,
+                                                correlationId));
+        }
+
+        /**
+         * Builds standardized error response object.
+         *
+         * @param code          error code for client processing
+         * @param message       human-readable error message
+         * @param status        HTTP status for the response
+         * @param correlationId request correlation ID for tracking
+         * @return error response record
+         */
+        private ApiError errorResponse(String code, String message, HttpStatus status, String correlationId) {
+                return errorResponse(code, message, status, correlationId, null, null, null);
+        }
+
+        private ApiError errorResponse(
+                        String code,
+                        String message,
+                        HttpStatus status,
+                        String correlationId,
+                        String referenceId,
+                        String nextAction,
+                        String supportAction) {
+                return new ApiError(
+                                code,
+                                message,
+                                status.value(),
+                                Instant.now(clock).toString(),
+                                correlationId,
+                                null,
+                                referenceId,
+                                nextAction,
+                                supportAction);
+        }
+
+        private SelfRegistrationGuidance selfRegistrationGuidance(String errorCode) {
+                return switch (errorCode) {
+                        case "USER_ALREADY_EXISTS" ->
+                                new SelfRegistrationGuidance(
+                                                "Sign in with the existing account or use password recovery instead of registering again.",
+                                                "Confirm that the submitted username or derived email username already maps to an active user in pos-security-service. Preserve the existing account.");
+                        case "ACCOUNT_RECOVERY_REQUIRED" ->
+                                new SelfRegistrationGuidance(
+                                                "Use account recovery or reactivation instead of self-registration.",
+                                                "Locate the existing inactive or already-linked account, verify the person linkage, and recover or reactivate it rather than creating a second user.");
+                        case "PERSON_ALREADY_HAS_ACTIVE_USER" ->
+                                new SelfRegistrationGuidance(
+                                                "Use the already-linked account instead of creating a new one.",
+                                                "Review the resolved person's linked users in pos-people and pos-security-service. Maintain the 1:1 person-to-active-user rule.");
+                        case "USER_PERSON_LINK_CONFLICT" ->
+                                new SelfRegistrationGuidance(
+                                                "Retry later or contact support with the correlation ID.",
+                                                "Investigate user-person linkage consistency between pos-security-service and pos-people before retrying registration.");
+                        case "CRM_PERSON_CONFLICT" ->
+                                new SelfRegistrationGuidance(
+                                                "Do not retry self-registration. Contact support to review the existing customer or contact identity.",
+                                                "Review CRM person matches, people resolution output, and linked users before creating or linking any account.");
+                        case "IDEMPOTENCY_KEY_REUSED" ->
+                                new SelfRegistrationGuidance(
+                                                "Retry with the original request payload or generate a new idempotency key.",
+                                                "Confirm whether the original request already completed, then either reuse that payload or instruct the caller to submit a new key.");
+                        default ->
+                                new SelfRegistrationGuidance(
+                                                "Contact support with the correlation ID if the problem continues.",
+                                                "Review the self-registration correlation ID and downstream identity resolution logs.");
+                };
+        }
+
+        private record SelfRegistrationGuidance(String nextAction, String supportAction) {
+        }
+
+        /**
+         * Extracts correlation ID from request header or generates new one.
+         *
+         * **Priority:**
+         * 1. X-Correlation-Id header (if present)
+         * 2. Generate new UUID v4
+         *
+         * @param request the web request
+         * @return correlation ID (never null)
+         */
+        private String extractCorrelationId(WebRequest request) {
+                String correlationId = request.getHeader("X-Correlation-Id");
+                if (correlationId == null || correlationId.isBlank()) {
+                        correlationId = UUIDv7Generator.generate().toString();
+                }
+                return correlationId;
+        }
+
+        private String getCurrentUsername() {
+                Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+                if (authentication != null && authentication.isAuthenticated()) {
+                        return authentication.getName();
+                }
+                return "system";
+        }
 }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditController.java
@@ -1,6 +1,7 @@
 package com.positivity.securityservice.internal.controller;
 
 import com.positivity.events.EmitEvent;
+import com.positivity.securityservice.internal.dto.AuditEventSearchFilter;
 import com.positivity.securityservice.internal.dto.AuditEventCreatedResponse;
 import com.positivity.securityservice.internal.dto.AuditLogEventDto;
 import com.positivity.securityservice.internal.dto.AuditLogEventRequest;
@@ -21,6 +22,8 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,6 +47,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/audit")
 @RequiredArgsConstructor
 @Tag(name = "Audit", description = "Audit event and pricing snapshot endpoints with immutable write-once behavior")
+@io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
 public class AuditController {
 
         private final AuditEventService auditEventService;
@@ -51,12 +55,11 @@ public class AuditController {
 
         @EmitEvent(id = "SECURITY_AUDIT_EVENT_CREATE", apiVersion = "1")
         @PostMapping("/events")
-        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-                        "security:audit:create" })
         @PreAuthorize("hasAuthority('security:audit:create')")
         @Operation(summary = "Create audit event", description = "Creates an immutable audit event record and returns the generated event identifier.")
-        @ApiResponse(responseCode = "201", description = "Audit event created")
+        @ApiResponse(responseCode = "201", description = "Audit event created", content = @Content(schema = @Schema(implementation = AuditEventCreatedResponse.class)))
         @ApiResponse(responseCode = "400", description = "Invalid audit event payload", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Insufficient authority", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<AuditEventCreatedResponse> createEvent(
                         @RequestBody @NonNull AuditLogEventRequest request) {
                 AuditLogEventDto created = auditEventService.createEvent(request);
@@ -68,52 +71,57 @@ public class AuditController {
         }
 
         @GetMapping("/events/{eventId}")
-        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-                        "security:audit:view" })
         @PreAuthorize("hasAuthority('security:audit:view')")
         @Operation(summary = "Get audit event", description = "Returns a previously recorded audit event by its event identifier.")
-        @ApiResponse(responseCode = "200", description = "Audit event returned successfully")
+        @ApiResponse(responseCode = "200", description = "Audit event returned successfully", content = @Content(schema = @Schema(implementation = AuditLogEventDto.class)))
+        @ApiResponse(responseCode = "403", description = "Insufficient authority", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "404", description = "Audit event not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<AuditLogEventDto> getEvent(@PathVariable @NonNull UUID eventId) {
                 return ResponseEntity.ok(auditEventService.getEvent(eventId));
         }
 
         @GetMapping("/events")
-        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-                        "security:audit:view" })
         @PreAuthorize("hasAuthority('security:audit:view')")
-        @Operation(summary = "Search audit events", description = "Searches audit events by event type alone or by entity identity with an optional time range.")
-        @ApiResponse(responseCode = "200", description = "Audit events returned successfully")
-        @ApiResponse(responseCode = "400", description = "Invalid audit search criteria", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<List<AuditLogEventDto>> searchEvents(
-                        @Parameter(description = "Entity identifier to match. Must be supplied together with entityType.") @RequestParam(required = false) String entityId,
-                        @Parameter(description = "Entity type to match. Must be supplied together with entityId.") @RequestParam(required = false) String entityType,
-                        @Parameter(description = "Event type code to search by when not searching by entity.") @RequestParam(required = false) String eventType,
-                        @Parameter(description = "Inclusive start timestamp for the audit search window.", example = "2026-01-01T00:00:00Z") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
-                        @Parameter(description = "Inclusive end timestamp for the audit search window.", example = "2026-01-31T23:59:59Z") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
-                if (eventType != null
-                                && !eventType.isBlank()
-                                && entityId == null
-                                && entityType == null
-                                && from == null
-                                && to == null) {
-                        return ResponseEntity.ok(auditEventService.searchByEventType(eventType));
-                }
+        @Operation(operationId = "searchAuditEvents", summary = "Search audit events", description = "Searches audit events using rich filter criteria with pagination support.")
+        @ApiResponse(responseCode = "200", description = "Audit events returned successfully", content = @Content(schema = @Schema(description = "Paged list of audit events")))
+        @ApiResponse(responseCode = "400", description = "Invalid filter criteria", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Insufficient authority", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<Page<AuditLogEventDto>> searchAuditEvents(
+                        @Parameter(description = "Inclusive start timestamp (ISO-8601)", example = "2026-01-01T00:00:00Z") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant fromDate,
+                        @Parameter(description = "Exclusive end timestamp (ISO-8601)", example = "2026-12-31T23:59:59Z") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant toDate,
+                        @Parameter(description = "Actor username or user identifier", example = "advisor.jane") @RequestParam(required = false) String actorId,
+                        @Parameter(description = "Workorder UUID - one word per workspace naming policy") @RequestParam(required = false) UUID workorderId,
+                        @Parameter(description = "Movement UUID", example = "77777777-7777-7777-7777-777777777777") @RequestParam(required = false) UUID movementId,
+                        @Parameter(description = "Product UUID", example = "88888888-8888-8888-8888-888888888888") @RequestParam(required = false) UUID productId,
+                        @Parameter(description = "SKU code", example = "BRAKE-PAD-001") @RequestParam(required = false) String sku,
+                        @Parameter(description = "Event type code", example = "PERMISSION_DENIED") @RequestParam(required = false) String eventType,
+                        @Parameter(description = "Aggregate identifier", example = "role:manager") @RequestParam(required = false) String aggregateId,
+                        @Parameter(description = "Correlation ID UUID for distributed tracing", example = "99999999-9999-9999-9999-999999999999") @RequestParam(required = false) UUID correlationId,
+                        @Parameter(description = "Reason code string", example = "MANUAL_REVIEW") @RequestParam(required = false) String reasonCode,
+                        @Parameter(description = "Cursor token for page navigation", example = "eyJwYWdlIjoyfQ") @RequestParam(required = false) String pageToken,
+                        @Parameter(description = "Location UUID list - repeated query param", example = "11111111-1111-1111-1111-111111111111") @RequestParam(required = false) List<String> locationIds,
+                        @Parameter(hidden = true) Pageable pageable) {
 
-                if ((entityId == null) != (entityType == null)) {
-                        throw new IllegalArgumentException("entityId and entityType must be provided together");
-                }
+                AuditEventSearchFilter filter = AuditEventSearchFilter.builder()
+                                .fromDate(fromDate)
+                                .toDate(toDate)
+                                .actorId(actorId)
+                                .workorderId(workorderId)
+                                .movementId(movementId)
+                                .productId(productId)
+                                .sku(sku)
+                                .eventType(eventType)
+                                .aggregateId(aggregateId)
+                                .correlationId(correlationId)
+                                .reasonCode(reasonCode)
+                                .pageToken(pageToken)
+                                .locationIds(locationIds)
+                                .build();
 
-                if (entityId == null && entityType == null) {
-                        throw new IllegalArgumentException("Provide eventType or both entityId and entityType");
-                }
-
-                return ResponseEntity.ok(auditEventService.searchEvents(entityId, entityType, from, to));
+                return ResponseEntity.ok(auditEventService.searchEventsFiltered(filter, pageable));
         }
 
         @DeleteMapping("/events/**")
-        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-                        "security:audit:create" })
         @PreAuthorize("hasAuthority('security:audit:create')")
         @Operation(summary = "Delete audit events not allowed", description = "Audit events are immutable and cannot be deleted once recorded.")
         @ApiResponse(responseCode = "405", description = "Method not allowed for immutable audit events")
@@ -122,8 +130,6 @@ public class AuditController {
         }
 
         @PutMapping("/events/**")
-        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-                        "security:audit:create" })
         @PreAuthorize("hasAuthority('security:audit:create')")
         @Operation(summary = "Update audit events not allowed", description = "Audit events are immutable and cannot be modified after creation.")
         @ApiResponse(responseCode = "405", description = "Method not allowed for immutable audit events")
@@ -133,8 +139,6 @@ public class AuditController {
 
         @EmitEvent(id = "SECURITY_AUDIT_PRICING_SNAPSHOT_CREATE", apiVersion = "1")
         @PostMapping("/pricing-snapshots")
-        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-                        "security:audit:create" })
         @PreAuthorize("hasAuthority('security:audit:create')")
         @Operation(summary = "Create pricing snapshot", description = "Creates an immutable pricing snapshot record for later audit and traceability.")
         @ApiResponse(responseCode = "201", description = "Pricing snapshot created")
@@ -149,8 +153,6 @@ public class AuditController {
         }
 
         @GetMapping("/pricing-snapshots/{snapshotId}")
-        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-                        "security:audit:view" })
         @PreAuthorize("hasAuthority('security:audit:view')")
         @Operation(summary = "Get pricing snapshot", description = "Returns an immutable pricing snapshot by its snapshot identifier.")
         @ApiResponse(responseCode = "200", description = "Pricing snapshot returned successfully")

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditController.java
@@ -83,7 +83,7 @@ public class AuditController {
         @GetMapping("/events")
         @PreAuthorize("hasAuthority('security:audit:view')")
         @Operation(operationId = "searchAuditEvents", summary = "Search audit events", description = "Searches audit events using rich filter criteria with pagination support.")
-        @ApiResponse(responseCode = "200", description = "Audit events returned successfully", content = @Content(schema = @Schema(description = "Paged list of audit events")))
+        @ApiResponse(responseCode = "200", description = "Audit events returned successfully")
         @ApiResponse(responseCode = "400", description = "Invalid filter criteria", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "403", description = "Insufficient authority", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<Page<AuditLogEventDto>> searchAuditEvents(

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditExportController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditExportController.java
@@ -1,0 +1,71 @@
+package com.positivity.securityservice.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.securityservice.internal.dto.AuditExportJobResponse;
+import com.positivity.securityservice.internal.dto.AuditExportRequest;
+import com.positivity.securityservice.service.AuditExportService;
+import com.positivity.shared.error.ApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/audit/exports")
+@RequiredArgsConstructor
+@Tag(name = "Audit Exports", description = "Asynchronous audit export job management")
+@io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
+public class AuditExportController {
+
+  private final AuditExportService auditExportService;
+
+  @EmitEvent(id = "SECURITY_AUDIT_EXPORT_REQUEST", apiVersion = "1")
+  @PostMapping
+  @PreAuthorize("hasAuthority('security:audit:export')")
+  /**
+   * Note: This endpoint intentionally returns 202 Accepted (not 201 Created)
+   * because
+   * audit export job submission is an async operation. The job is created and
+   * queued
+   * immediately, but execution is deferred. 202 Accepted is semantically correct
+   * per
+   * RFC 7231 section 6.3.3 for asynchronous processing. ADR-0017 covers
+   * synchronous resource
+   * creation (201); this deviation is intentional for async job endpoints.
+   */
+  @Operation(operationId = "requestAuditExport", summary = "Request audit export", description = "Submits an asynchronous audit export job. Returns 202 Accepted with the created job reference.")
+  @ApiResponse(responseCode = "202", description = "Export job created", content = @Content(schema = @Schema(implementation = AuditExportJobResponse.class)))
+  @ApiResponse(responseCode = "400", description = "Invalid export request", content = @Content(schema = @Schema(implementation = ApiError.class)))
+  @ApiResponse(responseCode = "403", description = "Insufficient authority", content = @Content(schema = @Schema(implementation = ApiError.class)))
+  public ResponseEntity<AuditExportJobResponse> requestAuditExport(
+      @RequestBody @Valid @NonNull AuditExportRequest request) {
+    AuditExportJobResponse response = auditExportService.requestExport(request);
+    return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
+  }
+
+  @GetMapping("/{jobId}")
+  @PreAuthorize("hasAuthority('security:audit:export')")
+  @Operation(operationId = "getAuditExportJob", summary = "Get audit export job status", description = "Returns the current status of a previously submitted audit export job.")
+  @ApiResponse(responseCode = "200", description = "Export job status", content = @Content(schema = @Schema(implementation = AuditExportJobResponse.class)))
+  @ApiResponse(responseCode = "403", description = "Insufficient authority", content = @Content(schema = @Schema(implementation = ApiError.class)))
+  @ApiResponse(responseCode = "404", description = "Export job not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
+  public ResponseEntity<AuditExportJobResponse> getAuditExportJob(
+      @Parameter(description = "Export job UUID", required = true, example = "550e8400-e29b-41d4-a716-446655440000") @PathVariable @NonNull UUID jobId) {
+    return ResponseEntity.ok(auditExportService.getExportJob(jobId));
+  }
+}

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/PermissionController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/PermissionController.java
@@ -10,7 +10,12 @@ import com.positivity.securityservice.internal.dto.PermissionRegistrationRespons
 import com.positivity.securityservice.service.PermissionCatalogVersionService;
 import com.positivity.securityservice.service.PermissionRegistryService;
 import com.positivity.securityservice.service.PermissionService;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -18,6 +23,8 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.StringUtils;
@@ -101,18 +108,6 @@ public class PermissionController {
     }
 
     /**
-     * Issue #42: Query permissions by domain.
-     */
-    @GetMapping(params = "domain")
-    @Operation(summary = "Query permissions by domain", description = "Returns all registered permissions for the requested domain using the domain query parameter.")
-    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-            "security:permission:view" })
-    @PreAuthorize("hasAuthority('security:permission:view')")
-    public ResponseEntity<List<PermissionDto>> getPermissionsByDomainQuery(@RequestParam @NonNull String domain) {
-        return ResponseEntity.ok(permissionService.getByDomain(domain));
-    }
-
-    /**
      * Register or update permissions from a service
      */
     @EmitEvent(id = "SECURITY_PERMISSION_REGISTER", apiVersion = "1")
@@ -135,16 +130,19 @@ public class PermissionController {
         }
     }
 
-    /**
-     * Get all registered permissions
-     */
     @GetMapping
-    @PreAuthorize("hasAuthority('security:permission:view')")
-    @Operation(summary = "Get all registered permissions", description = "Returns all permissions in the registry")
+    @Operation(operationId = "listPermissions", summary = "List permissions", description = "Returns a paged list of registered permissions, optionally filtered by domain.")
+    @ApiResponse(responseCode = "200", description = "Permissions returned", content = @Content(schema = @Schema(implementation = Page.class)))
+    @ApiResponse(responseCode = "400", description = "Invalid pagination parameters", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(responseCode = "403", description = "Insufficient authority", content = @Content(schema = @Schema(implementation = ApiError.class)))
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
             "security:permission:view" })
-    public ResponseEntity<List<PermissionDto>> getAllPermissions() {
-        return ResponseEntity.ok(permissionRegistryService.getAllPermissions());
+    @PreAuthorize("hasAuthority('security:permission:view')")
+    public ResponseEntity<Page<PermissionDto>> listPermissions(
+            @Parameter(description = "Optional domain filter", required = false, example = "catalog") @RequestParam(required = false) String domain,
+            @Parameter(hidden = true) Pageable pageable) {
+        Page<PermissionDto> permissions = permissionService.listPermissions(domain, pageable);
+        return ResponseEntity.ok(permissions);
     }
 
     /**

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/dto/AuditEventSearchFilter.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/dto/AuditEventSearchFilter.java
@@ -1,0 +1,60 @@
+package com.positivity.securityservice.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Rich filter criteria for the audit event search endpoint (B-3).
+ * All fields are optional; an empty filter returns all events paged.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Filter criteria for audit event search")
+public class AuditEventSearchFilter {
+  @Schema(description = "Inclusive start timestamp (ISO-8601)", example = "2026-01-01T00:00:00Z")
+  private Instant fromDate;
+
+  @Schema(description = "Exclusive end timestamp (ISO-8601)", example = "2026-12-31T23:59:59Z")
+  private Instant toDate;
+
+  @Schema(description = "Actor username/service principal")
+  private String actorId;
+
+  @Schema(description = "Workorder UUID - one word per workspace naming policy")
+  private UUID workorderId;
+
+  @Schema(description = "Movement UUID")
+  private UUID movementId;
+
+  @Schema(description = "Product UUID")
+  private UUID productId;
+
+  @Schema(description = "SKU code")
+  private String sku;
+
+  @Schema(description = "Event type code")
+  private String eventType;
+
+  @Schema(description = "Aggregate identifier (string)")
+  private String aggregateId;
+
+  @Schema(description = "Correlation ID UUID for tracing")
+  private UUID correlationId;
+
+  @Schema(description = "Reason code string")
+  private String reasonCode;
+
+  @Schema(description = "Cursor token for page-based navigation")
+  private String pageToken;
+
+  @Schema(description = "Location UUID list filter")
+  private List<String> locationIds;
+}

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/dto/AuditExportJobResponse.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/dto/AuditExportJobResponse.java
@@ -1,0 +1,39 @@
+package com.positivity.securityservice.internal.dto;
+
+import com.positivity.securityservice.internal.enums.AuditExportStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response for audit export job operations (B-4).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Audit export job status response")
+public class AuditExportJobResponse {
+
+  @Schema(description = "Export job UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+  private UUID jobId;
+
+  @Schema(description = "Current status of the export job")
+  private AuditExportStatus status;
+
+  @Schema(description = "Timestamp when the export was requested")
+  private Instant requestedAt;
+
+  @Schema(description = "Timestamp when the export completed (null if not yet complete)")
+  private Instant completedAt;
+
+  @Schema(description = "Pre-signed download URL (null until COMPLETED)")
+  private String downloadUrl;
+
+  @Schema(description = "Error message when status is FAILED")
+  private String errorMessage;
+}

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/dto/AuditExportRequest.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/dto/AuditExportRequest.java
@@ -1,0 +1,32 @@
+package com.positivity.securityservice.internal.dto;
+
+import com.positivity.securityservice.internal.enums.AuditDeliveryMode;
+import com.positivity.securityservice.internal.enums.AuditExportFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request body for POST /v1/audit/exports (B-4).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Audit export job submission request")
+public class AuditExportRequest {
+
+  @Schema(description = "Filter criteria to scope the export", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  private AuditEventSearchFilter filters;
+
+  @NotNull
+  @Schema(description = "Output format for the export", example = "CSV")
+  private AuditExportFormat format;
+
+  @NotNull
+  @Schema(description = "Delivery mode for the exported file", example = "DOWNLOAD")
+  private AuditDeliveryMode deliveryMode;
+}

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/AuditDeliveryMode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/AuditDeliveryMode.java
@@ -1,0 +1,9 @@
+package com.positivity.securityservice.internal.enums;
+
+/**
+ * Delivery mode for an asynchronous audit export job.
+ */
+public enum AuditDeliveryMode {
+  DOWNLOAD,
+  WEBHOOK
+}

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/AuditExportFormat.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/AuditExportFormat.java
@@ -1,0 +1,9 @@
+package com.positivity.securityservice.internal.enums;
+
+/**
+ * Output format for an asynchronous audit export job.
+ */
+public enum AuditExportFormat {
+  CSV,
+  JSON
+}

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/AuditExportStatus.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/AuditExportStatus.java
@@ -1,0 +1,11 @@
+package com.positivity.securityservice.internal.enums;
+
+/**
+ * Lifecycle statuses for an asynchronous audit export job.
+ */
+public enum AuditExportStatus {
+  PENDING,
+  IN_PROGRESS,
+  COMPLETED,
+  FAILED
+}

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/repository/AuditLogEventRepository.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/repository/AuditLogEventRepository.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -13,7 +14,8 @@ import org.springframework.stereotype.Repository;
  * Issue: #41
  */
 @Repository
-public interface AuditLogEventRepository extends JpaRepository<AuditLogEvent, UUID> {
+public interface AuditLogEventRepository
+        extends JpaRepository<AuditLogEvent, UUID>, JpaSpecificationExecutor<AuditLogEvent> {
 
     List<AuditLogEvent> findByEventTypeOrderByTimestampDesc(String eventType);
 

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/repository/PermissionRepository.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/repository/PermissionRepository.java
@@ -4,6 +4,8 @@ import com.positivity.securityservice.internal.entity.Permission;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,6 +20,8 @@ public interface PermissionRepository extends JpaRepository<Permission, UUID> {
     boolean existsByName(String name);
 
     List<Permission> findByDomain(String domain);
+
+    Page<Permission> findByDomain(String domain, Pageable pageable);
 
     List<Permission> findByDomainAndResource(String domain, String resource);
 

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/AuditEventServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/AuditEventServiceImpl.java
@@ -2,16 +2,22 @@ package com.positivity.securityservice.internal.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.positivity.securityservice.internal.dto.AuditEventSearchFilter;
 import com.positivity.securityservice.internal.dto.AuditLogEventDto;
 import com.positivity.securityservice.internal.dto.AuditLogEventRequest;
 import com.positivity.securityservice.internal.entity.AuditLogEvent;
 import com.positivity.securityservice.internal.repository.AuditLogEventRepository;
 import com.positivity.securityservice.service.AuditEventService;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -52,7 +58,8 @@ public class AuditEventServiceImpl implements AuditEventService {
     public AuditLogEventDto getEvent(@NonNull UUID eventId) {
         AuditLogEvent event = auditLogEventRepository
                 .findById(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("Audit event not found: " + eventId));
+                .orElseThrow(
+                        () -> new jakarta.persistence.EntityNotFoundException("Audit event not found: " + eventId));
         return toDto(event);
     }
 
@@ -84,6 +91,47 @@ public class AuditEventServiceImpl implements AuditEventService {
         return auditLogEventRepository.findByEventTypeOrderByTimestampDesc(eventType).stream()
                 .map(this::toDto)
                 .toList();
+    }
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public Page<AuditLogEventDto> searchEventsFiltered(
+            @NonNull AuditEventSearchFilter filter, @NonNull Pageable pageable) {
+        if (filter.getFromDate() != null && filter.getToDate() != null
+                && !filter.getFromDate().isBefore(filter.getToDate())) {
+            throw new IllegalArgumentException("fromDate must be before toDate");
+        }
+
+        Specification<AuditLogEvent> specification = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (filter.getFromDate() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("timestamp"), filter.getFromDate()));
+            }
+            if (filter.getToDate() != null) {
+                predicates.add(cb.lessThan(root.get("timestamp"), filter.getToDate()));
+            }
+            if (!isBlank(filter.getEventType())) {
+                predicates.add(cb.equal(root.get("eventType"), filter.getEventType()));
+            }
+            if (!isBlank(filter.getActorId())) {
+                predicates.add(cb.equal(root.get("actorId"), filter.getActorId()));
+            }
+            if (!isBlank(filter.getAggregateId())) {
+                predicates.add(cb.equal(root.get("entityId"), filter.getAggregateId()));
+            }
+
+            // TODO(B-3): workorderId filter - column 'workorder_id' not yet indexed on
+            // audit_log_event; planned for follow-on story
+            // TODO(B-3): movementId filter - column not yet present on audit_log_event
+            // TODO(B-3): productId filter - column not yet present
+            // TODO(B-3): sku filter - column not yet present
+            // TODO(B-3): correlationId filter - column not yet present
+            // TODO(B-3): reasonCode filter - column not yet present
+            // TODO(B-3): locationIds filter - column not yet present
+            return cb.and(predicates.toArray(Predicate[]::new));
+        };
+        return auditLogEventRepository.findAll(specification, pageable).map(this::toDto);
     }
 
     private void validateCreateRequest(@NonNull AuditLogEventRequest request) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/AuditExportServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/AuditExportServiceImpl.java
@@ -1,0 +1,50 @@
+package com.positivity.securityservice.internal.service;
+
+import com.positivity.securityservice.internal.dto.AuditExportJobResponse;
+import com.positivity.securityservice.internal.dto.AuditExportRequest;
+import com.positivity.securityservice.internal.enums.AuditExportStatus;
+import com.positivity.securityservice.service.AuditExportService;
+import com.positivity.time.TimeSource;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+
+/**
+ * Temporary in-memory stub for audit export jobs.
+ */
+@Service
+public class AuditExportServiceImpl implements AuditExportService {
+
+  // TODO(B-4): Replace in-memory job store with persisted AuditExportJob
+  // entity/repository.
+  private final ConcurrentMap<UUID, AuditExportJobResponse> jobs = new ConcurrentHashMap<>();
+
+  @Override
+  @NonNull
+  public AuditExportJobResponse requestExport(@NonNull AuditExportRequest request) {
+    UUID jobId = UUID.randomUUID();
+    AuditExportJobResponse response = AuditExportJobResponse.builder()
+        .jobId(jobId)
+        .status(AuditExportStatus.PENDING)
+        .requestedAt(TimeSource.instant())
+        .completedAt(null)
+        .downloadUrl(null)
+        .errorMessage(null)
+        .build();
+    jobs.put(jobId, response);
+    return response;
+  }
+
+  @Override
+  @NonNull
+  public AuditExportJobResponse getExportJob(@NonNull UUID jobId) {
+    AuditExportJobResponse response = jobs.get(jobId);
+    if (response == null) {
+      throw new EntityNotFoundException("Audit export job not found: " + jobId);
+    }
+    return response;
+  }
+}

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PermissionServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PermissionServiceImpl.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,8 +41,7 @@ public class PermissionServiceImpl implements PermissionService {
                 throw new IllegalArgumentException("Permission key must match domain:resource:action");
             }
 
-            Permission permission =
-                    permissionRepository.findByName(permissionKey).orElseGet(Permission::new);
+            Permission permission = permissionRepository.findByName(permissionKey).orElseGet(Permission::new);
             permission.setName(permissionKey);
             permission.setDescription(definition.getDescription());
             permission.setRegisteredByService(
@@ -58,7 +60,7 @@ public class PermissionServiceImpl implements PermissionService {
     public PermissionDto getPermission(@NonNull UUID id) {
         Permission permission = permissionRepository
                 .findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Permission not found: " + id));
+                .orElseThrow(() -> new jakarta.persistence.EntityNotFoundException("Permission not found: " + id));
         return toDto(permission);
     }
 
@@ -68,6 +70,16 @@ public class PermissionServiceImpl implements PermissionService {
         return permissionRepository.findByDomain(domain).stream()
                 .map(this::toDto)
                 .toList();
+    }
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public Page<PermissionDto> listPermissions(@Nullable String domain, @NonNull Pageable pageable) {
+        if (domain == null || domain.isBlank()) {
+            return permissionRepository.findAll(pageable).map(this::toDto);
+        }
+        return permissionRepository.findByDomain(domain, pageable).map(this::toDto);
     }
 
     private boolean isValidPermissionKey(String permissionKey) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/service/AuditEventService.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/service/AuditEventService.java
@@ -2,10 +2,13 @@ package com.positivity.securityservice.service;
 
 import com.positivity.securityservice.internal.dto.AuditLogEventDto;
 import com.positivity.securityservice.internal.dto.AuditLogEventRequest;
+import com.positivity.securityservice.internal.dto.AuditEventSearchFilter;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Public API for immutable audit event operations.
@@ -21,4 +24,14 @@ public interface AuditEventService {
     List<AuditLogEventDto> searchEvents(String entityId, String entityType, Instant from, Instant to);
 
     List<AuditLogEventDto> searchByEventType(@NonNull String eventType);
+
+    /**
+     * Searches audit events using a rich filter set with pagination.
+     *
+     * @param filter   search criteria (all fields optional)
+     * @param pageable pagination specification
+     * @return page of matching audit events
+     */
+    @NonNull
+    Page<AuditLogEventDto> searchEventsFiltered(@NonNull AuditEventSearchFilter filter, @NonNull Pageable pageable);
 }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/service/AuditExportService.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/service/AuditExportService.java
@@ -1,0 +1,31 @@
+package com.positivity.securityservice.service;
+
+import com.positivity.securityservice.internal.dto.AuditExportJobResponse;
+import com.positivity.securityservice.internal.dto.AuditExportRequest;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Service contract for asynchronous audit export jobs (B-4).
+ */
+public interface AuditExportService {
+
+  /**
+   * Submits an audit export request and returns the created job response.
+   *
+   * @param request export parameters including filters, format, and delivery mode
+   * @return the created job reference with PENDING status
+   */
+  @NonNull
+  AuditExportJobResponse requestExport(@NonNull AuditExportRequest request);
+
+  /**
+   * Returns the current status of a previously submitted export job.
+   *
+   * @param jobId the export job UUID
+   * @return job status response
+   * @throws jakarta.persistence.EntityNotFoundException if jobId is not found
+   */
+  @NonNull
+  AuditExportJobResponse getExportJob(@NonNull UUID jobId);
+}

--- a/pos-security-service/src/main/java/com/positivity/securityservice/service/PermissionService.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/service/PermissionService.java
@@ -5,6 +5,9 @@ import com.positivity.securityservice.internal.dto.PermissionRegistrationRequest
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Service API for RBAC permission registration and query operations.
@@ -18,4 +21,15 @@ public interface PermissionService {
     PermissionDto getPermission(@NonNull UUID id);
 
     List<PermissionDto> getByDomain(@NonNull String domain);
+
+    /**
+     * Returns a paged list of registered permissions, optionally filtered by
+     * domain.
+     *
+     * @param domain   optional domain filter; null returns all permissions
+     * @param pageable pagination and sort specification
+     * @return page of matching permissions
+     */
+    @NonNull
+    Page<PermissionDto> listPermissions(@Nullable String domain, @NonNull Pageable pageable);
 }

--- a/pos-security-service/src/test/java/com/positivity/securityservice/contract/AuditTrailContractBehaviorIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/contract/AuditTrailContractBehaviorIT.java
@@ -28,191 +28,195 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  *
  * Issue: #41
  */
-@SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        classes = PosSecurityServiceApplication.class,
-        properties = {"security.jwt.secret=test-jwt-secret-key-01234567890123456789"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = PosSecurityServiceApplication.class, properties = {
+                "security.jwt.secret=test-jwt-secret-key-01234567890123456789" })
 @ActiveProfiles("test")
-@WithMockUser(
-        username = "system-admin",
-        roles = {"ADMIN"})
+@WithMockUser(username = "system-admin", roles = { "ADMIN" })
 @DisplayName("Issue #41 Immutable Audit Trail Contract Behavior")
 class AuditTrailContractBehaviorIT extends BaseContractIntegrationTest {
 
-    @MockitoBean
-    private TokenRevocationManager tokenRevocationManager;
+        @MockitoBean
+        private TokenRevocationManager tokenRevocationManager;
 
-    private MockHttpServletRequestBuilder withAuditAdminAuth(MockHttpServletRequestBuilder builder) {
-        return withAuth(builder, "ROLE_ADMIN,security:audit:create,security:audit:view");
-    }
+        private MockHttpServletRequestBuilder withAuditAdminAuth(MockHttpServletRequestBuilder builder) {
+                return withAuth(builder, "ROLE_ADMIN,security:audit:create,security:audit:view");
+        }
 
-    // Issue #41: AC1 validates audit event append-only create endpoint contract.
-    @Test
-    @DisplayName("AC1: create audit event returns 201 with eventId and timestamp")
-    void ac1_createAuditEvent_returnsCreatedWithIdentifiers() throws Exception {
-        String payload = objectMapper.writeValueAsString(Map.of(
-                "eventType", "PRICE_BOOK_UPDATE",
-                "actorId", "user-123",
-                "entityId", "PRODUCT-123",
-                "entityType", "Product",
-                "oldValue", Map.of("price", "10.00"),
-                "newValue", Map.of("price", "12.50")));
+        // Issue #41: AC1 validates audit event append-only create endpoint contract.
+        @Test
+        @DisplayName("AC1: create audit event returns 201 with eventId and timestamp")
+        void ac1_createAuditEvent_returnsCreatedWithIdentifiers() throws Exception {
+                String payload = objectMapper.writeValueAsString(Map.of(
+                                "eventType", "PRICE_BOOK_UPDATE",
+                                "actorId", "user-123",
+                                "entityId", "PRODUCT-123",
+                                "entityType", "Product",
+                                "oldValue", Map.of("price", "10.00"),
+                                "newValue", Map.of("price", "12.50")));
 
-        mockMvc.perform(withAuditAdminAuth(post("/v1/audit/events")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(payload)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.eventId").isNotEmpty())
-                .andExpect(jsonPath("$.timestamp").isNotEmpty());
-    }
+                mockMvc.perform(withAuditAdminAuth(post("/v1/audit/events")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(payload)))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$.eventId").isNotEmpty())
+                                .andExpect(jsonPath("$.timestamp").isNotEmpty());
+        }
 
-    // Issue #41: AC2 validates DELETE immutability enforcement with 405.
-    @Test
-    @DisplayName("AC2: deleting audit event is method-not-allowed")
-    void ac2_deleteAuditEvent_returnsMethodNotAllowed() throws Exception {
-        String eventId = createAuditEventAndReturnId("PRODUCT-DELETE-1");
+        // Issue #41: AC2 validates DELETE immutability enforcement with 405.
+        @Test
+        @DisplayName("AC2: deleting audit event is method-not-allowed")
+        void ac2_deleteAuditEvent_returnsMethodNotAllowed() throws Exception {
+                String eventId = createAuditEventAndReturnId("PRODUCT-DELETE-1");
 
-        mockMvc.perform(withAuditAdminAuth(delete("/v1/audit/events/{eventId}", eventId)))
-                .andExpect(status().isMethodNotAllowed());
-    }
+                mockMvc.perform(withAuditAdminAuth(delete("/v1/audit/events/{eventId}", eventId)))
+                                .andExpect(status().isMethodNotAllowed());
+        }
 
-    // Issue #41: AC3 validates PUT immutability enforcement with 405.
-    @Test
-    @DisplayName("AC3: updating audit event is method-not-allowed")
-    void ac3_updateAuditEvent_returnsMethodNotAllowed() throws Exception {
-        String eventId = createAuditEventAndReturnId("PRODUCT-PUT-1");
+        // Issue #41: AC3 validates PUT immutability enforcement with 405.
+        @Test
+        @DisplayName("AC3: updating audit event is method-not-allowed")
+        void ac3_updateAuditEvent_returnsMethodNotAllowed() throws Exception {
+                String eventId = createAuditEventAndReturnId("PRODUCT-PUT-1");
 
-        String updatePayload = objectMapper.writeValueAsString(Map.of(
-                "eventType", "PRICE_BOOK_UPDATE",
-                "actorId", "user-456",
-                "entityId", "PRODUCT-PUT-1",
-                "entityType", "Product",
-                "oldValue", Map.of("price", "12.50"),
-                "newValue", Map.of("price", "13.00")));
+                String updatePayload = objectMapper.writeValueAsString(Map.of(
+                                "eventType", "PRICE_BOOK_UPDATE",
+                                "actorId", "user-456",
+                                "entityId", "PRODUCT-PUT-1",
+                                "entityType", "Product",
+                                "oldValue", Map.of("price", "12.50"),
+                                "newValue", Map.of("price", "13.00")));
 
-        mockMvc.perform(withAuditAdminAuth(put("/v1/audit/events/{eventId}", eventId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(updatePayload)))
-                .andExpect(status().isMethodNotAllowed());
-    }
+                mockMvc.perform(withAuditAdminAuth(put("/v1/audit/events/{eventId}", eventId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(updatePayload)))
+                                .andExpect(status().isMethodNotAllowed());
+        }
 
-    // Issue #41: AC4 validates pricing snapshot + rule trace creation contract.
-    @Test
-    @DisplayName("AC4: create pricing snapshot returns 201 with snapshotId")
-    void ac4_createPricingSnapshot_returnsCreatedWithSnapshotId() throws Exception {
-        String payload = objectMapper.writeValueAsString(Map.of(
-                "quoteContext", Map.of("productIds", List.of("SKU-1"), "quantity", 2),
-                "finalPrice", "25.00",
-                "evaluationSteps",
-                        List.of(
-                                Map.of("ruleId", "R1", "status", "APPLIED", "inputs", Map.of(), "outputs", Map.of()),
-                                Map.of(
-                                        "ruleId",
-                                        "R2",
-                                        "status",
-                                        "REJECTED",
-                                        "inputs",
-                                        Map.of(),
-                                        "outputs",
-                                        Map.of()))));
+        // Issue #41: AC4 validates pricing snapshot + rule trace creation contract.
+        @Test
+        @DisplayName("AC4: create pricing snapshot returns 201 with snapshotId")
+        void ac4_createPricingSnapshot_returnsCreatedWithSnapshotId() throws Exception {
+                String payload = objectMapper.writeValueAsString(Map.of(
+                                "quoteContext", Map.of("productIds", List.of("SKU-1"), "quantity", 2),
+                                "finalPrice", "25.00",
+                                "evaluationSteps",
+                                List.of(
+                                                Map.of("ruleId", "R1", "status", "APPLIED", "inputs", Map.of(),
+                                                                "outputs", Map.of()),
+                                                Map.of(
+                                                                "ruleId",
+                                                                "R2",
+                                                                "status",
+                                                                "REJECTED",
+                                                                "inputs",
+                                                                Map.of(),
+                                                                "outputs",
+                                                                Map.of()))));
 
-        mockMvc.perform(withAuditAdminAuth(post("/v1/audit/pricing-snapshots")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(payload)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.snapshotId").isNotEmpty());
-    }
+                mockMvc.perform(withAuditAdminAuth(post("/v1/audit/pricing-snapshots")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(payload)))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$.snapshotId").isNotEmpty());
+        }
 
-    // Issue #41: AC5 validates retrieval of pricing snapshot including evaluation
-    // steps.
-    @Test
-    @DisplayName("AC5: get pricing snapshot returns snapshot with evaluation steps")
-    void ac5_getPricingSnapshot_returnsTraceDetails() throws Exception {
-        String snapshotId = createPricingSnapshotAndReturnId();
+        // Issue #41: AC5 validates retrieval of pricing snapshot including evaluation
+        // steps.
+        @Test
+        @DisplayName("AC5: get pricing snapshot returns snapshot with evaluation steps")
+        void ac5_getPricingSnapshot_returnsTraceDetails() throws Exception {
+                String snapshotId = createPricingSnapshotAndReturnId();
 
-        mockMvc.perform(withAuditAdminAuth(get("/v1/audit/pricing-snapshots/{snapshotId}", snapshotId)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.snapshotId").value(snapshotId))
-                .andExpect(jsonPath("$.evaluationSteps").isArray())
-                .andExpect(jsonPath("$.evaluationSteps.length()").value(2));
-    }
+                mockMvc.perform(withAuditAdminAuth(get("/v1/audit/pricing-snapshots/{snapshotId}", snapshotId)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.snapshotId").value(snapshotId))
+                                .andExpect(jsonPath("$.evaluationSteps").isArray())
+                                .andExpect(jsonPath("$.evaluationSteps.length()").value(2));
+        }
 
-    // Issue #41: AC6 validates search endpoint filtering by entity id/type.
-    @Test
-    @DisplayName("AC6: search audit events by entity returns matching entries")
-    void ac6_searchAuditEvents_filtersByEntity() throws Exception {
-        createAuditEventAndReturnId("PRODUCT-456");
+        // Issue #41: AC6 validates search endpoint filtering by entity id/type.
+        @Test
+        @DisplayName("AC6: search audit events by entity returns matching entries")
+        void ac6_searchAuditEvents_filtersByEntity() throws Exception {
+                createAuditEventAndReturnId("PRODUCT-456");
 
-        String responseBody = mockMvc.perform(withAuditAdminAuth(
-                        get("/v1/audit/events").param("entityId", "PRODUCT-456").param("entityType", "Product")))
-                .andExpect(status().isOk())
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
+                String responseBody = mockMvc.perform(withAuditAdminAuth(
+                                get("/v1/audit/events").param("entityId", "PRODUCT-456").param("entityType",
+                                                "Product")))
+                                .andExpect(status().isOk())
+                                .andReturn()
+                                .getResponse()
+                                .getContentAsString();
 
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> events = objectMapper.readValue(responseBody, List.class);
-        assertThat(events)
-                .as("Expected at least one audit event for PRODUCT-456")
-                .isNotEmpty()
-                .anySatisfy(event -> {
-                    assertThat(event).containsEntry("entityId", "PRODUCT-456").containsEntry("entityType", "Product");
-                });
-    }
+                // Response is Page<AuditLogEventDto>; deserialize as Map and extract content
+                // list
+                @SuppressWarnings("unchecked")
+                Map<String, Object> pageResponse = objectMapper.readValue(responseBody, Map.class);
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> events = (List<Map<String, Object>>) pageResponse.get("content");
+                assertThat(events)
+                                .as("Expected at least one audit event for PRODUCT-456")
+                                .isNotEmpty()
+                                .anySatisfy(event -> {
+                                        assertThat(event).containsEntry("entityId", "PRODUCT-456")
+                                                        .containsEntry("entityType", "Product");
+                                });
+        }
 
-    private String createAuditEventAndReturnId(String entityId) throws Exception {
-        String payload = objectMapper.writeValueAsString(Map.of(
-                "eventType",
-                "PRICE_BOOK_UPDATE",
-                "actorId",
-                "user-123",
-                "entityId",
-                entityId,
-                "entityType",
-                "Product",
-                "oldValue",
-                Map.of("price", "10.00"),
-                "newValue",
-                Map.of("price", "12.50")));
+        private String createAuditEventAndReturnId(String entityId) throws Exception {
+                String payload = objectMapper.writeValueAsString(Map.of(
+                                "eventType",
+                                "PRICE_BOOK_UPDATE",
+                                "actorId",
+                                "user-123",
+                                "entityId",
+                                entityId,
+                                "entityType",
+                                "Product",
+                                "oldValue",
+                                Map.of("price", "10.00"),
+                                "newValue",
+                                Map.of("price", "12.50")));
 
-        MvcResult result = mockMvc.perform(withAuditAdminAuth(post("/v1/audit/events")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(payload)))
-                .andExpect(status().isCreated())
-                .andReturn();
+                MvcResult result = mockMvc.perform(withAuditAdminAuth(post("/v1/audit/events")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(payload)))
+                                .andExpect(status().isCreated())
+                                .andReturn();
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> response =
-                objectMapper.readValue(result.getResponse().getContentAsString(), Map.class);
-        return String.valueOf(response.get("eventId"));
-    }
+                @SuppressWarnings("unchecked")
+                Map<String, Object> response = objectMapper.readValue(result.getResponse().getContentAsString(),
+                                Map.class);
+                return String.valueOf(response.get("eventId"));
+        }
 
-    private String createPricingSnapshotAndReturnId() throws Exception {
-        String payload = objectMapper.writeValueAsString(Map.of(
-                "quoteContext", Map.of("productIds", List.of("SKU-1"), "quantity", 2),
-                "finalPrice", "25.00",
-                "evaluationSteps",
-                        List.of(
-                                Map.of("ruleId", "R1", "status", "APPLIED", "inputs", Map.of(), "outputs", Map.of()),
-                                Map.of(
-                                        "ruleId",
-                                        "R2",
-                                        "status",
-                                        "REJECTED",
-                                        "inputs",
-                                        Map.of(),
-                                        "outputs",
-                                        Map.of()))));
+        private String createPricingSnapshotAndReturnId() throws Exception {
+                String payload = objectMapper.writeValueAsString(Map.of(
+                                "quoteContext", Map.of("productIds", List.of("SKU-1"), "quantity", 2),
+                                "finalPrice", "25.00",
+                                "evaluationSteps",
+                                List.of(
+                                                Map.of("ruleId", "R1", "status", "APPLIED", "inputs", Map.of(),
+                                                                "outputs", Map.of()),
+                                                Map.of(
+                                                                "ruleId",
+                                                                "R2",
+                                                                "status",
+                                                                "REJECTED",
+                                                                "inputs",
+                                                                Map.of(),
+                                                                "outputs",
+                                                                Map.of()))));
 
-        MvcResult result = mockMvc.perform(withAuditAdminAuth(post("/v1/audit/pricing-snapshots")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(payload)))
-                .andExpect(status().isCreated())
-                .andReturn();
+                MvcResult result = mockMvc.perform(withAuditAdminAuth(post("/v1/audit/pricing-snapshots")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(payload)))
+                                .andExpect(status().isCreated())
+                                .andReturn();
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> response =
-                objectMapper.readValue(result.getResponse().getContentAsString(), Map.class);
-        return String.valueOf(response.get("snapshotId"));
-    }
+                @SuppressWarnings("unchecked")
+                Map<String, Object> response = objectMapper.readValue(result.getResponse().getContentAsString(),
+                                Map.class);
+                return String.valueOf(response.get("snapshotId"));
+        }
 }

--- a/pos-security-service/src/test/java/com/positivity/securityservice/contract/PermissionManagementContractIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/contract/PermissionManagementContractIT.java
@@ -36,389 +36,414 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 /**
  * Contract behavior tests for the POS roles and permission matrix.
  *
- * <p>Validates:
+ * <p>
+ * Validates:
  * <ul>
- *   <li>AC1 – HTTP 403 on insufficient authority triggers a {@code PermissionDenied} audit event.</li>
- *   <li>AC2 – Principal with the required permission receives an {@code allow} authorization decision.</li>
- *   <li>AC3 – Successful role assignment persists a {@code RoleAssignedToUser} audit event.</li>
- *   <li>AC4 – Successful role revocation persists a {@code RoleRevokedFromUser} audit event.</li>
- *   <li>AC5 – Audit events are queryable by {@code eventType}.</li>
+ * <li>AC1 – HTTP 403 on insufficient authority triggers a
+ * {@code PermissionDenied} audit event.</li>
+ * <li>AC2 – Principal with the required permission receives an {@code allow}
+ * authorization decision.</li>
+ * <li>AC3 – Successful role assignment persists a {@code RoleAssignedToUser}
+ * audit event.</li>
+ * <li>AC4 – Successful role revocation persists a {@code RoleRevokedFromUser}
+ * audit event.</li>
+ * <li>AC5 – Audit events are queryable by {@code eventType}.</li>
  * </ul>
  *
- * <p>Actor fields are sourced from the security context per ADR-0018; no caller-supplied
+ * <p>
+ * Actor fields are sourced from the security context per ADR-0018; no
+ * caller-supplied
  * actor fields are accepted.
  *
  * Issue: #2
  */
-@SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        classes = PosSecurityServiceApplication.class,
-        properties = {"security.jwt.secret=test-jwt-secret-key-01234567890123456789"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = PosSecurityServiceApplication.class, properties = {
+                "security.jwt.secret=test-jwt-secret-key-01234567890123456789" })
 @ActiveProfiles("test")
-@WithMockUser(
-        username = "system-admin",
-        roles = {"ADMIN"})
+@WithMockUser(username = "system-admin", roles = { "ADMIN" })
 @DisplayName("Issue #2: Permission Management Contract Behavior")
 class PermissionManagementContractIT extends BaseContractIntegrationTest {
-    private static final String ROLE_ASSIGN_AUTH = "ROLE_ADMIN,security:role:assign";
-    private static final String AUTHZ_DECISION_AUTH = "ROLE_ADMIN,security:authorization:decide";
-    private static final String AUDIT_VIEW_AUTH = "ROLE_ADMIN,security:audit:view";
+        private static final String ROLE_ASSIGN_AUTH = "ROLE_ADMIN,security:role:assign";
+        private static final String AUTHZ_DECISION_AUTH = "ROLE_ADMIN,security:authorization:decide";
+        private static final String AUDIT_VIEW_AUTH = "ROLE_ADMIN,security:audit:view";
 
-    @MockitoBean
-    private TokenRevocationManager tokenRevocationManager;
+        @MockitoBean
+        private TokenRevocationManager tokenRevocationManager;
 
-    @Autowired
-    private UserRepository userRepository;
+        @Autowired
+        private UserRepository userRepository;
 
-    @Autowired
-    private RoleRepository roleRepository;
+        @Autowired
+        private RoleRepository roleRepository;
 
-    @Autowired
-    private RoleAssignmentRepository roleAssignmentRepository;
+        @Autowired
+        private RoleAssignmentRepository roleAssignmentRepository;
 
-    @Autowired
-    private AuditLogEventRepository auditLogEventRepository;
+        @Autowired
+        private AuditLogEventRepository auditLogEventRepository;
 
-    @Autowired
-    private PrincipalRoleRepository principalRoleRepository;
+        @Autowired
+        private PrincipalRoleRepository principalRoleRepository;
 
-    @Autowired
-    private PermissionRepository permissionRepository;
+        @Autowired
+        private PermissionRepository permissionRepository;
 
-    /** Test-owned role, re-created per test. */
-    private Role testRole;
+        /** Test-owned role, re-created per test. */
+        private Role testRole;
 
-    /** Test-owned user on whom role operations are performed. */
-    private User subjectUser;
+        /** Test-owned user on whom role operations are performed. */
+        private User subjectUser;
 
-    /**
-     * Cleans all test-owned state in FK-safe order and seeds fresh entities
-     * before each test.
-     *
-     * <p>Cleanup order prevents FK constraint violations:
-     * <ol>
-     *   <li>{@code role_assignments} → references user + role</li>
-     *   <li>{@code principal_roles} → references role</li>
-     *   <li>{@code audit_log_events} → standalone</li>
-     *   <li>{@code users} → cascade-clears {@code user_roles} join table</li>
-     *   <li>{@code roles} → cascade-clears {@code role_permissions} join table</li>
-     *   <li>{@code permissions} → now FK-free</li>
-     * </ol>
-     */
-    @BeforeEach
-    void seedTestData() {
-        roleAssignmentRepository.deleteAll();
-        principalRoleRepository.deleteAll();
-        auditLogEventRepository.deleteAll();
-        userRepository.deleteAll();
-        roleRepository.deleteAll();
-        permissionRepository.deleteAll();
+        /**
+         * Cleans all test-owned state in FK-safe order and seeds fresh entities
+         * before each test.
+         *
+         * <p>
+         * Cleanup order prevents FK constraint violations:
+         * <ol>
+         * <li>{@code role_assignments} → references user + role</li>
+         * <li>{@code principal_roles} → references role</li>
+         * <li>{@code audit_log_events} → standalone</li>
+         * <li>{@code users} → cascade-clears {@code user_roles} join table</li>
+         * <li>{@code roles} → cascade-clears {@code role_permissions} join table</li>
+         * <li>{@code permissions} → now FK-free</li>
+         * </ol>
+         */
+        @BeforeEach
+        void seedTestData() {
+                roleAssignmentRepository.deleteAll();
+                principalRoleRepository.deleteAll();
+                auditLogEventRepository.deleteAll();
+                userRepository.deleteAll();
+                roleRepository.deleteAll();
+                permissionRepository.deleteAll();
 
-        testRole = buildRole("TestRole-" + System.currentTimeMillis(), "Contract test role – Issue #2");
-        subjectUser = buildUser("subject-" + System.currentTimeMillis());
-    }
+                testRole = buildRole("TestRole-" + System.currentTimeMillis(), "Contract test role – Issue #2");
+                subjectUser = buildUser("subject-" + System.currentTimeMillis());
+        }
 
-    // ── AC1 ──────────────────────────────────────────────────────────────────
+        // ── AC1 ──────────────────────────────────────────────────────────────────
 
-    /**
-     * AC1: An authenticated user without the required authority receives HTTP 403
-     * AND a {@code PermissionDenied} audit event is persisted in
-     * {@code audit_log_events} containing actor_id (from security context per
-     * ADR-0018) and timestamp.
-     *
-     * <p><b>GREEN path:</b> {@code GlobalExceptionHandler.handleAuthorizationDeniedException()}
-     * persists a {@code PermissionDenied} audit event on HTTP 403 using
-     * actor identity from security context (ADR-0018).
-     */
-    @Test
-    @DisplayName("AC1: cashier denied role-assign operation – PermissionDenied audit event persisted")
-    void ac1_cashierDeniedRoleAssign_permissionDeniedAuditEventPersisted() throws Exception {
-        // When: CASHIER (no ROLE_ADMIN) attempts to assign a role — endpoint requires ROLE_ADMIN
-        mockMvc.perform(withAuth(
-                        put("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
-                        "ROLE_CASHIER"))
-                .andExpect(status().isForbidden());
+        /**
+         * AC1: An authenticated user without the required authority receives HTTP 403
+         * AND a {@code PermissionDenied} audit event is persisted in
+         * {@code audit_log_events} containing actor_id (from security context per
+         * ADR-0018) and timestamp.
+         *
+         * <p>
+         * <b>GREEN path:</b>
+         * {@code GlobalExceptionHandler.handleAuthorizationDeniedException()}
+         * persists a {@code PermissionDenied} audit event on HTTP 403 using
+         * actor identity from security context (ADR-0018).
+         */
+        @Test
+        @DisplayName("AC1: cashier denied role-assign operation – PermissionDenied audit event persisted")
+        void ac1_cashierDeniedRoleAssign_permissionDeniedAuditEventPersisted() throws Exception {
+                // When: CASHIER (no ROLE_ADMIN) attempts to assign a role — endpoint requires
+                // ROLE_ADMIN
+                mockMvc.perform(withAuth(
+                                put("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
+                                "ROLE_CASHIER"))
+                                .andExpect(status().isForbidden());
 
-        // Then: a PermissionDenied audit event must be persisted
-        List<AuditLogEvent> deniedEvents = auditLogEventRepository.findAll().stream()
-                .filter(e -> "PermissionDenied".equals(e.getEventType()))
-                .toList();
+                // Then: a PermissionDenied audit event must be persisted
+                List<AuditLogEvent> deniedEvents = auditLogEventRepository.findAll().stream()
+                                .filter(e -> "PermissionDenied".equals(e.getEventType()))
+                                .toList();
 
-        // Issue #2 GREEN: GlobalExceptionHandler persists PermissionDenied audit event on HTTP 403
-        assertThat(deniedEvents)
-                .as(
-                        "Expected 1 AuditLogEvent with eventType='PermissionDenied' after HTTP 403, but found %d",
-                        deniedEvents.size())
-                .hasSize(1);
+                // Issue #2 GREEN: GlobalExceptionHandler persists PermissionDenied audit event
+                // on HTTP 403
+                assertThat(deniedEvents)
+                                .as(
+                                                "Expected 1 AuditLogEvent with eventType='PermissionDenied' after HTTP 403, but found %d",
+                                                deniedEvents.size())
+                                .hasSize(1);
 
-        AuditLogEvent event = deniedEvents.get(0);
-        // ADR-0018: actorId must be sourced from security context, not request body
-        assertThat(event.getActorId())
-                .as("actorId must equal the authenticated principal in the security context (ADR-0018)")
-                .isEqualTo(TEST_USER);
-        assertThat(event.getTimestamp())
-                .as("PermissionDenied event must carry a non-null timestamp")
-                .isNotNull();
-    }
+                AuditLogEvent event = deniedEvents.get(0);
+                // ADR-0018: actorId must be sourced from security context, not request body
+                assertThat(event.getActorId())
+                                .as("actorId must equal the authenticated principal in the security context (ADR-0018)")
+                                .isEqualTo(TEST_USER);
+                assertThat(event.getTimestamp())
+                                .as("PermissionDenied event must carry a non-null timestamp")
+                                .isNotNull();
+        }
 
-    // ── AC2 ──────────────────────────────────────────────────────────────────
+        // ── AC2 ──────────────────────────────────────────────────────────────────
 
-    /**
-     * AC2 (GREEN): A principal whose role carries the {@code order:refund:approve}
-     * permission receives an {@code allow} authorization decision.
-     *
-     * <p>This test exercises the existing {@code AuthorizationServiceImpl} and is
-     * expected to pass once the role–permission–principal chain is seeded.
-     */
-    @Test
-    @DisplayName("AC2: principal with APPROVE_REFUND permission via Manager role gets 'allow' authorization decision")
-    void ac2_managerWithApproveRefundPermission_authorizationDecisionIsAllow() throws Exception {
-        // Given: order:refund:approve permission exists and is linked to testRole
-        Permission approveRefund = buildPermission("order:refund:approve", "order", "refund", "approve");
-        testRole.getPermissions().add(approveRefund);
-        testRole = roleRepository.save(testRole);
+        /**
+         * AC2 (GREEN): A principal whose role carries the {@code order:refund:approve}
+         * permission receives an {@code allow} authorization decision.
+         *
+         * <p>
+         * This test exercises the existing {@code AuthorizationServiceImpl} and is
+         * expected to pass once the role–permission–principal chain is seeded.
+         */
+        @Test
+        @DisplayName("AC2: principal with APPROVE_REFUND permission via Manager role gets 'allow' authorization decision")
+        void ac2_managerWithApproveRefundPermission_authorizationDecisionIsAllow() throws Exception {
+                // Given: order:refund:approve permission exists and is linked to testRole
+                Permission approveRefund = buildPermission("order:refund:approve", "order", "refund", "approve");
+                testRole.getPermissions().add(approveRefund);
+                testRole = roleRepository.save(testRole);
 
-        // Assign testRole (acting as Manager) to a string-keyed principal
-        String managerPrincipal = "manager-principal-" + System.currentTimeMillis();
-        PrincipalRole principalRole = new PrincipalRole();
-        principalRole.setPrincipalId(managerPrincipal);
-        principalRole.setRole(testRole);
-        principalRoleRepository.save(principalRole);
+                // Assign testRole (acting as Manager) to a string-keyed principal
+                String managerPrincipal = "manager-principal-" + System.currentTimeMillis();
+                PrincipalRole principalRole = new PrincipalRole();
+                principalRole.setPrincipalId(managerPrincipal);
+                principalRole.setRole(testRole);
+                principalRoleRepository.save(principalRole);
 
-        // When: Admin queries the authorization decision for the manager principal
-        // Then: decision must be allow
-        mockMvc.perform(withAuth(
-                        get("/v1/users/authorization/decision")
-                                .param("principalId", managerPrincipal)
-                                .param("permission", "order:refund:approve"),
-                        AUTHZ_DECISION_AUTH))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.decision").value("allow"));
-    }
+                // When: Admin queries the authorization decision for the manager principal
+                // Then: decision must be allow
+                mockMvc.perform(withAuth(
+                                get("/v1/users/authorization/decision")
+                                                .param("principalId", managerPrincipal)
+                                                .param("permission", "order:refund:approve"),
+                                AUTHZ_DECISION_AUTH))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.decision").value("allow"));
+        }
 
-    // ── AC2b ─────────────────────────────────────────────────────────────────
+        // ── AC2b ─────────────────────────────────────────────────────────────────
 
-    /**
-     * AC2b (GREEN): A principal with NO role assignments receives a {@code deny}
-     * authorization decision for {@code order:refund:approve}.
-     *
-     * <p>This is the deny-path complement to AC2. The principal string used here
-     * has never been assigned any role, so the authorization service must return
-     * {@code deny} per the default-deny policy.
-     *
-     * Issue: #2
-     */
-    @Test
-    @DisplayName("AC2b: principal without permission gets 'deny' authorization decision")
-    void ac2b_principalWithoutPermission_authorizationDecisionIsDeny() throws Exception {
-        // Given: a principal that has no role assignments at all
-        String unprivilegedPrincipal = "no-role-principal-" + System.currentTimeMillis();
+        /**
+         * AC2b (GREEN): A principal with NO role assignments receives a {@code deny}
+         * authorization decision for {@code order:refund:approve}.
+         *
+         * <p>
+         * This is the deny-path complement to AC2. The principal string used here
+         * has never been assigned any role, so the authorization service must return
+         * {@code deny} per the default-deny policy.
+         *
+         * Issue: #2
+         */
+        @Test
+        @DisplayName("AC2b: principal without permission gets 'deny' authorization decision")
+        void ac2b_principalWithoutPermission_authorizationDecisionIsDeny() throws Exception {
+                // Given: a principal that has no role assignments at all
+                String unprivilegedPrincipal = "no-role-principal-" + System.currentTimeMillis();
 
-        // When: Admin queries the authorization decision for the unprivileged principal
-        // Then: decision must be deny (default-deny policy)
-        mockMvc.perform(withAuth(
-                        get("/v1/users/authorization/decision")
-                                .param("principalId", unprivilegedPrincipal)
-                                .param("permission", "order:refund:approve"),
-                        AUTHZ_DECISION_AUTH))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.decision").value("deny"));
-    }
+                // When: Admin queries the authorization decision for the unprivileged principal
+                // Then: decision must be deny (default-deny policy)
+                mockMvc.perform(withAuth(
+                                get("/v1/users/authorization/decision")
+                                                .param("principalId", unprivilegedPrincipal)
+                                                .param("permission", "order:refund:approve"),
+                                AUTHZ_DECISION_AUTH))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.decision").value("deny"));
+        }
 
-    // ── AC3 ──────────────────────────────────────────────────────────────────
+        // ── AC3 ──────────────────────────────────────────────────────────────────
 
-    /**
-     * AC3: A successful role assignment via {@code PUT /v1/users/{userId}/roles/{roleId}}
-     * must persist a {@code RoleAssignedToUser} audit event in {@code audit_log_events}
-     * recording actor_id (from security context), subject user_id, entity type, and timestamp.
-     *
-     * <p><b>GREEN path:</b> {@code RoleManagementServiceImpl.assignRoleToUser()} now emits
-     * a {@code RoleAssignedToUser} audit event via {@code AuditEventService} after
-     * persisting the assignment.
-     */
-    @Test
-    @DisplayName(
-            "AC3: role assignment persists RoleAssignedToUser audit event with actor, subject, role, and timestamp")
-    void ac3_roleAssignment_persistsRoleAssignedToUserAuditEvent() throws Exception {
-        // When: Admin assigns testRole to subjectUser
-        mockMvc.perform(withAuth(
-                        put("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
-                        ROLE_ASSIGN_AUTH))
-                .andExpect(status().isCreated());
+        /**
+         * AC3: A successful role assignment via
+         * {@code PUT /v1/users/{userId}/roles/{roleId}}
+         * must persist a {@code RoleAssignedToUser} audit event in
+         * {@code audit_log_events}
+         * recording actor_id (from security context), subject user_id, entity type, and
+         * timestamp.
+         *
+         * <p>
+         * <b>GREEN path:</b> {@code RoleManagementServiceImpl.assignRoleToUser()} now
+         * emits
+         * a {@code RoleAssignedToUser} audit event via {@code AuditEventService} after
+         * persisting the assignment.
+         */
+        @Test
+        @DisplayName("AC3: role assignment persists RoleAssignedToUser audit event with actor, subject, role, and timestamp")
+        void ac3_roleAssignment_persistsRoleAssignedToUserAuditEvent() throws Exception {
+                // When: Admin assigns testRole to subjectUser
+                mockMvc.perform(withAuth(
+                                put("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
+                                ROLE_ASSIGN_AUTH))
+                                .andExpect(status().isCreated());
 
-        // Then: a RoleAssignedToUser audit event must be persisted
-        List<AuditLogEvent> assignedEvents = auditLogEventRepository.findAll().stream()
-                .filter(e -> "RoleAssignedToUser".equals(e.getEventType()))
-                .toList();
+                // Then: a RoleAssignedToUser audit event must be persisted
+                List<AuditLogEvent> assignedEvents = auditLogEventRepository.findAll().stream()
+                                .filter(e -> "RoleAssignedToUser".equals(e.getEventType()))
+                                .toList();
 
-        // Issue #2 GREEN: RoleManagementServiceImpl.assignRoleToUser() emits AuditLogEvent
-        assertThat(assignedEvents)
-                .as(
-                        "Expected 1 AuditLogEvent with eventType='RoleAssignedToUser' after"
-                                + " PUT /v1/users/{userId}/roles/{roleId}, but found %d",
-                        assignedEvents.size())
-                .hasSize(1);
+                // Issue #2 GREEN: RoleManagementServiceImpl.assignRoleToUser() emits
+                // AuditLogEvent
+                assertThat(assignedEvents)
+                                .as(
+                                                "Expected 1 AuditLogEvent with eventType='RoleAssignedToUser' after"
+                                                                + " PUT /v1/users/{userId}/roles/{roleId}, but found %d",
+                                                assignedEvents.size())
+                                .hasSize(1);
 
-        AuditLogEvent event = assignedEvents.get(0);
-        // ADR-0018: actorId must be sourced from security context
-        assertThat(event.getActorId())
-                .as("actorId must equal the authenticated principal from the security context (ADR-0018)")
-                .isEqualTo(TEST_USER);
-        assertThat(event.getEntityId())
-                .as("entityId must be the subject user's UUID string")
-                .isEqualTo(subjectUser.getId().toString());
-        assertThat(event.getEntityType())
-                .as("entityType must identify the domain object on which the action was performed")
-                .isEqualTo("User");
-        assertThat(event.getTimestamp())
-                .as("RoleAssignedToUser event must carry a non-null timestamp")
-                .isNotNull();
-        assertThat(event.getNewValue())
-                .as("newValue must contain the role name for audit traceability")
-                .contains(testRole.getName());
-    }
+                AuditLogEvent event = assignedEvents.get(0);
+                // ADR-0018: actorId must be sourced from security context
+                assertThat(event.getActorId())
+                                .as("actorId must equal the authenticated principal from the security context (ADR-0018)")
+                                .isEqualTo(TEST_USER);
+                assertThat(event.getEntityId())
+                                .as("entityId must be the subject user's UUID string")
+                                .isEqualTo(subjectUser.getId().toString());
+                assertThat(event.getEntityType())
+                                .as("entityType must identify the domain object on which the action was performed")
+                                .isEqualTo("User");
+                assertThat(event.getTimestamp())
+                                .as("RoleAssignedToUser event must carry a non-null timestamp")
+                                .isNotNull();
+                assertThat(event.getNewValue())
+                                .as("newValue must contain the role name for audit traceability")
+                                .contains(testRole.getName());
+        }
 
-    // ── AC4 ──────────────────────────────────────────────────────────────────
+        // ── AC4 ──────────────────────────────────────────────────────────────────
 
-    /**
-     * AC4: A successful role revocation via {@code DELETE /v1/users/{userId}/roles/{roleId}}
-     * must persist a {@code RoleRevokedFromUser} audit event in {@code audit_log_events}
-     * recording actor_id (from security context), subject user_id, and timestamp.
-     *
-     * <p><b>GREEN path:</b> {@code RoleManagementServiceImpl.revokeRoleFromUser()} now emits
-     * a {@code RoleRevokedFromUser} audit event via {@code AuditEventService} after
-     * updating assignment end-date metadata.
-     */
-    @Test
-    @DisplayName("AC4: role revocation persists RoleRevokedFromUser audit event with actor, subject, and timestamp")
-    void ac4_roleRevocation_persistsRoleRevokedFromUserAuditEvent() throws Exception {
-        // Given: subjectUser has testRole assigned
-        mockMvc.perform(withAuth(
-                        put("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
-                        ROLE_ASSIGN_AUTH))
-                .andExpect(status().isCreated());
+        /**
+         * AC4: A successful role revocation via
+         * {@code DELETE /v1/users/{userId}/roles/{roleId}}
+         * must persist a {@code RoleRevokedFromUser} audit event in
+         * {@code audit_log_events}
+         * recording actor_id (from security context), subject user_id, and timestamp.
+         *
+         * <p>
+         * <b>GREEN path:</b> {@code RoleManagementServiceImpl.revokeRoleFromUser()} now
+         * emits
+         * a {@code RoleRevokedFromUser} audit event via {@code AuditEventService} after
+         * updating assignment end-date metadata.
+         */
+        @Test
+        @DisplayName("AC4: role revocation persists RoleRevokedFromUser audit event with actor, subject, and timestamp")
+        void ac4_roleRevocation_persistsRoleRevokedFromUserAuditEvent() throws Exception {
+                // Given: subjectUser has testRole assigned
+                mockMvc.perform(withAuth(
+                                put("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
+                                ROLE_ASSIGN_AUTH))
+                                .andExpect(status().isCreated());
 
-        // Clear any events from the assignment setup to isolate the revocation assertion
-        auditLogEventRepository.deleteAll();
+                // Clear any events from the assignment setup to isolate the revocation
+                // assertion
+                auditLogEventRepository.deleteAll();
 
-        // When: Admin revokes testRole from subjectUser
-        mockMvc.perform(withAuth(
-                        delete("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
-                        ROLE_ASSIGN_AUTH))
-                .andExpect(status().isNoContent());
+                // When: Admin revokes testRole from subjectUser
+                mockMvc.perform(withAuth(
+                                delete("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
+                                ROLE_ASSIGN_AUTH))
+                                .andExpect(status().isNoContent());
 
-        // Then: a RoleRevokedFromUser audit event must be persisted
-        List<AuditLogEvent> revokedEvents = auditLogEventRepository.findAll().stream()
-                .filter(e -> "RoleRevokedFromUser".equals(e.getEventType()))
-                .toList();
+                // Then: a RoleRevokedFromUser audit event must be persisted
+                List<AuditLogEvent> revokedEvents = auditLogEventRepository.findAll().stream()
+                                .filter(e -> "RoleRevokedFromUser".equals(e.getEventType()))
+                                .toList();
 
-        // Issue #2 GREEN: RoleManagementServiceImpl.revokeRoleFromUser() emits AuditLogEvent
-        assertThat(revokedEvents)
-                .as(
-                        "Expected 1 AuditLogEvent with eventType='RoleRevokedFromUser' after"
-                                + " DELETE /v1/users/{userId}/roles/{roleId}, but found %d",
-                        revokedEvents.size())
-                .hasSize(1);
+                // Issue #2 GREEN: RoleManagementServiceImpl.revokeRoleFromUser() emits
+                // AuditLogEvent
+                assertThat(revokedEvents)
+                                .as(
+                                                "Expected 1 AuditLogEvent with eventType='RoleRevokedFromUser' after"
+                                                                + " DELETE /v1/users/{userId}/roles/{roleId}, but found %d",
+                                                revokedEvents.size())
+                                .hasSize(1);
 
-        AuditLogEvent event = revokedEvents.get(0);
-        // ADR-0018: actorId must be sourced from security context
-        assertThat(event.getActorId())
-                .as("actorId must equal the authenticated principal from the security context (ADR-0018)")
-                .isEqualTo(TEST_USER);
-        assertThat(event.getEntityId())
-                .as("entityId must identify the subject user whose role was revoked")
-                .isEqualTo(subjectUser.getId().toString());
-        assertThat(event.getTimestamp())
-                .as("RoleRevokedFromUser event must carry a non-null timestamp")
-                .isNotNull();
-    }
+                AuditLogEvent event = revokedEvents.get(0);
+                // ADR-0018: actorId must be sourced from security context
+                assertThat(event.getActorId())
+                                .as("actorId must equal the authenticated principal from the security context (ADR-0018)")
+                                .isEqualTo(TEST_USER);
+                assertThat(event.getEntityId())
+                                .as("entityId must identify the subject user whose role was revoked")
+                                .isEqualTo(subjectUser.getId().toString());
+                assertThat(event.getTimestamp())
+                                .as("RoleRevokedFromUser event must carry a non-null timestamp")
+                                .isNotNull();
+        }
 
-    // ── AC5 ──────────────────────────────────────────────────────────────────
+        // ── AC5 ──────────────────────────────────────────────────────────────────
 
-    /**
-     * AC5: A Security Officer must be able to query {@code audit_log_events} by
-     * {@code eventType} to retrieve role-assignment history with timestamp,
-     * actor identity, subject identity, and role name.
-     *
-     * <p><b>GREEN path:</b> {@code AuditController.searchEvents()} supports
-     * querying by {@code eventType} alone and AC3 persists
-     * {@code RoleAssignedToUser}, enabling a non-empty history response.
-     */
-    @Test
-    @DisplayName("AC5: audit events queryable by eventType=RoleAssignedToUser returns role assignment history")
-    void ac5_auditEvents_queryableByEventType_returnsRoleAssignmentHistory() throws Exception {
-        // Given: a role assignment has occurred
-        mockMvc.perform(withAuth(
-                        put("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
-                        ROLE_ASSIGN_AUTH))
-                .andExpect(status().isCreated());
+        /**
+         * AC5: A Security Officer must be able to query {@code audit_log_events} by
+         * {@code eventType} to retrieve role-assignment history with timestamp,
+         * actor identity, subject identity, and role name.
+         *
+         * <p>
+         * <b>GREEN path:</b> {@code AuditController.searchEvents()} supports
+         * querying by {@code eventType} alone and AC3 persists
+         * {@code RoleAssignedToUser}, enabling a non-empty history response.
+         */
+        @Test
+        @DisplayName("AC5: audit events queryable by eventType=RoleAssignedToUser returns role assignment history")
+        void ac5_auditEvents_queryableByEventType_returnsRoleAssignmentHistory() throws Exception {
+                // Given: a role assignment has occurred
+                mockMvc.perform(withAuth(
+                                put("/v1/users/{userId}/roles/{roleId}", subjectUser.getId(), testRole.getId()),
+                                ROLE_ASSIGN_AUTH))
+                                .andExpect(status().isCreated());
 
-        // When: Security Officer queries audit events by eventType
-        // Issue #2 GREEN: endpoint supports eventType-only query and returns matching history
-        mockMvc.perform(withAuth(get("/v1/audit/events").param("eventType", "RoleAssignedToUser"), AUDIT_VIEW_AUTH))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].eventType").value("RoleAssignedToUser"))
-                .andExpect(jsonPath("$[0].actorId").isNotEmpty())
-                .andExpect(jsonPath("$[0].entityId").isNotEmpty())
-                .andExpect(jsonPath("$[0].timestamp").isNotEmpty());
-    }
+                // When: Security Officer queries audit events by eventType
+                // Issue #2 GREEN: endpoint supports eventType-only query and returns matching
+                // history
+                // Response is Page<AuditLogEventDto>; events live in $.content
+                mockMvc.perform(withAuth(get("/v1/audit/events").param("eventType", "RoleAssignedToUser"),
+                                AUDIT_VIEW_AUTH))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.content").isArray())
+                                .andExpect(jsonPath("$.content.length()").value(1))
+                                .andExpect(jsonPath("$.content[0].eventType").value("RoleAssignedToUser"))
+                                .andExpect(jsonPath("$.content[0].actorId").isNotEmpty())
+                                .andExpect(jsonPath("$.content[0].entityId").isNotEmpty())
+                                .andExpect(jsonPath("$.content[0].timestamp").isNotEmpty());
+        }
 
-    // ── Entity builders ───────────────────────────────────────────────────────
+        // ── Entity builders ───────────────────────────────────────────────────────
 
-    /**
-     * Creates and persists a {@link Role} with a unique name.
-     *
-     * @param name        unique role name
-     * @param description human-readable description
-     * @return the persisted {@link Role}
-     */
-    private Role buildRole(String name, String description) {
-        Role role = new Role();
-        role.setId(UUIDv7Generator.generate());
-        role.setName(name);
-        role.setDescription(description);
-        role.setCreatedBy("test-issue-2");
-        role.setCreatedAt(Instant.now());
-        return roleRepository.save(role);
-    }
+        /**
+         * Creates and persists a {@link Role} with a unique name.
+         *
+         * @param name        unique role name
+         * @param description human-readable description
+         * @return the persisted {@link Role}
+         */
+        private Role buildRole(String name, String description) {
+                Role role = new Role();
+                role.setId(UUIDv7Generator.generate());
+                role.setName(name);
+                role.setDescription(description);
+                role.setCreatedBy("test-issue-2");
+                role.setCreatedAt(Instant.now());
+                return roleRepository.save(role);
+        }
 
-    /**
-     * Creates and persists a {@link User} with a unique username.
-     *
-     * @param username unique username
-     * @return the persisted {@link User}
-     */
-    private User buildUser(String username) {
-        User user = new User();
-        user.setId(UUIDv7Generator.generate());
-        user.setUsername(username);
-        user.setPassword("{noop}test-password");
-        return userRepository.save(user);
-    }
+        /**
+         * Creates and persists a {@link User} with a unique username.
+         *
+         * @param username unique username
+         * @return the persisted {@link User}
+         */
+        private User buildUser(String username) {
+                User user = new User();
+                user.setId(UUIDv7Generator.generate());
+                user.setUsername(username);
+                user.setPassword("{noop}test-password");
+                return userRepository.save(user);
+        }
 
-    /**
-     * Creates and persists a {@link Permission} following the
-     * {@code domain:resource:action} naming convention.
-     *
-     * @param name     full permission key (e.g. {@code order:refund:approve})
-     * @param domain   domain segment (e.g. {@code order})
-     * @param resource resource segment (e.g. {@code refund})
-     * @param action   action segment (e.g. {@code approve})
-     * @return the persisted {@link Permission}
-     */
-    private Permission buildPermission(String name, String domain, String resource, String action) {
-        Permission permission = new Permission();
-        permission.setId(UUIDv7Generator.generate());
-        permission.setName(name);
-        permission.setDomain(domain);
-        permission.setResource(resource);
-        permission.setAction(action);
-        permission.setDescription("Permission for " + name + " – Issue #2 test data");
-        permission.setDeprecated(false);
-        permission.setRegisteredAt(Instant.now());
-        permission.setRegisteredByService("test-issue-2");
-        return permissionRepository.save(permission);
-    }
+        /**
+         * Creates and persists a {@link Permission} following the
+         * {@code domain:resource:action} naming convention.
+         *
+         * @param name     full permission key (e.g. {@code order:refund:approve})
+         * @param domain   domain segment (e.g. {@code order})
+         * @param resource resource segment (e.g. {@code refund})
+         * @param action   action segment (e.g. {@code approve})
+         * @return the persisted {@link Permission}
+         */
+        private Permission buildPermission(String name, String domain, String resource, String action) {
+                Permission permission = new Permission();
+                permission.setId(UUIDv7Generator.generate());
+                permission.setName(name);
+                permission.setDomain(domain);
+                permission.setResource(resource);
+                permission.setAction(action);
+                permission.setDescription("Permission for " + name + " – Issue #2 test data");
+                permission.setDeprecated(false);
+                permission.setRegisteredAt(Instant.now());
+                permission.setRegisteredByService("test-issue-2");
+                return permissionRepository.save(permission);
+        }
 }

--- a/pos-security-service/src/test/java/com/positivity/securityservice/contract/RolePermissionContractBehaviorIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/contract/RolePermissionContractBehaviorIT.java
@@ -29,169 +29,170 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  *
  * Issue: #42
  */
-@SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        classes = PosSecurityServiceApplication.class,
-        properties = {"security.jwt.secret=test-jwt-secret-key-01234567890123456789"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = PosSecurityServiceApplication.class, properties = {
+                "security.jwt.secret=test-jwt-secret-key-01234567890123456789" })
 @ActiveProfiles("test")
 @RecordApplicationEvents
-@WithMockUser(
-        username = "system-admin",
-        roles = {"ADMIN"})
+@WithMockUser(username = "system-admin", roles = { "ADMIN" })
 @DisplayName("Issue #42 RBAC Role/Permission Contract Behavior")
 class RolePermissionContractBehaviorIT extends BaseContractIntegrationTest {
 
-    @MockitoBean
-    private TokenRevocationManager tokenRevocationManager;
+        @MockitoBean
+        private TokenRevocationManager tokenRevocationManager;
 
-    private MockHttpServletRequestBuilder withSystemAdminAuth(MockHttpServletRequestBuilder builder) {
-        return withAuth(
-                builder,
-                "ROLE_ADMIN,security:permission:register,security:permission:view,security:role:create,security:role:edit,security:role:view,security:role:assign,security:authorization:decide");
-    }
+        private MockHttpServletRequestBuilder withSystemAdminAuth(MockHttpServletRequestBuilder builder) {
+                return withAuth(
+                                builder,
+                                "ROLE_ADMIN,security:permission:register,security:permission:view,security:role:create,security:role:edit,security:role:view,security:role:assign,security:authorization:decide");
+        }
 
-    // Issue #42: AC1 validates domain:resource:action permission naming on
-    // registration.
-    @Test
-    @DisplayName("AC1: registerPermissions accepts valid permission naming convention")
-    void ac1_registerPermissions_acceptsValidPermissionFormat() throws Exception {
-        String payload = objectMapper.writeValueAsString(Map.of(
-                "permissions",
-                List.of(Map.of(
-                        "id", "pricing:price_book:edit",
-                        "description", "Edit price book entries"))));
+        // Issue #42: AC1 validates domain:resource:action permission naming on
+        // registration.
+        @Test
+        @DisplayName("AC1: registerPermissions accepts valid permission naming convention")
+        void ac1_registerPermissions_acceptsValidPermissionFormat() throws Exception {
+                String payload = objectMapper.writeValueAsString(Map.of(
+                                "permissions",
+                                List.of(Map.of(
+                                                "id", "pricing:price_book:edit",
+                                                "description", "Edit price book entries"))));
 
-        mockMvc.perform(withSystemAdminAuth(post("/v1/users/permissions/registerPermissions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(payload)))
-                .andExpect(status().isOk());
-    }
+                mockMvc.perform(withSystemAdminAuth(post("/v1/users/permissions/registerPermissions")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(payload)))
+                                .andExpect(status().isOk());
+        }
 
-    // Issue #42: AC1 rejects non-conforming permission key naming format.
-    @Test
-    @DisplayName("AC1: registerPermissions rejects invalid permission naming convention")
-    void ac1_registerPermissions_rejectsInvalidPermissionFormat() throws Exception {
-        String payload = objectMapper.writeValueAsString(Map.of(
-                "permissions",
-                List.of(Map.of(
-                        "id", "invalid_key",
-                        "description", "Invalid key"))));
+        // Issue #42: AC1 rejects non-conforming permission key naming format.
+        @Test
+        @DisplayName("AC1: registerPermissions rejects invalid permission naming convention")
+        void ac1_registerPermissions_rejectsInvalidPermissionFormat() throws Exception {
+                String payload = objectMapper.writeValueAsString(Map.of(
+                                "permissions",
+                                List.of(Map.of(
+                                                "id", "invalid_key",
+                                                "description", "Invalid key"))));
 
-        mockMvc.perform(withSystemAdminAuth(post("/v1/users/permissions/registerPermissions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(payload)))
-                .andExpect(status().isBadRequest());
-    }
+                mockMvc.perform(withSystemAdminAuth(post("/v1/users/permissions/registerPermissions")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(payload)))
+                                .andExpect(status().isBadRequest());
+        }
 
-    // Issue #42: AC2 ensures permission registration is idempotent.
-    @Test
-    @DisplayName("AC2: registerPermissions is idempotent for duplicate registration")
-    void ac2_registerPermissions_isIdempotent() throws Exception {
-        String permissionKey = "pricing:price_book:edit";
-        String payload = objectMapper.writeValueAsString(
-                Map.of("permissions", List.of(Map.of("id", permissionKey, "description", "Edit price book entries"))));
+        // Issue #42: AC2 ensures permission registration is idempotent.
+        @Test
+        @DisplayName("AC2: registerPermissions is idempotent for duplicate registration")
+        void ac2_registerPermissions_isIdempotent() throws Exception {
+                String permissionKey = "pricing:price_book:edit";
+                String payload = objectMapper.writeValueAsString(
+                                Map.of("permissions", List.of(Map.of("id", permissionKey, "description",
+                                                "Edit price book entries"))));
 
-        mockMvc.perform(withSystemAdminAuth(post("/v1/users/permissions/registerPermissions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(payload)))
-                .andExpect(status().isOk());
+                mockMvc.perform(withSystemAdminAuth(post("/v1/users/permissions/registerPermissions")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(payload)))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(withSystemAdminAuth(post("/v1/users/permissions/registerPermissions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(payload)))
-                .andExpect(status().isOk());
+                mockMvc.perform(withSystemAdminAuth(post("/v1/users/permissions/registerPermissions")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(payload)))
+                                .andExpect(status().isOk());
 
-        String queryResponse = mockMvc.perform(
-                        withSystemAdminAuth(get("/v1/users/permissions").param("domain", "pricing")))
-                .andExpect(status().isOk())
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
+                String queryResponse = mockMvc.perform(
+                                withSystemAdminAuth(get("/v1/users/permissions").param("domain", "pricing")))
+                                .andExpect(status().isOk())
+                                .andReturn()
+                                .getResponse()
+                                .getContentAsString();
 
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> permissions = objectMapper.readValue(queryResponse, List.class);
-        long duplicateCount = permissions.stream()
-                .filter(permission -> permissionKey.equals(String.valueOf(permission.get("name"))))
-                .count();
-        assertThat(duplicateCount).isEqualTo(1);
-    }
+                // Response is Page<PermissionDto>; deserialize as Map and extract content list
+                @SuppressWarnings("unchecked")
+                Map<String, Object> permPage = objectMapper.readValue(queryResponse, Map.class);
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> permissions = (List<Map<String, Object>>) permPage.get("content");
+                long duplicateCount = permissions.stream()
+                                .filter(permission -> permissionKey.equals(String.valueOf(permission.get("name"))))
+                                .count();
+                assertThat(duplicateCount).isEqualTo(1);
+        }
 
-    // Issue #42: AC3 verifies allow decision for principal with role-permission
-    // grant.
-    @Test
-    @DisplayName("AC3: authorization decision returns allow when principal has granted permission")
-    void ac3_authorizationDecision_returnsAllow() throws Exception {
-        String rolePayload = objectMapper.writeValueAsString(Map.of(
-                "name", "PricingAnalyst",
-                "description", "Pricing analyst role"));
+        // Issue #42: AC3 verifies allow decision for principal with role-permission
+        // grant.
+        @Test
+        @DisplayName("AC3: authorization decision returns allow when principal has granted permission")
+        void ac3_authorizationDecision_returnsAllow() throws Exception {
+                String rolePayload = objectMapper.writeValueAsString(Map.of(
+                                "name", "PricingAnalyst",
+                                "description", "Pricing analyst role"));
 
-        String roleResponse = mockMvc.perform(withSystemAdminAuth(post("/v1/users/roles")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(rolePayload)))
-                .andExpect(status().isCreated())
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
+                String roleResponse = mockMvc.perform(withSystemAdminAuth(post("/v1/users/roles")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(rolePayload)))
+                                .andExpect(status().isCreated())
+                                .andReturn()
+                                .getResponse()
+                                .getContentAsString();
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> createdRole = objectMapper.readValue(roleResponse, Map.class);
-        String roleId = String.valueOf(createdRole.get("id"));
+                @SuppressWarnings("unchecked")
+                Map<String, Object> createdRole = objectMapper.readValue(roleResponse, Map.class);
+                String roleId = String.valueOf(createdRole.get("id"));
 
-        mockMvc.perform(withSystemAdminAuth(put("/v1/users/roles/{roleId}/permissions/grant", roleId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("permission", "pricing:msrp:edit")))))
-                .andExpect(status().isOk());
+                mockMvc.perform(withSystemAdminAuth(put("/v1/users/roles/{roleId}/permissions/grant", roleId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(Map.of("permission", "pricing:msrp:edit")))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(withSystemAdminAuth(post("/v1/users/principals/{principalId}/roles/{roleId}", "userA", roleId)))
-                .andExpect(status().isOk());
+                mockMvc.perform(withSystemAdminAuth(
+                                post("/v1/users/principals/{principalId}/roles/{roleId}", "userA", roleId)))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(withSystemAdminAuth(get("/v1/users/authorization/decision")
-                        .param("principalId", "userA")
-                        .param("permission", "pricing:msrp:edit")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.decision").value("allow"));
-    }
+                mockMvc.perform(withSystemAdminAuth(get("/v1/users/authorization/decision")
+                                .param("principalId", "userA")
+                                .param("permission", "pricing:msrp:edit")))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.decision").value("allow"));
+        }
 
-    // Issue #42: AC4 verifies deny-by-default behavior for unassigned principal.
-    @Test
-    @DisplayName("AC4: authorization decision returns deny by default")
-    void ac4_authorizationDecision_returnsDenyByDefault() throws Exception {
-        mockMvc.perform(withSystemAdminAuth(get("/v1/users/authorization/decision")
-                        .param("principalId", "userB")
-                        .param("permission", "pricing:msrp:edit")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.decision").value("deny"));
-    }
+        // Issue #42: AC4 verifies deny-by-default behavior for unassigned principal.
+        @Test
+        @DisplayName("AC4: authorization decision returns deny by default")
+        void ac4_authorizationDecision_returnsDenyByDefault() throws Exception {
+                mockMvc.perform(withSystemAdminAuth(get("/v1/users/authorization/decision")
+                                .param("principalId", "userB")
+                                .param("permission", "pricing:msrp:edit")))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.decision").value("deny"));
+        }
 
-    // Issue #42: AC5 verifies role.permission.grant audit event emission when
-    // granting.
-    @Test
-    @DisplayName("AC5: granting permission emits role.permission.grant audit event")
-    void ac5_grantPermission_emitsAuditEvent(ApplicationEvents applicationEvents) throws Exception {
-        String rolePayload = objectMapper.writeValueAsString(Map.of(
-                "name", "PricingApprover",
-                "description", "Pricing approver role"));
+        // Issue #42: AC5 verifies role.permission.grant audit event emission when
+        // granting.
+        @Test
+        @DisplayName("AC5: granting permission emits role.permission.grant audit event")
+        void ac5_grantPermission_emitsAuditEvent(ApplicationEvents applicationEvents) throws Exception {
+                String rolePayload = objectMapper.writeValueAsString(Map.of(
+                                "name", "PricingApprover",
+                                "description", "Pricing approver role"));
 
-        String roleResponse = mockMvc.perform(withSystemAdminAuth(post("/v1/users/roles")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(rolePayload)))
-                .andExpect(status().isCreated())
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
+                String roleResponse = mockMvc.perform(withSystemAdminAuth(post("/v1/users/roles")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(rolePayload)))
+                                .andExpect(status().isCreated())
+                                .andReturn()
+                                .getResponse()
+                                .getContentAsString();
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> createdRole = objectMapper.readValue(roleResponse, Map.class);
-        String roleId = String.valueOf(createdRole.get("id"));
+                @SuppressWarnings("unchecked")
+                Map<String, Object> createdRole = objectMapper.readValue(roleResponse, Map.class);
+                String roleId = String.valueOf(createdRole.get("id"));
 
-        mockMvc.perform(withSystemAdminAuth(put("/v1/users/roles/{roleId}/permissions/grant", roleId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("permission", "pricing:msrp:edit")))))
-                .andExpect(status().isOk());
+                mockMvc.perform(withSystemAdminAuth(put("/v1/users/roles/{roleId}/permissions/grant", roleId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(Map.of("permission", "pricing:msrp:edit")))))
+                                .andExpect(status().isOk());
 
-        boolean grantEventObserved = applicationEvents.stream(ApplicationEvent.class)
-                .anyMatch(event -> event.toString().contains("role.permission.grant"));
+                boolean grantEventObserved = applicationEvents.stream(ApplicationEvent.class)
+                                .anyMatch(event -> event.toString().contains("role.permission.grant"));
 
-        assertThat(grantEventObserved).isTrue();
-    }
+                assertThat(grantEventObserved).isTrue();
+        }
 }

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/SecurityEventTypeInitializerTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/SecurityEventTypeInitializerTest.java
@@ -87,15 +87,15 @@ class SecurityEventTypeInitializerTest {
     // =========================================================
 
     @Nested
-    @DisplayName("T_SETI1: run() registers all 31 event types")
+    @DisplayName("T_SETI1: run() registers all 32 event types")
     class RegistersAllEventTypes {
 
         @Test
-        @DisplayName("T_SETI1 — SecurityEventTypes.all() defines exactly 31 entries")
+        @DisplayName("T_SETI1 — SecurityEventTypes.all() defines exactly 32 entries")
         void securityEventTypes_definesExactly31Types() {
             assertThat(EventTypes.all())
-                    .as("SecurityEventTypes.all() must define exactly 31 event type registrations")
-                    .hasSize(31);
+                    .as("SecurityEventTypes.all() must define exactly 32 event type registrations")
+                    .hasSize(32);
         }
 
         @Test
@@ -120,8 +120,8 @@ class SecurityEventTypeInitializerTest {
         @DisplayName("T_SETI3 — run() calls header(SECRET_HEADER, secret) for every event type when secret is set")
         void run_withSecret_setsSecretHeader() {
             String secret = "test-api-secret-value";
-            EventTypeInitializer sutWithSecret =
-                    new EventTypeInitializer(restClientBuilder, "http://localhost:8085", secret);
+            EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, "http://localhost:8085",
+                    secret);
 
             sutWithSecret.run(null);
 

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/controller/AuditControllerTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/controller/AuditControllerTest.java
@@ -1,0 +1,339 @@
+package com.positivity.securityservice.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.securityservice.internal.dto.AuditExportJobResponse;
+import com.positivity.securityservice.internal.dto.AuditLogEventDto;
+import com.positivity.securityservice.internal.enums.AuditExportStatus;
+import com.positivity.securityservice.internal.security.JwtAuthenticationFilter;
+import com.positivity.securityservice.internal.service.CustomUserDetailsService;
+import com.positivity.securityservice.service.AuditEventService;
+import com.positivity.securityservice.service.AuditExportService;
+import com.positivity.securityservice.service.PricingSnapshotService;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.FilterChain;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+/**
+ * Controller slice tests for B-3 search and B-4 export endpoints from the SDK
+ * migration Wave 1.
+ */
+@WebMvcTest({ AuditController.class, AuditExportController.class })
+@DisplayName("AuditControllerTest — B-3 searchAuditEvents, B-4 export endpoints")
+class AuditControllerTest {
+
+  private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC);
+  private static final UUID KNOWN_JOB_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final UUID UNKNOWN_JOB_ID = UUID.fromString("00000000-0000-0000-0000-000000000099");
+  private static final UUID WORKORDER_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  // ── Service dependencies ──────────────────────────────────────────────────
+
+  @MockitoBean
+  private AuditEventService auditEventService;
+
+  @MockitoBean
+  private AuditExportService auditExportService;
+
+  @MockitoBean
+  private PricingSnapshotService pricingSnapshotService;
+
+  // ── Security infrastructure ───────────────────────────────────────────────
+
+  @MockitoBean
+  private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  @MockitoBean
+  private CustomUserDetailsService customUserDetailsService;
+
+  @BeforeEach
+  void configureJwtFilterPassthrough() throws Exception {
+    doAnswer(inv -> {
+      ((FilterChain) inv.getArgument(2)).doFilter(inv.getArgument(0), inv.getArgument(1));
+      return null;
+    })
+        .when(jwtAuthenticationFilter)
+        .doFilter(any(), any(), any());
+  }
+
+  // ── B-3: GET /v1/audit/events ─────────────────────────────────────────────
+
+  /**
+   * B-3: GET /v1/audit/events?page=0&size=10 returns 200 with a paged result.
+   */
+  @Test
+  @WithMockUser(authorities = "security:audit:view")
+  @DisplayName("GET /v1/audit/events?page=0&size=10 → 200 with page")
+  void searchAuditEvents_noFilters_returnsPage() throws Exception {
+    AuditLogEventDto event = AuditLogEventDto.builder()
+        .eventId(UUID.randomUUID())
+        .timestamp(Instant.parse("2026-01-15T10:00:00Z"))
+        .eventType("PERMISSION_DENIED")
+        .actorId("user@example.com")
+        .entityId("entity-1")
+        .entityType("Permission")
+        .build();
+    when(auditEventService.searchEventsFiltered(any(), any()))
+        .thenReturn(new PageImpl<>(List.of(event)));
+
+    mockMvc.perform(get("/v1/audit/events").param("page", "0").param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].eventType").value("PERMISSION_DENIED"));
+  }
+
+  /**
+   * B-3: GET /v1/audit/events?actorId=<string> returns 200 with filtered results.
+   */
+  @Test
+  @WithMockUser(authorities = "security:audit:view")
+  @DisplayName("GET /v1/audit/events?actorId=<string> → 200 with filtered page")
+  void searchAuditEvents_withActorId_returnsFilteredPage() throws Exception {
+    String actorId = "advisor.jane";
+    AuditLogEventDto event = AuditLogEventDto.builder()
+        .eventId(UUID.randomUUID())
+        .timestamp(Instant.parse("2026-02-01T08:00:00Z"))
+        .eventType("LOGIN_SUCCESS")
+        .actorId(actorId)
+        .entityId("session-1")
+        .entityType("Session")
+        .build();
+    when(auditEventService.searchEventsFiltered(any(), any()))
+        .thenReturn(new PageImpl<>(List.of(event)));
+
+    mockMvc.perform(get("/v1/audit/events").param("actorId", actorId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].actorId").value(actorId));
+  }
+
+  /**
+   * B-3: GET /v1/audit/events?workorderId=<uuid> returns 200 with filtered
+   * results.
+   */
+  @Test
+  @WithMockUser(authorities = "security:audit:view")
+  @DisplayName("GET /v1/audit/events?workorderId=<uuid> → 200 with filtered page")
+  void searchAuditEvents_withWorkorderId_returnsFilteredPage() throws Exception {
+    AuditLogEventDto event = AuditLogEventDto.builder()
+        .eventId(UUID.randomUUID())
+        .timestamp(Instant.parse("2026-03-01T12:00:00Z"))
+        .eventType("WORKORDER_CREATED")
+        .actorId("advisor@shop.com")
+        .entityId(WORKORDER_ID.toString())
+        .entityType("Workorder")
+        .build();
+    when(auditEventService.searchEventsFiltered(any(), any()))
+        .thenReturn(new PageImpl<>(List.of(event)));
+
+    mockMvc.perform(get("/v1/audit/events").param("workorderId", WORKORDER_ID.toString()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].entityType").value("Workorder"));
+  }
+
+  /**
+   * B-3: GET /v1/audit/events?fromDate=...&toDate=... returns 200 with
+   * date-scoped page.
+   */
+  @Test
+  @WithMockUser(authorities = "security:audit:view")
+  @DisplayName("GET /v1/audit/events?fromDate=...&toDate=... → 200 with date-filtered page")
+  void searchAuditEvents_withDateRange_returnsFilteredPage() throws Exception {
+    AuditLogEventDto event = AuditLogEventDto.builder()
+        .eventId(UUID.randomUUID())
+        .timestamp(Instant.parse("2026-06-15T09:00:00Z"))
+        .eventType("ROLE_ASSIGNED")
+        .actorId("admin@shop.com")
+        .entityId("role-1")
+        .entityType("Role")
+        .build();
+    when(auditEventService.searchEventsFiltered(any(), any()))
+        .thenReturn(new PageImpl<>(List.of(event)));
+
+    mockMvc.perform(get("/v1/audit/events")
+        .param("fromDate", "2026-01-01T00:00:00Z")
+        .param("toDate", "2026-12-31T23:59:59Z"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].eventType").value("ROLE_ASSIGNED"));
+  }
+
+  /**
+   * B-3: GET /v1/audit/events without the required authority returns 403.
+   */
+  @Test
+  @WithMockUser(roles = "VIEWER")
+  @DisplayName("GET /v1/audit/events without security:audit:view authority → 403 Forbidden")
+  void searchAuditEvents_missingAuthority_returns403() throws Exception {
+    mockMvc.perform(get("/v1/audit/events"))
+        .andExpect(status().isForbidden());
+  }
+
+  // ── B-4: POST /v1/audit/exports ───────────────────────────────────────────
+
+  /**
+   * B-4: POST /v1/audit/exports with a valid body returns 202 Accepted.
+   */
+  @Test
+  @WithMockUser(authorities = "security:audit:export")
+  @DisplayName("POST /v1/audit/exports with valid request → 202 Accepted")
+  void requestAuditExport_validRequest_returns202() throws Exception {
+    AuditExportJobResponse stub = AuditExportJobResponse.builder()
+        .jobId(KNOWN_JOB_ID)
+        .status(AuditExportStatus.PENDING)
+        .requestedAt(Instant.parse("2026-01-01T00:00:00Z"))
+        .build();
+    when(auditExportService.requestExport(any())).thenReturn(stub);
+
+    mockMvc.perform(post("/v1/audit/exports")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"format\":\"CSV\",\"deliveryMode\":\"DOWNLOAD\"}"))
+        .andExpect(status().isAccepted())
+        .andExpect(jsonPath("$.jobId").value(KNOWN_JOB_ID.toString()))
+        .andExpect(jsonPath("$.status").value("PENDING"));
+  }
+
+  /**
+   * B-4: POST /v1/audit/exports without the required authority returns 403.
+   */
+  @Test
+  @WithMockUser(roles = "VIEWER")
+  @DisplayName("POST /v1/audit/exports without security:audit:export authority → 403 Forbidden")
+  void requestAuditExport_missingAuthority_returns403() throws Exception {
+    mockMvc.perform(post("/v1/audit/exports")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"format\":\"CSV\",\"deliveryMode\":\"DOWNLOAD\"}"))
+        .andExpect(status().isForbidden());
+  }
+
+  // ── B-4: GET /v1/audit/exports/{jobId} ───────────────────────────────────
+
+  /**
+   * B-4: GET /v1/audit/exports/{jobId} for a known job returns 200 with job
+   * response.
+   */
+  @Test
+  @WithMockUser(authorities = "security:audit:export")
+  @DisplayName("GET /v1/audit/exports/{jobId} for known job → 200 with job response")
+  void getAuditExportJob_existingJob_returns200() throws Exception {
+    AuditExportJobResponse stub = AuditExportJobResponse.builder()
+        .jobId(KNOWN_JOB_ID)
+        .status(AuditExportStatus.PENDING)
+        .requestedAt(Instant.parse("2026-01-01T00:00:00Z"))
+        .build();
+    when(auditExportService.getExportJob(KNOWN_JOB_ID)).thenReturn(stub);
+
+    mockMvc.perform(get("/v1/audit/exports/{jobId}", KNOWN_JOB_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.jobId").value(KNOWN_JOB_ID.toString()))
+        .andExpect(jsonPath("$.status").value("PENDING"));
+  }
+
+  /**
+   * B-4: GET /v1/audit/exports/{jobId} for an unknown job returns 404.
+   */
+  @Test
+  @WithMockUser(authorities = "security:audit:export")
+  @DisplayName("GET /v1/audit/exports/{unknownId} → 404 Not Found")
+  void getAuditExportJob_unknownJob_returns404() throws Exception {
+    when(auditExportService.getExportJob(UNKNOWN_JOB_ID))
+        .thenThrow(new EntityNotFoundException("Audit export job not found: " + UNKNOWN_JOB_ID));
+
+    mockMvc.perform(get("/v1/audit/exports/{jobId}", UNKNOWN_JOB_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  /**
+   * B-4: GET /v1/audit/exports/{jobId} without the required authority returns
+   * 403.
+   */
+  @Test
+  @WithMockUser(roles = "VIEWER")
+  @DisplayName("GET /v1/audit/exports/{jobId} without security:audit:export authority → 403 Forbidden")
+  void getAuditExportJob_missingAuthority_returns403() throws Exception {
+    mockMvc.perform(get("/v1/audit/exports/{jobId}", KNOWN_JOB_ID))
+        .andExpect(status().isForbidden());
+  }
+
+  // ── Test slice configuration ──────────────────────────────────────────────
+
+  @TestConfiguration
+  @EnableMethodSecurity(prePostEnabled = true)
+  static class SliceTestConfig {
+
+    @Bean
+    Clock clock() {
+      return TEST_CLOCK;
+    }
+
+    @Bean
+    SecurityExceptionControllerAdvice securityExceptionControllerAdvice() {
+      return new SecurityExceptionControllerAdvice();
+    }
+  }
+
+  /**
+   * Maps Spring Security exceptions to HTTP 401/403 in this MockMvc slice.
+   * {@code @Order(HIGHEST_PRECEDENCE)} ensures this advice is consulted before
+   * {@link com.positivity.securityservice.internal.config.GlobalExceptionHandler}
+   * which would otherwise return 500 for unhandled security exceptions.
+   */
+  @ControllerAdvice
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  static class SecurityExceptionControllerAdvice {
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    void handleAccessDenied() {
+      // Intentionally empty: @ResponseStatus drives the HTTP mapping in this slice.
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    void handleUnauthenticated() {
+      // Intentionally empty: @ResponseStatus drives the HTTP mapping in this slice.
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    void handleNotFound() {
+      // Intentionally empty: @ResponseStatus drives the HTTP mapping in this slice.
+    }
+  }
+}

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/controller/PermissionCatalogControllerTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/controller/PermissionCatalogControllerTest.java
@@ -3,6 +3,8 @@ package com.positivity.securityservice.internal.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -10,6 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.positivity.securityservice.internal.dto.PermissionDto;
 import com.positivity.securityservice.internal.security.JwtAuthenticationFilter;
 import com.positivity.securityservice.internal.service.CustomUserDetailsService;
 import com.positivity.securityservice.service.PermissionCatalogVersionService;
@@ -20,12 +23,15 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -95,9 +101,9 @@ class PermissionCatalogControllerTest {
     @BeforeEach
     void configureJwtFilterPassthrough() throws Exception {
         doAnswer(inv -> {
-                    ((FilterChain) inv.getArgument(2)).doFilter(inv.getArgument(0), inv.getArgument(1));
-                    return null;
-                })
+            ((FilterChain) inv.getArgument(2)).doFilter(inv.getArgument(0), inv.getArgument(1));
+            return null;
+        })
                 .when(jwtAuthenticationFilter)
                 .doFilter(any(), any(), any());
     }
@@ -151,8 +157,8 @@ class PermissionCatalogControllerTest {
                 .thenReturn(List.of("accounting:je:view", "accounting:je:create"));
 
         mockMvc.perform(post("/v1/permissions/decode")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"perm_bits\":\"Aw\",\"perm_ver\":1}"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"perm_bits\":\"Aw\",\"perm_ver\":1}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.permissions").isArray());
     }
@@ -168,8 +174,8 @@ class PermissionCatalogControllerTest {
     @DisplayName("POST /v1/permissions/decode without security:permission:view authority → 403 Forbidden")
     void decodePermissions_requires_security_permission_view_authority() throws Exception {
         mockMvc.perform(post("/v1/permissions/decode")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"perm_bits\":\"Aw\",\"perm_ver\":1}"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"perm_bits\":\"Aw\",\"perm_ver\":1}"))
                 .andExpect(status().isForbidden());
     }
 
@@ -186,8 +192,8 @@ class PermissionCatalogControllerTest {
     @DisplayName("POST /v1/permissions/decode with null perm_bits → 400 Bad Request")
     void decodePermissions_validates_perm_bits_not_null() throws Exception {
         mockMvc.perform(post("/v1/permissions/decode")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"perm_bits\":null,\"perm_ver\":1}"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"perm_bits\":null,\"perm_ver\":1}"))
                 .andExpect(status().isBadRequest());
     }
 
@@ -196,8 +202,8 @@ class PermissionCatalogControllerTest {
     @DisplayName("POST /decode with empty perm_bits returns 400 Bad Request")
     void decodePermissions_emptyPermBits_returns400() throws Exception {
         mockMvc.perform(post("/v1/permissions/decode")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"perm_bits\":\"\",\"perm_ver\":1}"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"perm_bits\":\"\",\"perm_ver\":1}"))
                 .andExpect(status().isBadRequest());
     }
 
@@ -206,9 +212,70 @@ class PermissionCatalogControllerTest {
     @DisplayName("POST /decode with perm_ver <= 0 returns 400 Bad Request")
     void decodePermissions_nonPositivePermVer_returns400() throws Exception {
         mockMvc.perform(post("/v1/permissions/decode")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"perm_bits\":\"Aw==\",\"perm_ver\":0}"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"perm_bits\":\"Aw==\",\"perm_ver\":0}"))
                 .andExpect(status().isBadRequest());
+    }
+
+    // ── B-1: GET /v1/permissions — paged list ────────────────────────────────
+
+    /**
+     * B-1: GET /v1/permissions?page=0&size=20 returns 200 with a paged content
+     * array.
+     */
+    @Test
+    @WithMockUser(authorities = "security:permission:view")
+    @DisplayName("GET /v1/permissions?page=0&size=20 → 200 with paged result")
+    void listPermissions_noFilter_returnsPage() throws Exception {
+        PermissionDto dto = PermissionDto.builder()
+                .id(UUID.randomUUID())
+                .name("catalog:product:view")
+                .domain("catalog")
+                .description("View products")
+                .deprecated(false)
+                .build();
+        when(permissionService.listPermissions(isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(dto)));
+
+        mockMvc.perform(get("/v1/permissions").param("page", "0").param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].name").value("catalog:product:view"));
+    }
+
+    /**
+     * B-1: GET /v1/permissions?domain=catalog returns 200 with only catalog-scoped
+     * results.
+     */
+    @Test
+    @WithMockUser(authorities = "security:permission:view")
+    @DisplayName("GET /v1/permissions?domain=catalog → 200 with filtered results")
+    void listPermissions_withDomainFilter_returnsFilteredPage() throws Exception {
+        PermissionDto dto = PermissionDto.builder()
+                .id(UUID.randomUUID())
+                .name("catalog:product:view")
+                .domain("catalog")
+                .description("View products")
+                .deprecated(false)
+                .build();
+        when(permissionService.listPermissions(eq("catalog"), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(dto)));
+
+        mockMvc.perform(get("/v1/permissions").param("domain", "catalog"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].domain").value("catalog"));
+    }
+
+    /**
+     * B-1: GET /v1/permissions without the required authority returns 403.
+     */
+    @Test
+    @WithMockUser(roles = "VIEWER")
+    @DisplayName("GET /v1/permissions without security:permission:view authority → 403 Forbidden")
+    void listPermissions_missingAuthority_returns403() throws Exception {
+        mockMvc.perform(get("/v1/permissions"))
+                .andExpect(status().isForbidden());
     }
 
     // ── Test slice configuration ──────────────────────────────────────────────

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/PermissionServiceImplTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/PermissionServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.positivity.securityservice.internal.dto.PermissionRegistrationRequest;
 import com.positivity.securityservice.internal.entity.Permission;
 import com.positivity.securityservice.internal.repository.PermissionRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -149,7 +150,7 @@ class PermissionServiceImplTest {
             when(permissionRepository.findById(permissionId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> sut.getPermission(permissionId))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(EntityNotFoundException.class)
                     .hasMessageContaining("Permission not found");
         }
     }

--- a/pos-security-service/src/test/java/com/positivity/securityservice/service/AuditEventServiceImplTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/service/AuditEventServiceImplTest.java
@@ -12,6 +12,7 @@ import com.positivity.securityservice.internal.dto.AuditLogEventRequest;
 import com.positivity.securityservice.internal.entity.AuditLogEvent;
 import com.positivity.securityservice.internal.repository.AuditLogEventRepository;
 import com.positivity.securityservice.internal.service.AuditEventServiceImpl;
+import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -27,226 +28,229 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class AuditEventServiceImplTest {
 
-    @Mock
-    private AuditLogEventRepository auditLogEventRepository;
+        @Mock
+        private AuditLogEventRepository auditLogEventRepository;
 
-    @Mock
-    private ObjectMapper objectMapper;
+        @Mock
+        private ObjectMapper objectMapper;
 
-    @InjectMocks
-    private AuditEventServiceImpl auditEventService;
+        @InjectMocks
+        private AuditEventServiceImpl auditEventService;
 
-    @Test
-    @DisplayName("createEvent stores immutable payload and returns mapped dto")
-    void createEvent_success_returnsMappedDto() throws JsonProcessingException {
-        AuditLogEventRequest request = new AuditLogEventRequest(
-                "PRICING_OVERRIDE",
-                "user-1",
-                "quote-1",
-                "QUOTE",
-                Map.of("price", 100),
-                Map.of("price", 95),
-                Map.of("reason", "manager approval"));
+        @Test
+        @DisplayName("createEvent stores immutable payload and returns mapped dto")
+        void createEvent_success_returnsMappedDto() throws JsonProcessingException {
+                AuditLogEventRequest request = new AuditLogEventRequest(
+                                "PRICING_OVERRIDE",
+                                "user-1",
+                                "quote-1",
+                                "QUOTE",
+                                Map.of("price", 100),
+                                Map.of("price", 95),
+                                Map.of("reason", "manager approval"));
 
-        UUID eventId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        Instant timestamp = Instant.parse("2026-02-21T10:00:00Z");
+                UUID eventId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                Instant timestamp = Instant.parse("2026-02-21T10:00:00Z");
 
-        when(objectMapper.writeValueAsString(request.getOldValue())).thenReturn("{\"price\":100}");
-        when(objectMapper.writeValueAsString(request.getNewValue())).thenReturn("{\"price\":95}");
-        when(objectMapper.writeValueAsString(request.getContext())).thenReturn("{\"reason\":\"manager approval\"}");
-        when(auditLogEventRepository.save(any(AuditLogEvent.class))).thenAnswer(invocation -> {
-            AuditLogEvent event = invocation.getArgument(0);
-            event.setEventId(eventId);
-            event.setTimestamp(timestamp);
-            return event;
-        });
+                when(objectMapper.writeValueAsString(request.getOldValue())).thenReturn("{\"price\":100}");
+                when(objectMapper.writeValueAsString(request.getNewValue())).thenReturn("{\"price\":95}");
+                when(objectMapper.writeValueAsString(request.getContext()))
+                                .thenReturn("{\"reason\":\"manager approval\"}");
+                when(auditLogEventRepository.save(any(AuditLogEvent.class))).thenAnswer(invocation -> {
+                        AuditLogEvent event = invocation.getArgument(0);
+                        event.setEventId(eventId);
+                        event.setTimestamp(timestamp);
+                        return event;
+                });
 
-        var result = auditEventService.createEvent(request);
+                var result = auditEventService.createEvent(request);
 
-        assertThat(result.getEventId()).isEqualTo(eventId);
-        assertThat(result.getTimestamp()).isEqualTo(timestamp);
-        assertThat(result.getEventType()).isEqualTo("PRICING_OVERRIDE");
-        assertThat(result.getActorId()).isEqualTo("system");
-        assertThat(result.getEntityId()).isEqualTo("quote-1");
-        assertThat(result.getEntityType()).isEqualTo("QUOTE");
-        assertThat(result.getOldValue()).isEqualTo("{\"price\":100}");
-        assertThat(result.getNewValue()).isEqualTo("{\"price\":95}");
-        assertThat(result.getContext()).isEqualTo("{\"reason\":\"manager approval\"}");
+                assertThat(result.getEventId()).isEqualTo(eventId);
+                assertThat(result.getTimestamp()).isEqualTo(timestamp);
+                assertThat(result.getEventType()).isEqualTo("PRICING_OVERRIDE");
+                assertThat(result.getActorId()).isEqualTo("system");
+                assertThat(result.getEntityId()).isEqualTo("quote-1");
+                assertThat(result.getEntityType()).isEqualTo("QUOTE");
+                assertThat(result.getOldValue()).isEqualTo("{\"price\":100}");
+                assertThat(result.getNewValue()).isEqualTo("{\"price\":95}");
+                assertThat(result.getContext()).isEqualTo("{\"reason\":\"manager approval\"}");
 
-        verify(auditLogEventRepository).save(any(AuditLogEvent.class));
-    }
+                verify(auditLogEventRepository).save(any(AuditLogEvent.class));
+        }
 
-    @Test
-    @DisplayName("createEvent accepts null context")
-    void createEvent_nullContext_persistsNullContext() throws JsonProcessingException {
-        AuditLogEventRequest request = new AuditLogEventRequest(
-                "PRICING_OVERRIDE", "user-1", "quote-1", "QUOTE", Map.of("price", 100), Map.of("price", 95), null);
+        @Test
+        @DisplayName("createEvent accepts null context")
+        void createEvent_nullContext_persistsNullContext() throws JsonProcessingException {
+                AuditLogEventRequest request = new AuditLogEventRequest(
+                                "PRICING_OVERRIDE", "user-1", "quote-1", "QUOTE", Map.of("price", 100),
+                                Map.of("price", 95), null);
 
-        when(objectMapper.writeValueAsString(request.getOldValue())).thenReturn("{\"price\":100}");
-        when(objectMapper.writeValueAsString(request.getNewValue())).thenReturn("{\"price\":95}");
-        when(auditLogEventRepository.save(any(AuditLogEvent.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+                when(objectMapper.writeValueAsString(request.getOldValue())).thenReturn("{\"price\":100}");
+                when(objectMapper.writeValueAsString(request.getNewValue())).thenReturn("{\"price\":95}");
+                when(auditLogEventRepository.save(any(AuditLogEvent.class)))
+                                .thenAnswer(invocation -> invocation.getArgument(0));
 
-        var result = auditEventService.createEvent(request);
+                var result = auditEventService.createEvent(request);
 
-        assertThat(result.getContext()).isNull();
-    }
+                assertThat(result.getContext()).isNull();
+        }
 
-    @Test
-    @DisplayName("createEvent throws when required fields are missing")
-    void createEvent_missingFields_throws() {
-        AuditLogEventRequest request =
-                new AuditLogEventRequest(null, "user-1", "quote-1", "QUOTE", Map.of(), Map.of(), null);
+        @Test
+        @DisplayName("createEvent throws when required fields are missing")
+        void createEvent_missingFields_throws() {
+                AuditLogEventRequest request = new AuditLogEventRequest(null, "user-1", "quote-1", "QUOTE", Map.of(),
+                                Map.of(), null);
 
-        assertThatThrownBy(() -> auditEventService.createEvent(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("eventType is required");
-    }
+                assertThatThrownBy(() -> auditEventService.createEvent(request))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("eventType is required");
+        }
 
-    @Test
-    @DisplayName("createEvent throws when json serialization fails")
-    void createEvent_jsonSerializationFailure_throws() throws JsonProcessingException {
-        AuditLogEventRequest request = new AuditLogEventRequest(
-                "PRICING_OVERRIDE",
-                "user-1",
-                "quote-1",
-                "QUOTE",
-                Map.of("price", 100),
-                Map.of("price", 95),
-                Map.of("reason", "invalid"));
+        @Test
+        @DisplayName("createEvent throws when json serialization fails")
+        void createEvent_jsonSerializationFailure_throws() throws JsonProcessingException {
+                AuditLogEventRequest request = new AuditLogEventRequest(
+                                "PRICING_OVERRIDE",
+                                "user-1",
+                                "quote-1",
+                                "QUOTE",
+                                Map.of("price", 100),
+                                Map.of("price", 95),
+                                Map.of("reason", "invalid"));
 
-        when(objectMapper.writeValueAsString(request.getOldValue()))
-                .thenThrow(new JsonProcessingException("bad json") {});
+                when(objectMapper.writeValueAsString(request.getOldValue()))
+                                .thenThrow(new JsonProcessingException("bad json") {
+                                });
 
-        assertThatThrownBy(() -> auditEventService.createEvent(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Failed to serialize JSON field");
-    }
+                assertThatThrownBy(() -> auditEventService.createEvent(request))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("Failed to serialize JSON field");
+        }
 
-    @Test
-    @DisplayName("getEvent returns mapped dto when event exists")
-    void getEvent_found_returnsDto() {
-        UUID eventId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        AuditLogEvent event = new AuditLogEvent();
-        event.setEventId(eventId);
-        event.setTimestamp(Instant.parse("2026-02-21T12:00:00Z"));
-        event.setEventType("PRICING_OVERRIDE");
-        event.setActorId("user-2");
-        event.setEntityId("quote-2");
-        event.setEntityType("QUOTE");
-        event.setOldValue("{\"price\":120}");
-        event.setNewValue("{\"price\":110}");
-        event.setContext("{\"reason\":\"discount\"}");
+        @Test
+        @DisplayName("getEvent returns mapped dto when event exists")
+        void getEvent_found_returnsDto() {
+                UUID eventId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                AuditLogEvent event = new AuditLogEvent();
+                event.setEventId(eventId);
+                event.setTimestamp(Instant.parse("2026-02-21T12:00:00Z"));
+                event.setEventType("PRICING_OVERRIDE");
+                event.setActorId("user-2");
+                event.setEntityId("quote-2");
+                event.setEntityType("QUOTE");
+                event.setOldValue("{\"price\":120}");
+                event.setNewValue("{\"price\":110}");
+                event.setContext("{\"reason\":\"discount\"}");
 
-        when(auditLogEventRepository.findById(eventId)).thenReturn(Optional.of(event));
+                when(auditLogEventRepository.findById(eventId)).thenReturn(Optional.of(event));
 
-        var result = auditEventService.getEvent(eventId);
+                var result = auditEventService.getEvent(eventId);
 
-        assertThat(result.getEventId()).isEqualTo(eventId);
-        assertThat(result.getActorId()).isEqualTo("user-2");
-    }
+                assertThat(result.getEventId()).isEqualTo(eventId);
+                assertThat(result.getActorId()).isEqualTo("user-2");
+        }
 
-    @Test
-    @DisplayName("getEvent throws when event does not exist")
-    void getEvent_notFound_throws() {
-        UUID eventId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        when(auditLogEventRepository.findById(eventId)).thenReturn(Optional.empty());
+        @Test
+        @DisplayName("getEvent throws when event does not exist")
+        void getEvent_notFound_throws() {
+                UUID eventId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                when(auditLogEventRepository.findById(eventId)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> auditEventService.getEvent(eventId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Audit event not found");
-    }
+                assertThatThrownBy(() -> auditEventService.getEvent(eventId))
+                                .isInstanceOf(EntityNotFoundException.class)
+                                .hasMessageContaining("Audit event not found");
+        }
 
-    @Test
-    @DisplayName("searchEvents uses range query when from and to are provided")
-    void searchEvents_withRange_usesRangeRepositoryMethod() {
-        Instant from = Instant.parse("2026-02-20T00:00:00Z");
-        Instant to = Instant.parse("2026-02-22T00:00:00Z");
+        @Test
+        @DisplayName("searchEvents uses range query when from and to are provided")
+        void searchEvents_withRange_usesRangeRepositoryMethod() {
+                Instant from = Instant.parse("2026-02-20T00:00:00Z");
+                Instant to = Instant.parse("2026-02-22T00:00:00Z");
 
-        AuditLogEvent event = new AuditLogEvent();
-        event.setEventId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
-        event.setTimestamp(Instant.parse("2026-02-21T13:00:00Z"));
-        event.setEventType("PRICING_OVERRIDE");
-        event.setActorId("user-3");
-        event.setEntityId("quote-3");
-        event.setEntityType("QUOTE");
-        event.setOldValue("{\"price\":140}");
-        event.setNewValue("{\"price\":130}");
+                AuditLogEvent event = new AuditLogEvent();
+                event.setEventId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+                event.setTimestamp(Instant.parse("2026-02-21T13:00:00Z"));
+                event.setEventType("PRICING_OVERRIDE");
+                event.setActorId("user-3");
+                event.setEntityId("quote-3");
+                event.setEntityType("QUOTE");
+                event.setOldValue("{\"price\":140}");
+                event.setNewValue("{\"price\":130}");
 
-        when(auditLogEventRepository.findByEntityIdAndEntityTypeAndTimestampBetweenOrderByTimestampDesc(
-                        "quote-3", "QUOTE", from, to))
-                .thenReturn(List.of(event));
+                when(auditLogEventRepository.findByEntityIdAndEntityTypeAndTimestampBetweenOrderByTimestampDesc(
+                                "quote-3", "QUOTE", from, to))
+                                .thenReturn(List.of(event));
 
-        var result = auditEventService.searchEvents("quote-3", "QUOTE", from, to);
+                var result = auditEventService.searchEvents("quote-3", "QUOTE", from, to);
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getEntityId()).isEqualTo("quote-3");
-    }
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getEntityId()).isEqualTo("quote-3");
+        }
 
-    @Test
-    @DisplayName("searchEvents uses non-range query when from or to is missing")
-    void searchEvents_withoutRange_usesNonRangeRepositoryMethod() {
-        AuditLogEvent event = new AuditLogEvent();
-        event.setEventId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
-        event.setTimestamp(Instant.parse("2026-02-21T14:00:00Z"));
-        event.setEventType("PRICING_OVERRIDE");
-        event.setActorId("user-4");
-        event.setEntityId("quote-4");
-        event.setEntityType("QUOTE");
-        event.setOldValue("{\"price\":150}");
-        event.setNewValue("{\"price\":145}");
+        @Test
+        @DisplayName("searchEvents uses non-range query when from or to is missing")
+        void searchEvents_withoutRange_usesNonRangeRepositoryMethod() {
+                AuditLogEvent event = new AuditLogEvent();
+                event.setEventId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+                event.setTimestamp(Instant.parse("2026-02-21T14:00:00Z"));
+                event.setEventType("PRICING_OVERRIDE");
+                event.setActorId("user-4");
+                event.setEntityId("quote-4");
+                event.setEntityType("QUOTE");
+                event.setOldValue("{\"price\":150}");
+                event.setNewValue("{\"price\":145}");
 
-        when(auditLogEventRepository.findByEntityIdAndEntityTypeOrderByTimestampDesc("quote-4", "QUOTE"))
-                .thenReturn(List.of(event));
+                when(auditLogEventRepository.findByEntityIdAndEntityTypeOrderByTimestampDesc("quote-4", "QUOTE"))
+                                .thenReturn(List.of(event));
 
-        var result = auditEventService.searchEvents("quote-4", "QUOTE", null, null);
+                var result = auditEventService.searchEvents("quote-4", "QUOTE", null, null);
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getEntityType()).isEqualTo("QUOTE");
-    }
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getEntityType()).isEqualTo("QUOTE");
+        }
 
-    @Test
-    @DisplayName("searchEvents throws when entity filters are missing")
-    void searchEvents_missingFilters_throws() {
-        assertThatThrownBy(() -> auditEventService.searchEvents(" ", "QUOTE", null, null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("entityId and entityType are required");
+        @Test
+        @DisplayName("searchEvents throws when entity filters are missing")
+        void searchEvents_missingFilters_throws() {
+                assertThatThrownBy(() -> auditEventService.searchEvents(" ", "QUOTE", null, null))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("entityId and entityType are required");
 
-        assertThatThrownBy(() -> auditEventService.searchEvents("quote-5", " ", null, null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("entityId and entityType are required");
-    }
+                assertThatThrownBy(() -> auditEventService.searchEvents("quote-5", " ", null, null))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("entityId and entityType are required");
+        }
 
-    // Issue #: searchByEventType unit coverage (Cycle 3 Low finding)
-    @Test
-    @DisplayName("searchByEventType returns mapped DTOs for matching events")
-    void searchByEventType_returnsMatchingEvents() {
-        AuditLogEvent event = new AuditLogEvent();
-        event.setEventId(UUID.fromString("00000000-0000-0000-0000-000000000010"));
-        event.setTimestamp(Instant.parse("2026-02-21T15:00:00Z"));
-        event.setEventType("RoleAssignedToUser");
-        event.setActorId("admin-1");
-        event.setEntityId("user-10");
-        event.setEntityType("USER");
-        event.setOldValue("{}");
-        event.setNewValue("{\"role\":\"MANAGER\"}");
+        // Issue #: searchByEventType unit coverage (Cycle 3 Low finding)
+        @Test
+        @DisplayName("searchByEventType returns mapped DTOs for matching events")
+        void searchByEventType_returnsMatchingEvents() {
+                AuditLogEvent event = new AuditLogEvent();
+                event.setEventId(UUID.fromString("00000000-0000-0000-0000-000000000010"));
+                event.setTimestamp(Instant.parse("2026-02-21T15:00:00Z"));
+                event.setEventType("RoleAssignedToUser");
+                event.setActorId("admin-1");
+                event.setEntityId("user-10");
+                event.setEntityType("USER");
+                event.setOldValue("{}");
+                event.setNewValue("{\"role\":\"MANAGER\"}");
 
-        when(auditLogEventRepository.findByEventTypeOrderByTimestampDesc("RoleAssignedToUser"))
-                .thenReturn(List.of(event));
+                when(auditLogEventRepository.findByEventTypeOrderByTimestampDesc("RoleAssignedToUser"))
+                                .thenReturn(List.of(event));
 
-        var result = auditEventService.searchByEventType("RoleAssignedToUser");
+                var result = auditEventService.searchByEventType("RoleAssignedToUser");
 
-        verify(auditLogEventRepository).findByEventTypeOrderByTimestampDesc("RoleAssignedToUser");
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getEventType()).isEqualTo("RoleAssignedToUser");
-        assertThat(result.get(0).getEntityId()).isEqualTo("user-10");
-    }
+                verify(auditLogEventRepository).findByEventTypeOrderByTimestampDesc("RoleAssignedToUser");
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getEventType()).isEqualTo("RoleAssignedToUser");
+                assertThat(result.get(0).getEntityId()).isEqualTo("user-10");
+        }
 
-    @Test
-    @DisplayName("searchByEventType throws when eventType is blank")
-    void searchByEventType_withBlankEventType_throwsIllegalArgumentException() {
-        assertThatThrownBy(() -> auditEventService.searchByEventType(""))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("eventType is required");
-    }
+        @Test
+        @DisplayName("searchByEventType throws when eventType is blank")
+        void searchByEventType_withBlankEventType_throwsIllegalArgumentException() {
+                assertThatThrownBy(() -> auditEventService.searchByEventType(""))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("eventType is required");
+        }
 }

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ShopAuditController.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ShopAuditController.java
@@ -1,9 +1,15 @@
 package com.positivity.shopmanager.internal.controller;
 
-import com.positivity.events.EmitEvent;
 import com.positivity.shopmanager.internal.dto.ShopAuditEntryResponse;
 import com.positivity.shopmanager.internal.dto.ShopAuditFilter;
 import com.positivity.shopmanager.service.ShopAuditService;
+import com.positivity.shared.error.ApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -24,10 +30,10 @@ import org.springframework.web.bind.annotation.RestController;
  * records.
  */
 @RestController
-@io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = { "shop:schedule:view",
-        "appointments:view" })
+@SecurityRequirement(name = "bearerAuth")
 @RequestMapping("/v1/shop/audit")
 @RequiredArgsConstructor
+@Tag(name = "Shop Audit", description = "Shop schedule and assignment audit trail.")
 public class ShopAuditController {
 
     private final ShopAuditService shopAuditService;
@@ -41,7 +47,10 @@ public class ShopAuditController {
      */
     @GetMapping
     @PreAuthorize("hasAnyAuthority('shop:schedule:view', 'appointments:view')")
-    @EmitEvent(id = "SHOPMGR_AUDIT_SEARCH", apiVersion = "1")
+    @Operation(operationId = "searchShopAudit", summary = "Search shop audit trail", description = "Searches the shop audit trail using filter criteria. At least one filter criterion is required.")
+    @ApiResponse(responseCode = "200", description = "Audit entries returned")
+    @ApiResponse(responseCode = "400", description = "No filter criteria provided", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(responseCode = "403", description = "Insufficient authority", content = @Content(schema = @Schema(implementation = ApiError.class)))
     public @NonNull List<ShopAuditEntryResponse> searchAudit(@ModelAttribute ShopAuditFilter filter) {
         return shopAuditService.search(filter);
     }
@@ -54,8 +63,11 @@ public class ShopAuditController {
      */
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('shop:schedule:view', 'appointments:view')")
-    @EmitEvent(id = "SHOPMGR_AUDIT_GET_BY_ID", apiVersion = "1")
-    public @NonNull ResponseEntity<ShopAuditEntryResponse> getAuditById(@PathVariable UUID id) {
+    @Operation(operationId = "getShopAuditEntry", summary = "Get shop audit entry by ID", description = "Returns a single shop audit entry by its UUID.")
+    @ApiResponse(responseCode = "200", description = "Audit entry returned")
+    @ApiResponse(responseCode = "403", description = "Insufficient authority", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(responseCode = "404", description = "Audit entry not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public @NonNull ResponseEntity<ShopAuditEntryResponse> getAuditById(@PathVariable @NonNull UUID id) {
         return shopAuditService
                 .findById(id)
                 .map(ResponseEntity::ok)

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/dto/ShopAuditFilter.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/dto/ShopAuditFilter.java
@@ -1,6 +1,7 @@
 package com.positivity.shopmanager.internal.dto;
 
 import com.positivity.shopmanager.internal.enums.ShopAuditEventType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,19 +17,33 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Filter criteria for querying the shop audit trail. At least one field must be non-null.")
 public class ShopAuditFilter {
 
+    @Schema(description = "Workorder UUID to filter by - one word per workspace naming policy")
     private String workorderId;
+
+    @Schema(description = "Appointment UUID to filter by")
     private String appointmentId;
+
+    @Schema(description = "Mechanic user ID to filter by")
     private String mechanicId;
+
+    @Schema(description = "Actor user ID to filter by")
     private String actorUserId;
+
+    @Schema(description = "Specific audit event type to filter by")
     private ShopAuditEventType eventType;
+
+    @Schema(description = "Location ID to filter by")
     private String locationId;
 
     /** Inclusive start of the date-time range filter (defaults to 90 days ago). */
+    @Schema(description = "Inclusive start timestamp for date-time range filter", example = "2026-01-01T00:00:00Z")
     private Instant fromDateTime;
 
     /** Inclusive end of the date-time range filter (defaults to now). */
+    @Schema(description = "Inclusive end timestamp for date-time range filter", example = "2026-12-31T23:59:59Z")
     private Instant toDateTime;
 
     /**


### PR DESCRIPTION
# cap/sdk-migration: Wave 1 — B-1 · B-2 · B-3 · B-4

## Objective
Unblock Angular SDK migration (durion-positivity-frontend Wave 3/4) by resolving backend blockers B-1 through B-4 in `pos-security-service` and `pos-shop-manager`.

## Linked Specification
- `durion-positivity-backend/docs/PRD-sdk-migration-backend-unblock.md`
- Blockers B-1, B-2, B-3, B-4

## Modules Changed
`pos-security-service`, `pos-shop-manager`

---

## Changes by Blocker

### B-1 — GET /v1/permissions paged list (pos-security-service)
- `PermissionService.java` — added `listPermissions(@Nullable domain, @NonNull Pageable)` interface method
- `PermissionServiceImpl.java` — implemented with optional domain filter; `getPermission()` now throws `EntityNotFoundException`
- `PermissionRepository.java` — added paged query with optional domain filter
- `PermissionController.java` — added `GET /v1/permissions` paged list; `operationId="listPermissions"`; `@PreAuthorize("hasAuthority('security:permission:view')")`; 200/400/403 ApiResponses
- `GlobalExceptionHandler.java` — added `EntityNotFoundException` → 404 handler

### B-2 — Shop audit SDK annotation fix (pos-shop-manager)
- `ShopAuditController.java` — added `@Tag("Shop Audit")`, `@SecurityRequirement(name="bearerAuth")`, `@Operation`+`@ApiResponse` on both endpoints; removed stray `@EmitEvent` from GET methods
- `ShopAuditFilter.java` — added `@Schema` class-level + field-level on all 8 fields

Note: `shop:schedule:view`/`appointments:view` scopes retained; `shop:audit:view` realignment is a follow-on.

### B-3 — Expanded audit search (pos-security-service)
- `AuditEventSearchFilter.java` (new) — 13-field filter DTO with `@Schema` on all fields
- `AuditEventService.java` — added `searchEventsFiltered` interface method
- `AuditEventServiceImpl.java` — implemented via JPA Specification; `actorId` is String (stores username)
- `AuditLogEventRepository.java` — added `JpaSpecificationExecutor`
- `AuditController.java` — `searchAuditEvents` replaces old 5-param method; returns `Page<AuditLogEventDto>`; `operationId="searchAuditEvents"`; 200/400/403 with content schemas

**SDK contract change (backwards-incompatible):** response shape changed List→Page. Frontend wave PR must adopt simultaneously.
**Known limitation:** 7 filter fields accepted but not yet indexed (workorderId, movementId, productId, sku, correlationId, reasonCode, locationIds) — TODO(B-3) in code.

### B-4 — Audit export endpoints (pos-security-service)
- `AuditExportController.java` (new) — `@Tag("Audit Exports")` at `/v1/audit/exports`; POST 202 Accepted (async, RFC 7231 §6.3.3); GET /{jobId}; `@EmitEvent(SECURITY_AUDIT_EXPORT_REQUEST)`; `@PreAuthorize("hasAuthority('security:audit:export')")`
- `AuditExportService.java` / `AuditExportServiceImpl.java` (new) — in-memory stub
- `AuditExportRequest.java`, `AuditExportJobResponse.java`, `AuditExportFormat`, `AuditDeliveryMode`, `AuditExportStatus` (new DTOs/enums)
- `EventTypes.java` — added `SECURITY_AUDIT_EXPORT_REQUEST`

**Known limitation:** Export service uses in-memory ConcurrentHashMap stub; persistence entity is follow-on.

---

## Test Files
- `PermissionCatalogControllerTest.java` — 3 new tests (paged list: no filter, domain filter, 403)
- `AuditControllerTest.java` — 10 new tests (searchAuditEvents + export POST/GET)
- `PermissionServiceImplTest.java`, `AuditEventServiceImplTest.java` — not-found → EntityNotFoundException
- `SecurityEventTypeInitializerTest.java` — count 31→32
- `PermissionManagementContractIT.java`, `AuditTrailContractBehaviorIT.java`, `RolePermissionContractBehaviorIT.java` — Page-shape fix (`$.content`)

---

## Verification Evidence

| Gate | Module | Result |
|------|--------|--------|
| verify (tests) | pos-security-service | BUILD SUCCESS — 74/0/0 run/fail/err |
| verify (tests) | pos-shop-manager | BUILD SUCCESS |
| lint | pos-security-service | PASS — 0 findings, 27 files |
| lint | pos-shop-manager | PASS — 0 findings, 2 files |
| Code Review | Wave 1 | Verdict: PASS (Cycle 2) |

---

## Follow-up / Risks
- B-3: 7 filter fields deferred (entity schema migration required)
- B-4: Export persistence entity + async queue are follow-on
- B-2: `shop:audit:view` scope realignment is follow-on (ADR + permission catalog)
- **Wave 2 (B-5 pos-bulk-loader): BLOCKED** — awaiting product decision on bulk correction contract
- Frontend adoption: `searchAuditEvents` List→Page shape change requires simultaneous frontend update
