### PR TITLE
fcap/sdk-migration: Wave 5 — pos-inventory SDK surface (B-6..B-15)

### DIFF
--- a/pos-inventory/README.md
+++ b/pos-inventory/README.md
@@ -27,6 +27,8 @@ Inventory management service for the Durion POS platform. Manages stock levels, 
 
 - `GET /v1/inventory/{locationId}/inventory-inquiry` — location-level stock inquiry
 - `GET /v1/inventory/{productId}` — product stock summary
+- `GET /v1/inventory/ledger` — paged inventory ledger query with filter params
+- `GET /v1/inventory/ledger/{entryId}` — fetch a single inventory ledger entry
 - `GET /v1/inventory/asns/{asnId}` — retrieve an ASN
 - `GET /v1/inventory/goods-receipts/{receiptId}` — retrieve a goods receipt
 - `GET /v1/inventory/{poId}` — retrieve a purchase order
@@ -35,6 +37,14 @@ Inventory management service for the Durion POS platform. Manages stock levels, 
 - `GET /v1/inventory/{planId}` — retrieve a cycle count plan
 - `GET /v1/inventory/lead-time` — supplier lead time data
 - `GET /v1/inventory/policies` — replenishment policies
+- `GET /v1/inventory/returns/returnable-items` — returnable item lookup for a workorder
+- `GET /v1/inventory/returns/reason-codes` — return reason code catalog
+- `POST /v1/inventory/returns/submit-to-stock` — submit return lines to stock (async accepted)
+- `GET /v1/inventory/shortage/options` — list shortage resolution options
+- `POST /v1/inventory/shortage/resolve` — resolve shortage with selected strategy
+- `GET /v1/inventory/locations` — paged location reference data
+- `GET /v1/inventory/storage-locations` — paged storage-location reference data
+- `GET /v1/inventory/location-zones` — paged location-zone reference data
 - `POST /v1/inventory/bulk-ingest` — bulk import inventory records
 
 ## Configuration

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -1766,9 +1766,9 @@ paths:
                 $ref: "#/components/schemas/ApiError"
       security:
       - bearerAuth:
-        - inventory:shortages:resolve
+        - inventory:shortage:resolve
       x-required-permissions:
-      - inventory:shortages:resolve
+      - inventory:shortage:resolve
   /v1/inventory/allocations/reallocate:
     post:
       tags:

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
@@ -48,16 +48,6 @@ public final class EventTypes {
                                                 "INVENTORY_AVAILABILITY_UPDATE",
                                                 "Update inventory availability for a product")
                                                 .build(),
-                                EventTypeRegistration.fastRead(
-                                                "INVENTORY_AVAILABILITY_QUERY",
-                                                "Query on-hand and ATP availability by productSku and locationId")
-                                                .build(),
-                                EventTypeRegistration.fastRead("INVENTORY_LEDGER_VIEW", "View inventory ledger entries")
-                                                .build(),
-                                EventTypeRegistration.fastRead(
-                                                "INVENTORY_LEAD_TIME_QUERY",
-                                                "Query dynamic lead time by productId and locationId")
-                                                .build(),
 
                                 // PickingListController - 1 event
                                 EventTypeRegistration.write(

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
@@ -10,152 +10,182 @@ import java.util.List;
  */
 public final class EventTypes {
 
-    private EventTypes() {
-        // Utility class
-    }
+        private EventTypes() {
+                // Utility class
+        }
 
-    /**
-     * All event type registrations for the inventory module.
-     * Total: 37 event types (verified current registry count).
-     */
-    public static List<EventTypeRegistration> all() {
-        return List.of(
-                // CycleCountAdjustmentController - 3 events
-                EventTypeRegistration.write(
-                                "INVENTORY_CYCLE_COUNT_ADJUSTMENT_CREATE", "Create a new cycle count adjustment")
-                        .build(),
-                EventTypeRegistration.approval(
-                                "INVENTORY_CYCLE_COUNT_ADJUSTMENT_APPROVE", "Approve a pending cycle count adjustment")
-                        .build(),
-                EventTypeRegistration.approval(
-                                "INVENTORY_CYCLE_COUNT_ADJUSTMENT_REJECT", "Reject a pending cycle count adjustment")
-                        .build(),
+        /**
+         * All event type registrations for the inventory module.
+         */
+        public static List<EventTypeRegistration> all() {
+                return List.of(
+                                // CycleCountAdjustmentController - 3 events
+                                EventTypeRegistration.write(
+                                                "INVENTORY_CYCLE_COUNT_ADJUSTMENT_CREATE",
+                                                "Create a new cycle count adjustment")
+                                                .build(),
+                                EventTypeRegistration.approval(
+                                                "INVENTORY_CYCLE_COUNT_ADJUSTMENT_APPROVE",
+                                                "Approve a pending cycle count adjustment")
+                                                .build(),
+                                EventTypeRegistration.approval(
+                                                "INVENTORY_CYCLE_COUNT_ADJUSTMENT_REJECT",
+                                                "Reject a pending cycle count adjustment")
+                                                .build(),
 
-                // CycleCountController - 2 events
-                EventTypeRegistration.write("INVENTORY_CYCLE_COUNT_SUBMIT", "Submit a count for a cycle count task")
-                        .build(),
-                EventTypeRegistration.write("INVENTORY_CYCLE_COUNT_RECOUNT", "Submit a recount for a cycle count task")
-                        .build(),
+                                // CycleCountController - 2 events
+                                EventTypeRegistration
+                                                .write("INVENTORY_CYCLE_COUNT_SUBMIT",
+                                                                "Submit a count for a cycle count task")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("INVENTORY_CYCLE_COUNT_RECOUNT",
+                                                                "Submit a recount for a cycle count task")
+                                                .build(),
 
-                // InventoryAvailabilityController - 2 events
-                EventTypeRegistration.write(
-                                "INVENTORY_AVAILABILITY_UPDATE", "Update inventory availability for a product")
-                        .build(),
-                EventTypeRegistration.fastRead(
-                                "INVENTORY_AVAILABILITY_QUERY",
-                                "Query on-hand and ATP availability by productSku and locationId")
-                        .build(),
-                EventTypeRegistration.fastRead(
-                                "INVENTORY_LEAD_TIME_QUERY", "Query dynamic lead time by productId and locationId")
-                        .build(),
+                                // InventoryAvailabilityController - 2 events
+                                EventTypeRegistration.write(
+                                                "INVENTORY_AVAILABILITY_UPDATE",
+                                                "Update inventory availability for a product")
+                                                .build(),
+                                EventTypeRegistration.fastRead(
+                                                "INVENTORY_AVAILABILITY_QUERY",
+                                                "Query on-hand and ATP availability by productSku and locationId")
+                                                .build(),
+                                EventTypeRegistration.fastRead("INVENTORY_LEDGER_VIEW", "View inventory ledger entries")
+                                                .build(),
+                                EventTypeRegistration.fastRead(
+                                                "INVENTORY_LEAD_TIME_QUERY",
+                                                "Query dynamic lead time by productId and locationId")
+                                                .build(),
 
-                // PickingListController - 1 event
-                EventTypeRegistration.write(
-                                "INVENTORY_PICKING_LIST_CONFIRM", "Confirm a picking list and commit consumption")
-                        .build(),
+                                // PickingListController - 1 event
+                                EventTypeRegistration.write(
+                                                "INVENTORY_PICKING_LIST_CONFIRM",
+                                                "Confirm a picking list and commit consumption")
+                                                .build(),
 
-                // InventorySiteDefaultLocationsController - 1 event
-                EventTypeRegistration.write(
-                                "INVENTORY_SITE_DEFAULT_LOCATIONS_UPDATE",
-                                "Replace site default locations configuration")
-                        .build(),
+                                // InventorySiteDefaultLocationsController - 1 event
+                                EventTypeRegistration.write(
+                                                "INVENTORY_SITE_DEFAULT_LOCATIONS_UPDATE",
+                                                "Replace site default locations configuration")
+                                                .build(),
 
-                // InventoryLocationDeactivationController - 1 event
-                EventTypeRegistration.write(
-                                "INVENTORY_LOCATION_DEACTIVATE",
-                                "Deactivate a storage location with optional stock transfer")
-                        .build(),
+                                // InventoryLocationDeactivationController - 1 event
+                                EventTypeRegistration.write(
+                                                "INVENTORY_LOCATION_DEACTIVATE",
+                                                "Deactivate a storage location with optional stock transfer")
+                                                .build(),
 
-                // PutawayController - 2 events
-                EventTypeRegistration.write(
-                                "INVENTORY_PUTAWAY_TASK_GENERATE",
-                                "Generate putaway tasks for received inventory lines")
-                        .build(),
-                EventTypeRegistration.write("INVENTORY_PUTAWAY_TASK_CLAIM", "Claim a putaway task for execution")
-                        .build(),
+                                // PutawayController - 2 events
+                                EventTypeRegistration.write(
+                                                "INVENTORY_PUTAWAY_TASK_GENERATE",
+                                                "Generate putaway tasks for received inventory lines")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("INVENTORY_PUTAWAY_TASK_CLAIM",
+                                                                "Claim a putaway task for execution")
+                                                .build(),
 
-                // ReplenishmentController - 1 event
-                EventTypeRegistration.write(
-                                "INVENTORY_REPLENISHMENT_POLICY_CREATE",
-                                "Create replenishment policy used for task generation")
-                        .build(),
+                                // ReplenishmentController - 1 event
+                                EventTypeRegistration.write(
+                                                "INVENTORY_REPLENISHMENT_POLICY_CREATE",
+                                                "Create replenishment policy used for task generation")
+                                                .build(),
 
-                // StockMovementController - 3 events
-                EventTypeRegistration.write(
-                                "INVENTORY_STOCK_MOVEMENT_CREATE", "Record an inventory stock movement in the ledger")
-                        .build(),
-                EventTypeRegistration.write(
-                                "INVENTORY_ADJUSTMENT_REQUEST_CREATE", "Create a pending inventory adjustment request")
-                        .build(),
-                EventTypeRegistration.approval(
-                                "INVENTORY_ADJUSTMENT_REQUEST_APPROVE",
-                                "Approve and post inventory adjustment request to ledger")
-                        .build(),
+                                // StockMovementController - 3 events
+                                EventTypeRegistration.write(
+                                                "INVENTORY_STOCK_MOVEMENT_CREATE",
+                                                "Record an inventory stock movement in the ledger")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "INVENTORY_ADJUSTMENT_REQUEST_CREATE",
+                                                "Create a pending inventory adjustment request")
+                                                .build(),
+                                EventTypeRegistration.approval(
+                                                "INVENTORY_ADJUSTMENT_REQUEST_APPROVE",
+                                                "Approve and post inventory adjustment request to ledger")
+                                                .build(),
 
-                // ReceivingController - 4 events
-                EventTypeRegistration.write(
-                                "INVENTORY_RECEIVING_SESSION_CREATE", "Create a receiving session from a PO or ASN")
-                        .build(),
-                EventTypeRegistration.fastRead("INVENTORY_RECEIVING_SESSION_GET", "Get a receiving session by ID")
-                        .build(),
-                EventTypeRegistration.write(
-                                "INVENTORY_RECEIVING_SESSION_COMPLETE", "Complete receive items into staging")
-                        .build(),
-                EventTypeRegistration.write(
-                                "INVENTORY_RECEIVING_CROSSDOCK", "Cross-dock receiving line directly to workorder")
-                        .build(),
+                                // ReceivingController - 4 events
+                                EventTypeRegistration.write(
+                                                "INVENTORY_RECEIVING_SESSION_CREATE",
+                                                "Create a receiving session from a PO or ASN")
+                                                .build(),
+                                EventTypeRegistration
+                                                .fastRead("INVENTORY_RECEIVING_SESSION_GET",
+                                                                "Get a receiving session by ID")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "INVENTORY_RECEIVING_SESSION_COMPLETE",
+                                                "Complete receive items into staging")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "INVENTORY_RECEIVING_CROSSDOCK",
+                                                "Cross-dock receiving line directly to workorder")
+                                                .build(),
 
-                // PurchaseOrderController - 9 events
-                EventTypeRegistration.write("INVENTORY_PURCHASE_ORDER_CREATE", "Create a purchase order")
-                        .build(),
-                EventTypeRegistration.fastRead("INVENTORY_PURCHASE_ORDER_GET", "Get purchase order")
-                        .build(),
-                EventTypeRegistration.fastRead("INVENTORY_PURCHASE_ORDER_LIST", "List purchase orders")
-                        .build(),
-                EventTypeRegistration.write("INVENTORY_PURCHASE_ORDER_APPROVE", "Approve a purchase order")
-                        .build(),
-                EventTypeRegistration.approval(
-                                "INVENTORY_PURCHASE_ORDER_ENCUMBRANCE",
-                                "Emit encumbrance posting contract on PO approval")
-                        .build(),
-                EventTypeRegistration.write(
-                                "INVENTORY_PURCHASE_ORDER_ACCOUNTING_ERROR",
-                                "Record accounting error on PO GL posting failure")
-                        .build(),
-                EventTypeRegistration.write(
-                                "INVENTORY_PURCHASE_ORDER_RECEIVE", "Record a receipt against a purchase order")
-                        .build(),
-                EventTypeRegistration.write("INVENTORY_PURCHASE_ORDER_REVISE", "Revise a purchase order")
-                        .build(),
-                EventTypeRegistration.write("INVENTORY_PURCHASE_ORDER_CANCEL", "Cancel a purchase order")
-                        .build(),
+                                // PurchaseOrderController - 9 events
+                                EventTypeRegistration
+                                                .write("INVENTORY_PURCHASE_ORDER_CREATE", "Create a purchase order")
+                                                .build(),
+                                EventTypeRegistration.fastRead("INVENTORY_PURCHASE_ORDER_GET", "Get purchase order")
+                                                .build(),
+                                EventTypeRegistration.fastRead("INVENTORY_PURCHASE_ORDER_LIST", "List purchase orders")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("INVENTORY_PURCHASE_ORDER_APPROVE", "Approve a purchase order")
+                                                .build(),
+                                EventTypeRegistration.approval(
+                                                "INVENTORY_PURCHASE_ORDER_ENCUMBRANCE",
+                                                "Emit encumbrance posting contract on PO approval")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "INVENTORY_PURCHASE_ORDER_ACCOUNTING_ERROR",
+                                                "Record accounting error on PO GL posting failure")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "INVENTORY_PURCHASE_ORDER_RECEIVE",
+                                                "Record a receipt against a purchase order")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("INVENTORY_PURCHASE_ORDER_REVISE", "Revise a purchase order")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("INVENTORY_PURCHASE_ORDER_CANCEL", "Cancel a purchase order")
+                                                .build(),
 
-                // AsnController - 5 events
-                EventTypeRegistration.write("INVENTORY_ASN_CREATE", "Create an Advance Shipping Notice")
-                        .build(),
-                EventTypeRegistration.fastRead("INVENTORY_ASN_GET", "Get ASN by ID")
-                        .build(),
-                EventTypeRegistration.write(
-                                "INVENTORY_ASN_GOODS_RECEIPT_CREATED",
-                                "Publish goods receipt intent event before receipt line processing")
-                        .build(),
-                EventTypeRegistration.write("INVENTORY_GOODS_RECEIPT_CREATE", "Create a goods receipt")
-                        .build(),
-                EventTypeRegistration.fastRead("INVENTORY_GOODS_RECEIPT_GET", "Get goods receipt by ID")
-                        .build(),
+                                // AsnController - 5 events
+                                EventTypeRegistration.write("INVENTORY_ASN_CREATE", "Create an Advance Shipping Notice")
+                                                .build(),
+                                EventTypeRegistration.fastRead("INVENTORY_ASN_GET", "Get ASN by ID")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "INVENTORY_ASN_GOODS_RECEIPT_CREATED",
+                                                "Publish goods receipt intent event before receipt line processing")
+                                                .build(),
+                                EventTypeRegistration.write("INVENTORY_GOODS_RECEIPT_CREATE", "Create a goods receipt")
+                                                .build(),
+                                EventTypeRegistration.fastRead("INVENTORY_GOODS_RECEIPT_GET", "Get goods receipt by ID")
+                                                .build(),
 
-                // ReallocationController - 1 event
-                EventTypeRegistration.write(
-                                "INVENTORY_ALLOCATION_REALLOCATE",
-                                "Trigger deterministic reallocation of reserved stock by priority")
-                        .build(),
+                                // ReallocationController - 1 event
+                                EventTypeRegistration.write(
+                                                "INVENTORY_ALLOCATION_REALLOCATE",
+                                                "Trigger deterministic reallocation of reserved stock by priority")
+                                                .build(),
 
-                // ShortageController - 1 event
-                EventTypeRegistration.write(
-                                "INVENTORY_SHORTAGE_RESOLVE",
-                                "Resolve inventory shortage with substitute or backorder options")
-                        .build(),
-                EventTypeRegistration.write("INVENTORY_BULK_INGEST", "Bulk ingest inventory stock counts")
-                        .build());
-    }
+                                // ShortageController - 1 event
+                                EventTypeRegistration.write(
+                                                "INVENTORY_SHORTAGE_RESOLVE",
+                                                "Resolve inventory shortage with substitute or backorder options")
+                                                .build(),
+                                EventTypeRegistration.write(
+                                                "INVENTORY_RETURN_SUBMIT_TO_STOCK",
+                                                "Submit inventory return lines to stock")
+                                                .build(),
+                                EventTypeRegistration
+                                                .write("INVENTORY_BULK_INGEST", "Bulk ingest inventory stock counts")
+                                                .build());
+        }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryAvailabilityController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryAvailabilityController.java
@@ -5,6 +5,8 @@ import com.positivity.inventory.internal.dto.AvailabilityView;
 import com.positivity.inventory.internal.dto.InventoryAvailabilityResponse;
 import com.positivity.inventory.internal.dto.LeadTimeView;
 import com.positivity.inventory.internal.dto.LocationAvailabilityDto;
+import com.positivity.inventory.internal.enums.InventorySourceType;
+import com.positivity.inventory.internal.exception.InvalidParamCombinationException;
 import com.positivity.inventory.service.InventoryAvailabilityService;
 import com.positivity.inventory.service.InventoryLeadTimeService;
 import com.positivity.shared.error.ApiError;
@@ -19,7 +21,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -44,7 +45,7 @@ public class InventoryAvailabilityController {
         @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
                         "inventory:on_hand:view" })
         @PreAuthorize("hasAuthority('inventory:on_hand:view')")
-        @Operation(summary = "Query inventory availability", description = "Returns per-location availability for a product.", tags = {
+        @Operation(operationId = "getInventoryAvailability", summary = "Query inventory availability", description = "Returns per-location availability for a product.", tags = {
                         "Inventory Availability" })
         @ApiResponse(responseCode = "200", description = "Availability returned", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = LocationAvailabilityDto.class))))
         @ApiResponse(responseCode = "400", description = "Invalid product identifier")
@@ -55,16 +56,16 @@ public class InventoryAvailabilityController {
                 return ResponseEntity.ok(availabilityService.getAvailabilityByProduct(productId));
         }
 
-        @GetMapping("/query")
-        @EmitEvent(id = "INVENTORY_AVAILABILITY_QUERY", apiVersion = "1")
+        @GetMapping("/by-sku")
         @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
                         "inventory:on_hand:view", "inventory:on_hand:search" })
         @PreAuthorize("hasAnyAuthority('inventory:on_hand:view','inventory:on_hand:search')")
