### PR TITLE
cap/639 feat(pos-mcp-server): Enhance tool usage selection and execution coherence

### DIFF
--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -1084,8 +1084,6 @@ paths:
 tags:
 - name: pos-accounting
   description: Operations served by pos-accounting
-- name: pos-api-gateway
-  description: Operations served by pos-api-gateway
 - name: pos-bulk-loader
   description: Operations served by pos-bulk-loader
 - name: pos-catalog
@@ -1098,8 +1096,6 @@ tags:
   description: Operations served by pos-event-receiver
 - name: pos-image
   description: Operations served by pos-image
-- name: pos-inquiry
-  description: Operations served by pos-inquiry
 - name: pos-inventory
   description: Operations served by pos-inventory
 - name: pos-invoice
@@ -1128,14 +1124,12 @@ tags:
   description: Operations served by pos-workorder
 x-aggregated-modules:
 - pos-accounting
-- pos-api-gateway
 - pos-bulk-loader
 - pos-catalog
 - pos-customer
 - pos-documents
 - pos-event-receiver
 - pos-image
-- pos-inquiry
 - pos-inventory
 - pos-invoice
 - pos-location

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -559,6 +559,12 @@ paths:
     $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1llm-apis~1{id}
   /v1/mcp/chat:
     $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1mcp~1chat
+  /v1/mcp/chat/stream:
+    $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1mcp~1chat~1stream
+  /v1/mcp/documents:
+    $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1mcp~1documents
+  /v1/mcp/documents/jobs/{jobId}:
+    $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1mcp~1documents~1jobs~1{jobId}
   /v1/nlt/audit:
     $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1nlt~1audit
   /v1/nlt/requests:
@@ -1096,6 +1102,8 @@ tags:
   description: Operations served by pos-event-receiver
 - name: pos-image
   description: Operations served by pos-image
+- name: pos-inquiry
+  description: Operations served by pos-inquiry
 - name: pos-inventory
   description: Operations served by pos-inventory
 - name: pos-invoice
@@ -1130,6 +1138,7 @@ x-aggregated-modules:
 - pos-documents
 - pos-event-receiver
 - pos-image
+- pos-inquiry
 - pos-inventory
 - pos-invoice
 - pos-location

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -1030,11 +1030,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/UomConversionDto'
-                unevaluatedItems: {}
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -3537,10 +3534,10 @@ components:
         number:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
         pageable:
           $ref: '#/components/schemas/PageableObject'
+        sort:
+          $ref: '#/components/schemas/SortObject'
         first:
           type: boolean
         last:
@@ -3556,16 +3553,16 @@ components:
         offset:
           type: integer
           format: int64
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        paged:
-          type: boolean
         pageNumber:
           type: integer
           format: int32
         pageSize:
           type: integer
           format: int32
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
         unpaged:
           type: boolean
     SortObject:
@@ -3596,10 +3593,10 @@ components:
         number:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
         pageable:
           $ref: '#/components/schemas/PageableObject'
+        sort:
+          $ref: '#/components/schemas/SortObject'
         first:
           type: boolean
         last:

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -1030,8 +1030,11 @@ paths:
             application/json:
               schema:
                 type: array
+                additionalProperties: {}
+                contains: {}
                 items:
                   $ref: '#/components/schemas/UomConversionDto'
+                unevaluatedItems: {}
       security:
       - bearerAuth:
         - ROLE_ADMIN

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/UomConversionController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/UomConversionController.java
@@ -7,6 +7,7 @@ import com.positivity.catalog.service.UomConversionService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -52,7 +53,9 @@ public class UomConversionController {
                         "ROLE_CATALOG_VIEW" })
         @GetMapping
         @Operation(summary = "List active conversions", description = "Returns all active unit-of-measure conversion records.", operationId = "listUomConversions")
-        @ApiResponse(responseCode = "200", description = "Conversions listed", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UomConversionDto[].class)))
+        @ApiResponse(responseCode = "200", description = "Conversions listed",
+                        content = @Content(mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = UomConversionDto.class))))
         public ResponseEntity<List<UomConversionDto>> list() {
                 return ResponseEntity.ok(uomConversionService.listActiveConversions());
         }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/UomConversionController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/UomConversionController.java
@@ -7,7 +7,6 @@ import com.positivity.catalog.service.UomConversionService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -53,7 +52,7 @@ public class UomConversionController {
                         "ROLE_CATALOG_VIEW" })
         @GetMapping
         @Operation(summary = "List active conversions", description = "Returns all active unit-of-measure conversion records.", operationId = "listUomConversions")
-        @ApiResponse(responseCode = "200", description = "Conversions listed", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = UomConversionDto.class))))
+        @ApiResponse(responseCode = "200", description = "Conversions listed", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UomConversionDto[].class)))
         public ResponseEntity<List<UomConversionDto>> list() {
                 return ResponseEntity.ok(uomConversionService.listActiveConversions());
         }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/UomConversionController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/UomConversionController.java
@@ -53,9 +53,7 @@ public class UomConversionController {
                         "ROLE_CATALOG_VIEW" })
         @GetMapping
         @Operation(summary = "List active conversions", description = "Returns all active unit-of-measure conversion records.", operationId = "listUomConversions")
-        @ApiResponse(responseCode = "200", description = "Conversions listed",
-                        content = @Content(mediaType = "application/json",
-                                        array = @ArraySchema(schema = @Schema(implementation = UomConversionDto.class))))
+        @ApiResponse(responseCode = "200", description = "Conversions listed", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = UomConversionDto.class))))
         public ResponseEntity<List<UomConversionDto>> list() {
                 return ResponseEntity.ok(uomConversionService.listActiveConversions());
         }

--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -2452,12 +2452,12 @@ components:
     PageCustomerDTO:
       type: object
       properties:
-        totalPages:
-          type: integer
-          format: int32
         totalElements:
           type: integer
           format: int64
+        totalPages:
+          type: integer
+          format: int32
         size:
           type: integer
           format: int32

--- a/pos-inquiry/openapi.yaml
+++ b/pos-inquiry/openapi.yaml
@@ -9,6 +9,7 @@ info:
 servers:
 - url: http://localhost:8086
   description: Generated server url
+paths: {}
 components:
   securitySchemes:
     bearerAuth:

--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -87,6 +87,8 @@ Prompts are managed via the `/v1/prompts` CRUD API (requires `mcp:system_prompt:
 
 On each chat request `ToolRegistryService.resolveCandidateTools()` narrows the active tool set using pgvector ANN (`<=>` cosine distance) gated by role, while workflow-state routing beyond `IDLE` is intentionally deferred (current managers evaluate with `WORKFLOW_IDLE` only):
 
+> **TODO (AC8):** Derive workflow state from session context and pass it into `ToolSelectionContext` so non-IDLE states (`CREATING_PO`, `PROCESSING_RETURN`, etc.) activate their respective tool sets. Requires persisting workflow state on `NltiSession` and threading it through both `SessionAgentManager` and `StreamingSessionAgentManager`. `ToolRegistryLoader` will also need to preload tools for active workflow states beyond `IDLE`.
+
 1. `ToolMetadataRepository.findTopKByEmbeddingForRole()` executes an ANN query that JOINs `mcp_tool`, `mcp_role`, `mcp_tool_role`, and `mcp_workflow_state` — only tools authorized for the user's role and the current workflow state enter the scoring window.
 2. `ToolScorer` ranks candidates using a weighted combination of semantic similarity and normalized priority (`Math.clamp(priority, 0.0, 1.0)`).
 3. If no embeddings are stored yet, a deterministic fallback returns gated tools sorted by `priority DESC, name ASC`.

--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -17,10 +17,12 @@ AI orchestration and MCP (Model Context Protocol) server for the Durion Positivi
 - `AgentOrchestrationService` — coordinates per-user LangChain4j chat agents with tool narrowing
 - `StreamingAgentOrchestrationService` — streaming SSE variant of the agent orchestration path
 - `ToolRegistrationService` — loads tool metadata from DB and wires facade tool beans
+- `ToolRegistryService` — per-request semantic tool selection using pgvector ANN gated by role and workflow state
+- `McpRoleResolver` — extracts the primary Spring Security role from an `Authentication` using a priority-ordered list (ADMIN > MANAGER > SERVICE_WRITER > CASHIER > SUPPLIER > TECHNICIAN > ROLE_USER fallback)
 - `DocumentIngestionService` — asynchronous RAG document ingestion with chunking and embedding
 - `IntentParserService` — classifies inbound messages to route direct vs. agent paths
 - `SystemPromptService` — manages named system prompts stored in PostgreSQL
-- `RolePromptResolver` — resolves the active system prompt for a given role (role → "default" → built-in fallback)
+- `RolePromptResolver` — resolves the active system prompt for a given role (role → "default" → built-in fallback; warns when falling back)
 - `StaticRagPreloadService` — preloads configured static classpath documents into the RAG store on startup (alpha profile)
 
 ## API Endpoints
@@ -36,15 +38,16 @@ AI orchestration and MCP (Model Context Protocol) server for the Durion Positivi
 
 ## Configuration
 
-| Property                                        | Default            | Description                               |
-| ----------------------------------------------- | ------------------ | ----------------------------------------- |
-| `langchain4j.ollama.chat-model.model-name`      | `llama3.1:8b`      | Ollama chat model                         |
-| `langchain4j.ollama.embedding-model.model-name` | `nomic-embed-text` | Embedding model for RAG                   |
-| `mcp.agent.cache-ttl-minutes`                   | `30`               | Per-user session agent cache TTL          |
-| `mcp.rag.chunking.enabled`                      | `true`             | Enable document chunking before embedding |
-| `mcp.rag.preload.docs`                          | `[]`               | Static classpath documents to preload     |
-| `mcp.tuning.enabled`                            | `true`             | Enable adaptive tool priority tuning      |
-| `mcp.tuning.cron`                               | `0 0 2 * * ?`      | Tuning schedule (daily at 02:00)          |
+| Property                                        | Default            | Description                                       |
+| ----------------------------------------------- | ------------------ | ------------------------------------------------- |
+| `langchain4j.ollama.chat-model.model-name`      | `llama3.1:8b`      | Ollama chat model                                 |
+| `langchain4j.ollama.embedding-model.model-name` | `nomic-embed-text` | Embedding model for RAG                           |
+| `mcp.agent.cache-ttl-minutes`                   | `30`               | Agent cache TTL (role agents + sessions)          |
+| `mcp.agent.candidate-tool-limit`                | `2`                | Max tools from semantic selector per chat request |
+| `mcp.rag.chunking.enabled`                      | `true`             | Enable document chunking before embedding         |
+| `mcp.rag.preload.docs`                          | `[]`               | Static classpath documents to preload             |
+| `mcp.tuning.enabled`                            | `true`             | Enable adaptive tool priority tuning              |
+| `mcp.tuning.cron`                               | `0 0 2 * * ?`      | Tuning schedule (daily at 02:00)                  |
 
 ## Dependencies
 
@@ -75,10 +78,22 @@ Three ApplicationRunner beans execute on startup (in addition to tool and event-
 The system prompt used for each chat session is resolved per-role by `RolePromptResolver`:
 
 1. Look up a system prompt by name exactly matching the user's Spring Security role (e.g. `ROLE_CASHIER`).
-2. If not found, look up the prompt named `default`.
-3. If not found, use the built-in hardcoded fallback prompt.
+2. If not found, log a WARN and look up the prompt named `default`.
+3. If not found, log a WARN and use the built-in hardcoded fallback prompt.
 
 Prompts are managed via the `/v1/prompts` CRUD API (requires `mcp:system_prompt:*` permission).
+
+### Semantic Per-Request Tool Selection
+
+On each chat request `ToolRegistryService.resolveCandidateTools()` narrows the active tool set using pgvector ANN (`<=>` cosine distance) **gated by role and workflow state**:
+
+1. `ToolMetadataRepository.findTopKByEmbeddingForRole()` executes an ANN query that JOINs `mcp_tool`, `mcp_role`, `mcp_tool_role`, and `mcp_workflow_state` — only tools authorized for the user's role and the current workflow state enter the scoring window.
+2. `ToolScorer` ranks candidates using a weighted combination of semantic similarity and normalized priority (`Math.clamp(priority, 0.0, 1.0)`).
+3. If no embeddings are stored yet, a deterministic fallback returns gated tools sorted by `priority DESC, name ASC`.
+4. The streaming manager (`StreamingSessionAgentManager`) applies the same selection per message and caches the resulting agent keyed by `role::toolCacheKey` (sorted tool names joined with `+`).
+5. Role agents expire after `mcp.agent.cache-ttl-minutes` (default 30 min) so tool and prompt edits in the database become effective without a service restart.
+
+Roles are loaded dynamically from the `mcp_role` table (`ToolRegistryLoader`). `McpRoleResolver` resolves the primary role from `Authentication` in priority order: ADMIN > MANAGER > SERVICE_WRITER > CASHIER > SUPPLIER > TECHNICIAN > ROLE_USER fallback.
 
 ### Static RAG Preload Configuration
 

--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -85,7 +85,7 @@ Prompts are managed via the `/v1/prompts` CRUD API (requires `mcp:system_prompt:
 
 ### Semantic Per-Request Tool Selection
 
-On each chat request `ToolRegistryService.resolveCandidateTools()` narrows the active tool set using pgvector ANN (`<=>` cosine distance) **gated by role and workflow state**:
+On each chat request `ToolRegistryService.resolveCandidateTools()` narrows the active tool set using pgvector ANN (`<=>` cosine distance) gated by role, while workflow-state routing beyond `IDLE` is intentionally deferred (current managers evaluate with `WORKFLOW_IDLE` only):
 
 1. `ToolMetadataRepository.findTopKByEmbeddingForRole()` executes an ANN query that JOINs `mcp_tool`, `mcp_role`, `mcp_tool_role`, and `mcp_workflow_state` — only tools authorized for the user's role and the current workflow state enter the scoring window.
 2. `ToolScorer` ranks candidates using a weighted combination of semantic similarity and normalized priority (`Math.clamp(priority, 0.0, 1.0)`).

--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -93,7 +93,7 @@ On each chat request `ToolRegistryService.resolveCandidateTools()` narrows the a
 2. `ToolScorer` ranks candidates using a weighted combination of semantic similarity and normalized priority (`Math.clamp(priority, 0.0, 1.0)`).
 3. If no embeddings are stored yet, a deterministic fallback returns gated tools sorted by `priority DESC, name ASC`.
 4. The streaming manager (`StreamingSessionAgentManager`) applies the same selection per message and caches the resulting agent keyed by `role::toolCacheKey` (sorted tool names joined with `+`).
-5. Role agents expire after `mcp.agent.cache-ttl-minutes` (default 30 min) so tool and prompt edits in the database become effective without a service restart.
+5. Role agents expire after `mcp.agent.cache-ttl-minutes` (default 30 min) so prompt edits and semantic tool-selection rankings in the database become effective without a service restart; changes to the role-tool fallback mapping (ToolRegistry) require a service restart.
 
 Roles are loaded dynamically from the `mcp_role` table (`ToolRegistryLoader`). `McpRoleResolver` resolves the primary role from `Authentication` in priority order: ADMIN > MANAGER > SERVICE_WRITER > CASHIER > SUPPLIER > TECHNICIAN > ROLE_USER fallback.
 

--- a/pos-mcp-server/openapi.yaml
+++ b/pos-mcp-server/openapi.yaml
@@ -6,10 +6,12 @@ servers:
 - url: http://localhost:8086
   description: Generated server url
 tags:
+- name: LLM API Configuration
+  description: LLM provider API configuration management
+- name: Document Ingestion
+  description: RAG document ingestion job management
 - name: NLTI Audit
   description: NLTI Audit Ledger Query
-- name: MCP Chat API
-  description: Model Context Protocol (MCP) chatbot endpoint for invoking MCP tools
 - name: NLTI
   description: Natural Language Task Interface
 paths:
@@ -29,9 +31,12 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 $ref: '#/components/schemas/SystemPromptResponse'
+      security:
+      - bearerAuth:
+        - mcp:system_prompt:view
     put:
       tags:
       - system-prompt-controller
@@ -53,9 +58,12 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 $ref: '#/components/schemas/SystemPromptResponse'
+      security:
+      - bearerAuth:
+        - mcp:system_prompt:update
     delete:
       tags:
       - system-prompt-controller
@@ -70,10 +78,15 @@ paths:
       responses:
         '200':
           description: OK
+      security:
+      - bearerAuth:
+        - mcp:system_prompt:delete
   /v1/llm-apis/{id}:
     get:
       tags:
-      - llm-api-config-controller
+      - LLM API Configuration
+      summary: Get an LLM API configuration
+      description: Retrieve a single LLM API provider configuration by its identifier.
       operationId: get_1
       parameters:
       - name: id
@@ -86,12 +99,17 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 $ref: '#/components/schemas/LlmApiConfigResponse'
+      security:
+      - bearerAuth:
+        - mcp:llm_api:view
     put:
       tags:
-      - llm-api-config-controller
+      - LLM API Configuration
+      summary: Update an LLM API configuration
+      description: Update an existing LLM API provider configuration by its identifier.
       operationId: update_1
       parameters:
       - name: id
@@ -110,12 +128,17 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 $ref: '#/components/schemas/LlmApiConfigResponse'
+      security:
+      - bearerAuth:
+        - mcp:llm_api:update
     delete:
       tags:
-      - llm-api-config-controller
+      - LLM API Configuration
+      summary: Delete an LLM API configuration
+      description: Delete an existing LLM API provider configuration by its identifier.
       operationId: delete_1
       parameters:
       - name: id
@@ -127,6 +150,9 @@ paths:
       responses:
         '200':
           description: OK
+      security:
+      - bearerAuth:
+        - mcp:llm_api:delete
   /v1/prompts:
     get:
       tags:
@@ -136,11 +162,14 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/SystemPromptResponse'
+      security:
+      - bearerAuth:
+        - mcp:system_prompt:view
     post:
       tags:
       - system-prompt-controller
@@ -155,9 +184,12 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 $ref: '#/components/schemas/SystemPromptResponse'
+      security:
+      - bearerAuth:
+        - mcp:system_prompt:create
   /v1/nlt/requests:
     post:
       tags:
@@ -180,57 +212,105 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 $ref: '#/components/schemas/NltiResponseV1'
-  /v1/mcp/chat:
+      security:
+      - bearerAuth:
+        - nlti:request:submit
+  /v1/mcp/documents:
     post:
       tags:
-      - MCP Chat API
-      summary: Execute MCP Tool
-      description: Synchronously execute an MCP tool with the provided arguments and return the result
-      operationId: chat
+      - Document Ingestion
+      summary: Queue a document for ingestion into the RAG vector store
+      description: Submit a document for asynchronous ingestion into the RAG vector store. The request includes the document content and optional metadata. The response returns a job ID that can be used to track the ingestion status.
+      operationId: ingestDocument
       requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DocumentIngestionRequest'
         required: true
       responses:
-        '400':
-          description: Invalid request - missing or empty toolName
-          content:
-            text/plain:
-              example: '''toolName'' is required'
         '200':
-          description: Tool execution succeeded
+          description: OK
           content:
             application/json:
               schema:
-                description: MCP CallToolResult containing tool output
-              example:
-                content:
-                - type: text
-                  text: Pong from positivity-ping
-                isError: false
-        '500':
-          description: Tool execution failed
+                $ref: '#/components/schemas/DocumentIngestionJobResponse'
+      security:
+      - bearerAuth:
+        - mcp:document:ingest
+  /v1/mcp/chat:
+    post:
+      tags:
+      - mcp-chat-controller
+      summary: Execute MCP chat message
+      operationId: chat
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
           content:
-            text/plain:
-              example: 'Failed to execute MCP tool: Tool not found'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatResponse'
+      security:
+      - bearerAuth:
+        - mcp:chat:execute
+  /v1/mcp/chat/stream:
+    post:
+      tags:
+      - mcp-streaming-chat-controller
+      summary: Execute MCP streaming chat - returns SSE token stream
+      operationId: streamChat
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StreamChatRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            text/event-stream:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServerSentEventString'
+      security:
+      - bearerAuth:
+        - mcp:chat:stream
   /v1/llm-apis:
     get:
       tags:
-      - llm-api-config-controller
+      - LLM API Configuration
+      summary: List LLM API configurations
+      description: Retrieve all configured LLM API provider definitions that are available to the MCP server.
       operationId: list_1
       responses:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/LlmApiConfigResponse'
+      security:
+      - bearerAuth:
+        - mcp:llm_api:view
     post:
       tags:
-      - llm-api-config-controller
+      - LLM API Configuration
+      summary: Create an LLM API configuration
+      description: Create a new LLM API provider configuration for use by the MCP server.
       operationId: create_1
       requestBody:
         content:
@@ -242,14 +322,18 @@ paths:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 $ref: '#/components/schemas/LlmApiConfigResponse'
+      security:
+      - bearerAuth:
+        - mcp:llm_api:create
   /v1/nlt/audit:
     get:
       tags:
       - NLTI Audit
       summary: Query the NLTI audit ledger
+      description: Query the NLTI audit ledger with optional filters for correlation ID, time range, and event type. Results are paginated.
       operationId: queryAudit
       parameters:
       - name: correlationId
@@ -280,6 +364,7 @@ paths:
         description: Zero-based page index (0..N)
         required: false
         schema:
+          type: integer
           default: 0
           minimum: 0
       - name: size
@@ -287,6 +372,7 @@ paths:
         description: The size of the page to be returned
         required: false
         schema:
+          type: integer
           default: 20
           minimum: 1
       - name: sort
@@ -297,13 +383,42 @@ paths:
           type: array
           default:
           - timestamp,ASC
+          items:
+            type: string
       responses:
         '200':
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
                 $ref: '#/components/schemas/PageAuditEventResponse'
+      security:
+      - bearerAuth:
+        - nlti:audit:read
+  /v1/mcp/documents/jobs/{jobId}:
+    get:
+      tags:
+      - Document Ingestion
+      summary: Get RAG document ingestion job status
+      description: Retrieve the status and details of an asynchronous document ingestion job using its job ID. The response includes the current status, timestamps, and any error messages if applicable.
+      operationId: getIngestionJob
+      parameters:
+      - name: jobId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentIngestionJobResponse'
+      security:
+      - bearerAuth:
+        - mcp:document:ingest
 components:
   schemas:
     SystemPromptRequest:
@@ -311,8 +426,10 @@ components:
       properties:
         name:
           type: string
+          minLength: 1
         content:
           type: string
+          minLength: 1
       required:
       - content
       - name
@@ -337,12 +454,16 @@ components:
       properties:
         apiId:
           type: string
+          minLength: 1
         model:
           type: string
+          minLength: 1
         baseUrl:
           type: string
+          minLength: 1
         apiKey:
           type: string
+          minLength: 1
         headers:
           type: object
           additionalProperties:
@@ -381,6 +502,7 @@ components:
       properties:
         prompt:
           type: string
+          minLength: 1
         sessionId:
           type: string
           format: uuid
@@ -404,6 +526,86 @@ components:
           type: string
         meta:
           type: object
+    DocumentIngestionRequest:
+      type: object
+      description: Document ingestion payload
+      example:
+        content: sample
+        metadata:
+          document_id: policy-123
+          source: manual
+      properties:
+        content:
+          type: string
+          minLength: 1
+        metadata:
+          type: object
+          description: Optional key-value metadata for the document
+      required:
+      - content
+    DocumentIngestionJobResponse:
+      type: object
+      description: Asynchronous document ingestion job status
+      properties:
+        jobId:
+          type: string
+          format: uuid
+        documentId:
+          type: string
+        status:
+          type: string
+          enum:
+          - PENDING
+          - RUNNING
+          - SUCCEEDED
+          - FAILED
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        startedAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+        chunkCount:
+          type: integer
+          format: int32
+        errorMessage:
+          type: string
+    ChatRequest:
+      type: object
+      description: Chat request payload
+      example:
+        message: Hello
+      properties:
+        message:
+          type: string
+          minLength: 1
+      required:
+      - message
+    ChatResponse:
+      type: object
+      description: Chat response payload
+      example:
+        response: Hi!
+      properties:
+        response:
+          type: string
+    StreamChatRequest:
+      type: object
+      description: Streaming chat request payload
+      example:
+        message: Hello
+      properties:
+        message:
+          type: string
+          minLength: 1
+      required:
+      - message
     AuditEventResponse:
       type: object
       properties:
@@ -431,10 +633,6 @@ components:
         totalPages:
           type: integer
           format: int32
-        first:
-          type: boolean
-        last:
-          type: boolean
         size:
           type: integer
           format: int32
@@ -445,23 +643,25 @@ components:
         number:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/Sortnull'
+        first:
+          type: boolean
+        last:
+          type: boolean
         numberOfElements:
           type: integer
           format: int32
         pageable:
-          $ref: '#/components/schemas/Pageablenull'
+          $ref: '#/components/schemas/PageableObject'
+        sort:
+          $ref: '#/components/schemas/SortObject'
         empty:
           type: boolean
-    Pageablenull:
+    PageableObject:
       type: object
       properties:
         offset:
           type: integer
           format: int64
-        sort:
-          $ref: '#/components/schemas/Sortnull'
         paged:
           type: boolean
         pageNumber:
@@ -470,14 +670,16 @@ components:
         pageSize:
           type: integer
           format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
         unpaged:
           type: boolean
-    Sortnull:
+    SortObject:
       type: object
       properties:
         empty:
           type: boolean
-        unsorted:
-          type: boolean
         sorted:
+          type: boolean
+        unsorted:
           type: boolean

--- a/pos-mcp-server/openapi.yaml
+++ b/pos-mcp-server/openapi.yaml
@@ -191,7 +191,6 @@ paths:
       description: Synchronously execute an MCP tool with the provided arguments and return the result
       operationId: chat
       requestBody:
-        content: {}
         required: true
       responses:
         '400':

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/TestProfileOrchestrationFallbackConfig.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/TestProfileOrchestrationFallbackConfig.java
@@ -1,0 +1,94 @@
+package com.positivity.mcp.internal.config;
+
+import com.positivity.mcp.service.AgentOrchestrationService;
+import com.positivity.mcp.service.DocumentIngestionJob;
+import com.positivity.mcp.service.DocumentIngestionJobStatus;
+import com.positivity.mcp.service.DocumentIngestionService;
+import com.positivity.mcp.service.StreamingAgentOrchestrationService;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import reactor.core.publisher.Flux;
+
+@Configuration
+@Profile("test")
+public class TestProfileOrchestrationFallbackConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(AgentOrchestrationService.class)
+    AgentOrchestrationService testAgentOrchestrationService() {
+        return new AgentOrchestrationService() {
+            @Override
+            public @NonNull String chat(@NonNull String userId, @NonNull String role, @NonNull String message) {
+                return "OpenAPI test-profile fallback response";
+            }
+
+            @Override
+            public void evict(@NonNull String userId) {
+                // No-op fallback for test-profile OpenAPI generation.
+            }
+        };
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(StreamingAgentOrchestrationService.class)
+    StreamingAgentOrchestrationService testStreamingAgentOrchestrationService() {
+        return new StreamingAgentOrchestrationService() {
+            @Override
+            public @NonNull Flux<String> streamChat(
+                    @NonNull String userId, @NonNull String role, @NonNull String message) {
+                return Flux.just("OpenAPI", "test-profile", "fallback", "stream");
+            }
+
+            @Override
+            public void evict(@NonNull String userId) {
+                // No-op fallback for test-profile OpenAPI generation.
+            }
+        };
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(DocumentIngestionService.class)
+    DocumentIngestionService testDocumentIngestionService() {
+        return new DocumentIngestionService() {
+            @Override
+            public @NonNull DocumentIngestionJob submitDocument(
+                    @NonNull String content, @NonNull Map<String, Object> metadata) {
+                OffsetDateTime now = OffsetDateTime.now();
+                return new DocumentIngestionJob(
+                        UUID.randomUUID(),
+                        "openapi-test-document",
+                        DocumentIngestionJobStatus.PENDING,
+                        now,
+                        now,
+                        null,
+                        null,
+                        null,
+                        null);
+            }
+
+            @Override
+            public @NonNull Optional<DocumentIngestionJob> getIngestionJob(@NonNull UUID jobId) {
+                return Optional.empty();
+            }
+
+            @Override
+            public void ingestDocument(@NonNull String content, @NonNull Map<String, Object> metadata) {
+                // No-op fallback for test-profile OpenAPI generation.
+            }
+
+            @Override
+            public void ingestDocuments(
+                    @NonNull List<String> contents, @NonNull List<Map<String, Object>> metadataList) {
+                // No-op fallback for test-profile OpenAPI generation.
+            }
+        };
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/TestProfileOrchestrationFallbackConfig.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/TestProfileOrchestrationFallbackConfig.java
@@ -21,74 +21,74 @@ import reactor.core.publisher.Flux;
 @Profile("test")
 public class TestProfileOrchestrationFallbackConfig {
 
-    @Bean
-    @ConditionalOnMissingBean(AgentOrchestrationService.class)
-    AgentOrchestrationService testAgentOrchestrationService() {
-        return new AgentOrchestrationService() {
-            @Override
-            public @NonNull String chat(@NonNull String userId, @NonNull String role, @NonNull String message) {
-                return "OpenAPI test-profile fallback response";
-            }
+  @Bean
+  @ConditionalOnMissingBean(AgentOrchestrationService.class)
+  AgentOrchestrationService testAgentOrchestrationService() {
+    return new AgentOrchestrationService() {
+      @Override
+      public @NonNull String chat(@NonNull String userId, @NonNull String role, @NonNull String message) {
+        return "OpenAPI test-profile fallback response";
+      }
 
-            @Override
-            public void evict(@NonNull String userId) {
-                // No-op fallback for test-profile OpenAPI generation.
-            }
-        };
-    }
+      @Override
+      public void evict(@NonNull String userId) {
+        // No-op fallback for test-profile OpenAPI generation.
+      }
+    };
+  }
 
-    @Bean
-    @ConditionalOnMissingBean(StreamingAgentOrchestrationService.class)
-    StreamingAgentOrchestrationService testStreamingAgentOrchestrationService() {
-        return new StreamingAgentOrchestrationService() {
-            @Override
-            public @NonNull Flux<String> streamChat(
-                    @NonNull String userId, @NonNull String role, @NonNull String message) {
-                return Flux.just("OpenAPI", "test-profile", "fallback", "stream");
-            }
+  @Bean
+  @ConditionalOnMissingBean(StreamingAgentOrchestrationService.class)
+  StreamingAgentOrchestrationService testStreamingAgentOrchestrationService() {
+    return new StreamingAgentOrchestrationService() {
+      @Override
+      public @NonNull Flux<String> streamChat(
+          @NonNull String userId, @NonNull String role, @NonNull String message) {
+        return Flux.just("OpenAPI", "test-profile", "fallback", "stream");
+      }
 
-            @Override
-            public void evict(@NonNull String userId) {
-                // No-op fallback for test-profile OpenAPI generation.
-            }
-        };
-    }
+      @Override
+      public void evict(@NonNull String userId) {
+        // No-op fallback for test-profile OpenAPI generation.
+      }
+    };
+  }
 
-    @Bean
-    @ConditionalOnMissingBean(DocumentIngestionService.class)
-    DocumentIngestionService testDocumentIngestionService() {
-        return new DocumentIngestionService() {
-            @Override
-            public @NonNull DocumentIngestionJob submitDocument(
-                    @NonNull String content, @NonNull Map<String, Object> metadata) {
-                OffsetDateTime now = OffsetDateTime.now();
-                return new DocumentIngestionJob(
-                        UUID.randomUUID(),
-                        "openapi-test-document",
-                        DocumentIngestionJobStatus.PENDING,
-                        now,
-                        now,
-                        null,
-                        null,
-                        null,
-                        null);
-            }
+  @Bean
+  @ConditionalOnMissingBean(DocumentIngestionService.class)
+  DocumentIngestionService testDocumentIngestionService() {
+    return new DocumentIngestionService() {
+      @Override
+      public @NonNull DocumentIngestionJob submitDocument(
+          @NonNull String content, @NonNull Map<String, Object> metadata) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return new DocumentIngestionJob(
+            UUID.randomUUID(),
+            "openapi-test-document",
+            DocumentIngestionJobStatus.PENDING,
+            now,
+            now,
+            null,
+            null,
+            null,
+            null);
+      }
 
-            @Override
-            public @NonNull Optional<DocumentIngestionJob> getIngestionJob(@NonNull UUID jobId) {
-                return Optional.empty();
-            }
+      @Override
+      public @NonNull Optional<DocumentIngestionJob> getIngestionJob(@NonNull UUID jobId) {
+        return Optional.empty();
+      }
 
-            @Override
-            public void ingestDocument(@NonNull String content, @NonNull Map<String, Object> metadata) {
-                // No-op fallback for test-profile OpenAPI generation.
-            }
+      @Override
+      public void ingestDocument(@NonNull String content, @NonNull Map<String, Object> metadata) {
+        // No-op fallback for test-profile OpenAPI generation.
+      }
 
-            @Override
-            public void ingestDocuments(
-                    @NonNull List<String> contents, @NonNull List<Map<String, Object>> metadataList) {
-                // No-op fallback for test-profile OpenAPI generation.
-            }
-        };
-    }
+      @Override
+      public void ingestDocuments(
+          @NonNull List<String> contents, @NonNull List<Map<String, Object>> metadataList) {
+        // No-op fallback for test-profile OpenAPI generation.
+      }
+    };
+  }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpChatController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpChatController.java
@@ -3,21 +3,17 @@ package com.positivity.mcp.internal.controller;
 import com.positivity.events.EmitEvent;
 import com.positivity.mcp.internal.security.McpPermissions;
 import com.positivity.mcp.service.AgentOrchestrationService;
+import com.positivity.mcp.service.McpRoleResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.CurrentSecurityContext;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,58 +29,41 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/mcp")
 public class McpChatController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(McpChatController.class);
+        private static final Logger LOGGER = LoggerFactory.getLogger(McpChatController.class);
 
-    private final AgentOrchestrationService agentOrchestrationService;
+        private final AgentOrchestrationService agentOrchestrationService;
+        private final McpRoleResolver mcpRoleResolver;
 
-    public McpChatController(@NonNull AgentOrchestrationService agentOrchestrationService) {
-        this.agentOrchestrationService = agentOrchestrationService;
-    }
+        public McpChatController(
+                        @NonNull AgentOrchestrationService agentOrchestrationService,
+                        @NonNull McpRoleResolver mcpRoleResolver) {
+                this.agentOrchestrationService = agentOrchestrationService;
+                this.mcpRoleResolver = mcpRoleResolver;
+        }
 
-    @Operation(summary = "Execute MCP chat message")
-    @PostMapping("/chat")
-    @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_EXECUTE + "')")
-    @EmitEvent(id = "MCP_CHAT_EXECUTE", apiVersion = "1")
-    public ResponseEntity<ChatResponse> chat(
-            @RequestBody @Valid @NonNull ChatRequest request,
-            @CurrentSecurityContext(expression = "authentication") @NonNull Authentication authentication) {
+        @Operation(summary = "Execute MCP chat message")
+        @PostMapping("/chat")
+        @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_EXECUTE + "')")
+        @EmitEvent(id = "MCP_CHAT_EXECUTE", apiVersion = "1")
+        public ResponseEntity<ChatResponse> chat(
+                        @RequestBody @Valid @NonNull ChatRequest request,
+                        @CurrentSecurityContext(expression = "authentication") @NonNull Authentication authentication) {
 
-        @NonNull
-        String userId = authentication.getName();
-        @NonNull
-        String role = extractPrimaryRole(authentication);
-        String response = agentOrchestrationService.chat(userId, role, request.message());
-        return ResponseEntity.ok(new ChatResponse(response));
-    }
+                @NonNull
+                String userId = authentication.getName();
+                @NonNull
+                String role = mcpRoleResolver.resolvePrimaryRole(authentication);
+                LOGGER.debug("MCP chat selected role principal={} selectedRole={} fallback={}", userId, role,
+                                "ROLE_USER".equals(role));
+                String response = agentOrchestrationService.chat(userId, role, request.message());
+                return ResponseEntity.ok(new ChatResponse(response));
+        }
 
-    private static final List<String> ROLE_PRIORITY = List.of(
-            "ROLE_ADMIN", "ROLE_MANAGER", "ROLE_SERVICE_WRITER",
-            "ROLE_CASHIER", "ROLE_SUPPLIER", "ROLE_TECHNICIAN");
+        @Schema(name = "ChatRequest", description = "Chat request payload", example = "{\"message\":\"Hello\"}")
+        public record ChatRequest(@NotBlank @NonNull String message) {
+        }
 
-    private @NonNull String extractPrimaryRole(@NonNull Authentication auth) {
-        Set<String> userRoles = auth.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .filter(Objects::nonNull)
-                .filter(a -> a.startsWith("ROLE_"))
-                .collect(Collectors.toSet());
-        String resolvedRole = ROLE_PRIORITY.stream()
-                .filter(userRoles::contains)
-                .findFirst()
-                .orElse("ROLE_USER");
-        LOGGER.debug(
-                "MCP chat role resolution principal={} roleAuthorities={} selectedRole={} fallback={}",
-                auth.getName(),
-                userRoles,
-                resolvedRole,
-                "ROLE_USER".equals(resolvedRole));
-        return resolvedRole;
-    }
-
-    @Schema(name = "ChatRequest", description = "Chat request payload", example = "{\"message\":\"Hello\"}")
-    public record ChatRequest(@NotBlank @NonNull String message) {
-    }
-
-    @Schema(name = "ChatResponse", description = "Chat response payload", example = "{\"response\":\"Hi!\"}")
-    public record ChatResponse(@NonNull String response) {
-    }
+        @Schema(name = "ChatResponse", description = "Chat response payload", example = "{\"response\":\"Hi!\"}")
+        public record ChatResponse(@NonNull String response) {
+        }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpChatController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpChatController.java
@@ -41,7 +41,13 @@ public class McpChatController {
                 this.mcpRoleResolver = mcpRoleResolver;
         }
 
-        @Operation(summary = "Execute MCP chat message")
+        @Operation(
+                        summary = "Execute MCP chat message",
+                        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                                        required = true,
+                                        content = @io.swagger.v3.oas.annotations.media.Content(
+                                                        mediaType = org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                                                        schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = McpChatController.ChatRequest.class))))
         @PostMapping("/chat")
         @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_EXECUTE + "')")
         @EmitEvent(id = "MCP_CHAT_EXECUTE", apiVersion = "1")

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpStreamingChatController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpStreamingChatController.java
@@ -2,15 +2,12 @@ package com.positivity.mcp.internal.controller;
 
 import com.positivity.events.EmitEvent;
 import com.positivity.mcp.internal.security.McpPermissions;
+import com.positivity.mcp.service.McpRoleResolver;
 import com.positivity.mcp.service.StreamingAgentOrchestrationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +15,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.CurrentSecurityContext;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,56 +27,39 @@ import reactor.core.publisher.Flux;
 @RequestMapping("/v1/mcp")
 public class McpStreamingChatController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(McpStreamingChatController.class);
+        private static final Logger LOGGER = LoggerFactory.getLogger(McpStreamingChatController.class);
 
-    private final StreamingAgentOrchestrationService streamingSessionAgentManager;
+        private final StreamingAgentOrchestrationService streamingSessionAgentManager;
+        private final McpRoleResolver mcpRoleResolver;
 
-    public McpStreamingChatController(@NonNull StreamingAgentOrchestrationService streamingSessionAgentManager) {
-        this.streamingSessionAgentManager = streamingSessionAgentManager;
-    }
+        public McpStreamingChatController(
+                        @NonNull StreamingAgentOrchestrationService streamingSessionAgentManager,
+                        @NonNull McpRoleResolver mcpRoleResolver) {
+                this.streamingSessionAgentManager = streamingSessionAgentManager;
+                this.mcpRoleResolver = mcpRoleResolver;
+        }
 
-    @Operation(summary = "Execute MCP streaming chat - returns SSE token stream")
-    @PostMapping(value = "/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_STREAM + "')")
-    @EmitEvent(id = "MCP_CHAT_STREAM_EXECUTE", apiVersion = "1")
-    public Flux<ServerSentEvent<String>> streamChat(
-            @RequestBody @Valid @NonNull StreamChatRequest request,
-            @CurrentSecurityContext(expression = "authentication") @NonNull Authentication authentication) {
+        @Operation(summary = "Execute MCP streaming chat - returns SSE token stream")
+        @PostMapping(value = "/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+        @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_STREAM + "')")
+        @EmitEvent(id = "MCP_CHAT_STREAM_EXECUTE", apiVersion = "1")
+        public Flux<ServerSentEvent<String>> streamChat(
+                        @RequestBody @Valid @NonNull StreamChatRequest request,
+                        @CurrentSecurityContext(expression = "authentication") @NonNull Authentication authentication) {
 
-        @NonNull
-        String userId = authentication.getName();
-        @NonNull
-        String role = extractPrimaryRole(authentication);
+                @NonNull
+                String userId = authentication.getName();
+                @NonNull
+                String role = mcpRoleResolver.resolvePrimaryRole(authentication);
+                LOGGER.debug("MCP streaming selected role principal={} selectedRole={} fallback={}", userId, role,
+                                "ROLE_USER".equals(role));
 
-        return streamingSessionAgentManager
-                .streamChat(userId, role, request.message())
-                .map(token -> ServerSentEvent.<String>builder(token).event("chat").build());
-    }
+                return streamingSessionAgentManager
+                                .streamChat(userId, role, request.message())
+                                .map(token -> ServerSentEvent.<String>builder(token).event("chat").build());
+        }
 
-    private static final List<String> ROLE_PRIORITY = List.of(
-            "ROLE_ADMIN", "ROLE_MANAGER", "ROLE_SERVICE_WRITER",
-            "ROLE_CASHIER", "ROLE_SUPPLIER", "ROLE_TECHNICIAN");
-
-    private @NonNull String extractPrimaryRole(@NonNull Authentication auth) {
-        Set<String> userRoles = auth.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .filter(Objects::nonNull)
-                .filter(a -> a.startsWith("ROLE_"))
-                .collect(Collectors.toSet());
-        String resolvedRole = ROLE_PRIORITY.stream()
-                .filter(userRoles::contains)
-                .findFirst()
-                .orElse("ROLE_USER");
-        LOGGER.debug(
-                "MCP streaming role resolution principal={} roleAuthorities={} selectedRole={} fallback={}",
-                auth.getName(),
-                userRoles,
-                resolvedRole,
-                "ROLE_USER".equals(resolvedRole));
-        return resolvedRole;
-    }
-
-    @Schema(name = "StreamChatRequest", description = "Streaming chat request payload", example = "{\"message\":\"Hello\"}")
-    public record StreamChatRequest(@NotBlank @NonNull String message) {
-    }
+        @Schema(name = "StreamChatRequest", description = "Streaming chat request payload", example = "{\"message\":\"Hello\"}")
+        public record StreamChatRequest(@NotBlank @NonNull String message) {
+        }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -114,7 +114,10 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                 .maximumSize(Math.max(1, maxCachedAgents))
                 .expireAfterAccess(Duration.ofMinutes(cacheTtlMinutes))
                 .build();
-        this.roleAgentCache = Caffeine.newBuilder().maximumSize(Math.max(1, maxCachedAgents)).build();
+        this.roleAgentCache = Caffeine.newBuilder()
+                .maximumSize(Math.max(1, maxCachedAgents))
+                .expireAfterWrite(Duration.ofMinutes(cacheTtlMinutes))
+                .build();
         prebuildRoleAgents();
     }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -48,6 +48,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SessionAgentManager.class);
     private static final String MEMORY_KEY_SEPARATOR = "::";
+    // TODO(AC8): derive workflow state from session context instead of hardcoding IDLE
     private static final String WORKFLOW_IDLE = "IDLE";
     private static final String FULL_TOOL_CACHE_KEY = "full";
     private static final int MAX_LOG_PREVIEW_LENGTH = 160;

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -49,6 +49,7 @@ public class StreamingSessionAgentManager
     private static final Logger LOGGER = LoggerFactory.getLogger(StreamingSessionAgentManager.class);
     private static final String MEMORY_KEY_SEPARATOR = "::";
     private static final String FULL_TOOL_CACHE_KEY = "full";
+    // TODO(AC8): derive workflow state from session context instead of hardcoding IDLE
     private static final String WORKFLOW_IDLE = "IDLE";
     private static final int MAX_LOG_PREVIEW_LENGTH = 160;
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -7,6 +7,8 @@ import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.domain.ToolSelectionContext;
 import com.positivity.mcp.internal.exception.RateLimitExceededException;
 import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
+import com.positivity.mcp.internal.orchestration.tools.InventoryFacadeTool;
+import com.positivity.mcp.internal.orchestration.tools.OrderFacadeTool;
 import com.positivity.mcp.internal.service.ToolAuditService;
 import com.positivity.mcp.internal.service.ToolRegistryService;
 import com.positivity.mcp.service.RolePromptResolver;
@@ -21,8 +23,11 @@ import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jspecify.annotations.NonNull;
@@ -55,6 +60,8 @@ public class StreamingSessionAgentManager
     private final PgVectorEmbeddingStore embeddingStore;
     private final ToolRegistry toolRegistry;
     private final ExaWebSearchTool exaWebSearchTool;
+    private final InventoryFacadeTool inventoryFacadeTool;
+    private final OrderFacadeTool orderFacadeTool;
     private final RolePromptResolver rolePromptResolver;
 
     @Nullable
@@ -73,6 +80,8 @@ public class StreamingSessionAgentManager
             @NonNull PgVectorEmbeddingStore embeddingStore,
             @NonNull ToolRegistry toolRegistry,
             @NonNull ExaWebSearchTool exaWebSearchTool,
+            @NonNull InventoryFacadeTool inventoryFacadeTool,
+            @NonNull OrderFacadeTool orderFacadeTool,
             @NonNull RolePromptResolver rolePromptResolver,
             @Nullable ToolRegistryService toolRegistryService,
             @Nullable ToolAuditService toolAuditService,
@@ -86,6 +95,8 @@ public class StreamingSessionAgentManager
         this.embeddingStore = embeddingStore;
         this.toolRegistry = toolRegistry;
         this.exaWebSearchTool = exaWebSearchTool;
+        this.inventoryFacadeTool = inventoryFacadeTool;
+        this.orderFacadeTool = orderFacadeTool;
         this.rolePromptResolver = rolePromptResolver;
         this.toolRegistryService = toolRegistryService;
         this.toolAuditService = toolAuditService;
@@ -132,7 +143,9 @@ public class StreamingSessionAgentManager
         StreamingPosAssistant agent;
         if (toolRegistryService != null) {
             List<Object> roleTools = roleToolsForMessage(role, message);
-            List<Object> allTools = ToolSelectionSupport.mergeWithoutDuplicateToolNames(roleTools, exaWebSearchTool);
+            List<Object> fallbackTools = fallbackToolsForMessage(message);
+            List<Object> allTools =
+                ToolSelectionSupport.mergeWithoutDuplicateToolNames(roleTools, fallbackTools.toArray());
             String cacheKey = toolCacheKey(allTools);
             LOGGER.debug(
                     "MCP streaming tool selection userId={} role={} cacheKey={} tools={}",
@@ -188,10 +201,6 @@ public class StreamingSessionAgentManager
     @Override
     public long getCacheSize() {
         return roleAgentCache.estimatedSize();
-    }
-
-    private @NonNull StreamingPosAssistant getOrCreateAgent(@NonNull String userId, @NonNull String role) {
-        return roleAgentCache.get(role + MEMORY_KEY_SEPARATOR + FULL_TOOL_CACHE_KEY, ignored -> buildAgent(role));
     }
 
     private @NonNull StreamingPosAssistant buildAgent(@NonNull String role) {
@@ -302,6 +311,23 @@ public class StreamingSessionAgentManager
         }
     }
 
+    private @NonNull List<Object> fallbackToolsForMessage(@NonNull String message) {
+        String text = message.toLowerCase(Locale.ROOT);
+        List<Object> selected = new ArrayList<>();
+        if (containsAny(text, Set.of("current", "internet", "news", "online", "recent", "web"))) {
+            selected.add(exaWebSearchTool);
+        }
+        if (containsAny(
+                text, Set.of("availability", "inventory", "location", "part", "product", "sku", "stock", "store"))) {
+            selected.add(inventoryFacadeTool);
+        }
+        if (containsAny(text, Set.of("order", "po", "purchase", "sale", "sales"))) {
+            selected.add(orderFacadeTool);
+        }
+        LOGGER.debug("MCP streaming fallback tool matches tools={}", toolNames(selected));
+        return selected;
+    }
+
     private static @NonNull String toolCacheKey(@NonNull List<Object> tools) {
         TreeSet<String> names = new TreeSet<>(Comparator.naturalOrder());
         tools.forEach(tool -> names.add(ClassUtils.getUserClass(tool).getSimpleName()));
@@ -312,6 +338,15 @@ public class StreamingSessionAgentManager
         return tools.stream()
                 .map(tool -> ClassUtils.getUserClass(tool).getSimpleName())
                 .toList();
+    }
+
+    private static boolean containsAny(@NonNull String text, @NonNull Set<String> tokens) {
+        for (String token : tokens) {
+            if (text.matches(".*\\b" + token + "\\b.*")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static @NonNull String preview(@NonNull String text) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -144,8 +144,8 @@ public class StreamingSessionAgentManager
         if (toolRegistryService != null) {
             List<Object> roleTools = roleToolsForMessage(role, message);
             List<Object> fallbackTools = fallbackToolsForMessage(message);
-            List<Object> allTools =
-                ToolSelectionSupport.mergeWithoutDuplicateToolNames(roleTools, fallbackTools.toArray());
+            List<Object> allTools = ToolSelectionSupport.mergeWithoutDuplicateToolNames(roleTools,
+                    fallbackTools.toArray());
             String cacheKey = toolCacheKey(allTools);
             LOGGER.debug(
                     "MCP streaming tool selection userId={} role={} cacheKey={} tools={}",

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -101,7 +101,10 @@ public class StreamingSessionAgentManager
                 .maximumSize(sanitizedMaxCachedAgents)
                 .expireAfterAccess(Duration.ofMinutes(cacheTtlMinutes))
                 .build();
-        this.roleAgentCache = Caffeine.newBuilder().maximumSize(sanitizedMaxCachedAgents).build();
+        this.roleAgentCache = Caffeine.newBuilder()
+                .maximumSize(sanitizedMaxCachedAgents)
+                .expireAfterWrite(Duration.ofMinutes(cacheTtlMinutes))
+                .build();
         prebuildRoleAgents();
     }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -3,9 +3,12 @@ package com.positivity.mcp.internal.orchestration;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.positivity.mcp.internal.classification.SimpleChatRuleCatalog;
+import com.positivity.mcp.internal.domain.ToolMetadata;
+import com.positivity.mcp.internal.domain.ToolSelectionContext;
 import com.positivity.mcp.internal.exception.RateLimitExceededException;
 import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
 import com.positivity.mcp.internal.service.ToolAuditService;
+import com.positivity.mcp.internal.service.ToolRegistryService;
 import com.positivity.mcp.service.RolePromptResolver;
 import com.positivity.mcp.service.StreamingAgentOrchestrationService;
 import com.positivity.mcp.service.StreamingSessionAgentCacheMetrics;
@@ -18,7 +21,9 @@ import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -27,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 
@@ -37,6 +43,8 @@ public class StreamingSessionAgentManager
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StreamingSessionAgentManager.class);
     private static final String MEMORY_KEY_SEPARATOR = "::";
+    private static final String FULL_TOOL_CACHE_KEY = "full";
+    private static final String WORKFLOW_IDLE = "IDLE";
     private static final int MAX_LOG_PREVIEW_LENGTH = 160;
 
     private final Cache<String, StreamingPosAssistant> roleAgentCache;
@@ -50,9 +58,13 @@ public class StreamingSessionAgentManager
     private final RolePromptResolver rolePromptResolver;
 
     @Nullable
+    private final ToolRegistryService toolRegistryService;
+
+    @Nullable
     private final ToolAuditService toolAuditService;
 
     private final int memoryMaxMessages;
+    private final int candidateToolLimit;
     private final int rateLimitPerSession;
 
     public StreamingSessionAgentManager(
@@ -62,10 +74,12 @@ public class StreamingSessionAgentManager
             @NonNull ToolRegistry toolRegistry,
             @NonNull ExaWebSearchTool exaWebSearchTool,
             @NonNull RolePromptResolver rolePromptResolver,
+            @Nullable ToolRegistryService toolRegistryService,
             @Nullable ToolAuditService toolAuditService,
             @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
             @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
             @Value("${mcp.agent.memory-max-messages:50}") int memoryMaxMessages,
+            @Value("${mcp.agent.candidate-tool-limit:2}") int candidateToolLimit,
             @Value("${pos.nlti.rate-limit.per-session:100}") int rateLimitPerSession) {
         this.streamingChatModel = streamingChatModel;
         this.embeddingModel = embeddingModel;
@@ -73,8 +87,10 @@ public class StreamingSessionAgentManager
         this.toolRegistry = toolRegistry;
         this.exaWebSearchTool = exaWebSearchTool;
         this.rolePromptResolver = rolePromptResolver;
+        this.toolRegistryService = toolRegistryService;
         this.toolAuditService = toolAuditService;
         this.memoryMaxMessages = memoryMaxMessages;
+        this.candidateToolLimit = Math.max(1, candidateToolLimit);
         this.rateLimitPerSession = rateLimitPerSession;
         int sanitizedMaxCachedAgents = Math.max(1, maxCachedAgents);
         this.requestCountCache = Caffeine.newBuilder()
@@ -98,7 +114,6 @@ public class StreamingSessionAgentManager
             throw new RateLimitExceededException("Rate limit exceeded");
         }
 
-        StreamingPosAssistant agent = getOrCreateAgent(userId, role);
         String roleContext = "Current user role: " + role;
         long startMs = System.currentTimeMillis();
         String memoryId = memoryKey(userId, role);
@@ -110,6 +125,25 @@ public class StreamingSessionAgentManager
                 message.length(),
                 tokenCount(message),
                 messagePreview);
+
+        StreamingPosAssistant agent;
+        if (toolRegistryService != null) {
+            List<Object> roleTools = roleToolsForMessage(role, message);
+            List<Object> allTools = ToolSelectionSupport.mergeWithoutDuplicateToolNames(roleTools, exaWebSearchTool);
+            String cacheKey = toolCacheKey(allTools);
+            LOGGER.debug(
+                    "MCP streaming tool selection userId={} role={} cacheKey={} tools={}",
+                    userId,
+                    role,
+                    cacheKey,
+                    toolNames(allTools));
+            agent = roleAgentCache.get(
+                    role + MEMORY_KEY_SEPARATOR + cacheKey, ignored -> buildAgent(role, allTools));
+        } else {
+            agent = roleAgentCache.get(
+                    role + MEMORY_KEY_SEPARATOR + FULL_TOOL_CACHE_KEY, ignored -> buildAgent(role));
+        }
+
         return Flux.<String>create(emitter -> streamTokens(agent, memoryId, message, roleContext, emitter))
                 .doOnComplete(() -> {
                     int elapsedMs = (int) (System.currentTimeMillis() - startMs);
@@ -154,14 +188,18 @@ public class StreamingSessionAgentManager
     }
 
     private @NonNull StreamingPosAssistant getOrCreateAgent(@NonNull String userId, @NonNull String role) {
-        return roleAgentCache.get(role, this::buildAgent);
+        return roleAgentCache.get(role + MEMORY_KEY_SEPARATOR + FULL_TOOL_CACHE_KEY, ignored -> buildAgent(role));
     }
 
     private @NonNull StreamingPosAssistant buildAgent(@NonNull String role) {
-        long startNanos = System.nanoTime();
         List<Object> tools = ToolSelectionSupport.mergeWithoutDuplicateToolNames(
                 toolRegistry.resolveToolsForRole(role), exaWebSearchTool);
+        return buildAgent(role, tools);
+    }
 
+    private @NonNull StreamingPosAssistant buildAgent(
+            @NonNull String role, @NonNull List<Object> tools) {
+        long startNanos = System.nanoTime();
         ContentRetriever contentRetriever = EmbeddingStoreContentRetriever.builder()
                 .embeddingStore(embeddingStore)
                 .embeddingModel(embeddingModel)
@@ -206,7 +244,7 @@ public class StreamingSessionAgentManager
         int prebuilt = 0;
         for (String role : toolRegistry.preloadableRoles()) {
             try {
-                roleAgentCache.put(role, buildAgent(role));
+                roleAgentCache.put(role + MEMORY_KEY_SEPARATOR + FULL_TOOL_CACHE_KEY, buildAgent(role));
                 prebuilt++;
             } catch (RuntimeException exception) {
                 LOGGER.warn("Failed to prebuild MCP streaming role agent role={}", role, exception);
@@ -224,6 +262,55 @@ public class StreamingSessionAgentManager
         return userId + MEMORY_KEY_SEPARATOR + role;
     }
 
+    private @NonNull List<Object> roleToolsForMessage(@NonNull String role, @NonNull String message) {
+        List<Object> fullRoleTools = toolRegistry.resolveToolsForRole(role);
+        if (toolRegistryService == null) {
+            return fullRoleTools;
+        }
+        try {
+            List<String> selectedNames = toolRegistryService
+                    .resolveCandidateTools(new ToolSelectionContext(message, role, WORKFLOW_IDLE), candidateToolLimit)
+                    .stream()
+                    .map(ToolMetadata::name)
+                    .toList();
+            if (selectedNames.isEmpty()) {
+                LOGGER.debug(
+                        "MCP streaming tool selector returned no candidates role={} fullRoleTools={}; using full role tool set",
+                        role,
+                        toolNames(fullRoleTools));
+                return fullRoleTools;
+            }
+            List<Object> resolvedTools = toolRegistry.resolveToolsForRole(role, selectedNames);
+            if (resolvedTools.isEmpty() && !fullRoleTools.isEmpty()) {
+                LOGGER.debug(
+                        "MCP streaming tool candidates resolved to zero role tools role={} candidateNames={}; using full role tool set",
+                        role,
+                        selectedNames);
+                return fullRoleTools;
+            }
+            return resolvedTools;
+        } catch (RuntimeException exception) {
+            LOGGER.warn(
+                    "MCP streaming tool selection failed role={} error={}; using full role tool set",
+                    role,
+                    exception.getClass().getSimpleName(),
+                    exception);
+            return fullRoleTools;
+        }
+    }
+
+    private static @NonNull String toolCacheKey(@NonNull List<Object> tools) {
+        TreeSet<String> names = new TreeSet<>(Comparator.naturalOrder());
+        tools.forEach(tool -> names.add(ClassUtils.getUserClass(tool).getSimpleName()));
+        return names.isEmpty() ? "none" : String.join("+", names);
+    }
+
+    private static @NonNull List<String> toolNames(@NonNull List<Object> tools) {
+        return tools.stream()
+                .map(tool -> ClassUtils.getUserClass(tool).getSimpleName())
+                .toList();
+    }
+
     private static @NonNull String preview(@NonNull String text) {
         String normalized = text.replaceAll("\\s+", " ").trim();
         if (normalized.length() <= MAX_LOG_PREVIEW_LENGTH) {
@@ -234,10 +321,6 @@ public class StreamingSessionAgentManager
 
     private static int tokenCount(@NonNull String text) {
         return SimpleChatRuleCatalog.tokenize(SimpleChatRuleCatalog.normalize(text)).size();
-    }
-
-    private static @NonNull List<String> toolNames(@NonNull List<Object> tools) {
-        return tools.stream().map(tool -> tool.getClass().getSimpleName()).toList();
     }
 
     private static long elapsedMs(long startNanos) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
@@ -16,9 +16,11 @@ public interface ToolMetadataRepository {
     List<ToolMetadata> findEnabledByRoleAndWorkflow(@NonNull String role, @NonNull String workflowState);
 
     /**
-     * Returns up to {@code limit} tools ordered by semantic similarity to the given embedding,
+     * Returns up to {@code limit} tools ordered by semantic similarity to the given
+     * embedding,
      * restricted to tools authorized for {@code role} in {@code workflowState}.
-     * Gating is performed in SQL — unauthorized tools never enter the ranking window.
+     * Gating is performed in SQL — unauthorized tools never enter the ranking
+     * window.
      */
     @NonNull
     List<ToolMetadata> findTopKByEmbeddingForRole(

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
@@ -15,6 +15,15 @@ public interface ToolMetadataRepository {
     @NonNull
     List<ToolMetadata> findEnabledByRoleAndWorkflow(@NonNull String role, @NonNull String workflowState);
 
+    /**
+     * Returns up to {@code limit} tools ordered by semantic similarity to the given embedding,
+     * restricted to tools authorized for {@code role} in {@code workflowState}.
+     * Gating is performed in SQL — unauthorized tools never enter the ranking window.
+     */
+    @NonNull
+    List<ToolMetadata> findTopKByEmbeddingForRole(
+            float @NonNull [] embedding, int limit, @NonNull String role, @NonNull String workflowState);
+
     @NonNull
     List<ToolMetadata> findTopKByEmbedding(float @NonNull [] embedding, int limit);
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
@@ -6,6 +6,12 @@ import org.jspecify.annotations.NonNull;
 
 public interface ToolMetadataRepository {
 
+    /**
+     * Returns all role names currently defined in the mcp_role table.
+     */
+    @NonNull
+    List<String> findAllRoleNames();
+
     @NonNull
     List<ToolMetadata> findEnabledByRoleAndWorkflow(@NonNull String role, @NonNull String workflowState);
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -47,6 +47,29 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
     }
 
     @Override
+    public @NonNull List<ToolMetadata> findTopKByEmbeddingForRole(
+            float @NonNull [] embedding, int limit, @NonNull String role, @NonNull String workflowState) {
+        String sql = """
+                SELECT t.id, t.name, t.display_name, t.description,
+                       t.domain, t.priority, t.cost_level,
+                       t.avg_latency_ms, t.enabled, t.handler_bean
+                FROM mcp_tool t
+                JOIN mcp_tool_role tr ON t.id = tr.tool_id
+                JOIN mcp_role r ON tr.role_id = r.id
+                JOIN mcp_tool_workflow tw ON t.id = tw.tool_id
+                JOIN mcp_workflow_state ws ON tw.workflow_state_id = ws.id
+                WHERE t.enabled = true
+                  AND t.embedding IS NOT NULL
+                  AND r.name = ?
+                  AND ws.name = ?
+                ORDER BY t.embedding <=> ?::vector, t.id
+                LIMIT ?
+                """;
+
+        return jdbcTemplate.query(sql, this::mapRow, role, workflowState, toVectorPGobject(embedding), limit);
+    }
+
+    @Override
     public @NonNull List<ToolMetadata> findTopKByEmbedding(float @NonNull [] embedding, int limit) {
         String sql = """
                 SELECT id, name, display_name, description,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -22,21 +22,26 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
     }
 
     @Override
+    public @NonNull List<String> findAllRoleNames() {
+        return jdbcTemplate.queryForList("SELECT name FROM mcp_role ORDER BY name", String.class);
+    }
+
+    @Override
     public @NonNull List<ToolMetadata> findEnabledByRoleAndWorkflow(
             @NonNull String role, @NonNull String workflowState) {
         String sql = """
-        SELECT t.id, t.name, t.display_name, t.description,
-               t.domain, t.priority, t.cost_level,
-               t.avg_latency_ms, t.enabled, t.handler_bean
-        FROM mcp_tool t
-        JOIN mcp_tool_role tr ON t.id = tr.tool_id
-        JOIN mcp_role r ON tr.role_id = r.id
-        JOIN mcp_tool_workflow tw ON t.id = tw.tool_id
-        JOIN mcp_workflow_state ws ON tw.workflow_state_id = ws.id
-        WHERE t.enabled = true
-          AND r.name = ?
-          AND ws.name = ?
-        """;
+                SELECT t.id, t.name, t.display_name, t.description,
+                       t.domain, t.priority, t.cost_level,
+                       t.avg_latency_ms, t.enabled, t.handler_bean
+                FROM mcp_tool t
+                JOIN mcp_tool_role tr ON t.id = tr.tool_id
+                JOIN mcp_role r ON tr.role_id = r.id
+                JOIN mcp_tool_workflow tw ON t.id = tw.tool_id
+                JOIN mcp_workflow_state ws ON tw.workflow_state_id = ws.id
+                WHERE t.enabled = true
+                  AND r.name = ?
+                  AND ws.name = ?
+                """;
 
         return jdbcTemplate.query(sql, this::mapRow, role, workflowState);
     }
@@ -44,15 +49,15 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
     @Override
     public @NonNull List<ToolMetadata> findTopKByEmbedding(float @NonNull [] embedding, int limit) {
         String sql = """
-        SELECT id, name, display_name, description,
-               domain, priority, cost_level,
-               avg_latency_ms, enabled, handler_bean
-        FROM mcp_tool
-        WHERE enabled = true
-          AND embedding IS NOT NULL
-        ORDER BY embedding <=> ?::vector, id
-        LIMIT ?
-        """;
+                SELECT id, name, display_name, description,
+                       domain, priority, cost_level,
+                       avg_latency_ms, enabled, handler_bean
+                FROM mcp_tool
+                WHERE enabled = true
+                  AND embedding IS NOT NULL
+                ORDER BY embedding <=> ?::vector, id
+                LIMIT ?
+                """;
 
         return jdbcTemplate.query(sql, this::mapRow, toVectorPGobject(embedding), limit);
     }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/McpRoleResolverImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/McpRoleResolverImpl.java
@@ -1,0 +1,34 @@
+package com.positivity.mcp.internal.service;
+
+import com.positivity.mcp.service.McpRoleResolver;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+@Service
+public class McpRoleResolverImpl implements McpRoleResolver {
+
+  static final String FALLBACK_ROLE = "ROLE_USER";
+
+  private static final List<String> ROLE_PRIORITY = List.of(
+      "ROLE_ADMIN", "ROLE_MANAGER", "ROLE_SERVICE_WRITER",
+      "ROLE_CASHIER", "ROLE_SUPPLIER", "ROLE_TECHNICIAN");
+
+  @Override
+  public @NonNull String resolvePrimaryRole(@NonNull Authentication authentication) {
+    Set<String> userRoles = authentication.getAuthorities().stream()
+        .map(GrantedAuthority::getAuthority)
+        .filter(Objects::nonNull)
+        .filter(a -> a.startsWith("ROLE_"))
+        .collect(Collectors.toSet());
+    return ROLE_PRIORITY.stream()
+        .filter(userRoles::contains)
+        .findFirst()
+        .orElse(FALLBACK_ROLE);
+  }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RolePromptResolverImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RolePromptResolverImpl.java
@@ -4,12 +4,15 @@ import com.positivity.mcp.internal.entity.SystemPrompt;
 import com.positivity.mcp.internal.repository.SystemPromptRepository;
 import com.positivity.mcp.service.RolePromptResolver;
 import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class RolePromptResolverImpl implements RolePromptResolver {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(RolePromptResolverImpl.class);
   private static final String DEFAULT_PROMPT_NAME = "default";
   private static final String BUILT_IN_PROMPT = SystemPromptDefaults.DEFAULT_PROMPT_TEXT;
 
@@ -24,7 +27,13 @@ public class RolePromptResolverImpl implements RolePromptResolver {
   public @NonNull String resolvePrompt(@NonNull String role) {
     return systemPromptRepository.findByName(role)
         .map(SystemPrompt::getContent)
-        .or(() -> systemPromptRepository.findByName(DEFAULT_PROMPT_NAME).map(SystemPrompt::getContent))
-        .orElse(BUILT_IN_PROMPT);
+        .or(() -> {
+          LOGGER.warn("MCP no role-specific system prompt found role={}; falling back to 'default' prompt", role);
+          return systemPromptRepository.findByName(DEFAULT_PROMPT_NAME).map(SystemPrompt::getContent);
+        })
+        .orElseGet(() -> {
+          LOGGER.warn("MCP no system prompt found role={} name=default; using built-in prompt", role);
+          return BUILT_IN_PROMPT;
+        });
   }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryLoader.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryLoader.java
@@ -23,6 +23,7 @@ public class ToolRegistryLoader {
 
     private static final Logger log = LoggerFactory.getLogger(ToolRegistryLoader.class);
 
+    // TODO(AC8): preload additional workflow states once session-driven routing is implemented
     private static final String WORKFLOW_IDLE = "IDLE";
 
     private final ToolMetadataRepository repository;

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryLoader.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryLoader.java
@@ -25,9 +25,6 @@ public class ToolRegistryLoader {
 
     private static final String WORKFLOW_IDLE = "IDLE";
 
-    private static final List<String> KNOWN_ROLES =
-            List.of("ROLE_CASHIER", "ROLE_SERVICE_WRITER", "ROLE_MANAGER", "ROLE_ADMIN", "ROLE_SUPPLIER");
-
     private final ToolMetadataRepository repository;
     private final ApplicationContext applicationContext;
 
@@ -46,8 +43,12 @@ public class ToolRegistryLoader {
      * Tools are resolved by their Spring bean name (handler_bean column).
      */
     public @NonNull Map<String, List<Object>> loadRoleToolMappings() {
+        List<String> roles = repository.findAllRoleNames();
+        if (roles.isEmpty()) {
+            log.warn("No roles found in mcp_role table; tool registry will be empty");
+        }
         Map<String, List<Object>> result = new HashMap<>();
-        for (String role : KNOWN_ROLES) {
+        for (String role : roles) {
             List<ToolMetadata> tools = repository.findEnabledByRoleAndWorkflow(role, WORKFLOW_IDLE);
             List<Object> beans = new ArrayList<>();
             for (ToolMetadata meta : tools) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryService.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryService.java
@@ -5,11 +5,9 @@ import com.positivity.mcp.internal.domain.ToolSelectionContext;
 import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.IntStream;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
@@ -80,17 +78,30 @@ public class ToolRegistryService {
 
         float[] embedding = embeddingModel.embed(context.userInput()).content().vector();
         int semanticLimit = Math.max(topK, 10);
-        List<ToolMetadata> semanticCandidates = repository.findTopKByEmbedding(embedding, semanticLimit);
 
-        Set<UUID> gatedIds = new HashSet<>();
-        for (ToolMetadata gated : gatedTools) {
-            gatedIds.add(gated.id());
+        // Phase 2 fix: gated ANN — only tools authorized for this role+workflow enter the
+        // ranking window. Unauthorized tools can never displace authorized ones.
+        List<ToolMetadata> semanticCandidates = repository.findTopKByEmbeddingForRole(
+                embedding, semanticLimit, context.role(), context.workflowState());
+
+        if (semanticCandidates.isEmpty()) {
+            // Fallback: tools have no embeddings yet; return highest-priority gated tools
+            LOGGER.debug(
+                    "MCP tool scoring no-embedding fallback role={} workflow={} returning top-{} by priority",
+                    context.role(),
+                    context.workflowState(),
+                    topK);
+            return gatedTools.stream()
+                    .sorted(Comparator.comparingDouble(ToolMetadata::priority)
+                            .reversed()
+                            .thenComparing(ToolMetadata::name))
+                    .limit(topK)
+                    .toList();
         }
 
-        List<ScoredTool> gatedScoredCandidates = IntStream.range(0, semanticCandidates.size())
+        List<ScoredTool> scoredCandidates = IntStream.range(0, semanticCandidates.size())
                 .mapToObj(index -> new ScoredTool(
                         semanticCandidates.get(index), scorer.score(semanticCandidates.get(index), index), index))
-                .filter(scored -> gatedIds.contains(scored.tool().id()))
                 .sorted(Comparator.comparingDouble((ScoredTool scored) -> scored.score().total())
                         .reversed()
                         .thenComparingInt(ScoredTool::rankPosition)
@@ -99,16 +110,16 @@ public class ToolRegistryService {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(
-                    "MCP tool scoring role={} workflow={} topK={} gatedTools={} semanticCandidates={} gatedCandidateScores={}",
+                    "MCP tool scoring role={} workflow={} topK={} gatedTools={} semanticCandidates={} scoredCandidates={}",
                     context.role(),
                     context.workflowState(),
                     topK,
                     toolNames(gatedTools),
                     semanticCandidateSummaries(semanticCandidates),
-                    scoredCandidateSummaries(gatedScoredCandidates));
+                    scoredCandidateSummaries(scoredCandidates));
         }
 
-        return gatedScoredCandidates.stream().limit(topK).map(ScoredTool::tool).toList();
+        return scoredCandidates.stream().limit(topK).map(ScoredTool::tool).toList();
     }
 
     private @NonNull List<ToolMetadata> adminFastPathSelection(
@@ -150,7 +161,7 @@ public class ToolRegistryService {
 
         @NonNull ToolScore score(@NonNull ToolMetadata tool, int rankPosition) {
             double semanticScore = 1.0 / (rankPosition + 1);
-            double priorityBoost = tool.priority();
+            double priorityBoost = Math.clamp(tool.priority(), 0.0, 1.0);
             double latencyPenalty = Math.min(tool.avgLatencyMs() / 1000.0, 1.0) * 0.2;
             double costPenalty =
                     switch (tool.costLevel().toLowerCase()) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryService.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryService.java
@@ -22,32 +22,30 @@ public class ToolRegistryService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ToolRegistryService.class);
     private static final String ROLE_ADMIN = "ROLE_ADMIN";
     private static final String ADMIN_FACADE_TOOL = "AdminFacadeTool";
-    private static final Set<String> ADMIN_QUERY_KEYWORDS =
-            Set.of(
-                    "user",
-                    "users",
-                    "role",
-                    "roles",
-                    "permission",
-                    "permissions",
-                    "access",
-                    "account",
-                    "accounts",
-                    "audit",
-                    "audits",
-                    "registered",
-                    "registration",
-                    "login",
-                    "logins");
-    private static final Set<String> ADMIN_QUERY_PHRASES =
-            Set.of(
-                    "who has access",
-                    "who can access",
-                    "audit log",
-                    "access review",
-                    "user count",
-                    "registered users",
-                    "account state");
+    private static final Set<String> ADMIN_QUERY_KEYWORDS = Set.of(
+            "user",
+            "users",
+            "role",
+            "roles",
+            "permission",
+            "permissions",
+            "access",
+            "account",
+            "accounts",
+            "audit",
+            "audits",
+            "registered",
+            "registration",
+            "login",
+            "logins");
+    private static final Set<String> ADMIN_QUERY_PHRASES = Set.of(
+            "who has access",
+            "who can access",
+            "audit log",
+            "access review",
+            "user count",
+            "registered users",
+            "account state");
 
     private final ToolMetadataRepository repository;
     private final EmbeddingModel embeddingModel;
@@ -64,8 +62,8 @@ public class ToolRegistryService {
             return List.of();
         }
 
-        List<ToolMetadata> gatedTools =
-                repository.findEnabledByRoleAndWorkflow(context.role(), context.workflowState());
+        List<ToolMetadata> gatedTools = repository.findEnabledByRoleAndWorkflow(context.role(),
+                context.workflowState());
 
         if (gatedTools.isEmpty()) {
             return List.of();
@@ -79,7 +77,8 @@ public class ToolRegistryService {
         float[] embedding = embeddingModel.embed(context.userInput()).content().vector();
         int semanticLimit = Math.max(topK, 10);
 
-        // Phase 2 fix: gated ANN — only tools authorized for this role+workflow enter the
+        // Phase 2 fix: gated ANN — only tools authorized for this role+workflow enter
+        // the
         // ranking window. Unauthorized tools can never displace authorized ones.
         List<ToolMetadata> semanticCandidates = repository.findTopKByEmbeddingForRole(
                 embedding, semanticLimit, context.role(), context.workflowState());
@@ -159,16 +158,16 @@ public class ToolRegistryService {
 
     static final class ToolScorer {
 
-        @NonNull ToolScore score(@NonNull ToolMetadata tool, int rankPosition) {
+        @NonNull
+        ToolScore score(@NonNull ToolMetadata tool, int rankPosition) {
             double semanticScore = 1.0 / (rankPosition + 1);
             double priorityBoost = Math.clamp(tool.priority(), 0.0, 1.0);
             double latencyPenalty = Math.min(tool.avgLatencyMs() / 1000.0, 1.0) * 0.2;
-            double costPenalty =
-                    switch (tool.costLevel().toLowerCase()) {
-                        case "high" -> 0.2;
-                        case "medium" -> 0.1;
-                        default -> 0.0;
-                    };
+            double costPenalty = switch (tool.costLevel().toLowerCase()) {
+                case "high" -> 0.2;
+                case "medium" -> 0.1;
+                default -> 0.0;
+            };
             return new ToolScore(
                     semanticScore + priorityBoost - latencyPenalty - costPenalty,
                     semanticScore,
@@ -206,7 +205,9 @@ public class ToolRegistryService {
     }
 
     private record ToolScore(
-            double total, double semanticScore, double priorityBoost, double latencyPenalty, double costPenalty) {}
+            double total, double semanticScore, double priorityBoost, double latencyPenalty, double costPenalty) {
+    }
 
-    private record ScoredTool(@NonNull ToolMetadata tool, @NonNull ToolScore score, int rankPosition) {}
+    private record ScoredTool(@NonNull ToolMetadata tool, @NonNull ToolScore score, int rankPosition) {
+    }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/service/McpRoleResolver.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/service/McpRoleResolver.java
@@ -1,0 +1,20 @@
+package com.positivity.mcp.service;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Resolves the primary role for an authenticated MCP caller.
+ * Returns the highest-priority ROLE_ authority present, or "ROLE_USER" as a
+ * safe default when no known role is present.
+ */
+public interface McpRoleResolver {
+
+  /**
+   * Returns the single highest-priority role for the given authentication.
+   * The role is selected by a deterministic priority list. Falls back to
+   * "ROLE_USER" if none of the known roles are present.
+   */
+  @NonNull
+  String resolvePrimaryRole(@NonNull Authentication authentication);
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
@@ -62,6 +62,12 @@ public class SessionAgentManagerTestConfiguration {
             }
 
             @Override
+            public java.util.List<com.positivity.mcp.internal.domain.ToolMetadata> findTopKByEmbeddingForRole(
+                    float[] embedding, int limit, String role, String workflowState) {
+                return List.of();
+            }
+
+            @Override
             public java.util.List<com.positivity.mcp.internal.domain.ToolMetadata> findTopKByEmbedding(
                     float[] embedding, int limit) {
                 return List.of();

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
@@ -51,6 +51,11 @@ public class SessionAgentManagerTestConfiguration {
     ToolMetadataRepository toolMetadataRepository() {
         return new ToolMetadataRepository() {
             @Override
+            public java.util.List<String> findAllRoleNames() {
+                return List.of();
+            }
+
+            @Override
             public java.util.List<com.positivity.mcp.internal.domain.ToolMetadata> findEnabledByRoleAndWorkflow(
                     String role, String workflowState) {
                 return List.of();

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpChatControllerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpChatControllerTest.java
@@ -73,10 +73,10 @@ class McpChatControllerTest {
                         new SimpleGrantedAuthority(McpPermissions.MCP_CHAT_EXECUTE)));
 
         mockMvc.perform(post("/v1/mcp/chat")
-                        .principal(authentication)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"test\"}"))
+                .principal(authentication)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"message\":\"test\"}"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.response").value("assistant reply"));
@@ -97,10 +97,10 @@ class McpChatControllerTest {
                         new SimpleGrantedAuthority(McpPermissions.MCP_CHAT_EXECUTE)));
 
         mockMvc.perform(post("/v1/mcp/chat")
-                        .principal(authentication)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"test\"}"))
+                .principal(authentication)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"message\":\"test\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.response").value("assistant reply"));
 
@@ -115,9 +115,9 @@ class McpChatControllerTest {
                 .thenThrow(new RuntimeException("boom"));
 
         mockMvc.perform(post("/v1/mcp/chat")
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"test\"}"))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"message\":\"test\"}"))
                 .andExpect(status().isInternalServerError())
                 .andExpect(header().exists("X-Correlation-Id"))
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -132,9 +132,9 @@ class McpChatControllerTest {
     @DisplayName("POST /v1/mcp/chat unauthenticated returns 401 ApiError envelope")
     void chat_unauthenticated_returns401() throws Exception {
         mockMvc.perform(post("/v1/mcp/chat")
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"test\"}"))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"message\":\"test\"}"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(header().exists("X-Correlation-Id"))
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -150,8 +150,8 @@ class McpChatControllerTest {
     @WithMockUser(authorities = "ROLE_USER")
     void postChat_withoutChatExecuteAuthority_returns403() throws Exception {
         mockMvc.perform(post("/v1/mcp/chat")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"test\"}"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"message\":\"test\"}"))
                 .andExpect(status().isForbidden());
     }
 
@@ -160,9 +160,9 @@ class McpChatControllerTest {
     @DisplayName("POST /v1/mcp/chat with blank message returns 400 ApiError envelope")
     void chat_withBlankMessage_returns400() throws Exception {
         mockMvc.perform(post("/v1/mcp/chat")
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"\"}"))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"message\":\"\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(header().exists("X-Correlation-Id"))
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpChatControllerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpChatControllerTest.java
@@ -1,5 +1,6 @@
 package com.positivity.mcp.internal.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,7 +13,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.positivity.mcp.internal.security.McpPermissions;
 import com.positivity.mcp.service.AgentOrchestrationService;
+import com.positivity.mcp.service.McpRoleResolver;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -46,6 +50,14 @@ class McpChatControllerTest {
 
     @MockitoBean
     private AgentOrchestrationService agentOrchestrationService;
+
+    @MockitoBean
+    private McpRoleResolver mcpRoleResolver;
+
+    @BeforeEach
+    void stubRoleResolver() {
+        when(mcpRoleResolver.resolvePrimaryRole(any(Authentication.class))).thenReturn("ROLE_USER");
+    }
 
     @Test
     @WithMockUser(username = "test-user", authorities = McpPermissions.MCP_CHAT_EXECUTE)
@@ -74,6 +86,7 @@ class McpChatControllerTest {
     @WithMockUser(username = "admin.alpha", authorities = McpPermissions.MCP_CHAT_EXECUTE)
     @DisplayName("POST /v1/mcp/chat prefers ROLE_ADMIN when present in authorities")
     void chat_withAdminRole_usesAdminRoleForOrchestration() throws Exception {
+        when(mcpRoleResolver.resolvePrimaryRole(any(Authentication.class))).thenReturn("ROLE_ADMIN");
         when(agentOrchestrationService.chat(anyString(), anyString(), anyString()))
                 .thenReturn("assistant reply");
         var authentication = new UsernamePasswordAuthenticationToken(

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpStreamingChatControllerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpStreamingChatControllerTest.java
@@ -1,5 +1,6 @@
 package com.positivity.mcp.internal.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -9,13 +10,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.positivity.mcp.internal.exception.RateLimitExceededException;
+import com.positivity.mcp.service.McpRoleResolver;
 import com.positivity.mcp.service.StreamingAgentOrchestrationService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
@@ -32,6 +36,14 @@ class McpStreamingChatControllerTest {
 
     @MockitoBean
     private StreamingAgentOrchestrationService streamingSessionAgentManager;
+
+    @MockitoBean
+    private McpRoleResolver mcpRoleResolver;
+
+    @BeforeEach
+    void stubRoleResolver() {
+        when(mcpRoleResolver.resolvePrimaryRole(any(Authentication.class))).thenReturn("ROLE_USER");
+    }
 
     @Test
     @WithMockUser(username = "stream-user", authorities = "mcp:chat:stream")

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpStreamingChatControllerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpStreamingChatControllerTest.java
@@ -31,66 +31,66 @@ import reactor.core.publisher.Flux;
 @ActiveProfiles("test")
 class McpStreamingChatControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @MockitoBean
-    private StreamingAgentOrchestrationService streamingSessionAgentManager;
+        @MockitoBean
+        private StreamingAgentOrchestrationService streamingSessionAgentManager;
 
-    @MockitoBean
-    private McpRoleResolver mcpRoleResolver;
+        @MockitoBean
+        private McpRoleResolver mcpRoleResolver;
 
-    @BeforeEach
-    void stubRoleResolver() {
-        when(mcpRoleResolver.resolvePrimaryRole(any(Authentication.class))).thenReturn("ROLE_USER");
-    }
+        @BeforeEach
+        void stubRoleResolver() {
+                when(mcpRoleResolver.resolvePrimaryRole(any(Authentication.class))).thenReturn("ROLE_USER");
+        }
 
-    @Test
-    @WithMockUser(username = "stream-user", authorities = "mcp:chat:stream")
-    @DisplayName("POST /v1/mcp/chat/stream returns SSE chat events")
-    void streamChat_withValidRequest_returnsSse() throws Exception {
-        when(streamingSessionAgentManager.streamChat(anyString(), anyString(), anyString()))
-                .thenReturn(Flux.just("token-1", "token-2"));
-        var authentication = new UsernamePasswordAuthenticationToken(
-                "stream-user", "n/a", java.util.List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        @Test
+        @WithMockUser(username = "stream-user", authorities = "mcp:chat:stream")
+        @DisplayName("POST /v1/mcp/chat/stream returns SSE chat events")
+        void streamChat_withValidRequest_returnsSse() throws Exception {
+                when(streamingSessionAgentManager.streamChat(anyString(), anyString(), anyString()))
+                                .thenReturn(Flux.just("token-1", "token-2"));
+                var authentication = new UsernamePasswordAuthenticationToken(
+                                "stream-user", "n/a", java.util.List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
-        mockMvc.perform(post("/v1/mcp/chat/stream")
-                        .principal(authentication)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"hello\"}"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
-                .andExpect(content().string(org.hamcrest.Matchers.containsString("event:chat")))
-                .andExpect(content().string(org.hamcrest.Matchers.containsString("data:token-1")));
-    }
+                mockMvc.perform(post("/v1/mcp/chat/stream")
+                                .principal(authentication)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"message\":\"hello\"}"))
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
+                                .andExpect(content().string(org.hamcrest.Matchers.containsString("event:chat")))
+                                .andExpect(content().string(org.hamcrest.Matchers.containsString("data:token-1")));
+        }
 
-    @Test
-    @WithMockUser(username = "stream-user", authorities = "mcp:chat:stream")
-    @DisplayName("POST /v1/mcp/chat/stream with blank message returns 400")
-    void streamChat_withBlankMessage_returns400() throws Exception {
-        mockMvc.perform(post("/v1/mcp/chat/stream")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"\"}"))
-                .andExpect(status().isBadRequest());
-    }
+        @Test
+        @WithMockUser(username = "stream-user", authorities = "mcp:chat:stream")
+        @DisplayName("POST /v1/mcp/chat/stream with blank message returns 400")
+        void streamChat_withBlankMessage_returns400() throws Exception {
+                mockMvc.perform(post("/v1/mcp/chat/stream")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"message\":\"\"}"))
+                                .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @WithMockUser(username = "stream-user", authorities = "mcp:chat:stream")
-    @DisplayName("POST /v1/mcp/chat/stream when rate-limited returns 429 ApiError")
-    void streamChat_whenRateLimited_returns429ApiError() throws Exception {
-        when(streamingSessionAgentManager.streamChat(anyString(), anyString(), anyString()))
-                .thenThrow(new RateLimitExceededException("Rate limit exceeded"));
-        var authentication = new UsernamePasswordAuthenticationToken(
-                "stream-user", "n/a", java.util.List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        @Test
+        @WithMockUser(username = "stream-user", authorities = "mcp:chat:stream")
+        @DisplayName("POST /v1/mcp/chat/stream when rate-limited returns 429 ApiError")
+        void streamChat_whenRateLimited_returns429ApiError() throws Exception {
+                when(streamingSessionAgentManager.streamChat(anyString(), anyString(), anyString()))
+                                .thenThrow(new RateLimitExceededException("Rate limit exceeded"));
+                var authentication = new UsernamePasswordAuthenticationToken(
+                                "stream-user", "n/a", java.util.List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
-        mockMvc.perform(post("/v1/mcp/chat/stream")
-                        .principal(authentication)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"message\":\"hello\"}"))
-                .andExpect(status().isTooManyRequests())
-                .andExpect(header().exists("X-Correlation-Id"))
-                .andExpect(jsonPath("$.code").value("RATE_LIMIT_EXCEEDED"))
-                .andExpect(jsonPath("$.message").value("Rate limit exceeded"))
-                .andExpect(jsonPath("$.status").value(429));
-    }
+                mockMvc.perform(post("/v1/mcp/chat/stream")
+                                .principal(authentication)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"message\":\"hello\"}"))
+                                .andExpect(status().isTooManyRequests())
+                                .andExpect(header().exists("X-Correlation-Id"))
+                                .andExpect(jsonPath("$.code").value("RATE_LIMIT_EXCEEDED"))
+                                .andExpect(jsonPath("$.message").value("Rate limit exceeded"))
+                                .andExpect(jsonPath("$.status").value(429));
+        }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -70,216 +70,217 @@ import org.springframework.web.client.RestClient;
 @ExtendWith(MockitoExtension.class)
 class SessionAgentManagerTest {
 
-    @Mock
-    private ChatModel chatModel;
+        @Mock
+        private ChatModel chatModel;
 
-    @Mock
-    private EmbeddingModel embeddingModel;
+        @Mock
+        private EmbeddingModel embeddingModel;
 
-    @Mock
-    private PgVectorEmbeddingStore embeddingStore;
+        @Mock
+        private PgVectorEmbeddingStore embeddingStore;
 
-    @Mock
-    private ToolRegistry toolRegistry;
+        @Mock
+        private ToolRegistry toolRegistry;
 
-    @Mock
-    private ToolRegistryService toolRegistryService;
+        @Mock
+        private ToolRegistryService toolRegistryService;
 
-    @Mock
-    private RolePromptResolver rolePromptResolver;
+        @Mock
+        private RolePromptResolver rolePromptResolver;
 
-    // Real instance required: Mockito subclasses cause @Tool duplicate registration
-    // in LangChain4j
-    private ExaWebSearchTool exaWebSearchTool;
-    private InventoryFacadeTool inventoryFacadeTool;
-    private OrderFacadeTool orderFacadeTool;
-    private SimpleChatClassifier simpleChatClassifier;
+        // Real instance required: Mockito subclasses cause @Tool duplicate registration
+        // in LangChain4j
+        private ExaWebSearchTool exaWebSearchTool;
+        private InventoryFacadeTool inventoryFacadeTool;
+        private OrderFacadeTool orderFacadeTool;
+        private SimpleChatClassifier simpleChatClassifier;
 
-    private SessionAgentManager manager;
+        private SessionAgentManager manager;
 
-    @BeforeEach
-    void setUp() {
-        // Return a FRESH list on every invocation so buildAgent mutations don't bleed
-        // across calls
-        when(toolRegistry.resolveToolsForRole(anyString())).thenAnswer(inv -> new ArrayList<>());
-        lenient()
-                .when(toolRegistry.resolveToolsForRole(anyString(), anyCollection()))
-                .thenAnswer(inv -> new ArrayList<>());
-        when(toolRegistry.preloadableRoles()).thenReturn(Set.of("ROLE_CASHIER", "ROLE_MANAGER"));
-        lenient()
-                .when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), anyInt()))
-                .thenReturn(List.of());
-        lenient().when(rolePromptResolver.resolvePrompt(anyString())).thenReturn("Default role prompt");
-        lenient().when(embeddingModel.embed(anyString()))
-                .thenReturn(Response.from(Embedding.from(new float[] { 0.1f })));
-        lenient().when(embeddingStore.search(any())).thenReturn(new EmbeddingSearchResult<>(List.of()));
-        exaWebSearchTool = new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
-        inventoryFacadeTool = new InventoryFacadeTool(RestClient.builder(), "http://localhost/v1/inventory");
-        orderFacadeTool = new OrderFacadeTool(RestClient.builder(), "http://localhost/v1/orders");
-        simpleChatClassifier = new SimpleChatClassifier(SimpleChatRuleDefaults.defaultCatalog());
-        manager = new SessionAgentManager(
-                chatModel,
-                embeddingModel,
-                embeddingStore,
-                toolRegistry,
-                exaWebSearchTool,
-                inventoryFacadeTool,
-                orderFacadeTool,
-                toolRegistryService,
-                null,
-                rolePromptResolver,
-                simpleChatClassifier,
-                30,
-                500,
-                50,
-                5,
-                100);
-        clearInvocations(toolRegistry);
-        clearInvocations(toolRegistryService);
-    }
+        @BeforeEach
+        void setUp() {
+                // Return a FRESH list on every invocation so buildAgent mutations don't bleed
+                // across calls
+                when(toolRegistry.resolveToolsForRole(anyString())).thenAnswer(inv -> new ArrayList<>());
+                lenient()
+                                .when(toolRegistry.resolveToolsForRole(anyString(), anyCollection()))
+                                .thenAnswer(inv -> new ArrayList<>());
+                when(toolRegistry.preloadableRoles()).thenReturn(Set.of("ROLE_CASHIER", "ROLE_MANAGER"));
+                lenient()
+                                .when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class),
+                                                anyInt()))
+                                .thenReturn(List.of());
+                lenient().when(rolePromptResolver.resolvePrompt(anyString())).thenReturn("Default role prompt");
+                lenient().when(embeddingModel.embed(anyString()))
+                                .thenReturn(Response.from(Embedding.from(new float[] { 0.1f })));
+                lenient().when(embeddingStore.search(any())).thenReturn(new EmbeddingSearchResult<>(List.of()));
+                exaWebSearchTool = new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
+                inventoryFacadeTool = new InventoryFacadeTool(RestClient.builder(), "http://localhost/v1/inventory");
+                orderFacadeTool = new OrderFacadeTool(RestClient.builder(), "http://localhost/v1/orders");
+                simpleChatClassifier = new SimpleChatClassifier(SimpleChatRuleDefaults.defaultCatalog());
+                manager = new SessionAgentManager(
+                                chatModel,
+                                embeddingModel,
+                                embeddingStore,
+                                toolRegistry,
+                                exaWebSearchTool,
+                                inventoryFacadeTool,
+                                orderFacadeTool,
+                                toolRegistryService,
+                                null,
+                                rolePromptResolver,
+                                simpleChatClassifier,
+                                30,
+                                500,
+                                50,
+                                5,
+                                100);
+                clearInvocations(toolRegistry);
+                clearInvocations(toolRegistryService);
+        }
 
-    @Test
-    @DisplayName("getOrCreateAgent returns the same proxy instance for the same userId")
-    void getOrCreateAgent_returnsSameInstanceForSameUser() {
-        PosAssistant first = manager.getOrCreateAgent("user-1", "TECH");
-        PosAssistant second = manager.getOrCreateAgent("user-1", "TECH");
+        @Test
+        @DisplayName("getOrCreateAgent returns the same proxy instance for the same userId")
+        void getOrCreateAgent_returnsSameInstanceForSameUser() {
+                PosAssistant first = manager.getOrCreateAgent("user-1", "TECH");
+                PosAssistant second = manager.getOrCreateAgent("user-1", "TECH");
 
-        assertThat(first).isSameAs(second);
-    }
+                assertThat(first).isSameAs(second);
+        }
 
-    @Test
-    @DisplayName("getOrCreateAgent reuses the prebuilt role proxy for different userIds")
-    void getOrCreateAgent_reusesRoleProxyForDifferentUsers() {
-        PosAssistant forUser1 = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
-        PosAssistant forUser2 = manager.getOrCreateAgent("user-2", "ROLE_CASHIER");
+        @Test
+        @DisplayName("getOrCreateAgent reuses the prebuilt role proxy for different userIds")
+        void getOrCreateAgent_reusesRoleProxyForDifferentUsers() {
+                PosAssistant forUser1 = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+                PosAssistant forUser2 = manager.getOrCreateAgent("user-2", "ROLE_CASHIER");
 
-        assertThat(forUser1).isSameAs(forUser2);
-    }
+                assertThat(forUser1).isSameAs(forUser2);
+        }
 
-    @Test
-    @DisplayName("getOrCreateAgent rebuilds agent when role changes for same userId")
-    void getOrCreateAgent_roleChange_rebuildsAgent() {
-        PosAssistant original = manager.getOrCreateAgent("user-1", "TECH");
-        PosAssistant afterRoleChange = manager.getOrCreateAgent("user-1", "MANAGER");
+        @Test
+        @DisplayName("getOrCreateAgent rebuilds agent when role changes for same userId")
+        void getOrCreateAgent_roleChange_rebuildsAgent() {
+                PosAssistant original = manager.getOrCreateAgent("user-1", "TECH");
+                PosAssistant afterRoleChange = manager.getOrCreateAgent("user-1", "MANAGER");
 
-        assertThat(afterRoleChange).isNotSameAs(original);
-    }
+                assertThat(afterRoleChange).isNotSameAs(original);
+        }
 
-    @Test
-    @DisplayName("getOrCreateAgent skips fallback tools already resolved for the role")
-    void getOrCreateAgent_skipsDuplicateFallbackTool() {
-        when(toolRegistry.resolveToolsForRole("ROLE_DUPLICATE"))
-                .thenAnswer(inv -> new ArrayList<>(List.of(inventoryFacadeTool)));
+        @Test
+        @DisplayName("getOrCreateAgent skips fallback tools already resolved for the role")
+        void getOrCreateAgent_skipsDuplicateFallbackTool() {
+                when(toolRegistry.resolveToolsForRole("ROLE_DUPLICATE"))
+                                .thenAnswer(inv -> new ArrayList<>(List.of(inventoryFacadeTool)));
 
-        PosAssistant agent = manager.getOrCreateAgent("user-with-role-tool", "ROLE_DUPLICATE");
+                PosAssistant agent = manager.getOrCreateAgent("user-with-role-tool", "ROLE_DUPLICATE");
 
-        assertThat(agent).isNotNull();
-    }
+                assertThat(agent).isNotNull();
+        }
 
-    @Test
-    @DisplayName("evict leaves prebuilt role agent cached")
-    void evict_leavesPrebuiltRoleAgentCached() {
-        PosAssistant before = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
-        manager.evict("user-1");
+        @Test
+        @DisplayName("evict leaves prebuilt role agent cached")
+        void evict_leavesPrebuiltRoleAgentCached() {
+                PosAssistant before = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+                manager.evict("user-1");
 
-        @SuppressWarnings("unchecked")
-        Cache<String, ?> cache = (Cache<String, ?>) ReflectionTestUtils.getField(manager, "roleAgentCache");
-        assertThat(cache).isNotNull();
-        cache.cleanUp();
-        assertThat(cache.estimatedSize()).isPositive();
+                @SuppressWarnings("unchecked")
+                Cache<String, ?> cache = (Cache<String, ?>) ReflectionTestUtils.getField(manager, "roleAgentCache");
+                assertThat(cache).isNotNull();
+                cache.cleanUp();
+                assertThat(cache.estimatedSize()).isPositive();
 
-        PosAssistant after = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
-        assertThat(after).isSameAs(before);
-    }
+                PosAssistant after = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+                assertThat(after).isSameAs(before);
+        }
 
-    @Test
-    @DisplayName("chat with greeting uses simple no-tool model path")
-    void chat_withGreeting_usesSimpleModelPath() {
-        when(chatModel.chat(org.mockito.ArgumentMatchers.<List<ChatMessage>>any()))
-                .thenReturn(ChatResponse.builder()
-                        .aiMessage(AiMessage.from("Hello!"))
-                        .build());
+        @Test
+        @DisplayName("chat with greeting uses simple no-tool model path")
+        void chat_withGreeting_usesSimpleModelPath() {
+                when(chatModel.chat(org.mockito.ArgumentMatchers.<List<ChatMessage>>any()))
+                                .thenReturn(ChatResponse.builder()
+                                                .aiMessage(AiMessage.from("Hello!"))
+                                                .build());
 
-        String response = manager.chat("user-1", "ROLE_ADMIN", "hello");
+                String response = manager.chat("user-1", "ROLE_ADMIN", "hello");
 
-        assertThat(response).isEqualTo("Hello!");
-        verify(toolRegistryService, never()).resolveCandidateTools(any(ToolSelectionContext.class), anyInt());
-    }
+                assertThat(response).isEqualTo("Hello!");
+                verify(toolRegistryService, never()).resolveCandidateTools(any(ToolSelectionContext.class), anyInt());
+        }
 
-    @Test
-    @DisplayName("chat with business request narrows role tools per message")
-    void chat_withBusinessRequest_narrowsRoleToolsPerMessage() {
-        ToolMetadata inventoryTool = new ToolMetadata(
-                UUID.randomUUID(),
-                "inventoryFacadeTool",
-                "Inventory",
-                "Inventory availability",
-                "inventory",
-                1.0,
-                "low",
-                200,
-                true,
-                "inventoryFacadeTool");
-        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), anyInt()))
-                .thenReturn(List.of(inventoryTool));
-        when(toolRegistry.resolveToolsForRole("ROLE_ADMIN", List.of("inventoryFacadeTool")))
-                .thenReturn(new ArrayList<>(List.of(inventoryFacadeTool)));
-        when(chatModel.chat(any(ChatRequest.class)))
-                .thenReturn(ChatResponse.builder()
-                        .aiMessage(AiMessage.from("Stock found"))
-                        .build());
+        @Test
+        @DisplayName("chat with business request narrows role tools per message")
+        void chat_withBusinessRequest_narrowsRoleToolsPerMessage() {
+                ToolMetadata inventoryTool = new ToolMetadata(
+                                UUID.randomUUID(),
+                                "inventoryFacadeTool",
+                                "Inventory",
+                                "Inventory availability",
+                                "inventory",
+                                1.0,
+                                "low",
+                                200,
+                                true,
+                                "inventoryFacadeTool");
+                when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), anyInt()))
+                                .thenReturn(List.of(inventoryTool));
+                when(toolRegistry.resolveToolsForRole("ROLE_ADMIN", List.of("inventoryFacadeTool")))
+                                .thenReturn(new ArrayList<>(List.of(inventoryFacadeTool)));
+                when(chatModel.chat(any(ChatRequest.class)))
+                                .thenReturn(ChatResponse.builder()
+                                                .aiMessage(AiMessage.from("Stock found"))
+                                                .build());
 
-        String response = manager.chat("user-1", "ROLE_ADMIN", "check stock for sku ABC");
+                String response = manager.chat("user-1", "ROLE_ADMIN", "check stock for sku ABC");
 
-        assertThat(response).isEqualTo("Stock found");
-        verify(toolRegistryService).resolveCandidateTools(any(ToolSelectionContext.class), anyInt());
-        verify(toolRegistry).resolveToolsForRole("ROLE_ADMIN", List.of("inventoryFacadeTool"));
-    }
+                assertThat(response).isEqualTo("Stock found");
+                verify(toolRegistryService).resolveCandidateTools(any(ToolSelectionContext.class), anyInt());
+                verify(toolRegistry).resolveToolsForRole("ROLE_ADMIN", List.of("inventoryFacadeTool"));
+        }
 
-    @Test
-    @DisplayName("chat with empty semantic selection falls back to full role tool set")
-    void chat_withEmptySemanticSelection_usesFullRoleToolSet() {
-        when(toolRegistry.resolveToolsForRole("ROLE_ADMIN"))
-                .thenReturn(new ArrayList<>(List.of(inventoryFacadeTool)));
-        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), anyInt()))
-                .thenReturn(List.of());
-        when(chatModel.chat(any(ChatRequest.class)))
-                .thenReturn(ChatResponse.builder()
-                        .aiMessage(AiMessage.from("Stock found"))
-                        .build());
+        @Test
+        @DisplayName("chat with empty semantic selection falls back to full role tool set")
+        void chat_withEmptySemanticSelection_usesFullRoleToolSet() {
+                when(toolRegistry.resolveToolsForRole("ROLE_ADMIN"))
+                                .thenReturn(new ArrayList<>(List.of(inventoryFacadeTool)));
+                when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), anyInt()))
+                                .thenReturn(List.of());
+                when(chatModel.chat(any(ChatRequest.class)))
+                                .thenReturn(ChatResponse.builder()
+                                                .aiMessage(AiMessage.from("Stock found"))
+                                                .build());
 
-        String response = manager.chat("user-1", "ROLE_ADMIN", "check stock for sku ABC");
+                String response = manager.chat("user-1", "ROLE_ADMIN", "check stock for sku ABC");
 
-        assertThat(response).isEqualTo("Stock found");
-        verify(toolRegistry).resolveToolsForRole("ROLE_ADMIN");
-        verify(toolRegistry, never()).resolveToolsForRole("ROLE_ADMIN", List.of());
-    }
+                assertThat(response).isEqualTo("Stock found");
+                verify(toolRegistry).resolveToolsForRole("ROLE_ADMIN");
+                verify(toolRegistry, never()).resolveToolsForRole("ROLE_ADMIN", List.of());
+        }
 
-    @Test
-    @DisplayName("getOrCreateAgent rebuilds agent after cache TTL expiry")
-    void getOrCreateAgent_rebuildsAgentAfterCacheTtlExpiry() {
-        SessionAgentManager expiringManager = new SessionAgentManager(
-                chatModel,
-                embeddingModel,
-                embeddingStore,
-                toolRegistry,
-                exaWebSearchTool,
-                inventoryFacadeTool,
-                orderFacadeTool,
-                toolRegistryService,
-                null,
-                rolePromptResolver,
-                simpleChatClassifier,
-                0,
-                500,
-                50,
-                5,
-                100);
-        clearInvocations(toolRegistry);
+        @Test
+        @DisplayName("getOrCreateAgent rebuilds agent after cache TTL expiry")
+        void getOrCreateAgent_rebuildsAgentAfterCacheTtlExpiry() {
+                SessionAgentManager expiringManager = new SessionAgentManager(
+                                chatModel,
+                                embeddingModel,
+                                embeddingStore,
+                                toolRegistry,
+                                exaWebSearchTool,
+                                inventoryFacadeTool,
+                                orderFacadeTool,
+                                toolRegistryService,
+                                null,
+                                rolePromptResolver,
+                                simpleChatClassifier,
+                                0,
+                                500,
+                                50,
+                                5,
+                                100);
+                clearInvocations(toolRegistry);
 
-        expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
-        expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+                expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+                expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
 
-        verify(toolRegistry, times(2)).resolveToolsForRole("ROLE_CASHIER");
-    }
+                verify(toolRegistry, times(2)).resolveToolsForRole("ROLE_CASHIER");
+        }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -252,5 +253,33 @@ class SessionAgentManagerTest {
         assertThat(response).isEqualTo("Stock found");
         verify(toolRegistry).resolveToolsForRole("ROLE_ADMIN");
         verify(toolRegistry, never()).resolveToolsForRole("ROLE_ADMIN", List.of());
+    }
+
+    @Test
+    @DisplayName("getOrCreateAgent rebuilds agent after cache TTL expiry")
+    void getOrCreateAgent_rebuildsAgentAfterCacheTtlExpiry() {
+        SessionAgentManager expiringManager = new SessionAgentManager(
+                chatModel,
+                embeddingModel,
+                embeddingStore,
+                toolRegistry,
+                exaWebSearchTool,
+                inventoryFacadeTool,
+                orderFacadeTool,
+                toolRegistryService,
+                null,
+                rolePromptResolver,
+                simpleChatClassifier,
+                0,
+                500,
+                50,
+                5,
+                100);
+        clearInvocations(toolRegistry);
+
+        expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+        expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+
+        verify(toolRegistry, times(2)).resolveToolsForRole("ROLE_CASHIER");
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -6,9 +6,11 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
 import com.positivity.mcp.internal.orchestration.tools.InventoryFacadeTool;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestClient;
 import reactor.core.publisher.Flux;
 
@@ -221,5 +224,98 @@ class StreamingSessionAgentManagerTest {
         assertThat(result).isNotNull();
         // fallback resolves from role tool set
         verify(toolRegistry).resolveToolsForRole("ROLE_CASHIER");
+    }
+
+    @Test
+    @DisplayName("streamChat with inventory keyword includes inventory fallback tool")
+    void streamChat_withInventoryKeyword_includesInventoryFallbackTool() {
+        when(toolRegistryService.resolveCandidateTools(any(), anyInt())).thenReturn(List.of());
+
+        StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
+                streamingChatModel,
+                embeddingModel,
+                embeddingStore,
+                toolRegistry,
+                exaWebSearchTool,
+                inventoryFacadeTool,
+                orderFacadeTool,
+                rolePromptResolver,
+                toolRegistryService,
+                null,
+                30,
+                500,
+                50,
+                2,
+                100);
+
+        selectorManager.streamChat("user-1", "ROLE_CASHIER", "stock part 1234");
+
+        assertThat(roleAgentCacheKeys(selectorManager))
+                .contains("ROLE_CASHIER::InventoryFacadeTool")
+            .contains("ROLE_CASHIER::full");
+    }
+
+    @Test
+    @DisplayName("streamChat with web keyword includes exa fallback tool")
+    void streamChat_withWebKeyword_includesExaFallbackTool() {
+        when(toolRegistryService.resolveCandidateTools(any(), anyInt())).thenReturn(List.of());
+
+        StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
+                streamingChatModel,
+                embeddingModel,
+                embeddingStore,
+                toolRegistry,
+                exaWebSearchTool,
+                inventoryFacadeTool,
+                orderFacadeTool,
+                rolePromptResolver,
+                toolRegistryService,
+                null,
+                30,
+                500,
+                50,
+                2,
+                100);
+
+        selectorManager.streamChat("user-1", "ROLE_CASHIER", "latest internet news");
+
+        assertThat(roleAgentCacheKeys(selectorManager))
+                .contains("ROLE_CASHIER::ExaWebSearchTool")
+            .contains("ROLE_CASHIER::full");
+    }
+
+    @Test
+    @DisplayName("streamChat rebuilds agent after cache TTL expiry")
+    void streamChat_rebuildsAgentAfterCacheTtlExpiry() {
+        StreamingSessionAgentManager expiringManager = new StreamingSessionAgentManager(
+                streamingChatModel,
+                embeddingModel,
+                embeddingStore,
+                toolRegistry,
+                exaWebSearchTool,
+                inventoryFacadeTool,
+                orderFacadeTool,
+                rolePromptResolver,
+                null,
+                null,
+                0,
+                500,
+                50,
+                2,
+                100);
+        clearInvocations(toolRegistry);
+
+        expiringManager.streamChat("user-1", "ROLE_CASHIER", "first");
+        expiringManager.streamChat("user-1", "ROLE_CASHIER", "second");
+
+        verify(toolRegistry, times(2)).resolveToolsForRole("ROLE_CASHIER");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> roleAgentCacheKeys(StreamingSessionAgentManager selectorManager) {
+        Cache<String, ?> cache = (Cache<String, ?>) ReflectionTestUtils.getField(selectorManager, "roleAgentCache");
+        assertThat(cache).isNotNull();
+        cache.cleanUp();
+        return cache.asMap().keySet();
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -84,10 +84,12 @@ class StreamingSessionAgentManagerTest {
                 toolRegistry,
                 exaWebSearchTool,
                 rolePromptResolver,
-                null,
+                null, // toolRegistryService — null exercises null-safe fallback path
+                null, // toolAuditService
                 30,
                 500,
                 50,
+                2,
                 100);
         clearInvocations(toolRegistry);
     }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.when;
 
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
+import com.positivity.mcp.internal.orchestration.tools.InventoryFacadeTool;
+import com.positivity.mcp.internal.orchestration.tools.OrderFacadeTool;
 import com.positivity.mcp.internal.service.ToolRegistryService;
 import com.positivity.mcp.service.RolePromptResolver;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -73,6 +75,8 @@ class StreamingSessionAgentManagerTest {
 
     // Real instance required to prevent @Tool duplicate registration
     private ExaWebSearchTool exaWebSearchTool;
+    private InventoryFacadeTool inventoryFacadeTool;
+    private OrderFacadeTool orderFacadeTool;
 
     private StreamingSessionAgentManager manager;
 
@@ -84,12 +88,16 @@ class StreamingSessionAgentManagerTest {
         when(toolRegistry.preloadableRoles()).thenReturn(Set.of("ROLE_CASHIER", "ROLE_MANAGER"));
         lenient().when(rolePromptResolver.resolvePrompt(any())).thenReturn("Default role prompt");
         exaWebSearchTool = new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
+        inventoryFacadeTool = new InventoryFacadeTool(RestClient.builder(), "http://pos-inventory/v1/inventory");
+        orderFacadeTool = new OrderFacadeTool(RestClient.builder(), "http://pos-order/v1/orders");
         manager = new StreamingSessionAgentManager(
                 streamingChatModel,
                 embeddingModel,
                 embeddingStore,
                 toolRegistry,
                 exaWebSearchTool,
+            inventoryFacadeTool,
+            orderFacadeTool,
                 rolePromptResolver,
                 null, // toolRegistryService — null exercises null-safe fallback path
                 null, // toolAuditService
@@ -163,7 +171,7 @@ class StreamingSessionAgentManagerTest {
 
         StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
                 streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
-                exaWebSearchTool, rolePromptResolver,
+            exaWebSearchTool, inventoryFacadeTool, orderFacadeTool, rolePromptResolver,
                 toolRegistryService,
                 null, 30, 500, 50, 2, 100);
         clearInvocations(toolRegistry);
@@ -182,7 +190,7 @@ class StreamingSessionAgentManagerTest {
 
         StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
                 streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
-                exaWebSearchTool, rolePromptResolver,
+            exaWebSearchTool, inventoryFacadeTool, orderFacadeTool, rolePromptResolver,
                 toolRegistryService,
                 null, 30, 500, 50, 2, 100);
         clearInvocations(toolRegistry);
@@ -203,7 +211,7 @@ class StreamingSessionAgentManagerTest {
 
         StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
                 streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
-                exaWebSearchTool, rolePromptResolver,
+            exaWebSearchTool, inventoryFacadeTool, orderFacadeTool, rolePromptResolver,
                 toolRegistryService,
                 null, 30, 500, 50, 2, 100);
         clearInvocations(toolRegistry);

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -99,8 +99,8 @@ class StreamingSessionAgentManagerTest {
                 embeddingStore,
                 toolRegistry,
                 exaWebSearchTool,
-            inventoryFacadeTool,
-            orderFacadeTool,
+                inventoryFacadeTool,
+                orderFacadeTool,
                 rolePromptResolver,
                 null, // toolRegistryService — null exercises null-safe fallback path
                 null, // toolAuditService
@@ -174,7 +174,7 @@ class StreamingSessionAgentManagerTest {
 
         StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
                 streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
-            exaWebSearchTool, inventoryFacadeTool, orderFacadeTool, rolePromptResolver,
+                exaWebSearchTool, inventoryFacadeTool, orderFacadeTool, rolePromptResolver,
                 toolRegistryService,
                 null, 30, 500, 50, 2, 100);
         clearInvocations(toolRegistry);
@@ -193,7 +193,7 @@ class StreamingSessionAgentManagerTest {
 
         StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
                 streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
-            exaWebSearchTool, inventoryFacadeTool, orderFacadeTool, rolePromptResolver,
+                exaWebSearchTool, inventoryFacadeTool, orderFacadeTool, rolePromptResolver,
                 toolRegistryService,
                 null, 30, 500, 50, 2, 100);
         clearInvocations(toolRegistry);
@@ -214,7 +214,7 @@ class StreamingSessionAgentManagerTest {
 
         StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
                 streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
-            exaWebSearchTool, inventoryFacadeTool, orderFacadeTool, rolePromptResolver,
+                exaWebSearchTool, inventoryFacadeTool, orderFacadeTool, rolePromptResolver,
                 toolRegistryService,
                 null, 30, 500, 50, 2, 100);
         clearInvocations(toolRegistry);
@@ -252,7 +252,7 @@ class StreamingSessionAgentManagerTest {
 
         assertThat(roleAgentCacheKeys(selectorManager))
                 .contains("ROLE_CASHIER::InventoryFacadeTool")
-            .contains("ROLE_CASHIER::full");
+                .contains("ROLE_CASHIER::full");
     }
 
     @Test
@@ -281,7 +281,7 @@ class StreamingSessionAgentManagerTest {
 
         assertThat(roleAgentCacheKeys(selectorManager))
                 .contains("ROLE_CASHIER::ExaWebSearchTool")
-            .contains("ROLE_CASHIER::full");
+                .contains("ROLE_CASHIER::full");
     }
 
     @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -166,11 +166,12 @@ class StreamingSessionAgentManagerTest {
     @DisplayName("streamChat uses semantically narrowed tools when selector returns candidates")
     void streamChat_semanticSelection_narrowsToolsWhenCandidatesReturned() {
         ToolMetadata candidate = new ToolMetadata(
-                UUID.randomUUID(), "inventoryTool", "Inventory", "Manage inventory", "inventory",
+                UUID.randomUUID(), "InventoryFacadeTool", "Inventory", "Manage inventory", "inventory",
                 0.8, "LOW", 50, true, "inventoryFacadeTool");
         when(toolRegistryService.resolveCandidateTools(any(), anyInt())).thenReturn(List.of(candidate));
-        when(toolRegistry.resolveToolsForRole(any())).thenAnswer(inv -> new ArrayList<>());
-        when(toolRegistry.resolveToolsForRole(any(), any())).thenAnswer(inv -> new ArrayList<>());
+        when(toolRegistry.resolveToolsForRole(any())).thenReturn(List.of(exaWebSearchTool));
+        when(toolRegistry.resolveToolsForRole("ROLE_CASHIER", List.of("InventoryFacadeTool")))
+                .thenReturn(List.of(inventoryFacadeTool));
 
         StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
                 streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
@@ -183,6 +184,8 @@ class StreamingSessionAgentManagerTest {
 
         assertThat(result).isNotNull();
         verify(toolRegistryService).resolveCandidateTools(any(), anyInt());
+        verify(toolRegistry).resolveToolsForRole("ROLE_CASHIER", List.of("InventoryFacadeTool"));
+        verify(toolRegistry, times(1)).resolveToolsForRole("ROLE_CASHIER");
     }
 
     @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -2,13 +2,16 @@ package com.positivity.mcp.internal.orchestration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
+import com.positivity.mcp.internal.service.ToolRegistryService;
 import com.positivity.mcp.service.RolePromptResolver;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -16,6 +19,7 @@ import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,6 +67,9 @@ class StreamingSessionAgentManagerTest {
 
     @Mock
     private RolePromptResolver rolePromptResolver;
+
+    @Mock
+    private ToolRegistryService toolRegistryService;
 
     // Real instance required to prevent @Tool duplicate registration
     private ExaWebSearchTool exaWebSearchTool;
@@ -140,5 +147,71 @@ class StreamingSessionAgentManagerTest {
         Flux<String> result = manager.streamChat("user-with-role-tool", "ROLE_DUPLICATE", "hello");
 
         assertThat(result).isNotNull();
+    }
+
+    // --- Phase 3: semantic tool selection (toolRegistryService != null) ---
+
+    @Test
+    @DisplayName("streamChat uses semantically narrowed tools when selector returns candidates")
+    void streamChat_semanticSelection_narrowsToolsWhenCandidatesReturned() {
+        ToolMetadata candidate = new ToolMetadata(
+                UUID.randomUUID(), "inventoryTool", "Inventory", "Manage inventory", "inventory",
+                0.8, "LOW", 50, true, "inventoryFacadeTool");
+        when(toolRegistryService.resolveCandidateTools(any(), anyInt())).thenReturn(List.of(candidate));
+        when(toolRegistry.resolveToolsForRole(any())).thenAnswer(inv -> new ArrayList<>());
+        when(toolRegistry.resolveToolsForRole(any(), any())).thenAnswer(inv -> new ArrayList<>());
+
+        StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
+                streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
+                exaWebSearchTool, rolePromptResolver,
+                toolRegistryService,
+                null, 30, 500, 50, 2, 100);
+        clearInvocations(toolRegistry);
+
+        Flux<String> result = selectorManager.streamChat("user-1", "ROLE_CASHIER", "show me inventory levels");
+
+        assertThat(result).isNotNull();
+        verify(toolRegistryService).resolveCandidateTools(any(), anyInt());
+    }
+
+    @Test
+    @DisplayName("streamChat falls back to full role tools when selector returns empty")
+    void streamChat_semanticSelection_fallsBackToFullRoleToolsOnEmptyResult() {
+        when(toolRegistryService.resolveCandidateTools(any(), anyInt())).thenReturn(List.of());
+        when(toolRegistry.resolveToolsForRole(any())).thenAnswer(inv -> new ArrayList<>());
+
+        StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
+                streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
+                exaWebSearchTool, rolePromptResolver,
+                toolRegistryService,
+                null, 30, 500, 50, 2, 100);
+        clearInvocations(toolRegistry);
+
+        Flux<String> result = selectorManager.streamChat("user-2", "ROLE_CASHIER", "anything");
+
+        assertThat(result).isNotNull();
+        // resolveToolsForRole(role) is called for the fallback path
+        verify(toolRegistry).resolveToolsForRole("ROLE_CASHIER");
+    }
+
+    @Test
+    @DisplayName("streamChat falls back to full role tools when selector throws")
+    void streamChat_semanticSelection_fallsBackToFullRoleToolsOnException() {
+        when(toolRegistryService.resolveCandidateTools(any(), anyInt()))
+                .thenThrow(new RuntimeException("selector unavailable"));
+        when(toolRegistry.resolveToolsForRole(any())).thenAnswer(inv -> new ArrayList<>());
+
+        StreamingSessionAgentManager selectorManager = new StreamingSessionAgentManager(
+                streamingChatModel, embeddingModel, embeddingStore, toolRegistry,
+                exaWebSearchTool, rolePromptResolver,
+                toolRegistryService,
+                null, 30, 500, 50, 2, 100);
+        clearInvocations(toolRegistry);
+
+        Flux<String> result = selectorManager.streamChat("user-3", "ROLE_CASHIER", "anything");
+
+        assertThat(result).isNotNull();
+        // fallback resolves from role tool set
+        verify(toolRegistry).resolveToolsForRole("ROLE_CASHIER");
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
@@ -103,7 +103,8 @@ class ToolMetadataRepositoryImplTest {
     @SuppressWarnings("unchecked")
     void findTopKByEmbeddingForRole_returnsBoundedGatedList() {
         float[] embedding = new float[768];
-        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("ROLE_CASHIER"), eq("IDLE"), any(PGobject.class), eq(5)))
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("ROLE_CASHIER"), eq("IDLE"), any(PGobject.class),
+                eq(5)))
                 .thenReturn(List.of(SAMPLE_TOOL));
 
         List<ToolMetadata> result = repository.findTopKByEmbeddingForRole(embedding, 5, "ROLE_CASHIER", "IDLE");

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
@@ -86,4 +86,15 @@ class ToolMetadataRepositoryImplTest {
         assertThat(result).hasSize(1);
         assertThat(result.getFirst().handlerBean()).isEqualTo("customerFacadeTool");
     }
+
+    @Test
+    @DisplayName("findAllRoleNames delegates to JdbcTemplate and returns role name list")
+    void findAllRoleNames_returnsList() {
+        when(jdbcTemplate.queryForList(anyString(), eq(String.class)))
+                .thenReturn(List.of("ROLE_ADMIN", "ROLE_CASHIER", "ROLE_TECHNICIAN"));
+
+        List<String> result = repository.findAllRoleNames();
+
+        assertThat(result).containsExactly("ROLE_ADMIN", "ROLE_CASHIER", "ROLE_TECHNICIAN");
+    }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
@@ -97,4 +97,18 @@ class ToolMetadataRepositoryImplTest {
 
         assertThat(result).containsExactly("ROLE_ADMIN", "ROLE_CASHIER", "ROLE_TECHNICIAN");
     }
+
+    @Test
+    @DisplayName("findTopKByEmbeddingForRole delegates gated ANN query to JdbcTemplate")
+    @SuppressWarnings("unchecked")
+    void findTopKByEmbeddingForRole_returnsBoundedGatedList() {
+        float[] embedding = new float[768];
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("ROLE_CASHIER"), eq("IDLE"), any(PGobject.class), eq(5)))
+                .thenReturn(List.of(SAMPLE_TOOL));
+
+        List<ToolMetadata> result = repository.findTopKByEmbeddingForRole(embedding, 5, "ROLE_CASHIER", "IDLE");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().name()).isEqualTo("customerFacadeTool");
+    }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/McpRoleResolverImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/McpRoleResolverImplTest.java
@@ -1,0 +1,91 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@ExtendWith(MockitoExtension.class)
+class McpRoleResolverImplTest {
+
+  @Mock
+  private Authentication authentication;
+
+  private McpRoleResolverImpl resolver;
+
+  @BeforeEach
+  void setUp() {
+    resolver = new McpRoleResolverImpl();
+  }
+
+  private void givenAuthorities(String... roles) {
+    Collection<? extends GrantedAuthority> authorities = Stream.of(roles).map(SimpleGrantedAuthority::new).toList();
+    when(authentication.getAuthorities()).thenAnswer(inv -> authorities);
+  }
+
+  @Test
+  @DisplayName("resolvePrimaryRole returns ROLE_ADMIN when caller has admin authority")
+  void resolvePrimaryRole_admin_returnsAdmin() {
+    givenAuthorities("ROLE_ADMIN", "ROLE_CASHIER");
+    assertThat(resolver.resolvePrimaryRole(authentication)).isEqualTo("ROLE_ADMIN");
+  }
+
+  @Test
+  @DisplayName("resolvePrimaryRole returns ROLE_TECHNICIAN when only technician role present")
+  void resolvePrimaryRole_technicianOnly_returnsTechnician() {
+    givenAuthorities("ROLE_TECHNICIAN");
+    assertThat(resolver.resolvePrimaryRole(authentication)).isEqualTo("ROLE_TECHNICIAN");
+  }
+
+  @Test
+  @DisplayName("resolvePrimaryRole falls back to ROLE_USER when no known role present")
+  void resolvePrimaryRole_noKnownRole_returnsUser() {
+    givenAuthorities("ROLE_UNKNOWN");
+    assertThat(resolver.resolvePrimaryRole(authentication)).isEqualTo("ROLE_USER");
+  }
+
+  @Test
+  @DisplayName("resolvePrimaryRole falls back to ROLE_USER when authority list is empty")
+  void resolvePrimaryRole_emptyAuthorities_returnsUser() {
+    when(authentication.getAuthorities()).thenAnswer(inv -> List.of());
+    assertThat(resolver.resolvePrimaryRole(authentication)).isEqualTo("ROLE_USER");
+  }
+
+  @ParameterizedTest(name = "highest-priority role from {0} is {1}")
+  @MethodSource("rolePriorityScenarios")
+  @DisplayName("resolvePrimaryRole selects highest-priority role")
+  void resolvePrimaryRole_selectsHighestPriority(List<String> roles, String expected) {
+    givenAuthorities(roles.toArray(String[]::new));
+    assertThat(resolver.resolvePrimaryRole(authentication)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> rolePriorityScenarios() {
+    return Stream.of(
+        Arguments.of(List.of("ROLE_MANAGER", "ROLE_CASHIER"), "ROLE_MANAGER"),
+        Arguments.of(List.of("ROLE_SERVICE_WRITER", "ROLE_TECHNICIAN"), "ROLE_SERVICE_WRITER"),
+        Arguments.of(List.of("ROLE_CASHIER", "ROLE_SUPPLIER"), "ROLE_CASHIER"),
+        Arguments.of(List.of("ROLE_SUPPLIER", "ROLE_TECHNICIAN"), "ROLE_SUPPLIER"),
+        Arguments.of(List.of("ROLE_TECHNICIAN"), "ROLE_TECHNICIAN"));
+  }
+
+  @Test
+  @DisplayName("resolvePrimaryRole ignores non-ROLE_ authorities")
+  void resolvePrimaryRole_ignoresNonRoleAuthorities() {
+    givenAuthorities("mcp:chat:execute", "ROLE_CASHIER");
+    assertThat(resolver.resolvePrimaryRole(authentication)).isEqualTo("ROLE_CASHIER");
+  }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryLoaderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryLoaderTest.java
@@ -45,10 +45,8 @@ class ToolRegistryLoaderTest {
     @DisplayName("loadRoleToolMappings resolves bean by handlerBean name for an enabled tool")
     void loadRoleToolMappings_withEnabledTool_resolvesBean() {
         Object fakeTool = new Object();
-        // default: all roles return empty list
+        when(repository.findAllRoleNames()).thenReturn(List.of("ROLE_CASHIER", "ROLE_MANAGER"));
         when(repository.findEnabledByRoleAndWorkflow(anyString(), anyString())).thenReturn(List.of());
-        // override ROLE_CASHIER to return the sample tool (last stub wins for this
-        // matcher)
         when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE")).thenReturn(List.of(SAMPLE_META));
         when(applicationContext.getBean("customerFacadeTool")).thenReturn(fakeTool);
 
@@ -59,20 +57,33 @@ class ToolRegistryLoaderTest {
     }
 
     @Test
-    @DisplayName("loadRoleToolMappings returns empty lists for all known roles when no tools enabled")
+    @DisplayName("loadRoleToolMappings returns empty lists for all roles when no tools enabled")
     void loadRoleToolMappings_withNoEnabledTools_returnsEmptyListsForAllRoles() {
+        when(repository.findAllRoleNames()).thenReturn(List.of("ROLE_CASHIER", "ROLE_TECHNICIAN"));
         when(repository.findEnabledByRoleAndWorkflow(anyString(), anyString())).thenReturn(List.of());
 
         ToolRegistryLoader loader = new ToolRegistryLoader(repository, applicationContext);
         Map<String, List<Object>> result = loader.loadRoleToolMappings();
 
-        assertThat(result).isNotEmpty();
+        assertThat(result).containsOnlyKeys("ROLE_CASHIER", "ROLE_TECHNICIAN");
         result.values().forEach(tools -> assertThat(tools).isEmpty());
+    }
+
+    @Test
+    @DisplayName("loadRoleToolMappings returns empty map and logs warning when mcp_role table is empty")
+    void loadRoleToolMappings_withNoRoles_returnsEmptyMap() {
+        when(repository.findAllRoleNames()).thenReturn(List.of());
+
+        ToolRegistryLoader loader = new ToolRegistryLoader(repository, applicationContext);
+        Map<String, List<Object>> result = loader.loadRoleToolMappings();
+
+        assertThat(result).isEmpty();
     }
 
     @Test
     @DisplayName("loadRoleToolMappings skips tools whose handler bean is missing from ApplicationContext")
     void loadRoleToolMappings_withMissingBean_skipsSilently() {
+        when(repository.findAllRoleNames()).thenReturn(List.of("ROLE_CASHIER"));
         when(repository.findEnabledByRoleAndWorkflow(anyString(), anyString())).thenReturn(List.of());
         when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE")).thenReturn(List.of(SAMPLE_META));
         when(applicationContext.getBean("customerFacadeTool"))

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryLoaderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryLoaderTest.java
@@ -70,7 +70,7 @@ class ToolRegistryLoaderTest {
     }
 
     @Test
-    @DisplayName("loadRoleToolMappings returns empty map and logs warning when mcp_role table is empty")
+    @DisplayName("loadRoleToolMappings returns empty map when mcp_role table is empty")
     void loadRoleToolMappings_withNoRoles_returnsEmptyMap() {
         when(repository.findAllRoleNames()).thenReturn(List.of());
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
@@ -108,8 +108,8 @@ class ToolRegistryServiceTest {
     }
 
     @Test
-    @DisplayName("resolveCandidateTools filters semantic candidates not in gated role-workflow set")
-    void resolveCandidateTools_filtersToolsNotInGatedSet() {
+        @DisplayName("resolveCandidateTools falls back to priority-ordered gated set when ANN returns empty")
+        void resolveCandidateTools_fallsBackToGatedSet_whenAnnReturnsEmpty() {
         // This test documents the Phase 2 fix: the gated ANN returns only authorized
         // tools,
         // so an unauthorized tool can never displace an authorized one.

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
@@ -1,7 +1,10 @@
 package com.positivity.mcp.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.positivity.mcp.internal.domain.ToolMetadata;
@@ -73,7 +76,8 @@ class ToolRegistryServiceTest {
 
         when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE")).thenReturn(List.of(SAMPLE_TOOL));
         when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(vector)));
-        when(repository.findTopKByEmbedding(vector, 10)).thenReturn(List.of(SAMPLE_TOOL));
+        when(repository.findTopKByEmbeddingForRole(eq(vector), anyInt(), eq("ROLE_CASHIER"), eq("IDLE")))
+                .thenReturn(List.of(SAMPLE_TOOL));
 
         List<ToolMetadata> result = service.resolveCandidateTools(context, 5);
 
@@ -106,20 +110,40 @@ class ToolRegistryServiceTest {
     @Test
     @DisplayName("resolveCandidateTools filters semantic candidates not in gated role-workflow set")
     void resolveCandidateTools_filtersToolsNotInGatedSet() {
+        // This test documents the Phase 2 fix: the gated ANN returns only authorized tools,
+        // so an unauthorized tool can never displace an authorized one.
         ToolSelectionContext context = new ToolSelectionContext("look up customer", "ROLE_CASHIER", "IDLE");
         float[] vector = new float[] {0.1f, 0.2f};
 
-        UUID otherId = UUID.fromString("00000000-0000-0000-0000-000000000002");
-        ToolMetadata otherTool = new ToolMetadata(
-                otherId, "otherTool", "Other Tool", "Other", "other", 0.5, "low", 100, true, "otherTool");
+        when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE")).thenReturn(List.of(SAMPLE_TOOL));
+        when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(vector)));
+        // Gated ANN returns empty — simulates no embeddings for authorized tools
+        when(repository.findTopKByEmbeddingForRole(any(float[].class), anyInt(), eq("ROLE_CASHIER"), eq("IDLE")))
+                .thenReturn(List.of());
+
+        // Should fall back to priority-ordered gated tools, not empty
+        List<ToolMetadata> result = service.resolveCandidateTools(context, 5);
+
+        assertThat(result).containsExactly(SAMPLE_TOOL);
+    }
+
+    @Test
+    @DisplayName("resolveCandidateTools returns authorized tool that would have been excluded by global ANN")
+    void resolveCandidateTools_authorizedToolNotInGlobalTopK_isReturnedByGatedAnn() {
+        // Phase 2 correctness proof: authorized tool ranks beyond global top-K but is
+        // correctly returned because gated ANN searches only authorized tools.
+        ToolSelectionContext context = new ToolSelectionContext("look up customer", "ROLE_CASHIER", "IDLE");
+        float[] vector = new float[] {0.1f, 0.2f};
 
         when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE")).thenReturn(List.of(SAMPLE_TOOL));
         when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(vector)));
-        when(repository.findTopKByEmbedding(vector, 10)).thenReturn(List.of(otherTool));
+        // Gated ANN finds the authorized tool directly — no Java-filter step
+        when(repository.findTopKByEmbeddingForRole(any(float[].class), anyInt(), eq("ROLE_CASHIER"), eq("IDLE")))
+                .thenReturn(List.of(SAMPLE_TOOL));
 
         List<ToolMetadata> result = service.resolveCandidateTools(context, 5);
 
-        assertThat(result).isEmpty();
+        assertThat(result).containsExactly(SAMPLE_TOOL);
     }
 
     @Test
@@ -159,7 +183,8 @@ class ToolRegistryServiceTest {
 
         when(repository.findEnabledByRoleAndWorkflow("ROLE_MANAGER", "IDLE")).thenReturn(List.of(SAMPLE_TOOL));
         when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(vector)));
-        when(repository.findTopKByEmbedding(vector, 10)).thenReturn(List.of(SAMPLE_TOOL));
+        when(repository.findTopKByEmbeddingForRole(any(float[].class), anyInt(), eq("ROLE_MANAGER"), eq("IDLE")))
+                .thenReturn(List.of(SAMPLE_TOOL));
 
         List<ToolMetadata> result = service.resolveCandidateTools(context, 2);
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
@@ -72,7 +72,7 @@ class ToolRegistryServiceTest {
     @DisplayName("resolveCandidateTools returns scored and limited list when gated tools exist")
     void resolveCandidateTools_withGatedTools_returnsScoredList() {
         ToolSelectionContext context = new ToolSelectionContext("look up customer", "ROLE_CASHIER", "IDLE");
-        float[] vector = new float[] {0.1f, 0.2f, 0.3f};
+        float[] vector = new float[] { 0.1f, 0.2f, 0.3f };
 
         when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE")).thenReturn(List.of(SAMPLE_TOOL));
         when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(vector)));
@@ -110,10 +110,11 @@ class ToolRegistryServiceTest {
     @Test
     @DisplayName("resolveCandidateTools filters semantic candidates not in gated role-workflow set")
     void resolveCandidateTools_filtersToolsNotInGatedSet() {
-        // This test documents the Phase 2 fix: the gated ANN returns only authorized tools,
+        // This test documents the Phase 2 fix: the gated ANN returns only authorized
+        // tools,
         // so an unauthorized tool can never displace an authorized one.
         ToolSelectionContext context = new ToolSelectionContext("look up customer", "ROLE_CASHIER", "IDLE");
-        float[] vector = new float[] {0.1f, 0.2f};
+        float[] vector = new float[] { 0.1f, 0.2f };
 
         when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE")).thenReturn(List.of(SAMPLE_TOOL));
         when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(vector)));
@@ -133,7 +134,7 @@ class ToolRegistryServiceTest {
         // Phase 2 correctness proof: authorized tool ranks beyond global top-K but is
         // correctly returned because gated ANN searches only authorized tools.
         ToolSelectionContext context = new ToolSelectionContext("look up customer", "ROLE_CASHIER", "IDLE");
-        float[] vector = new float[] {0.1f, 0.2f};
+        float[] vector = new float[] { 0.1f, 0.2f };
 
         when(repository.findEnabledByRoleAndWorkflow("ROLE_CASHIER", "IDLE")).thenReturn(List.of(SAMPLE_TOOL));
         when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(vector)));
@@ -149,8 +150,8 @@ class ToolRegistryServiceTest {
     @Test
     @DisplayName("resolveCandidateTools uses admin fast-path for user and access questions")
     void resolveCandidateTools_adminQuery_usesAdminFastPath() {
-        ToolSelectionContext context =
-                new ToolSelectionContext("How many users do I have in the system?", "ROLE_ADMIN", "IDLE");
+        ToolSelectionContext context = new ToolSelectionContext("How many users do I have in the system?", "ROLE_ADMIN",
+                "IDLE");
 
         when(repository.findEnabledByRoleAndWorkflow("ROLE_ADMIN", "IDLE"))
                 .thenReturn(List.of(ADMIN_TOOL, SAMPLE_TOOL));
@@ -163,8 +164,8 @@ class ToolRegistryServiceTest {
     @Test
     @DisplayName("resolveCandidateTools uses admin fast-path for audit and account-governance questions")
     void resolveCandidateTools_adminAuditQuery_usesAdminFastPath() {
-        ToolSelectionContext context =
-                new ToolSelectionContext("Search the audit log for failed admin logins", "ROLE_ADMIN", "IDLE");
+        ToolSelectionContext context = new ToolSelectionContext("Search the audit log for failed admin logins",
+                "ROLE_ADMIN", "IDLE");
 
         when(repository.findEnabledByRoleAndWorkflow("ROLE_ADMIN", "IDLE"))
                 .thenReturn(List.of(ADMIN_TOOL, SAMPLE_TOOL));
@@ -177,9 +178,9 @@ class ToolRegistryServiceTest {
     @Test
     @DisplayName("resolveCandidateTools does not use admin fast-path for non-admin roles")
     void resolveCandidateTools_nonAdminRole_doesNotUseAdminFastPath() {
-        ToolSelectionContext context =
-                new ToolSelectionContext("How many users do I have in the system?", "ROLE_MANAGER", "IDLE");
-        float[] vector = new float[] {0.4f, 0.5f};
+        ToolSelectionContext context = new ToolSelectionContext("How many users do I have in the system?",
+                "ROLE_MANAGER", "IDLE");
+        float[] vector = new float[] { 0.4f, 0.5f };
 
         when(repository.findEnabledByRoleAndWorkflow("ROLE_MANAGER", "IDLE")).thenReturn(List.of(SAMPLE_TOOL));
         when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(vector)));

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistryServiceTest.java
@@ -108,8 +108,8 @@ class ToolRegistryServiceTest {
     }
 
     @Test
-        @DisplayName("resolveCandidateTools falls back to priority-ordered gated set when ANN returns empty")
-        void resolveCandidateTools_fallsBackToGatedSet_whenAnnReturnsEmpty() {
+    @DisplayName("resolveCandidateTools falls back to priority-ordered gated set when ANN returns empty")
+    void resolveCandidateTools_fallsBackToGatedSet_whenAnnReturnsEmpty() {
         // This test documents the Phase 2 fix: the gated ANN returns only authorized
         // tools,
         // so an unauthorized tool can never displace an authorized one.

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -3096,8 +3096,11 @@ paths:
             application/json:
               schema:
                 type: array
+                additionalProperties: {}
+                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickedItemResponse'
+                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3168,8 +3171,11 @@ paths:
             application/json:
               schema:
                 type: array
+                additionalProperties: {}
+                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickTaskResponse'
+                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3484,6 +3490,7 @@ paths:
             application/pdf:
               schema:
                 type: string
+                additionalProperties: {}
         '404':
           description: Estimate not found
           content:

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -3096,11 +3096,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickedItemResponse'
-                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3171,11 +3168,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickTaskResponse'
-                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3490,7 +3484,7 @@ paths:
             application/pdf:
               schema:
                 type: string
-                additionalProperties: {}
+                format: byte
         '404':
           description: Estimate not found
           content:

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/EstimateController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/EstimateController.java
@@ -668,7 +668,7 @@ public class EstimateController {
             + "line items grouped by type (parts and labor), and financial totals. "
             + "Rendered via pos-documents service.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "PDF generated successfully", content = @Content(mediaType = "application/pdf")),
+            @ApiResponse(responseCode = "200", description = "PDF generated successfully", content = @Content(mediaType = "application/pdf", schema = @Schema(type = "string", format = "byte"))),
             @ApiResponse(responseCode = "404", description = "Estimate not found"),
             @ApiResponse(responseCode = "502", description = "Document service unavailable")
     })

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickFacadeController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickFacadeController.java
@@ -11,6 +11,7 @@ import com.positivity.workorder.internal.dto.pick.WorkorderPickTaskResponse;
 import com.positivity.workorder.service.WorkorderPickFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -59,7 +60,9 @@ public class WorkorderPickFacadeController {
                         "inventory:pick_list:view" })
         @PreAuthorize("hasAuthority('inventory:pick_list:view')")
         @Operation(summary = "Get pick tasks for workorder")
-        @ApiResponse(responseCode = "200", description = "Pick tasks retrieved successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = WorkorderPickTaskResponse[].class)))
+        @ApiResponse(responseCode = "200", description = "Pick tasks retrieved successfully",
+                        content = @Content(mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = WorkorderPickTaskResponse.class))))
         @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "404", description = "Workorder not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<WorkorderPickTaskResponse>> getPickTasks(

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickFacadeController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickFacadeController.java
@@ -11,7 +11,6 @@ import com.positivity.workorder.internal.dto.pick.WorkorderPickTaskResponse;
 import com.positivity.workorder.service.WorkorderPickFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -60,7 +59,7 @@ public class WorkorderPickFacadeController {
                         "inventory:pick_list:view" })
         @PreAuthorize("hasAuthority('inventory:pick_list:view')")
         @Operation(summary = "Get pick tasks for workorder")
-        @ApiResponse(responseCode = "200", description = "Pick tasks retrieved successfully", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = WorkorderPickTaskResponse.class))))
+        @ApiResponse(responseCode = "200", description = "Pick tasks retrieved successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = WorkorderPickTaskResponse[].class)))
         @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "404", description = "Workorder not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<WorkorderPickTaskResponse>> getPickTasks(

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickFacadeController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickFacadeController.java
@@ -60,9 +60,7 @@ public class WorkorderPickFacadeController {
                         "inventory:pick_list:view" })
         @PreAuthorize("hasAuthority('inventory:pick_list:view')")
         @Operation(summary = "Get pick tasks for workorder")
-        @ApiResponse(responseCode = "200", description = "Pick tasks retrieved successfully",
-                        content = @Content(mediaType = "application/json",
-                                        array = @ArraySchema(schema = @Schema(implementation = WorkorderPickTaskResponse.class))))
+        @ApiResponse(responseCode = "200", description = "Pick tasks retrieved successfully", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = WorkorderPickTaskResponse.class))))
         @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "404", description = "Workorder not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<WorkorderPickTaskResponse>> getPickTasks(

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickedItemsController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickedItemsController.java
@@ -8,7 +8,6 @@ import com.positivity.workorder.internal.dto.pick.WorkorderPickedItemResponse;
 import com.positivity.workorder.service.WorkorderPickFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -42,7 +41,7 @@ public class WorkorderPickedItemsController {
                         "inventory:pick_list:view" })
         @PreAuthorize("hasAuthority('inventory:pick_list:view')")
         @Operation(summary = "Get picked items for workorder")
-        @ApiResponse(responseCode = "200", description = "Picked items retrieved successfully", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = WorkorderPickedItemResponse.class))))
+        @ApiResponse(responseCode = "200", description = "Picked items retrieved successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = WorkorderPickedItemResponse[].class)))
         @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<WorkorderPickedItemResponse>> getPickedItems(
                         @Parameter(description = "Workorder ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000") @PathVariable @NonNull UUID workorderId) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickedItemsController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickedItemsController.java
@@ -42,9 +42,7 @@ public class WorkorderPickedItemsController {
                         "inventory:pick_list:view" })
         @PreAuthorize("hasAuthority('inventory:pick_list:view')")
         @Operation(summary = "Get picked items for workorder")
-        @ApiResponse(responseCode = "200", description = "Picked items retrieved successfully",
-                        content = @Content(mediaType = "application/json",
-                                        array = @ArraySchema(schema = @Schema(implementation = WorkorderPickedItemResponse.class))))
+        @ApiResponse(responseCode = "200", description = "Picked items retrieved successfully", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = WorkorderPickedItemResponse.class))))
         @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<WorkorderPickedItemResponse>> getPickedItems(
                         @Parameter(description = "Workorder ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000") @PathVariable @NonNull UUID workorderId) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickedItemsController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderPickedItemsController.java
@@ -8,6 +8,7 @@ import com.positivity.workorder.internal.dto.pick.WorkorderPickedItemResponse;
 import com.positivity.workorder.service.WorkorderPickFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -41,7 +42,9 @@ public class WorkorderPickedItemsController {
                         "inventory:pick_list:view" })
         @PreAuthorize("hasAuthority('inventory:pick_list:view')")
         @Operation(summary = "Get picked items for workorder")
-        @ApiResponse(responseCode = "200", description = "Picked items retrieved successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = WorkorderPickedItemResponse[].class)))
+        @ApiResponse(responseCode = "200", description = "Picked items retrieved successfully",
+                        content = @Content(mediaType = "application/json",
+                                        array = @ArraySchema(schema = @Schema(implementation = WorkorderPickedItemResponse.class))))
         @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<WorkorderPickedItemResponse>> getPickedItems(
                         @Parameter(description = "Workorder ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000") @PathVariable @NonNull UUID workorderId) {

--- a/scripts/generate-openapi.sh
+++ b/scripts/generate-openapi.sh
@@ -160,12 +160,15 @@ specs = []
 for module in modules:
     spec_path = root_dir / module / "openapi.yaml"
     if not spec_path.is_file():
+        print(f"WARN: {module}/openapi.yaml not found; skipping", file=sys.stderr)
         continue
     with spec_path.open("r", encoding="utf-8") as f:
         spec = yaml.safe_load(f)
     if not isinstance(spec, dict):
+        print(f"WARN: {module}/openapi.yaml is not a valid object; skipping", file=sys.stderr)
         continue
     if not isinstance(spec.get("paths"), dict):
+        print(f"WARN: {module}/openapi.yaml has no paths section; skipping from aggregate", file=sys.stderr)
         continue
     specs.append((module, spec_path, spec))
 

--- a/scripts/sanitize-openapi.py
+++ b/scripts/sanitize-openapi.py
@@ -30,8 +30,32 @@ from pathlib import Path
 import yaml
 
 
+# Structural OpenAPI keys that must be preserved even when empty.
+_STRUCTURAL_KEYS = frozenset(
+    {
+        "paths",
+        "components",
+        "tags",
+        "schemas",
+        "responses",
+        "parameters",
+        "requestBodies",
+        "headers",
+        "securitySchemes",
+        "links",
+        "callbacks",
+    }
+)
+
+
 def _is_empty_default(value: object) -> bool:
     return value is None or value == ""
+
+
+def _should_drop_key(key: object, value: object) -> bool:
+    if key == "default" and _is_empty_default(value):
+        return True
+    return key not in _STRUCTURAL_KEYS and (value is None or value == {})
 
 
 def _clean(node: object) -> object:
@@ -43,14 +67,8 @@ def _clean(node: object) -> object:
 
         cleaned: dict[object, object] = {}
         for key, value in node.items():
-            if key == "default" and _is_empty_default(value):
-                continue
-            # Drop any key whose value is null or an empty mapping. Springdoc
-            # emits many such placeholder keys (additionalProperties, contains,
-            # unevaluatedItems, propertyNames, ...) which are syntactically
-            # valid YAML but fail OpenAPI 3.x spec validation because the
-            # validator expects a Schema object.
-            if value is None or value == {}:
+            # Drop springdoc placeholder keys that break OpenAPI 3.x validation.
+            if _should_drop_key(key, value):
                 continue
             cleaned[key] = _clean(value)
         return cleaned


### PR DESCRIPTION
# cap/639 — Enhance pos-mcp-server tool usage selection and execution coherence

## Objective

Implement 5-phase coherence improvements to `pos-mcp-server` tool usage selection and execution, addressing correctness and observability gaps identified in CAP-639.

## Specification Sources

- `/home/louis-burroughs/IdeaProjects/durion-positivity-backend/cap-637-processing.md`
- `/home/louis-burroughs/IdeaProjects/durion-positivity-backend/Durion-Processing.md` (wave-6-mcp-coherence)
- GitHub issue #639

## Modules/Files Changed

**`pos-mcp-server`** — 21 files changed

### New files
- `com.positivity.mcp.service.McpRoleResolver` — interface for priority-ordered role extraction from `Authentication`
- `com.positivity.mcp.internal.service.McpRoleResolverImpl` — ADMIN > MANAGER > SERVICE_WRITER > CASHIER > SUPPLIER > TECHNICIAN > ROLE_USER fallback
- `com.positivity.mcp.internal.service.McpRoleResolverImplTest` — 10 tests

### Modified files (production)
- `McpChatController` — inject and use `McpRoleResolver`; remove duplicated `extractPrimaryRole()`
- `McpStreamingChatController` — same
- `ToolMetadataRepository` — add `findAllRoleNames()`, `findTopKByEmbeddingForRole(float[], int, String, String)`
- `ToolMetadataRepositoryImpl` — implement gated ANN query with JOIN on `mcp_role`+`mcp_tool_role`+`mcp_workflow_state`
- `ToolRegistryLoader` — remove `KNOWN_ROLES` constant; load roles dynamically from DB via `findAllRoleNames()`
- `ToolRegistryService` — use gated `findTopKByEmbeddingForRole()`; remove post-query Java filter; add deterministic fallback; normalize `priorityBoost` with `Math.clamp`
- `SessionAgentManager` — add `expireAfterWrite(cacheTtlMinutes)` to `roleAgentCache`
- `StreamingSessionAgentManager` — inject `@Nullable ToolRegistryService`, `candidateToolLimit`; per-message `roleToolsForMessage()`; `buildAgent(role, tools)` overload; `toolCacheKey`; `role::full` cache key; `expireAfterWrite` on `roleAgentCache`
- `RolePromptResolverImpl` — add WARN log on both fallback levels

### Modified files (test)
- `StreamingSessionAgentManagerTest` — 3 new Phase 3 semantic-selection tests + constructor updated (13 params)
- `SessionAgentManagerTestConfiguration` — stub `findAllRoleNames()` and `findTopKByEmbeddingForRole()`
- `McpChatControllerTest`, `McpStreamingChatControllerTest` — updated for `McpRoleResolver` mock
- `ToolMetadataRepositoryImplTest`, `ToolRegistryLoaderTest`, `ToolRegistryServiceTest` — updated for new methods

### Documentation
- `pos-mcp-server/README.md` — document new classes, `mcp.agent.candidate-tool-limit` config, and Semantic Per-Request Tool Selection section

## Problem → Fix Summary

| # | Root Defect | Fix |
|---|---|---|
| 1 | `KNOWN_ROLES` hardcoded in `ToolRegistryLoader` — missing `ROLE_TECHNICIAN`, `ROLE_SUPPLIER` | Dynamic `findAllRoleNames()` from `mcp_role` table |
| 2 | Duplicated `extractPrimaryRole()` in both controllers | Shared `McpRoleResolver` interface + impl |
| 3 | `findTopKByEmbedding` fetched global top-K then Java-filtered by role — authorized tools could be excluded before scoring window | `findTopKByEmbeddingForRole()` gates by role+workflow in SQL before ANN |
| 4 | `priorityBoost` unnormalized — could exceed 1.0 | `Math.clamp(priority, 0.0, 1.0)` in `ToolScorer` |
| 5 | `StreamingSessionAgentManager` skipped `ToolRegistryService`; no semantic selection | Per-message `roleToolsForMessage()` with null-safe fallback |
| 6 | `roleAgentCache` had no TTL — tool/prompt edits invisible until restart | `expireAfterWrite(cacheTtlMinutes)` on both managers |
| 7 | Silent prompt fallback made debugging difficult | WARN log on both fallback levels in `RolePromptResolverImpl` |

## Verification Evidence

```
./mvnw -pl pos-mcp-server -DskipTests=false verify
Tests run: 308, Failures: 0, Errors: 0, Skipped: 0
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0  (NltiRequestServiceIT)
BUILD SUCCESS
```

Lint: `lint-run-hook.sh --module pos-mcp-server` — passed (no uncommitted changes).

Code review: PASS (one MAJOR finding — missing Phase 3 regression tests — addressed in commit `6a03462e`).

## Commits

- `0033e6c9` feat: Phase 1 — shared role resolution and dynamic role preload
- `ed10a689` feat: Phase 2 — gated ANN retrieval and normalized priority scoring
- `030e5981` feat: Phase 3 — per-message semantic tool selection in streaming manager
- `9f326c3e` feat: Phase 4 — add TTL to roleAgentCache in both agent managers
- `d6eb4830` feat: Phase 5 — observability and documentation
- `6a03462e` test: add Phase 3 streaming semantic-selection coverage tests

## Risks and Follow-ups

- `toolCacheKey` uses `ClassUtils.getUserClass` to unwrap CGLIB proxies; should remain stable as long as tool beans are Spring singletons.
- `candidateToolLimit` default of 2 is intentionally conservative; can be raised via `mcp.agent.candidate-tool-limit` once embeddings are populated in production.
- No schema migrations required; this change is read-only against existing tables.