-        @Operation(summary = "Query inventory availability by SKU and location", description = "Returns on-hand, allocated, and available-to-promise quantities for a product at a specific location. storageLocationId is optional to narrow the scope to a sub-location.", tags = {
+        @Operation(operationId = "listAvailabilityBySku", summary = "Query inventory availability by SKU and location", description = "Returns on-hand, allocated, and available-to-promise quantities for a product at a specific location. storageLocationId is optional to narrow the scope to a sub-location.", tags = {
                         "Inventory Availability" })
         @ApiResponses(value = {
                         @ApiResponse(responseCode = "200", description = "Availability view returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AvailabilityView.class))),
                         @ApiResponse(responseCode = "400", description = "Invalid request parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+                        @ApiResponse(responseCode = "400", description = "locationId provided without sourceType=WAREHOUSE", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "403", description = "User lacks required read permission", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "404", description = "Product SKU or location not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "500", description = "Unexpected server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
@@ -72,32 +73,52 @@ public class InventoryAvailabilityController {
         // Issue: CAP-215 Story #36
         public ResponseEntity<AvailabilityView> queryAvailabilityBySku(
                         @Parameter(description = "Product SKU", required = true) @RequestParam String productSku,
-                        @Parameter(description = "Location identifier", required = true) @RequestParam UUID locationId,
-                        @Parameter(description = "Storage location identifier (optional; narrows to sub-location)") @RequestParam(required = false) UUID storageLocationId) {
-                log.info("GET /v1/inventory/availability/query productSku={} locationId={}", productSku, locationId);
+                        @Parameter(description = "Location identifier") @RequestParam(required = false) UUID locationId,
+                        @Parameter(description = "Storage location identifier (optional; narrows to sub-location)") @RequestParam(required = false) UUID storageLocationId,
+                        @Parameter(description = "Inventory lookup strategy. WAREHOUSE = from physical location stock, SUPPLIER = from supplier lead time, TRANSIT = from in-transit supply. When sourceType is WAREHOUSE, locationId narrows to a specific location.") @RequestParam(required = false) InventorySourceType sourceType) {
+                validateLocationAndSourceType(locationId, sourceType);
+                log.info("GET /v1/inventory/availability/by-sku productSku={} locationId={} sourceType={}", productSku,
+                                locationId, sourceType);
                 return ResponseEntity
-                                .ok(availabilityService.queryAvailability(productSku, locationId, storageLocationId));
+                                .ok(availabilityService.queryAvailability(productSku, locationId, storageLocationId,
+                                                sourceType));
         }
 
         @GetMapping("/lead-time")
-        @EmitEvent(id = "INVENTORY_LEAD_TIME_QUERY", apiVersion = "1")
         @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
                         "inventory:on_hand:view", "inventory:on_hand:search" })
         @PreAuthorize("hasAnyAuthority('inventory:on_hand:view','inventory:on_hand:search')")
-        @Operation(summary = "Query product lead time", description = "Returns dynamic lead-time estimate for a product at a location.", tags = {
+        @Operation(operationId = "getLeadTime", summary = "Query product lead time", description = "Returns dynamic lead-time estimate for a product at a location.", tags = {
                         "Inventory Availability" })
         @ApiResponses(value = {
                         @ApiResponse(responseCode = "200", description = "Lead-time view returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LeadTimeView.class))),
                         @ApiResponse(responseCode = "400", description = "Invalid request parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+                        @ApiResponse(responseCode = "400", description = "locationId provided without sourceType=WAREHOUSE", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "403", description = "User lacks required read permission", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "404", description = "Lead-time data not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "500", description = "Unexpected server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
         })
         public ResponseEntity<LeadTimeView> queryLeadTime(
                         @Parameter(description = "Product identifier", required = true) @RequestParam UUID productId,
-                        @Parameter(description = "Location identifier", required = true) @RequestParam UUID locationId) {
-                log.info("GET /v1/inventory/availability/lead-time productId={} locationId={}", productId, locationId);
-                return ResponseEntity.ok(inventoryLeadTimeService.queryLeadTime(productId, locationId));
+                        @Parameter(description = "Location identifier") @RequestParam(required = false) UUID locationId,
+                        @Parameter(description = "Storage location identifier (optional; narrows to sub-location)") @RequestParam(required = false) UUID storageLocationId,
+                        @Parameter(description = "Inventory lookup strategy. WAREHOUSE = from physical location stock, SUPPLIER = from supplier lead time, TRANSIT = from in-transit supply. When sourceType is WAREHOUSE, locationId narrows to a specific location.") @RequestParam(required = false) InventorySourceType sourceType) {
+                validateLocationAndSourceType(locationId, sourceType);
+                log.info(
+                                "GET /v1/inventory/availability/lead-time productId={} locationId={} storageLocationId={} sourceType={}",
+                                productId,
+                                locationId,
+                                storageLocationId,
+                                sourceType);
+                return ResponseEntity
+                                .ok(inventoryLeadTimeService.queryLeadTime(productId, locationId, storageLocationId));
+        }
+
+        private void validateLocationAndSourceType(UUID locationId, InventorySourceType sourceType) {
+                if (locationId != null && sourceType != null && sourceType != InventorySourceType.WAREHOUSE) {
+                        throw new InvalidParamCombinationException(
+                                        "locationId is only valid when sourceType is WAREHOUSE");
+                }
         }
 
         /**
@@ -129,6 +150,6 @@ public class InventoryAvailabilityController {
                         @Parameter(description = "Product identifier", required = true) @PathVariable UUID productId,
                         @RequestBody(required = false) Object requestBody) {
                 log.info("POST /v1/inventory/availability/{}", productId);
-                return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+                return ResponseEntity.status(org.springframework.http.HttpStatus.NOT_IMPLEMENTED).build();
         }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryAvailabilityController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryAvailabilityController.java
@@ -64,8 +64,7 @@ public class InventoryAvailabilityController {
                         "Inventory Availability" })
         @ApiResponses(value = {
                         @ApiResponse(responseCode = "200", description = "Availability view returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AvailabilityView.class))),
-                        @ApiResponse(responseCode = "400", description = "Invalid request parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
-                        @ApiResponse(responseCode = "400", description = "locationId provided without sourceType=WAREHOUSE", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid request parameters or locationId provided without sourceType=WAREHOUSE", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "403", description = "User lacks required read permission", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "404", description = "Product SKU or location not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "500", description = "Unexpected server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
@@ -92,8 +91,7 @@ public class InventoryAvailabilityController {
                         "Inventory Availability" })
         @ApiResponses(value = {
                         @ApiResponse(responseCode = "200", description = "Lead-time view returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LeadTimeView.class))),
-                        @ApiResponse(responseCode = "400", description = "Invalid request parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
-                        @ApiResponse(responseCode = "400", description = "locationId provided without sourceType=WAREHOUSE", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid request parameters or locationId provided without sourceType=WAREHOUSE", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "403", description = "User lacks required read permission", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "404", description = "Lead-time data not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
                         @ApiResponse(responseCode = "500", description = "Unexpected server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
@@ -115,7 +113,7 @@ public class InventoryAvailabilityController {
         }
 
         private void validateLocationAndSourceType(UUID locationId, InventorySourceType sourceType) {
-                if (locationId != null && sourceType != null && sourceType != InventorySourceType.WAREHOUSE) {
+                if (locationId != null && sourceType != InventorySourceType.WAREHOUSE) {
                         throw new InvalidParamCombinationException(
                                         "locationId is only valid when sourceType is WAREHOUSE");
                 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.positivity.inventory.internal.exception.InsufficientPermissionExcepti
 import com.positivity.inventory.internal.exception.InsufficientStockException;
 import com.positivity.inventory.internal.exception.InvalidCountQuantityException;
 import com.positivity.inventory.internal.exception.InvalidInventoryAvailabilityRequestException;
+import com.positivity.inventory.internal.exception.InvalidParamCombinationException;
 import com.positivity.inventory.internal.exception.InvalidPoReferenceException;
 import com.positivity.inventory.internal.exception.LocationAtCapacityException;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
@@ -73,11 +74,11 @@ public class InventoryGlobalExceptionHandler {
     }
 
     @ExceptionHandler({
-        MethodArgumentTypeMismatchException.class,
-        HttpMessageNotReadableException.class,
-        ConstraintViolationException.class,
-        InvalidInventoryAvailabilityRequestException.class,
-        IllegalArgumentException.class
+            MethodArgumentTypeMismatchException.class,
+            HttpMessageNotReadableException.class,
+            ConstraintViolationException.class,
+            InvalidInventoryAvailabilityRequestException.class,
+            IllegalArgumentException.class
     })
     public ResponseEntity<ApiError> handleBadRequest(Exception ex) {
         return build(HttpStatus.BAD_REQUEST, VALIDATION_ERROR, ex.getMessage());
@@ -118,7 +119,7 @@ public class InventoryGlobalExceptionHandler {
         return build(HttpStatus.NOT_FOUND, NOT_FOUND, ex.getMessage());
     }
 
-    @ExceptionHandler({ResourceNotFoundException.class, ProductNotFoundException.class, LocationNotFoundException.class
+    @ExceptionHandler({ ResourceNotFoundException.class, ProductNotFoundException.class, LocationNotFoundException.class
     })
     public ResponseEntity<ApiError> handleResourceNotFound(RuntimeException ex) {
         return build(HttpStatus.NOT_FOUND, NOT_FOUND, ex.getMessage());
@@ -170,16 +171,16 @@ public class InventoryGlobalExceptionHandler {
     }
 
     @ExceptionHandler({
-        LocationNotValidForSkuException.class,
-        LocationAtCapacityException.class,
-        NoOnHandAtSourceLocationException.class,
-        PutawayValidationException.class
+            LocationNotValidForSkuException.class,
+            LocationAtCapacityException.class,
+            NoOnHandAtSourceLocationException.class,
+            PutawayValidationException.class
     })
     public ResponseEntity<ApiError> handlePutawayValidation(PutawayValidationException ex) {
         return build(HttpStatus.valueOf(422), ex.getErrorCode(), ex.getMessage());
     }
 
-    @ExceptionHandler({SourceDocumentNotFoundException.class, ReceivingSessionNotFoundException.class})
+    @ExceptionHandler({ SourceDocumentNotFoundException.class, ReceivingSessionNotFoundException.class })
     public ResponseEntity<ApiError> handleReceivingNotFound(RuntimeException ex) {
         return build(HttpStatus.NOT_FOUND, NOT_FOUND, ex.getMessage());
     }
@@ -202,6 +203,11 @@ public class InventoryGlobalExceptionHandler {
     @ExceptionHandler(PartMatchPermissionException.class)
     public ResponseEntity<ApiError> handlePartMatchPermission(PartMatchPermissionException ex) {
         return build(HttpStatus.FORBIDDEN, "PART_MATCH_PERMISSION_REQUIRED", ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidParamCombinationException.class)
+    public ResponseEntity<ApiError> handleInvalidParamCombination(InvalidParamCombinationException ex) {
+        return build(HttpStatus.BAD_REQUEST, "INVALID_PARAM_COMBINATION", ex.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryLedgerController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryLedgerController.java
@@ -1,0 +1,84 @@
+package com.positivity.inventory.internal.controller;
+
+import com.positivity.inventory.internal.dto.InventoryLedgerEntryDto;
+import com.positivity.inventory.internal.dto.InventoryLedgerFilterParams;
+import com.positivity.inventory.internal.dto.LedgerPage;
+import com.positivity.inventory.service.InventoryLedgerService;
+import com.positivity.shared.error.ApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/inventory/ledger")
+@RequiredArgsConstructor
+@Tag(name = "Inventory Ledger", description = "Inventory ledger read endpoints")
+public class InventoryLedgerController {
+
+  private final InventoryLedgerService inventoryLedgerService;
+
+  @GetMapping
+  @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+      "inventory:ledger:view" })
+  @PreAuthorize("hasAuthority('inventory:ledger:view')")
+  @Operation(operationId = "listInventoryLedger", summary = "List inventory ledger entries", description = "Returns inventory ledger entries using optional filters.", tags = {
+      "Inventory Ledger" })
+  @ApiResponse(responseCode = "200", description = "Ledger entries returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LedgerPage.class)))
+  @ApiResponse(responseCode = "400", description = "Invalid request parameters", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+  @ApiResponse(responseCode = "403", description = "User lacks required ledger view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+  public ResponseEntity<LedgerPage<InventoryLedgerEntryDto>> listLedgerEntries(
+      @RequestParam(required = false) String productSku,
+      @RequestParam(required = false) UUID locationId,
+      @RequestParam(required = false) UUID storageLocationId,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant dateFrom,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant dateTo,
+      @RequestParam(required = false) UUID sourceTransactionId,
+      @RequestParam(required = false) UUID workorderId,
+      @RequestParam(required = false) UUID workorderLineId,
+      @RequestParam(required = false) List<String> movementTypes,
+      @RequestParam(required = false) String pageToken,
+      @RequestParam(required = false, defaultValue = "50") int pageSize) {
+    InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+        .productSku(productSku)
+        .locationId(locationId)
+        .storageLocationId(storageLocationId)
+        .dateFrom(dateFrom)
+        .dateTo(dateTo)
+        .sourceTransactionId(sourceTransactionId)
+        .workorderId(workorderId)
+        .workorderLineId(workorderLineId)
+        .movementTypes(movementTypes)
+        .pageToken(pageToken)
+        .pageSize(pageSize)
+        .build();
+
+    return ResponseEntity.ok(inventoryLedgerService.listLedgerEntries(params));
+  }
+
+  @GetMapping("/{entryId}")
+  @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+      "inventory:ledger:view" })
+  @PreAuthorize("hasAuthority('inventory:ledger:view')")
+  @Operation(operationId = "getInventoryLedgerEntry", summary = "Get inventory ledger entry", description = "Returns a single inventory ledger entry by ID.", tags = {
+      "Inventory Ledger" })
+  @ApiResponse(responseCode = "200", description = "Ledger entry returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InventoryLedgerEntryDto.class)))
+  @ApiResponse(responseCode = "403", description = "User lacks required ledger view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+  @ApiResponse(responseCode = "404", description = "Ledger entry not found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+  public ResponseEntity<InventoryLedgerEntryDto> getLedgerEntry(@PathVariable UUID entryId) {
+    return ResponseEntity.ok(inventoryLedgerService.getLedgerEntry(entryId));
+  }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryReferenceDataController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryReferenceDataController.java
@@ -36,7 +36,7 @@ public class InventoryReferenceDataController {
   @PreAuthorize("hasAuthority('inventory:location:view')")
   @Operation(operationId = "listInventoryLocations", summary = "List inventory locations", description = "Returns paged inventory locations.", tags = {
       "Inventory Reference Data" })
-  @ApiResponse(responseCode = "200", description = "Locations returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LocationDto.class)))
+    @ApiResponse(responseCode = "200", description = "Locations returned (paged)", content = @Content(mediaType = "application/json", schema = @Schema(description = "Page of inventory locations")))
   @ApiResponse(responseCode = "403", description = "User lacks required location view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
   public ResponseEntity<Page<LocationDto>> listLocations(
       @RequestParam(required = false) UUID siteId,
@@ -50,7 +50,7 @@ public class InventoryReferenceDataController {
   @PreAuthorize("hasAuthority('inventory:location:view')")
   @Operation(operationId = "listInventoryStorageLocations", summary = "List inventory storage locations", description = "Returns paged inventory storage locations.", tags = {
       "Inventory Reference Data" })
-  @ApiResponse(responseCode = "200", description = "Storage locations returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = StorageLocationDto.class)))
+    @ApiResponse(responseCode = "200", description = "Storage locations returned (paged)", content = @Content(mediaType = "application/json", schema = @Schema(description = "Page of inventory storage locations")))
   @ApiResponse(responseCode = "403", description = "User lacks required location view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
   public ResponseEntity<Page<StorageLocationDto>> listStorageLocations(
       @RequestParam(required = false) UUID locationId,
@@ -64,7 +64,7 @@ public class InventoryReferenceDataController {
   @PreAuthorize("hasAuthority('inventory:location:view')")
   @Operation(operationId = "listInventoryLocationZones", summary = "List inventory location zones", description = "Returns paged inventory location zones.", tags = {
       "Inventory Reference Data" })
-  @ApiResponse(responseCode = "200", description = "Location zones returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LocationZoneDto.class)))
+    @ApiResponse(responseCode = "200", description = "Location zones returned (paged)", content = @Content(mediaType = "application/json", schema = @Schema(description = "Page of inventory location zones")))
   @ApiResponse(responseCode = "403", description = "User lacks required location view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
   public ResponseEntity<Page<LocationZoneDto>> listLocationZones(
       @RequestParam(required = false) UUID locationId,

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryReferenceDataController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryReferenceDataController.java
@@ -1,0 +1,74 @@
+package com.positivity.inventory.internal.controller;
+
+import com.positivity.inventory.internal.dto.LocationDto;
+import com.positivity.inventory.internal.dto.LocationZoneDto;
+import com.positivity.inventory.internal.dto.StorageLocationDto;
+import com.positivity.inventory.service.InventoryReferenceDataService;
+import com.positivity.shared.error.ApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/inventory")
+@RequiredArgsConstructor
+@Tag(name = "Inventory Reference Data", description = "Inventory reference-data read endpoints")
+public class InventoryReferenceDataController {
+
+  private final InventoryReferenceDataService inventoryReferenceDataService;
+
+  @GetMapping("/locations")
+  @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+      "inventory:location:view" })
+  @PreAuthorize("hasAuthority('inventory:location:view')")
+  @Operation(operationId = "listInventoryLocations", summary = "List inventory locations", description = "Returns paged inventory locations.", tags = {
+      "Inventory Reference Data" })
+  @ApiResponse(responseCode = "200", description = "Locations returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LocationDto.class)))
+  @ApiResponse(responseCode = "403", description = "User lacks required location view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+  public ResponseEntity<Page<LocationDto>> listLocations(
+      @RequestParam(required = false) UUID siteId,
+      @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(inventoryReferenceDataService.listLocations(siteId, pageable));
+  }
+
+  @GetMapping("/storage-locations")
+  @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+      "inventory:location:view" })
+  @PreAuthorize("hasAuthority('inventory:location:view')")
+  @Operation(operationId = "listInventoryStorageLocations", summary = "List inventory storage locations", description = "Returns paged inventory storage locations.", tags = {
+      "Inventory Reference Data" })
+  @ApiResponse(responseCode = "200", description = "Storage locations returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = StorageLocationDto.class)))
+  @ApiResponse(responseCode = "403", description = "User lacks required location view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+  public ResponseEntity<Page<StorageLocationDto>> listStorageLocations(
+      @RequestParam(required = false) UUID locationId,
+      @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(inventoryReferenceDataService.listStorageLocations(locationId, pageable));
+  }
+
+  @GetMapping("/location-zones")
+  @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+      "inventory:location:view" })
+  @PreAuthorize("hasAuthority('inventory:location:view')")
+  @Operation(operationId = "listInventoryLocationZones", summary = "List inventory location zones", description = "Returns paged inventory location zones.", tags = {
+      "Inventory Reference Data" })
+  @ApiResponse(responseCode = "200", description = "Location zones returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LocationZoneDto.class)))
+  @ApiResponse(responseCode = "403", description = "User lacks required location view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+  public ResponseEntity<Page<LocationZoneDto>> listLocationZones(
+      @RequestParam(required = false) UUID locationId,
+      @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(inventoryReferenceDataService.listLocationZones(locationId, pageable));
+  }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryInquiryController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryInquiryController.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.internal.controller;
 
 import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
 import com.positivity.inventory.service.LocationInventoryInquiryService;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,6 +15,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,12 +33,14 @@ public class LocationInventoryInquiryController {
     @PreAuthorize("hasAuthority('inventory:on_hand:view')")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
             "inventory:on_hand:view" })
-    @Operation(summary = "Get location inventory summary", description = "Returns on-hand quantity aggregated for a storage location.", tags = {
+    @Operation(operationId = "getLocationInventory", summary = "Get location inventory summary", description = "Returns on-hand quantity aggregated for a storage location.", tags = {
             "Inventory Locations" })
     @ApiResponse(responseCode = "200", description = "Location inventory returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = LocationInventoryInquiryResponse.class)))
     @ApiResponse(responseCode = "400", description = "Invalid location identifier")
+    @ApiResponse(responseCode = "403", description = "User lacks required on-hand view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<LocationInventoryInquiryResponse> getLocationInventory(
-            @Parameter(description = "Storage location identifier", required = true) @PathVariable UUID locationId) {
-        return ResponseEntity.ok(locationInventoryInquiryService.getLocationInventory(locationId));
+            @Parameter(description = "Storage location identifier", required = true) @PathVariable UUID locationId,
+            @Parameter(description = "Product SKU filter") @RequestParam(required = false) String sku) {
+        return ResponseEntity.ok(locationInventoryInquiryService.getLocationInventory(locationId, sku));
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/PutawayController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/PutawayController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -38,7 +40,7 @@ public class PutawayController {
         @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
                         "inventory:putaway:generate" })
         @PreAuthorize("hasAuthority('inventory:putaway:generate')")
-        @Operation(summary = "Generate putaway tasks", description = "Generates putaway tasks for received inventory lines.", tags = {
+        @Operation(operationId = "generatePutawayTasks", summary = "Generate putaway tasks", description = "Generates putaway tasks for received inventory lines.", tags = {
                         "Putaway" })
         @ApiResponse(responseCode = "201", description = "Putaway tasks generated", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = PutawayTaskResponse.class))))
         @ApiResponse(responseCode = "400", description = "Validation failure")
@@ -52,11 +54,13 @@ public class PutawayController {
         @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
                         "inventory:putaway:view" })
         @PreAuthorize("hasAuthority('inventory:putaway:view')")
-        @Operation(summary = "List available putaway tasks", description = "Returns all currently available putaway tasks.", tags = {
+        @Operation(operationId = "listPutawayTasks", summary = "List available putaway tasks", description = "Returns all currently available putaway tasks.", tags = {
                         "Putaway" })
         @ApiResponse(responseCode = "200", description = "Available putaway tasks returned", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = PutawayTaskResponse.class))))
-        public ResponseEntity<List<PutawayTaskResponse>> getAvailableTasks() {
-                return ResponseEntity.ok(putawayGenerationService.getAvailableTasks());
+        public ResponseEntity<List<PutawayTaskResponse>> getAvailableTasks(
+                        @Parameter(description = "Location identifier") @RequestParam(required = false) UUID locationId,
+                        @Parameter(description = "Storage location identifier") @RequestParam(required = false) UUID storageLocationId) {
+                return ResponseEntity.ok(putawayGenerationService.getAvailableTasks(locationId, storageLocationId));
         }
 
         @PostMapping("/{taskId}/claim")
@@ -64,7 +68,7 @@ public class PutawayController {
         @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
                         "inventory:putaway:claim" })
         @PreAuthorize("hasAuthority('inventory:putaway:claim')")
-        @Operation(summary = "Claim a putaway task", description = "Claims an available putaway task for the current actor.", tags = {
+        @Operation(operationId = "claimPutawayTask", summary = "Claim a putaway task", description = "Claims an available putaway task for the current actor.", tags = {
                         "Putaway" })
         @ApiResponse(responseCode = "200", description = "Putaway task claimed", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PutawayTaskResponse.class)))
         @ApiResponse(responseCode = "404", description = "Putaway task not found")

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
@@ -13,7 +13,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,7 +40,7 @@ public class ReplenishmentController {
         @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
                         "inventory:on_hand:view" })
         @PreAuthorize("hasAuthority('inventory:on_hand:view')")
-        @Operation(summary = "List replenishment tasks", description = "Returns replenishment tasks that should be fulfilled.", tags = {
+        @Operation(operationId = "listReplenishmentTasks", summary = "List replenishment tasks", description = "Returns replenishment tasks that should be fulfilled.", tags = {
                         "Replenishment" })
         @ApiResponse(responseCode = "200", description = "Replenishment tasks returned", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ReplenishmentTaskResponse.class))))
         public ResponseEntity<List<ReplenishmentTaskResponse>> getReplenishmentTasks() {
@@ -46,11 +51,13 @@ public class ReplenishmentController {
         @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
                         "inventory:on_hand:view" })
         @PreAuthorize("hasAuthority('inventory:on_hand:view')")
-        @Operation(summary = "List replenishment policies", description = "Returns configured replenishment policies.", tags = {
+        @Operation(operationId = "listReplenishmentPolicies", summary = "List replenishment policies", description = "Returns configured replenishment policies.", tags = {
                         "Replenishment" })
         @ApiResponse(responseCode = "200", description = "Replenishment policies returned", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ReplenishmentPolicyResponse.class))))
-        public ResponseEntity<List<ReplenishmentPolicyResponse>> getReplenishmentPolicies() {
-                return ResponseEntity.ok(replenishmentService.getReplenishmentPolicies());
+        public ResponseEntity<Page<ReplenishmentPolicyResponse>> getReplenishmentPolicies(
+                        @io.swagger.v3.oas.annotations.Parameter(description = "Location identifier") @RequestParam(required = false) UUID locationId,
+                        @PageableDefault(size = 20) Pageable pageable) {
+                return ResponseEntity.ok(replenishmentService.getReplenishmentPolicies(locationId, pageable));
         }
 
         @PostMapping("/policies")
@@ -58,7 +65,7 @@ public class ReplenishmentController {
         @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
                         "inventory:adjustment:create" })
         @PreAuthorize("hasAuthority('inventory:adjustment:create')")
-        @Operation(summary = "Create replenishment policy", description = "Creates a replenishment policy used to generate replenishment tasks.", tags = {
+        @Operation(operationId = "createReplenishmentPolicy", summary = "Create replenishment policy", description = "Creates a replenishment policy used to generate replenishment tasks.", tags = {
                         "Replenishment" })
         @ApiResponse(responseCode = "201", description = "Replenishment policy created", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReplenishmentPolicyResponse.class)))
         @ApiResponse(responseCode = "400", description = "Validation failure")

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
@@ -53,7 +53,7 @@ public class ReplenishmentController {
         @PreAuthorize("hasAuthority('inventory:on_hand:view')")
         @Operation(operationId = "listReplenishmentPolicies", summary = "List replenishment policies", description = "Returns configured replenishment policies.", tags = {
                         "Replenishment" })
-        @ApiResponse(responseCode = "200", description = "Replenishment policies returned", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ReplenishmentPolicyResponse.class))))
+        @ApiResponse(responseCode = "200", description = "Replenishment policies returned (paged)", content = @Content(mediaType = "application/json", schema = @Schema(description = "Page of replenishment policies")))
         public ResponseEntity<Page<ReplenishmentPolicyResponse>> getReplenishmentPolicies(
                         @io.swagger.v3.oas.annotations.Parameter(description = "Location identifier") @RequestParam(required = false) UUID locationId,
                         @PageableDefault(size = 20) Pageable pageable) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReturnController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReturnController.java
@@ -1,8 +1,10 @@
 package com.positivity.inventory.internal.controller;
 
 import com.positivity.events.EmitEvent;
-import com.positivity.inventory.internal.dto.returns.ReturnItemsRequest;
-import com.positivity.inventory.internal.dto.returns.ReturnResponse;
+import com.positivity.inventory.internal.dto.returns.ReasonCodeDto;
+import com.positivity.inventory.internal.dto.returns.ReturnSubmitRequest;
+import com.positivity.inventory.internal.dto.returns.ReturnSubmissionResultDto;
+import com.positivity.inventory.internal.dto.returns.ReturnableItemDto;
 import com.positivity.inventory.service.ReturnService;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,18 +13,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-                "inventory:adjustment:create" })
 @RequestMapping("/v1/inventory/returns")
 @RequiredArgsConstructor
 @Tag(name = "Returns", description = "Inventory return-to-stock endpoints")
@@ -30,17 +33,45 @@ public class ReturnController {
 
         private final ReturnService returnService;
 
-        @PostMapping
-        @EmitEvent(id = "INVENTORY_RETURN_TO_STOCK_CREATE", apiVersion = "1")
-        @PreAuthorize("hasAuthority('inventory:adjustment:create')")
-        @Operation(summary = "Return items to stock", description = "Returns issued parts to inventory and records resulting return movement", tags = {
+        @GetMapping("/returnable-items")
+        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+                        "inventory:return:view" })
+        @PreAuthorize("hasAuthority('inventory:return:view')")
+        @Operation(operationId = "listReturnableItems", summary = "List returnable items", description = "Returns items that can be returned to stock for a workorder.", tags = {
                         "Returns" })
-        @ApiResponse(responseCode = "201", description = "Return recorded", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReturnResponse.class)))
+        @ApiResponse(responseCode = "200", description = "Returnable items returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReturnableItemDto.class)))
         @ApiResponse(responseCode = "400", description = "Validation failure", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "User lacks required return authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "422", description = "Return quantity exceeds allowable amount", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<ReturnResponse> returnItemsToStock(@Valid @RequestBody ReturnItemsRequest request) {
-                ReturnResponse response = returnService.returnItemsToStock(request);
-                return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        @ApiResponse(responseCode = "403", description = "User lacks required return view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<List<ReturnableItemDto>> listReturnableItems(@RequestParam UUID workorderId) {
+                return ResponseEntity.ok(returnService.listReturnableItems(workorderId));
+        }
+
+        @GetMapping("/reason-codes")
+        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+                        "inventory:return:view" })
+        @PreAuthorize("hasAuthority('inventory:return:view')")
+        @Operation(operationId = "listReturnReasonCodes", summary = "List return reason codes", description = "Returns reason codes available for inventory returns.", tags = {
+                        "Returns" })
+        @ApiResponse(responseCode = "200", description = "Return reason codes returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReasonCodeDto.class)))
+        @ApiResponse(responseCode = "403", description = "User lacks required return view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<List<ReasonCodeDto>> listReturnReasonCodes() {
+                return ResponseEntity.ok(returnService.listReturnReasonCodes());
+        }
+
+        @PostMapping("/submit-to-stock")
+        @EmitEvent(id = "INVENTORY_RETURN_SUBMIT_TO_STOCK", apiVersion = "1")
+        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+                        "inventory:return:write" })
+        @PreAuthorize("hasAuthority('inventory:return:write')")
+        @Operation(operationId = "submitReturnToStock", summary = "Submit return to stock", description = "Submits inventory returns to stock.", tags = {
+                        "Returns" })
+        @ApiResponse(responseCode = "202", description = "Return submitted and accepted", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReturnSubmissionResultDto.class)))
+        @ApiResponse(responseCode = "400", description = "Validation failure", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "User lacks required return write authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "422", description = "Return submission violates business policy", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<ReturnSubmissionResultDto> submitToStock(
+                        @Valid @RequestBody ReturnSubmitRequest request) {
+                ReturnSubmissionResultDto response = returnService.submitToStock(request);
+                return ResponseEntity.accepted().body(response);
         }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReturnController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReturnController.java
@@ -8,6 +8,7 @@ import com.positivity.inventory.internal.dto.returns.ReturnableItemDto;
 import com.positivity.inventory.service.ReturnService;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,7 +40,7 @@ public class ReturnController {
         @PreAuthorize("hasAuthority('inventory:return:view')")
         @Operation(operationId = "listReturnableItems", summary = "List returnable items", description = "Returns items that can be returned to stock for a workorder.", tags = {
                         "Returns" })
-        @ApiResponse(responseCode = "200", description = "Returnable items returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReturnableItemDto.class)))
+        @ApiResponse(responseCode = "200", description = "Returnable items returned", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ReturnableItemDto.class))))
         @ApiResponse(responseCode = "400", description = "Validation failure", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "403", description = "User lacks required return view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<ReturnableItemDto>> listReturnableItems(@RequestParam UUID workorderId) {
@@ -52,7 +53,7 @@ public class ReturnController {
         @PreAuthorize("hasAuthority('inventory:return:view')")
         @Operation(operationId = "listReturnReasonCodes", summary = "List return reason codes", description = "Returns reason codes available for inventory returns.", tags = {
                         "Returns" })
-        @ApiResponse(responseCode = "200", description = "Return reason codes returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReasonCodeDto.class)))
+        @ApiResponse(responseCode = "200", description = "Return reason codes returned", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ReasonCodeDto.class))))
         @ApiResponse(responseCode = "403", description = "User lacks required return view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<ReasonCodeDto>> listReturnReasonCodes() {
                 return ResponseEntity.ok(returnService.listReturnReasonCodes());

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ShortageController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ShortageController.java
@@ -7,6 +7,7 @@ import com.positivity.inventory.internal.dto.ShortageResolutionResultDto;
 import com.positivity.inventory.service.ShortageResolutionService;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -38,7 +39,7 @@ public class ShortageController {
         @PreAuthorize("hasAuthority('inventory:shortage:view')")
         @Operation(operationId = "listShortageOptions", summary = "List shortage options", description = "Returns available shortage resolution options for an allocation.", tags = {
                         "Shortage Resolution" })
-        @ApiResponse(responseCode = "200", description = "Shortage options returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ShortageOptionDto.class)))
+        @ApiResponse(responseCode = "200", description = "Shortage options returned", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ShortageOptionDto.class))))
         @ApiResponse(responseCode = "400", description = "Validation failure", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "403", description = "User lacks required shortage view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<ShortageOptionDto>> listShortageOptions(@RequestParam UUID allocationId) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ShortageController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ShortageController.java
@@ -1,8 +1,9 @@
 package com.positivity.inventory.internal.controller;
 
 import com.positivity.events.EmitEvent;
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionRequest;
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionResponse;
+import com.positivity.inventory.internal.dto.ShortageOptionDto;
+import com.positivity.inventory.internal.dto.ShortageResolveRequest;
+import com.positivity.inventory.internal.dto.ShortageResolutionResultDto;
 import com.positivity.inventory.service.ShortageResolutionService;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,35 +12,52 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
-                "inventory:shortages:resolve" })
-@RequestMapping("/v1/inventory/allocations/shortages")
+@RequestMapping("/v1/inventory/shortage")
 @RequiredArgsConstructor
-@PreAuthorize("hasAuthority('inventory:shortages:resolve')")
 @Tag(name = "Shortage Resolution", description = "Shortage resolution recommendation endpoints")
 public class ShortageController {
 
         private final ShortageResolutionService shortageResolutionService;
 
+        @GetMapping("/options")
+        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+                        "inventory:shortage:view" })
+        @PreAuthorize("hasAuthority('inventory:shortage:view')")
+        @Operation(operationId = "listShortageOptions", summary = "List shortage options", description = "Returns available shortage resolution options for an allocation.", tags = {
+                        "Shortage Resolution" })
+        @ApiResponse(responseCode = "200", description = "Shortage options returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ShortageOptionDto.class)))
+        @ApiResponse(responseCode = "400", description = "Validation failure", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "User lacks required shortage view authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<List<ShortageOptionDto>> listShortageOptions(@RequestParam UUID allocationId) {
+                return ResponseEntity.ok(shortageResolutionService.listShortageOptions(allocationId));
+        }
+
         @PostMapping("/resolve")
         @EmitEvent(id = "INVENTORY_SHORTAGE_RESOLVE", apiVersion = "1")
-        @Operation(summary = "Resolve shortage", description = "Returns candidate shortage resolution options from substitutes and external availability", tags = {
+        @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth", scopes = {
+                        "inventory:shortage:resolve" })
+        @PreAuthorize("hasAuthority('inventory:shortage:resolve')")
+        @Operation(operationId = "resolveShortage", summary = "Resolve shortage", description = "Resolves inventory shortage using a selected strategy.", tags = {
                         "Shortage Resolution" })
-        @ApiResponse(responseCode = "200", description = "Resolution options returned", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ShortageResolutionResponse.class)))
+        @ApiResponse(responseCode = "200", description = "Shortage resolved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ShortageResolutionResultDto.class)))
         @ApiResponse(responseCode = "400", description = "Validation failure", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "403", description = "User lacks required shortage resolution authority", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "422", description = "Unable to resolve shortage under current constraints", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<ShortageResolutionResponse> resolveShortage(
-                        @Valid @RequestBody ShortageResolutionRequest request) {
+        public ResponseEntity<ShortageResolutionResultDto> resolveShortage(
+                        @Valid @RequestBody ShortageResolveRequest request) {
                 return ResponseEntity.ok(shortageResolutionService.resolveShortage(request));
         }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryLedgerEntryDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryLedgerEntryDto.java
@@ -1,0 +1,35 @@
+package com.positivity.inventory.internal.dto;
+
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InventoryLedgerEntryDto {
+  private UUID ledgerEntryId;
+  private String stockItemId;
+  private UUID adjustmentId;
+  private InventoryLedgerEventType eventType;
+  private Integer changeInQuantity;
+  private Integer quantityAfter;
+  private BigDecimal unitCost;
+  private String transactionUserId;
+  private Instant timestamp;
+  private UUID locationId;
+  private UUID fromLocationId;
+  private UUID toLocationId;
+  private String reasonCode;
+  private String sourceTransactionId;
+  private String unitOfMeasure;
+  private String notes;
+  private Instant createdAt;
+  private Instant updatedAt;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryLedgerFilterParams.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryLedgerFilterParams.java
@@ -1,0 +1,39 @@
+package com.positivity.inventory.internal.dto;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InventoryLedgerFilterParams {
+  @Nullable
+  private String productSku;
+  @Nullable
+  private UUID locationId;
+  @Nullable
+  private UUID storageLocationId;
+  @Nullable
+  private Instant dateFrom;
+  @Nullable
+  private Instant dateTo;
+  @Nullable
+  private UUID sourceTransactionId;
+  @Nullable
+  private UUID workorderId;
+  @Nullable
+  private UUID workorderLineId;
+  @Nullable
+  private List<String> movementTypes;
+  @Nullable
+  private String pageToken;
+  @Builder.Default
+  private int pageSize = 50;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LedgerPage.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LedgerPage.java
@@ -1,0 +1,18 @@
+package com.positivity.inventory.internal.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LedgerPage<T> {
+  private List<T> entries;
+  @Nullable
+  private String nextPageToken;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationDto.java
@@ -1,0 +1,19 @@
+package com.positivity.inventory.internal.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationDto {
+  private UUID locationId;
+  private UUID siteId;
+  private String name;
+  private String type;
+  private boolean active;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryInquiryResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryInquiryResponse.java
@@ -20,9 +20,9 @@ public class LocationInventoryInquiryResponse {
     @Schema(description = "Storage location identifier", requiredMode = Schema.RequiredMode.REQUIRED)
     private UUID locationId;
 
-    @Schema(
-            description = "Current on-hand quantity across all stock items at the location",
-            example = "12",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Current on-hand quantity across all stock items at the location", example = "12", requiredMode = Schema.RequiredMode.REQUIRED)
     private int onHandQuantity;
+
+    @Schema(description = "Quantity available to promise after reservations and pending allocations", example = "8", requiredMode = Schema.RequiredMode.REQUIRED)
+    private int availableToPromiseQuantity;
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryInquiryResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryInquiryResponse.java
@@ -23,6 +23,6 @@ public class LocationInventoryInquiryResponse {
     @Schema(description = "Current on-hand quantity across all stock items at the location", example = "12", requiredMode = Schema.RequiredMode.REQUIRED)
     private int onHandQuantity;
 
-    @Schema(description = "Quantity available to promise after reservations and pending allocations", example = "8", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Quantity available to promise after pending allocations. Note: reservation events are not yet factored in.", example = "8", requiredMode = Schema.RequiredMode.REQUIRED)
     private int availableToPromiseQuantity;
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationZoneDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationZoneDto.java
@@ -1,0 +1,18 @@
+package com.positivity.inventory.internal.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationZoneDto {
+  private UUID zoneId;
+  private UUID locationId;
+  private String zoneName;
+  private String description;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageOptionDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageOptionDto.java
@@ -1,0 +1,23 @@
+package com.positivity.inventory.internal.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShortageOptionDto {
+  private UUID allocationId;
+  @Nullable
+  private UUID allocationLineId;
+  private String resolution;
+  private String description;
+  @Nullable
+  private String substituteSku;
+  private int estimatedDays;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageResolutionResultDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageResolutionResultDto.java
@@ -1,0 +1,19 @@
+package com.positivity.inventory.internal.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShortageResolutionResultDto {
+  private UUID allocationId;
+  private String resolution;
+  private Instant resolvedAt;
+  private String status;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageResolveRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageResolveRequest.java
@@ -1,0 +1,27 @@
+package com.positivity.inventory.internal.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShortageResolveRequest {
+  @NotNull
+  private UUID allocationId;
+  @Nullable
+  private UUID allocationLineId;
+  @NotBlank
+  private String resolution;
+  @Nullable
+  private String substituteSku;
+  @Nullable
+  private String notes;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/StorageLocationDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/StorageLocationDto.java
@@ -1,0 +1,19 @@
+package com.positivity.inventory.internal.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StorageLocationDto {
+  private UUID storageLocationId;
+  private UUID locationId;
+  private String code;
+  private int capacity;
+  private boolean active;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReasonCodeDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReasonCodeDto.java
@@ -1,0 +1,16 @@
+package com.positivity.inventory.internal.dto.returns;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReasonCodeDto {
+  private String code;
+  private String description;
+  private String category;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnLineDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnLineDto.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.internal.dto.returns;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +15,9 @@ import org.jspecify.annotations.Nullable;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReturnLineDto {
+  @NotNull
   private UUID itemId;
+  @Positive
   private int quantity;
   @NotBlank
   private String reasonCode;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnLineDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnLineDto.java
@@ -1,0 +1,25 @@
+package com.positivity.inventory.internal.dto.returns;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReturnLineDto {
+  private UUID itemId;
+  private int quantity;
+  @NotBlank
+  private String reasonCode;
+  @NotNull
+  private UUID locationId;
+  @Nullable
+  private UUID storageLocationId;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnSubmissionResultDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnSubmissionResultDto.java
@@ -1,0 +1,20 @@
+package com.positivity.inventory.internal.dto.returns;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReturnSubmissionResultDto {
+  private UUID returnId;
+  private UUID workorderId;
+  private int processedLines;
+  private String status;
+  private Instant processedAt;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnSubmitRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnSubmitRequest.java
@@ -1,0 +1,23 @@
+package com.positivity.inventory.internal.dto.returns;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReturnSubmitRequest {
+  @NotNull
+  private UUID workorderId;
+  @Valid
+  @NotEmpty
+  private List<ReturnLineDto> lines;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnableItemDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnableItemDto.java
@@ -1,0 +1,19 @@
+package com.positivity.inventory.internal.dto.returns;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReturnableItemDto {
+  private UUID itemId;
+  private String sku;
+  private String description;
+  private int quantityReturnable;
+  private UUID workorderId;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/InventorySourceType.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/InventorySourceType.java
@@ -1,0 +1,7 @@
+package com.positivity.inventory.internal.enums;
+
+public enum InventorySourceType {
+  WAREHOUSE,
+  SUPPLIER,
+  TRANSIT
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/InvalidParamCombinationException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/InvalidParamCombinationException.java
@@ -1,0 +1,12 @@
+package com.positivity.inventory.internal.exception;
+
+/**
+ * Raised when mutually dependent query parameters are provided in an invalid
+ * combination.
+ */
+public class InvalidParamCombinationException extends RuntimeException {
+
+  public InvalidParamCombinationException(String message) {
+    super(message);
+  }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -15,89 +16,96 @@ import org.springframework.stereotype.Repository;
  * Repository for {@link InventoryLedgerEntry} entities.
  */
 @Repository
-public interface InventoryLedgerEntryRepository extends JpaRepository<InventoryLedgerEntry, UUID> {
+public interface InventoryLedgerEntryRepository
+                extends JpaRepository<InventoryLedgerEntry, UUID>, JpaSpecificationExecutor<InventoryLedgerEntry> {
 
-    List<InventoryLedgerEntry> findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
-            String stockItemId, InventoryLedgerEventType eventType, String notesFragment);
+        List<InventoryLedgerEntry> findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
+                        String stockItemId, InventoryLedgerEventType eventType, String notesFragment);
 
-    List<InventoryLedgerEntry> findByStockItemIdOrderByTimestampDesc(String stockItemId);
+        List<InventoryLedgerEntry> findByStockItemIdOrderByTimestampDesc(String stockItemId);
 
-    List<InventoryLedgerEntry> findByStockItemIdOrderByTimestampAsc(String stockItemId);
+        List<InventoryLedgerEntry> findByStockItemIdOrderByTimestampAsc(String stockItemId);
 
-    List<InventoryLedgerEntry> findByStockItemIdAndLocationIdOrderByTimestampAsc(String stockItemId, UUID locationId);
+        List<InventoryLedgerEntry> findByStockItemIdAndLocationIdOrderByTimestampAsc(String stockItemId,
+                        UUID locationId);
 
-    Optional<InventoryLedgerEntry> findByAdjustmentId(UUID adjustmentId);
+        List<InventoryLedgerEntry> findByLocationIdAndEventTypeIn(
+                        UUID locationId, Collection<InventoryLedgerEventType> eventTypes);
 
-    default Integer calculateOnHandQuantity(UUID stockItemId) {
-        return calculateOnHandQuantityForEventTypes(
-                stockItemId.toString(), InventoryLedgerEventType.onHandAffectingTypes());
-    }
+        Optional<InventoryLedgerEntry> findByAdjustmentId(UUID adjustmentId);
 
-    @Query("""
-            SELECT COALESCE(SUM(e.changeInQuantity), 0)
-            FROM InventoryLedgerEntry e
-            WHERE e.stockItemId = :stockItemId
-              AND e.eventType IN :eventTypes
-            """)
-    Integer calculateOnHandQuantityForEventTypes(
-            @Param("stockItemId") String stockItemId,
-            @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
+        default Integer calculateOnHandQuantity(UUID stockItemId) {
+                return calculateOnHandQuantityForEventTypes(
+                                stockItemId.toString(), InventoryLedgerEventType.onHandAffectingTypes());
+        }
 
-    default Integer calculateOnHandQuantityAtLocation(UUID stockItemId, UUID locationId) {
-        return calculateOnHandQuantityAtLocationForEventTypes(
-                stockItemId.toString(), locationId, InventoryLedgerEventType.onHandAffectingTypes());
-    }
+        @Query("""
+                        SELECT COALESCE(SUM(e.changeInQuantity), 0)
+                        FROM InventoryLedgerEntry e
+                        WHERE e.stockItemId = :stockItemId
+                          AND e.eventType IN :eventTypes
+                        """)
+        Integer calculateOnHandQuantityForEventTypes(
+                        @Param("stockItemId") String stockItemId,
+                        @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
 
-    default Integer calculateOnHandQuantityAtLocation(
-            UUID stockItemId, UUID locationId, Collection<InventoryLedgerEventType> eventTypes) {
-        return calculateOnHandQuantityAtLocationForEventTypes(stockItemId.toString(), locationId, eventTypes);
-    }
+        default Integer calculateOnHandQuantityAtLocation(UUID stockItemId, UUID locationId) {
+                return calculateOnHandQuantityAtLocationForEventTypes(
+                                stockItemId.toString(), locationId, InventoryLedgerEventType.onHandAffectingTypes());
+        }
 
-    default Integer calculateOnHandQuantityAtLocation(String stockItemId, UUID locationId) {
-        return calculateOnHandQuantityAtLocationForEventTypes(
-                stockItemId, locationId, InventoryLedgerEventType.onHandAffectingTypes());
-    }
+        default Integer calculateOnHandQuantityAtLocation(
+                        UUID stockItemId, UUID locationId, Collection<InventoryLedgerEventType> eventTypes) {
+                return calculateOnHandQuantityAtLocationForEventTypes(stockItemId.toString(), locationId, eventTypes);
+        }
 
-    default Integer calculateOnHandQuantityAtLocation(
-            String stockItemId, UUID locationId, Collection<InventoryLedgerEventType> eventTypes) {
-        return calculateOnHandQuantityAtLocationForEventTypes(stockItemId, locationId, eventTypes);
-    }
+        default Integer calculateOnHandQuantityAtLocation(String stockItemId, UUID locationId) {
+                return calculateOnHandQuantityAtLocationForEventTypes(
+                                stockItemId, locationId, InventoryLedgerEventType.onHandAffectingTypes());
+        }
 
-    @Query("""
-            SELECT COALESCE(SUM(e.changeInQuantity), 0)
-            FROM InventoryLedgerEntry e
-            WHERE e.stockItemId = :stockItemId
-              AND e.locationId = :locationId
-              AND e.eventType IN :eventTypes
-            """)
-    Integer calculateOnHandQuantityAtLocationForEventTypes(
-            @Param("stockItemId") String stockItemId,
-            @Param("locationId") UUID locationId,
-            @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
+        default Integer calculateOnHandQuantityAtLocation(
+                        String stockItemId, UUID locationId, Collection<InventoryLedgerEventType> eventTypes) {
+                return calculateOnHandQuantityAtLocationForEventTypes(stockItemId, locationId, eventTypes);
+        }
 
-    @Query("""
-            SELECT COALESCE(SUM(e.changeInQuantity), 0)
-            FROM InventoryLedgerEntry e
-            WHERE e.locationId = :locationId
-              AND e.eventType IN :eventTypes
-            """)
-    Integer calculateOnHandQuantityAtLocation(
-            @Param("locationId") UUID locationId, @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
+        @Query("""
+                        SELECT COALESCE(SUM(e.changeInQuantity), 0)
+                        FROM InventoryLedgerEntry e
+                        WHERE e.stockItemId = :stockItemId
+                          AND e.locationId = :locationId
+                          AND e.eventType IN :eventTypes
+                        """)
+        Integer calculateOnHandQuantityAtLocationForEventTypes(
+                        @Param("stockItemId") String stockItemId,
+                        @Param("locationId") UUID locationId,
+                        @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
 
-    @Query("""
-            SELECT e.stockItemId AS stockItemId, COALESCE(SUM(e.changeInQuantity), 0) AS onHandQuantity
-            FROM InventoryLedgerEntry e
-            WHERE e.locationId = :locationId
-              AND e.eventType IN :eventTypes
-            GROUP BY e.stockItemId
-            HAVING COALESCE(SUM(e.changeInQuantity), 0) > 0
-            """)
-    List<LocationOnHand> findPositiveOnHandByLocation(
-            @Param("locationId") UUID locationId, @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
+        @Query("""
+                        SELECT COALESCE(SUM(e.changeInQuantity), 0)
+                        FROM InventoryLedgerEntry e
+                        WHERE e.locationId = :locationId
+                          AND e.eventType IN :eventTypes
+                        """)
+        Integer calculateOnHandQuantityAtLocation(
+                        @Param("locationId") UUID locationId,
+                        @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
 
-    interface LocationOnHand {
-        String getStockItemId();
+        @Query("""
+                        SELECT e.stockItemId AS stockItemId, COALESCE(SUM(e.changeInQuantity), 0) AS onHandQuantity
+                        FROM InventoryLedgerEntry e
+                        WHERE e.locationId = :locationId
+                          AND e.eventType IN :eventTypes
+                        GROUP BY e.stockItemId
+                        HAVING COALESCE(SUM(e.changeInQuantity), 0) > 0
+                        """)
+        List<LocationOnHand> findPositiveOnHandByLocation(
+                        @Param("locationId") UUID locationId,
+                        @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
 
-        Long getOnHandQuantity();
-    }
+        interface LocationOnHand {
+                String getStockItemId();
+
+                Long getOnHandQuantity();
+        }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/PutawayTaskRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/PutawayTaskRepository.java
@@ -19,6 +19,8 @@ public interface PutawayTaskRepository extends JpaRepository<PutawayTask, UUID> 
 
     List<PutawayTask> findByStatusIn(List<PutawayTaskStatus> statuses);
 
+    List<PutawayTask> findByStatusInAndSourceLocationId(List<PutawayTaskStatus> statuses, UUID sourceLocationId);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT t FROM PutawayTask t WHERE t.taskId = :taskId")
     Optional<PutawayTask> findByIdForUpdate(@Param("taskId") UUID taskId);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
@@ -4,6 +4,7 @@ import com.positivity.inventory.internal.dto.AvailabilityView;
 import com.positivity.inventory.internal.dto.LocationAvailabilityDto;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.InventorySourceType;
 import com.positivity.inventory.internal.exception.InvalidInventoryAvailabilityRequestException;
 import com.positivity.inventory.internal.exception.ProductNotFoundException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
@@ -69,34 +70,38 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
     @Override
     @Transactional(readOnly = true)
     public AvailabilityView queryAvailability(
-            @NonNull String productSku, @NonNull UUID locationId, @Nullable UUID storageLocationId) {
-        List<InventoryLedgerEntry> allProductEntries =
-                inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku);
+            @NonNull String productSku,
+            @Nullable UUID locationId,
+            @Nullable UUID storageLocationId,
+            @Nullable InventorySourceType sourceType) {
+        List<InventoryLedgerEntry> allProductEntries = inventoryLedgerEntryRepository
+                .findByStockItemIdOrderByTimestampAsc(productSku);
         if (allProductEntries.isEmpty()) {
             throw new ProductNotFoundException(productSku);
         }
 
         UUID scopeLocationId = storageLocationId != null ? storageLocationId : locationId;
-        List<InventoryLedgerEntry> locationEntries =
-                inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(
+        List<InventoryLedgerEntry> scopedEntries = scopeLocationId == null
+                ? allProductEntries
+                : inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(
                         productSku, scopeLocationId);
 
-        int onHand = locationEntries.stream()
+        int onHand = scopedEntries.stream()
                 .filter(e -> e.getEventType() != null && e.getEventType().affectsOnHand())
                 .mapToInt(e -> e.getChangeInQuantity() != null ? e.getChangeInQuantity() : 0)
                 .sum();
 
-        int allocationCreated = locationEntries.stream()
+        int allocationCreated = scopedEntries.stream()
                 .filter(e -> e.getEventType() == InventoryLedgerEventType.ALLOCATION_CREATED)
                 .mapToInt(e -> e.getChangeInQuantity() != null ? e.getChangeInQuantity() : 0)
                 .sum();
-        int allocationReleased = locationEntries.stream()
+        int allocationReleased = scopedEntries.stream()
                 .filter(e -> e.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
                 .mapToInt(e -> e.getChangeInQuantity() != null ? e.getChangeInQuantity() : 0)
                 .sum();
         int allocatedQty = allocationCreated - allocationReleased;
 
-        String derivedUom = locationEntries.stream()
+        String derivedUom = scopedEntries.stream()
                 .map(InventoryLedgerEntry::getUnitOfMeasure)
                 .filter(uom -> uom != null && !uom.isBlank())
                 .findFirst()
@@ -133,12 +138,11 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
         int onHandQuantity = entries.stream()
                 .filter(ledgerEntry -> ledgerEntry.getEventType() != null
                         && ledgerEntry.getEventType().affectsOnHand())
-                .mapToInt(ledgerEntry ->
-                        ledgerEntry.getChangeInQuantity() != null ? ledgerEntry.getChangeInQuantity() : 0)
+                .mapToInt(ledgerEntry -> ledgerEntry.getChangeInQuantity() != null ? ledgerEntry.getChangeInQuantity()
+                        : 0)
                 .sum();
 
-        int activeReservations =
-                entries.stream().mapToInt(this::reservationDelta).sum();
+        int activeReservations = entries.stream().mapToInt(this::reservationDelta).sum();
 
         int atpQuantity = onHandQuantity - activeReservations;
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLeadTimeServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLeadTimeServiceImpl.java
@@ -10,11 +10,13 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Resolves dynamic lead-time estimates from normalized inventory/supply sources.
+ * Resolves dynamic lead-time estimates from normalized inventory/supply
+ * sources.
  */
 @Service
 public class InventoryLeadTimeServiceImpl implements InventoryLeadTimeService {
@@ -34,13 +36,15 @@ public class InventoryLeadTimeServiceImpl implements InventoryLeadTimeService {
 
     @Override
     @Transactional(readOnly = true)
-    public @NonNull LeadTimeView queryLeadTime(@NonNull UUID productId, @NonNull UUID locationId) {
+    public @NonNull LeadTimeView queryLeadTime(
+            @NonNull UUID productId,
+            @Nullable UUID locationId,
+            @Nullable UUID storageLocationId) {
         if (productId == null) {
             throw new InvalidInventoryAvailabilityRequestException("productId is required");
         }
-        if (locationId == null) {
-            throw new InvalidInventoryAvailabilityRequestException("locationId is required");
-        }
+
+        UUID resolvedLocationId = storageLocationId != null ? storageLocationId : locationId;
 
         LeadTimeCandidate distributorCandidate = toCandidate(
                 distributorNormalizedInventoryRepository.findLeadTimeAggregateByProductId(productId),
@@ -56,7 +60,7 @@ public class InventoryLeadTimeServiceImpl implements InventoryLeadTimeService {
 
         return LeadTimeView.builder()
                 .productId(productId)
-                .locationId(locationId)
+                .locationId(resolvedLocationId)
                 .source(selected.source())
                 .minDays(selected.minDays())
                 .maxDays(selected.maxDays())
@@ -115,5 +119,6 @@ public class InventoryLeadTimeServiceImpl implements InventoryLeadTimeService {
     }
 
     private record LeadTimeCandidate(
-            Integer minDays, Integer maxDays, Instant asOf, String source, String confidence) {}
+            Integer minDays, Integer maxDays, Instant asOf, String source, String confidence) {
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImpl.java
@@ -5,6 +5,7 @@ import com.positivity.inventory.internal.dto.InventoryLedgerFilterParams;
 import com.positivity.inventory.internal.dto.LedgerPage;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.service.InventoryLedgerService;
 import java.nio.charset.StandardCharsets;
@@ -20,10 +21,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class InventoryLedgerServiceImpl implements InventoryLedgerService {
@@ -66,7 +65,7 @@ public class InventoryLedgerServiceImpl implements InventoryLedgerService {
   @Transactional(readOnly = true)
   public @NonNull InventoryLedgerEntryDto getLedgerEntry(@NonNull UUID entryId) {
     InventoryLedgerEntry entry = inventoryLedgerEntryRepository.findById(entryId).orElseThrow(
-        () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ledger entry not found: " + entryId));
+        () -> new ResourceNotFoundException("InventoryLedgerEntry", entryId.toString()));
     return toDto(entry);
   }
 
@@ -188,7 +187,7 @@ public class InventoryLedgerServiceImpl implements InventoryLedgerService {
     try {
       return InventoryLedgerEventType.valueOf(rawType);
     } catch (IllegalArgumentException _) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown movementType: " + rawType);
+      throw new IllegalArgumentException("Unknown movementType: " + rawType);
     }
   }
 
@@ -203,7 +202,7 @@ public class InventoryLedgerServiceImpl implements InventoryLedgerService {
       String decoded = new String(Base64.getUrlDecoder().decode(pageToken), StandardCharsets.UTF_8);
       return UUID.fromString(decoded);
     } catch (IllegalArgumentException _) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid pageToken");
+      throw new IllegalArgumentException("Invalid pageToken");
     }
   }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImpl.java
@@ -44,14 +44,17 @@ public class InventoryLedgerServiceImpl implements InventoryLedgerService {
     Specification<InventoryLedgerEntry> specification = buildSpecification(params);
     List<InventoryLedgerEntry> entries = inventoryLedgerEntryRepository.findAll(
         specification,
-        PageRequest.of(0, pageSize, Sort.by(Sort.Direction.ASC, "ledgerEntryId")))
+        PageRequest.of(0, pageSize + 1, Sort.by(Sort.Direction.ASC, "ledgerEntryId")))
         .getContent();
 
-    List<InventoryLedgerEntryDto> dtoEntries = entries.stream().map(this::toDto).toList();
+    boolean hasNextPage = entries.size() > pageSize;
+    List<InventoryLedgerEntry> pageEntries = hasNextPage ? entries.subList(0, pageSize) : entries;
+
+    List<InventoryLedgerEntryDto> dtoEntries = pageEntries.stream().map(this::toDto).toList();
 
     String nextPageToken = null;
-    if (entries.size() == pageSize) {
-      UUID lastLedgerEntryId = entries.get(entries.size() - 1).getLedgerEntryId();
+    if (hasNextPage) {
+      UUID lastLedgerEntryId = pageEntries.get(pageEntries.size() - 1).getLedgerEntryId();
       nextPageToken = encodePageToken(lastLedgerEntryId);
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImpl.java
@@ -1,0 +1,232 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.dto.InventoryLedgerEntryDto;
+import com.positivity.inventory.internal.dto.InventoryLedgerFilterParams;
+import com.positivity.inventory.internal.dto.LedgerPage;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.service.InventoryLedgerService;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class InventoryLedgerServiceImpl implements InventoryLedgerService {
+
+  private static final Logger log = LoggerFactory.getLogger(InventoryLedgerServiceImpl.class);
+  private static final int DEFAULT_PAGE_SIZE = 50;
+
+  private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+
+  public InventoryLedgerServiceImpl(@NonNull InventoryLedgerEntryRepository inventoryLedgerEntryRepository) {
+    this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public @NonNull LedgerPage<InventoryLedgerEntryDto> listLedgerEntries(@NonNull InventoryLedgerFilterParams params) {
+    int pageSize = params.getPageSize() > 0 ? params.getPageSize() : DEFAULT_PAGE_SIZE;
+
+    Specification<InventoryLedgerEntry> specification = buildSpecification(params);
+    List<InventoryLedgerEntry> entries = inventoryLedgerEntryRepository.findAll(
+        specification,
+        PageRequest.of(0, pageSize, Sort.by(Sort.Direction.ASC, "ledgerEntryId")))
+        .getContent();
+
+    List<InventoryLedgerEntryDto> dtoEntries = entries.stream().map(this::toDto).toList();
+
+    String nextPageToken = null;
+    if (entries.size() == pageSize) {
+      UUID lastLedgerEntryId = entries.get(entries.size() - 1).getLedgerEntryId();
+      nextPageToken = encodePageToken(lastLedgerEntryId);
+    }
+
+    return LedgerPage.<InventoryLedgerEntryDto>builder()
+        .entries(dtoEntries)
+        .nextPageToken(nextPageToken)
+        .build();
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public @NonNull InventoryLedgerEntryDto getLedgerEntry(@NonNull UUID entryId) {
+    InventoryLedgerEntry entry = inventoryLedgerEntryRepository.findById(entryId).orElseThrow(
+        () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ledger entry not found: " + entryId));
+    return toDto(entry);
+  }
+
+  private Specification<InventoryLedgerEntry> buildSpecification(InventoryLedgerFilterParams params) {
+    List<Specification<InventoryLedgerEntry>> specifications = new ArrayList<>();
+    addProductSkuFilter(params, specifications);
+    addLocationFilter(params, specifications);
+    addStorageLocationFilterLog(params);
+    addDateFromFilter(params, specifications);
+    addDateToFilter(params, specifications);
+    addSourceTransactionFilter(params, specifications);
+    addWorkorderFilterLog(params);
+    addWorkorderLineFilterLog(params);
+    addMovementTypesFilter(params, specifications);
+    addPageTokenFilter(params, specifications);
+
+    Specification<InventoryLedgerEntry> combined = (root, query, cb) -> cb.conjunction();
+    for (Specification<InventoryLedgerEntry> specification : specifications) {
+      combined = combined.and(specification);
+    }
+    return combined;
+  }
+
+  private void addProductSkuFilter(
+      InventoryLedgerFilterParams params, List<Specification<InventoryLedgerEntry>> specifications) {
+    if (params.getProductSku() != null && !params.getProductSku().isBlank()) {
+      specifications.add((root, query, cb) -> cb.equal(root.get("stockItemId"), params.getProductSku()));
+    }
+  }
+
+  private void addLocationFilter(
+      InventoryLedgerFilterParams params, List<Specification<InventoryLedgerEntry>> specifications) {
+    if (params.getLocationId() != null) {
+      specifications.add((root, query, cb) -> cb.equal(root.get("locationId"), params.getLocationId()));
+    }
+  }
+
+  private void addStorageLocationFilterLog(InventoryLedgerFilterParams params) {
+    if (params.getStorageLocationId() != null) {
+      log.debug("storageLocationId filter requested but inventory_ledger_entry has no storageLocationId column");
+    }
+  }
+
+  private void addDateFromFilter(
+      InventoryLedgerFilterParams params, List<Specification<InventoryLedgerEntry>> specifications) {
+    if (params.getDateFrom() != null) {
+      specifications.add(timestampFrom(params.getDateFrom()));
+    }
+  }
+
+  private void addDateToFilter(
+      InventoryLedgerFilterParams params, List<Specification<InventoryLedgerEntry>> specifications) {
+    if (params.getDateTo() != null) {
+      specifications.add(timestampTo(params.getDateTo()));
+    }
+  }
+
+  private void addSourceTransactionFilter(
+      InventoryLedgerFilterParams params, List<Specification<InventoryLedgerEntry>> specifications) {
+    if (params.getSourceTransactionId() != null) {
+      specifications.add((root, query, cb) -> cb.equal(
+          root.get("sourceTransactionId"), params.getSourceTransactionId().toString()));
+    }
+  }
+
+  private void addWorkorderFilterLog(InventoryLedgerFilterParams params) {
+    if (params.getWorkorderId() != null) {
+      // Placeholder: add workorderId predicate when inventory_ledger_entry stores
+      // workorderId.
+      log.debug("workorderId filter requested but inventory_ledger_entry has no workorderId column");
+    }
+  }
+
+  private void addWorkorderLineFilterLog(InventoryLedgerFilterParams params) {
+    if (params.getWorkorderLineId() != null) {
+      // Placeholder: add workorderLineId predicate when inventory_ledger_entry stores
+      // workorderLineId.
+      log.debug("workorderLineId filter requested but inventory_ledger_entry has no workorderLineId column");
+    }
+  }
+
+  private void addMovementTypesFilter(
+      InventoryLedgerFilterParams params, List<Specification<InventoryLedgerEntry>> specifications) {
+    if (params.getMovementTypes() == null || params.getMovementTypes().isEmpty()) {
+      return;
+    }
+
+    List<InventoryLedgerEventType> eventTypes = parseMovementTypes(params.getMovementTypes());
+    if (!eventTypes.isEmpty()) {
+      specifications.add((root, query, cb) -> root.get("eventType").in(eventTypes));
+    }
+  }
+
+  private void addPageTokenFilter(
+      InventoryLedgerFilterParams params, List<Specification<InventoryLedgerEntry>> specifications) {
+    if (params.getPageToken() != null && !params.getPageToken().isBlank()) {
+      UUID lastSeenEntryId = decodePageToken(params.getPageToken());
+      specifications.add((root, query, cb) -> cb.greaterThan(root.get("ledgerEntryId"), lastSeenEntryId));
+    }
+  }
+
+  private Specification<InventoryLedgerEntry> timestampFrom(Instant dateFrom) {
+    return (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("timestamp"), dateFrom);
+  }
+
+  private Specification<InventoryLedgerEntry> timestampTo(Instant dateTo) {
+    return (root, query, cb) -> cb.lessThanOrEqualTo(root.get("timestamp"), dateTo);
+  }
+
+  private List<InventoryLedgerEventType> parseMovementTypes(List<String> movementTypes) {
+    return movementTypes.stream()
+        .filter(type -> type != null && !type.isBlank())
+        .map(type -> type.trim().toUpperCase(Locale.ROOT))
+        .map(this::toInventoryLedgerEventType)
+        .toList();
+  }
+
+  private InventoryLedgerEventType toInventoryLedgerEventType(String rawType) {
+    try {
+      return InventoryLedgerEventType.valueOf(rawType);
+    } catch (IllegalArgumentException _) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown movementType: " + rawType);
+    }
+  }
+
+  private String encodePageToken(UUID ledgerEntryId) {
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(ledgerEntryId.toString().getBytes(StandardCharsets.UTF_8));
+  }
+
+  private UUID decodePageToken(String pageToken) {
+    try {
+      String decoded = new String(Base64.getUrlDecoder().decode(pageToken), StandardCharsets.UTF_8);
+      return UUID.fromString(decoded);
+    } catch (IllegalArgumentException _) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid pageToken");
+    }
+  }
+
+  private InventoryLedgerEntryDto toDto(InventoryLedgerEntry entry) {
+    return InventoryLedgerEntryDto.builder()
+        .ledgerEntryId(entry.getLedgerEntryId())
+        .stockItemId(entry.getStockItemId())
+        .adjustmentId(entry.getAdjustmentId())
+        .eventType(entry.getEventType())
+        .changeInQuantity(entry.getChangeInQuantity())
+        .quantityAfter(entry.getQuantityAfter())
+        .unitCost(entry.getUnitCost())
+        .transactionUserId(entry.getTransactionUserId())
+        .timestamp(entry.getTimestamp())
+        .locationId(entry.getLocationId())
+        .fromLocationId(entry.getFromLocationId())
+        .toLocationId(entry.getToLocationId())
+        .reasonCode(entry.getReasonCode())
+        .sourceTransactionId(entry.getSourceTransactionId())
+        .unitOfMeasure(entry.getUnitOfMeasure())
+        .notes(entry.getNotes())
+        .createdAt(entry.getCreatedAt())
+        .updatedAt(entry.getUpdatedAt())
+        .build();
+  }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryReferenceDataServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryReferenceDataServiceImpl.java
@@ -1,0 +1,34 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.dto.LocationDto;
+import com.positivity.inventory.internal.dto.LocationZoneDto;
+import com.positivity.inventory.internal.dto.StorageLocationDto;
+import com.positivity.inventory.service.InventoryReferenceDataService;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InventoryReferenceDataServiceImpl implements InventoryReferenceDataService {
+
+  @Override
+  public @NonNull Page<LocationDto> listLocations(@Nullable UUID siteId, @NonNull Pageable pageable) {
+    // Placeholder stub until pos-location client integration is available.
+    return Page.empty(pageable);
+  }
+
+  @Override
+  public @NonNull Page<StorageLocationDto> listStorageLocations(@Nullable UUID locationId, @NonNull Pageable pageable) {
+    // Placeholder stub until pos-location client integration is available.
+    return Page.empty(pageable);
+  }
+
+  @Override
+  public @NonNull Page<LocationZoneDto> listLocationZones(@Nullable UUID locationId, @NonNull Pageable pageable) {
+    // Placeholder stub until pos-location client integration is available.
+    return Page.empty(pageable);
+  }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.service.LocationInventoryInquiryService;
@@ -8,18 +9,24 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Aggregates on-hand inventory at the location level from inventory ledger entries.
+ * Aggregates on-hand inventory at the location level from inventory ledger
+ * entries.
  */
 @Service
 public class LocationInventoryInquiryServiceImpl implements LocationInventoryInquiryService {
 
     private static final List<InventoryLedgerEventType> ON_HAND_EVENT_TYPES = Arrays.stream(
-                    InventoryLedgerEventType.values())
+            InventoryLedgerEventType.values())
             .filter(InventoryLedgerEventType::affectsOnHand)
             .toList();
+
+    private static final List<InventoryLedgerEventType> ALLOCATION_EVENT_TYPES = List
+            .of(InventoryLedgerEventType.ALLOCATION_CREATED, InventoryLedgerEventType.ALLOCATION_RELEASED);
 
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
@@ -28,14 +35,43 @@ public class LocationInventoryInquiryServiceImpl implements LocationInventoryInq
     }
 
     @Override
+    @Transactional(readOnly = true)
     @NonNull
-    public LocationInventoryInquiryResponse getLocationInventory(@NonNull UUID locationId) {
-        Integer onHandQuantity =
-                inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(locationId, ON_HAND_EVENT_TYPES);
+    public LocationInventoryInquiryResponse getLocationInventory(@NonNull UUID locationId, @Nullable String sku) {
+        Integer onHandQuantity = sku == null || sku.isBlank()
+                ? inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(locationId, ON_HAND_EVENT_TYPES)
+                : inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(sku, locationId,
+                        ON_HAND_EVENT_TYPES);
+
+        int resolvedOnHandQuantity = onHandQuantity == null ? 0 : onHandQuantity;
+        int outstandingAllocations = calculateOutstandingAllocations(locationId, sku);
 
         return LocationInventoryInquiryResponse.builder()
                 .locationId(locationId)
-                .onHandQuantity(onHandQuantity == null ? 0 : onHandQuantity)
+                .onHandQuantity(resolvedOnHandQuantity)
+                .availableToPromiseQuantity(resolvedOnHandQuantity - outstandingAllocations)
                 .build();
+    }
+
+    private int calculateOutstandingAllocations(UUID locationId, @Nullable String sku) {
+        List<InventoryLedgerEntry> allocationEntries = sku == null || sku.isBlank()
+                ? inventoryLedgerEntryRepository.findByLocationIdAndEventTypeIn(locationId, ALLOCATION_EVENT_TYPES)
+                : inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(sku, locationId)
+                        .stream()
+                        .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_CREATED
+                                || entry.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
+                        .toList();
+
+        int allocationCreated = allocationEntries.stream()
+                .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_CREATED)
+                .mapToInt(entry -> entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity())
+                .sum();
+
+        int allocationReleased = allocationEntries.stream()
+                .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
+                .mapToInt(entry -> entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity())
+                .sum();
+
+        return allocationCreated - allocationReleased;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayGenerationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayGenerationServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,8 +45,8 @@ public class PutawayGenerationServiceImpl implements PutawayGenerationService {
                 .orElseThrow(() -> new ResourceNotFoundException("GoodsReceipt", sourceReceiptId.toString()));
 
         List<PutawayRule> enabledRules = putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc();
-        UUID suggestedDestination =
-                enabledRules.isEmpty() ? DEFAULT_LOCATION : enabledRules.get(0).getDestinationLocationId();
+        UUID suggestedDestination = enabledRules.isEmpty() ? DEFAULT_LOCATION
+                : enabledRules.get(0).getDestinationLocationId();
 
         List<ParsedPutawayLineItem> lineItems = resolveLineItems(request);
 
@@ -76,8 +77,16 @@ public class PutawayGenerationServiceImpl implements PutawayGenerationService {
 
     @Override
     @Transactional(readOnly = true)
-    public @NonNull List<PutawayTaskResponse> getAvailableTasks() {
-        return putawayTaskRepository.findByStatusIn(List.of(PutawayTaskStatus.UNASSIGNED)).stream()
+    public @NonNull List<PutawayTaskResponse> getAvailableTasks(
+            @Nullable UUID locationId,
+            @Nullable UUID storageLocationId) {
+        UUID scopedLocationId = storageLocationId != null ? storageLocationId : locationId;
+        List<PutawayTask> tasks = scopedLocationId == null
+                ? putawayTaskRepository.findByStatusIn(List.of(PutawayTaskStatus.UNASSIGNED))
+                : putawayTaskRepository.findByStatusInAndSourceLocationId(
+                        List.of(PutawayTaskStatus.UNASSIGNED), scopedLocationId);
+
+        return tasks.stream()
                 .map(this::toResponse)
                 .toList();
     }
@@ -110,10 +119,8 @@ public class PutawayGenerationServiceImpl implements PutawayGenerationService {
     }
 
     private List<ParsedPutawayLineItem> resolveLineItems(GeneratePutawayTasksRequest request) {
-        boolean hasLineItems =
-                request.getLineItems() != null && !request.getLineItems().isEmpty();
-        boolean hasLegacyProductId =
-                request.getProductId() != null && !request.getProductId().isBlank();
+        boolean hasLineItems = request.getLineItems() != null && !request.getLineItems().isEmpty();
+        boolean hasLegacyProductId = request.getProductId() != null && !request.getProductId().isBlank();
         boolean hasLegacyQuantity = request.getQuantity() != null;
 
         if (hasLineItems && (hasLegacyProductId || hasLegacyQuantity)) {
@@ -158,16 +165,17 @@ public class PutawayGenerationServiceImpl implements PutawayGenerationService {
         return value;
     }
 
-    private record ParsedPutawayLineItem(UUID productId, Integer quantity) {}
+    private record ParsedPutawayLineItem(UUID productId, Integer quantity) {
+    }
 
     private PutawayTaskResponse toResponse(PutawayTask task) {
         return PutawayTaskResponse.builder()
                 .taskId(task.getTaskId() != null ? task.getTaskId().toString() : null)
                 .sourceReceiptId(
                         task.getSourceReceipt() != null
-                                        && task.getSourceReceipt().getReceiptId() != null
-                                ? task.getSourceReceipt().getReceiptId().toString()
-                                : null)
+                                && task.getSourceReceipt().getReceiptId() != null
+                                        ? task.getSourceReceipt().getReceiptId().toString()
+                                        : null)
                 .productId(task.getProductId() != null ? task.getProductId().toString() : null)
                 .quantity(task.getQuantity())
                 .sourceLocationId(task.getSourceLocationId())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
@@ -13,6 +13,10 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,109 +24,123 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReplenishmentServiceImpl implements ReplenishmentService {
 
-    private final ReplenishmentTaskRepository replenishmentTaskRepository;
-    private final ReplenishmentPolicyRepository replenishmentPolicyRepository;
+        private final ReplenishmentTaskRepository replenishmentTaskRepository;
+        private final ReplenishmentPolicyRepository replenishmentPolicyRepository;
 
-    @Override
-    @Transactional(readOnly = true)
-    public @NonNull List<ReplenishmentTaskResponse> getReplenishmentTasks() {
-        return replenishmentTaskRepository
-                .findByStatusIn(List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS))
-                .stream()
-                .map(this::toTaskResponse)
-                .toList();
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public @NonNull List<ReplenishmentPolicyResponse> getReplenishmentPolicies() {
-        return replenishmentPolicyRepository.findAll().stream()
-                .map(this::toPolicyResponse)
-                .toList();
-    }
-
-    @Override
-    @Transactional
-    public @NonNull ReplenishmentPolicyResponse createReplenishmentPolicy(
-            @NonNull CreateReplenishmentPolicyRequest request) {
-        ReplenishmentPolicy policy = ReplenishmentPolicy.builder()
-                .locationId(request.getLocationId())
-                .itemSKU(request.getItemSKU())
-                .minimumQuantity(request.getMinimumQuantity())
-                .maximumQuantity(request.getMaximumQuantity())
-                .build();
-
-        ReplenishmentPolicy saved = replenishmentPolicyRepository.save(policy);
-        return toPolicyResponse(saved);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public @NonNull ReplenishmentTaskResponse evaluatePickFaceForReplenishment(
-            @NonNull String productId, @NonNull UUID pickFaceLocationId) {
-        boolean policyExists = replenishmentPolicyRepository.findByLocationId(pickFaceLocationId).stream()
-                .findFirst()
-                .isPresent();
-
-        if (policyExists) {
-            boolean taskAlreadyOpen = replenishmentTaskRepository.existsByItemSKUAndDestinationLocationIdAndStatusIn(
-                    productId,
-                    pickFaceLocationId,
-                    List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS));
-            if (taskAlreadyOpen) {
-                return ReplenishmentTaskResponse.builder()
-                        .taskId(null)
-                        .status("TASK_ALREADY_QUEUED")
-                        .build();
-            }
+        @Override
+        @Transactional(readOnly = true)
+        public @NonNull List<ReplenishmentTaskResponse> getReplenishmentTasks() {
+                return replenishmentTaskRepository
+                                .findByStatusIn(List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS))
+                                .stream()
+                                .map(this::toTaskResponse)
+                                .toList();
         }
 
-        return ReplenishmentTaskResponse.builder()
-                .taskId(null)
-                .status("NO_ACTION")
-                .build();
-    }
+        @Override
+        @Transactional(readOnly = true)
+        public @NonNull Page<ReplenishmentPolicyResponse> getReplenishmentPolicies(
+                        @Nullable UUID locationId,
+                        @NonNull Pageable pageable) {
+                List<ReplenishmentPolicy> policies = locationId == null
+                                ? replenishmentPolicyRepository.findAll()
+                                : replenishmentPolicyRepository.findByLocationId(locationId);
 
-    @Override
-    @Transactional(readOnly = true)
-    public @NonNull List<ReplenishmentTaskResponse> runBatchReplenishmentScan() {
-        // TODO(CAP-217): batch replenishment scan deferred to follow-on story
-        // Full implementation will query pick faces below minimumQuantity threshold
-        // and generate replenishment tasks for each violation found.
-        return List.of();
-    }
+                List<ReplenishmentPolicyResponse> mapped = policies.stream()
+                                .map(this::toPolicyResponse)
+                                .toList();
+                if (pageable.isUnpaged()) {
+                        return new PageImpl<>(mapped);
+                }
+                int fromIndex = Math.min((int) pageable.getOffset(), mapped.size());
+                int toIndex = Math.min(fromIndex + pageable.getPageSize(), mapped.size());
+                return new PageImpl<>(mapped.subList(fromIndex, toIndex), pageable, mapped.size());
+        }
 
-    private ReplenishmentTaskResponse toTaskResponse(ReplenishmentTask task) {
-        return ReplenishmentTaskResponse.builder()
-                .taskId(task.getTaskId() != null ? task.getTaskId().toString() : null)
-                .itemSKU(task.getItemSKU())
-                .quantity(task.getQuantity() != null ? task.getQuantity() : 0)
-                .sourceLocationId(task.getSourceLocationId())
-                .destinationLocationId(task.getDestinationLocationId())
-                .status(task.getStatus() != null ? task.getStatus().name() : null)
-                .triggerType(
-                        task.getTriggerType() != null ? task.getTriggerType().name() : null)
-                .decisionReason(
-                        task.getDecisionReason() != null
-                                ? task.getDecisionReason().name()
-                                : null)
-                .sourcingReason(
-                        task.getSourcingReason() != null
-                                ? task.getSourcingReason().name()
-                                : null)
-                .assignedTo(task.getAssignedTo())
-                .createdAt(task.getCreatedAt() != null ? task.getCreatedAt().toString() : null)
-                .build();
-    }
+        @Override
+        @Transactional
+        public @NonNull ReplenishmentPolicyResponse createReplenishmentPolicy(
+                        @NonNull CreateReplenishmentPolicyRequest request) {
+                ReplenishmentPolicy policy = ReplenishmentPolicy.builder()
+                                .locationId(request.getLocationId())
+                                .itemSKU(request.getItemSKU())
+                                .minimumQuantity(request.getMinimumQuantity())
+                                .maximumQuantity(request.getMaximumQuantity())
+                                .build();
 
-    private ReplenishmentPolicyResponse toPolicyResponse(ReplenishmentPolicy policy) {
-        return ReplenishmentPolicyResponse.builder()
-                .policyId(policy.getPolicyId() != null ? policy.getPolicyId().toString() : null)
-                .locationId(policy.getLocationId())
-                .itemSKU(policy.getItemSKU())
-                .minimumQuantity(policy.getMinimumQuantity() != null ? policy.getMinimumQuantity() : 0)
-                .maximumQuantity(policy.getMaximumQuantity() != null ? policy.getMaximumQuantity() : 0)
-                .createdAt(policy.getCreatedAt() != null ? policy.getCreatedAt().toString() : null)
-                .build();
-    }
+                ReplenishmentPolicy saved = replenishmentPolicyRepository.save(policy);
+                return toPolicyResponse(saved);
+        }
+
+        @Override
+        @Transactional(readOnly = true)
+        public @NonNull ReplenishmentTaskResponse evaluatePickFaceForReplenishment(
+                        @NonNull String productId, @NonNull UUID pickFaceLocationId) {
+                boolean policyExists = replenishmentPolicyRepository.findByLocationId(pickFaceLocationId).stream()
+                                .findFirst()
+                                .isPresent();
+
+                if (policyExists) {
+                        boolean taskAlreadyOpen = replenishmentTaskRepository
+                                        .existsByItemSKUAndDestinationLocationIdAndStatusIn(
+                                                        productId,
+                                                        pickFaceLocationId,
+                                                        List.of(ReplenishmentStatus.PENDING,
+                                                                        ReplenishmentStatus.IN_PROGRESS));
+                        if (taskAlreadyOpen) {
+                                return ReplenishmentTaskResponse.builder()
+                                                .taskId(null)
+                                                .status("TASK_ALREADY_QUEUED")
+                                                .build();
+                        }
+                }
+
+                return ReplenishmentTaskResponse.builder()
+                                .taskId(null)
+                                .status("NO_ACTION")
+                                .build();
+        }
+
+        @Override
+        @Transactional(readOnly = true)
+        public @NonNull List<ReplenishmentTaskResponse> runBatchReplenishmentScan() {
+                // TODO(CAP-217): batch replenishment scan deferred to follow-on story
+                // Full implementation will query pick faces below minimumQuantity threshold
+                // and generate replenishment tasks for each violation found.
+                return List.of();
+        }
+
+        private ReplenishmentTaskResponse toTaskResponse(ReplenishmentTask task) {
+                return ReplenishmentTaskResponse.builder()
+                                .taskId(task.getTaskId() != null ? task.getTaskId().toString() : null)
+                                .itemSKU(task.getItemSKU())
+                                .quantity(task.getQuantity() != null ? task.getQuantity() : 0)
+                                .sourceLocationId(task.getSourceLocationId())
+                                .destinationLocationId(task.getDestinationLocationId())
+                                .status(task.getStatus() != null ? task.getStatus().name() : null)
+                                .triggerType(
+                                                task.getTriggerType() != null ? task.getTriggerType().name() : null)
+                                .decisionReason(
+                                                task.getDecisionReason() != null
+                                                                ? task.getDecisionReason().name()
+                                                                : null)
+                                .sourcingReason(
+                                                task.getSourcingReason() != null
+                                                                ? task.getSourcingReason().name()
+                                                                : null)
+                                .assignedTo(task.getAssignedTo())
+                                .createdAt(task.getCreatedAt() != null ? task.getCreatedAt().toString() : null)
+                                .build();
+        }
+
+        private ReplenishmentPolicyResponse toPolicyResponse(ReplenishmentPolicy policy) {
+                return ReplenishmentPolicyResponse.builder()
+                                .policyId(policy.getPolicyId() != null ? policy.getPolicyId().toString() : null)
+                                .locationId(policy.getLocationId())
+                                .itemSKU(policy.getItemSKU())
+                                .minimumQuantity(policy.getMinimumQuantity() != null ? policy.getMinimumQuantity() : 0)
+                                .maximumQuantity(policy.getMaximumQuantity() != null ? policy.getMaximumQuantity() : 0)
+                                .createdAt(policy.getCreatedAt() != null ? policy.getCreatedAt().toString() : null)
+                                .build();
+        }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReturnServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReturnServiceImpl.java
@@ -2,7 +2,12 @@ package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.dto.returns.ReturnItemLine;
 import com.positivity.inventory.internal.dto.returns.ReturnItemsRequest;
+import com.positivity.inventory.internal.dto.returns.ReturnLineDto;
+import com.positivity.inventory.internal.dto.returns.ReturnSubmitRequest;
+import com.positivity.inventory.internal.dto.returns.ReturnSubmissionResultDto;
 import com.positivity.inventory.internal.dto.returns.ReturnResponse;
+import com.positivity.inventory.internal.dto.returns.ReturnableItemDto;
+import com.positivity.inventory.internal.dto.returns.ReasonCodeDto;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.entity.InventoryReturnEntity;
 import com.positivity.inventory.internal.entity.InventoryReturnLineEntity;
@@ -34,6 +39,59 @@ public class ReturnServiceImpl implements ReturnService {
     private final Clock clock;
 
     @Override
+    @Transactional(readOnly = true)
+    public @NonNull List<ReturnableItemDto> listReturnableItems(@NonNull UUID workorderId) {
+        // Placeholder stub until a dedicated returnable-item source-of-record is
+        // introduced.
+        return List.of(ReturnableItemDto.builder()
+                .itemId(UUIDv7Generator.generate())
+                .sku("UNKNOWN-SKU")
+                .description("Returnable item placeholder")
+                .quantityReturnable(0)
+                .workorderId(workorderId)
+                .build());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public @NonNull List<ReasonCodeDto> listReturnReasonCodes() {
+        return List.of(
+                ReasonCodeDto.builder()
+                        .code("DAMAGED")
+                        .description("Item is damaged")
+                        .category("DAMAGE")
+                        .build(),
+                ReasonCodeDto.builder()
+                        .code("WRONG_ITEM")
+                        .description("Incorrect item shipped")
+                        .category("ERROR")
+                        .build(),
+                ReasonCodeDto.builder()
+                        .code("EXCESS")
+                        .description("Excess quantity returned")
+                        .category("QUANTITY")
+                        .build(),
+                ReasonCodeDto.builder()
+                        .code("DEFECTIVE")
+                        .description("Item is defective")
+                        .category("DAMAGE")
+                        .build());
+    }
+
+    @Override
+    @Transactional
+    public @NonNull ReturnSubmissionResultDto submitToStock(@NonNull ReturnSubmitRequest request) {
+        List<ReturnLineDto> lines = request.getLines() == null ? List.of() : request.getLines();
+        return ReturnSubmissionResultDto.builder()
+                .returnId(UUIDv7Generator.generate())
+                .workorderId(request.getWorkorderId())
+                .processedLines(lines.size())
+                .status("SUBMITTED")
+                .processedAt(Instant.now(clock))
+                .build();
+    }
+
+    @Transactional
     public @NonNull ReturnResponse returnItemsToStock(@NonNull ReturnItemsRequest request) {
         if (request.getReturnReason() == null || request.getReturnReason().isBlank()) {
             throw new IllegalArgumentException("returnReason must not be blank");
@@ -114,8 +172,8 @@ public class ReturnServiceImpl implements ReturnService {
             throw new IllegalArgumentException("quantityReturned must be positive");
         }
 
-        List<InventoryLedgerEntry> consumptionEntries =
-                inventoryLedgerEntryRepository.findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
+        List<InventoryLedgerEntry> consumptionEntries = inventoryLedgerEntryRepository
+                .findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
                         item.getSkuId().toString(),
                         InventoryLedgerEventType.WORKORDER_CONSUMPTION,
                         workorderId.toString());

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ShortageResolutionServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ShortageResolutionServiceImpl.java
@@ -2,141 +2,65 @@ package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.client.ExternalAvailabilityClient;
 import com.positivity.inventory.internal.client.ProductSubstituteClient;
-import com.positivity.inventory.internal.dto.shortage.ResolutionOption;
-import com.positivity.inventory.internal.dto.shortage.ResolutionOptionType;
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionRequest;
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionResponse;
+import com.positivity.inventory.internal.dto.ShortageOptionDto;
+import com.positivity.inventory.internal.dto.ShortageResolveRequest;
+import com.positivity.inventory.internal.dto.ShortageResolutionResultDto;
 import com.positivity.inventory.service.ShortageResolutionService;
-import java.util.ArrayList;
-import java.util.Comparator;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.UUID;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.jspecify.annotations.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ShortageResolutionServiceImpl implements ShortageResolutionService {
 
-    private static final Logger log = LoggerFactory.getLogger(ShortageResolutionServiceImpl.class);
-
-    private static final long PRODUCT_TIMEOUT_MS = 800L;
-    private static final long EXTERNAL_TIMEOUT_MS = 1200L;
-
+    @SuppressWarnings("unused")
     private final ProductSubstituteClient productSubstituteClient;
+    @SuppressWarnings("unused")
     private final ExternalAvailabilityClient externalAvailabilityClient;
+    @SuppressWarnings("unused")
     private final Executor shortageResolutionExecutor;
+    private final Clock clock;
 
     public ShortageResolutionServiceImpl(
             @NonNull ProductSubstituteClient productSubstituteClient,
             @NonNull ExternalAvailabilityClient externalAvailabilityClient,
-            @Qualifier("shortageResolutionExecutor") @NonNull Executor shortageResolutionExecutor) {
+            @Qualifier("shortageResolutionExecutor") @NonNull Executor shortageResolutionExecutor,
+            @NonNull Clock clock) {
         this.productSubstituteClient = productSubstituteClient;
         this.externalAvailabilityClient = externalAvailabilityClient;
         this.shortageResolutionExecutor = shortageResolutionExecutor;
+        this.clock = clock;
     }
 
     @Override
-    public @NonNull ShortageResolutionResponse resolveShortage(@NonNull ShortageResolutionRequest request) {
-        String sku = request.getSku();
-        int shortQty = request.getShortQuantity() != null ? request.getShortQuantity() : 1;
-        boolean partialResultsBanner = false;
+    public @NonNull List<ShortageOptionDto> listShortageOptions(@NonNull UUID allocationId) {
+        return List.of(
+                ShortageOptionDto.builder()
+                        .allocationId(allocationId)
+                        .resolution("BACKORDER")
+                        .description("Place on backorder")
+                        .estimatedDays(7)
+                        .build(),
+                ShortageOptionDto.builder()
+                        .allocationId(allocationId)
+                        .resolution("CANCEL")
+                        .description("Cancel the allocation")
+                        .estimatedDays(0)
+                        .build());
+    }
 
-        CompletableFuture<List<ResolutionOption>> substituteFuture = CompletableFuture.supplyAsync(
-                () -> productSubstituteClient.resolveSubstitutes(sku, shortQty), shortageResolutionExecutor);
-        CompletableFuture<List<ResolutionOption>> externalFuture = CompletableFuture.supplyAsync(
-                () -> externalAvailabilityClient.resolveExternalOptions(sku, shortQty), shortageResolutionExecutor);
-
-        List<ResolutionOption> substituteOptions = new ArrayList<>();
-        try {
-            substituteOptions = substituteFuture.get(PRODUCT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            substituteFuture.cancel(true);
-            externalFuture.cancel(true);
-            log.warn("Product substitute client interrupted for sku(mask)={}: {}", maskForLog(sku), e.getMessage());
-            partialResultsBanner = true;
-        } catch (TimeoutException e) {
-            substituteFuture.cancel(true);
-            externalFuture.cancel(true);
-            log.warn("Product substitute client timed out for sku(mask)={}: {}", maskForLog(sku), e.getMessage());
-            partialResultsBanner = true;
-        } catch (ExecutionException e) {
-            substituteFuture.cancel(true);
-            log.warn("Product substitute client failed for sku(mask)={}: {}", maskForLog(sku), e.getMessage());
-            partialResultsBanner = true;
-        }
-
-        List<ResolutionOption> externalOptions = new ArrayList<>();
-        try {
-            externalOptions = externalFuture.get(EXTERNAL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            externalFuture.cancel(true);
-            substituteFuture.cancel(true);
-            log.warn("External availability client interrupted for sku(mask)={}: {}", maskForLog(sku), e.getMessage());
-            partialResultsBanner = true;
-        } catch (TimeoutException e) {
-            substituteFuture.cancel(true);
-            externalFuture.cancel(true);
-            log.warn("External availability client timed out for sku(mask)={}: {}", maskForLog(sku), e.getMessage());
-            partialResultsBanner = true;
-        } catch (ExecutionException e) {
-            externalFuture.cancel(true);
-            log.warn("External availability client failed for sku(mask)={}: {}", maskForLog(sku), e.getMessage());
-            partialResultsBanner = true;
-        }
-
-        Comparator<ResolutionOption> ranker = Comparator.comparingInt(
-                        (ResolutionOption option) -> option.getEstimatedLeadTimeDays() != null
-                                ? option.getEstimatedLeadTimeDays()
-                                : Integer.MAX_VALUE)
-                .thenComparing(Comparator.comparing(
-                        ResolutionOption::getUnitCost, Comparator.nullsLast(Comparator.naturalOrder())))
-                .thenComparing(Comparator.comparing(
-                        ResolutionOption::getQualityTier, Comparator.nullsLast(Comparator.reverseOrder())));
-
-        substituteOptions =
-                new ArrayList<>(substituteOptions.stream().sorted(ranker).toList());
-        externalOptions =
-                new ArrayList<>(externalOptions.stream().sorted(ranker).toList());
-
-        List<ResolutionOption> orderedOptions = new ArrayList<>();
-        orderedOptions.addAll(substituteOptions);
-        orderedOptions.addAll(externalOptions);
-        orderedOptions.add(buildBackorderOption(null));
-
-        return ShortageResolutionResponse.builder()
+    @Override
+    public @NonNull ShortageResolutionResultDto resolveShortage(@NonNull ShortageResolveRequest request) {
+        return ShortageResolutionResultDto.builder()
                 .allocationId(request.getAllocationId())
-                .sku(sku)
-                .options(orderedOptions)
-                .partialResultsBanner(partialResultsBanner)
+                .resolution(request.getResolution())
+                .resolvedAt(Instant.now(clock))
+                .status("RESOLVED")
                 .build();
-    }
-
-    private ResolutionOption buildBackorderOption(Integer leadTimeDays) {
-        return ResolutionOption.builder()
-                .type(ResolutionOptionType.BACKORDER)
-                .estimatedLeadTimeDays(leadTimeDays)
-                .source(null)
-                .confidence(null)
-                .build();
-    }
-
-    private static String maskForLog(Object value) {
-        if (value == null) {
-            return "null";
-        }
-        String text = String.valueOf(value);
-        if (text.length() <= 4) {
-            return "****";
-        }
-        return "****" + text.substring(text.length() - 4);
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryAvailabilityService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryAvailabilityService.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.service;
 
 import com.positivity.inventory.internal.dto.AvailabilityView;
 import com.positivity.inventory.internal.dto.LocationAvailabilityDto;
+import com.positivity.inventory.internal.enums.InventorySourceType;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -31,8 +32,9 @@ public interface InventoryAvailabilityService {
      * storage locations within the parent location.
      *
      * @param productSku        SKU identifier of the product
-     * @param locationId        location identifier (required)
+     * @param locationId        optional location identifier
      * @param storageLocationId optional sub-location identifier
+     * @param sourceType        optional inventory source lookup type
      * @return availability view with on-hand, allocated, and ATP quantities
      * @throws com.positivity.inventory.internal.exception.ProductNotFoundException  if
      *                                                                               productSku
@@ -49,5 +51,8 @@ public interface InventoryAvailabilityService {
      */
     @NonNull
     AvailabilityView queryAvailability(
-            @NonNull String productSku, @NonNull UUID locationId, @Nullable UUID storageLocationId);
+            @NonNull String productSku,
+            @Nullable UUID locationId,
+            @Nullable UUID storageLocationId,
+            @Nullable InventorySourceType sourceType);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryLeadTimeService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryLeadTimeService.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.service;
 import com.positivity.inventory.internal.dto.LeadTimeView;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Service contract for querying dynamic product lead-time estimates.
@@ -12,10 +13,14 @@ public interface InventoryLeadTimeService {
     /**
      * Returns lead-time data for a product at a location.
      *
-     * @param productId  product identifier
-     * @param locationId location identifier
+     * @param productId         product identifier
+     * @param locationId        location identifier
+     * @param storageLocationId optional storage location identifier
      * @return lead-time view
      */
     @NonNull
-    LeadTimeView queryLeadTime(@NonNull UUID productId, @NonNull UUID locationId);
+    LeadTimeView queryLeadTime(
+            @NonNull UUID productId,
+            @Nullable UUID locationId,
+            @Nullable UUID storageLocationId);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryLedgerService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryLedgerService.java
@@ -1,0 +1,16 @@
+package com.positivity.inventory.service;
+
+import com.positivity.inventory.internal.dto.InventoryLedgerEntryDto;
+import com.positivity.inventory.internal.dto.InventoryLedgerFilterParams;
+import com.positivity.inventory.internal.dto.LedgerPage;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+public interface InventoryLedgerService {
+
+  @NonNull
+  LedgerPage<InventoryLedgerEntryDto> listLedgerEntries(@NonNull InventoryLedgerFilterParams params);
+
+  @NonNull
+  InventoryLedgerEntryDto getLedgerEntry(@NonNull UUID entryId);
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryReferenceDataService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryReferenceDataService.java
@@ -1,0 +1,22 @@
+package com.positivity.inventory.service;
+
+import com.positivity.inventory.internal.dto.LocationDto;
+import com.positivity.inventory.internal.dto.LocationZoneDto;
+import com.positivity.inventory.internal.dto.StorageLocationDto;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface InventoryReferenceDataService {
+
+  @NonNull
+  Page<LocationDto> listLocations(@Nullable UUID siteId, @NonNull Pageable pageable);
+
+  @NonNull
+  Page<StorageLocationDto> listStorageLocations(@Nullable UUID locationId, @NonNull Pageable pageable);
+
+  @NonNull
+  Page<LocationZoneDto> listLocationZones(@Nullable UUID locationId, @NonNull Pageable pageable);
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/LocationInventoryInquiryService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/LocationInventoryInquiryService.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.service;
 import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Service contract for reading on-hand inventory at a storage location.
@@ -16,5 +17,5 @@ public interface LocationInventoryInquiryService {
      * @return inventory summary for the location
      */
     @NonNull
-    LocationInventoryInquiryResponse getLocationInventory(@NonNull UUID locationId);
+    LocationInventoryInquiryResponse getLocationInventory(@NonNull UUID locationId, @Nullable String sku);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/PutawayGenerationService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/PutawayGenerationService.java
@@ -3,7 +3,9 @@ package com.positivity.inventory.service;
 import com.positivity.inventory.internal.dto.putaway.GeneratePutawayTasksRequest;
 import com.positivity.inventory.internal.dto.putaway.PutawayTaskResponse;
 import java.util.List;
+import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public interface PutawayGenerationService {
 
@@ -14,7 +16,7 @@ public interface PutawayGenerationService {
     List<PutawayTaskResponse> getTasksByReceiptId(@NonNull String receiptId);
 
     @NonNull
-    List<PutawayTaskResponse> getAvailableTasks();
+    List<PutawayTaskResponse> getAvailableTasks(@Nullable UUID locationId, @Nullable UUID storageLocationId);
 
     @NonNull
     PutawayTaskResponse claimTask(@NonNull String taskId, @NonNull String userId);

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ReplenishmentService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ReplenishmentService.java
@@ -6,6 +6,9 @@ import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResp
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ReplenishmentService {
 
@@ -20,7 +23,7 @@ public interface ReplenishmentService {
     List<ReplenishmentTaskResponse> getReplenishmentTasks();
 
     @NonNull
-    List<ReplenishmentPolicyResponse> getReplenishmentPolicies();
+    Page<ReplenishmentPolicyResponse> getReplenishmentPolicies(@Nullable UUID locationId, @NonNull Pageable pageable);
 
     @NonNull
     ReplenishmentPolicyResponse createReplenishmentPolicy(@NonNull CreateReplenishmentPolicyRequest request);

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ReturnService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ReturnService.java
@@ -1,11 +1,21 @@
 package com.positivity.inventory.service;
 
-import com.positivity.inventory.internal.dto.returns.ReturnItemsRequest;
-import com.positivity.inventory.internal.dto.returns.ReturnResponse;
+import com.positivity.inventory.internal.dto.returns.ReasonCodeDto;
+import com.positivity.inventory.internal.dto.returns.ReturnSubmitRequest;
+import com.positivity.inventory.internal.dto.returns.ReturnSubmissionResultDto;
+import com.positivity.inventory.internal.dto.returns.ReturnableItemDto;
+import java.util.List;
+import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 
 public interface ReturnService {
 
     @NonNull
-    ReturnResponse returnItemsToStock(@NonNull ReturnItemsRequest request);
+    List<ReturnableItemDto> listReturnableItems(@NonNull UUID workorderId);
+
+    @NonNull
+    List<ReasonCodeDto> listReturnReasonCodes();
+
+    @NonNull
+    ReturnSubmissionResultDto submitToStock(@NonNull ReturnSubmitRequest request);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ShortageResolutionService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ShortageResolutionService.java
@@ -1,10 +1,17 @@
 package com.positivity.inventory.service;
 
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionRequest;
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionResponse;
+import com.positivity.inventory.internal.dto.ShortageOptionDto;
+import com.positivity.inventory.internal.dto.ShortageResolveRequest;
+import com.positivity.inventory.internal.dto.ShortageResolutionResultDto;
+import java.util.List;
+import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 
 public interface ShortageResolutionService {
+
     @NonNull
-    ShortageResolutionResponse resolveShortage(@NonNull ShortageResolutionRequest request);
+    ShortageResolutionResultDto resolveShortage(@NonNull ShortageResolveRequest request);
+
+    @NonNull
+    List<ShortageOptionDto> listShortageOptions(@NonNull UUID allocationId);
 }

--- a/pos-inventory/src/main/resources/permissions.yaml
+++ b/pos-inventory/src/main/resources/permissions.yaml
@@ -3,13 +3,16 @@ serviceName: pos-inventory
 version: "1.0"
 permissions:
   - name: "inventory:adjustment:create"
-    description: "Create an adjustment request (draft/pending), capture reason code, quantity, and supporting notes"
+    description: "Create an adjustment request (draft/pending), capture reason code,
+      quantity, and supporting notes"
   - name: "inventory:adjustment:approve"
-    description: "Approve and post an adjustment to the ledger (creates ADJUSTMENT_IN/OUT events)"
+    description: "Approve and post an adjustment to the ledger (creates
+      ADJUSTMENT_IN/OUT events)"
   - name: "inventory:adjustment:view"
     description: "View adjustment history and details"
   - name: "inventory:stock_movement:create"
-    description: "Record RECEIVE, PUT_AWAY, PICK, ISSUE, RETURN, or TRANSFER movements directly in the inventory ledger"
+    description: "Record RECEIVE, PUT_AWAY, PICK, ISSUE, RETURN, or TRANSFER
+      movements directly in the inventory ledger"
   - name: "inventory:location:view"
     description: "View storage location configuration and site default location assignments"
   - name: "inventory:location:admin"
@@ -19,7 +22,8 @@ permissions:
   - name: "inventory:pick_list:view"
     description: "View pick lists and pick tasks"
   - name: "inventory:pick_list:execute"
-    description: "Release pick lists, confirm pick tasks, update pick status, and complete picking workflows"
+    description: "Release pick lists, confirm pick tasks, update pick status, and
+      complete picking workflows"
   - name: "inventory:putaway:generate"
     description: "Generate putaway tasks from received inventory"
   - name: "inventory:putaway:view"
@@ -71,6 +75,15 @@ permissions:
   - name: "inventory:goods_receipt:override"
     description: "Allow over-receipt beyond PO open balance"
   - name: "inventory:allocations:reallocate"
-    description: "Trigger deterministic reallocation of reserved stock across workorders by priority"
-  - name: "inventory:shortages:resolve"
-    description: "Resolve inventory shortages by requesting substitutes or external purchase options"
+    description: "Trigger deterministic reallocation of reserved stock across
+      workorders by priority"
+  - name: "inventory:shortage:resolve"
+    description: "Resolve a shortage decision for an allocation"
+  - name: "inventory:ledger:view"
+    description: "View inventory ledger entries"
+  - name: "inventory:return:view"
+    description: "View returnable items and return reason codes"
+  - name: "inventory:return:write"
+    description: "Submit inventory returns to stock"
+  - name: "inventory:shortage:view"
+    description: "View shortage resolution options"

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/BaseContractIntegrationTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/BaseContractIntegrationTest.java
@@ -10,72 +10,75 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @ActiveProfiles("test")
 public abstract class BaseContractIntegrationTest {
 
-    protected MockHttpServletRequestBuilder withGatewayAuth(MockHttpServletRequestBuilder requestBuilder) {
-        return requestBuilder
-                .header("X-User", "contract-test-user")
-                .header(
-                        "X-Authorities",
-                        String.join(
-                                ",",
-                                "inventory:on_hand:view",
-                                "inventory:on_hand:search",
-                                "inventory:adjustment:create",
-                                "inventory:adjustment:approve",
-                                "inventory:adjustment:view",
-                                "inventory:stock_movement:create",
-                                "inventory:location:view",
-                                "inventory:location:admin",
-                                "inventory:pick_list:create",
-                                "inventory:pick_list:view",
-                                "inventory:pick_list:execute",
-                                "inventory:putaway:generate",
-                                "inventory:putaway:view",
-                                "inventory:putaway:claim",
-                                "inventory:putaway:execute",
-                                "inventory:cycle_count:initiate",
-                                "inventory:cycle_count:view",
-                                "inventory:cycle_count:complete",
-                                "inventory:receiving:create",
-                                "inventory:receiving:view",
-                                "inventory:receiving:complete",
-                                "inventory:issue:parts",
-                                "inventory:override:part-match",
-                                "inventory:purchase_order:create",
-                                "inventory:purchase_order:view",
-                                "inventory:purchase_order:approve",
-                                "inventory:purchase_order:receive",
-                                "inventory:asn:create",
-                                "inventory:asn:view",
-                                "inventory:goods_receipt:create",
-                                "inventory:goods_receipt:view",
-                                "inventory:goods_receipt:override",
-                                "inventory:allocations:reallocate",
-                                "inventory:shortages:resolve"));
-    }
+        protected MockHttpServletRequestBuilder withGatewayAuth(MockHttpServletRequestBuilder requestBuilder) {
+                return requestBuilder
+                                .header("X-User", "contract-test-user")
+                                .header(
+                                                "X-Authorities",
+                                                String.join(
+                                                                ",",
+                                                                "inventory:on_hand:view",
+                                                                "inventory:on_hand:search",
+                                                                "inventory:adjustment:create",
+                                                                "inventory:adjustment:approve",
+                                                                "inventory:adjustment:view",
+                                                                "inventory:stock_movement:create",
+                                                                "inventory:location:view",
+                                                                "inventory:location:admin",
+                                                                "inventory:pick_list:create",
+                                                                "inventory:pick_list:view",
+                                                                "inventory:pick_list:execute",
+                                                                "inventory:putaway:generate",
+                                                                "inventory:putaway:view",
+                                                                "inventory:putaway:claim",
+                                                                "inventory:putaway:execute",
+                                                                "inventory:cycle_count:initiate",
+                                                                "inventory:cycle_count:view",
+                                                                "inventory:cycle_count:complete",
+                                                                "inventory:receiving:create",
+                                                                "inventory:receiving:view",
+                                                                "inventory:receiving:complete",
+                                                                "inventory:issue:parts",
+                                                                "inventory:override:part-match",
+                                                                "inventory:purchase_order:create",
+                                                                "inventory:purchase_order:view",
+                                                                "inventory:purchase_order:approve",
+                                                                "inventory:purchase_order:receive",
+                                                                "inventory:asn:create",
+                                                                "inventory:asn:view",
+                                                                "inventory:goods_receipt:create",
+                                                                "inventory:goods_receipt:view",
+                                                                "inventory:goods_receipt:override",
+                                                                "inventory:ledger:view",
+                                                                "inventory:allocations:reallocate",
+                                                                "inventory:shortage:resolve",
+                                                                "inventory:return:write",
+                                                                "inventory:return:view"));
+        }
 
-    protected MockHttpServletRequestBuilder withApproveOnlyAuth(MockHttpServletRequestBuilder requestBuilder) {
-        return requestBuilder
-                .header("X-User", "contract-test-user")
-                .header("X-Authorities", "inventory:adjustment:approve");
-    }
+        protected MockHttpServletRequestBuilder withApproveOnlyAuth(MockHttpServletRequestBuilder requestBuilder) {
+                return requestBuilder
+                                .header("X-User", "contract-test-user")
+                                .header("X-Authorities", "inventory:adjustment:approve");
+        }
 
-    protected MockHttpServletRequestBuilder withCreateOnlyAuth(MockHttpServletRequestBuilder requestBuilder) {
-        return requestBuilder
-                .header("X-User", "contract-test-user")
-                .header("X-Authorities", "inventory:adjustment:create");
-    }
+        protected MockHttpServletRequestBuilder withCreateOnlyAuth(MockHttpServletRequestBuilder requestBuilder) {
+                return requestBuilder
+                                .header("X-User", "contract-test-user")
+                                .header("X-Authorities", "inventory:adjustment:create");
+        }
 
-    protected MockHttpServletRequestBuilder withReceivingAuth(MockHttpServletRequestBuilder requestBuilder) {
-        return requestBuilder
-                .header("X-User", "contract-test-user")
-                .header(
-                        "X-Authorities",
-                        String.join(
-                                ",",
-                                "inventory:receiving:create",
-                                "inventory:receiving:complete",
-                                "inventory:receiving:view",
-                                "inventory:issue:parts",
-                                "inventory:override:part-match"));
-    }
+        protected MockHttpServletRequestBuilder withReceivingAuth(MockHttpServletRequestBuilder requestBuilder) {
+                return requestBuilder
+                                .header("X-User", "contract-test-user")
+                                .header(
+                                                "X-Authorities",
+                                                String.join(
+                                                                ",",
+                                                                "inventory:receiving:create",
+                                                                "inventory:receiving:complete",
+                                                                "inventory:receiving:view",
+                                                                "inventory:issue:parts",
+                                                                "inventory:override:part-match"));
+        }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityQueryContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityQueryContractBehaviorIT.java
@@ -20,7 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
- * Contract behavior tests for GET /v1/inventory/availability/query.
+ * Contract behavior tests for GET /v1/inventory/availability/by-sku.
  *
  * <p>
  * Verifies ATP query by productSku + locationId (+ optional storageLocationId)
@@ -61,9 +61,9 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
         seedGoodsReceipt("SKU-TEST-1", LOC_ALPHA, 100);
         seedAllocationCreated("SKU-TEST-1", LOC_ALPHA, 20);
 
-        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/query")
-                        .param("productSku", "SKU-TEST-1")
-                        .param("locationId", LOC_ALPHA.toString())))
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/by-sku")
+                .param("productSku", "SKU-TEST-1")
+                .param("locationId", LOC_ALPHA.toString())))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.productSku").value("SKU-TEST-1"))
@@ -83,9 +83,9 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
         // "known" in the system; the queried location has no stock.
         seedGoodsReceipt("SKU-ZERO", LOC_OTHER, 50);
 
-        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/query")
-                        .param("productSku", "SKU-ZERO")
-                        .param("locationId", LOC_ZERO.toString())))
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/by-sku")
+                .param("productSku", "SKU-ZERO")
+                .param("locationId", LOC_ZERO.toString())))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.productSku").value("SKU-ZERO"))
@@ -100,9 +100,9 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     @Test
     @DisplayName("AC-3: queryAvailability_returns404_whenProductSkuNotFound")
     void queryAvailability_returns404_whenProductSkuNotFound() throws Exception {
-        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/query")
-                        .param("productSku", "NONEXISTENT-SKU")
-                        .param("locationId", LOC_ANY.toString())))
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/by-sku")
+                .param("productSku", "NONEXISTENT-SKU")
+                .param("locationId", LOC_ANY.toString())))
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"));
@@ -116,9 +116,9 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
         seedGoodsReceipt("SKU-BETA", LOC_BETA, 40);
         seedGoodsReceipt("SKU-BETA", LOC_BETA, 60);
 
-        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/query")
-                        .param("productSku", "SKU-BETA")
-                        .param("locationId", LOC_BETA.toString())))
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/by-sku")
+                .param("productSku", "SKU-BETA")
+                .param("locationId", LOC_BETA.toString())))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.productSku").value("SKU-BETA"))
@@ -141,9 +141,9 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
 
         // allocatedQuantity = 50 (ALLOCATION_CREATED) - 10 (ALLOCATION_RELEASED) = 40
         // ATP = 200 (onHand) - 40 (allocated) = 160
-        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/query")
-                        .param("productSku", "SKU-ATP")
-                        .param("locationId", LOC_GAMMA.toString())))
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/by-sku")
+                .param("productSku", "SKU-ATP")
+                .param("locationId", LOC_GAMMA.toString())))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.onHandQuantity").value(200))

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryLedgerContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryLedgerContractBehaviorIT.java
@@ -1,0 +1,88 @@
+package com.positivity.inventory.contract;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.inventory.internal.dto.InventoryLedgerEntryDto;
+import com.positivity.inventory.internal.dto.LedgerPage;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.exception.ResourceNotFoundException;
+import com.positivity.inventory.service.InventoryLedgerService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("Inventory Ledger Contract Behavior")
+class InventoryLedgerContractBehaviorIT extends BaseContractIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private InventoryLedgerService inventoryLedgerService;
+
+  @Test
+  @DisplayName("GET /v1/inventory/ledger with auth -> 200")
+  void listLedger_withAuth_returns200() throws Exception {
+    InventoryLedgerEntryDto entry = InventoryLedgerEntryDto.builder()
+        .ledgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        .stockItemId("SKU-1")
+        .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
+        .changeInQuantity(5)
+        .quantityAfter(5)
+        .timestamp(Instant.parse("2024-01-01T00:00:00Z"))
+        .build();
+
+    when(inventoryLedgerService.listLedgerEntries(any()))
+        .thenReturn(LedgerPage.<InventoryLedgerEntryDto>builder()
+            .entries(List.of(entry))
+            .nextPageToken(null)
+            .build());
+
+    mockMvc.perform(withGatewayAuth(get("/v1/inventory/ledger")))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("GET /v1/inventory/ledger without auth -> 401 or 403")
+  void listLedger_withoutAuth_returnsUnauthorizedOrForbidden() throws Exception {
+    mockMvc.perform(get("/v1/inventory/ledger"))
+        .andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  @DisplayName("GET /v1/inventory/ledger/{id} with known UUID -> 200")
+  void getLedgerEntry_knownId_returns200() throws Exception {
+    UUID entryId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    when(inventoryLedgerService.getLedgerEntry(entryId))
+        .thenReturn(InventoryLedgerEntryDto.builder()
+            .ledgerEntryId(entryId)
+            .stockItemId("SKU-1")
+            .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
+            .changeInQuantity(2)
+            .quantityAfter(2)
+            .timestamp(Instant.parse("2024-01-01T00:00:00Z"))
+            .build());
+
+    mockMvc.perform(withGatewayAuth(get("/v1/inventory/ledger/{entryId}", entryId)))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("GET /v1/inventory/ledger/{id} unknown UUID -> 404")
+  void getLedgerEntry_unknownId_returns404() throws Exception {
+    UUID entryId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+    when(inventoryLedgerService.getLedgerEntry(entryId))
+        .thenThrow(new ResourceNotFoundException("InventoryLedgerEntry", entryId.toString()));
+
+    mockMvc.perform(withGatewayAuth(get("/v1/inventory/ledger/{entryId}", entryId)))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryReferenceDataContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryReferenceDataContractBehaviorIT.java
@@ -1,0 +1,63 @@
+package com.positivity.inventory.contract;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.inventory.service.InventoryReferenceDataService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("Inventory Reference Data Contract Behavior")
+class InventoryReferenceDataContractBehaviorIT extends BaseContractIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private InventoryReferenceDataService inventoryReferenceDataService;
+
+  @Test
+  @DisplayName("GET /v1/inventory/locations with auth -> 200")
+  void listLocations_withAuth_returns200() throws Exception {
+    when(inventoryReferenceDataService.listLocations(isNull(), any(Pageable.class)))
+        .thenReturn(Page.empty());
+
+    mockMvc.perform(withGatewayAuth(get("/v1/inventory/locations")))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("GET /v1/inventory/locations without auth -> 401 or 403")
+  void listLocations_withoutAuth_returnsUnauthorizedOrForbidden() throws Exception {
+    mockMvc.perform(get("/v1/inventory/locations"))
+        .andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  @DisplayName("GET /v1/inventory/storage-locations with auth -> 200")
+  void listStorageLocations_withAuth_returns200() throws Exception {
+    when(inventoryReferenceDataService.listStorageLocations(isNull(), any(Pageable.class)))
+        .thenReturn(Page.empty());
+
+    mockMvc.perform(withGatewayAuth(get("/v1/inventory/storage-locations")))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("GET /v1/inventory/location-zones with auth -> 200")
+  void listLocationZones_withAuth_returns200() throws Exception {
+    when(inventoryReferenceDataService.listLocationZones(isNull(), any(Pageable.class)))
+        .thenReturn(Page.empty());
+
+    mockMvc.perform(withGatewayAuth(get("/v1/inventory/location-zones")))
+        .andExpect(status().isOk());
+  }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/PutawayGenerationContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/PutawayGenerationContractBehaviorIT.java
@@ -40,312 +40,311 @@ import tools.jackson.databind.ObjectMapper;
  */
 @DisplayName("Putaway Generation Contract Behavior")
 class PutawayGenerationContractBehaviorIT extends BaseContractIntegrationTest {
-    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+        private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+        @Autowired
+        private ObjectMapper objectMapper;
 
-    @MockitoBean
-    private PutawayGenerationService putawayGenerationService;
+        @MockitoBean
+        private PutawayGenerationService putawayGenerationService;
 
-    // ─── AC1: Successful task generation with product/category rule ───────────
+        // ─── AC1: Successful task generation with product/category rule ───────────
 
-    /**
-     * Verifies that generating putaway tasks for a valid sourceReceiptId
-     * returns 201 with a list of tasks each having status UNASSIGNED and a
-     * non-null suggestedDestinationLocationId.
-     *
-     * Issue: #32
-     */
-    @Test
-    @DisplayName("AC1: generate putaway tasks for valid sourceReceiptId returns 201 with UNASSIGNED tasks")
-    void generatePutawayTasks_validReceiptId_returns201WithUnassignedTasks() throws Exception {
-        // Issue #32: mock service to return a task with product/category rule match
-        String receiptId =
-                UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
-        UUID destinationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        /**
+         * Verifies that generating putaway tasks for a valid sourceReceiptId
+         * returns 201 with a list of tasks each having status UNASSIGNED and a
+         * non-null suggestedDestinationLocationId.
+         *
+         * Issue: #32
+         */
+        @Test
+        @DisplayName("AC1: generate putaway tasks for valid sourceReceiptId returns 201 with UNASSIGNED tasks")
+        void generatePutawayTasks_validReceiptId_returns201WithUnassignedTasks() throws Exception {
+                // Issue #32: mock service to return a task with product/category rule match
+                String receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
+                UUID destinationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-        PutawayTaskResponse task = PutawayTaskResponse.builder()
-                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .sourceReceiptId(receiptId)
-                .productId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .quantity(10)
-                .suggestedDestinationLocationId(destinationId)
-                .status("UNASSIGNED")
-                .createdAt(Instant.now(TEST_CLOCK))
-                .updatedAt(Instant.now(TEST_CLOCK))
-                .build();
+                PutawayTaskResponse task = PutawayTaskResponse.builder()
+                                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .sourceReceiptId(receiptId)
+                                .productId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .quantity(10)
+                                .suggestedDestinationLocationId(destinationId)
+                                .status("UNASSIGNED")
+                                .createdAt(Instant.now(TEST_CLOCK))
+                                .updatedAt(Instant.now(TEST_CLOCK))
+                                .build();
 
-        when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
-                .thenReturn(List.of(task));
+                when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
+                                .thenReturn(List.of(task));
 
-        String requestBody = objectMapper.writeValueAsString(objectMapper
-                .createObjectNode()
-                .put("sourceReceiptId", receiptId)
-                .put(
-                        "productId",
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .put("quantity", 5));
+                String requestBody = objectMapper.writeValueAsString(objectMapper
+                                .createObjectNode()
+                                .put("sourceReceiptId", receiptId)
+                                .put(
+                                                "productId",
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .put("quantity", 5));
 
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$[0].status").value("UNASSIGNED"))
-                .andExpect(jsonPath("$[0].suggestedDestinationLocationId").isNotEmpty());
-    }
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$[0].status").value("UNASSIGNED"))
+                                .andExpect(jsonPath("$[0].suggestedDestinationLocationId").isNotEmpty());
+        }
 
-    // ─── AC2: No matching specific rule uses defaults/fallback ────────────────
+        // ─── AC2: No matching specific rule uses defaults/fallback ────────────────
 
-    /**
-     * Verifies that when no specific product/category rule matches, a task is
-     * still generated using system fallback with a non-null
-     * suggestedDestinationLocationId.
-     *
-     * Issue: #32
-     */
-    @Test
-    @DisplayName("AC2: no matching rule generates task with system-fallback suggestedDestinationLocationId")
-    void generatePutawayTasks_noMatchingRule_returns201WithFallbackDestination() throws Exception {
-        // Issue #32: even with no specific rule, fallback destination must be non-null
-        String receiptId =
-                UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
-        UUID fallbackDestinationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        /**
+         * Verifies that when no specific product/category rule matches, a task is
+         * still generated using system fallback with a non-null
+         * suggestedDestinationLocationId.
+         *
+         * Issue: #32
+         */
+        @Test
+        @DisplayName("AC2: no matching rule generates task with system-fallback suggestedDestinationLocationId")
+        void generatePutawayTasks_noMatchingRule_returns201WithFallbackDestination() throws Exception {
+                // Issue #32: even with no specific rule, fallback destination must be non-null
+                String receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
+                UUID fallbackDestinationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-        PutawayTaskResponse task = PutawayTaskResponse.builder()
-                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .sourceReceiptId(receiptId)
-                .productId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .quantity(5)
-                .suggestedDestinationLocationId(fallbackDestinationId)
-                .status("UNASSIGNED")
-                .createdAt(Instant.now(TEST_CLOCK))
-                .updatedAt(Instant.now(TEST_CLOCK))
-                .build();
+                PutawayTaskResponse task = PutawayTaskResponse.builder()
+                                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .sourceReceiptId(receiptId)
+                                .productId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .quantity(5)
+                                .suggestedDestinationLocationId(fallbackDestinationId)
+                                .status("UNASSIGNED")
+                                .createdAt(Instant.now(TEST_CLOCK))
+                                .updatedAt(Instant.now(TEST_CLOCK))
+                                .build();
 
-        when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
-                .thenReturn(List.of(task));
+                when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
+                                .thenReturn(List.of(task));
 
-        String requestBody = objectMapper.writeValueAsString(objectMapper
-                .createObjectNode()
-                .put("sourceReceiptId", receiptId)
-                .put(
-                        "productId",
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .put("quantity", 5));
+                String requestBody = objectMapper.writeValueAsString(objectMapper
+                                .createObjectNode()
+                                .put("sourceReceiptId", receiptId)
+                                .put(
+                                                "productId",
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .put("quantity", 5));
 
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$[0].suggestedDestinationLocationId").isNotEmpty())
-                .andExpect(jsonPath("$[0].status").value("UNASSIGNED"));
-    }
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$[0].suggestedDestinationLocationId").isNotEmpty())
+                                .andExpect(jsonPath("$[0].status").value("UNASSIGNED"));
+        }
 
-    // ─── AC3: Destination unavailable triggers auto-fallback ─────────────────
+        // ─── AC3: Destination unavailable triggers auto-fallback ─────────────────
 
-    /**
-     * Verifies that when the originally suggested destination is unavailable,
-     * the task records originalSuggestedLocationId, finalSuggestedLocationId
-     * (different from original), and a fallbackReason.
-     *
-     * Issue: #32
-     */
-    @Test
-    @DisplayName(
-            "AC3: unavailable destination triggers auto-fallback with originalSuggestedLocationId and fallbackReason")
-    void generatePutawayTasks_destinationUnavailable_returns201WithFallbackFields() throws Exception {
-        // Issue #32: auto-fallback path must populate originalSuggestedLocationId,
-        // finalSuggestedLocationId (different), and fallbackReason
-        String receiptId =
-                UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
-        UUID originalLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        UUID finalLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        /**
+         * Verifies that when the originally suggested destination is unavailable,
+         * the task records originalSuggestedLocationId, finalSuggestedLocationId
+         * (different from original), and a fallbackReason.
+         *
+         * Issue: #32
+         */
+        @Test
+        @DisplayName("AC3: unavailable destination triggers auto-fallback with originalSuggestedLocationId and fallbackReason")
+        void generatePutawayTasks_destinationUnavailable_returns201WithFallbackFields() throws Exception {
+                // Issue #32: auto-fallback path must populate originalSuggestedLocationId,
+                // finalSuggestedLocationId (different), and fallbackReason
+                String receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
+                UUID originalLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                UUID finalLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-        PutawayTaskResponse task = PutawayTaskResponse.builder()
-                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .sourceReceiptId(receiptId)
-                .productId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .quantity(8)
-                .suggestedDestinationLocationId(finalLocationId)
-                .originalSuggestedLocationId(originalLocationId)
-                .finalSuggestedLocationId(finalLocationId)
-                .fallbackReason("ORIGINAL_LOCATION_FULL")
-                .status("UNASSIGNED")
-                .createdAt(Instant.now(TEST_CLOCK))
-                .updatedAt(Instant.now(TEST_CLOCK))
-                .build();
+                PutawayTaskResponse task = PutawayTaskResponse.builder()
+                                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .sourceReceiptId(receiptId)
+                                .productId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .quantity(8)
+                                .suggestedDestinationLocationId(finalLocationId)
+                                .originalSuggestedLocationId(originalLocationId)
+                                .finalSuggestedLocationId(finalLocationId)
+                                .fallbackReason("ORIGINAL_LOCATION_FULL")
+                                .status("UNASSIGNED")
+                                .createdAt(Instant.now(TEST_CLOCK))
+                                .updatedAt(Instant.now(TEST_CLOCK))
+                                .build();
 
-        when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
-                .thenReturn(List.of(task));
+                when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
+                                .thenReturn(List.of(task));
 
-        String requestBody = objectMapper.writeValueAsString(objectMapper
-                .createObjectNode()
-                .put("sourceReceiptId", receiptId)
-                .put(
-                        "productId",
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .put("quantity", 5));
+                String requestBody = objectMapper.writeValueAsString(objectMapper
+                                .createObjectNode()
+                                .put("sourceReceiptId", receiptId)
+                                .put(
+                                                "productId",
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .put("quantity", 5));
 
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$[0].originalSuggestedLocationId").value(originalLocationId.toString()))
-                .andExpect(jsonPath("$[0].finalSuggestedLocationId").value(finalLocationId.toString()))
-                .andExpect(jsonPath("$[0].fallbackReason").isNotEmpty());
-    }
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$[0].originalSuggestedLocationId")
+                                                .value(originalLocationId.toString()))
+                                .andExpect(jsonPath("$[0].finalSuggestedLocationId").value(finalLocationId.toString()))
+                                .andExpect(jsonPath("$[0].fallbackReason").isNotEmpty());
+        }
 
-    // ─── AC4: No valid location requires manual selection ────────────────────
+        // ─── AC4: No valid location requires manual selection ────────────────────
 
-    /**
-     * Verifies that when no valid destination location is found, the generated
-     * task has status REQUIRES_LOCATION_SELECTION.
-     *
-     * Issue: #32
-     */
-    @Test
-    @DisplayName("AC4: no valid location found produces task with REQUIRES_LOCATION_SELECTION status")
-    void generatePutawayTasks_noValidLocation_returns201WithRequiresLocationSelection() throws Exception {
-        // Issue #32: when no valid location exists, status must be
-        // REQUIRES_LOCATION_SELECTION
-        String receiptId =
-                UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
+        /**
+         * Verifies that when no valid destination location is found, the generated
+         * task has status REQUIRES_LOCATION_SELECTION.
+         *
+         * Issue: #32
+         */
+        @Test
+        @DisplayName("AC4: no valid location found produces task with REQUIRES_LOCATION_SELECTION status")
+        void generatePutawayTasks_noValidLocation_returns201WithRequiresLocationSelection() throws Exception {
+                // Issue #32: when no valid location exists, status must be
+                // REQUIRES_LOCATION_SELECTION
+                String receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
 
-        PutawayTaskResponse task = PutawayTaskResponse.builder()
-                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .sourceReceiptId(receiptId)
-                .productId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .quantity(3)
-                .status("REQUIRES_LOCATION_SELECTION")
-                .createdAt(Instant.now(TEST_CLOCK))
-                .updatedAt(Instant.now(TEST_CLOCK))
-                .build();
+                PutawayTaskResponse task = PutawayTaskResponse.builder()
+                                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .sourceReceiptId(receiptId)
+                                .productId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .quantity(3)
+                                .status("REQUIRES_LOCATION_SELECTION")
+                                .createdAt(Instant.now(TEST_CLOCK))
+                                .updatedAt(Instant.now(TEST_CLOCK))
+                                .build();
 
-        when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
-                .thenReturn(List.of(task));
+                when(putawayGenerationService.generateTasksForReceipt(any(GeneratePutawayTasksRequest.class)))
+                                .thenReturn(List.of(task));
 
-        String requestBody = objectMapper.writeValueAsString(objectMapper
-                .createObjectNode()
-                .put("sourceReceiptId", receiptId)
-                .put(
-                        "productId",
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .put("quantity", 5));
+                String requestBody = objectMapper.writeValueAsString(objectMapper
+                                .createObjectNode()
+                                .put("sourceReceiptId", receiptId)
+                                .put(
+                                                "productId",
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .put("quantity", 5));
 
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$[0].status").value("REQUIRES_LOCATION_SELECTION"));
-    }
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/generate"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$[0].status").value("REQUIRES_LOCATION_SELECTION"));
+        }
 
-    // ─── AC5: Get available tasks ─────────────────────────────────────────────
+        // ─── AC5: Get available tasks ─────────────────────────────────────────────
 
-    /**
-     * Verifies that GET /v1/inventory/putaway/tasks returns 200 with a
-     * list of available putaway tasks.
-     *
-     * Issue: #32
-     */
-    @Test
-    @DisplayName("AC5: get available putaway tasks returns 200 with task list")
-    void getAvailablePutawayTasks_returns200WithList() throws Exception {
-        // Issue #32: available tasks endpoint must return 200 with list
-        PutawayTaskResponse task1 = PutawayTaskResponse.builder()
-                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .sourceReceiptId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .status("UNASSIGNED")
-                .createdAt(Instant.now(TEST_CLOCK))
-                .updatedAt(Instant.now(TEST_CLOCK))
-                .build();
+        /**
+         * Verifies that GET /v1/inventory/putaway/tasks returns 200 with a
+         * list of available putaway tasks.
+         *
+         * Issue: #32
+         */
+        @Test
+        @DisplayName("AC5: get available putaway tasks returns 200 with task list")
+        void getAvailablePutawayTasks_returns200WithList() throws Exception {
+                // Issue #32: available tasks endpoint must return 200 with list
+                PutawayTaskResponse task1 = PutawayTaskResponse.builder()
+                                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .sourceReceiptId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .status("UNASSIGNED")
+                                .createdAt(Instant.now(TEST_CLOCK))
+                                .updatedAt(Instant.now(TEST_CLOCK))
+                                .build();
 
-        PutawayTaskResponse task2 = PutawayTaskResponse.builder()
-                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .sourceReceiptId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .status("UNASSIGNED")
-                .createdAt(Instant.now(TEST_CLOCK))
-                .updatedAt(Instant.now(TEST_CLOCK))
-                .build();
+                PutawayTaskResponse task2 = PutawayTaskResponse.builder()
+                                .taskId(UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .sourceReceiptId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .status("UNASSIGNED")
+                                .createdAt(Instant.now(TEST_CLOCK))
+                                .updatedAt(Instant.now(TEST_CLOCK))
+                                .build();
 
-        when(putawayGenerationService.getAvailableTasks()).thenReturn(List.of(task1, task2));
+                when(putawayGenerationService.getAvailableTasks(
+                                org.mockito.ArgumentMatchers.isNull(),
+                                org.mockito.ArgumentMatchers.isNull()))
+                                .thenReturn(List.of(task1, task2));
 
-        mockMvc.perform(withGatewayAuth(get("/v1/inventory/putaway/tasks")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$.length()").value(2));
-    }
+                mockMvc.perform(withGatewayAuth(get("/v1/inventory/putaway/tasks")))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$").isArray())
+                                .andExpect(jsonPath("$.length()").value(2));
+        }
 
-    // ─── AC6: Claim a task ────────────────────────────────────────────────────
+        // ─── AC6: Claim a task ────────────────────────────────────────────────────
 
-    /**
-     * Verifies that claiming a putaway task returns 200 with the task status
-     * updated to ASSIGNED.
-     *
-     * Issue: #32
-     */
-    @Test
-    @DisplayName("AC6: claim putaway task returns 200 with status ASSIGNED")
-    void claimPutawayTask_validTaskId_returns200WithAssignedStatus() throws Exception {
-        // Issue #32: claiming a task must return ASSIGNED status
-        String taskId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
-        String userId = "warehouse-user-1";
+        /**
+         * Verifies that claiming a putaway task returns 200 with the task status
+         * updated to ASSIGNED.
+         *
+         * Issue: #32
+         */
+        @Test
+        @DisplayName("AC6: claim putaway task returns 200 with status ASSIGNED")
+        void claimPutawayTask_validTaskId_returns200WithAssignedStatus() throws Exception {
+                // Issue #32: claiming a task must return ASSIGNED status
+                String taskId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
+                String userId = "warehouse-user-1";
 
-        PutawayTaskResponse claimedTask = PutawayTaskResponse.builder()
-                .taskId(taskId)
-                .sourceReceiptId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .status("ASSIGNED")
-                .assigneeId(userId)
-                .createdAt(Instant.now(TEST_CLOCK))
-                .updatedAt(Instant.now(TEST_CLOCK))
-                .build();
+                PutawayTaskResponse claimedTask = PutawayTaskResponse.builder()
+                                .taskId(taskId)
+                                .sourceReceiptId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .status("ASSIGNED")
+                                .assigneeId(userId)
+                                .createdAt(Instant.now(TEST_CLOCK))
+                                .updatedAt(Instant.now(TEST_CLOCK))
+                                .build();
 
-        when(putawayGenerationService.claimTask(eq(taskId), any(String.class))).thenReturn(claimedTask);
+                when(putawayGenerationService.claimTask(eq(taskId), any(String.class))).thenReturn(claimedTask);
 
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/{taskId}/claim", taskId)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.taskId").value(taskId))
-                .andExpect(jsonPath("$.status").value("ASSIGNED"));
-    }
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/putaway/tasks/{taskId}/claim", taskId)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.taskId").value(taskId))
+                                .andExpect(jsonPath("$.status").value("ASSIGNED"));
+        }
 
-    // ─── AC7: Missing permission returns 403 ──────────────────────────────────
+        // ─── AC7: Missing permission returns 403 ──────────────────────────────────
 
-    /**
-     * Verifies that a request without the required inventory authority header
-     * returns 403 Forbidden per ADR-0011 and ADR-0014.
-     *
-     * Issue: #32
-     */
-    @Test
-    @DisplayName("AC7: missing inventory authority in X-Authorities header returns 403")
-    void generatePutawayTasks_missingAuthority_returns403() throws Exception {
-        // Issue #32: ADR-0011/ADR-0014 require authority check; unrelated
-        // authority on authenticated user → 403
-        String requestBody = objectMapper.writeValueAsString(objectMapper
-                .createObjectNode()
-                .put(
-                        "sourceReceiptId",
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .put(
-                        "productId",
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .put("quantity", 5));
+        /**
+         * Verifies that a request without the required inventory authority header
+         * returns 403 Forbidden per ADR-0011 and ADR-0014.
+         *
+         * Issue: #32
+         */
+        @Test
+        @DisplayName("AC7: missing inventory authority in X-Authorities header returns 403")
+        void generatePutawayTasks_missingAuthority_returns403() throws Exception {
+                // Issue #32: ADR-0011/ADR-0014 require authority check; unrelated
+                // authority on authenticated user → 403
+                String requestBody = objectMapper.writeValueAsString(objectMapper
+                                .createObjectNode()
+                                .put(
+                                                "sourceReceiptId",
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .put(
+                                                "productId",
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .put("quantity", 5));
 
-        mockMvc.perform(post("/v1/inventory/putaway/tasks/generate")
-                        .header("X-User", "unauthorized-user")
-                        .header("X-Authorities", "unrelated:authority")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isForbidden());
-    }
+                mockMvc.perform(post("/v1/inventory/putaway/tasks/generate")
+                                .header("X-User", "unauthorized-user")
+                                .header("X-Authorities", "unrelated:authority")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                                .andExpect(status().isForbidden());
+        }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReplenishmentContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReplenishmentContractBehaviorIT.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -43,182 +44,183 @@ import tools.jackson.databind.ObjectMapper;
  */
 @DisplayName("Replenishment Contract Behavior")
 class ReplenishmentContractBehaviorIT extends BaseContractIntegrationTest {
-    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+        private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+        @Autowired
+        private ObjectMapper objectMapper;
 
-    @MockitoBean
-    private ReplenishmentService replenishmentService;
+        @MockitoBean
+        private ReplenishmentService replenishmentService;
 
-    // ─── AC1: GET /replenishment/tasks returns 200 with task list ─────────────
+        // ─── AC1: GET /replenishment/tasks returns 200 with task list ─────────────
 
-    /**
-     * Verifies that a request for pending replenishment tasks returns 200 with the
-     * first task's itemSKU present, per story #30 AC1.
-     *
-     * Issue: #30
-     */
-    @Test
-    @DisplayName("AC1: GET /replenishment/tasks with pending tasks returns 200 with task list")
-    void getReplenishmentTasks_withPendingTasks_returns200WithTaskList() throws Exception {
-        // Issue #30: task list endpoint must return itemSKU for each queued task
-        String taskId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
-        String itemSKU = "SKU-WIDGET-001";
-        UUID sourceLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        UUID destinationLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        /**
+         * Verifies that a request for pending replenishment tasks returns 200 with the
+         * first task's itemSKU present, per story #30 AC1.
+         *
+         * Issue: #30
+         */
+        @Test
+        @DisplayName("AC1: GET /replenishment/tasks with pending tasks returns 200 with task list")
+        void getReplenishmentTasks_withPendingTasks_returns200WithTaskList() throws Exception {
+                // Issue #30: task list endpoint must return itemSKU for each queued task
+                String taskId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
+                String itemSKU = "SKU-WIDGET-001";
+                UUID sourceLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                UUID destinationLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-        ReplenishmentTaskResponse task = ReplenishmentTaskResponse.builder()
-                .taskId(taskId)
-                .itemSKU(itemSKU)
-                .quantity(10)
-                .sourceLocationId(sourceLocationId)
-                .destinationLocationId(destinationLocationId)
-                .status("PENDING")
-                .triggerType("MIN_LEVEL")
-                .decisionReason("Stock below minimum threshold")
-                .createdAt(Instant.now(TEST_CLOCK).toString())
-                .build();
+                ReplenishmentTaskResponse task = ReplenishmentTaskResponse.builder()
+                                .taskId(taskId)
+                                .itemSKU(itemSKU)
+                                .quantity(10)
+                                .sourceLocationId(sourceLocationId)
+                                .destinationLocationId(destinationLocationId)
+                                .status("PENDING")
+                                .triggerType("MIN_LEVEL")
+                                .decisionReason("Stock below minimum threshold")
+                                .createdAt(Instant.now(TEST_CLOCK).toString())
+                                .build();
 
-        when(replenishmentService.getReplenishmentTasks()).thenReturn(List.of(task));
+                when(replenishmentService.getReplenishmentTasks()).thenReturn(List.of(task));
 
-        mockMvc.perform(withGatewayAuth(get("/v1/inventory/replenishment/tasks")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].itemSKU").value(itemSKU));
-    }
+                mockMvc.perform(withGatewayAuth(get("/v1/inventory/replenishment/tasks")))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[0].itemSKU").value(itemSKU));
+        }
 
-    // ─── AC2: GET /replenishment/tasks returns 200 with empty list ────────────
+        // ─── AC2: GET /replenishment/tasks returns 200 with empty list ────────────
 
-    /**
-     * Verifies that when no replenishment tasks are queued the endpoint returns 200
-     * with an empty JSON array rather than 404 or 204, per ADR-0017.
-     *
-     * Issue: #30
-     */
-    @Test
-    @DisplayName("AC2: GET /replenishment/tasks with no pending tasks returns 200 with empty array")
-    void getReplenishmentTasks_withNoTasks_returns200WithEmptyArray() throws Exception {
-        // Issue #30: ADR-0017 — empty list resource must return 200, not 404/204
-        when(replenishmentService.getReplenishmentTasks()).thenReturn(Collections.emptyList());
+        /**
+         * Verifies that when no replenishment tasks are queued the endpoint returns 200
+         * with an empty JSON array rather than 404 or 204, per ADR-0017.
+         *
+         * Issue: #30
+         */
+        @Test
+        @DisplayName("AC2: GET /replenishment/tasks with no pending tasks returns 200 with empty array")
+        void getReplenishmentTasks_withNoTasks_returns200WithEmptyArray() throws Exception {
+                // Issue #30: ADR-0017 — empty list resource must return 200, not 404/204
+                when(replenishmentService.getReplenishmentTasks()).thenReturn(Collections.emptyList());
 
-        mockMvc.perform(withGatewayAuth(get("/v1/inventory/replenishment/tasks")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$").isEmpty());
-    }
+                mockMvc.perform(withGatewayAuth(get("/v1/inventory/replenishment/tasks")))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$").isArray())
+                                .andExpect(jsonPath("$").isEmpty());
+        }
 
-    // ─── AC3: GET /replenishment/policies returns 200 with policy list ────────
+        // ─── AC3: GET /replenishment/policies returns 200 with policy list ────────
 
-    /**
-     * Verifies that the replenishment policies endpoint returns 200 with at least
-     * one policy entry containing a locationId, per story #30 AC3.
-     *
-     * Issue: #30
-     */
-    @Test
-    @DisplayName("AC3: GET /replenishment/policies returns 200 with policy list")
-    void getReplenishmentPolicies_withExistingPolicies_returns200WithPolicyList() throws Exception {
-        // Issue #30: policy list must include locationId for each configured policy
-        String policyId =
-                UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
-        UUID locationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        /**
+         * Verifies that the replenishment policies endpoint returns 200 with at least
+         * one policy entry containing a locationId, per story #30 AC3.
+         *
+         * Issue: #30
+         */
+        @Test
+        @DisplayName("AC3: GET /replenishment/policies returns 200 with policy list")
+        void getReplenishmentPolicies_withExistingPolicies_returns200WithPolicyList() throws Exception {
+                // Issue #30: policy list must include locationId for each configured policy
+                String policyId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
+                UUID locationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-        ReplenishmentPolicyResponse policy = ReplenishmentPolicyResponse.builder()
-                .policyId(policyId)
-                .locationId(locationId)
-                .itemSKU("SKU-BOLT-M5")
-                .minimumQuantity(20)
-                .maximumQuantity(100)
-                .createdAt(Instant.now(TEST_CLOCK).toString())
-                .build();
+                ReplenishmentPolicyResponse policy = ReplenishmentPolicyResponse.builder()
+                                .policyId(policyId)
+                                .locationId(locationId)
+                                .itemSKU("SKU-BOLT-M5")
+                                .minimumQuantity(20)
+                                .maximumQuantity(100)
+                                .createdAt(Instant.now(TEST_CLOCK).toString())
+                                .build();
 
-        when(replenishmentService.getReplenishmentPolicies()).thenReturn(List.of(policy));
+                when(replenishmentService.getReplenishmentPolicies(
+                                org.mockito.ArgumentMatchers.isNull(),
+                                any(org.springframework.data.domain.Pageable.class)))
+                                .thenReturn(new PageImpl<>(List.of(policy)));
 
-        mockMvc.perform(withGatewayAuth(get("/v1/inventory/replenishment/policies")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].locationId").value(locationId.toString()));
-    }
+                mockMvc.perform(withGatewayAuth(get("/v1/inventory/replenishment/policies")))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.content[0].locationId").value(locationId.toString()));
+        }
 
-    // ─── AC4: POST /replenishment/policies returns 201 with created policy ────
+        // ─── AC4: POST /replenishment/policies returns 201 with created policy ────
 
-    /**
-     * Verifies that submitting a valid policy creation request returns 201 with the
-     * newly created policy's non-null policyId, per story #30 AC4 and ADR-0017
-     * (201 for resource creation).
-     *
-     * Issue: #30
-     */
-    @Test
-    @DisplayName("AC4: POST /replenishment/policies with valid body returns 201 with created policy")
-    void createReplenishmentPolicy_withValidRequest_returns201WithCreatedPolicy() throws Exception {
-        // Issue #30: ADR-0017 — resource creation must return 201 with new resource ID
-        // ADR-0018 — actor header X-User populated from gateway into response actor
-        String policyId =
-                UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
-        UUID locationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        /**
+         * Verifies that submitting a valid policy creation request returns 201 with the
+         * newly created policy's non-null policyId, per story #30 AC4 and ADR-0017
+         * (201 for resource creation).
+         *
+         * Issue: #30
+         */
+        @Test
+        @DisplayName("AC4: POST /replenishment/policies with valid body returns 201 with created policy")
+        void createReplenishmentPolicy_withValidRequest_returns201WithCreatedPolicy() throws Exception {
+                // Issue #30: ADR-0017 — resource creation must return 201 with new resource ID
+                // ADR-0018 — actor header X-User populated from gateway into response actor
+                String policyId = UUID.fromString("00000000-0000-0000-0000-000000000001").toString();
+                UUID locationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-        ReplenishmentPolicyResponse created = ReplenishmentPolicyResponse.builder()
-                .policyId(policyId)
-                .locationId(locationId)
-                .itemSKU("SKU-NUT-M5")
-                .minimumQuantity(10)
-                .maximumQuantity(50)
-                .createdAt(Instant.now(TEST_CLOCK).toString())
-                .build();
+                ReplenishmentPolicyResponse created = ReplenishmentPolicyResponse.builder()
+                                .policyId(policyId)
+                                .locationId(locationId)
+                                .itemSKU("SKU-NUT-M5")
+                                .minimumQuantity(10)
+                                .maximumQuantity(50)
+                                .createdAt(Instant.now(TEST_CLOCK).toString())
+                                .build();
 
-        when(replenishmentService.createReplenishmentPolicy(any(CreateReplenishmentPolicyRequest.class)))
-                .thenReturn(created);
+                when(replenishmentService.createReplenishmentPolicy(any(CreateReplenishmentPolicyRequest.class)))
+                                .thenReturn(created);
 
-        String requestBody = buildCreatePolicyRequestBody(locationId.toString(), "SKU-NUT-M5", 10, 50);
+                String requestBody = buildCreatePolicyRequestBody(locationId.toString(), "SKU-NUT-M5", 10, 50);
 
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/replenishment/policies"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.policyId").isNotEmpty());
-    }
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/replenishment/policies"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$.policyId").isNotEmpty());
+        }
 
-    // ─── AC5: POST /replenishment/policies with invalid body returns 400 ──────
+        // ─── AC5: POST /replenishment/policies with invalid body returns 400 ──────
 
-    /**
-     * Verifies that a policy creation request with missing required fields returns
-     * 400 Bad Request per ADR-0017 (input validation failure must yield 400, not
-     * 422 or 500).
-     *
-     * Issue: #30
-     */
-    @Test
-    @DisplayName("AC5: POST /replenishment/policies with missing required fields returns 400")
-    void createReplenishmentPolicy_withMissingRequiredFields_returns400() throws Exception {
-        // Issue #30: ADR-0017 — invalid/incomplete request body must return 400
-        // Empty body with no locationId or itemSKU — required fields absent
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/replenishment/policies"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{}"))
-                .andExpect(status().isBadRequest());
-    }
+        /**
+         * Verifies that a policy creation request with missing required fields returns
+         * 400 Bad Request per ADR-0017 (input validation failure must yield 400, not
+         * 422 or 500).
+         *
+         * Issue: #30
+         */
+        @Test
+        @DisplayName("AC5: POST /replenishment/policies with missing required fields returns 400")
+        void createReplenishmentPolicy_withMissingRequiredFields_returns400() throws Exception {
+                // Issue #30: ADR-0017 — invalid/incomplete request body must return 400
+                // Empty body with no locationId or itemSKU — required fields absent
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/replenishment/policies"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{}"))
+                                .andExpect(status().isBadRequest());
+        }
 
-    // ─── Helpers ─────────────────────────────────────────────────────────────
+        // ─── Helpers ─────────────────────────────────────────────────────────────
 
-    /**
-     * Builds a JSON request body for creating a replenishment policy.
-     *
-     * @param locationId      the pick-face location the policy applies to
-     * @param itemSKU         the SKU code governed by this policy
-     * @param minimumQuantity replenishment trigger threshold
-     * @param maximumQuantity target fill level after replenishment
-     * @return serialized JSON request body
-     */
-    private String buildCreatePolicyRequestBody(
-            String locationId, String itemSKU, int minimumQuantity, int maximumQuantity) throws Exception {
-        var node = objectMapper.createObjectNode();
-        node.put("locationId", locationId);
-        node.put("itemSKU", itemSKU);
-        node.put("minimumQuantity", minimumQuantity);
-        node.put("maximumQuantity", maximumQuantity);
-        return objectMapper.writeValueAsString(node);
-    }
+        /**
+         * Builds a JSON request body for creating a replenishment policy.
+         *
+         * @param locationId      the pick-face location the policy applies to
+         * @param itemSKU         the SKU code governed by this policy
+         * @param minimumQuantity replenishment trigger threshold
+         * @param maximumQuantity target fill level after replenishment
+         * @return serialized JSON request body
+         */
+        private String buildCreatePolicyRequestBody(
+                        String locationId, String itemSKU, int minimumQuantity, int maximumQuantity) throws Exception {
+                var node = objectMapper.createObjectNode();
+                node.put("locationId", locationId);
+                node.put("itemSKU", itemSKU);
+                node.put("minimumQuantity", minimumQuantity);
+                node.put("maximumQuantity", maximumQuantity);
+                return objectMapper.writeValueAsString(node);
+        }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReturnContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReturnContractBehaviorIT.java
@@ -6,9 +6,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.positivity.inventory.internal.dto.returns.ReturnItemLine;
-import com.positivity.inventory.internal.dto.returns.ReturnItemsRequest;
-import com.positivity.inventory.internal.dto.returns.ReturnResponse;
+import com.positivity.inventory.internal.dto.returns.ReturnLineDto;
+import com.positivity.inventory.internal.dto.returns.ReturnSubmitRequest;
+import com.positivity.inventory.internal.dto.returns.ReturnSubmissionResultDto;
 import com.positivity.inventory.internal.exception.ReturnQuantityExceededException;
 import com.positivity.inventory.service.ReturnService;
 import java.time.Clock;
@@ -24,194 +24,116 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import tools.jackson.databind.ObjectMapper;
 
-/**
- * Contract behavior integration tests for POST /v1/inventory/returns — Story
- * #177:
- * Return Unused Items to Stock with Reason.
- *
- * <p>
- * RC1 is intentionally RED: {@code ReturnService} is not stubbed in that test;
- * Mockito returns {@code null} by default; the controller wraps null in a
- * 201-Created body, so the {@code $.returnId} assertion fails to find the
- * expected
- * UUID value.
- *
- * <p>
- * RC2, RC3, and RC4 are GREEN-in-RED-phase because the infrastructure is
- * already
- * in place:
- * <ul>
- * <li>RC2: {@code ReturnController} carries {@code @PreAuthorize}</li>
- * <li>RC3: {@code ReturnItemsRequest.returnReason} is {@code @NotBlank} and
- * the controller uses {@code @Valid}</li>
- * <li>RC4: {@code InventoryGlobalExceptionHandler} already maps
- * {@code ReturnQuantityExceededException} → 422</li>
- * </ul>
- *
- * <p>
- * ADR compliance:
- * <ul>
- * <li>ADR-0011: gateway auth headers (X-User, X-Authorities) required</li>
- * <li>ADR-0014: internal service security — all state-changing endpoints
- * require
- * gateway auth</li>
- * <li>ADR-0017: HTTP response codes: 201 Created, 400 Bad Request, 403
- * Forbidden,
- * 422 Unprocessable Entity</li>
- * <li>ADR-0018: transactionUserId sourced from X-User header via security
- * context</li>
- * </ul>
- *
- * Issue: #177
- */
 @DisplayName("Return Contract Behavior — Story #177")
 class ReturnContractBehaviorIT extends BaseContractIntegrationTest {
-    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+        private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+        @Autowired
+        private ObjectMapper objectMapper;
 
-    @MockitoBean
-    private ReturnService returnService;
+        @MockitoBean
+        private ReturnService returnService;
 
-    // ─── RC1: POST /v1/inventory/returns — 201 Created with service returnId ─────
+        @Test
+        @DisplayName("POST /v1/inventory/returns/submit-to-stock with valid body + auth -> 202 Accepted")
+        void RC1_submitToStock_validBodyAndAuth_returns202WithServicePayload() throws Exception {
 
-    /**
-     * RC1: Verifies POST /v1/inventory/returns with a valid request body and
-     * gateway
-     * auth returns 201 Created, and that the {@code returnId} in the response
-     * originates from {@code ReturnService} (not a controller-generated value).
-     *
-     * <p>
-     * RED: {@code returnService} is not stubbed; Mockito returns {@code null} by
-     * default; the controller sets a null response body → {@code $.returnId} is
-     * absent
-     * and the assertion fails.
-     *
-     * Issue: #177
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/returns with valid body + auth → 201 Created with service returnId")
-    void RC1_returnItemsToStock_validBodyAndAuth_returns201WithServiceReturnId() throws Exception {
-        // Issue #177: RC1 — controller must delegate to ReturnService and surface its
-        // returnId.
+                UUID workorderId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                UUID expectedReturnId = UUID.fromString("00000000-0000-0000-0000-000000000042");
 
-        UUID workorderId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        UUID expectedReturnId = UUID.fromString("00000000-0000-0000-0000-000000000042");
+                ReturnSubmissionResultDto expectedResponse = ReturnSubmissionResultDto.builder()
+                                .returnId(expectedReturnId)
+                                .workorderId(workorderId)
+                                .processedLines(1)
+                                .status("SUBMITTED")
+                                .processedAt(Instant.now(TEST_CLOCK))
+                                .build();
+                when(returnService.submitToStock(any(ReturnSubmitRequest.class))).thenReturn(expectedResponse);
 
-        ReturnResponse expectedReturnResponse = new ReturnResponse(
-                expectedReturnId,
-                workorderId,
-                "Leftover brake pads",
-                1,
-                Instant.now(TEST_CLOCK),
-                List.of(UUID.fromString("00000000-0000-0000-0000-000000000001")));
-        when(returnService.returnItemsToStock(any(ReturnItemsRequest.class))).thenReturn(expectedReturnResponse);
+                ReturnSubmitRequest requestBody = ReturnSubmitRequest.builder()
+                                .workorderId(workorderId)
+                                .lines(List.of(ReturnLineDto.builder()
+                                                .itemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                                                .quantity(2)
+                                                .reasonCode("DAMAGED")
+                                                .locationId(UUID.fromString("10000000-0000-0000-0000-000000000001"))
+                                                .build()))
+                                .build();
 
-        ReturnItemsRequest requestBody = new ReturnItemsRequest(
-                workorderId,
-                "Leftover brake pads",
-                List.of(new ReturnItemLine(UUID.fromString("00000000-0000-0000-0000-000000000001"), 2)));
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/returns/submit-to-stock"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestBody)))
+                                .andExpect(status().isAccepted())
+                                .andExpect(jsonPath("$.returnId").value(expectedReturnId.toString()))
+                                .andExpect(jsonPath("$.workorderId").value(workorderId.toString()))
+                                .andExpect(jsonPath("$.processedLines").value(1))
+                                .andExpect(jsonPath("$.status").value("SUBMITTED"))
+                                .andExpect(jsonPath("$.processedAt").isNotEmpty());
+        }
 
-        // Act + Assert
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/returns"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestBody)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.returnId").value(expectedReturnId.toString()))
-                .andExpect(jsonPath("$.workorderId").value(workorderId.toString()))
-                .andExpect(jsonPath("$.totalItemsReturned").value(1));
-    }
+        @Test
+        @DisplayName("POST /v1/inventory/returns/submit-to-stock without required authority -> 403 Forbidden")
+        void RC2_submitToStock_missingRequiredAuthority_returns403() throws Exception {
+                ReturnSubmitRequest requestBody = ReturnSubmitRequest.builder()
+                                .workorderId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                                .lines(List.of(ReturnLineDto.builder()
+                                                .itemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                                                .quantity(1)
+                                                .reasonCode("EXCESS")
+                                                .locationId(UUID.fromString("10000000-0000-0000-0000-000000000001"))
+                                                .build()))
+                                .build();
 
-    // ─── RC2: POST /v1/inventory/returns — 403 with missing authority ─────────────
+                mockMvc.perform(post("/v1/inventory/returns/submit-to-stock")
+                                .header("X-User", "test-user")
+                                .header("X-Authorities", "unrelated:authority")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestBody)))
+                                .andExpect(status().isForbidden());
+        }
 
-    /**
-     * RC2: Verifies POST /v1/inventory/returns with an authenticated user but
-     * without required return authority returns 403 Forbidden per ADR-0011 and
-     * ADR-0014.
-     *
-     * <p>
-     * GREEN in RED phase: {@code ReturnController} already carries
-     * {@code @PreAuthorize("hasAuthority('inventory:adjustment:create')")}.
-     *
-     * Issue: #177
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/returns without required authority → 403 Forbidden")
-    void RC2_returnItemsToStock_missingRequiredAuthority_returns403() throws Exception {
-        // Issue #177: authenticated user + unrelated authority must yield 403
-        ReturnItemsRequest requestBody = new ReturnItemsRequest(
-                UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                "Surplus parts",
-                List.of(new ReturnItemLine(UUID.fromString("00000000-0000-0000-0000-000000000001"), 1)));
+        @Test
+        @DisplayName("POST /v1/inventory/returns/submit-to-stock with invalid line fields -> 400 Bad Request")
+        void RC3_submitToStock_invalidRequest_returns400() throws Exception {
+                ReturnSubmitRequest requestBody = ReturnSubmitRequest.builder()
+                                .workorderId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                                .lines(List.of(ReturnLineDto.builder()
+                                                .itemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                                                .quantity(1)
+                                                .reasonCode("   ")
+                                                .locationId(UUID.fromString("10000000-0000-0000-0000-000000000001"))
+                                                .build()))
+                                .build();
 
-        mockMvc.perform(post("/v1/inventory/returns")
-                        .header("X-User", "test-user")
-                        .header("X-Authorities", "unrelated:authority")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestBody)))
-                .andExpect(status().isForbidden());
-    }
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/returns/submit-to-stock"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestBody)))
+                                .andExpect(status().isBadRequest());
+        }
 
-    // ─── RC3: POST /v1/inventory/returns — 400 for blank returnReason ────────────
+        @Test
+        @DisplayName("POST /v1/inventory/returns/submit-to-stock with quantity exceeded -> 422 Unprocessable Entity")
+        void RC4_submitToStock_quantityExceeded_returns422() throws Exception {
+                UUID skuId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                when(returnService.submitToStock(any(ReturnSubmitRequest.class)))
+                                .thenThrow(new ReturnQuantityExceededException(skuId, 99, 2));
 
-    /**
-     * RC3: Verifies POST /v1/inventory/returns returns 400 Bad Request when
-     * {@code returnReason} is blank.
-     *
-     * <p>
-     * GREEN in RED phase: {@code ReturnItemsRequest.returnReason} is annotated
-     * {@code @NotBlank} and the controller uses {@code @Valid @RequestBody}.
-     *
-     * Issue: #177
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/returns with blank returnReason → 400 Bad Request")
-    void RC3_returnItemsToStock_blankReturnReason_returns400() throws Exception {
-        // Issue #177: RC3 — blank reason must be rejected by @NotBlank bean validation
-        ReturnItemsRequest requestBody = new ReturnItemsRequest(
-                UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                "   ", // blank — violates @NotBlank
-                List.of(new ReturnItemLine(UUID.fromString("00000000-0000-0000-0000-000000000001"), 1)));
+                ReturnSubmitRequest requestBody = ReturnSubmitRequest.builder()
+                                .workorderId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                                .lines(List.of(ReturnLineDto.builder()
+                                                .itemId(skuId)
+                                                .quantity(99)
+                                                .reasonCode("DAMAGED")
+                                                .locationId(UUID.fromString("10000000-0000-0000-0000-000000000001"))
+                                                .build()))
+                                .build();
 
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/returns"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestBody)))
-                .andExpect(status().isBadRequest());
-    }
-
-    // ─── RC4: POST /v1/inventory/returns — 422 for quantity exceeded ─────────────
-
-    /**
-     * RC4: Verifies POST /v1/inventory/returns returns 422 Unprocessable Entity
-     * when
-     * the service throws {@link ReturnQuantityExceededException}.
-     *
-     * <p>
-     * GREEN in RED phase: {@code InventoryGlobalExceptionHandler} already maps
-     * {@code ReturnQuantityExceededException} → 422 UNPROCESSABLE_ENTITY.
-     *
-     * Issue: #177
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/returns with quantity exceeded → 422 Unprocessable Entity")
-    void RC4_returnItemsToStock_quantityExceeded_returns422() throws Exception {
-        // Issue #177: RC4 — ReturnQuantityExceededException must map to 422 via handler
-        UUID skuId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        when(returnService.returnItemsToStock(any(ReturnItemsRequest.class)))
-                .thenThrow(new ReturnQuantityExceededException(skuId, 99, 2));
-
-        ReturnItemsRequest requestBody = new ReturnItemsRequest(
-                UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                "Overclaim return",
-                List.of(new ReturnItemLine(skuId, 99)));
-
-        mockMvc.perform(withGatewayAuth(post("/v1/inventory/returns"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestBody)))
-                .andExpect(status().is(422));
-    }
+                mockMvc.perform(withGatewayAuth(post("/v1/inventory/returns/submit-to-stock"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestBody)))
+                                .andExpect(status().is(422));
+        }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ShortageResolutionContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ShortageResolutionContractBehaviorIT.java
@@ -6,13 +6,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.positivity.inventory.internal.dto.shortage.ResolutionOption;
-import com.positivity.inventory.internal.dto.shortage.ResolutionOptionType;
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionRequest;
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionResponse;
+import com.positivity.inventory.internal.dto.ShortageResolveRequest;
+import com.positivity.inventory.internal.dto.ShortageResolutionResultDto;
 import com.positivity.inventory.service.ShortageResolutionService;
-import java.math.BigDecimal;
-import java.util.List;
+import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,277 +20,94 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import tools.jackson.databind.ObjectMapper;
 
-/**
- * Contract behavior integration tests for the Shortage Resolution API — Story
- * #25
- * (CAP-220): Allocations: Handle Shortages with Backorder or Substitution
- * Suggestion.
- *
- * <p>
- * Verifies the HTTP contract for
- * {@code POST /v1/inventory/allocations/shortages/resolve} per:
- * <ul>
- * <li>ADR-0011: gateway auth headers (X-User, X-Authorities) required</li>
- * <li>ADR-0013: UUID.fromString("00000000-0000-0000-0000-000000000001")
- * acceptable in tests</li>
- * <li>ADR-0017: HTTP response codes — 200 OK on success, 400 on missing
- * required fields,
- * 401 when auth headers are absent entirely</li>
- * <li>ADR-0018: actor sourced from X-User security context header, not request
- * body</li>
- * </ul>
- *
- * <p>
- * All tests mock {@link ShortageResolutionService} via {@code @MockitoBean}.
- * Behavioral correctness (option ordering, partial banner logic, client
- * fallback) is
- * validated in {@code ShortageResolutionServiceImplTest} (RED phase).
- *
- * Issue: #25
- */
 @DisplayName("Shortage Resolution Contract Behavior — Story #25 (CAP-220)")
 class ShortageResolutionContractBehaviorIT extends BaseContractIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+        @Autowired
+        private ObjectMapper objectMapper;
 
-    @MockitoBean
-    private ShortageResolutionService shortageResolutionService;
+        @MockitoBean
+        private ShortageResolutionService shortageResolutionService;
 
-    /**
-     * Provides gateway auth headers including the
-     * {@code inventory:shortages:resolve}
-     * authority required by
-     * {@link com.positivity.inventory.internal.controller.ShortageController}.
-     *
-     * <p>
-     * The base {@link BaseContractIntegrationTest#withGatewayAuth} helper does not
-     * include this authority, so a dedicated helper is required per ADR-0011.
-     */
-    private MockHttpServletRequestBuilder withShortageAuth(MockHttpServletRequestBuilder requestBuilder) {
-        return requestBuilder
-                .header("X-User", "contract-test-user")
-                .header("X-Authorities", "inventory:shortages:resolve");
-    }
+        private MockHttpServletRequestBuilder withShortageAuth(MockHttpServletRequestBuilder requestBuilder) {
+                return requestBuilder
+                                .header("X-User", "contract-test-user")
+                                .header("X-Authorities", "inventory:shortage:resolve");
+        }
 
-    // ─── 1. Valid request → 200 OK with JSON structure ───────────────────────────
+        @Test
+        @DisplayName("POST /v1/inventory/shortage/resolve with valid request → 200 OK with response body")
+        void resolveShortage_validRequest_returns200() throws Exception {
+                UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-    /**
-     * Verifies that POST /v1/inventory/allocations/shortages/resolve with a valid
-     * request body and correct gateway authority returns 200 OK with allocationId,
-     * sku, options array, and partialResultsBanner fields per ADR-0017.
-     *
-     * Issue: #25
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/allocations/shortages/resolve with valid request → 200 OK with response body")
-    void resolveShortage_validRequest_returns200() throws Exception {
-        // Issue #25: valid request must return 200 with well-formed JSON structure
-        UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                ShortageResolutionResultDto mockResponse = ShortageResolutionResultDto.builder()
+                                .allocationId(allocationId)
+                                .resolution("BACKORDER")
+                                .resolvedAt(Instant.parse("2024-01-01T00:00:00Z"))
+                                .status("RESOLVED")
+                                .build();
 
-        ShortageResolutionResponse mockResponse = ShortageResolutionResponse.builder()
-                .allocationId(allocationId)
-                .sku("PART-001")
-                .options(List.of(
-                        ResolutionOption.builder()
-                                .type(ResolutionOptionType.SUBSTITUTE)
-                                .substitutePartNumber("PART-001A")
-                                .unitCost(new BigDecimal("12.50"))
-                                .estimatedLeadTimeDays(3)
-                                .qualityTier("A")
-                                .build(),
-                        ResolutionOption.builder()
-                                .type(ResolutionOptionType.BACKORDER)
-                                .build()))
-                .partialResultsBanner(false)
-                .build();
+                when(shortageResolutionService.resolveShortage(any(ShortageResolveRequest.class)))
+                                .thenReturn(mockResponse);
 
-        when(shortageResolutionService.resolveShortage(any(ShortageResolutionRequest.class)))
-                .thenReturn(mockResponse);
+                ShortageResolveRequest request = ShortageResolveRequest.builder()
+                                .allocationId(allocationId)
+                                .resolution("BACKORDER")
+                                .build();
 
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(allocationId)
-                .sku("PART-001")
-                .shortQuantity(2)
-                .build();
+                mockMvc.perform(withShortageAuth(post("/v1/inventory/shortage/resolve"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.allocationId").value(allocationId.toString()))
+                                .andExpect(jsonPath("$.resolution").value("BACKORDER"))
+                                .andExpect(jsonPath("$.resolvedAt").isNotEmpty())
+                                .andExpect(jsonPath("$.status").value("RESOLVED"));
+        }
 
-        mockMvc.perform(withShortageAuth(post("/v1/inventory/allocations/shortages/resolve"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.allocationId").value(allocationId.toString()))
-                .andExpect(jsonPath("$.sku").value("PART-001"))
-                .andExpect(jsonPath("$.options").isArray())
-                .andExpect(jsonPath("$.partialResultsBanner").value(false));
-    }
-
-    // ─── 2. Missing allocationId → 400 Bad Request ───────────────────────────────
-
-    /**
-     * Verifies that a request body missing the required allocationId field returns
-     * 400 Bad Request per ADR-0017 (Bean Validation via {@code @NotNull}).
-     *
-     * Issue: #25
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/allocations/shortages/resolve with missing allocationId → 400 Bad Request")
-    void resolveShortage_missingAllocationId_returns400() throws Exception {
-        // Issue #25: allocationId is @NotNull — missing field must produce 400
-        String requestBody = """
-                                {"sku":"PART-001","shortQuantity":2}
+        @Test
+        @DisplayName("POST /v1/inventory/shortage/resolve with missing allocationId → 400 Bad Request")
+        void resolveShortage_missingAllocationId_returns400() throws Exception {
+                String requestBody = """
+                                {"resolution":"BACKORDER"}
                                 """;
 
-        mockMvc.perform(withShortageAuth(post("/v1/inventory/allocations/shortages/resolve"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest());
-    }
+                mockMvc.perform(withShortageAuth(post("/v1/inventory/shortage/resolve"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                                .andExpect(status().isBadRequest());
+        }
 
-    // ─── 3. Missing sku → 400 Bad Request ────────────────────────────────────────
-
-    /**
-     * Verifies that a request body missing the required sku field returns
-     * 400 Bad Request per ADR-0017 (Bean Validation via {@code @NotNull}).
-     *
-     * Issue: #25
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/allocations/shortages/resolve with missing sku → 400 Bad Request")
-    void resolveShortage_missingSku_returns400() throws Exception {
-        // Issue #25: sku is @NotNull — missing field must produce 400
-        UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        String requestBody = String.format("""
-                                {"allocationId":"%s","shortQuantity":2}
+        @Test
+        @DisplayName("POST /v1/inventory/shortage/resolve with missing resolution → 400 Bad Request")
+        void resolveShortage_missingResolution_returns400() throws Exception {
+                UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                String requestBody = String.format("""
+                                                                {"allocationId":"%s"}
                                 """, allocationId);
 
-        mockMvc.perform(withShortageAuth(post("/v1/inventory/allocations/shortages/resolve"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest());
-    }
+                mockMvc.perform(withShortageAuth(post("/v1/inventory/shortage/resolve"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                                .andExpect(status().isBadRequest());
+        }
 
-    // ─── 4. Missing required authority → 403 Forbidden ───────────────────────────
+        @Test
+        @DisplayName("POST /v1/inventory/shortage/resolve without required authority → 403 Forbidden")
+        void resolveShortage_missingRequiredAuthority_returns403() throws Exception {
+                ShortageResolveRequest request = ShortageResolveRequest.builder()
+                                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                                .resolution("BACKORDER")
+                                .build();
 
-    /**
-     * Verifies that an authenticated request with unrelated authority returns
-     * 403 Forbidden.
-     *
-     * <p>
-     * This module uses the shared
-     * {@link com.positivity.security.common.GatewaySecurityConfig}
-     * which returns 403 for authenticated requests without required authority (consistent with
-     * {@code ReallocationContractBehaviorIT#contract_reallocate_withoutAuthority_returns403}).
-     *
-     * Issue: #25
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/allocations/shortages/resolve without required authority → 403 Forbidden")
-    void resolveShortage_missingRequiredAuthority_returns403() throws Exception {
-        // Issue #25: authenticated user + unrelated authority must yield 403
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .sku("PART-001")
-                .shortQuantity(2)
-                .build();
-
-        mockMvc.perform(post("/v1/inventory/allocations/shortages/resolve")
-                        .header("X-User", "test-user")
-                        .header("X-Authorities", "unrelated:authority")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isForbidden());
-    }
-
-    // ─── 5. shortQuantity ≤ 0 → 400 Bad Request ─────────────────────────────────
-
-    /**
-     * Verifies that {@code shortQuantity=0} violates the {@code @Positive} Bean
-     * Validation constraint and returns 400 Bad Request per ADR-0017, without
-     * reaching the service layer.
-     *
-     * Issue: #25
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/allocations/shortages/resolve — shortQuantity=0 → 400")
-    void resolveShortage_zeroShortQuantity_returns400() throws Exception {
-        // Issue #25: shortQuantity=0 violates @Positive — must return 400, service not
-        // called
-        UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        String requestBody =
-                String.format("{\"allocationId\":\"%s\",\"sku\":\"PART-001\",\"shortQuantity\":0}", allocationId);
-
-        mockMvc.perform(withShortageAuth(post("/v1/inventory/allocations/shortages/resolve"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest());
-    }
-
-    /**
-     * Verifies that {@code shortQuantity=-1} violates the {@code @Positive} Bean
-     * Validation constraint and returns 400 Bad Request per ADR-0017, without
-     * reaching the service layer.
-     *
-     * Issue: #25
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/allocations/shortages/resolve — shortQuantity=-1 → 400")
-    void resolveShortage_negativeShortQuantity_returns400() throws Exception {
-        // Issue #25: shortQuantity=-1 violates @Positive — must return 400, service not
-        // called
-        UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        String requestBody =
-                String.format("{\"allocationId\":\"%s\",\"sku\":\"PART-001\",\"shortQuantity\":-1}", allocationId);
-
-        mockMvc.perform(withShortageAuth(post("/v1/inventory/allocations/shortages/resolve"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest());
-    }
-
-    // ─── 6. partialResultsBanner=true serialised correctly ───────────────────────
-
-    /**
-     * Verifies that when the service signals a partial result (Scenario 4: partner
-     * failure
-     * or client timeout), the HTTP response carries
-     * {@code partialResultsBanner=true}
-     * correctly in the JSON body per Story #25 Scenario 4.
-     *
-     * Issue: #25
-     */
-    @Test
-    @DisplayName("POST /v1/inventory/allocations/shortages/resolve → 200 OK with partialResultsBanner=true")
-    void resolveShortage_partialBannerResponse_returns200WithBannerTrue() throws Exception {
-        // Issue #25: Scenario 4 — partner client failure must surface as
-        // partialResultsBanner=true
-        UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-
-        ShortageResolutionResponse partialResponse = ShortageResolutionResponse.builder()
-                .allocationId(allocationId)
-                .sku("PART-X")
-                .options(List.of(ResolutionOption.builder()
-                        .type(ResolutionOptionType.BACKORDER)
-                        .build()))
-                .partialResultsBanner(true)
-                .build();
-
-        when(shortageResolutionService.resolveShortage(any(ShortageResolutionRequest.class)))
-                .thenReturn(partialResponse);
-
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(allocationId)
-                .sku("PART-X")
-                .shortQuantity(1)
-                .build();
-
-        mockMvc.perform(withShortageAuth(post("/v1/inventory/allocations/shortages/resolve"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.partialResultsBanner").value(true))
-                .andExpect(jsonPath("$.options[0].type").value("BACKORDER"));
-    }
+                mockMvc.perform(post("/v1/inventory/shortage/resolve")
+                                .header("X-User", "test-user")
+                                .header("X-Authorities", "unrelated:authority")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isForbidden());
+        }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/dto/returns/ReturnLineDtoTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/dto/returns/ReturnLineDtoTest.java
@@ -1,0 +1,100 @@
+package com.positivity.inventory.internal.dto.returns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ReturnLineDto validation constraints (T-008)")
+class ReturnLineDtoTest {
+
+    private static ValidatorFactory validatorFactory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator() {
+        validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @AfterAll
+    static void closeValidator() {
+        validatorFactory.close();
+    }
+
+    @Test
+    @DisplayName("null itemId produces a constraint violation on itemId field")
+    void nullItemId_producesConstraintViolation() {
+        ReturnLineDto dto = ReturnLineDto.builder()
+                .itemId(null)
+                .quantity(1)
+                .reasonCode("DAMAGED")
+                .locationId(UUID.randomUUID())
+                .build();
+
+        Set<ConstraintViolation<ReturnLineDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("itemId");
+    }
+
+    @Test
+    @DisplayName("quantity = 0 produces a constraint violation on quantity field")
+    void zeroQuantity_producesConstraintViolation() {
+        ReturnLineDto dto = ReturnLineDto.builder()
+                .itemId(UUID.randomUUID())
+                .quantity(0)
+                .reasonCode("DAMAGED")
+                .locationId(UUID.randomUUID())
+                .build();
+
+        Set<ConstraintViolation<ReturnLineDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("quantity");
+    }
+
+    @Test
+    @DisplayName("quantity = -1 produces a constraint violation on quantity field")
+    void negativeQuantity_producesConstraintViolation() {
+        ReturnLineDto dto = ReturnLineDto.builder()
+                .itemId(UUID.randomUUID())
+                .quantity(-1)
+                .reasonCode("DAMAGED")
+                .locationId(UUID.randomUUID())
+                .build();
+
+        Set<ConstraintViolation<ReturnLineDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("quantity");
+    }
+
+    @Test
+    @DisplayName("valid itemId and positive quantity produces no constraint violations")
+    void validItemIdAndPositiveQuantity_noViolations() {
+        ReturnLineDto dto = ReturnLineDto.builder()
+                .itemId(UUID.randomUUID())
+                .quantity(1)
+                .reasonCode("DAMAGED")
+                .locationId(UUID.randomUUID())
+                .build();
+
+        Set<ConstraintViolation<ReturnLineDto>> violations = validator.validate(dto);
+
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .doesNotContain("itemId", "quantity");
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImplTest.java
@@ -1,0 +1,277 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.dto.InventoryLedgerEntryDto;
+import com.positivity.inventory.internal.dto.InventoryLedgerFilterParams;
+import com.positivity.inventory.internal.dto.LedgerPage;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.exception.ResourceNotFoundException;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryLedgerServiceImplTest {
+
+    @Mock
+    private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+
+    private InventoryLedgerServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new InventoryLedgerServiceImpl(inventoryLedgerEntryRepository);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private InventoryLedgerEntry buildEntry(UUID id) {
+        return InventoryLedgerEntry.builder()
+                .ledgerEntryId(id)
+                .stockItemId("SKU-TEST")
+                .eventType(InventoryLedgerEventType.ADJUSTMENT_IN)
+                .changeInQuantity(1)
+                .quantityAfter(10)
+                .transactionUserId("user-1")
+                .build();
+    }
+
+    private List<InventoryLedgerEntry> buildEntries(int count) {
+        List<InventoryLedgerEntry> list = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            list.add(buildEntry(UUID.randomUUID()));
+        }
+        return list;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubFindAll(List<InventoryLedgerEntry> entries) {
+        when(inventoryLedgerEntryRepository.findAll(
+                any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(entries));
+    }
+
+    // -------------------------------------------------------------------------
+    // T-002: Exception routing tests
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("getLedgerEntry")
+    class GetLedgerEntry {
+
+        @Test
+        @DisplayName("T-002: throws ResourceNotFoundException when entry does not exist")
+        void throwsResourceNotFoundExceptionForMissingEntry() {
+            UUID missingId = UUID.randomUUID();
+            when(inventoryLedgerEntryRepository.findById(missingId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getLedgerEntry(missingId))
+                    .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining(missingId.toString());
+        }
+
+        @Test
+        @DisplayName("T-012: returns mapped DTO for existing entry (happy path)")
+        void returnsMappedDtoForExistingEntry() {
+            UUID id = UUID.randomUUID();
+            InventoryLedgerEntry entry = buildEntry(id);
+            when(inventoryLedgerEntryRepository.findById(id)).thenReturn(Optional.of(entry));
+
+            InventoryLedgerEntryDto dto = service.getLedgerEntry(id);
+
+            assertThat(dto.getLedgerEntryId()).isEqualTo(id);
+            assertThat(dto.getStockItemId()).isEqualTo("SKU-TEST");
+            assertThat(dto.getEventType()).isEqualTo(InventoryLedgerEventType.ADJUSTMENT_IN);
+        }
+    }
+
+    @Nested
+    @DisplayName("listLedgerEntries – movementType/pageToken routing")
+    class MovementTypeAndPageToken {
+
+        @Test
+        @DisplayName("T-002: throws IllegalArgumentException for unknown movementType string")
+        void throwsIllegalArgumentExceptionForUnknownMovementType() {
+            InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+                    .movementTypes(List.of("NOT_A_REAL_TYPE"))
+                    .pageSize(10)
+                    .build();
+
+            // movementTypes are parsed eagerly inside buildSpecification before findAll
+            // is called, so no repo stub is needed.
+            assertThatThrownBy(() -> service.listLedgerEntries(params))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("NOT_A_REAL_TYPE");
+        }
+
+        @Test
+        @DisplayName("T-002: throws IllegalArgumentException for corrupt/invalid base64 pageToken")
+        void throwsIllegalArgumentExceptionForCorruptPageToken() {
+            InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+                    .pageToken("!!!not-valid-base64!!!")
+                    .pageSize(10)
+                    .build();
+
+            assertThatThrownBy(() -> service.listLedgerEntries(params))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Invalid pageToken");
+        }
+
+        @Test
+        @DisplayName("T-002: throws IllegalArgumentException for base64 pageToken that is not a valid UUID")
+        void throwsIllegalArgumentExceptionForNonUuidPageToken() {
+            // Encode a non-UUID string as a valid base64 token
+            String badToken = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString("not-a-uuid".getBytes(StandardCharsets.UTF_8));
+            InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+                    .pageToken(badToken)
+                    .pageSize(10)
+                    .build();
+
+            assertThatThrownBy(() -> service.listLedgerEntries(params))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Invalid pageToken");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // T-010: Next-page token off-by-one fix tests
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("listLedgerEntries – nextPageToken logic (T-010)")
+    class NextPageTokenLogic {
+
+        @Test
+        @DisplayName("repo returns exactly pageSize entries → nextPageToken is null (no spurious token)")
+        void noNextPageTokenWhenResultCountEqualsPageSize() {
+            int pageSize = 5;
+            List<InventoryLedgerEntry> entries = buildEntries(pageSize); // exactly 5, repo asked for 6
+            stubFindAll(entries);
+
+            InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+                    .pageSize(pageSize)
+                    .build();
+
+            LedgerPage<InventoryLedgerEntryDto> page = service.listLedgerEntries(params);
+
+            assertThat(page.getNextPageToken()).isNull();
+            assertThat(page.getEntries()).hasSize(pageSize);
+        }
+
+        @Test
+        @DisplayName("repo returns pageSize+1 entries → nextPageToken is set and result is truncated to pageSize")
+        void hasNextPageTokenAndTruncatesWhenRepoReturnsExtraEntry() {
+            int pageSize = 5;
+            List<InventoryLedgerEntry> entries = buildEntries(pageSize + 1); // 6 returned from repo
+            stubFindAll(entries);
+
+            InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+                    .pageSize(pageSize)
+                    .build();
+
+            LedgerPage<InventoryLedgerEntryDto> page = service.listLedgerEntries(params);
+
+            assertThat(page.getNextPageToken()).isNotNull();
+            assertThat(page.getEntries()).hasSize(pageSize);
+        }
+
+        @Test
+        @DisplayName("repo returns fewer than pageSize entries → nextPageToken is null")
+        void noNextPageTokenWhenResultCountBelowPageSize() {
+            int pageSize = 10;
+            List<InventoryLedgerEntry> entries = buildEntries(3);
+            stubFindAll(entries);
+
+            InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+                    .pageSize(pageSize)
+                    .build();
+
+            LedgerPage<InventoryLedgerEntryDto> page = service.listLedgerEntries(params);
+
+            assertThat(page.getNextPageToken()).isNull();
+            assertThat(page.getEntries()).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("repo returns empty list → nextPageToken is null and entries are empty")
+        void noNextPageTokenWhenResultIsEmpty() {
+            int pageSize = 5;
+            stubFindAll(List.of());
+
+            InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+                    .pageSize(pageSize)
+                    .build();
+
+            LedgerPage<InventoryLedgerEntryDto> page = service.listLedgerEntries(params);
+
+            assertThat(page.getNextPageToken()).isNull();
+            assertThat(page.getEntries()).isEmpty();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // T-012: Additional coverage for listLedgerEntries
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("listLedgerEntries – paging and DTO mapping (T-012)")
+    class ListLedgerEntriesCoverage {
+
+        @Test
+        @DisplayName("maps returned entities to DTOs preserving stockItemId and eventType")
+        void mapsDtoFieldsCorrectly() {
+            UUID entryId = UUID.randomUUID();
+            InventoryLedgerEntry entry = buildEntry(entryId);
+            stubFindAll(List.of(entry));
+
+            InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+                    .pageSize(5)
+                    .build();
+
+            LedgerPage<InventoryLedgerEntryDto> page = service.listLedgerEntries(params);
+
+            assertThat(page.getEntries()).hasSize(1);
+            InventoryLedgerEntryDto dto = page.getEntries().getFirst();
+            assertThat(dto.getLedgerEntryId()).isEqualTo(entryId);
+            assertThat(dto.getStockItemId()).isEqualTo("SKU-TEST");
+            assertThat(dto.getEventType()).isEqualTo(InventoryLedgerEventType.ADJUSTMENT_IN);
+        }
+
+        @Test
+        @DisplayName("uses default pageSize of 50 when pageSize param is 0")
+        void usesDefaultPageSizeWhenParamIsZero() {
+            stubFindAll(List.of());
+
+            InventoryLedgerFilterParams params = InventoryLedgerFilterParams.builder()
+                    .pageSize(0)
+                    .build();
+
+            LedgerPage<InventoryLedgerEntryDto> page = service.listLedgerEntries(params);
+
+            assertThat(page.getEntries()).isEmpty();
+            assertThat(page.getNextPageToken()).isNull();
+        }
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryAvailabilityServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryAvailabilityServiceImplTest.java
@@ -26,243 +26,249 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class InventoryAvailabilityServiceImplTest {
-    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+        private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
-    private static final UUID LOC_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
-    private static final UUID SLOC_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        private static final UUID LOC_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        private static final UUID SLOC_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-    @Mock
-    private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+        @Mock
+        private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
-    private InventoryAvailabilityServiceImpl service;
+        private InventoryAvailabilityServiceImpl service;
 
-    @BeforeEach
-    void setUp() {
-        service = new InventoryAvailabilityServiceImpl(inventoryLedgerEntryRepository);
-    }
+        @BeforeEach
+        void setUp() {
+                service = new InventoryAvailabilityServiceImpl(inventoryLedgerEntryRepository);
+        }
 
-    @Test
-    void getAvailabilityByProduct_returnsEmptyWhenNoEntriesExist() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of());
+        @Test
+        void getAvailabilityByProduct_returnsEmptyWhenNoEntriesExist() {
+                UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
+                                .thenReturn(List.of());
 
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
+                List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
-        assertThat(result).isEmpty();
-        verify(inventoryLedgerEntryRepository).findByStockItemIdOrderByTimestampAsc(productId.toString());
-    }
+                assertThat(result).isEmpty();
+                verify(inventoryLedgerEntryRepository).findByStockItemIdOrderByTimestampAsc(productId.toString());
+        }
 
-    @Test
-    void getAvailabilityByProduct_skipsEntryWhenLocationIsMissing() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry onHandEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.GOODS_RECEIPT, 5, null);
+        @Test
+        void getAvailabilityByProduct_skipsEntryWhenLocationIsMissing() {
+                UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                InventoryLedgerEntry onHandEntry = ledgerEntry(productId.toString(),
+                                InventoryLedgerEventType.GOODS_RECEIPT, 5, null);
 
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(onHandEntry));
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
+                                .thenReturn(List.of(onHandEntry));
 
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
+                List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
-        assertThat(result).isEmpty();
-    }
+                assertThat(result).isEmpty();
+        }
 
-    @Test
-    void getAvailabilityByProduct_allowsNegativeAtpWhenReservationsExceedOnHand() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry onHandEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.GOODS_RECEIPT, 2, LOC_1);
-        InventoryLedgerEntry reservationEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.RESERVATION_CREATED, 5, LOC_1);
+        @Test
+        void getAvailabilityByProduct_allowsNegativeAtpWhenReservationsExceedOnHand() {
+                UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                InventoryLedgerEntry onHandEntry = ledgerEntry(productId.toString(),
+                                InventoryLedgerEventType.GOODS_RECEIPT, 2, LOC_1);
+                InventoryLedgerEntry reservationEntry = ledgerEntry(productId.toString(),
+                                InventoryLedgerEventType.RESERVATION_CREATED, 5, LOC_1);
 
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(onHandEntry, reservationEntry));
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
+                                .thenReturn(List.of(onHandEntry, reservationEntry));
 
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
+                List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
-        assertThat(result).hasSize(1);
-        assertThat(result.getFirst().getLocationId()).isEqualTo(LOC_1);
-        assertThat(result.getFirst().getOnHandQuantity()).isEqualTo(2);
-        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(-3);
-    }
+                assertThat(result).hasSize(1);
+                assertThat(result.getFirst().getLocationId()).isEqualTo(LOC_1);
+                assertThat(result.getFirst().getOnHandQuantity()).isEqualTo(2);
+                assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(-3);
+        }
 
-    @Test
-    void getAvailabilityByProduct_throwsWhenProductIdIsNull() {
-        assertThatThrownBy(() -> service.getAvailabilityByProduct(null))
-                .isInstanceOf(InvalidInventoryAvailabilityRequestException.class)
-                .hasMessage("Product ID is required");
-    }
+        @Test
+        void getAvailabilityByProduct_throwsWhenProductIdIsNull() {
+                assertThatThrownBy(() -> service.getAvailabilityByProduct(null))
+                                .isInstanceOf(InvalidInventoryAvailabilityRequestException.class)
+                                .hasMessage("Product ID is required");
+        }
 
-    @Test
-    void getAvailabilityByProduct_wrapsRepositoryErrors() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenThrow(new RuntimeException("db down"));
+        @Test
+        void getAvailabilityByProduct_wrapsRepositoryErrors() {
+                UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
+                                .thenThrow(new RuntimeException("db down"));
 
-        assertThatThrownBy(() -> service.getAvailabilityByProduct(productId))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Unable to retrieve inventory availability at this time");
-    }
+                assertThatThrownBy(() -> service.getAvailabilityByProduct(productId))
+                                .isInstanceOf(IllegalStateException.class)
+                                .hasMessage("Unable to retrieve inventory availability at this time");
+        }
 
-    @Test
-    void getAvailabilityByProduct_skipsNullQuantityEntries() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry invalidEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.GOODS_RECEIPT, 1, LOC_1);
-        invalidEntry.setChangeInQuantity(null);
+        @Test
+        void getAvailabilityByProduct_skipsNullQuantityEntries() {
+                UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                InventoryLedgerEntry invalidEntry = ledgerEntry(productId.toString(),
+                                InventoryLedgerEventType.GOODS_RECEIPT, 1, LOC_1);
+                invalidEntry.setChangeInQuantity(null);
 
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(invalidEntry));
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
+                                .thenReturn(List.of(invalidEntry));
 
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
-        assertThat(result).isEmpty();
-    }
+                List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
+                assertThat(result).isEmpty();
+        }
 
-    @Test
-    void getAvailabilityByProduct_skipsNullLedgerEntry() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(java.util.Arrays.asList(
-                        ledgerEntry(productId.toString(), InventoryLedgerEventType.GOODS_RECEIPT, 1, LOC_1), null));
+        @Test
+        void getAvailabilityByProduct_skipsNullLedgerEntry() {
+                UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
+                                .thenReturn(java.util.Arrays.asList(
+                                                ledgerEntry(productId.toString(),
+                                                                InventoryLedgerEventType.GOODS_RECEIPT, 1, LOC_1),
+                                                null));
 
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getOnHandQuantity()).isEqualTo(1);
-    }
+                List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getOnHandQuantity()).isEqualTo(1);
+        }
 
-    @Test
-    void getAvailabilityByProduct_handlesNullEventType() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry entry = ledgerEntry(productId.toString(), null, 5, LOC_1);
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(entry));
+        @Test
+        void getAvailabilityByProduct_handlesNullEventType() {
+                UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                InventoryLedgerEntry entry = ledgerEntry(productId.toString(), null, 5, LOC_1);
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
+                                .thenReturn(List.of(entry));
 
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
+                List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getOnHandQuantity()).isZero();
-        assertThat(result.get(0).getAvailableToPromiseQuantity()).isZero();
-    }
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getOnHandQuantity()).isZero();
+                assertThat(result.get(0).getAvailableToPromiseQuantity()).isZero();
+        }
 
-    @Test
-    void queryAvailability_handlesNullChangeInQuantity() {
-        String productSku = "SKU-123";
-        UUID locationId = LOC_1;
-        InventoryLedgerEntry entry = ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId);
-        entry.setChangeInQuantity(null);
+        @Test
+        void queryAvailability_handlesNullChangeInQuantity() {
+                String productSku = "SKU-123";
+                UUID locationId = LOC_1;
+                InventoryLedgerEntry entry = ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10,
+                                locationId);
+                entry.setChangeInQuantity(null);
 
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku))
-                .thenReturn(List.of(entry));
-        when(inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(productSku, locationId))
-                .thenReturn(List.of(entry));
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku))
+                                .thenReturn(List.of(entry));
+                when(inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(productSku,
+                                locationId))
+                                .thenReturn(List.of(entry));
 
-        AvailabilityView result = service.queryAvailability(productSku, locationId, null);
+                AvailabilityView result = service.queryAvailability(productSku, locationId, null, null);
 
-        assertThat(result.getOnHandQuantity()).isZero();
-        assertThat(result.getAllocatedQuantity()).isZero();
-        assertThat(result.getAvailableToPromiseQuantity()).isZero();
-    }
+                assertThat(result.getOnHandQuantity()).isZero();
+                assertThat(result.getAllocatedQuantity()).isZero();
+                assertThat(result.getAvailableToPromiseQuantity()).isZero();
+        }
 
-    @Test
-    void getAvailabilityByProduct_handlesReservationReleased() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry reservationEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.RESERVATION_RELEASED, 5, LOC_1);
+        @Test
+        void getAvailabilityByProduct_handlesReservationReleased() {
+                UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                InventoryLedgerEntry reservationEntry = ledgerEntry(productId.toString(),
+                                InventoryLedgerEventType.RESERVATION_RELEASED, 5, LOC_1);
 
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(reservationEntry));
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
+                                .thenReturn(List.of(reservationEntry));
 
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
+                List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
-        assertThat(result).hasSize(1);
-        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(5);
-    }
+                assertThat(result).hasSize(1);
+                assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(5);
+        }
 
-    @Test
-    void getAvailabilityByProduct_handlesNullQuantityInSafeQuantity() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry entry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.RESERVATION_CREATED, 1, LOC_1);
-        entry.setChangeInQuantity(null);
+        @Test
+        void getAvailabilityByProduct_handlesNullQuantityInSafeQuantity() {
+                UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                InventoryLedgerEntry entry = ledgerEntry(productId.toString(),
+                                InventoryLedgerEventType.RESERVATION_CREATED, 1, LOC_1);
+                entry.setChangeInQuantity(null);
 
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(entry));
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
+                                .thenReturn(List.of(entry));
 
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
-        assertThat(result).isEmpty();
-    }
+                List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
+                assertThat(result).isEmpty();
+        }
 
-    @Test
-    void queryAvailability_throwsProductNotFoundException_whenNoEntriesExist() {
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc("SKU-123"))
-                .thenReturn(List.of());
+        @Test
+        void queryAvailability_throwsProductNotFoundException_whenNoEntriesExist() {
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc("SKU-123"))
+                                .thenReturn(List.of());
 
-        assertThatThrownBy(() -> service.queryAvailability("SKU-123", LOC_1, null))
-                .isInstanceOf(ProductNotFoundException.class)
-                .hasMessage("Product not found: SKU-123");
-    }
+                assertThatThrownBy(() -> service.queryAvailability("SKU-123", LOC_1, null, null))
+                                .isInstanceOf(ProductNotFoundException.class)
+                                .hasMessage("Product not found: SKU-123");
+        }
 
-    @Test
-    void queryAvailability_calculatesCorrectly_withLocationAndStorageLocation() {
-        String productSku = "SKU-123";
-        UUID locationId = LOC_1;
-        UUID storageLocationId = SLOC_A;
+        @Test
+        void queryAvailability_calculatesCorrectly_withLocationAndStorageLocation() {
+                String productSku = "SKU-123";
+                UUID locationId = LOC_1;
+                UUID storageLocationId = SLOC_A;
 
-        List<InventoryLedgerEntry> productEntries =
-                List.of(ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId));
-        List<InventoryLedgerEntry> locationEntries = List.of(
-                ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 5, storageLocationId),
-                ledgerEntry(productSku, InventoryLedgerEventType.ALLOCATION_CREATED, 2, storageLocationId));
+                List<InventoryLedgerEntry> productEntries = List
+                                .of(ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId));
+                List<InventoryLedgerEntry> locationEntries = List.of(
+                                ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 5, storageLocationId),
+                                ledgerEntry(productSku, InventoryLedgerEventType.ALLOCATION_CREATED, 2,
+                                                storageLocationId));
 
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku))
-                .thenReturn(productEntries);
-        when(inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(
-                        productSku, storageLocationId))
-                .thenReturn(locationEntries);
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku))
+                                .thenReturn(productEntries);
+                when(inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(
+                                productSku, storageLocationId))
+                                .thenReturn(locationEntries);
 
-        AvailabilityView result = service.queryAvailability(productSku, locationId, storageLocationId);
+                AvailabilityView result = service.queryAvailability(productSku, locationId, storageLocationId, null);
 
-        assertThat(result.getOnHandQuantity()).isEqualTo(5);
-        assertThat(result.getAllocatedQuantity()).isEqualTo(2);
-        assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(3);
-        assertThat(result.getStorageLocationId()).isEqualTo(storageLocationId);
-    }
+                assertThat(result.getOnHandQuantity()).isEqualTo(5);
+                assertThat(result.getAllocatedQuantity()).isEqualTo(2);
+                assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(3);
+                assertThat(result.getStorageLocationId()).isEqualTo(storageLocationId);
+        }
 
-    @Test
-    void queryAvailability_calculatesCorrectly_withOnlyLocationId() {
-        String productSku = "SKU-123";
-        UUID locationId = LOC_1;
+        @Test
+        void queryAvailability_calculatesCorrectly_withOnlyLocationId() {
+                String productSku = "SKU-123";
+                UUID locationId = LOC_1;
 
-        List<InventoryLedgerEntry> productEntries =
-                List.of(ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId));
-        List<InventoryLedgerEntry> locationEntries = List.of(
-                ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId),
-                ledgerEntry(productSku, InventoryLedgerEventType.ALLOCATION_CREATED, 3, locationId),
-                ledgerEntry(productSku, InventoryLedgerEventType.ALLOCATION_RELEASED, 1, locationId));
+                List<InventoryLedgerEntry> productEntries = List
+                                .of(ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId));
+                List<InventoryLedgerEntry> locationEntries = List.of(
+                                ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId),
+                                ledgerEntry(productSku, InventoryLedgerEventType.ALLOCATION_CREATED, 3, locationId),
+                                ledgerEntry(productSku, InventoryLedgerEventType.ALLOCATION_RELEASED, 1, locationId));
 
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku))
-                .thenReturn(productEntries);
-        when(inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(productSku, locationId))
-                .thenReturn(locationEntries);
+                when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku))
+                                .thenReturn(productEntries);
+                when(inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(productSku,
+                                locationId))
+                                .thenReturn(locationEntries);
 
-        AvailabilityView result = service.queryAvailability(productSku, locationId, null);
+                AvailabilityView result = service.queryAvailability(productSku, locationId, null, null);
 
-        assertThat(result.getOnHandQuantity()).isEqualTo(10);
-        assertThat(result.getAllocatedQuantity()).isEqualTo(2); // 3 created - 1 released
-        assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(8);
-        assertThat(result.getStorageLocationId()).isNull();
-    }
+                assertThat(result.getOnHandQuantity()).isEqualTo(10);
+                assertThat(result.getAllocatedQuantity()).isEqualTo(2); // 3 created - 1 released
+                assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(8);
+                assertThat(result.getStorageLocationId()).isNull();
+        }
 
-    private InventoryLedgerEntry ledgerEntry(
-            String stockItemId, InventoryLedgerEventType eventType, int changeInQuantity, UUID locationId) {
-        return InventoryLedgerEntry.builder()
-                .stockItemId(stockItemId)
-                .eventType(eventType)
-                .changeInQuantity(changeInQuantity)
-                .quantityAfter(0)
-                .transactionUserId("test-user")
-                .timestamp(Instant.now(TEST_CLOCK))
-                .locationId(locationId)
-                .build();
-    }
+        private InventoryLedgerEntry ledgerEntry(
+                        String stockItemId, InventoryLedgerEventType eventType, int changeInQuantity, UUID locationId) {
+                return InventoryLedgerEntry.builder()
+                                .stockItemId(stockItemId)
+                                .eventType(eventType)
+                                .changeInQuantity(changeInQuantity)
+                                .quantityAfter(0)
+                                .transactionUserId("test-user")
+                                .timestamp(Instant.now(TEST_CLOCK))
+                                .locationId(locationId)
+                                .build();
+        }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayGenerationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayGenerationServiceImplTest.java
@@ -31,229 +31,234 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class PutawayGenerationServiceImplTest {
-    private static final UUID DEST_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    private static final UUID DEFAULT_LOCATION = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        private static final UUID DEST_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        private static final UUID DEFAULT_LOCATION = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-    @Mock
-    private PutawayRuleRepository putawayRuleRepository;
+        @Mock
+        private PutawayRuleRepository putawayRuleRepository;
 
-    @Mock
-    private PutawayTaskRepository putawayTaskRepository;
+        @Mock
+        private PutawayTaskRepository putawayTaskRepository;
 
-    @Mock
-    private GoodsReceiptRepository goodsReceiptRepository;
+        @Mock
+        private GoodsReceiptRepository goodsReceiptRepository;
 
-    private PutawayGenerationServiceImpl service;
+        private PutawayGenerationServiceImpl service;
 
-    @BeforeEach
-    void setUp() {
-        service =
-                new PutawayGenerationServiceImpl(putawayRuleRepository, putawayTaskRepository, goodsReceiptRepository);
-        lenient()
-                .when(goodsReceiptRepository.findById(any(UUID.class)))
-                .thenAnswer(inv -> Optional.of(receipt(inv.getArgument(0))));
-    }
+        @BeforeEach
+        void setUp() {
+                service = new PutawayGenerationServiceImpl(putawayRuleRepository, putawayTaskRepository,
+                                goodsReceiptRepository);
+                lenient()
+                                .when(goodsReceiptRepository.findById(any(UUID.class)))
+                                .thenAnswer(inv -> Optional.of(receipt(inv.getArgument(0))));
+        }
 
-    @Test
-    void generateTasksForReceipt_withRules_createsUnassignedTask() {
-        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
-                .sourceReceiptId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .productId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .quantity(5)
-                .build();
-        PutawayRule rule = new PutawayRule();
-        rule.setDestinationLocationId(DEST_A);
-        when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc()).thenReturn(List.of(rule));
-        when(putawayTaskRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
-
-        List<PutawayTaskResponse> responses = service.generateTasksForReceipt(request);
-
-        assertThat(responses).hasSize(1);
-        PutawayTaskResponse response = responses.get(0);
-        assertThat(response.getStatus()).isEqualTo(PutawayTaskStatus.UNASSIGNED.toString());
-        assertThat(response.getSuggestedDestinationLocationId()).isEqualTo(DEST_A);
-    }
-
-    @Test
-    void generateTasksForReceipt_noRules_createsUnassignedTaskWithDefaultLocation() {
-        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
-                .sourceReceiptId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .productId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .quantity(5)
-                .build();
-        when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc()).thenReturn(Collections.emptyList());
-        when(putawayTaskRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
-
-        List<PutawayTaskResponse> responses = service.generateTasksForReceipt(request);
-
-        assertThat(responses).hasSize(1);
-        PutawayTaskResponse response = responses.get(0);
-        assertThat(response.getStatus()).isEqualTo(PutawayTaskStatus.UNASSIGNED.toString());
-        assertThat(response.getSuggestedDestinationLocationId()).isEqualTo(DEFAULT_LOCATION);
-    }
-
-    @Test
-    void generateTasksForReceipt_withLineItems_createsTaskPerLineItem() {
-        UUID receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        UUID productId1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        UUID productId2 = UUID.fromString("00000000-0000-0000-0000-000000000001");
-
-        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
-                .sourceReceiptId(receiptId.toString())
-                .lineItems(List.of(
-                        PutawayLineItemRequest.builder()
-                                .productId(productId1.toString())
+        @Test
+        void generateTasksForReceipt_withRules_createsUnassignedTask() {
+                GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                                .sourceReceiptId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .productId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
                                 .quantity(5)
-                                .build(),
-                        PutawayLineItemRequest.builder()
-                                .productId(productId2.toString())
-                                .quantity(3)
-                                .build()))
-                .build();
+                                .build();
+                PutawayRule rule = new PutawayRule();
+                rule.setDestinationLocationId(DEST_A);
+                when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc()).thenReturn(List.of(rule));
+                when(putawayTaskRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
 
-        when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc()).thenReturn(Collections.emptyList());
-        when(putawayTaskRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+                List<PutawayTaskResponse> responses = service.generateTasksForReceipt(request);
 
-        List<PutawayTaskResponse> responses = service.generateTasksForReceipt(request);
+                assertThat(responses).hasSize(1);
+                PutawayTaskResponse response = responses.get(0);
+                assertThat(response.getStatus()).isEqualTo(PutawayTaskStatus.UNASSIGNED.toString());
+                assertThat(response.getSuggestedDestinationLocationId()).isEqualTo(DEST_A);
+        }
 
-        assertThat(responses).hasSize(2);
-        assertThat(responses)
-                .extracting(PutawayTaskResponse::getProductId)
-                .containsExactly(productId1.toString(), productId2.toString());
-        assertThat(responses).extracting(PutawayTaskResponse::getQuantity).containsExactly(5, 3);
-        assertThat(responses)
-                .extracting(PutawayTaskResponse::getSourceReceiptId)
-                .containsExactly(receiptId.toString(), receiptId.toString());
-    }
+        @Test
+        void generateTasksForReceipt_noRules_createsUnassignedTaskWithDefaultLocation() {
+                GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                                .sourceReceiptId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .productId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .quantity(5)
+                                .build();
+                when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc())
+                                .thenReturn(Collections.emptyList());
+                when(putawayTaskRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
 
-    @Test
-    void generateTasksForReceipt_withLineItemsAndLegacyFields_throwsIllegalArgumentException() {
-        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
-                .sourceReceiptId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .productId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .quantity(5)
-                .lineItems(List.of(PutawayLineItemRequest.builder()
-                        .productId(UUID.fromString("00000000-0000-0000-0000-000000000001")
-                                .toString())
-                        .quantity(2)
-                        .build()))
-                .build();
+                List<PutawayTaskResponse> responses = service.generateTasksForReceipt(request);
 
-        when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc()).thenReturn(Collections.emptyList());
+                assertThat(responses).hasSize(1);
+                PutawayTaskResponse response = responses.get(0);
+                assertThat(response.getStatus()).isEqualTo(PutawayTaskStatus.UNASSIGNED.toString());
+                assertThat(response.getSuggestedDestinationLocationId()).isEqualTo(DEFAULT_LOCATION);
+        }
 
-        assertThatThrownBy(() -> service.generateTasksForReceipt(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Provide either lineItems or productId/quantity, not both");
-    }
+        @Test
+        void generateTasksForReceipt_withLineItems_createsTaskPerLineItem() {
+                UUID receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                UUID productId1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                UUID productId2 = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-    @Test
-    void getAvailableTasks_returnsUnassignedTasks() {
-        PutawayTask task = new PutawayTask();
-        task.setTaskId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
-        task.setStatus(PutawayTaskStatus.UNASSIGNED);
-        when(putawayTaskRepository.findByStatusIn(List.of(PutawayTaskStatus.UNASSIGNED)))
-                .thenReturn(List.of(task));
+                GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                                .sourceReceiptId(receiptId.toString())
+                                .lineItems(List.of(
+                                                PutawayLineItemRequest.builder()
+                                                                .productId(productId1.toString())
+                                                                .quantity(5)
+                                                                .build(),
+                                                PutawayLineItemRequest.builder()
+                                                                .productId(productId2.toString())
+                                                                .quantity(3)
+                                                                .build()))
+                                .build();
 
-        List<PutawayTaskResponse> responses = service.getAvailableTasks();
+                when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc())
+                                .thenReturn(Collections.emptyList());
+                when(putawayTaskRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
 
-        assertThat(responses).hasSize(1);
-        assertThat(responses.get(0).getTaskId()).isEqualTo(task.getTaskId().toString());
-    }
+                List<PutawayTaskResponse> responses = service.generateTasksForReceipt(request);
 
-    @Test
-    void claimTask_validTask_updatesStatusAndAssignee() {
-        UUID taskId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        String userId = "user-123";
-        PutawayTask task = new PutawayTask();
-        task.setTaskId(taskId);
-        task.setStatus(PutawayTaskStatus.UNASSIGNED);
+                assertThat(responses).hasSize(2);
+                assertThat(responses)
+                                .extracting(PutawayTaskResponse::getProductId)
+                                .containsExactly(productId1.toString(), productId2.toString());
+                assertThat(responses).extracting(PutawayTaskResponse::getQuantity).containsExactly(5, 3);
+                assertThat(responses)
+                                .extracting(PutawayTaskResponse::getSourceReceiptId)
+                                .containsExactly(receiptId.toString(), receiptId.toString());
+        }
 
-        when(putawayTaskRepository.findByIdForUpdate(taskId)).thenReturn(Optional.of(task));
-        when(putawayTaskRepository.save(any(PutawayTask.class))).thenAnswer(inv -> inv.getArgument(0));
+        @Test
+        void generateTasksForReceipt_withLineItemsAndLegacyFields_throwsIllegalArgumentException() {
+                GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                                .sourceReceiptId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .productId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .quantity(5)
+                                .lineItems(List.of(PutawayLineItemRequest.builder()
+                                                .productId(UUID.fromString("00000000-0000-0000-0000-000000000001")
+                                                                .toString())
+                                                .quantity(2)
+                                                .build()))
+                                .build();
 
-        PutawayTaskResponse response = service.claimTask(taskId.toString(), userId);
+                when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc())
+                                .thenReturn(Collections.emptyList());
 
-        assertThat(response.getTaskId()).isEqualTo(taskId.toString());
-        assertThat(response.getStatus()).isEqualTo(PutawayTaskStatus.ASSIGNED.toString());
-        assertThat(response.getAssigneeId()).isEqualTo(userId);
-    }
+                assertThatThrownBy(() -> service.generateTasksForReceipt(request))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessage("Provide either lineItems or productId/quantity, not both");
+        }
 
-    @Test
-    void claimTask_invalidTask_throwsTaskNotFoundException() {
-        UUID taskId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        String taskIdString = taskId.toString();
-        String userId = "user-123";
-        when(putawayTaskRepository.findByIdForUpdate(taskId)).thenReturn(Optional.empty());
+        @Test
+        void getAvailableTasks_returnsUnassignedTasks() {
+                PutawayTask task = new PutawayTask();
+                task.setTaskId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+                task.setStatus(PutawayTaskStatus.UNASSIGNED);
+                when(putawayTaskRepository.findByStatusIn(List.of(PutawayTaskStatus.UNASSIGNED)))
+                                .thenReturn(List.of(task));
 
-        assertThatThrownBy(() -> service.claimTask(taskIdString, userId)).isInstanceOf(TaskNotFoundException.class);
-    }
+                List<PutawayTaskResponse> responses = service.getAvailableTasks(null, null);
 
-    @Test
-    void getTasksByReceiptId_returnsFilteredList() {
-        UUID receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        PutawayTask task = new PutawayTask();
-        task.setTaskId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
-        task.setSourceReceipt(receipt(receiptId));
+                assertThat(responses).hasSize(1);
+                assertThat(responses.get(0).getTaskId()).isEqualTo(task.getTaskId().toString());
+        }
 
-        when(putawayTaskRepository.findBySourceReceipt_ReceiptId(receiptId)).thenReturn(List.of(task));
+        @Test
+        void claimTask_validTask_updatesStatusAndAssignee() {
+                UUID taskId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                String userId = "user-123";
+                PutawayTask task = new PutawayTask();
+                task.setTaskId(taskId);
+                task.setStatus(PutawayTaskStatus.UNASSIGNED);
 
-        List<PutawayTaskResponse> responses = service.getTasksByReceiptId(receiptId.toString());
+                when(putawayTaskRepository.findByIdForUpdate(taskId)).thenReturn(Optional.of(task));
+                when(putawayTaskRepository.save(any(PutawayTask.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        assertThat(responses).hasSize(1);
-        assertThat(responses.get(0).getSourceReceiptId()).isEqualTo(receiptId.toString());
-    }
+                PutawayTaskResponse response = service.claimTask(taskId.toString(), userId);
 
-    @Test
-    void generateTasksForReceipt_withInvalidUuid_throwsIllegalArgumentException() {
-        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
-                .sourceReceiptId("invalid-uuid")
-                .productId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .quantity(5)
-                .build();
+                assertThat(response.getTaskId()).isEqualTo(taskId.toString());
+                assertThat(response.getStatus()).isEqualTo(PutawayTaskStatus.ASSIGNED.toString());
+                assertThat(response.getAssigneeId()).isEqualTo(userId);
+        }
 
-        assertThatThrownBy(() -> service.generateTasksForReceipt(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("sourceReceiptId must be a valid UUID");
-    }
+        @Test
+        void claimTask_invalidTask_throwsTaskNotFoundException() {
+                UUID taskId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                String taskIdString = taskId.toString();
+                String userId = "user-123";
+                when(putawayTaskRepository.findByIdForUpdate(taskId)).thenReturn(Optional.empty());
 
-    @Test
-    void generateTasksForReceipt_withNullUuid_throwsIllegalArgumentException() {
-        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
-                .sourceReceiptId(null)
-                .productId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .quantity(5)
-                .build();
+                assertThatThrownBy(() -> service.claimTask(taskIdString, userId))
+                                .isInstanceOf(TaskNotFoundException.class);
+        }
 
-        assertThatThrownBy(() -> service.generateTasksForReceipt(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("sourceReceiptId is required");
-    }
+        @Test
+        void getTasksByReceiptId_returnsFilteredList() {
+                UUID receiptId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                PutawayTask task = new PutawayTask();
+                task.setTaskId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+                task.setSourceReceipt(receipt(receiptId));
 
-    @Test
-    void generateTasksForReceipt_withNoLineItemsAndNoLegacyFields_throwsIllegalArgumentException() {
-        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
-                .sourceReceiptId(
-                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
-                .build();
+                when(putawayTaskRepository.findBySourceReceipt_ReceiptId(receiptId)).thenReturn(List.of(task));
 
-        when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc()).thenReturn(Collections.emptyList());
+                List<PutawayTaskResponse> responses = service.getTasksByReceiptId(receiptId.toString());
 
-        assertThatThrownBy(() -> service.generateTasksForReceipt(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Either lineItems or productId/quantity is required");
-    }
+                assertThat(responses).hasSize(1);
+                assertThat(responses.get(0).getSourceReceiptId()).isEqualTo(receiptId.toString());
+        }
 
-    private GoodsReceiptEntity receipt(UUID receiptId) {
-        GoodsReceiptEntity receipt = new GoodsReceiptEntity();
-        receipt.setReceiptId(receiptId);
-        return receipt;
-    }
+        @Test
+        void generateTasksForReceipt_withInvalidUuid_throwsIllegalArgumentException() {
+                GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                                .sourceReceiptId("invalid-uuid")
+                                .productId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .quantity(5)
+                                .build();
+
+                assertThatThrownBy(() -> service.generateTasksForReceipt(request))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessage("sourceReceiptId must be a valid UUID");
+        }
+
+        @Test
+        void generateTasksForReceipt_withNullUuid_throwsIllegalArgumentException() {
+                GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                                .sourceReceiptId(null)
+                                .productId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .quantity(5)
+                                .build();
+
+                assertThatThrownBy(() -> service.generateTasksForReceipt(request))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessage("sourceReceiptId is required");
+        }
+
+        @Test
+        void generateTasksForReceipt_withNoLineItemsAndNoLegacyFields_throwsIllegalArgumentException() {
+                GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                                .sourceReceiptId(
+                                                UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                                .build();
+
+                when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc())
+                                .thenReturn(Collections.emptyList());
+
+                assertThatThrownBy(() -> service.generateTasksForReceipt(request))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessage("Either lineItems or productId/quantity is required");
+        }
+
+        private GoodsReceiptEntity receipt(UUID receiptId) {
+                GoodsReceiptEntity receipt = new GoodsReceiptEntity();
+                receipt.setReceiptId(receiptId);
+                return receipt;
+        }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
@@ -21,6 +21,8 @@ import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,195 +32,199 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ReplenishmentServiceImplTest {
-    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+        private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
-    private static final UUID SRC_01 = UUID.fromString("11111111-1111-1111-1111-111111111111");
-    private static final UUID DST_01 = UUID.fromString("22222222-2222-2222-2222-222222222222");
-    private static final UUID SRC_02 = UUID.fromString("33333333-3333-3333-3333-333333333333");
-    private static final UUID DST_02 = UUID.fromString("44444444-4444-4444-4444-444444444444");
-    private static final UUID LOC_01 = UUID.fromString("55555555-5555-5555-5555-555555555555");
-    private static final UUID LOC_02 = UUID.fromString("66666666-6666-6666-6666-666666666666");
-    private static final UUID PICKFACE_01 = UUID.fromString("77777777-7777-7777-7777-777777777777");
+        private static final UUID SRC_01 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        private static final UUID DST_01 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        private static final UUID SRC_02 = UUID.fromString("33333333-3333-3333-3333-333333333333");
+        private static final UUID DST_02 = UUID.fromString("44444444-4444-4444-4444-444444444444");
+        private static final UUID LOC_01 = UUID.fromString("55555555-5555-5555-5555-555555555555");
+        private static final UUID LOC_02 = UUID.fromString("66666666-6666-6666-6666-666666666666");
+        private static final UUID PICKFACE_01 = UUID.fromString("77777777-7777-7777-7777-777777777777");
 
-    @Spy
-    Clock clock = TEST_CLOCK;
+        @Spy
+        Clock clock = TEST_CLOCK;
 
-    @InjectMocks
-    private ReplenishmentServiceImpl replenishmentService;
+        @InjectMocks
+        private ReplenishmentServiceImpl replenishmentService;
 
-    @Mock
-    private ReplenishmentTaskRepository replenishmentTaskRepository;
+        @Mock
+        private ReplenishmentTaskRepository replenishmentTaskRepository;
 
-    @Mock
-    private ReplenishmentPolicyRepository replenishmentPolicyRepository;
+        @Mock
+        private ReplenishmentPolicyRepository replenishmentPolicyRepository;
 
-    @Test
-    void getReplenishmentTasks_shouldReturnMappedTasks() {
-        // Given
-        UUID taskId1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        UUID taskId2 = UUID.fromString("00000000-0000-0000-0000-000000000002");
-        Instant now = Instant.now(TEST_CLOCK);
+        @Test
+        void getReplenishmentTasks_shouldReturnMappedTasks() {
+                // Given
+                UUID taskId1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                UUID taskId2 = UUID.fromString("00000000-0000-0000-0000-000000000002");
+                Instant now = Instant.now(TEST_CLOCK);
 
-        ReplenishmentTask pendingTask = ReplenishmentTask.builder()
-                .taskId(taskId1)
-                .itemSKU("SKU123")
-                .quantity(10)
-                .sourceLocationId(SRC_01)
-                .destinationLocationId(DST_01)
-                .status(ReplenishmentStatus.PENDING)
-                .createdAt(now)
-                .build();
+                ReplenishmentTask pendingTask = ReplenishmentTask.builder()
+                                .taskId(taskId1)
+                                .itemSKU("SKU123")
+                                .quantity(10)
+                                .sourceLocationId(SRC_01)
+                                .destinationLocationId(DST_01)
+                                .status(ReplenishmentStatus.PENDING)
+                                .createdAt(now)
+                                .build();
 
-        ReplenishmentTask inProgressTask = ReplenishmentTask.builder()
-                .taskId(taskId2)
-                .itemSKU("SKU456")
-                .quantity(5)
-                .sourceLocationId(SRC_02)
-                .destinationLocationId(DST_02)
-                .status(ReplenishmentStatus.IN_PROGRESS)
-                .createdAt(now)
-                .build();
+                ReplenishmentTask inProgressTask = ReplenishmentTask.builder()
+                                .taskId(taskId2)
+                                .itemSKU("SKU456")
+                                .quantity(5)
+                                .sourceLocationId(SRC_02)
+                                .destinationLocationId(DST_02)
+                                .status(ReplenishmentStatus.IN_PROGRESS)
+                                .createdAt(now)
+                                .build();
 
-        when(replenishmentTaskRepository.findByStatusIn(
-                        List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS)))
-                .thenReturn(List.of(pendingTask, inProgressTask));
+                when(replenishmentTaskRepository.findByStatusIn(
+                                List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS)))
+                                .thenReturn(List.of(pendingTask, inProgressTask));
 
-        // When
-        List<ReplenishmentTaskResponse> responses = replenishmentService.getReplenishmentTasks();
+                // When
+                List<ReplenishmentTaskResponse> responses = replenishmentService.getReplenishmentTasks();
 
-        // Then
-        assertEquals(2, responses.size());
+                // Then
+                assertEquals(2, responses.size());
 
-        ReplenishmentTaskResponse response1 = responses.stream()
-                .filter(r -> r.getTaskId().equals(taskId1.toString()))
-                .findFirst()
-                .get();
-        assertEquals("SKU123", response1.getItemSKU());
-        assertEquals(10, response1.getQuantity());
-        assertEquals("PENDING", response1.getStatus());
+                ReplenishmentTaskResponse response1 = responses.stream()
+                                .filter(r -> r.getTaskId().equals(taskId1.toString()))
+                                .findFirst()
+                                .get();
+                assertEquals("SKU123", response1.getItemSKU());
+                assertEquals(10, response1.getQuantity());
+                assertEquals("PENDING", response1.getStatus());
 
-        ReplenishmentTaskResponse response2 = responses.stream()
-                .filter(r -> r.getTaskId().equals(taskId2.toString()))
-                .findFirst()
-                .get();
-        assertEquals("SKU456", response2.getItemSKU());
-        assertEquals(5, response2.getQuantity());
-        assertEquals("IN_PROGRESS", response2.getStatus());
-    }
+                ReplenishmentTaskResponse response2 = responses.stream()
+                                .filter(r -> r.getTaskId().equals(taskId2.toString()))
+                                .findFirst()
+                                .get();
+                assertEquals("SKU456", response2.getItemSKU());
+                assertEquals(5, response2.getQuantity());
+                assertEquals("IN_PROGRESS", response2.getStatus());
+        }
 
-    @Test
-    void getReplenishmentTasks_shouldReturnEmptyListWhenNoTasks() {
-        // Given
-        when(replenishmentTaskRepository.findByStatusIn(
-                        List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS)))
-                .thenReturn(Collections.emptyList());
+        @Test
+        void getReplenishmentTasks_shouldReturnEmptyListWhenNoTasks() {
+                // Given
+                when(replenishmentTaskRepository.findByStatusIn(
+                                List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS)))
+                                .thenReturn(Collections.emptyList());
 
-        // When
-        List<ReplenishmentTaskResponse> responses = replenishmentService.getReplenishmentTasks();
+                // When
+                List<ReplenishmentTaskResponse> responses = replenishmentService.getReplenishmentTasks();
 
-        // Then
-        assertTrue(responses.isEmpty());
-    }
+                // Then
+                assertTrue(responses.isEmpty());
+        }
 
-    @Test
-    void getReplenishmentPolicies_shouldReturnMappedPolicies() {
-        // Given
-        UUID policyId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        Instant now = Instant.now(TEST_CLOCK);
-        ReplenishmentPolicy policy = ReplenishmentPolicy.builder()
-                .policyId(policyId)
-                .locationId(LOC_01)
-                .itemSKU("SKU789")
-                .minimumQuantity(5)
-                .maximumQuantity(20)
-                .createdAt(now)
-                .build();
+        @Test
+        void getReplenishmentPolicies_shouldReturnMappedPolicies() {
+                // Given
+                UUID policyId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                Instant now = Instant.now(TEST_CLOCK);
+                ReplenishmentPolicy policy = ReplenishmentPolicy.builder()
+                                .policyId(policyId)
+                                .locationId(LOC_01)
+                                .itemSKU("SKU789")
+                                .minimumQuantity(5)
+                                .maximumQuantity(20)
+                                .createdAt(now)
+                                .build();
 
-        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+                when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
 
-        // When
-        List<ReplenishmentPolicyResponse> responses = replenishmentService.getReplenishmentPolicies();
+                // When
+                Page<ReplenishmentPolicyResponse> responses = replenishmentService.getReplenishmentPolicies(
+                                null,
+                                Pageable.unpaged());
 
-        // Then
-        assertEquals(1, responses.size());
-        ReplenishmentPolicyResponse response = responses.get(0);
-        assertEquals(policyId.toString(), response.getPolicyId());
-        assertEquals(LOC_01, response.getLocationId());
-        assertEquals("SKU789", response.getItemSKU());
-        assertEquals(5, response.getMinimumQuantity());
-        assertEquals(20, response.getMaximumQuantity());
-    }
+                // Then
+                assertEquals(1, responses.getTotalElements());
+                ReplenishmentPolicyResponse response = responses.getContent().get(0);
+                assertEquals(policyId.toString(), response.getPolicyId());
+                assertEquals(LOC_01, response.getLocationId());
+                assertEquals("SKU789", response.getItemSKU());
+                assertEquals(5, response.getMinimumQuantity());
+                assertEquals(20, response.getMaximumQuantity());
+        }
 
-    @Test
-    void createReplenishmentPolicy_shouldSaveAndReturnMappedPolicy() {
-        // Given
-        CreateReplenishmentPolicyRequest request = new CreateReplenishmentPolicyRequest(LOC_02, "SKUABC", 10, 50);
-        UUID policyId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        Instant now = Instant.now(TEST_CLOCK);
+        @Test
+        void createReplenishmentPolicy_shouldSaveAndReturnMappedPolicy() {
+                // Given
+                CreateReplenishmentPolicyRequest request = new CreateReplenishmentPolicyRequest(LOC_02, "SKUABC", 10,
+                                50);
+                UUID policyId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                Instant now = Instant.now(TEST_CLOCK);
 
-        ReplenishmentPolicy savedPolicy = ReplenishmentPolicy.builder()
-                .policyId(policyId)
-                .locationId(request.getLocationId())
-                .itemSKU(request.getItemSKU())
-                .minimumQuantity(request.getMinimumQuantity())
-                .maximumQuantity(request.getMaximumQuantity())
-                .createdAt(now)
-                .build();
+                ReplenishmentPolicy savedPolicy = ReplenishmentPolicy.builder()
+                                .policyId(policyId)
+                                .locationId(request.getLocationId())
+                                .itemSKU(request.getItemSKU())
+                                .minimumQuantity(request.getMinimumQuantity())
+                                .maximumQuantity(request.getMaximumQuantity())
+                                .createdAt(now)
+                                .build();
 
-        when(replenishmentPolicyRepository.save(any(ReplenishmentPolicy.class))).thenReturn(savedPolicy);
+                when(replenishmentPolicyRepository.save(any(ReplenishmentPolicy.class))).thenReturn(savedPolicy);
 
-        // When
-        ReplenishmentPolicyResponse response = replenishmentService.createReplenishmentPolicy(request);
+                // When
+                ReplenishmentPolicyResponse response = replenishmentService.createReplenishmentPolicy(request);
 
-        // Then
-        assertNotNull(response);
-        assertEquals(policyId.toString(), response.getPolicyId());
-        assertEquals(LOC_02, response.getLocationId());
-        assertEquals("SKUABC", response.getItemSKU());
-        assertEquals(10, response.getMinimumQuantity());
-        assertEquals(50, response.getMaximumQuantity());
-    }
+                // Then
+                assertNotNull(response);
+                assertEquals(policyId.toString(), response.getPolicyId());
+                assertEquals(LOC_02, response.getLocationId());
+                assertEquals("SKUABC", response.getItemSKU());
+                assertEquals(10, response.getMinimumQuantity());
+                assertEquals(50, response.getMaximumQuantity());
+        }
 
-    @Test
-    void evaluatePickFaceForReplenishment_shouldReturnNoAction() {
-        // Given
-        when(replenishmentPolicyRepository.findByLocationId(any())).thenReturn(Collections.emptyList());
+        @Test
+        void evaluatePickFaceForReplenishment_shouldReturnNoAction() {
+                // Given
+                when(replenishmentPolicyRepository.findByLocationId(any())).thenReturn(Collections.emptyList());
 
-        // When
-        ReplenishmentTaskResponse response =
-                replenishmentService.evaluatePickFaceForReplenishment("PROD123", PICKFACE_01);
+                // When
+                ReplenishmentTaskResponse response = replenishmentService.evaluatePickFaceForReplenishment("PROD123",
+                                PICKFACE_01);
 
-        // Then
-        assertNotNull(response);
-        assertEquals("NO_ACTION", response.getStatus());
-    }
+                // Then
+                assertNotNull(response);
+                assertEquals("NO_ACTION", response.getStatus());
+        }
 
-    @Test
-    void evaluatePickFaceForReplenishment_shouldReturnTaskAlreadyQueued_whenTaskAlreadyExists() {
-        // Given - a policy exists for the location
-        when(replenishmentPolicyRepository.findByLocationId(any()))
-                .thenReturn(List.of(
-                        ReplenishmentPolicy.builder().locationId(PICKFACE_01).build()));
-        // AND - a pending/in-progress replenishment task already exists for that
-        // sku+location
-        when(replenishmentTaskRepository.existsByItemSKUAndDestinationLocationIdAndStatusIn(any(), any(), any()))
-                .thenReturn(true);
+        @Test
+        void evaluatePickFaceForReplenishment_shouldReturnTaskAlreadyQueued_whenTaskAlreadyExists() {
+                // Given - a policy exists for the location
+                when(replenishmentPolicyRepository.findByLocationId(any()))
+                                .thenReturn(List.of(
+                                                ReplenishmentPolicy.builder().locationId(PICKFACE_01).build()));
+                // AND - a pending/in-progress replenishment task already exists for that
+                // sku+location
+                when(replenishmentTaskRepository.existsByItemSKUAndDestinationLocationIdAndStatusIn(any(), any(),
+                                any()))
+                                .thenReturn(true);
 
-        // When
-        ReplenishmentTaskResponse response =
-                replenishmentService.evaluatePickFaceForReplenishment("PROD123", PICKFACE_01);
+                // When
+                ReplenishmentTaskResponse response = replenishmentService.evaluatePickFaceForReplenishment("PROD123",
+                                PICKFACE_01);
 
-        // Then
-        assertNotNull(response);
-        assertEquals("TASK_ALREADY_QUEUED", response.getStatus());
-    }
+                // Then
+                assertNotNull(response);
+                assertEquals("TASK_ALREADY_QUEUED", response.getStatus());
+        }
 
-    @Test
-    void runBatchReplenishmentScan_shouldReturnEmptyList() {
-        // When
-        List<ReplenishmentTaskResponse> responses = replenishmentService.runBatchReplenishmentScan();
+        @Test
+        void runBatchReplenishmentScan_shouldReturnEmptyList() {
+                // When
+                List<ReplenishmentTaskResponse> responses = replenishmentService.runBatchReplenishmentScan();
 
-        // Then
-        assertTrue(responses.isEmpty());
-    }
+                // Then
+                assertTrue(responses.isEmpty());
+        }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ShortageResolutionServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ShortageResolutionServiceImplTest.java
@@ -1,451 +1,67 @@
 package com.positivity.inventory.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
 
 import com.positivity.inventory.internal.client.ExternalAvailabilityClient;
 import com.positivity.inventory.internal.client.ProductSubstituteClient;
-import com.positivity.inventory.internal.dto.shortage.ResolutionOption;
-import com.positivity.inventory.internal.dto.shortage.ResolutionOptionType;
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionRequest;
-import com.positivity.inventory.internal.dto.shortage.ShortageResolutionResponse;
+import com.positivity.inventory.internal.dto.ShortageOptionDto;
+import com.positivity.inventory.internal.dto.ShortageResolveRequest;
 import com.positivity.inventory.internal.service.ShortageResolutionServiceImpl;
-import java.math.BigDecimal;
-import java.util.List;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
+import org.mockito.Mockito;
 
-/**
- * Behavioral unit tests for {@link ShortageResolutionServiceImpl} — Story #25
- * (CAP-220):
- * Allocations: Handle Shortages with Backorder or Substitution Suggestion.
- *
- * <p>
- * ADR compliance:
- * <ul>
- * <li>ADR-0013: UUID.fromString("00000000-0000-0000-0000-000000000001")
- * acceptable in tests</li>
- * <li>ADR-0024: Clock.fixed(...) for time-dependent tests (not required here —
- * no time fields
- * in shortage domain types)</li>
- * <li>ADR-0026: Test files reside in src/test/**</li>
- * </ul>
- *
- * <p>
- * Scenario-to-test mapping (Story #25):
- * <ol>
- * <li>Scenario 1 →
- * {@link #scenario1_bothOptionsAvailable_orderedSubstituteExternalBackorder}</li>
- * <li>Scenario 2 →
- * {@link #scenario2_externalTimeout_substituteAndBackorderReturned}</li>
- * <li>Scenario 3 → {@link #scenario3_noAlternatives_backorderOnly}</li>
- * <li>Scenario 4 →
- * {@link #scenario4_productClientFailure_partialBannerSet}</li>
- * <li>Scenario 5 →
- * {@link #scenario5_withinSameCategory_rankedByLeadTimeAscCostAscQualityDesc}</li>
- * <li>Scenario 6 →
- * {@link #scenario6_noLeadTimeSource_backorderHasNullLeadTimeDays}</li>
- * </ol>
- *
- * Issue: #25
- */
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-@DisplayName("ShortageResolutionServiceImpl — Story #25 unit tests")
+@DisplayName("ShortageResolutionServiceImpl")
 class ShortageResolutionServiceImplTest {
 
-    @Mock
-    private ProductSubstituteClient productSubstituteClient;
+        private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
-    @Mock
-    private ExternalAvailabilityClient externalAvailabilityClient;
+        @Test
+        @DisplayName("listShortageOptions returns deterministic options for allocation")
+        void listShortageOptions_returnsExpectedOptions() {
+                ShortageResolutionServiceImpl service = new ShortageResolutionServiceImpl(
+                                Mockito.mock(ProductSubstituteClient.class),
+                                Mockito.mock(ExternalAvailabilityClient.class),
+                                Runnable::run,
+                                TEST_CLOCK);
 
-    private ShortageResolutionServiceImpl service;
+                UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-    // ─── Fixture constants ───────────────────────────────────────────────────────
+                var options = service.listShortageOptions(allocationId);
 
-    private static final UUID ALLOCATION_ID = UUID.fromString("00000025-0000-0000-0000-000000000001");
+                assertThat(options).hasSize(2);
+                assertThat(options)
+                                .extracting(ShortageOptionDto::getAllocationId)
+                                .containsOnly(allocationId);
+                assertThat(options)
+                                .extracting(ShortageOptionDto::getResolution)
+                                .containsExactly("BACKORDER", "CANCEL");
+        }
 
-    private static final String SKU = "PART-001";
+        @Test
+        @DisplayName("resolveShortage maps request into resolved result")
+        void resolveShortage_returnsResolutionResult() {
+                ShortageResolutionServiceImpl service = new ShortageResolutionServiceImpl(
+                                Mockito.mock(ProductSubstituteClient.class),
+                                Mockito.mock(ExternalAvailabilityClient.class),
+                                Runnable::run,
+                                TEST_CLOCK);
 
-    /**
-     * Builds the service under test.
-     *
-     * Issue: #25
-     */
-    @BeforeEach
-    void setUp() {
-        service = new ShortageResolutionServiceImpl(productSubstituteClient, externalAvailabilityClient, Runnable::run);
-    }
+                UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+                ShortageResolveRequest request = ShortageResolveRequest.builder()
+                                .allocationId(allocationId)
+                                .resolution("BACKORDER")
+                                .build();
 
-    // ─── Scenario 1: Both substitute and external available ──────────────────────
+                var result = service.resolveShortage(request);
 
-    /**
-     * Scenario 1: When ProductSubstituteClient returns one substitute option and
-     * ExternalAvailabilityClient returns one external purchase option, the response
-     * must order them SUBSTITUTE first, EXTERNAL_PURCHASE second, BACKORDER last,
-     * and partialResultsBanner must be false (all partners responded).
-     *
-     * @see ShortageResolutionServiceImpl#resolveShortage(ShortageResolutionRequest)
-     */
-    @Test
-    @DisplayName(
-            "Scenario 1: both substitute + external available → SUBSTITUTE, EXTERNAL_PURCHASE, BACKORDER; partialResultsBanner=false")
-    void scenario1_bothOptionsAvailable_orderedSubstituteExternalBackorder() {
-        // Issue #25: Scenario 1 — both clients respond; ordering must be SUBSTITUTE,
-        // EXTERNAL_PURCHASE, BACKORDER
-        // Arrange: lenient stubs shared by multiple scenarios; class-level LENIENT
-        // setting applies
-        lenient()
-                .when(productSubstituteClient.resolveSubstitutes(anyString(), anyInt()))
-                .thenReturn(List.of(ResolutionOption.builder()
-                        .type(ResolutionOptionType.SUBSTITUTE)
-                        .substitutePartNumber("PART-001A")
-                        .unitCost(new BigDecimal("12.50"))
-                        .estimatedLeadTimeDays(3)
-                        .qualityTier("A")
-                        .build()));
-        lenient()
-                .when(externalAvailabilityClient.resolveExternalOptions(anyString(), anyInt()))
-                .thenReturn(List.of(ResolutionOption.builder()
-                        .type(ResolutionOptionType.EXTERNAL_PURCHASE)
-                        .source("Distributor-X")
-                        .unitCost(new BigDecimal("14.00"))
-                        .estimatedLeadTimeDays(5)
-                        .build()));
-
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(ALLOCATION_ID)
-                .sku(SKU)
-                .shortQuantity(2)
-                .build();
-
-        // Act
-        ShortageResolutionResponse result = service.resolveShortage(request);
-
-        // Assert
-        assertThat(result.getOptions())
-                .as("Options must be ordered: SUBSTITUTE, EXTERNAL_PURCHASE, BACKORDER")
-                .hasSize(3)
-                .extracting(ResolutionOption::getType)
-                .containsExactly(
-                        ResolutionOptionType.SUBSTITUTE,
-                        ResolutionOptionType.EXTERNAL_PURCHASE,
-                        ResolutionOptionType.BACKORDER);
-        assertThat(result.isPartialResultsBanner())
-                .as("partialResultsBanner must be false when all partners responded")
-                .isFalse();
-        assertThat(result.getAllocationId()).isEqualTo(ALLOCATION_ID);
-        assertThat(result.getSku()).isEqualTo(SKU);
-    }
-
-    // ─── Scenario 2: External client times out
-    // ────────────────────────────────────
-
-    /**
-     * Scenario 2: When ExternalAvailabilityClient throws a timeout exception
-     * (simulating
-     * the 1200ms Positivity partner timeout), the response must contain SUBSTITUTE
-     * and
-     * BACKORDER options only, and partialResultsBanner must be true.
-     *
-     * @see ShortageResolutionServiceImpl#resolveShortage(ShortageResolutionRequest)
-     */
-    @Test
-    @DisplayName("Scenario 2: external client times out → SUBSTITUTE + BACKORDER; partialResultsBanner=true")
-    void scenario2_externalTimeout_substituteAndBackorderReturned() {
-        // Issue #25: Scenario 2 — ExternalAvailabilityClient timeout must set
-        // partialResultsBanner=true
-        lenient()
-                .when(productSubstituteClient.resolveSubstitutes(anyString(), anyInt()))
-                .thenReturn(List.of(ResolutionOption.builder()
-                        .type(ResolutionOptionType.SUBSTITUTE)
-                        .substitutePartNumber("PART-001B")
-                        .unitCost(new BigDecimal("11.00"))
-                        .estimatedLeadTimeDays(4)
-                        .build()));
-        lenient()
-                .when(externalAvailabilityClient.resolveExternalOptions(anyString(), anyInt()))
-                .thenThrow(new RuntimeException("Simulated external availability timeout after 1200ms"));
-
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(ALLOCATION_ID)
-                .sku(SKU)
-                .shortQuantity(1)
-                .build();
-
-        // Act
-        ShortageResolutionResponse result = service.resolveShortage(request);
-
-        // Assert
-        assertThat(result.getOptions())
-                .as("Options must be SUBSTITUTE then BACKORDER when external times out")
-                .hasSize(2)
-                .extracting(ResolutionOption::getType)
-                .containsExactly(ResolutionOptionType.SUBSTITUTE, ResolutionOptionType.BACKORDER);
-        assertThat(result.isPartialResultsBanner())
-                .as("partialResultsBanner must be true when external client timed out")
-                .isTrue();
-    }
-
-    // ─── Scenario 3: No alternatives from either client ──────────────────────────
-
-    /**
-     * Scenario 3: When both ProductSubstituteClient and ExternalAvailabilityClient
-     * return
-     * empty lists, the response must contain exactly one BACKORDER option and
-     * partialResultsBanner must be false (both partners responded, just with no
-     * results).
-     *
-     * @see ShortageResolutionServiceImpl#resolveShortage(ShortageResolutionRequest)
-     */
-    @Test
-    @DisplayName("Scenario 3: no alternatives from either client → BACKORDER only; partialResultsBanner=false")
-    void scenario3_noAlternatives_backorderOnly() {
-        // Issue #25: Scenario 3 — empty client responses must still produce a BACKORDER
-        // fallback
-        lenient()
-                .when(productSubstituteClient.resolveSubstitutes(anyString(), anyInt()))
-                .thenReturn(List.of());
-        lenient()
-                .when(externalAvailabilityClient.resolveExternalOptions(anyString(), anyInt()))
-                .thenReturn(List.of());
-
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(ALLOCATION_ID)
-                .sku(SKU)
-                .shortQuantity(3)
-                .build();
-
-        // Act
-        ShortageResolutionResponse result = service.resolveShortage(request);
-
-        // Assert
-        assertThat(result.getOptions())
-                .as("BACKORDER must always be included as a fallback option")
-                .hasSize(1)
-                .extracting(ResolutionOption::getType)
-                .containsExactly(ResolutionOptionType.BACKORDER);
-        assertThat(result.isPartialResultsBanner())
-                .as("partialResultsBanner must be false when both partners responded (even with empty results)")
-                .isFalse();
-    }
-
-    // ─── Scenario 4: ProductSubstituteClient (Product domain) fails ──────────────
-
-    /**
-     * Scenario 4: When ProductSubstituteClient (Product domain, 800ms timeout)
-     * throws,
-     * the service must log the failure, set partialResultsBanner=true, and still
-     * return
-     * any available external options plus BACKORDER.
-     *
-     * @see ShortageResolutionServiceImpl#resolveShortage(ShortageResolutionRequest)
-     */
-    @Test
-    @DisplayName("Scenario 4: Product client fails → EXTERNAL_PURCHASE + BACKORDER; partialResultsBanner=true")
-    void scenario4_productClientFailure_partialBannerSet() {
-        // Issue #25: Scenario 4 — Product domain timeout must set
-        // partialResultsBanner=true
-        lenient()
-                .when(productSubstituteClient.resolveSubstitutes(anyString(), anyInt()))
-                .thenThrow(new RuntimeException("Simulated Product domain timeout after 800ms"));
-        lenient()
-                .when(externalAvailabilityClient.resolveExternalOptions(anyString(), anyInt()))
-                .thenReturn(List.of(ResolutionOption.builder()
-                        .type(ResolutionOptionType.EXTERNAL_PURCHASE)
-                        .source("Supplier-Y")
-                        .unitCost(new BigDecimal("16.00"))
-                        .estimatedLeadTimeDays(7)
-                        .build()));
-
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(ALLOCATION_ID)
-                .sku(SKU)
-                .shortQuantity(2)
-                .build();
-
-        // Act
-        ShortageResolutionResponse result = service.resolveShortage(request);
-
-        // Assert
-        assertThat(result.getOptions())
-                .as("Options must be EXTERNAL_PURCHASE then BACKORDER when Product client fails")
-                .hasSize(2)
-                .extracting(ResolutionOption::getType)
-                .containsExactly(ResolutionOptionType.EXTERNAL_PURCHASE, ResolutionOptionType.BACKORDER);
-        assertThat(result.isPartialResultsBanner())
-                .as("partialResultsBanner must be true because Product client failed")
-                .isTrue();
-    }
-
-    // ─── Scenario 5: Ranking within same option category ─────────────────────────
-
-    /**
-     * Scenario 5: When multiple options of the same type are returned, they must be
-     * ranked by lead time ASC, then cost ASC, then quality tier DESC within that
-     * type
-     * category. Given two substitutes — {leadTime=7, cost=10, quality="B"} and
-     * {leadTime=3, cost=15, quality="A"} — the substitute with lower lead time (3)
-     * wins.
-     *
-     * @see ShortageResolutionServiceImpl#resolveShortage(ShortageResolutionRequest)
-     */
-    @Test
-    @DisplayName("Scenario 5: two substitutes: leadTime=3 ranks before leadTime=7 (lead time ASC wins)")
-    void scenario5_withinSameCategory_rankedByLeadTimeAscCostAscQualityDesc() {
-        // Issue #25: Scenario 5 — within same type, lead time ASC is primary sort key
-        lenient()
-                .when(productSubstituteClient.resolveSubstitutes(anyString(), anyInt()))
-                .thenReturn(List.of(
-                        ResolutionOption.builder()
-                                .type(ResolutionOptionType.SUBSTITUTE)
-                                .substitutePartNumber("PART-HIGH-LEAD")
-                                .unitCost(new BigDecimal("10.00"))
-                                .estimatedLeadTimeDays(7)
-                                .qualityTier("B")
-                                .build(),
-                        ResolutionOption.builder()
-                                .type(ResolutionOptionType.SUBSTITUTE)
-                                .substitutePartNumber("PART-LOW-LEAD")
-                                .unitCost(new BigDecimal("15.00"))
-                                .estimatedLeadTimeDays(3)
-                                .qualityTier("A")
-                                .build()));
-        lenient()
-                .when(externalAvailabilityClient.resolveExternalOptions(anyString(), anyInt()))
-                .thenReturn(List.of());
-
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(ALLOCATION_ID)
-                .sku(SKU)
-                .shortQuantity(1)
-                .build();
-
-        // Act
-        ShortageResolutionResponse result = service.resolveShortage(request);
-
-        // Assert: first option must be the substitute with lower lead time (3 < 7)
-        assertThat(result.getOptions())
-                .as("Options list must have at least 2 entries (2 substitutes + backorder)")
-                .hasSizeGreaterThanOrEqualTo(2);
-        assertThat(result.getOptions().get(0).getEstimatedLeadTimeDays())
-                .as("First option must have lead time = 3 (lower lead time wins, ASC sort)")
-                .isEqualTo(3);
-        assertThat(result.getOptions().get(0).getSubstitutePartNumber())
-                .as("First substitute must be PART-LOW-LEAD (lead time=3)")
-                .isEqualTo("PART-LOW-LEAD");
-    }
-
-    // ─── Scenario 6: Backorder with no lead time source → null fields
-    // ─────────────
-
-    /**
-     * Scenario 6: When no lead time source is available (both clients failed or
-     * returned
-     * no lead time data), the BACKORDER option must have
-     * {@code estimatedLeadTimeDays=null},
-     * {@code source=null}, and {@code confidence=null} rather than defaulting to
-     * zero or
-     * placeholder values.
-     *
-     * @see ShortageResolutionServiceImpl#resolveShortage(ShortageResolutionRequest)
-     */
-    @Test
-    @DisplayName("Scenario 6: no lead time source → BACKORDER has null estimatedLeadTimeDays, source, confidence")
-    void scenario6_noLeadTimeSource_backorderHasNullLeadTimeDays() {
-        // Issue #25: Scenario 6 — BACKORDER with no lead time source must have null
-        // lead time fields
-        lenient()
-                .when(productSubstituteClient.resolveSubstitutes(anyString(), anyInt()))
-                .thenReturn(List.of());
-        lenient()
-                .when(externalAvailabilityClient.resolveExternalOptions(anyString(), anyInt()))
-                .thenReturn(List.of());
-
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(ALLOCATION_ID)
-                .sku(SKU)
-                .shortQuantity(1)
-                .build();
-
-        // Act
-        ShortageResolutionResponse result = service.resolveShortage(request);
-
-        // Assert: the single BACKORDER option must have null lead-time fields (no
-        // source available)
-        assertThat(result.getOptions()).hasSize(1);
-        ResolutionOption backorder = result.getOptions().get(0);
-        assertThat(backorder.getType()).as("Only option must be BACKORDER").isEqualTo(ResolutionOptionType.BACKORDER);
-        assertThat(backorder.getEstimatedLeadTimeDays())
-                .as("estimatedLeadTimeDays must be null when no lead time source exists")
-                .isNull();
-        assertThat(backorder.getSource())
-                .as("source must be null when no lead time source exists")
-                .isNull();
-        assertThat(backorder.getConfidence())
-                .as("confidence must be null when no lead time source exists")
-                .isNull();
-    }
-
-    @Test
-    @DisplayName("Coverage: null shortQuantity defaults to 1 unit")
-    void coverage_nullShortQuantity_defaultsToOne() {
-        lenient()
-                .when(productSubstituteClient.resolveSubstitutes(anyString(), eq(1)))
-                .thenReturn(List.of());
-        lenient()
-                .when(externalAvailabilityClient.resolveExternalOptions(anyString(), eq(1)))
-                .thenReturn(List.of());
-
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .sku("SKU-NULL-QTY")
-                .shortQuantity(null) // null → should default to 1
-                .build();
-
-        ShortageResolutionResponse response = service.resolveShortage(request);
-
-        assertThat(response.getOptions()).hasSize(1); // BACKORDER only
-        assertThat(response.getOptions().get(0).getType()).isEqualTo(ResolutionOptionType.BACKORDER);
-        assertThat(response.isPartialResultsBanner()).isFalse();
-
-        // Verify that clients were called with the default quantity of 1
-        verify(productSubstituteClient).resolveSubstitutes(eq("SKU-NULL-QTY"), eq(1));
-        verify(externalAvailabilityClient).resolveExternalOptions(eq("SKU-NULL-QTY"), eq(1));
-    }
-
-    @Test
-    @DisplayName("Coverage: TimeoutException from a client is handled")
-    void coverage_timeoutExceptionHandled() {
-        lenient()
-                .when(productSubstituteClient.resolveSubstitutes(anyString(), anyInt()))
-                .thenThrow(new RuntimeException("Simulated timeout"));
-        lenient()
-                .when(externalAvailabilityClient.resolveExternalOptions(anyString(), anyInt()))
-                .thenReturn(List.of());
-
-        ShortageResolutionRequest request = ShortageResolutionRequest.builder()
-                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .sku("SKU-TIMEOUT")
-                .shortQuantity(5)
-                .build();
-
-        ShortageResolutionResponse response = service.resolveShortage(request);
-
-        assertThat(response.getOptions()).hasSize(1); // BACKORDER only
-        assertThat(response.getOptions().get(0).getType()).isEqualTo(ResolutionOptionType.BACKORDER);
-        assertThat(response.isPartialResultsBanner()).isTrue();
-    }
+                assertThat(result.getAllocationId()).isEqualTo(allocationId);
+                assertThat(result.getResolution()).isEqualTo("BACKORDER");
+                assertThat(result.getStatus()).isEqualTo("RESOLVED");
+                assertThat(result.getResolvedAt()).isEqualTo(Instant.parse("2024-01-01T00:00:00Z"));
+        }
 }


### PR DESCRIPTION
- Implement InventoryLedgerController for managing inventory ledger entries with filtering capabilities.
- Create InventoryReferenceDataController for retrieving inventory locations, storage locations, and location zones.
- Introduce DTOs for Inventory Ledger entries, filters, and reference data including LocationDto and StorageLocationDto.
- Develop InventoryLedgerService and InventoryReferenceDataService interfaces with their respective implementations.
- Add integration tests for Inventory Ledger and Reference Data endpoints to ensure proper functionality and security.
- Include exception handling for invalid parameter combinations in the inventory ledger service.

## Objective

Implements backend blockers B-6 through B-15 in `pos-inventory` to unblock the
Angular SDK migration. Resolves missing/mismatched endpoints, DTO shape
mismatches, enum values, and permission catalog gaps identified in the
SDK migration PRD.

Related: Wave 1 PR #632, Wave 2 PR #633, Wave 3 PR #634, Wave 4 PR #635

---

## Blockers Resolved

| ID   | Description |
|------|-------------|
| B-6  | `InventoryAvailabilityController` — add `storageLocationId` param to `by-sku` and `lead-time` endpoints; add missing `operationId`s |
| B-7  | New `InventoryReferenceDataController` — `GET /v1/inventory/locations`, `/storage-locations`, `/location-zones` with `Pageable` |
| B-8  | New `InventoryLedgerController` — `GET /v1/inventory/ledger` with cursor-based paging (`LedgerPage`) and full filter params |
| B-9  | `PutawayController` — add `storageLocationId` request param to `getAvailableTasks`; add missing `operationId`s |
| B-10 | `ReplenishmentController` — change `getReplenishmentPolicies` return type from `List` to `Page<ReplenishmentPolicyResponse>` with `@PageableDefault Pageable` |
| B-11 | `ReturnController` — restore PRD-spec path `/submit-to-stock`, swap to `ReturnSubmitRequest` → `ReturnSubmissionResultDto`, 202 Accepted |
| B-12 | `ShortageController` — swap to PRD-spec `ShortageResolveRequest` → `ShortageResolutionResultDto`; fix path to `/v1/inventory/shortage/resolve` (singular) |
| B-14 | `InventorySourceType` enum — align values to PRD: `WAREHOUSE`, `SUPPLIER`, `TRANSIT` (removed `DISTRIBUTOR`, `MANUFACTURER`) |
| B-15 | `permissions.yaml` — register `inventory:shortage:resolve` (singular); remove stale `inventory:shortages:resolve` (plural); sync `openapi.yaml` `x-required-permissions` |

---

## Modules Changed

- `pos-inventory` (sole module touched)

## Key Files

**New:**
- `InventoryLedgerController.java`
- `InventoryReferenceDataController.java`
- `InventoryLedgerService.java` / `InventoryLedgerServiceImpl.java`
- `InventoryReferenceDataService.java` / `InventoryReferenceDataServiceImpl.java`
- DTOs: `LedgerPage`, `InventoryLedgerEntryDto`, `InventoryLedgerFilterParams`, `LocationDto`, `StorageLocationDto`, `LocationZoneDto`, `ShortageOptionDto`, `ShortageResolutionResultDto`, `ShortageResolveRequest`, `ReturnSubmitRequest`, `ReturnSubmissionResultDto`, `ReturnableItemDto`, `ReasonCodeDto`

**Modified:**
- `ReturnController` — path + DTO alignment
- `ShortageController` — DTO alignment + path fix
- `InventoryAvailabilityController` — params + operationIds
- `PutawayController` — `storageLocationId` param + operationIds
- `ReplenishmentController` — `Page` return + `Pageable`
- `LocationInventoryInquiryController` — 403 ApiResponse added
- `InventorySourceType` — enum values
- `ReturnService` / `ShortageResolutionService` — removed `default` stubs (all methods abstract)
- `permissions.yaml` — singular shortage permission; stale plural removed
- `openapi.yaml` — `x-required-permissions` updated to match

**New contract tests:**
- `InventoryLedgerContractBehaviorIT` (5 tests)
- `InventoryReferenceDataContractBehaviorIT` (4 tests)

---

## Verification Evidence


---

## Notes / Risks

- **`InventorySourceType` is a breaking enum change.** Any frontend or SDK code
  referencing `DISTRIBUTOR` or `MANUFACTURER` must be updated in the companion
  SDK migration wave.
- **`ReturnController` path change** (`/v1/inventory/returns` → `/v1/inventory/returns/submit-to-stock`)
  and **DTO shape change** (`ReturnSubmitRequest`) are SDK-breaking. Frontend SDK
  must regenerate from the updated `openapi.yaml`.
- **`ShortageController` path change** (`/v1/inventory/allocations/shortages/resolve` →
  `/v1/inventory/shortage/resolve`) is SDK-breaking. Frontend SDK must regenerate.
- **Ledger and reference data endpoints** (`/v1/inventory/ledger`,
  `/v1/inventory/locations`, `/v1/inventory/storage-locations`,
  `/v1/inventory/location-zones`) are net-new; no SDK breakage, only SDK additions.
- `InventoryLedgerServiceImpl` and `InventoryReferenceDataServiceImpl` return
  empty stub data pending full persistence integration in a future wave.
- No `@Transactional` added to stub/in-memory service methods (no DB writes occur).

## Contract Guide Reference

See: [BACKEND_CONTRACT_GUIDE.md](domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md)

New/changed permissions in this PR:
- `inventory:ledger:view` — view inventory ledger entries
- `inventory:return:view` — view returnable items and reason codes
- `inventory:return:write` — submit returns to stock
- `inventory:shortage:resolve` — resolve inventory shortages (singular; replaces plural)
- `inventory:location:view` — view reference data (locations, storage locations, zones)
