### PR TITLE
feat(pos-mcp-server): align prompts with agent scopes

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/StaticRagPreloadProperties.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/StaticRagPreloadProperties.java
@@ -13,5 +13,7 @@ public record StaticRagPreloadProperties(List<StaticDocEntry> docs) {
     }
 
     public record StaticDocEntry(
-            @NonNull String id, @NonNull String sourcePath, @Nullable String ragScope) {}
+            @NonNull String id,
+            @NonNull String sourcePath,
+            @Nullable String ragScope) {}
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/RagScope.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/RagScope.java
@@ -1,10 +1,10 @@
 package com.positivity.mcp.internal.domain;
 
-import java.util.Locale;
-import org.jspecify.annotations.Nullable;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public final class RagScope {
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -1,10 +1,10 @@
 package com.positivity.mcp.internal.orchestration;
 
-import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.positivity.mcp.internal.classification.SimpleChatRuleCatalog;
 import com.positivity.mcp.internal.exception.RateLimitExceededException;
+import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.positivity.mcp.internal.orchestration.memory.SemanticChatMemoryStore;
 import com.positivity.mcp.internal.orchestration.memory.SessionSummaryService;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
@@ -37,340 +37,329 @@ import org.springframework.stereotype.Component;
 @Profile("alpha")
 public class SessionAgentManager implements AgentOrchestrationService, SessionAgentCacheMetrics {
 
-        private static final Logger LOGGER = LoggerFactory.getLogger(SessionAgentManager.class);
-        private static final String MEMORY_KEY_SEPARATOR = "::";
-        private static final String FULL_TOOL_CACHE_KEY = "full";
-        private static final int TIER2_EXPANDED_QUERY_LIMIT = 3;
-        private static final int TIER2_RETRIEVAL_CANDIDATES = 20;
-        private static final int TIER2_FINAL_TOP_K = 5;
+    private static final Logger LOGGER = LoggerFactory.getLogger(SessionAgentManager.class);
+    private static final String MEMORY_KEY_SEPARATOR = "::";
+    private static final String FULL_TOOL_CACHE_KEY = "full";
+    private static final int TIER2_EXPANDED_QUERY_LIMIT = 3;
+    private static final int TIER2_RETRIEVAL_CANDIDATES = 20;
+    private static final int TIER2_FINAL_TOP_K = 5;
 
-        private final Cache<String, PosAssistant> roleAgentCache;
-        private final Cache<String, ChatMemory> chatMemoryCache;
-        private final Cache<String, AtomicInteger> requestCountCache;
-        private final ChatModel chatModel;
-        private final EmbeddingModel embeddingModel;
-        private final PgVectorEmbeddingStore embeddingStore;
-        private final MasterAgentRegistry toolRegistry;
-        private final SharedOrchestrationSupport sharedOrchestrationSupport;
-        private final ToolSelectionEngine toolSelectionEngine;
-        private final ScopedContentRetrieverFactory scopedContentRetrieverFactory;
+    private final Cache<String, PosAssistant> roleAgentCache;
+    private final Cache<String, ChatMemory> chatMemoryCache;
+    private final Cache<String, AtomicInteger> requestCountCache;
+    private final ChatModel chatModel;
+    private final EmbeddingModel embeddingModel;
+    private final PgVectorEmbeddingStore embeddingStore;
+    private final MasterAgentRegistry toolRegistry;
+    private final SharedOrchestrationSupport sharedOrchestrationSupport;
+    private final ToolSelectionEngine toolSelectionEngine;
+    private final ScopedContentRetrieverFactory scopedContentRetrieverFactory;
 
-        @Nullable
-        private final ToolExecutionAuditLogger toolExecutionAuditLogger;
+    @Nullable
+    private final ToolExecutionAuditLogger toolExecutionAuditLogger;
 
-        @Nullable
-        private final SessionSummaryService sessionSummaryService;
+    @Nullable
+    private final SessionSummaryService sessionSummaryService;
 
-        private final RolePromptResolver rolePromptResolver;
-        private final SimpleChatClassifier simpleChatClassifier;
+    private final RolePromptResolver rolePromptResolver;
+    private final SimpleChatClassifier simpleChatClassifier;
 
-        private final int memoryMaxMessages;
-        private final int rateLimitPerSession;
+    private final int memoryMaxMessages;
+    private final int rateLimitPerSession;
 
-        public SessionAgentManager(
-                        @NonNull ChatModel chatModel,
-                        @NonNull EmbeddingModel embeddingModel,
-                        @NonNull PgVectorEmbeddingStore embeddingStore,
-                        @NonNull MasterAgentRegistry toolRegistry,
-                        @NonNull SharedOrchestrationSupport sharedOrchestrationSupport,
-                        @NonNull ToolSelectionEngine toolSelectionEngine,
-                        @NonNull ScopedContentRetrieverFactory scopedContentRetrieverFactory,
-                        @Nullable ToolExecutionAuditLogger toolExecutionAuditLogger,
-                        @Nullable SessionSummaryService sessionSummaryService,
-                        @NonNull RolePromptResolver rolePromptResolver,
-                        @NonNull SimpleChatClassifier simpleChatClassifier,
-                        @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
-                        @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
-                        @Value("${mcp.agent.memory-max-messages:100}") int memoryMaxMessages,
-                        @Value("${pos.nlti.rate-limit.per-session:100}") int rateLimitPerSession) {
-                this.chatModel = chatModel;
-                this.embeddingModel = embeddingModel;
-                this.embeddingStore = embeddingStore;
-                this.toolRegistry = toolRegistry;
-                this.sharedOrchestrationSupport = sharedOrchestrationSupport;
-                this.toolSelectionEngine = toolSelectionEngine;
-                this.scopedContentRetrieverFactory = scopedContentRetrieverFactory;
-                this.toolExecutionAuditLogger = toolExecutionAuditLogger;
-                this.sessionSummaryService = sessionSummaryService;
-                this.rolePromptResolver = rolePromptResolver;
-                this.simpleChatClassifier = simpleChatClassifier;
-                this.memoryMaxMessages = memoryMaxMessages;
-                this.rateLimitPerSession = rateLimitPerSession;
-                this.requestCountCache = Caffeine.newBuilder()
-                                .maximumSize(Math.max(1, maxCachedAgents))
-                                .expireAfterAccess(Duration.ofMinutes(cacheTtlMinutes))
-                                .build();
-                this.chatMemoryCache = Caffeine.newBuilder()
-                                .maximumSize(Math.max(1, maxCachedAgents))
-                                .expireAfterAccess(Duration.ofMinutes(cacheTtlMinutes))
-                                .build();
-                this.roleAgentCache = Caffeine.newBuilder()
-                                .maximumSize(Math.max(1, maxCachedAgents))
-                                .expireAfterWrite(Duration.ofMinutes(cacheTtlMinutes))
-                                .build();
-                prebuildRoleAgents();
+    public SessionAgentManager(
+            @NonNull ChatModel chatModel,
+            @NonNull EmbeddingModel embeddingModel,
+            @NonNull PgVectorEmbeddingStore embeddingStore,
+            @NonNull MasterAgentRegistry toolRegistry,
+            @NonNull SharedOrchestrationSupport sharedOrchestrationSupport,
+            @NonNull ToolSelectionEngine toolSelectionEngine,
+            @NonNull ScopedContentRetrieverFactory scopedContentRetrieverFactory,
+            @Nullable ToolExecutionAuditLogger toolExecutionAuditLogger,
+            @Nullable SessionSummaryService sessionSummaryService,
+            @NonNull RolePromptResolver rolePromptResolver,
+            @NonNull SimpleChatClassifier simpleChatClassifier,
+            @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
+            @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
+            @Value("${mcp.agent.memory-max-messages:100}") int memoryMaxMessages,
+            @Value("${pos.nlti.rate-limit.per-session:100}") int rateLimitPerSession) {
+        this.chatModel = chatModel;
+        this.embeddingModel = embeddingModel;
+        this.embeddingStore = embeddingStore;
+        this.toolRegistry = toolRegistry;
+        this.sharedOrchestrationSupport = sharedOrchestrationSupport;
+        this.toolSelectionEngine = toolSelectionEngine;
+        this.scopedContentRetrieverFactory = scopedContentRetrieverFactory;
+        this.toolExecutionAuditLogger = toolExecutionAuditLogger;
+        this.sessionSummaryService = sessionSummaryService;
+        this.rolePromptResolver = rolePromptResolver;
+        this.simpleChatClassifier = simpleChatClassifier;
+        this.memoryMaxMessages = memoryMaxMessages;
+        this.rateLimitPerSession = rateLimitPerSession;
+        this.requestCountCache = Caffeine.newBuilder()
+                .maximumSize(Math.max(1, maxCachedAgents))
+                .expireAfterAccess(Duration.ofMinutes(cacheTtlMinutes))
+                .build();
+        this.chatMemoryCache = Caffeine.newBuilder()
+                .maximumSize(Math.max(1, maxCachedAgents))
+                .expireAfterAccess(Duration.ofMinutes(cacheTtlMinutes))
+                .build();
+        this.roleAgentCache = Caffeine.newBuilder()
+                .maximumSize(Math.max(1, maxCachedAgents))
+                .expireAfterWrite(Duration.ofMinutes(cacheTtlMinutes))
+                .build();
+        prebuildRoleAgents();
+    }
+
+    /**
+     * Returns a cached role agent, creating one if absent. User-specific
+     * conversation state is resolved later by the chat memory provider.
+     */
+    @NonNull
+    PosAssistant getOrCreateAgent(@NonNull String userId, @NonNull String role) {
+        return roleAgentCache.get(role + MEMORY_KEY_SEPARATOR + FULL_TOOL_CACHE_KEY, ignored -> buildAgent(role));
+    }
+
+    @Override
+    public @NonNull String chat(@NonNull CurrentUserContext currentUserContext, @NonNull String message) {
+        String username = currentUserContext.username();
+        String role = currentUserContext.primaryRole();
+        AtomicInteger requestCount = requestCountCache.get(username, key -> new AtomicInteger(0));
+        if (requestCount.incrementAndGet() > rateLimitPerSession) {
+            requestCount.decrementAndGet();
+            LOGGER.warn("Rate limit exceeded for username={} userId={}", username, currentUserContext.userId());
+            throw new RateLimitExceededException("Rate limit exceeded");
         }
 
-        /**
-         * Returns a cached role agent, creating one if absent. User-specific
-         * conversation state is resolved later by the chat memory provider.
-         */
-        @NonNull
-        PosAssistant getOrCreateAgent(@NonNull String userId, @NonNull String role) {
-                return roleAgentCache.get(role + MEMORY_KEY_SEPARATOR + FULL_TOOL_CACHE_KEY,
-                                ignored -> buildAgent(role));
-        }
-
-        @Override
-        public @NonNull String chat(@NonNull CurrentUserContext currentUserContext, @NonNull String message) {
-                String username = currentUserContext.username();
-                String role = currentUserContext.primaryRole();
-                AtomicInteger requestCount = requestCountCache.get(username, key -> new AtomicInteger(0));
-                if (requestCount.incrementAndGet() > rateLimitPerSession) {
-                        requestCount.decrementAndGet();
-                        LOGGER.warn("Rate limit exceeded for username={} userId={}", username,
-                                        currentUserContext.userId());
-                        throw new RateLimitExceededException("Rate limit exceeded");
-                }
-
-                long startMs = System.currentTimeMillis();
-                try {
-                        boolean simpleChat = simpleChatClassifier.isSimpleChat(message);
-                        if (LOGGER.isDebugEnabled()) {
-                                String messagePreview = sharedOrchestrationSupport.preview(message);
-                                int tokenCount = tokenCount(message);
-                                LOGGER.debug(
-                                                "MCP chat request received username={} role={} simpleChat={} chars={} tokens={} preview=\"{}\"",
-                                                username,
-                                                role,
-                                                simpleChat,
-                                                message.length(),
-                                                tokenCount,
-                                                messagePreview);
-                        }
-                        if (simpleChat) {
-                                String messagePreview = sharedOrchestrationSupport.preview(message);
-                                LOGGER.debug(
-                                                "MCP simple chat dispatch username={} role={} preview=\"{}\"", username,
-                                                role, messagePreview);
-                                return simpleChat(currentUserContext, message, startMs);
-                        }
-
-                        ToolSelectionEngine.ToolSelectionResult selection = toolSelectionEngine.selectRoleTools(role,
-                                        message);
-                        List<Object> selectedTools = sharedOrchestrationSupport.mergeTools(selection.roleTools(),
-                                        selection.fallbackTools());
-                        String cacheKey = sharedOrchestrationSupport.toolCacheKey(selectedTools);
-                        if (LOGGER.isDebugEnabled()) {
-                                String messagePreview = sharedOrchestrationSupport.preview(message);
-                                LOGGER.debug(
-                                                "MCP tool selection for username={} role={} selectedTools={} preview=\"{}\"",
-                                                username,
-                                                role,
-                                                selectedTools.size(),
-                                                messagePreview);
-                                LOGGER.debug(
-                                                "MCP agent chat dispatch username={} role={} cacheKey={} roleTools={} fallbackTools={} preview=\"{}\"",
-                                                username,
-                                                role,
-                                                cacheKey,
-                                                sharedOrchestrationSupport.toolNames(selection.roleTools()),
-                                                sharedOrchestrationSupport.toolNames(selection.fallbackTools()),
-                                                messagePreview);
-                        }
-                        PosAssistant agent = getOrCreateAgent(role, cacheKey, selection.roleTools(),
-                                        selection.fallbackTools());
-                        long agentStartNanos = System.nanoTime();
-                        String response = agent.chat(memoryKey(username, role), message,
-                                        formatUserContext(currentUserContext));
-                        int elapsedMs = (int) (System.currentTimeMillis() - startMs);
-                        LOGGER.info(
-                                        "MCP agent chat completed role={} selectedTools={} modelElapsedMs={} totalElapsedMs={}",
-                                        role,
-                                        selectedTools.size(),
-                                        elapsedMs(agentStartNanos),
-                                        elapsedMs);
-                        if (toolExecutionAuditLogger != null) {
-                                toolExecutionAuditLogger.logToolExecution(null, username, true, false, elapsedMs, null);
-                        }
-                        return response;
-                } catch (RuntimeException exception) {
-                        int elapsedMs = (int) (System.currentTimeMillis() - startMs);
-                        if (toolExecutionAuditLogger != null) {
-                                toolExecutionAuditLogger.logToolExecution(
-                                                null,
-                                                username,
-                                                false,
-                                                false,
-                                                elapsedMs,
-                                                exception.getClass().getSimpleName());
-                        }
-                        throw new IllegalStateException(
-                                        "MCP chat failed role=%s elapsedMs=%d errorName=%s"
-                                                        .formatted(role, elapsedMs,
-                                                                        exception.getClass().getSimpleName()),
-                                        exception);
-                }
-        }
-
-        @Override
-        public long getCacheSize() {
-                return roleAgentCache.estimatedSize();
-        }
-
-        private PosAssistant buildAgent(@NonNull String role) {
-                return buildAgent(role, toolRegistry.resolveDomainTools(role), toolSelectionEngine.fullFallbackTools());
-        }
-
-        private PosAssistant buildAgent(
-                        @NonNull String role, @NonNull Collection<Object> roleTools,
-                        @NonNull Collection<Object> fallbackTools) {
-                long startNanos = System.nanoTime();
-                List<Object> tools = sharedOrchestrationSupport.mergeTools(roleTools, fallbackTools);
-                String ragScope = toolRegistry.resolveRagScopeForTools(tools);
-                String promptName = SystemPromptDefaults.promptNameForRagScope(ragScope);
-                String prompt = rolePromptResolver.resolvePrompt(promptName);
-
-                // 2. Tier 2 retrieval pipeline: semantic + expanded + hybrid + re-ranking.
-                ContentRetriever semanticRetriever = scopedContentRetrieverFactory.create(ragScope, 10, 0.6);
-                ContentRetriever broadSemanticRetriever = scopedContentRetrieverFactory.create(ragScope,
-                                TIER2_RETRIEVAL_CANDIDATES, 0.55);
-                ContentRetriever expandedRetriever = new QueryExpansionContentRetriever(
-                                broadSemanticRetriever, TIER2_EXPANDED_QUERY_LIMIT, TIER2_RETRIEVAL_CANDIDATES);
-                ContentRetriever hybridRetriever = new HybridContentRetriever(
-                                List.of(semanticRetriever, expandedRetriever), TIER2_RETRIEVAL_CANDIDATES);
-                ContentRetriever rerankedRetriever = new RerankedContentRetriever(hybridRetriever, TIER2_FINAL_TOP_K);
-                ContentRetriever resilientContentRetriever = new ResilientContentRetriever(rerankedRetriever,
-                                "tier2-hybrid-reranked-retriever");
-
-                // Tier 3: Role-aware metadata filtering (deferred to dynamic context resolution
-                // at runtime)
-                // Note: RoleAwareMetadataFilter requires user roles from SecurityContext.
-                // Currently applied at chat boundary where user context is available.
-
-                // 3. Assemble AiServices proxy. Chat memory remains per user+role through
-                // the provider, so role-level agent prebuilds do not share conversations.
-                PosAssistant agent = AiServices.builder(PosAssistant.class)
-                                .chatModel(chatModel)
-                                .tools(tools)
-                                .contentRetriever(resilientContentRetriever)
-                                .systemMessageProvider(memoryId -> prompt)
-                                .chatMemoryProvider(this::chatMemoryFor)
-                                .build();
+        long startMs = System.currentTimeMillis();
+        try {
+            boolean simpleChat = simpleChatClassifier.isSimpleChat(message);
+            if (LOGGER.isDebugEnabled()) {
+                String messagePreview = sharedOrchestrationSupport.preview(message);
+                int tokenCount = tokenCount(message);
                 LOGGER.debug(
-                                "Built MCP role agent role={} promptName={} ragScope={} toolNames={}",
-                                role,
-                                promptName,
-                                ragScope,
-                                sharedOrchestrationSupport.toolNames(tools));
-                LOGGER.info(
-                                "Built MCP role agent role={} promptName={} ragScope={} tools={} in {} ms",
-                                role,
-                                promptName,
-                                ragScope,
-                                tools.size(),
-                                elapsedMs(startNanos));
-                return agent;
+                        "MCP chat request received username={} role={} simpleChat={} chars={} tokens={} preview=\"{}\"",
+                        username,
+                        role,
+                        simpleChat,
+                        message.length(),
+                        tokenCount,
+                        messagePreview);
+            }
+            if (simpleChat) {
+                String messagePreview = sharedOrchestrationSupport.preview(message);
+                LOGGER.debug(
+                        "MCP simple chat dispatch username={} role={} preview=\"{}\"", username, role, messagePreview);
+                return simpleChat(currentUserContext, message, startMs);
+            }
+
+            ToolSelectionEngine.ToolSelectionResult selection = toolSelectionEngine.selectRoleTools(role, message);
+            List<Object> selectedTools =
+                    sharedOrchestrationSupport.mergeTools(selection.roleTools(), selection.fallbackTools());
+            String cacheKey = sharedOrchestrationSupport.toolCacheKey(selectedTools);
+            if (LOGGER.isDebugEnabled()) {
+                String messagePreview = sharedOrchestrationSupport.preview(message);
+                LOGGER.debug(
+                        "MCP tool selection for username={} role={} selectedTools={} preview=\"{}\"",
+                        username,
+                        role,
+                        selectedTools.size(),
+                        messagePreview);
+                LOGGER.debug(
+                        "MCP agent chat dispatch username={} role={} cacheKey={} roleTools={} fallbackTools={} preview=\"{}\"",
+                        username,
+                        role,
+                        cacheKey,
+                        sharedOrchestrationSupport.toolNames(selection.roleTools()),
+                        sharedOrchestrationSupport.toolNames(selection.fallbackTools()),
+                        messagePreview);
+            }
+            PosAssistant agent = getOrCreateAgent(role, cacheKey, selection.roleTools(), selection.fallbackTools());
+            long agentStartNanos = System.nanoTime();
+            String response = agent.chat(memoryKey(username, role), message, formatUserContext(currentUserContext));
+            int elapsedMs = (int) (System.currentTimeMillis() - startMs);
+            LOGGER.info(
+                    "MCP agent chat completed role={} selectedTools={} modelElapsedMs={} totalElapsedMs={}",
+                    role,
+                    selectedTools.size(),
+                    elapsedMs(agentStartNanos),
+                    elapsedMs);
+            if (toolExecutionAuditLogger != null) {
+                toolExecutionAuditLogger.logToolExecution(null, username, true, false, elapsedMs, null);
+            }
+            return response;
+        } catch (RuntimeException exception) {
+            int elapsedMs = (int) (System.currentTimeMillis() - startMs);
+            if (toolExecutionAuditLogger != null) {
+                toolExecutionAuditLogger.logToolExecution(
+                        null,
+                        username,
+                        false,
+                        false,
+                        elapsedMs,
+                        exception.getClass().getSimpleName());
+            }
+            throw new IllegalStateException(
+                    "MCP chat failed role=%s elapsedMs=%d errorName=%s"
+                            .formatted(role, elapsedMs, exception.getClass().getSimpleName()),
+                    exception);
         }
+    }
 
-        private @NonNull PosAssistant getOrCreateAgent(
-                        @NonNull String role,
-                        @NonNull String toolCacheKey,
-                        @NonNull List<Object> roleTools,
-                        @NonNull List<Object> fallbackTools) {
-                return roleAgentCache.get(
-                                role + MEMORY_KEY_SEPARATOR + toolCacheKey,
-                                ignored -> buildAgent(role, roleTools, fallbackTools));
+    @Override
+    public long getCacheSize() {
+        return roleAgentCache.estimatedSize();
+    }
+
+    private PosAssistant buildAgent(@NonNull String role) {
+        return buildAgent(role, toolRegistry.resolveDomainTools(role), toolSelectionEngine.fullFallbackTools());
+    }
+
+    private PosAssistant buildAgent(
+            @NonNull String role, @NonNull Collection<Object> roleTools, @NonNull Collection<Object> fallbackTools) {
+        long startNanos = System.nanoTime();
+        List<Object> tools = sharedOrchestrationSupport.mergeTools(roleTools, fallbackTools);
+        String ragScope = toolRegistry.resolveRagScopeForTools(tools);
+        String promptName = SystemPromptDefaults.promptNameForRagScope(ragScope);
+
+        // 2. Tier 2 retrieval pipeline: semantic + expanded + hybrid + re-ranking.
+        ContentRetriever semanticRetriever = scopedContentRetrieverFactory.create(ragScope, 10, 0.6);
+        ContentRetriever broadSemanticRetriever =
+                scopedContentRetrieverFactory.create(ragScope, TIER2_RETRIEVAL_CANDIDATES, 0.55);
+        ContentRetriever expandedRetriever = new QueryExpansionContentRetriever(
+                broadSemanticRetriever, TIER2_EXPANDED_QUERY_LIMIT, TIER2_RETRIEVAL_CANDIDATES);
+        ContentRetriever hybridRetriever =
+                new HybridContentRetriever(List.of(semanticRetriever, expandedRetriever), TIER2_RETRIEVAL_CANDIDATES);
+        ContentRetriever rerankedRetriever = new RerankedContentRetriever(hybridRetriever, TIER2_FINAL_TOP_K);
+        ContentRetriever resilientContentRetriever =
+                new ResilientContentRetriever(rerankedRetriever, "tier2-hybrid-reranked-retriever");
+
+        // Tier 3: Role-aware metadata filtering (deferred to dynamic context resolution
+        // at runtime)
+        // Note: RoleAwareMetadataFilter requires user roles from SecurityContext.
+        // Currently applied at chat boundary where user context is available.
+
+        // 3. Assemble AiServices proxy. Chat memory remains per user+role through
+        // the provider, so role-level agent prebuilds do not share conversations.
+        // Prompt resolution is deferred per-message via systemMessageProvider so that
+        // database updates to prompts are visible immediately without agent rebuild.
+        PosAssistant agent = AiServices.builder(PosAssistant.class)
+                .chatModel(chatModel)
+                .tools(tools)
+                .contentRetriever(resilientContentRetriever)
+                .systemMessageProvider(memoryId -> rolePromptResolver.resolvePrompt(promptName))
+                .chatMemoryProvider(this::chatMemoryFor)
+                .build();
+        LOGGER.debug(
+                "Built MCP role agent role={} promptName={} ragScope={} toolNames={}",
+                role,
+                promptName,
+                ragScope,
+                sharedOrchestrationSupport.toolNames(tools));
+        LOGGER.info(
+                "Built MCP role agent role={} promptName={} ragScope={} tools={} in {} ms",
+                role,
+                promptName,
+                ragScope,
+                tools.size(),
+                elapsedMs(startNanos));
+        return agent;
+    }
+
+    private @NonNull PosAssistant getOrCreateAgent(
+            @NonNull String role,
+            @NonNull String toolCacheKey,
+            @NonNull List<Object> roleTools,
+            @NonNull List<Object> fallbackTools) {
+        return roleAgentCache.get(
+                role + MEMORY_KEY_SEPARATOR + toolCacheKey, ignored -> buildAgent(role, roleTools, fallbackTools));
+    }
+
+    /**
+     * Evicts a user's conversation state and rate counter. Role agents remain
+     * cached.
+     */
+    @Override
+    public void evict(@NonNull String userId) {
+        chatMemoryCache.asMap().keySet().removeIf(key -> key.startsWith(userId + MEMORY_KEY_SEPARATOR));
+        requestCountCache.invalidate(userId);
+    }
+
+    private void prebuildRoleAgents() {
+        long startNanos = System.nanoTime();
+        int prebuilt = 0;
+        for (String role : toolRegistry.preloadableRoleIdentifiers()) {
+            try {
+                ToolSelectionEngine.ToolSelectionResult selection = toolSelectionEngine.selectRoleTools(role, role);
+                List<Object> selectedTools =
+                        sharedOrchestrationSupport.mergeTools(selection.roleTools(), selection.fallbackTools());
+                String warmCacheKey = sharedOrchestrationSupport.toolCacheKey(selectedTools);
+                roleAgentCache.put(
+                        role + MEMORY_KEY_SEPARATOR + warmCacheKey,
+                        buildAgent(role, selection.roleTools(), selection.fallbackTools()));
+
+                // Keep the legacy full key warm for direct role-level access paths.
+                roleAgentCache.put(role + MEMORY_KEY_SEPARATOR + FULL_TOOL_CACHE_KEY, buildAgent(role));
+                prebuilt++;
+            } catch (RuntimeException exception) {
+                LOGGER.warn("Failed to prebuild MCP role agent role={}", role, exception);
+            }
         }
+        LOGGER.info("Prebuilt {} MCP role agents in {} ms", prebuilt, elapsedMs(startNanos));
+    }
 
-        /**
-         * Evicts a user's conversation state and rate counter. Role agents remain
-         * cached.
-         */
-        @Override
-        public void evict(@NonNull String userId) {
-                chatMemoryCache.asMap().keySet().removeIf(key -> key.startsWith(userId + MEMORY_KEY_SEPARATOR));
-                requestCountCache.invalidate(userId);
+    private @NonNull ChatMemory chatMemoryFor(@NonNull Object memoryId) {
+        // Tier 3: Replace MessageWindowChatMemory with SemanticChatMemoryStore
+        // for persistent semantic memory and session summarization
+        return chatMemoryCache.get(
+                String.valueOf(memoryId),
+                ignored -> new SemanticChatMemoryStore(
+                        memoryMaxMessages, chatModel, embeddingModel, embeddingStore, sessionSummaryService));
+    }
+
+    private @NonNull String simpleChat(
+            @NonNull CurrentUserContext currentUserContext, @NonNull String message, long requestStartMs) {
+        long simpleStartNanos = System.nanoTime();
+        String prompt = rolePromptResolver.resolvePrompt(SystemPromptDefaults.MASTER_PROMPT_NAME)
+                + System.lineSeparator()
+                + formatUserContext(currentUserContext);
+        String response = chatModel
+                .chat(List.of(SystemMessage.from(prompt), UserMessage.from(message)))
+                .aiMessage()
+                .text();
+        int elapsedMs = (int) (System.currentTimeMillis() - requestStartMs);
+        LOGGER.info(
+                "MCP simple chat completed role={} modelElapsedMs={} totalElapsedMs={}",
+                currentUserContext.primaryRole(),
+                elapsedMs(simpleStartNanos),
+                elapsedMs);
+        if (toolExecutionAuditLogger != null) {
+            toolExecutionAuditLogger.logToolExecution(
+                    null, currentUserContext.username(), true, false, elapsedMs, null);
         }
+        return response;
+    }
 
-        private void prebuildRoleAgents() {
-                long startNanos = System.nanoTime();
-                int prebuilt = 0;
-                for (String role : toolRegistry.preloadableRoleIdentifiers()) {
-                        try {
-                                ToolSelectionEngine.ToolSelectionResult selection = toolSelectionEngine
-                                                .selectRoleTools(role, role);
-                                List<Object> selectedTools = sharedOrchestrationSupport
-                                                .mergeTools(selection.roleTools(), selection.fallbackTools());
-                                String warmCacheKey = sharedOrchestrationSupport.toolCacheKey(selectedTools);
-                                roleAgentCache.put(
-                                                role + MEMORY_KEY_SEPARATOR + warmCacheKey,
-                                                buildAgent(role, selection.roleTools(), selection.fallbackTools()));
+    private static @NonNull String formatUserContext(@NonNull CurrentUserContext currentUserContext) {
+        return "Authenticated user context: username=" + currentUserContext.username()
+                + ", userId=" + currentUserContext.userId()
+                + ", primaryRole=" + currentUserContext.primaryRole()
+                + ", roles=" + currentUserContext.roles()
+                + ", authorityCount=" + currentUserContext.authorities().size()
+                + ". Interpret references to 'me', 'my', or 'current user' as this authenticated user."
+                + " If a question depends on the user's exact permissions, prefer a self-service permissions tool before asking for identifiers.";
+    }
 
-                                // Keep the legacy full key warm for direct role-level access paths.
-                                roleAgentCache.put(role + MEMORY_KEY_SEPARATOR + FULL_TOOL_CACHE_KEY, buildAgent(role));
-                                prebuilt++;
-                        } catch (RuntimeException exception) {
-                                LOGGER.warn("Failed to prebuild MCP role agent role={}", role, exception);
-                        }
-                }
-                LOGGER.info("Prebuilt {} MCP role agents in {} ms", prebuilt, elapsedMs(startNanos));
-        }
+    private static int tokenCount(@NonNull String text) {
+        return SimpleChatRuleCatalog.tokenize(SimpleChatRuleCatalog.normalize(text))
+                .size();
+    }
 
-        private @NonNull ChatMemory chatMemoryFor(@NonNull Object memoryId) {
-                // Tier 3: Replace MessageWindowChatMemory with SemanticChatMemoryStore
-                // for persistent semantic memory and session summarization
-                return chatMemoryCache.get(
-                                String.valueOf(memoryId),
-                                ignored -> new SemanticChatMemoryStore(
-                                                memoryMaxMessages, chatModel, embeddingModel, embeddingStore,
-                                                sessionSummaryService));
-        }
+    private static @NonNull String memoryKey(@NonNull String userId, @NonNull String role) {
+        return userId + MEMORY_KEY_SEPARATOR + role;
+    }
 
-        private @NonNull String simpleChat(
-                        @NonNull CurrentUserContext currentUserContext, @NonNull String message, long requestStartMs) {
-                long simpleStartNanos = System.nanoTime();
-                String prompt = rolePromptResolver.resolvePrompt(SystemPromptDefaults.MASTER_PROMPT_NAME)
-                                + System.lineSeparator()
-                                + formatUserContext(currentUserContext);
-                String response = chatModel
-                                .chat(List.of(SystemMessage.from(prompt), UserMessage.from(message)))
-                                .aiMessage()
-                                .text();
-                int elapsedMs = (int) (System.currentTimeMillis() - requestStartMs);
-                LOGGER.info(
-                                "MCP simple chat completed role={} modelElapsedMs={} totalElapsedMs={}",
-                                currentUserContext.primaryRole(),
-                                elapsedMs(simpleStartNanos),
-                                elapsedMs);
-                if (toolExecutionAuditLogger != null) {
-                        toolExecutionAuditLogger.logToolExecution(null, currentUserContext.username(), true, false,
-                                        elapsedMs, null);
-                }
-                return response;
-        }
-
-        private static @NonNull String formatUserContext(@NonNull CurrentUserContext currentUserContext) {
-                return "Authenticated user context: username=" + currentUserContext.username()
-                                + ", userId=" + currentUserContext.userId()
-                                + ", primaryRole=" + currentUserContext.primaryRole()
-                                + ", roles=" + currentUserContext.roles()
-                                + ", authorityCount=" + currentUserContext.authorities().size()
-                                + ". Interpret references to 'me', 'my', or 'current user' as this authenticated user."
-                                + " If a question depends on the user's exact permissions, prefer a self-service permissions tool before asking for identifiers.";
-        }
-
-        private static int tokenCount(@NonNull String text) {
-                return SimpleChatRuleCatalog.tokenize(SimpleChatRuleCatalog.normalize(text))
-                                .size();
-        }
-
-        private static @NonNull String memoryKey(@NonNull String userId, @NonNull String role) {
-                return userId + MEMORY_KEY_SEPARATOR + role;
-        }
-
-        private static long elapsedMs(long startNanos) {
-                return java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-        }
-
+    private static long elapsedMs(long startNanos) {
+        return java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+    }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -8,6 +8,7 @@ import com.positivity.mcp.internal.exception.RateLimitExceededException;
 import com.positivity.mcp.internal.orchestration.memory.SemanticChatMemoryStore;
 import com.positivity.mcp.internal.orchestration.memory.SessionSummaryService;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
+import com.positivity.mcp.internal.service.SystemPromptDefaults;
 import com.positivity.mcp.service.AgentOrchestrationService;
 import com.positivity.mcp.service.CurrentUserContext;
 import com.positivity.mcp.service.RolePromptResolver;
@@ -227,6 +228,8 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                 long startNanos = System.nanoTime();
                 List<Object> tools = sharedOrchestrationSupport.mergeTools(roleTools, fallbackTools);
                 String ragScope = toolRegistry.resolveRagScopeForTools(tools);
+                String promptName = SystemPromptDefaults.promptNameForRagScope(ragScope);
+                String prompt = rolePromptResolver.resolvePrompt(promptName);
 
                 // 2. Tier 2 retrieval pipeline: semantic + expanded + hybrid + re-ranking.
                 ContentRetriever semanticRetriever = scopedContentRetrieverFactory.create(ragScope, 10, 0.6);
@@ -251,17 +254,19 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                                 .chatModel(chatModel)
                                 .tools(tools)
                                 .contentRetriever(resilientContentRetriever)
-                                .systemMessageProvider(memoryId -> rolePromptResolver.resolvePrompt(role))
+                                .systemMessageProvider(memoryId -> prompt)
                                 .chatMemoryProvider(this::chatMemoryFor)
                                 .build();
                 LOGGER.debug(
-                                "Built MCP role agent role={} ragScope={} toolNames={}",
+                                "Built MCP role agent role={} promptName={} ragScope={} toolNames={}",
                                 role,
+                                promptName,
                                 ragScope,
                                 sharedOrchestrationSupport.toolNames(tools));
                 LOGGER.info(
-                                "Built MCP role agent role={} ragScope={} tools={} in {} ms",
+                                "Built MCP role agent role={} promptName={} ragScope={} tools={} in {} ms",
                                 role,
+                                promptName,
                                 ragScope,
                                 tools.size(),
                                 elapsedMs(startNanos));
@@ -325,7 +330,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         private @NonNull String simpleChat(
                         @NonNull CurrentUserContext currentUserContext, @NonNull String message, long requestStartMs) {
                 long simpleStartNanos = System.nanoTime();
-                String prompt = rolePromptResolver.resolvePrompt(currentUserContext.primaryRole())
+                String prompt = rolePromptResolver.resolvePrompt(SystemPromptDefaults.MASTER_PROMPT_NAME)
                                 + System.lineSeparator()
                                 + formatUserContext(currentUserContext);
                 String response = chatModel

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -1,10 +1,10 @@
 package com.positivity.mcp.internal.orchestration;
 
-import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.positivity.mcp.internal.classification.SimpleChatRuleCatalog;
 import com.positivity.mcp.internal.exception.RateLimitExceededException;
+import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
 import com.positivity.mcp.internal.service.SystemPromptDefaults;
 import com.positivity.mcp.service.CurrentUserContext;
@@ -125,8 +125,8 @@ public class StreamingSessionAgentManager
                 role,
                 cacheKey,
                 sharedOrchestrationSupport.toolNames(allTools));
-        StreamingPosAssistant agent = roleAgentCache.get(role + MEMORY_KEY_SEPARATOR + cacheKey,
-                ignored -> buildAgent(role, allTools));
+        StreamingPosAssistant agent =
+                roleAgentCache.get(role + MEMORY_KEY_SEPARATOR + cacheKey, ignored -> buildAgent(role, allTools));
 
         String userContext = formatUserContext(currentUserContext);
         return Flux.<String>create(emitter -> streamTokens(agent, memoryId, message, userContext, emitter))
@@ -182,23 +182,24 @@ public class StreamingSessionAgentManager
         long startNanos = System.nanoTime();
         String ragScope = toolRegistry.resolveRagScopeForTools(tools);
         String promptName = SystemPromptDefaults.promptNameForRagScope(ragScope);
-        String prompt = rolePromptResolver.resolvePrompt(promptName);
         ContentRetriever semanticRetriever = scopedContentRetrieverFactory.create(ragScope, 10, 0.6);
-        ContentRetriever broadSemanticRetriever = scopedContentRetrieverFactory.create(ragScope,
-                TIER2_RETRIEVAL_CANDIDATES, 0.55);
+        ContentRetriever broadSemanticRetriever =
+                scopedContentRetrieverFactory.create(ragScope, TIER2_RETRIEVAL_CANDIDATES, 0.55);
         ContentRetriever expandedRetriever = new QueryExpansionContentRetriever(
                 broadSemanticRetriever, TIER2_EXPANDED_QUERY_LIMIT, TIER2_RETRIEVAL_CANDIDATES);
-        ContentRetriever hybridRetriever = new HybridContentRetriever(List.of(semanticRetriever, expandedRetriever),
-                TIER2_RETRIEVAL_CANDIDATES);
+        ContentRetriever hybridRetriever =
+                new HybridContentRetriever(List.of(semanticRetriever, expandedRetriever), TIER2_RETRIEVAL_CANDIDATES);
         ContentRetriever rerankedRetriever = new RerankedContentRetriever(hybridRetriever, TIER2_FINAL_TOP_K);
-        ContentRetriever resilientContentRetriever = new ResilientContentRetriever(rerankedRetriever,
-                "tier2-hybrid-reranked-retriever");
+        ContentRetriever resilientContentRetriever =
+                new ResilientContentRetriever(rerankedRetriever, "tier2-hybrid-reranked-retriever");
 
+        // Prompt resolution is deferred per-message via systemMessageProvider so that
+        // database updates to prompts are visible immediately without agent rebuild.
         StreamingPosAssistant agent = AiServices.builder(StreamingPosAssistant.class)
                 .streamingChatModel(streamingChatModel)
                 .tools(tools)
                 .contentRetriever(resilientContentRetriever)
-                .systemMessageProvider(memoryId -> prompt)
+                .systemMessageProvider(memoryId -> rolePromptResolver.resolvePrompt(promptName))
                 .chatMemoryProvider(this::chatMemoryFor)
                 .build();
         LOGGER.debug(
@@ -240,8 +241,8 @@ public class StreamingSessionAgentManager
         for (String role : toolRegistry.preloadableRoleIdentifiers()) {
             try {
                 ToolSelectionEngine.ToolSelectionResult selection = toolSelectionEngine.selectRoleTools(role, role);
-                List<Object> selectedTools = sharedOrchestrationSupport.mergeTools(selection.roleTools(),
-                        selection.fallbackTools());
+                List<Object> selectedTools =
+                        sharedOrchestrationSupport.mergeTools(selection.roleTools(), selection.fallbackTools());
                 String warmCacheKey = sharedOrchestrationSupport.toolCacheKey(selectedTools);
                 roleAgentCache.put(role + MEMORY_KEY_SEPARATOR + warmCacheKey, buildAgent(role, selectedTools));
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -6,6 +6,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.positivity.mcp.internal.classification.SimpleChatRuleCatalog;
 import com.positivity.mcp.internal.exception.RateLimitExceededException;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
+import com.positivity.mcp.internal.service.SystemPromptDefaults;
 import com.positivity.mcp.service.CurrentUserContext;
 import com.positivity.mcp.service.RolePromptResolver;
 import com.positivity.mcp.service.StreamingAgentOrchestrationService;
@@ -180,6 +181,8 @@ public class StreamingSessionAgentManager
     private @NonNull StreamingPosAssistant buildAgent(@NonNull String role, @NonNull List<Object> tools) {
         long startNanos = System.nanoTime();
         String ragScope = toolRegistry.resolveRagScopeForTools(tools);
+        String promptName = SystemPromptDefaults.promptNameForRagScope(ragScope);
+        String prompt = rolePromptResolver.resolvePrompt(promptName);
         ContentRetriever semanticRetriever = scopedContentRetrieverFactory.create(ragScope, 10, 0.6);
         ContentRetriever broadSemanticRetriever = scopedContentRetrieverFactory.create(ragScope,
                 TIER2_RETRIEVAL_CANDIDATES, 0.55);
@@ -195,17 +198,19 @@ public class StreamingSessionAgentManager
                 .streamingChatModel(streamingChatModel)
                 .tools(tools)
                 .contentRetriever(resilientContentRetriever)
-                .systemMessageProvider(memoryId -> rolePromptResolver.resolvePrompt(role))
+                .systemMessageProvider(memoryId -> prompt)
                 .chatMemoryProvider(this::chatMemoryFor)
                 .build();
         LOGGER.debug(
-                "Built MCP streaming role agent role={} ragScope={} toolNames={}",
+                "Built MCP streaming role agent role={} promptName={} ragScope={} toolNames={}",
                 role,
+                promptName,
                 ragScope,
                 sharedOrchestrationSupport.toolNames(tools));
         LOGGER.info(
-                "Built MCP streaming role agent role={} ragScope={} tools={} in {} ms",
+                "Built MCP streaming role agent role={} promptName={} ragScope={} tools={} in {} ms",
                 role,
+                promptName,
                 ragScope,
                 tools.size(),
                 elapsedMs(startNanos));

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolSelectionEngine.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolSelectionEngine.java
@@ -83,7 +83,8 @@ public class ToolSelectionEngine {
             List<ToolMetadata> candidates = toolRegistryService.resolveCandidateTools(
                     new ToolSelectionContext(message, role, workflowState), candidateToolLimit);
             logCandidates(role, workflowState, candidates);
-            List<String> selectedNames = candidates.stream().map(ToolMetadata::name).toList();
+            List<String> selectedNames =
+                    candidates.stream().map(ToolMetadata::name).toList();
             if (selectedNames.isEmpty()) {
                 return logNoCandidates(role, message, fullRoleTools);
             }
@@ -214,8 +215,7 @@ public class ToolSelectionEngine {
             selected.add(orderFacadeTool);
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                    "MCP shared fallback tool matches tools={}", sharedOrchestrationSupport.toolNames(selected));
+            LOGGER.debug("MCP shared fallback tool matches tools={}", sharedOrchestrationSupport.toolNames(selected));
         }
         return selected;
     }
@@ -235,7 +235,5 @@ public class ToolSelectionEngine {
     }
 
     public record ToolSelectionResult(
-            @NonNull List<Object> roleTools,
-            @NonNull List<Object> fallbackTools) {
-    }
+            @NonNull List<Object> roleTools, @NonNull List<Object> fallbackTools) {}
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/agent/MasterAgentRegistry.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/agent/MasterAgentRegistry.java
@@ -62,7 +62,9 @@ public final class MasterAgentRegistry {
     }
 
     public @NonNull Optional<DomainAgentDefinition> findDomainAgent(@NonNull String agentName) {
-        return domainAgents.stream().filter(agent -> agent.agentName().equals(agentName)).findFirst();
+        return domainAgents.stream()
+                .filter(agent -> agent.agentName().equals(agentName))
+                .findFirst();
     }
 
     public @NonNull List<Object> resolveDomainTools(@NonNull String agentName) {
@@ -77,14 +79,17 @@ public final class MasterAgentRegistry {
             LOGGER.debug(
                     "MCP master registry resolve-all agentName={} sharedTools={} resolvedTools={}",
                     agentName,
-                    sharedTools.stream().map(tool -> ClassUtils.getUserClass(tool).getSimpleName()).toList(),
-                    resolvedTools.stream().map(tool -> ClassUtils.getUserClass(tool).getSimpleName()).toList());
+                    sharedTools.stream()
+                            .map(tool -> ClassUtils.getUserClass(tool).getSimpleName())
+                            .toList(),
+                    resolvedTools.stream()
+                            .map(tool -> ClassUtils.getUserClass(tool).getSimpleName())
+                            .toList());
         }
         return resolvedTools;
     }
 
-    public @NonNull List<Object> resolveDomainTools(
-            @NonNull String agentName, @NonNull Collection<String> toolNames) {
+    public @NonNull List<Object> resolveDomainTools(@NonNull String agentName, @NonNull Collection<String> toolNames) {
         Set<String> selectedNames = new HashSet<>();
         for (String toolName : toolNames) {
             selectedNames.add(toolName.toLowerCase(Locale.ROOT));
@@ -103,8 +108,12 @@ public final class MasterAgentRegistry {
                     "MCP master registry resolve-selected agentName={} selectedNames={} availableTools={} resolvedTools={}",
                     agentName,
                     new TreeSet<>(selectedNames),
-                    availableTools.stream().map(tool -> ClassUtils.getUserClass(tool).getSimpleName()).toList(),
-                    resolvedTools.stream().map(tool -> ClassUtils.getUserClass(tool).getSimpleName()).toList());
+                    availableTools.stream()
+                            .map(tool -> ClassUtils.getUserClass(tool).getSimpleName())
+                            .toList(),
+                    resolvedTools.stream()
+                            .map(tool -> ClassUtils.getUserClass(tool).getSimpleName())
+                            .toList());
         }
         return resolvedTools;
     }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/agent/MasterAgentRegistryFactory.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/agent/MasterAgentRegistryFactory.java
@@ -29,8 +29,8 @@ public final class MasterAgentRegistryFactory {
             @NonNull List<DomainAgentDefinition> domainAgents,
             @NonNull Map<String, List<Object>> roleToolAssignments) {
 
-        public LoadedMasterAgentRegistry(@NonNull List<Object> sharedTools,
-                @NonNull List<DomainAgentDefinition> domainAgents) {
+        public LoadedMasterAgentRegistry(
+                @NonNull List<Object> sharedTools, @NonNull List<DomainAgentDefinition> domainAgents) {
             this(sharedTools, domainAgents, Map.of());
         }
     }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/DocumentIngestionServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/DocumentIngestionServiceImpl.java
@@ -159,7 +159,7 @@ public class DocumentIngestionServiceImpl implements DocumentIngestionService {
     private @NonNull Map<String, Object> metadataWithDocumentId(
             @NonNull Map<String, Object> metadata, @NonNull String documentId) {
         java.util.LinkedHashMap<String, Object> normalized =
-            new java.util.LinkedHashMap<>(RagScope.normalizeInMetadata(metadata));
+                new java.util.LinkedHashMap<>(RagScope.normalizeInMetadata(metadata));
         normalized.put(DOCUMENT_ID, documentId);
         return normalized;
     }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/MasterAgentRegistryLoader.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/MasterAgentRegistryLoader.java
@@ -28,7 +28,8 @@ public class MasterAgentRegistryLoader {
     private final ApplicationContext applicationContext;
     private final String preloadWorkflowState;
 
-    MasterAgentRegistryLoader(@NonNull ToolMetadataRepository repository, @NonNull ApplicationContext applicationContext) {
+    MasterAgentRegistryLoader(
+            @NonNull ToolMetadataRepository repository, @NonNull ApplicationContext applicationContext) {
         this(repository, applicationContext, DEFAULT_PRELOAD_WORKFLOW_STATE);
     }
 
@@ -46,7 +47,9 @@ public class MasterAgentRegistryLoader {
         String workflowState = resolvePreloadWorkflowState();
         List<ToolMetadata> tools = repository.findEnabledByWorkflow(workflowState);
         if (tools.isEmpty()) {
-            log.warn("No workflow-scoped tools found for workflowState={}; master agent registry will be empty", workflowState);
+            log.warn(
+                    "No workflow-scoped tools found for workflowState={}; master agent registry will be empty",
+                    workflowState);
         }
         List<Object> sharedTools = new ArrayList<>();
         Map<String, List<Object>> domainScopedTools = new TreeMap<>();
@@ -57,7 +60,9 @@ public class MasterAgentRegistryLoader {
                 if (MASTER_DOMAINS.contains(domain)) {
                     sharedTools.add(bean);
                 } else {
-                    domainScopedTools.computeIfAbsent(domain, ignored -> new ArrayList<>()).add(bean);
+                    domainScopedTools
+                            .computeIfAbsent(domain, ignored -> new ArrayList<>())
+                            .add(bean);
                 }
             }
         }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RolePromptResolverImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RolePromptResolverImpl.java
@@ -30,10 +30,9 @@ public class RolePromptResolverImpl implements RolePromptResolver {
                 .map(SystemPrompt::getContent)
                 .or(() -> {
                     LOGGER.warn(
-                            "MCP no agent system prompt found promptName={}; falling back to master prompt", promptName);
-                    return systemPromptRepository
-                            .findByName(MASTER_PROMPT_NAME)
-                            .map(SystemPrompt::getContent);
+                            "MCP no agent system prompt found promptName={}; falling back to master prompt",
+                            promptName);
+                    return systemPromptRepository.findByName(MASTER_PROMPT_NAME).map(SystemPrompt::getContent);
                 })
                 .orElseGet(() -> {
                     LOGGER.warn(

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RolePromptResolverImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RolePromptResolverImpl.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RolePromptResolverImpl implements RolePromptResolver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RolePromptResolverImpl.class);
-    private static final String DEFAULT_PROMPT_NAME = SystemPromptDefaults.DEFAULT_PROMPT_NAME;
+    private static final String MASTER_PROMPT_NAME = SystemPromptDefaults.MASTER_PROMPT_NAME;
     private static final String BUILT_IN_PROMPT = SystemPromptDefaults.DEFAULT_PROMPT_TEXT;
 
     private final SystemPromptRepository systemPromptRepository;
@@ -24,19 +24,22 @@ public class RolePromptResolverImpl implements RolePromptResolver {
 
     @Override
     @Transactional(readOnly = true)
-    public @NonNull String resolvePrompt(@NonNull String role) {
+    public @NonNull String resolvePrompt(@NonNull String promptName) {
         return systemPromptRepository
-                .findByName(role)
+                .findByName(promptName)
                 .map(SystemPrompt::getContent)
                 .or(() -> {
                     LOGGER.warn(
-                            "MCP no role-specific system prompt found role={}; falling back to 'default' prompt", role);
+                            "MCP no agent system prompt found promptName={}; falling back to master prompt", promptName);
                     return systemPromptRepository
-                            .findByName(DEFAULT_PROMPT_NAME)
+                            .findByName(MASTER_PROMPT_NAME)
                             .map(SystemPrompt::getContent);
                 })
                 .orElseGet(() -> {
-                    LOGGER.warn("MCP no system prompt found role={} name=default; using built-in prompt", role);
+                    LOGGER.warn(
+                            "MCP no system prompt found promptName={} name={}; using built-in prompt",
+                            promptName,
+                            MASTER_PROMPT_NAME);
                     return BUILT_IN_PROMPT;
                 });
     }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/StaticRagPreloadServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/StaticRagPreloadServiceImpl.java
@@ -160,8 +160,8 @@ public class StaticRagPreloadServiceImpl implements StaticRagPreloadService {
         }
     }
 
-    private void preloadDocument(
-            @NonNull String documentId, @NonNull String sourcePath, @Nullable String ragScope) throws IOException {
+    private void preloadDocument(@NonNull String documentId, @NonNull String sourcePath, @Nullable String ragScope)
+            throws IOException {
         Resource resource = new ClassPathResource(resourcePath(sourcePath));
         byte[] bytes = resource.getContentAsByteArray();
         String content = new String(bytes, StandardCharsets.UTF_8);
@@ -193,12 +193,12 @@ public class StaticRagPreloadServiceImpl implements StaticRagPreloadService {
     private void persistFailedRecord(
             @NonNull String documentId, @Nullable String hash, @NonNull String sourcePath, @Nullable String ragScope) {
         persistRecord(
-            documentId,
-            hash != null ? hash : "",
-            sourcePath,
-            RagScope.normalize(ragScope),
-            RagPreloadStatus.FAILED,
-            null);
+                documentId,
+                hash != null ? hash : "",
+                sourcePath,
+                RagScope.normalize(ragScope),
+                RagPreloadStatus.FAILED,
+                null);
         meterRegistry
                 .counter(METRIC_PRELOAD_FAILED, TAG_DOCUMENT_ID, documentId)
                 .increment();

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptDefaults.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptDefaults.java
@@ -1,14 +1,17 @@
 package com.positivity.mcp.internal.service;
 
 import java.util.List;
+import java.util.Locale;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Shared default prompt constants. Package-private — not part of the public
  * service API.
  */
-final class SystemPromptDefaults {
+public final class SystemPromptDefaults {
 
-    static final String DEFAULT_PROMPT_NAME = "default";
+    public static final String MASTER_PROMPT_NAME = "master";
+    static final String DEFAULT_PROMPT_NAME = MASTER_PROMPT_NAME;
 
     // SQL-seeded security roles from pos-security-service
     // (R__seed_reference_security.sql)
@@ -35,8 +38,30 @@ final class SystemPromptDefaults {
             ROLE_CUSTOMER_PROMPT_NAME,
             ROLE_SELF_SERVICE_CUSTOMER_PROMPT_NAME);
 
-    static final String DEFAULT_PROMPT_TEXT = "You are a concise POS assistant for Positivity. Answer general conversation directly. "
-            + "Do not invent business data.";
+    static final String DEFAULT_PROMPT_TEXT = """
+            You are the concise POS assistant for Positivity and the master orchestration agent for Durion operations.
+            Help users reach the next correct action quickly, especially when a request spans multiple business domains.
+
+            Operating rules:
+            - Use tools before answering live-data, workflow-status, or record-specific questions.
+            - Never invent business data, identifiers, quantities, statuses, or policy outcomes.
+            - When the request is underspecified, ask only for the missing detail needed to act.
+            - Distinguish confirmed facts from inference, and call out important uncertainty or operational risk.
+            - When a request crosses domains, synthesize the answer into one clear response instead of giving siloed fragments.
+
+            Response style:
+            - concise, operational, and decision-oriented
+            - prefer short sections or bullets when they improve clarity
+            - include next actions when they materially help the user move forward
+            """;
+
+    public static @NonNull String promptNameForRagScope(@NonNull String ragScope) {
+        String normalized = ragScope.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isBlank() || "master".equals(normalized) || "shared".equals(normalized)) {
+            return MASTER_PROMPT_NAME;
+        }
+        return normalized;
+    }
 
     private SystemPromptDefaults() {
     }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptDefaults.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptDefaults.java
@@ -1,8 +1,10 @@
 package com.positivity.mcp.internal.service;
 
-import com.positivity.mcp.internal.domain.RagScope;
 import java.util.List;
+import java.util.Locale;
+import com.positivity.mcp.internal.domain.RagScope;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * System prompt definitions and defaults for seed initialization and agent configuration.
@@ -62,7 +64,12 @@ public final class SystemPromptDefaults {
             - include next actions when they materially help the user move forward
             """;
 
-    public static @NonNull String promptNameForRagScope(@NonNull String ragScope) {
+    /**
+     * Resolves the system prompt key for a RAG scope.
+     *
+     * <p>Null or blank values normalize to {@link RagScope#MASTER}.
+     */
+    public static @NonNull String promptNameForRagScope(@Nullable String ragScope) {
         // Delegate to RagScope.normalize() to maintain single source of truth for normalization logic.
         String normalizedScope = RagScope.normalize(ragScope);
         // Map "shared" scope to master prompt (semantic equivalence in agent context).
@@ -72,5 +79,6 @@ public final class SystemPromptDefaults {
         return normalizedScope;
     }
 
-    private SystemPromptDefaults() {}
+    private SystemPromptDefaults() {
+    }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptDefaults.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptDefaults.java
@@ -1,12 +1,19 @@
 package com.positivity.mcp.internal.service;
 
+import com.positivity.mcp.internal.domain.RagScope;
 import java.util.List;
-import java.util.Locale;
 import org.jspecify.annotations.NonNull;
 
 /**
- * Shared default prompt constants. Package-private — not part of the public
- * service API.
+ * System prompt definitions and defaults for seed initialization and agent configuration.
+ *
+ * This class provides constants for master prompt names, domain-specific prompt names,
+ * and role priority ordering. Constants are part of the public system prompt
+ * initialization contract and are used by SystemPromptSeedRunner, RolePromptResolverImpl,
+ * and orchestration managers.
+ *
+ * Note: Individual prompt name constants are service-internal configuration; they are not
+ * part of a versioned API contract and may change across releases without notice.
  */
 public final class SystemPromptDefaults {
 
@@ -56,13 +63,14 @@ public final class SystemPromptDefaults {
             """;
 
     public static @NonNull String promptNameForRagScope(@NonNull String ragScope) {
-        String normalized = ragScope.trim().toLowerCase(Locale.ROOT);
-        if (normalized.isBlank() || "master".equals(normalized) || "shared".equals(normalized)) {
+        // Delegate to RagScope.normalize() to maintain single source of truth for normalization logic.
+        String normalizedScope = RagScope.normalize(ragScope);
+        // Map "shared" scope to master prompt (semantic equivalence in agent context).
+        if ("shared".equals(normalizedScope)) {
             return MASTER_PROMPT_NAME;
         }
-        return normalized;
+        return normalizedScope;
     }
 
-    private SystemPromptDefaults() {
-    }
+    private SystemPromptDefaults() {}
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptSeedRunner.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptSeedRunner.java
@@ -24,6 +24,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "inventory",
                 domainPrompt(
+                        "inventory",
                         "Inventory",
                         "inventory availability, receiving, replenishment, and reconciliation",
                         "Confirm SKU, location, on-hand, available, committed, and inbound context before giving an answer.",
@@ -32,6 +33,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "order",
                 domainPrompt(
+                        "order",
                         "Order",
                         "purchase orders, sales orders, and order lifecycle coordination",
                         "Track order status, fulfillment blockers, supplier or store handoffs, and next-step dependencies.",
@@ -40,6 +42,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "customer",
                 domainPrompt(
+                        "customer",
                         "Customer",
                         "customer profile context, account history, and communication-sensitive answers",
                         "Use customer records to ground identity, history, and relationship context before responding.",
@@ -48,6 +51,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "pricing",
                 domainPrompt(
+                        "pricing",
                         "Pricing",
                         "price lookup, discounts, margin guidance, and pricing exceptions",
                         "Explain the source of a price, discount, override, or margin concern in operational terms.",
@@ -56,6 +60,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "workorder",
                 domainPrompt(
+                        "workorder",
                         "Workorder",
                         "workorder intake, execution status, assignment, and lifecycle coordination",
                         "Track workorder stage, blockers, technician handoff, required parts, and customer-facing next steps.",
@@ -64,6 +69,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "catalog",
                 domainPrompt(
+                        "catalog",
                         "Catalog",
                         "item discovery, product metadata, and catalog fit-for-use answers",
                         "Use catalog data to identify the right item, attributes, variants, and compatibility signals.",
@@ -72,6 +78,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "vehicle",
                 domainPrompt(
+                        "vehicle",
                         "Vehicle",
                         "VIN, fitment, compatibility, and vehicle-specific service context",
                         "Anchor recommendations to confirmed vehicle attributes before suggesting parts or service conclusions.",
@@ -80,6 +87,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "accounting",
                 domainPrompt(
+                        "accounting",
                         "Accounting",
                         "financial summaries, ledger-facing context, and reconciliation support",
                         "Explain accounting impacts, reconciliation questions, and financial status using explicit business facts.",
@@ -88,6 +96,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "invoice",
                 domainPrompt(
+                        "invoice",
                         "Invoice",
                         "invoice creation, status, and invoice issue resolution",
                         "Track invoice lifecycle, blockers, payment relevance, and document state clearly.",
@@ -96,6 +105,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "hr",
                 domainPrompt(
+                        "hr",
                         "HR",
                         "workforce scheduling, staffing context, and HR policy guidance",
                         "Use staffing data and policy context to answer schedule, availability, and operational workforce questions.",
@@ -104,6 +114,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "reporting",
                 domainPrompt(
+                        "reporting",
                         "Reporting",
                         "operational metrics, executive summaries, and performance interpretation",
                         "Translate reported numbers into the clearest operational takeaway for the user.",
@@ -112,6 +123,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "location",
                 domainPrompt(
+                        "location",
                         "Location",
                         "store context, branch-level operations, and location-specific constraints",
                         "Use location context to answer branch-specific staffing, stock, and operational questions.",
@@ -120,6 +132,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "shop-manager",
                 domainPrompt(
+                        "shop-manager",
                         "Shop Manager",
                         "branch operations, queue control, scheduling trade-offs, and execution oversight",
                         "Help a shop leader make the next operational decision with visibility into workload and blockers.",
@@ -128,6 +141,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "tax",
                 domainPrompt(
+                        "tax",
                         "Tax",
                         "tax calculation context, tax rule interpretation, and tax exceptions",
                         "Explain tax outcomes in terms of the triggering facts, rule boundaries, and operational consequences.",
@@ -136,6 +150,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "admin",
                 domainPrompt(
+                        "admin",
                         "Admin",
                         "platform governance, access administration, and operational controls",
                         "Help with administrative actions, permission-sensitive changes, and governance checks.",
@@ -144,6 +159,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         prompts.put(
                 "events",
                 domainPrompt(
+                        "events",
                         "Events",
                         "audit events, operational traces, and observability context",
                         "Use event history to reconstruct what happened, when it happened, and which action likely caused it.",
@@ -153,6 +169,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
     }
 
     private static @NonNull String domainPrompt(
+            @NonNull String promptKey,
             @NonNull String title,
             @NonNull String mission,
             @NonNull String responsibility,
@@ -176,7 +193,7 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         - %s
         - Prefer concrete statuses, exact entities, and next actions over generic advice.
         """.formatted(
-                title, mission, responsibility, title.toLowerCase(java.util.Locale.ROOT), guardrail, responseStyle);
+                title, mission, responsibility, promptKey, guardrail, responseStyle);
     }
 
     private final SystemPromptRepository systemPromptRepository;

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptSeedRunner.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptSeedRunner.java
@@ -15,102 +15,150 @@ import org.springframework.stereotype.Component;
 @Profile("!test")
 public class SystemPromptSeedRunner implements ApplicationRunner {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(SystemPromptSeedRunner.class);
-  private static final Map<String, String> SEED_PROMPTS = buildSeedPrompts();
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemPromptSeedRunner.class);
+    private static final Map<String, String> SEED_PROMPTS = buildSeedPrompts();
 
-  private static @NonNull Map<String, String> buildSeedPrompts() {
-    var prompts = new java.util.LinkedHashMap<String, String>();
-    prompts.put(SystemPromptDefaults.MASTER_PROMPT_NAME, SystemPromptDefaults.DEFAULT_PROMPT_TEXT);
-    prompts.put("inventory", domainPrompt("Inventory",
-        "inventory availability, receiving, replenishment, and reconciliation",
-        "Confirm SKU, location, on-hand, available, committed, and inbound context before giving an answer.",
-        "Do not blur physical stock, available stock, and expected stock; name the exact quantity status you are using.",
-        "operational, exact, and fast"));
-    prompts.put("order", domainPrompt("Order",
-        "purchase orders, sales orders, and order lifecycle coordination",
-        "Track order status, fulfillment blockers, supplier or store handoffs, and next-step dependencies.",
-        "Be explicit about whether an order is created, submitted, partially fulfilled, received, or blocked.",
-        "concise, status-driven, and action-oriented"));
-    prompts.put("customer", domainPrompt("Customer",
-        "customer profile context, account history, and communication-sensitive answers",
-        "Use customer records to ground identity, history, and relationship context before responding.",
-        "Protect privacy and avoid exposing or inferring customer details that are not confirmed by tools.",
-        "clear, empathetic, and factual"));
-    prompts.put("pricing", domainPrompt("Pricing",
-        "price lookup, discounts, margin guidance, and pricing exceptions",
-        "Explain the source of a price, discount, override, or margin concern in operational terms.",
-        "Never guess pricing outcomes; distinguish configured price, recommended price, and approved exception paths.",
-        "precise, commercially aware, and concise"));
-    prompts.put("workorder", domainPrompt("Workorder",
-        "workorder intake, execution status, assignment, and lifecycle coordination",
-        "Track workorder stage, blockers, technician handoff, required parts, and customer-facing next steps.",
-        "Call out missing approvals, missing parts, or scheduling conflicts instead of implying the work can proceed.",
-        "structured, practical, and step-by-step"));
-    prompts.put("catalog", domainPrompt("Catalog",
-        "item discovery, product metadata, and catalog fit-for-use answers",
-        "Use catalog data to identify the right item, attributes, variants, and compatibility signals.",
-        "Do not overstate certainty when multiple items match; surface the discriminating attributes the user needs.",
-        "focused, comparative, and exact"));
-    prompts.put("vehicle", domainPrompt("Vehicle",
-        "VIN, fitment, compatibility, and vehicle-specific service context",
-        "Anchor recommendations to confirmed vehicle attributes before suggesting parts or service conclusions.",
-        "If fitment is uncertain, say what vehicle detail or compatibility check is still required.",
-        "technical, careful, and easy to follow"));
-    prompts.put("accounting", domainPrompt("Accounting",
-        "financial summaries, ledger-facing context, and reconciliation support",
-        "Explain accounting impacts, reconciliation questions, and financial status using explicit business facts.",
-        "Stay audit-aware and never imply postings, balances, or adjustments that are not confirmed.",
-        "precise, controlled, and audit-ready"));
-    prompts.put("invoice", domainPrompt("Invoice",
-        "invoice creation, status, and invoice issue resolution",
-        "Track invoice lifecycle, blockers, payment relevance, and document state clearly.",
-        "Distinguish draft, issued, adjusted, and paid states so users know the exact document position.",
-        "clear, transactional, and decisive"));
-    prompts.put("hr", domainPrompt("HR",
-        "workforce scheduling, staffing context, and HR policy guidance",
-        "Use staffing data and policy context to answer schedule, availability, and operational workforce questions.",
-        "Be careful with sensitive personnel context and avoid unsupported policy interpretations.",
-        "professional, policy-aware, and direct"));
-    prompts.put("reporting", domainPrompt("Reporting",
-        "operational metrics, executive summaries, and performance interpretation",
-        "Translate reported numbers into the clearest operational takeaway for the user.",
-        "Do not over-explain every metric; focus on the signal, trend, exceptions, and likely drivers.",
-        "analytical, concise, and decision-oriented"));
-    prompts.put("location", domainPrompt("Location",
-        "store context, branch-level operations, and location-specific constraints",
-        "Use location context to answer branch-specific staffing, stock, and operational questions.",
-        "Always name the location dependency when the answer could differ across stores or branches.",
-        "practical, local-context aware, and fast"));
-    prompts.put("shop-manager", domainPrompt("Shop Manager",
-        "branch operations, queue control, scheduling trade-offs, and execution oversight",
-        "Help a shop leader make the next operational decision with visibility into workload and blockers.",
-        "Prioritize throughput, customer commitments, and exception handling over generic management advice.",
-        "decisive, operational, and management-ready"));
-    prompts.put("tax", domainPrompt("Tax",
-        "tax calculation context, tax rule interpretation, and tax exceptions",
-        "Explain tax outcomes in terms of the triggering facts, rule boundaries, and operational consequences.",
-        "Do not invent tax policy or legal certainty; point out when the available data is not sufficient.",
-        "careful, explicit, and compliance-aware"));
-    prompts.put("admin", domainPrompt("Admin",
-        "platform governance, access administration, and operational controls",
-        "Help with administrative actions, permission-sensitive changes, and governance checks.",
-        "Default to secure-by-design guidance and call out approval, audit, or blast-radius concerns.",
-        "secure, explicit, and controlled"));
-    prompts.put("events", domainPrompt("Events",
-        "audit events, operational traces, and observability context",
-        "Use event history to reconstruct what happened, when it happened, and which action likely caused it.",
-        "Separate observed events from interpretation so debugging stays trustworthy.",
-        "forensic, chronological, and succinct"));
-    return Map.copyOf(prompts);
-  }
+    private static @NonNull Map<String, String> buildSeedPrompts() {
+        var prompts = new java.util.LinkedHashMap<String, String>();
+        prompts.put(SystemPromptDefaults.MASTER_PROMPT_NAME, SystemPromptDefaults.DEFAULT_PROMPT_TEXT);
+        prompts.put(
+                "inventory",
+                domainPrompt(
+                        "Inventory",
+                        "inventory availability, receiving, replenishment, and reconciliation",
+                        "Confirm SKU, location, on-hand, available, committed, and inbound context before giving an answer.",
+                        "Do not blur physical stock, available stock, and expected stock; name the exact quantity status you are using.",
+                        "operational, exact, and fast"));
+        prompts.put(
+                "order",
+                domainPrompt(
+                        "Order",
+                        "purchase orders, sales orders, and order lifecycle coordination",
+                        "Track order status, fulfillment blockers, supplier or store handoffs, and next-step dependencies.",
+                        "Be explicit about whether an order is created, submitted, partially fulfilled, received, or blocked.",
+                        "concise, status-driven, and action-oriented"));
+        prompts.put(
+                "customer",
+                domainPrompt(
+                        "Customer",
+                        "customer profile context, account history, and communication-sensitive answers",
+                        "Use customer records to ground identity, history, and relationship context before responding.",
+                        "Protect privacy and avoid exposing or inferring customer details that are not confirmed by tools.",
+                        "clear, empathetic, and factual"));
+        prompts.put(
+                "pricing",
+                domainPrompt(
+                        "Pricing",
+                        "price lookup, discounts, margin guidance, and pricing exceptions",
+                        "Explain the source of a price, discount, override, or margin concern in operational terms.",
+                        "Never guess pricing outcomes; distinguish configured price, recommended price, and approved exception paths.",
+                        "precise, commercially aware, and concise"));
+        prompts.put(
+                "workorder",
+                domainPrompt(
+                        "Workorder",
+                        "workorder intake, execution status, assignment, and lifecycle coordination",
+                        "Track workorder stage, blockers, technician handoff, required parts, and customer-facing next steps.",
+                        "Call out missing approvals, missing parts, or scheduling conflicts instead of implying the work can proceed.",
+                        "structured, practical, and step-by-step"));
+        prompts.put(
+                "catalog",
+                domainPrompt(
+                        "Catalog",
+                        "item discovery, product metadata, and catalog fit-for-use answers",
+                        "Use catalog data to identify the right item, attributes, variants, and compatibility signals.",
+                        "Do not overstate certainty when multiple items match; surface the discriminating attributes the user needs.",
+                        "focused, comparative, and exact"));
+        prompts.put(
+                "vehicle",
+                domainPrompt(
+                        "Vehicle",
+                        "VIN, fitment, compatibility, and vehicle-specific service context",
+                        "Anchor recommendations to confirmed vehicle attributes before suggesting parts or service conclusions.",
+                        "If fitment is uncertain, say what vehicle detail or compatibility check is still required.",
+                        "technical, careful, and easy to follow"));
+        prompts.put(
+                "accounting",
+                domainPrompt(
+                        "Accounting",
+                        "financial summaries, ledger-facing context, and reconciliation support",
+                        "Explain accounting impacts, reconciliation questions, and financial status using explicit business facts.",
+                        "Stay audit-aware and never imply postings, balances, or adjustments that are not confirmed.",
+                        "precise, controlled, and audit-ready"));
+        prompts.put(
+                "invoice",
+                domainPrompt(
+                        "Invoice",
+                        "invoice creation, status, and invoice issue resolution",
+                        "Track invoice lifecycle, blockers, payment relevance, and document state clearly.",
+                        "Distinguish draft, issued, adjusted, and paid states so users know the exact document position.",
+                        "clear, transactional, and decisive"));
+        prompts.put(
+                "hr",
+                domainPrompt(
+                        "HR",
+                        "workforce scheduling, staffing context, and HR policy guidance",
+                        "Use staffing data and policy context to answer schedule, availability, and operational workforce questions.",
+                        "Be careful with sensitive personnel context and avoid unsupported policy interpretations.",
+                        "professional, policy-aware, and direct"));
+        prompts.put(
+                "reporting",
+                domainPrompt(
+                        "Reporting",
+                        "operational metrics, executive summaries, and performance interpretation",
+                        "Translate reported numbers into the clearest operational takeaway for the user.",
+                        "Do not over-explain every metric; focus on the signal, trend, exceptions, and likely drivers.",
+                        "analytical, concise, and decision-oriented"));
+        prompts.put(
+                "location",
+                domainPrompt(
+                        "Location",
+                        "store context, branch-level operations, and location-specific constraints",
+                        "Use location context to answer branch-specific staffing, stock, and operational questions.",
+                        "Always name the location dependency when the answer could differ across stores or branches.",
+                        "practical, local-context aware, and fast"));
+        prompts.put(
+                "shop-manager",
+                domainPrompt(
+                        "Shop Manager",
+                        "branch operations, queue control, scheduling trade-offs, and execution oversight",
+                        "Help a shop leader make the next operational decision with visibility into workload and blockers.",
+                        "Prioritize throughput, customer commitments, and exception handling over generic management advice.",
+                        "decisive, operational, and management-ready"));
+        prompts.put(
+                "tax",
+                domainPrompt(
+                        "Tax",
+                        "tax calculation context, tax rule interpretation, and tax exceptions",
+                        "Explain tax outcomes in terms of the triggering facts, rule boundaries, and operational consequences.",
+                        "Do not invent tax policy or legal certainty; point out when the available data is not sufficient.",
+                        "careful, explicit, and compliance-aware"));
+        prompts.put(
+                "admin",
+                domainPrompt(
+                        "Admin",
+                        "platform governance, access administration, and operational controls",
+                        "Help with administrative actions, permission-sensitive changes, and governance checks.",
+                        "Default to secure-by-design guidance and call out approval, audit, or blast-radius concerns.",
+                        "secure, explicit, and controlled"));
+        prompts.put(
+                "events",
+                domainPrompt(
+                        "Events",
+                        "audit events, operational traces, and observability context",
+                        "Use event history to reconstruct what happened, when it happened, and which action likely caused it.",
+                        "Separate observed events from interpretation so debugging stays trustworthy.",
+                        "forensic, chronological, and succinct"));
+        return Map.copyOf(prompts);
+    }
 
-  private static @NonNull String domainPrompt(
-      @NonNull String title,
-      @NonNull String mission,
-      @NonNull String responsibility,
-      @NonNull String guardrail,
-      @NonNull String responseStyle) {
-    return """
+    private static @NonNull String domainPrompt(
+            @NonNull String title,
+            @NonNull String mission,
+            @NonNull String responsibility,
+            @NonNull String guardrail,
+            @NonNull String responseStyle) {
+        return """
         You are the Durion Positivity %s domain agent.
         Focus on %s.
 
@@ -127,42 +175,43 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
         Response style:
         - %s
         - Prefer concrete statuses, exact entities, and next actions over generic advice.
-        """.formatted(title, mission, responsibility, title.toLowerCase(java.util.Locale.ROOT), guardrail, responseStyle);
-  }
+        """.formatted(
+                title, mission, responsibility, title.toLowerCase(java.util.Locale.ROOT), guardrail, responseStyle);
+    }
 
-  private final SystemPromptRepository systemPromptRepository;
+    private final SystemPromptRepository systemPromptRepository;
 
-  public SystemPromptSeedRunner(@NonNull SystemPromptRepository systemPromptRepository) {
-    this.systemPromptRepository = systemPromptRepository;
-  }
+    public SystemPromptSeedRunner(@NonNull SystemPromptRepository systemPromptRepository) {
+        this.systemPromptRepository = systemPromptRepository;
+    }
 
-  static @NonNull Map<String, String> seedPrompts() {
-    return SEED_PROMPTS;
-  }
+    static @NonNull Map<String, String> seedPrompts() {
+        return SEED_PROMPTS;
+    }
 
-  @Override
-  public void run(@NonNull ApplicationArguments args) {
-    SEED_PROMPTS.forEach((name, content) -> {
-      try {
-        var existingPrompt = systemPromptRepository.findByName(name);
-        if (existingPrompt.isPresent()) {
-          var prompt = existingPrompt.get();
-          if (!content.equals(prompt.getContent())) {
-            prompt.setContent(content);
-            systemPromptRepository.save(prompt);
-            LOGGER.info("Updated system prompt name={}", name);
-          }
-          return;
-        }
+    @Override
+    public void run(@NonNull ApplicationArguments args) {
+        SEED_PROMPTS.forEach((name, content) -> {
+            try {
+                var existingPrompt = systemPromptRepository.findByName(name);
+                if (existingPrompt.isPresent()) {
+                    var prompt = existingPrompt.get();
+                    if (!content.equals(prompt.getContent())) {
+                        prompt.setContent(content);
+                        systemPromptRepository.save(prompt);
+                        LOGGER.info("Updated system prompt name={}", name);
+                    }
+                    return;
+                }
 
-        var prompt = new SystemPrompt();
-        prompt.setName(name);
-        prompt.setContent(content);
-        systemPromptRepository.save(prompt);
-        LOGGER.info("Seeded system prompt name={}", name);
-      } catch (Exception exception) {
-        LOGGER.warn("Failed to seed system prompt name={}", name, exception);
-      }
-    });
-  }
+                var prompt = new SystemPrompt();
+                prompt.setName(name);
+                prompt.setContent(content);
+                systemPromptRepository.save(prompt);
+                LOGGER.info("Seeded system prompt name={}", name);
+            } catch (Exception exception) {
+                LOGGER.warn("Failed to seed system prompt name={}", name, exception);
+            }
+        });
+    }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptSeedRunner.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SystemPromptSeedRunner.java
@@ -20,145 +20,114 @@ public class SystemPromptSeedRunner implements ApplicationRunner {
 
   private static @NonNull Map<String, String> buildSeedPrompts() {
     var prompts = new java.util.LinkedHashMap<String, String>();
-    prompts.put(SystemPromptDefaults.DEFAULT_PROMPT_NAME, SystemPromptDefaults.DEFAULT_PROMPT_TEXT);
-    prompts.put(
-        SystemPromptDefaults.ROLE_ADMIN_PROMPT_NAME,
-        "You are a Durion Positivity ETSMS administrative assisstant's assistant. Help with platform administration, access governance, and operational controls. Be secure-by-default and explicit about risks.");
-    prompts.put(
-        SystemPromptDefaults.ROLE_SYSTEM_ADMINISTRATOR_PROMPT_NAME,
-        """
-                **System Prompt: Durion Positivity Platform Administrator**
-
-                    You are operating within the Durion Positivity ETSMS platform as a system administrator assistant. You have access to live platform tools — always call the appropriate tool to answer operational questions before responding. Never tell the user you cannot access platform data without first attempting to use a tool.
-
-                    ---
-
-                    **System Prompt: System Administration Helper (Roles & Permissions Expert)**
-
-                    You are a system administration assistant specializing in roles, permissions, identity management, and access control across enterprise systems. Your primary responsibility is to help design, implement, audit, and troubleshoot secure and scalable authorization models.
-
-                    ---
-
-                    ### **Core Responsibilities**
-
-                    * Design and enforce **role-based access control (RBAC)**, **attribute-based access control (ABAC)**, and hybrid models where appropriate
-                    * Define **roles, groups, and permission hierarchies** aligned with business functions
-                    * Assist in **least-privilege access design** and **separation of duties (SoD)**
-                    * Configure and validate **authentication and authorization flows**
-                    * Audit systems for **permission drift, over-provisioning, and security risks**
-                    * Troubleshoot **access issues**, including misconfigured roles, token claims, or policy conflicts
-                    * Provide guidance on **multi-tenant, multi-role, and hierarchical permission systems**
-
-
-                    ---
-
-                    ### **Behavioral Guidelines**
-
-                    * Provide **precise, implementation-oriented answers**
-                    * Default to **secure-by-design recommendations**
-                    * Clearly distinguish between:
-
-                      * **Authentication** (who the user is)
-                      * **Authorization** (what the user can do)
-                    * When ambiguous, request clarification on:
-
-                      * System type (e.g., SaaS, on-prem, microservices)
-                      * Identity provider (IdP)
-                      * Existing role/permission model
-                    * Avoid assumptions about implicit access; always require explicit definition
-
-                    ---
-
-                    ### **Technical Expectations**
-
-                    * Be fluent in:
-
-                      * RBAC, ABAC, ReBAC concepts
-                      * OAuth2, OIDC, SAML
-                      * JWT structure and claims design
-                      * Policy engines (e.g., OPA, Cedar-style policies)
-                      * Directory services (LDAP, Active Directory)
-                    * Provide examples in:
-
-                      * JSON (policies, JWTs)
-                      * YAML (configurations)
-                      * SQL (role/permission schemas)
-                      * Pseudocode where necessary
-
-                    ---
-
-                    ### **Design Principles**
-
-                    * Enforce **least privilege by default**
-                    * Prefer **composable roles over monolithic roles**
-                    * Separate:
-
-                      * **Business roles** (e.g., Technician, Manager)
-                      * **System roles** (e.g., ADMIN, SERVICE_ACCOUNT)
-                    * Ensure **auditability and traceability** of all access decisions
-                    * Design for **revocation, rotation, and lifecycle management**
-
-                    ---
-
-                    ### **Common Tasks You Support**
-
-                    * Designing a role and permission model from scratch
-                    * Mapping business responsibilities to system permissions
-                    * Creating permission schemas and access matrices
-                    * Debugging "user cannot access resource” scenarios
-                    * Reviewing and tightening existing access controls
-                    * Advising on token design (claims, scopes, audiences)
-                    * Supporting compliance requirements (e.g., SOC2, ISO, internal audit)
-
-                    ---
-
-                    ### **Response Style**
-
-                    * Structured and concise
-                    * Prefer diagrams (described textually), tables, or step-by-step procedures
-                    * Highlight risks and trade-offs explicitly
-                    * Provide actionable next steps when appropriate
-
-                    ---
-
-                    ### **Constraints**
-
-                    * Do not provide vague or generic security advice
-                    * Do not assume default roles or permissions without validation
-                    * Do not recommend broad permissions (e.g., "admin”) unless justified
-
-                    ---
-
-                    ### **Goal**
-
-                    Enable secure, maintainable, and scalable access control systems that align with both technical architecture and business operations.
-
-            """);
-    prompts.put(
-        SystemPromptDefaults.ROLE_LOCATION_MANAGER_PROMPT_NAME,
-        "You are a Durion Positivity ETSMS location manager assistant. Help with location-level operations, staffing coordination, and execution visibility. Be practical and decision-oriented.");
-    prompts.put(
-        SystemPromptDefaults.ROLE_ACCOUNT_MANAGER_PROMPT_NAME,
-        "You are a Durion Positivity ETSMS account manager assistant. Help with account relationships, customer commitments, and service coordination. Be concise and customer-outcome focused.");
-    prompts.put(
-        SystemPromptDefaults.ROLE_ACCOUNTING_ASSOCIATE_PROMPT_NAME,
-        "You are a Durion Positivity ETSMS accounting associate assistant. Help with accounting workflows, reconciliation support, and financial data checks. Be precise and audit-aware.");
-    prompts.put(
-        SystemPromptDefaults.ROLE_SERVICE_ADVISOR_PROMPT_NAME,
-        "You are a Durion Positivity ETSMS service advisor assistant. Help with customer intake, estimate communication, and repair-order coordination. Be clear, accurate, and customer-friendly.");
-    prompts.put(
-        SystemPromptDefaults.ROLE_DISPATCHER_PROMPT_NAME,
-        "You are a Durion Positivity ETSMS dispatcher assistant. Help with scheduling, queue management, technician assignment, and throughput balancing. Be fast and operationally precise.");
-    prompts.put(
-        SystemPromptDefaults.ROLE_TECHNICIAN_PROMPT_NAME,
-        "You are a Durion Positivity ETSMS technician assistant. Help with workorder execution, parts management, and vehicle service operations. Be practical and step-by-step.");
-    prompts.put(
-        SystemPromptDefaults.ROLE_CUSTOMER_PROMPT_NAME,
-        "You are a Durion Positivity ETSMS customer assistant. Help with appointment status, service updates, and next-step clarity. Be concise and easy to understand.");
-    prompts.put(
-        SystemPromptDefaults.ROLE_SELF_SERVICE_CUSTOMER_PROMPT_NAME,
-        "You are a Durion Positivity ETSMS self-service customer assistant. Help users complete tasks independently with clear, step-by-step guidance and concise status updates.");
+    prompts.put(SystemPromptDefaults.MASTER_PROMPT_NAME, SystemPromptDefaults.DEFAULT_PROMPT_TEXT);
+    prompts.put("inventory", domainPrompt("Inventory",
+        "inventory availability, receiving, replenishment, and reconciliation",
+        "Confirm SKU, location, on-hand, available, committed, and inbound context before giving an answer.",
+        "Do not blur physical stock, available stock, and expected stock; name the exact quantity status you are using.",
+        "operational, exact, and fast"));
+    prompts.put("order", domainPrompt("Order",
+        "purchase orders, sales orders, and order lifecycle coordination",
+        "Track order status, fulfillment blockers, supplier or store handoffs, and next-step dependencies.",
+        "Be explicit about whether an order is created, submitted, partially fulfilled, received, or blocked.",
+        "concise, status-driven, and action-oriented"));
+    prompts.put("customer", domainPrompt("Customer",
+        "customer profile context, account history, and communication-sensitive answers",
+        "Use customer records to ground identity, history, and relationship context before responding.",
+        "Protect privacy and avoid exposing or inferring customer details that are not confirmed by tools.",
+        "clear, empathetic, and factual"));
+    prompts.put("pricing", domainPrompt("Pricing",
+        "price lookup, discounts, margin guidance, and pricing exceptions",
+        "Explain the source of a price, discount, override, or margin concern in operational terms.",
+        "Never guess pricing outcomes; distinguish configured price, recommended price, and approved exception paths.",
+        "precise, commercially aware, and concise"));
+    prompts.put("workorder", domainPrompt("Workorder",
+        "workorder intake, execution status, assignment, and lifecycle coordination",
+        "Track workorder stage, blockers, technician handoff, required parts, and customer-facing next steps.",
+        "Call out missing approvals, missing parts, or scheduling conflicts instead of implying the work can proceed.",
+        "structured, practical, and step-by-step"));
+    prompts.put("catalog", domainPrompt("Catalog",
+        "item discovery, product metadata, and catalog fit-for-use answers",
+        "Use catalog data to identify the right item, attributes, variants, and compatibility signals.",
+        "Do not overstate certainty when multiple items match; surface the discriminating attributes the user needs.",
+        "focused, comparative, and exact"));
+    prompts.put("vehicle", domainPrompt("Vehicle",
+        "VIN, fitment, compatibility, and vehicle-specific service context",
+        "Anchor recommendations to confirmed vehicle attributes before suggesting parts or service conclusions.",
+        "If fitment is uncertain, say what vehicle detail or compatibility check is still required.",
+        "technical, careful, and easy to follow"));
+    prompts.put("accounting", domainPrompt("Accounting",
+        "financial summaries, ledger-facing context, and reconciliation support",
+        "Explain accounting impacts, reconciliation questions, and financial status using explicit business facts.",
+        "Stay audit-aware and never imply postings, balances, or adjustments that are not confirmed.",
+        "precise, controlled, and audit-ready"));
+    prompts.put("invoice", domainPrompt("Invoice",
+        "invoice creation, status, and invoice issue resolution",
+        "Track invoice lifecycle, blockers, payment relevance, and document state clearly.",
+        "Distinguish draft, issued, adjusted, and paid states so users know the exact document position.",
+        "clear, transactional, and decisive"));
+    prompts.put("hr", domainPrompt("HR",
+        "workforce scheduling, staffing context, and HR policy guidance",
+        "Use staffing data and policy context to answer schedule, availability, and operational workforce questions.",
+        "Be careful with sensitive personnel context and avoid unsupported policy interpretations.",
+        "professional, policy-aware, and direct"));
+    prompts.put("reporting", domainPrompt("Reporting",
+        "operational metrics, executive summaries, and performance interpretation",
+        "Translate reported numbers into the clearest operational takeaway for the user.",
+        "Do not over-explain every metric; focus on the signal, trend, exceptions, and likely drivers.",
+        "analytical, concise, and decision-oriented"));
+    prompts.put("location", domainPrompt("Location",
+        "store context, branch-level operations, and location-specific constraints",
+        "Use location context to answer branch-specific staffing, stock, and operational questions.",
+        "Always name the location dependency when the answer could differ across stores or branches.",
+        "practical, local-context aware, and fast"));
+    prompts.put("shop-manager", domainPrompt("Shop Manager",
+        "branch operations, queue control, scheduling trade-offs, and execution oversight",
+        "Help a shop leader make the next operational decision with visibility into workload and blockers.",
+        "Prioritize throughput, customer commitments, and exception handling over generic management advice.",
+        "decisive, operational, and management-ready"));
+    prompts.put("tax", domainPrompt("Tax",
+        "tax calculation context, tax rule interpretation, and tax exceptions",
+        "Explain tax outcomes in terms of the triggering facts, rule boundaries, and operational consequences.",
+        "Do not invent tax policy or legal certainty; point out when the available data is not sufficient.",
+        "careful, explicit, and compliance-aware"));
+    prompts.put("admin", domainPrompt("Admin",
+        "platform governance, access administration, and operational controls",
+        "Help with administrative actions, permission-sensitive changes, and governance checks.",
+        "Default to secure-by-design guidance and call out approval, audit, or blast-radius concerns.",
+        "secure, explicit, and controlled"));
+    prompts.put("events", domainPrompt("Events",
+        "audit events, operational traces, and observability context",
+        "Use event history to reconstruct what happened, when it happened, and which action likely caused it.",
+        "Separate observed events from interpretation so debugging stays trustworthy.",
+        "forensic, chronological, and succinct"));
     return Map.copyOf(prompts);
+  }
+
+  private static @NonNull String domainPrompt(
+      @NonNull String title,
+      @NonNull String mission,
+      @NonNull String responsibility,
+      @NonNull String guardrail,
+      @NonNull String responseStyle) {
+    return """
+        You are the Durion Positivity %s domain agent.
+        Focus on %s.
+
+        Core responsibilities:
+        - Use tools before answering live, record-specific, or status-sensitive questions.
+        - %s
+        - Stay inside %s scope; if another domain is required, say so plainly.
+
+        Guardrails:
+        - Never invent business data, identifiers, statuses, quantities, or policy outcomes.
+        - %s
+        - When the request is missing a key detail, ask only for the minimum clarification needed to continue.
+
+        Response style:
+        - %s
+        - Prefer concrete statuses, exact entities, and next actions over generic advice.
+        """.formatted(title, mission, responsibility, title.toLowerCase(java.util.Locale.ROOT), guardrail, responseStyle);
   }
 
   private final SystemPromptRepository systemPromptRepository;

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryService.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistryService.java
@@ -20,279 +20,276 @@ import org.springframework.stereotype.Service;
 @Profile("!test")
 public class ToolRegistryService {
 
-        private static final Logger LOGGER = LoggerFactory.getLogger(ToolRegistryService.class);
-        private static final int MAX_QUERY_PREVIEW_LENGTH = 160;
-        private static final String ROLE_ADMIN = "ROLE_ADMIN";
-        private static final String ADMIN_FACADE_TOOL = "AdminFacadeTool";
-        private static final Set<String> ADMIN_QUERY_KEYWORDS = Set.of(
-                        "user",
-                        "users",
-                        "role",
-                        "roles",
-                        "permission",
-                        "permissions",
-                        "access",
-                        "account",
-                        "accounts",
-                        "audit",
-                        "audits",
-                        "registered",
-                        "registration",
-                        "login",
-                        "logins");
-        private static final Set<String> ADMIN_QUERY_PHRASES = Set.of(
-                        "who has access",
-                        "who can access",
-                        "audit log",
-                        "access review",
-                        "user count",
-                        "registered users",
-                        "account state");
+    private static final Logger LOGGER = LoggerFactory.getLogger(ToolRegistryService.class);
+    private static final int MAX_QUERY_PREVIEW_LENGTH = 160;
+    private static final String ROLE_ADMIN = "ROLE_ADMIN";
+    private static final String ADMIN_FACADE_TOOL = "AdminFacadeTool";
+    private static final Set<String> ADMIN_QUERY_KEYWORDS = Set.of(
+            "user",
+            "users",
+            "role",
+            "roles",
+            "permission",
+            "permissions",
+            "access",
+            "account",
+            "accounts",
+            "audit",
+            "audits",
+            "registered",
+            "registration",
+            "login",
+            "logins");
+    private static final Set<String> ADMIN_QUERY_PHRASES = Set.of(
+            "who has access",
+            "who can access",
+            "audit log",
+            "access review",
+            "user count",
+            "registered users",
+            "account state");
 
-        private final ToolMetadataRepository repository;
-        private final EmbeddingModel embeddingModel;
-        private final ToolScorer scorer;
+    private final ToolMetadataRepository repository;
+    private final EmbeddingModel embeddingModel;
+    private final ToolScorer scorer;
 
-        public ToolRegistryService(@NonNull ToolMetadataRepository repository, @NonNull EmbeddingModel embeddingModel) {
-                this.repository = repository;
-                this.embeddingModel = embeddingModel;
-                this.scorer = new ToolScorer();
+    public ToolRegistryService(@NonNull ToolMetadataRepository repository, @NonNull EmbeddingModel embeddingModel) {
+        this.repository = repository;
+        this.embeddingModel = embeddingModel;
+        this.scorer = new ToolScorer();
+    }
+
+    public @NonNull List<ToolMetadata> resolveCandidateTools(@NonNull ToolSelectionContext context, int topK) {
+        if (topK <= 0) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "MCP tool lookup skipped role={} workflow={} topK={} reason=non-positive-topk queryPreview=\"{}\"",
+                        context.role(),
+                        context.workflowState(),
+                        topK,
+                        preview(context.userInput()));
+            }
+            return List.of();
         }
 
-        public @NonNull List<ToolMetadata> resolveCandidateTools(@NonNull ToolSelectionContext context, int topK) {
-                if (topK <= 0) {
-                        if (LOGGER.isDebugEnabled()) {
-                                LOGGER.debug(
-                                                "MCP tool lookup skipped role={} workflow={} topK={} reason=non-positive-topk queryPreview=\"{}\"",
-                                                context.role(),
-                                                context.workflowState(),
-                                                topK,
-                                                preview(context.userInput()));
-                        }
-                        return List.of();
-                }
+        List<ToolMetadata> gatedTools =
+                repository.findEnabledByRoleAndWorkflow(context.role(), context.workflowState());
 
-                List<ToolMetadata> gatedTools = repository.findEnabledByRoleAndWorkflow(context.role(),
-                                context.workflowState());
-
-                if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug(
-                                        "MCP tool lookup start role={} workflow={} topK={} gatedToolCount={} gatedTools={} queryPreview=\"{}\"",
-                                        context.role(),
-                                        context.workflowState(),
-                                        topK,
-                                        gatedTools.size(),
-                                        toolNames(gatedTools),
-                                        preview(context.userInput()));
-                }
-
-                if (gatedTools.isEmpty()) {
-                        if (LOGGER.isDebugEnabled()) {
-                                LOGGER.debug(
-                                                "MCP tool lookup no gated tools role={} workflow={} queryPreview=\"{}\"",
-                                                context.role(),
-                                                context.workflowState(),
-                                                preview(context.userInput()));
-                        }
-                        return List.of();
-                }
-
-                List<ToolMetadata> adminFastPathSelection = adminFastPathSelection(context, gatedTools);
-                if (!adminFastPathSelection.isEmpty()) {
-                        if (LOGGER.isDebugEnabled()) {
-                                LOGGER.debug(
-                                                "MCP tool lookup fast-path result role={} workflow={} selectedTools={} queryPreview=\"{}\"",
-                                                context.role(),
-                                                context.workflowState(),
-                                                toolNames(adminFastPathSelection),
-                                                preview(context.userInput()));
-                        }
-                        return adminFastPathSelection;
-                }
-
-                float[] embedding = embeddingModel.embed(context.userInput()).content().vector();
-                int semanticLimit = Math.max(topK, 10);
-
-                // Phase 2 fix: gated ANN — only tools authorized for this role+workflow enter
-                // the
-                // ranking window. Unauthorized tools can never displace authorized ones.
-                List<ToolMetadata> semanticCandidates = repository.findTopKByEmbeddingForRole(
-                                embedding, semanticLimit, context.role(), context.workflowState());
-
-                if (semanticCandidates.isEmpty()) {
-                        // Fallback: tools have no embeddings yet; return highest-priority gated tools
-                        if (LOGGER.isDebugEnabled()) {
-                                LOGGER.debug(
-                                                "MCP tool scoring no-embedding fallback role={} workflow={} returning top-{} by priority",
-                                                context.role(),
-                                                context.workflowState(),
-                                                topK);
-                        }
-                        return gatedTools.stream()
-                                        .sorted(Comparator.comparingDouble(ToolMetadata::priority)
-                                                        .reversed()
-                                                        .thenComparing(ToolMetadata::name))
-                                        .limit(topK)
-                                        .toList();
-                }
-
-                List<ScoredTool> scoredCandidates = IntStream.range(0, semanticCandidates.size())
-                                .mapToObj(index -> new ScoredTool(
-                                                semanticCandidates.get(index),
-                                                scorer.score(semanticCandidates.get(index), index), index))
-                                .sorted(Comparator.comparingDouble(
-                                                (ScoredTool scored) -> scored.score().total())
-                                                .reversed()
-                                                .thenComparingInt(ScoredTool::rankPosition)
-                                                .thenComparing(st -> st.tool().name()))
-                                .toList();
-
-                if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug(
-                                        "MCP tool scoring role={} workflow={} topK={} gatedTools={} semanticCandidates={} scoredCandidates={}",
-                                        context.role(),
-                                        context.workflowState(),
-                                        topK,
-                                        toolNames(gatedTools),
-                                        semanticCandidateSummaries(semanticCandidates),
-                                        scoredCandidateSummaries(scoredCandidates));
-                }
-
-                List<ToolMetadata> selectedTools = scoredCandidates.stream().limit(topK).map(ScoredTool::tool).toList();
-                if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug(
-                                        "MCP tool lookup result role={} workflow={} selectedTools={} queryPreview=\"{}\"",
-                                        context.role(),
-                                        context.workflowState(),
-                                        toolNames(selectedTools),
-                                        preview(context.userInput()));
-                }
-                return selectedTools;
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "MCP tool lookup start role={} workflow={} topK={} gatedToolCount={} gatedTools={} queryPreview=\"{}\"",
+                    context.role(),
+                    context.workflowState(),
+                    topK,
+                    gatedTools.size(),
+                    toolNames(gatedTools),
+                    preview(context.userInput()));
         }
 
-        private @NonNull List<ToolMetadata> adminFastPathSelection(
-                        @NonNull ToolSelectionContext context, @NonNull List<ToolMetadata> gatedTools) {
-                if (!ROLE_ADMIN.equals(context.role())) {
-                        return List.of();
-                }
-
-                Set<String> matchedTerms = matchedAdminQueryTerms(context.userInput());
-                if (matchedTerms.isEmpty()) {
-                        if (LOGGER.isDebugEnabled()) {
-                                LOGGER.debug(
-                                                "MCP tool fast-path skipped role={} workflow={} reason=no-admin-keywords queryPreview=\"{}\"",
-                                                context.role(),
-                                                context.workflowState(),
-                                                preview(context.userInput()));
-                        }
-                        return List.of();
-                }
-
-                List<ToolMetadata> adminTools = gatedTools.stream()
-                                .filter(tool -> ADMIN_FACADE_TOOL.equals(tool.name()))
-                                .toList();
-                if (!adminTools.isEmpty()) {
-                        if (LOGGER.isDebugEnabled()) {
-                                LOGGER.debug(
-                                                "MCP tool fast-path matched role={} workflow={} tool={} matchedTerms={} queryPreview=\"{}\"",
-                                                context.role(),
-                                                context.workflowState(),
-                                                ADMIN_FACADE_TOOL,
-                                                matchedTerms,
-                                                preview(context.userInput()));
-                        }
-                } else {
-                        if (LOGGER.isDebugEnabled()) {
-                                LOGGER.debug(
-                                                "MCP tool fast-path eligible but admin tool unavailable role={} workflow={} matchedTerms={} gatedTools={}",
-                                                context.role(),
-                                                context.workflowState(),
-                                                matchedTerms,
-                                                toolNames(gatedTools));
-                        }
-                }
-                return adminTools;
+        if (gatedTools.isEmpty()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "MCP tool lookup no gated tools role={} workflow={} queryPreview=\"{}\"",
+                        context.role(),
+                        context.workflowState(),
+                        preview(context.userInput()));
+            }
+            return List.of();
         }
 
-        private @NonNull Set<String> matchedAdminQueryTerms(@NonNull String userInput) {
-                String normalized = userInput.toLowerCase(Locale.ROOT);
-                Set<String> matches = new TreeSet<>();
-                for (String keyword : ADMIN_QUERY_KEYWORDS) {
-                        if (normalized.matches(".*\\b" + keyword + "\\b.*")) {
-                                matches.add(keyword);
-                        }
-                }
-                for (String phrase : ADMIN_QUERY_PHRASES) {
-                        if (normalized.contains(phrase)) {
-                                matches.add(phrase);
-                        }
-                }
-                return matches;
+        List<ToolMetadata> adminFastPathSelection = adminFastPathSelection(context, gatedTools);
+        if (!adminFastPathSelection.isEmpty()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "MCP tool lookup fast-path result role={} workflow={} selectedTools={} queryPreview=\"{}\"",
+                        context.role(),
+                        context.workflowState(),
+                        toolNames(adminFastPathSelection),
+                        preview(context.userInput()));
+            }
+            return adminFastPathSelection;
         }
 
-        static final class ToolScorer {
+        float[] embedding = embeddingModel.embed(context.userInput()).content().vector();
+        int semanticLimit = Math.max(topK, 10);
 
-                @NonNull
-                ToolScore score(@NonNull ToolMetadata tool, int rankPosition) {
-                        double semanticScore = 1.0 / (rankPosition + 1);
-                        double priorityBoost = Math.clamp(tool.priority(), 0.0, 1.0);
-                        double latencyPenalty = Math.min(tool.avgLatencyMs() / 1000.0, 1.0) * 0.2;
-                        double costPenalty = switch (tool.costLevel().toLowerCase()) {
-                                case "high" -> 0.2;
-                                case "medium" -> 0.1;
-                                default -> 0.0;
-                        };
-                        return new ToolScore(
-                                        semanticScore + priorityBoost - latencyPenalty - costPenalty,
-                                        semanticScore,
-                                        priorityBoost,
-                                        latencyPenalty,
-                                        costPenalty);
-                }
+        // Phase 2 fix: gated ANN — only tools authorized for this role+workflow enter
+        // the
+        // ranking window. Unauthorized tools can never displace authorized ones.
+        List<ToolMetadata> semanticCandidates = repository.findTopKByEmbeddingForRole(
+                embedding, semanticLimit, context.role(), context.workflowState());
+
+        if (semanticCandidates.isEmpty()) {
+            // Fallback: tools have no embeddings yet; return highest-priority gated tools
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "MCP tool scoring no-embedding fallback role={} workflow={} returning top-{} by priority",
+                        context.role(),
+                        context.workflowState(),
+                        topK);
+            }
+            return gatedTools.stream()
+                    .sorted(Comparator.comparingDouble(ToolMetadata::priority)
+                            .reversed()
+                            .thenComparing(ToolMetadata::name))
+                    .limit(topK)
+                    .toList();
         }
 
-        private static @NonNull List<String> toolNames(@NonNull List<ToolMetadata> tools) {
-                return tools.stream().map(ToolMetadata::name).toList();
+        List<ScoredTool> scoredCandidates = IntStream.range(0, semanticCandidates.size())
+                .mapToObj(index -> new ScoredTool(
+                        semanticCandidates.get(index), scorer.score(semanticCandidates.get(index), index), index))
+                .sorted(Comparator.comparingDouble(
+                                (ScoredTool scored) -> scored.score().total())
+                        .reversed()
+                        .thenComparingInt(ScoredTool::rankPosition)
+                        .thenComparing(st -> st.tool().name()))
+                .toList();
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "MCP tool scoring role={} workflow={} topK={} gatedTools={} semanticCandidates={} scoredCandidates={}",
+                    context.role(),
+                    context.workflowState(),
+                    topK,
+                    toolNames(gatedTools),
+                    semanticCandidateSummaries(semanticCandidates),
+                    scoredCandidateSummaries(scoredCandidates));
         }
 
-        private static @NonNull List<String> semanticCandidateSummaries(
-                        @NonNull List<ToolMetadata> semanticCandidates) {
-                return IntStream.range(0, semanticCandidates.size())
-                                .mapToObj(index -> index + ":" + semanticCandidates.get(index).name())
-                                .toList();
+        List<ToolMetadata> selectedTools =
+                scoredCandidates.stream().limit(topK).map(ScoredTool::tool).toList();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "MCP tool lookup result role={} workflow={} selectedTools={} queryPreview=\"{}\"",
+                    context.role(),
+                    context.workflowState(),
+                    toolNames(selectedTools),
+                    preview(context.userInput()));
+        }
+        return selectedTools;
+    }
+
+    private @NonNull List<ToolMetadata> adminFastPathSelection(
+            @NonNull ToolSelectionContext context, @NonNull List<ToolMetadata> gatedTools) {
+        if (!ROLE_ADMIN.equals(context.role())) {
+            return List.of();
         }
 
-        private static @NonNull List<String> scoredCandidateSummaries(@NonNull List<ScoredTool> scoredCandidates) {
-                return scoredCandidates.stream()
-                                .map(scored -> scored.tool().name()
-                                                + "[rank=" + scored.rankPosition()
-                                                + ",total=" + format(scored.score().total())
-                                                + ",semantic=" + format(scored.score().semanticScore())
-                                                + ",priority=" + format(scored.score().priorityBoost())
-                                                + ",latencyPenalty=" + format(scored.score().latencyPenalty())
-                                                + ",costPenalty=" + format(scored.score().costPenalty())
-                                                + "]")
-                                .toList();
+        Set<String> matchedTerms = matchedAdminQueryTerms(context.userInput());
+        if (matchedTerms.isEmpty()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "MCP tool fast-path skipped role={} workflow={} reason=no-admin-keywords queryPreview=\"{}\"",
+                        context.role(),
+                        context.workflowState(),
+                        preview(context.userInput()));
+            }
+            return List.of();
         }
 
-        private static @NonNull String format(double value) {
-                return String.format(java.util.Locale.ROOT, "%.3f", value);
+        List<ToolMetadata> adminTools = gatedTools.stream()
+                .filter(tool -> ADMIN_FACADE_TOOL.equals(tool.name()))
+                .toList();
+        if (!adminTools.isEmpty()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "MCP tool fast-path matched role={} workflow={} tool={} matchedTerms={} queryPreview=\"{}\"",
+                        context.role(),
+                        context.workflowState(),
+                        ADMIN_FACADE_TOOL,
+                        matchedTerms,
+                        preview(context.userInput()));
+            }
+        } else {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "MCP tool fast-path eligible but admin tool unavailable role={} workflow={} matchedTerms={} gatedTools={}",
+                        context.role(),
+                        context.workflowState(),
+                        matchedTerms,
+                        toolNames(gatedTools));
+            }
         }
+        return adminTools;
+    }
 
-        private static @NonNull String preview(@NonNull String userInput) {
-                String normalized = userInput.replaceAll("\\s+", " ").trim();
-                if (normalized.length() <= MAX_QUERY_PREVIEW_LENGTH) {
-                        return normalized;
-                }
-                return normalized.substring(0, MAX_QUERY_PREVIEW_LENGTH - 3) + "...";
+    private @NonNull Set<String> matchedAdminQueryTerms(@NonNull String userInput) {
+        String normalized = userInput.toLowerCase(Locale.ROOT);
+        Set<String> matches = new TreeSet<>();
+        for (String keyword : ADMIN_QUERY_KEYWORDS) {
+            if (normalized.matches(".*\\b" + keyword + "\\b.*")) {
+                matches.add(keyword);
+            }
         }
+        for (String phrase : ADMIN_QUERY_PHRASES) {
+            if (normalized.contains(phrase)) {
+                matches.add(phrase);
+            }
+        }
+        return matches;
+    }
 
-        private record ToolScore(
-                        double total, double semanticScore, double priorityBoost, double latencyPenalty,
-                        double costPenalty) {
-        }
+    static final class ToolScorer {
 
-        private record ScoredTool(
-                        @NonNull ToolMetadata tool, @NonNull ToolScore score, int rankPosition) {
+        @NonNull
+        ToolScore score(@NonNull ToolMetadata tool, int rankPosition) {
+            double semanticScore = 1.0 / (rankPosition + 1);
+            double priorityBoost = Math.clamp(tool.priority(), 0.0, 1.0);
+            double latencyPenalty = Math.min(tool.avgLatencyMs() / 1000.0, 1.0) * 0.2;
+            double costPenalty =
+                    switch (tool.costLevel().toLowerCase()) {
+                        case "high" -> 0.2;
+                        case "medium" -> 0.1;
+                        default -> 0.0;
+                    };
+            return new ToolScore(
+                    semanticScore + priorityBoost - latencyPenalty - costPenalty,
+                    semanticScore,
+                    priorityBoost,
+                    latencyPenalty,
+                    costPenalty);
         }
+    }
+
+    private static @NonNull List<String> toolNames(@NonNull List<ToolMetadata> tools) {
+        return tools.stream().map(ToolMetadata::name).toList();
+    }
+
+    private static @NonNull List<String> semanticCandidateSummaries(@NonNull List<ToolMetadata> semanticCandidates) {
+        return IntStream.range(0, semanticCandidates.size())
+                .mapToObj(index -> index + ":" + semanticCandidates.get(index).name())
+                .toList();
+    }
+
+    private static @NonNull List<String> scoredCandidateSummaries(@NonNull List<ScoredTool> scoredCandidates) {
+        return scoredCandidates.stream()
+                .map(scored -> scored.tool().name()
+                        + "[rank=" + scored.rankPosition()
+                        + ",total=" + format(scored.score().total())
+                        + ",semantic=" + format(scored.score().semanticScore())
+                        + ",priority=" + format(scored.score().priorityBoost())
+                        + ",latencyPenalty=" + format(scored.score().latencyPenalty())
+                        + ",costPenalty=" + format(scored.score().costPenalty())
+                        + "]")
+                .toList();
+    }
+
+    private static @NonNull String format(double value) {
+        return String.format(java.util.Locale.ROOT, "%.3f", value);
+    }
+
+    private static @NonNull String preview(@NonNull String userInput) {
+        String normalized = userInput.replaceAll("\\s+", " ").trim();
+        if (normalized.length() <= MAX_QUERY_PREVIEW_LENGTH) {
+            return normalized;
+        }
+        return normalized.substring(0, MAX_QUERY_PREVIEW_LENGTH - 3) + "...";
+    }
+
+    private record ToolScore(
+            double total, double semanticScore, double priorityBoost, double latencyPenalty, double costPenalty) {}
+
+    private record ScoredTool(
+            @NonNull ToolMetadata tool, @NonNull ToolScore score, int rankPosition) {}
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/service/RolePromptResolver.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/service/RolePromptResolver.java
@@ -5,5 +5,5 @@ import org.jspecify.annotations.NonNull;
 public interface RolePromptResolver {
 
     @NonNull
-    String resolvePrompt(@NonNull String role);
+    String resolvePrompt(@NonNull String promptName);
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/MasterAgentRegistryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/MasterAgentRegistryTest.java
@@ -45,8 +45,8 @@ class MasterAgentRegistryTest {
     @Test
     void resolveMasterToolsReturnsMutableCopy() {
         Object sharedTool = new SharedToolStub();
-        MasterAgentRegistry registry =
-                new MasterAgentRegistry(List.of(sharedTool), List.of(new DomainAgentDefinition("inventory", "inventory", List.of())));
+        MasterAgentRegistry registry = new MasterAgentRegistry(
+                List.of(sharedTool), List.of(new DomainAgentDefinition("inventory", "inventory", List.of())));
 
         List<Object> firstCall = registry.resolveMasterTools();
         firstCall.add(new Object());
@@ -61,8 +61,7 @@ class MasterAgentRegistryTest {
     void resolveDomainToolsReturnsMutableCopy() {
         Object domainTool = new Object();
         MasterAgentRegistry registry = new MasterAgentRegistry(
-                List.of(),
-                List.of(new DomainAgentDefinition("inventory", "inventory", List.of(domainTool))));
+                List.of(), List.of(new DomainAgentDefinition("inventory", "inventory", List.of(domainTool))));
 
         List<Object> firstCall = registry.resolveDomainTools("inventory");
         firstCall.add(new Object());
@@ -78,8 +77,7 @@ class MasterAgentRegistryTest {
         Object sharedTool = new SharedToolStub();
         Object domainTool = new InventoryFacadeToolStub();
         MasterAgentRegistry registry = new MasterAgentRegistry(
-                List.of(sharedTool),
-                List.of(new DomainAgentDefinition("inventory", "inventory", List.of(domainTool))));
+                List.of(sharedTool), List.of(new DomainAgentDefinition("inventory", "inventory", List.of(domainTool))));
 
         List<Object> tools = registry.resolveDomainTools("inventory", List.of("inventoryFacadeToolStub"));
 
@@ -134,18 +132,20 @@ class MasterAgentRegistryTest {
                 List.of(sharedTool),
                 List.of(new DomainAgentDefinition("inventory", "inventory", List.of(inventoryTool))));
 
-        assertThat(registry.resolveRagScopeForTools(List.of(sharedTool, inventoryTool))).isEqualTo("master");
+        assertThat(registry.resolveRagScopeForTools(List.of(sharedTool, inventoryTool)))
+                .isEqualTo("master");
     }
 
     @Test
     void resolveRagScopeForToolsReturnsMasterWhenUnregisteredFallbackAndDomainToolsMixed() {
-        ExaWebSearchTool exaWebSearchTool = new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
+        ExaWebSearchTool exaWebSearchTool =
+                new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
         Object inventoryTool = new InventoryFacadeToolStub();
         MasterAgentRegistry registry = new MasterAgentRegistry(
-                List.of(),
-                List.of(new DomainAgentDefinition("inventory", "inventory", List.of(inventoryTool))));
+                List.of(), List.of(new DomainAgentDefinition("inventory", "inventory", List.of(inventoryTool))));
 
-        assertThat(registry.resolveRagScopeForTools(List.of(inventoryTool, exaWebSearchTool))).isEqualTo("master");
+        assertThat(registry.resolveRagScopeForTools(List.of(inventoryTool, exaWebSearchTool)))
+                .isEqualTo("master");
     }
 
     private static final class SharedToolStub {}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -179,6 +180,7 @@ class SessionAgentManagerTest {
                 clearInvocations(toolRegistryService);
                 clearInvocations(toolSelectionEngine);
                 clearInvocations(scopedContentRetrieverFactory);
+                clearInvocations(rolePromptResolver);
         }
 
         @Test
@@ -246,6 +248,7 @@ class SessionAgentManagerTest {
                 String response = manager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), "hello");
 
                 assertThat(response).isEqualTo("Hello!");
+                verify(rolePromptResolver, atLeastOnce()).resolvePrompt("master");
                 verify(toolSelectionEngine, never()).selectRoleTools(anyString(), anyString());
                 verify(toolRegistryService, never()).resolveCandidateTools(any(ToolSelectionContext.class), anyInt());
         }
@@ -272,6 +275,7 @@ class SessionAgentManagerTest {
                 String response = selectorManager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), message);
 
                 assertThat(response).isEqualTo("Stock found");
+                verify(rolePromptResolver).resolvePrompt("inventory");
                 ArgumentCaptor<ToolSelectionContext> contextCaptor = ArgumentCaptor
                                 .forClass(ToolSelectionContext.class);
                 verify(toolRegistryService).resolveCandidateTools(contextCaptor.capture(), eq(3));
@@ -301,6 +305,7 @@ class SessionAgentManagerTest {
                 String response = selectorManager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), message);
 
                 assertThat(response).isEqualTo("Stock found");
+                verify(rolePromptResolver, atLeastOnce()).resolvePrompt("master");
                 verify(toolRegistryService).resolveCandidateTools(any(ToolSelectionContext.class), eq(3));
                 verify(scopedContentRetrieverFactory).create("master", 10, 0.6);
                 verify(scopedContentRetrieverFactory).create("master", 20, 0.55);

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -1,6 +1,5 @@
 package com.positivity.mcp.internal.orchestration;
 
-import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -11,7 +10,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -21,6 +19,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.positivity.mcp.internal.classification.SimpleChatRuleDefaults;
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.domain.ToolSelectionContext;
+import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
 import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
 import com.positivity.mcp.internal.orchestration.tools.InventoryFacadeTool;
@@ -79,335 +78,329 @@ import org.springframework.web.client.RestClient;
 @ExtendWith(MockitoExtension.class)
 class SessionAgentManagerTest {
 
-        private static final UUID USER_ID = UUID.fromString("00000000-0000-7000-8000-000000000301");
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-7000-8000-000000000301");
 
-        @Mock
-        private ChatModel chatModel;
+    @Mock
+    private ChatModel chatModel;
 
-        @Mock
-        private EmbeddingModel embeddingModel;
+    @Mock
+    private EmbeddingModel embeddingModel;
 
-        @Mock
-        private PgVectorEmbeddingStore embeddingStore;
+    @Mock
+    private PgVectorEmbeddingStore embeddingStore;
 
-        @Mock
-        private MasterAgentRegistry toolRegistry;
+    @Mock
+    private MasterAgentRegistry toolRegistry;
 
-        @Mock
-        private ToolRegistryService toolRegistryService;
+    @Mock
+    private ToolRegistryService toolRegistryService;
 
-        @Mock
-        private RolePromptResolver rolePromptResolver;
+    @Mock
+    private RolePromptResolver rolePromptResolver;
 
-        @Mock
-        private ToolSelectionEngine toolSelectionEngine;
+    @Mock
+    private ToolSelectionEngine toolSelectionEngine;
 
-        @Mock
-        private ScopedContentRetrieverFactory scopedContentRetrieverFactory;
+    @Mock
+    private ScopedContentRetrieverFactory scopedContentRetrieverFactory;
 
-        // Real instance required: Mockito subclasses cause @Tool duplicate registration
-        // in LangChain4j
-        private ExaWebSearchTool exaWebSearchTool;
-        private InventoryFacadeTool inventoryFacadeTool;
-        private OrderFacadeTool orderFacadeTool;
-        private SimpleChatClassifier simpleChatClassifier;
-        private SharedOrchestrationSupport sharedOrchestrationSupport;
+    // Real instance required: Mockito subclasses cause @Tool duplicate registration
+    // in LangChain4j
+    private ExaWebSearchTool exaWebSearchTool;
+    private InventoryFacadeTool inventoryFacadeTool;
+    private OrderFacadeTool orderFacadeTool;
+    private SimpleChatClassifier simpleChatClassifier;
+    private SharedOrchestrationSupport sharedOrchestrationSupport;
 
-        private SessionAgentManager manager;
+    private SessionAgentManager manager;
 
-        @BeforeEach
-        void setUp() {
-                // Return a FRESH list on every invocation so buildAgent mutations don't bleed
-                // across calls
-                lenient().when(toolRegistry.resolveDomainTools(anyString())).thenAnswer(inv -> new ArrayList<>());
-                lenient()
-                                .when(toolRegistry.resolveDomainTools(anyString(), anyCollection()))
-                                .thenAnswer(inv -> new ArrayList<>());
-                when(toolRegistry.preloadableRoleIdentifiers()).thenReturn(Set.of("ROLE_CASHIER", "ROLE_MANAGER"));
-                lenient()
-                                .when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class),
-                                                anyInt()))
-                                .thenReturn(List.of());
-                lenient()
-                                .when(toolSelectionEngine.selectRoleTools(anyString(), anyString()))
-                                .thenReturn(new ToolSelectionEngine.ToolSelectionResult(List.of(), List.of()));
-                lenient().when(rolePromptResolver.resolvePrompt(anyString())).thenReturn("Default role prompt");
-                lenient().when(embeddingModel.embed(anyString()))
-                                .thenReturn(Response.from(Embedding.from(new float[] { 0.1f })));
-                lenient().when(embeddingStore.search(any())).thenReturn(new EmbeddingSearchResult<>(List.of()));
-                exaWebSearchTool = new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
-                inventoryFacadeTool = new InventoryFacadeTool(
-                                RestClient.builder(),
-                                "http://api-gateway",
-                                "/inventory/v1/inventory/stock/{sku}",
-                                "/inventory/v1/inventory/search?q={query}",
-                                "/inventory/v1/inventory/locations/{locationId}/stock");
-                orderFacadeTool = new OrderFacadeTool(
-                                RestClient.builder(),
-                                "http://api-gateway",
-                                "/order/v1/orders/{orderId}",
-                                "/order/v1/orders/search?q={query}");
-                simpleChatClassifier = new SimpleChatClassifier(SimpleChatRuleDefaults.defaultCatalog());
-                sharedOrchestrationSupport = new SharedOrchestrationSupport();
-                ContentRetriever scopedRetriever = mock(ContentRetriever.class);
-                lenient().when(toolRegistry.sharedTools()).thenReturn(List.of());
-                lenient()
-                                .when(toolSelectionEngine.fullFallbackTools())
-                                .thenReturn(List.of(exaWebSearchTool, inventoryFacadeTool, orderFacadeTool));
-                lenient()
-                                .when(toolRegistry.resolveRagScopeForTools(anyCollection()))
-                                .thenAnswer(invocation -> ragScopeFor(invocation.getArgument(0)));
-                lenient()
-                                .when(scopedContentRetrieverFactory.create(anyString(), anyInt(), anyDouble()))
-                                .thenReturn(scopedRetriever);
-                manager = new SessionAgentManager(
-                                chatModel,
-                                embeddingModel,
-                                embeddingStore,
-                                toolRegistry,
-                                sharedOrchestrationSupport,
-                                toolSelectionEngine,
-                                scopedContentRetrieverFactory,
-                                null,
-                                null, // sessionSummaryService
-                                rolePromptResolver,
-                                simpleChatClassifier,
-                                30,
-                                500,
-                                50,
-                                100);
-                clearInvocations(toolRegistry);
-                clearInvocations(toolRegistryService);
-                clearInvocations(toolSelectionEngine);
-                clearInvocations(scopedContentRetrieverFactory);
-                clearInvocations(rolePromptResolver);
-        }
+    @BeforeEach
+    void setUp() {
+        // Return a FRESH list on every invocation so buildAgent mutations don't bleed
+        // across calls
+        lenient().when(toolRegistry.resolveDomainTools(anyString())).thenAnswer(inv -> new ArrayList<>());
+        lenient()
+                .when(toolRegistry.resolveDomainTools(anyString(), anyCollection()))
+                .thenAnswer(inv -> new ArrayList<>());
+        when(toolRegistry.preloadableRoleIdentifiers()).thenReturn(Set.of("ROLE_CASHIER", "ROLE_MANAGER"));
+        lenient()
+                .when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), anyInt()))
+                .thenReturn(List.of());
+        lenient()
+                .when(toolSelectionEngine.selectRoleTools(anyString(), anyString()))
+                .thenReturn(new ToolSelectionEngine.ToolSelectionResult(List.of(), List.of()));
+        lenient().when(rolePromptResolver.resolvePrompt(anyString())).thenReturn("Default role prompt");
+        lenient().when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(new float[] {0.1f})));
+        lenient().when(embeddingStore.search(any())).thenReturn(new EmbeddingSearchResult<>(List.of()));
+        exaWebSearchTool = new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
+        inventoryFacadeTool = new InventoryFacadeTool(
+                RestClient.builder(),
+                "http://api-gateway",
+                "/inventory/v1/inventory/stock/{sku}",
+                "/inventory/v1/inventory/search?q={query}",
+                "/inventory/v1/inventory/locations/{locationId}/stock");
+        orderFacadeTool = new OrderFacadeTool(
+                RestClient.builder(),
+                "http://api-gateway",
+                "/order/v1/orders/{orderId}",
+                "/order/v1/orders/search?q={query}");
+        simpleChatClassifier = new SimpleChatClassifier(SimpleChatRuleDefaults.defaultCatalog());
+        sharedOrchestrationSupport = new SharedOrchestrationSupport();
+        ContentRetriever scopedRetriever = mock(ContentRetriever.class);
+        lenient().when(toolRegistry.sharedTools()).thenReturn(List.of());
+        lenient()
+                .when(toolSelectionEngine.fullFallbackTools())
+                .thenReturn(List.of(exaWebSearchTool, inventoryFacadeTool, orderFacadeTool));
+        lenient()
+                .when(toolRegistry.resolveRagScopeForTools(anyCollection()))
+                .thenAnswer(invocation -> ragScopeFor(invocation.getArgument(0)));
+        lenient()
+                .when(scopedContentRetrieverFactory.create(anyString(), anyInt(), anyDouble()))
+                .thenReturn(scopedRetriever);
+        manager = new SessionAgentManager(
+                chatModel,
+                embeddingModel,
+                embeddingStore,
+                toolRegistry,
+                sharedOrchestrationSupport,
+                toolSelectionEngine,
+                scopedContentRetrieverFactory,
+                null,
+                null, // sessionSummaryService
+                rolePromptResolver,
+                simpleChatClassifier,
+                30,
+                500,
+                50,
+                100);
+        clearInvocations(toolRegistry);
+        clearInvocations(toolRegistryService);
+        clearInvocations(toolSelectionEngine);
+        clearInvocations(scopedContentRetrieverFactory);
+        clearInvocations(rolePromptResolver);
+    }
 
-        @Test
-        @DisplayName("getOrCreateAgent returns the same proxy instance for the same userId")
-        void getOrCreateAgent_returnsSameInstanceForSameUser() {
-                PosAssistant first = manager.getOrCreateAgent("user-1", "TECH");
-                PosAssistant second = manager.getOrCreateAgent("user-1", "TECH");
+    @Test
+    @DisplayName("getOrCreateAgent returns the same proxy instance for the same userId")
+    void getOrCreateAgent_returnsSameInstanceForSameUser() {
+        PosAssistant first = manager.getOrCreateAgent("user-1", "TECH");
+        PosAssistant second = manager.getOrCreateAgent("user-1", "TECH");
 
-                assertThat(first).isSameAs(second);
-        }
+        assertThat(first).isSameAs(second);
+    }
 
-        @Test
-        @DisplayName("getOrCreateAgent reuses the prebuilt role proxy for different userIds")
-        void getOrCreateAgent_reusesRoleProxyForDifferentUsers() {
-                PosAssistant forUser1 = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
-                PosAssistant forUser2 = manager.getOrCreateAgent("user-2", "ROLE_CASHIER");
+    @Test
+    @DisplayName("getOrCreateAgent reuses the prebuilt role proxy for different userIds")
+    void getOrCreateAgent_reusesRoleProxyForDifferentUsers() {
+        PosAssistant forUser1 = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+        PosAssistant forUser2 = manager.getOrCreateAgent("user-2", "ROLE_CASHIER");
 
-                assertThat(forUser1).isSameAs(forUser2);
-        }
+        assertThat(forUser1).isSameAs(forUser2);
+    }
 
-        @Test
-        @DisplayName("getOrCreateAgent rebuilds agent when role changes for same userId")
-        void getOrCreateAgent_roleChange_rebuildsAgent() {
-                PosAssistant original = manager.getOrCreateAgent("user-1", "TECH");
-                PosAssistant afterRoleChange = manager.getOrCreateAgent("user-1", "MANAGER");
+    @Test
+    @DisplayName("getOrCreateAgent rebuilds agent when role changes for same userId")
+    void getOrCreateAgent_roleChange_rebuildsAgent() {
+        PosAssistant original = manager.getOrCreateAgent("user-1", "TECH");
+        PosAssistant afterRoleChange = manager.getOrCreateAgent("user-1", "MANAGER");
 
-                assertThat(afterRoleChange).isNotSameAs(original);
-        }
+        assertThat(afterRoleChange).isNotSameAs(original);
+    }
 
-        @Test
-        @DisplayName("getOrCreateAgent skips fallback tools already resolved for the role")
-        void getOrCreateAgent_skipsDuplicateFallbackTool() {
-                when(toolRegistry.resolveDomainTools("ROLE_DUPLICATE"))
-                                .thenAnswer(inv -> new ArrayList<>(List.of(inventoryFacadeTool)));
+    @Test
+    @DisplayName("getOrCreateAgent skips fallback tools already resolved for the role")
+    void getOrCreateAgent_skipsDuplicateFallbackTool() {
+        when(toolRegistry.resolveDomainTools("ROLE_DUPLICATE"))
+                .thenAnswer(inv -> new ArrayList<>(List.of(inventoryFacadeTool)));
 
-                PosAssistant agent = manager.getOrCreateAgent("user-with-role-tool", "ROLE_DUPLICATE");
+        PosAssistant agent = manager.getOrCreateAgent("user-with-role-tool", "ROLE_DUPLICATE");
 
-                assertThat(agent).isNotNull();
-        }
+        assertThat(agent).isNotNull();
+    }
 
-        @Test
-        @DisplayName("evict leaves prebuilt role agent cached")
-        void evict_leavesPrebuiltRoleAgentCached() {
-                PosAssistant before = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
-                manager.evict("user-1");
-
-                @SuppressWarnings("unchecked")
-                Cache<String, ?> cache = (Cache<String, ?>) ReflectionTestUtils.getField(manager, "roleAgentCache");
-                assertThat(cache).isNotNull();
-                cache.cleanUp();
-                assertThat(cache.estimatedSize()).isPositive();
-
-                PosAssistant after = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
-                assertThat(after).isSameAs(before);
-        }
-
-        @Test
-        @DisplayName("chat with greeting uses simple no-tool model path")
-        void chat_withGreeting_usesSimpleModelPath() {
-                when(chatModel.chat(org.mockito.ArgumentMatchers.<List<ChatMessage>>any()))
-                                .thenReturn(ChatResponse.builder()
-                                                .aiMessage(AiMessage.from("Hello!"))
-                                                .build());
-
-                String response = manager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), "hello");
-
-                assertThat(response).isEqualTo("Hello!");
-                verify(rolePromptResolver, atLeastOnce()).resolvePrompt("master");
-                verify(toolSelectionEngine, never()).selectRoleTools(anyString(), anyString());
-                verify(toolRegistryService, never()).resolveCandidateTools(any(ToolSelectionContext.class), anyInt());
-        }
-
-        @Test
-        @DisplayName("chat with business request uses shared workflow derivation and tool narrowing")
-        void chat_withBusinessRequest_narrowsRoleToolsPerMessage() {
-                String message = "show stock for sku ABC";
-                ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
-                when(toolRegistry.resolveDomainTools("ROLE_ADMIN"))
-                                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
-                when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
-                                .thenReturn(List.of(inventoryToolMetadata()));
-                when(toolRegistry.resolveDomainTools("ROLE_ADMIN", List.of("inventoryFacadeTool")))
-                                .thenReturn(List.of(inventoryFacadeTool));
-                when(chatModel.chat(any(ChatRequest.class)))
-                                .thenReturn(ChatResponse.builder()
-                                                .aiMessage(AiMessage.from("Stock found"))
-                                                .build());
-                SessionAgentManager selectorManager = managerWithToolSelectionEngine(realToolSelectionEngine);
-                clearInvocations(toolRegistryService);
-                clearInvocations(scopedContentRetrieverFactory);
-
-                String response = selectorManager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), message);
-
-                assertThat(response).isEqualTo("Stock found");
-                verify(rolePromptResolver).resolvePrompt("inventory");
-                ArgumentCaptor<ToolSelectionContext> contextCaptor = ArgumentCaptor
-                                .forClass(ToolSelectionContext.class);
-                verify(toolRegistryService).resolveCandidateTools(contextCaptor.capture(), eq(3));
-                verify(scopedContentRetrieverFactory).create("inventory", 10, 0.6);
-                verify(scopedContentRetrieverFactory).create("inventory", 20, 0.55);
-                assertThat(contextCaptor.getValue().workflowState()).isEqualTo("READ");
-                assertThat(roleAgentCacheKeys(selectorManager)).contains("ROLE_ADMIN::InventoryFacadeTool");
-        }
-
-        @Test
-        @DisplayName("chat with empty shared selection falls back to full role tool set")
-        void chat_withEmptySemanticSelection_usesFullRoleToolSet() {
-                String message = "show stock for sku ABC";
-                ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
-                when(toolRegistry.resolveDomainTools("ROLE_ADMIN"))
-                                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
-                when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
-                                .thenReturn(List.of());
-                when(chatModel.chat(any(ChatRequest.class)))
-                                .thenReturn(ChatResponse.builder()
-                                                .aiMessage(AiMessage.from("Stock found"))
-                                                .build());
-                SessionAgentManager selectorManager = managerWithToolSelectionEngine(realToolSelectionEngine);
-                clearInvocations(toolRegistryService);
-                clearInvocations(scopedContentRetrieverFactory);
-
-                String response = selectorManager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), message);
-
-                assertThat(response).isEqualTo("Stock found");
-                verify(rolePromptResolver, atLeastOnce()).resolvePrompt("master");
-                verify(toolRegistryService).resolveCandidateTools(any(ToolSelectionContext.class), eq(3));
-                verify(scopedContentRetrieverFactory).create("master", 10, 0.6);
-                verify(scopedContentRetrieverFactory).create("master", 20, 0.55);
-                assertThat(roleAgentCacheKeys(selectorManager))
-                                .contains("ROLE_ADMIN::InventoryFacadeTool+OrderFacadeTool");
-        }
-
-        @Test
-        @DisplayName("getOrCreateAgent rebuilds agent after cache TTL expiry")
-        void getOrCreateAgent_rebuildsAgentAfterCacheTtlExpiry() {
-                SessionAgentManager expiringManager = new SessionAgentManager(
-                                chatModel,
-                                embeddingModel,
-                                embeddingStore,
-                                toolRegistry,
-                                sharedOrchestrationSupport,
-                                toolSelectionEngine,
-                                scopedContentRetrieverFactory,
-                                null,
-                                null, // sessionSummaryService
-                                rolePromptResolver,
-                                simpleChatClassifier,
-                                0,
-                                500,
-                                50,
-                                100);
-                clearInvocations(toolRegistry);
-
-                expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
-                expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
-
-                verify(toolRegistry, times(2)).resolveDomainTools("ROLE_CASHIER");
-        }
-
-        private static CurrentUserContext userContext(String username, UUID userId, String primaryRole) {
-                return new CurrentUserContext(
-                                username, userId, primaryRole, Set.of(primaryRole),
-                                Set.of(primaryRole, "mcp:chat:execute"));
-        }
-
-        private SessionAgentManager managerWithToolSelectionEngine(ToolSelectionEngine selectionEngine) {
-                return new SessionAgentManager(
-                                chatModel,
-                                embeddingModel,
-                                embeddingStore,
-                                toolRegistry,
-                                sharedOrchestrationSupport,
-                                selectionEngine,
-                                scopedContentRetrieverFactory,
-                                null,
-                                null,
-                                rolePromptResolver,
-                                simpleChatClassifier,
-                                30,
-                                500,
-                                50,
-                                100);
-        }
-
-        private ToolSelectionEngine realToolSelectionEngine() {
-                return new ToolSelectionEngine(
-                                toolRegistry,
-                                exaWebSearchTool,
-                                inventoryFacadeTool,
-                                orderFacadeTool,
-                                toolRegistryService,
-                                sharedOrchestrationSupport,
-                                3);
-        }
-
-        private static ToolMetadata inventoryToolMetadata() {
-                return new ToolMetadata(
-                                UUID.randomUUID(),
-                                "inventoryFacadeTool",
-                                "Inventory",
-                                "Inventory availability",
-                                "inventory",
-                                1.0,
-                                "low",
-                                200,
-                                true,
-                                "inventoryFacadeTool");
-        }
-
-        private static String ragScopeFor(java.util.Collection<?> tools) {
-                boolean hasInventory = tools.stream().anyMatch(InventoryFacadeTool.class::isInstance);
-                boolean hasOrder = tools.stream().anyMatch(OrderFacadeTool.class::isInstance);
-                if (hasInventory && !hasOrder) {
-                        return "inventory";
-                }
-                if (hasOrder && !hasInventory) {
-                        return "orders";
-                }
-                return "master";
-        }
+    @Test
+    @DisplayName("evict leaves prebuilt role agent cached")
+    void evict_leavesPrebuiltRoleAgentCached() {
+        PosAssistant before = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+        manager.evict("user-1");
 
         @SuppressWarnings("unchecked")
-        private static Set<String> roleAgentCacheKeys(SessionAgentManager sessionAgentManager) {
-                Cache<String, ?> cache = (Cache<String, ?>) ReflectionTestUtils.getField(sessionAgentManager,
-                                "roleAgentCache");
-                assertThat(cache).isNotNull();
-                cache.cleanUp();
-                return cache.asMap().keySet();
+        Cache<String, ?> cache = (Cache<String, ?>) ReflectionTestUtils.getField(manager, "roleAgentCache");
+        assertThat(cache).isNotNull();
+        cache.cleanUp();
+        assertThat(cache.estimatedSize()).isPositive();
+
+        PosAssistant after = manager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+        assertThat(after).isSameAs(before);
+    }
+
+    @Test
+    @DisplayName("chat with greeting uses simple no-tool model path")
+    void chat_withGreeting_usesSimpleModelPath() {
+        when(chatModel.chat(org.mockito.ArgumentMatchers.<List<ChatMessage>>any()))
+                .thenReturn(ChatResponse.builder()
+                        .aiMessage(AiMessage.from("Hello!"))
+                        .build());
+
+        String response = manager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), "hello");
+
+        assertThat(response).isEqualTo("Hello!");
+        // Prompt resolution now happens deferred in systemMessageProvider lambda at runtime
+        verify(toolSelectionEngine, never()).selectRoleTools(anyString(), anyString());
+        verify(toolRegistryService, never()).resolveCandidateTools(any(ToolSelectionContext.class), anyInt());
+    }
+
+    @Test
+    @DisplayName("chat with business request uses shared workflow derivation and tool narrowing")
+    void chat_withBusinessRequest_narrowsRoleToolsPerMessage() {
+        String message = "show stock for sku ABC";
+        ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
+        when(toolRegistry.resolveDomainTools("ROLE_ADMIN"))
+                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
+        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
+                .thenReturn(List.of(inventoryToolMetadata()));
+        when(toolRegistry.resolveDomainTools("ROLE_ADMIN", List.of("inventoryFacadeTool")))
+                .thenReturn(List.of(inventoryFacadeTool));
+        when(chatModel.chat(any(ChatRequest.class)))
+                .thenReturn(ChatResponse.builder()
+                        .aiMessage(AiMessage.from("Stock found"))
+                        .build());
+        SessionAgentManager selectorManager = managerWithToolSelectionEngine(realToolSelectionEngine);
+        clearInvocations(toolRegistryService);
+        clearInvocations(scopedContentRetrieverFactory);
+
+        String response = selectorManager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), message);
+
+        assertThat(response).isEqualTo("Stock found");
+        // Prompt resolution now happens deferred in systemMessageProvider lambda at runtime
+        ArgumentCaptor<ToolSelectionContext> contextCaptor = ArgumentCaptor.forClass(ToolSelectionContext.class);
+        verify(toolRegistryService).resolveCandidateTools(contextCaptor.capture(), eq(3));
+        verify(scopedContentRetrieverFactory).create("inventory", 10, 0.6);
+        verify(scopedContentRetrieverFactory).create("inventory", 20, 0.55);
+        assertThat(contextCaptor.getValue().workflowState()).isEqualTo("READ");
+        assertThat(roleAgentCacheKeys(selectorManager)).contains("ROLE_ADMIN::InventoryFacadeTool");
+    }
+
+    @Test
+    @DisplayName("chat with empty shared selection falls back to full role tool set")
+    void chat_withEmptySemanticSelection_usesFullRoleToolSet() {
+        String message = "show stock for sku ABC";
+        ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
+        when(toolRegistry.resolveDomainTools("ROLE_ADMIN"))
+                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
+        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
+                .thenReturn(List.of());
+        when(chatModel.chat(any(ChatRequest.class)))
+                .thenReturn(ChatResponse.builder()
+                        .aiMessage(AiMessage.from("Stock found"))
+                        .build());
+        SessionAgentManager selectorManager = managerWithToolSelectionEngine(realToolSelectionEngine);
+        clearInvocations(toolRegistryService);
+        clearInvocations(scopedContentRetrieverFactory);
+
+        String response = selectorManager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), message);
+
+        assertThat(response).isEqualTo("Stock found");
+        // Prompt resolution now happens deferred in systemMessageProvider lambda at runtime
+        verify(toolRegistryService).resolveCandidateTools(any(ToolSelectionContext.class), eq(3));
+        verify(scopedContentRetrieverFactory).create("master", 10, 0.6);
+        verify(scopedContentRetrieverFactory).create("master", 20, 0.55);
+        assertThat(roleAgentCacheKeys(selectorManager)).contains("ROLE_ADMIN::InventoryFacadeTool+OrderFacadeTool");
+    }
+
+    @Test
+    @DisplayName("getOrCreateAgent rebuilds agent after cache TTL expiry")
+    void getOrCreateAgent_rebuildsAgentAfterCacheTtlExpiry() {
+        SessionAgentManager expiringManager = new SessionAgentManager(
+                chatModel,
+                embeddingModel,
+                embeddingStore,
+                toolRegistry,
+                sharedOrchestrationSupport,
+                toolSelectionEngine,
+                scopedContentRetrieverFactory,
+                null,
+                null, // sessionSummaryService
+                rolePromptResolver,
+                simpleChatClassifier,
+                0,
+                500,
+                50,
+                100);
+        clearInvocations(toolRegistry);
+
+        expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+        expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
+
+        verify(toolRegistry, times(2)).resolveDomainTools("ROLE_CASHIER");
+    }
+
+    private static CurrentUserContext userContext(String username, UUID userId, String primaryRole) {
+        return new CurrentUserContext(
+                username, userId, primaryRole, Set.of(primaryRole), Set.of(primaryRole, "mcp:chat:execute"));
+    }
+
+    private SessionAgentManager managerWithToolSelectionEngine(ToolSelectionEngine selectionEngine) {
+        return new SessionAgentManager(
+                chatModel,
+                embeddingModel,
+                embeddingStore,
+                toolRegistry,
+                sharedOrchestrationSupport,
+                selectionEngine,
+                scopedContentRetrieverFactory,
+                null,
+                null,
+                rolePromptResolver,
+                simpleChatClassifier,
+                30,
+                500,
+                50,
+                100);
+    }
+
+    private ToolSelectionEngine realToolSelectionEngine() {
+        return new ToolSelectionEngine(
+                toolRegistry,
+                exaWebSearchTool,
+                inventoryFacadeTool,
+                orderFacadeTool,
+                toolRegistryService,
+                sharedOrchestrationSupport,
+                3);
+    }
+
+    private static ToolMetadata inventoryToolMetadata() {
+        return new ToolMetadata(
+                UUID.randomUUID(),
+                "inventoryFacadeTool",
+                "Inventory",
+                "Inventory availability",
+                "inventory",
+                1.0,
+                "low",
+                200,
+                true,
+                "inventoryFacadeTool");
+    }
+
+    private static String ragScopeFor(java.util.Collection<?> tools) {
+        boolean hasInventory = tools.stream().anyMatch(InventoryFacadeTool.class::isInstance);
+        boolean hasOrder = tools.stream().anyMatch(OrderFacadeTool.class::isInstance);
+        if (hasInventory && !hasOrder) {
+            return "inventory";
         }
+        if (hasOrder && !hasInventory) {
+            return "orders";
+        }
+        return "master";
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> roleAgentCacheKeys(SessionAgentManager sessionAgentManager) {
+        Cache<String, ?> cache = (Cache<String, ?>) ReflectionTestUtils.getField(sessionAgentManager, "roleAgentCache");
+        assertThat(cache).isNotNull();
+        cache.cleanUp();
+        return cache.asMap().keySet();
+    }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -1,6 +1,5 @@
 package com.positivity.mcp.internal.orchestration;
 
-import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -22,6 +21,7 @@ import static org.mockito.Mockito.when;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.domain.ToolSelectionContext;
+import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
 import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
 import com.positivity.mcp.internal.orchestration.tools.InventoryFacadeTool;
@@ -33,7 +33,6 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
-
 import java.lang.reflect.Member;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -75,408 +74,389 @@ import reactor.core.publisher.Flux;
 @ExtendWith(MockitoExtension.class)
 class StreamingSessionAgentManagerTest {
 
-        private static final UUID USER_ID = UUID.fromString("00000000-0000-7000-8000-000000000302");
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-7000-8000-000000000302");
 
-        @Mock
-        private StreamingChatModel streamingChatModel;
+    @Mock
+    private StreamingChatModel streamingChatModel;
 
-        @Mock
-        private EmbeddingModel embeddingModel;
+    @Mock
+    private EmbeddingModel embeddingModel;
 
-        @Mock
-        private PgVectorEmbeddingStore embeddingStore;
+    @Mock
+    private PgVectorEmbeddingStore embeddingStore;
 
-        @Mock
-        private MasterAgentRegistry toolRegistry;
+    @Mock
+    private MasterAgentRegistry toolRegistry;
 
-        @Mock
-        private RolePromptResolver rolePromptResolver;
+    @Mock
+    private RolePromptResolver rolePromptResolver;
 
-        @Mock
-        private ToolRegistryService toolRegistryService;
+    @Mock
+    private ToolRegistryService toolRegistryService;
 
-        @Mock
-        private ToolSelectionEngine toolSelectionEngine;
+    @Mock
+    private ToolSelectionEngine toolSelectionEngine;
 
-        @Mock
-        private ScopedContentRetrieverFactory scopedContentRetrieverFactory;
+    @Mock
+    private ScopedContentRetrieverFactory scopedContentRetrieverFactory;
 
-        // Real instance required to prevent @Tool duplicate registration
-        private ExaWebSearchTool exaWebSearchTool;
-        private InventoryFacadeTool inventoryFacadeTool;
-        private OrderFacadeTool orderFacadeTool;
-        private SharedOrchestrationSupport sharedOrchestrationSupport;
+    // Real instance required to prevent @Tool duplicate registration
+    private ExaWebSearchTool exaWebSearchTool;
+    private InventoryFacadeTool inventoryFacadeTool;
+    private OrderFacadeTool orderFacadeTool;
+    private SharedOrchestrationSupport sharedOrchestrationSupport;
 
-        private StreamingSessionAgentManager manager;
+    private StreamingSessionAgentManager manager;
 
-        @SuppressWarnings({ "rawtypes", "unchecked" })
-        private static <T> ArgumentCaptor<List<T>> listCaptor() {
-                return (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static <T> ArgumentCaptor<List<T>> listCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        // Return a fresh mutable list each invocation so buildAgent mutations don't
+        // bleed
+        when(toolRegistry.resolveDomainTools(any())).thenAnswer(inv -> new ArrayList<>());
+        when(toolRegistry.preloadableRoleIdentifiers()).thenReturn(Set.of("ROLE_CASHIER", "ROLE_MANAGER"));
+        lenient().when(rolePromptResolver.resolvePrompt(any())).thenReturn("Default role prompt");
+        lenient()
+                .when(toolSelectionEngine.selectRoleTools(any(), any()))
+                .thenReturn(new ToolSelectionEngine.ToolSelectionResult(List.of(), List.of()));
+        exaWebSearchTool = new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
+        inventoryFacadeTool = new InventoryFacadeTool(
+                RestClient.builder(),
+                "http://api-gateway",
+                "/inventory/v1/inventory/stock/{sku}",
+                "/inventory/v1/inventory/search?q={query}",
+                "/inventory/v1/inventory/locations/{locationId}/stock");
+        orderFacadeTool = new OrderFacadeTool(
+                RestClient.builder(),
+                "http://api-gateway",
+                "/order/v1/orders/{orderId}",
+                "/order/v1/orders/search?q={query}");
+        sharedOrchestrationSupport = new SharedOrchestrationSupport();
+        ContentRetriever scopedRetriever = mock(ContentRetriever.class);
+        lenient().when(toolRegistry.sharedTools()).thenReturn(List.of());
+        lenient()
+                .when(toolSelectionEngine.fullFallbackTools())
+                .thenReturn(List.of(exaWebSearchTool, inventoryFacadeTool, orderFacadeTool));
+        lenient()
+                .when(toolRegistry.resolveRagScopeForTools(anyCollection()))
+                .thenAnswer(invocation -> ragScopeFor(invocation.getArgument(0)));
+        lenient()
+                .when(scopedContentRetrieverFactory.create(anyString(), anyInt(), anyDouble()))
+                .thenReturn(scopedRetriever);
+        manager = new StreamingSessionAgentManager(
+                streamingChatModel,
+                toolRegistry,
+                sharedOrchestrationSupport,
+                toolSelectionEngine,
+                scopedContentRetrieverFactory,
+                rolePromptResolver,
+                null, // toolAuditService
+                30,
+                500,
+                50,
+                100);
+        clearInvocations(toolRegistry);
+        clearInvocations(toolSelectionEngine);
+        clearInvocations(scopedContentRetrieverFactory);
+        clearInvocations(rolePromptResolver);
+    }
+
+    @Test
+    @DisplayName("manager no longer retains tool registry service state")
+    void manager_doesNotRetainToolRegistryServiceField() {
+        assertThat(java.util.Arrays.stream(StreamingSessionAgentManager.class.getDeclaredFields())
+                        .map(Member::getName)
+                        .toList())
+                .doesNotContain("toolRegistryService");
+    }
+
+    @Test
+    @DisplayName("streamChat returns a non-null Flux")
+    void streamChat_returnsNonNullFlux() {
+        Flux<String> result = manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "hello");
+
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("streamChat reuses cached agent for same userId+role")
+    void streamChat_cachesAgentForSameUser() {
+        manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "first message");
+        manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "second message");
+
+        verify(toolRegistry, never()).resolveDomainTools("ROLE_CASHIER");
+    }
+
+    @Test
+    @DisplayName("evict removes cached agent so next streamChat rebuilds it")
+    void evict_removesFromCache() {
+        manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "first message");
+        manager.evict("user-1");
+        manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "after evict");
+
+        verify(toolRegistry, never()).resolveDomainTools("ROLE_CASHIER");
+    }
+
+    @Test
+    @DisplayName("streamChat rebuilds agent when role changes for same userId")
+    void streamChat_roleChange_rebuildsAgent() {
+        manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "first");
+        manager.streamChat(userContext("user-1", USER_ID, "ROLE_MANAGER"), "second");
+
+        verify(toolRegistry, never()).resolveDomainTools("ROLE_CASHIER");
+        verify(toolRegistry, never()).resolveDomainTools("ROLE_MANAGER");
+    }
+
+    @Test
+    @DisplayName("streamChat skips fallback tools already resolved for the role")
+    void streamChat_skipsDuplicateFallbackTool() {
+        when(toolSelectionEngine.selectRoleTools("ROLE_DUPLICATE", "hello"))
+                .thenReturn(new ToolSelectionEngine.ToolSelectionResult(
+                        List.of(exaWebSearchTool), List.of(exaWebSearchTool)));
+
+        Flux<String> result =
+                manager.streamChat(userContext("user-with-role-tool", USER_ID, "ROLE_DUPLICATE"), "hello");
+
+        assertThat(result).isNotNull();
+        assertThat(roleAgentCacheKeys(manager)).contains("ROLE_DUPLICATE::ExaWebSearchTool");
+    }
+
+    // --- Phase 3: semantic tool selection through ToolSelectionEngine ---
+
+    @Test
+    @DisplayName("streamChat uses shared workflow derivation and tool narrowing")
+    void streamChat_semanticSelection_narrowsToolsWhenCandidatesReturned() {
+        String message = "show me inventory levels";
+        ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
+        when(toolRegistry.resolveDomainTools("ROLE_CASHIER"))
+                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
+        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
+                .thenReturn(List.of(inventoryToolMetadata()));
+        when(toolRegistry.resolveDomainTools("ROLE_CASHIER", List.of("inventoryFacadeTool")))
+                .thenReturn(List.of(inventoryFacadeTool));
+
+        StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(realToolSelectionEngine);
+        clearInvocations(toolRegistryService);
+        clearInvocations(scopedContentRetrieverFactory);
+
+        Flux<String> result = selectorManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), message);
+
+        assertThat(result).isNotNull();
+        ArgumentCaptor<ToolSelectionContext> contextCaptor = ArgumentCaptor.forClass(ToolSelectionContext.class);
+        verify(toolRegistryService).resolveCandidateTools(contextCaptor.capture(), eq(3));
+        assertThat(contextCaptor.getValue().workflowState()).isEqualTo("READ");
+        assertThat(roleAgentCacheKeys(selectorManager)).contains("ROLE_CASHIER::InventoryFacadeTool");
+    }
+
+    @Test
+    @DisplayName("streamChat uses shared tool selection even when registry service is unavailable")
+    void streamChat_withoutRegistryService_usesSharedSelectionPath() {
+        String message = "latest internet sales report";
+        when(toolSelectionEngine.selectRoleTools("ROLE_CASHIER", message))
+                .thenReturn(new ToolSelectionEngine.ToolSelectionResult(
+                        List.of(orderFacadeTool), List.of(exaWebSearchTool, inventoryFacadeTool)));
+
+        Flux<String> result = manager.streamChat(userContext("user-shared-path", USER_ID, "ROLE_CASHIER"), message);
+
+        assertThat(result).isNotNull();
+        verify(toolSelectionEngine).selectRoleTools("ROLE_CASHIER", message);
+        assertThat(roleAgentCacheKeys(manager))
+                .contains("ROLE_CASHIER::ExaWebSearchTool+InventoryFacadeTool+OrderFacadeTool");
+    }
+
+    @Test
+    @DisplayName("streamChat falls back to shared full role selection when selector returns empty")
+    void streamChat_semanticSelection_fallsBackToFullRoleToolsOnEmptyResult() {
+        String message = "show sales orders";
+        ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
+        when(toolRegistry.resolveDomainTools("ROLE_CASHIER"))
+                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
+        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
+                .thenReturn(List.of());
+
+        StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(realToolSelectionEngine);
+        clearInvocations(toolRegistryService);
+        clearInvocations(scopedContentRetrieverFactory);
+
+        Flux<String> result = selectorManager.streamChat(userContext("user-2", USER_ID, "ROLE_CASHIER"), message);
+
+        assertThat(result).isNotNull();
+        verify(toolRegistryService).resolveCandidateTools(any(ToolSelectionContext.class), eq(3));
+        assertThat(roleAgentCacheKeys(selectorManager)).contains("ROLE_CASHIER::InventoryFacadeTool+OrderFacadeTool");
+    }
+
+    @Test
+    @DisplayName("streamChat falls back to shared full role selection when selector throws")
+    void streamChat_semanticSelection_fallsBackToFullRoleToolsOnException() {
+        ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
+        when(toolRegistry.resolveDomainTools("ROLE_CASHIER"))
+                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
+        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
+                .thenThrow(new IllegalStateException("selector unavailable"));
+
+        StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(realToolSelectionEngine);
+        clearInvocations(toolRegistryService);
+        clearInvocations(scopedContentRetrieverFactory);
+
+        Flux<String> result = selectorManager.streamChat(userContext("user-3", USER_ID, "ROLE_CASHIER"), "anything");
+
+        assertThat(result).isNotNull();
+        verify(toolRegistryService).resolveCandidateTools(any(ToolSelectionContext.class), eq(3));
+        assertThat(roleAgentCacheKeys(selectorManager)).contains("ROLE_CASHIER::InventoryFacadeTool+OrderFacadeTool");
+    }
+
+    @Test
+    @DisplayName("prebuild merges the full shared fallback tool set")
+    void constructor_prebuildRoleAgents_mergesFullSharedFallbackTools() {
+        SharedOrchestrationSupport sharedSupportSpy = spy(new SharedOrchestrationSupport());
+        when(toolRegistry.resolveDomainTools("ROLE_CASHIER")).thenReturn(new ArrayList<>());
+        when(toolRegistry.preloadableRoleIdentifiers()).thenReturn(Set.of("ROLE_CASHIER"));
+
+        new StreamingSessionAgentManager(
+                streamingChatModel,
+                toolRegistry,
+                sharedSupportSpy,
+                toolSelectionEngine,
+                scopedContentRetrieverFactory,
+                rolePromptResolver,
+                null,
+                30,
+                500,
+                50,
+                100);
+
+        ArgumentCaptor<List<Object>> fallbackToolsCaptor = listCaptor();
+        verify(sharedSupportSpy, atLeastOnce()).mergeTools(argThat(Collection::isEmpty), fallbackToolsCaptor.capture());
+        assertThat(fallbackToolsCaptor.getAllValues())
+                .anySatisfy(fallbackTools -> assertThat(fallbackTools)
+                        .containsExactly(exaWebSearchTool, inventoryFacadeTool, orderFacadeTool));
+        verify(scopedContentRetrieverFactory, atLeastOnce()).create("master", 10, 0.6);
+        verify(scopedContentRetrieverFactory, atLeastOnce()).create("master", 20, 0.55);
+    }
+
+    @Test
+    @DisplayName("streamChat applies shared inventory fallback selection")
+    void streamChat_withInventoryKeyword_includesInventoryFallbackTool() {
+        ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
+        when(toolRegistry.resolveDomainTools("ROLE_CASHIER")).thenReturn(new ArrayList<>());
+        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
+                .thenReturn(List.of());
+
+        StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(realToolSelectionEngine);
+
+        selectorManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "stock part 1234");
+
+        assertThat(roleAgentCacheKeys(selectorManager))
+                .contains("ROLE_CASHIER::InventoryFacadeTool")
+                .contains("ROLE_CASHIER::full");
+    }
+
+    @Test
+    @DisplayName("streamChat applies shared web fallback selection")
+    void streamChat_withWebKeyword_includesExaFallbackTool() {
+        ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
+        when(toolRegistry.resolveDomainTools("ROLE_CASHIER")).thenReturn(new ArrayList<>());
+        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
+                .thenReturn(List.of());
+
+        StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(realToolSelectionEngine);
+
+        selectorManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "latest internet news");
+
+        assertThat(roleAgentCacheKeys(selectorManager))
+                .contains("ROLE_CASHIER::ExaWebSearchTool")
+                .contains("ROLE_CASHIER::full");
+    }
+
+    @Test
+    @DisplayName("streamChat rebuilds agent after cache TTL expiry")
+    void streamChat_rebuildsAgentAfterCacheTtlExpiry() {
+        StreamingSessionAgentManager expiringManager = new StreamingSessionAgentManager(
+                streamingChatModel,
+                toolRegistry,
+                sharedOrchestrationSupport,
+                toolSelectionEngine,
+                scopedContentRetrieverFactory,
+                rolePromptResolver,
+                null,
+                0,
+                500,
+                50,
+                100);
+        clearInvocations(toolRegistry);
+
+        expiringManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "first");
+        expiringManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "second");
+
+        verify(toolSelectionEngine, times(3)).selectRoleTools(eq("ROLE_CASHIER"), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> roleAgentCacheKeys(StreamingSessionAgentManager selectorManager) {
+        Cache<String, ?> cache = (Cache<String, ?>) ReflectionTestUtils.getField(selectorManager, "roleAgentCache");
+        assertThat(cache).isNotNull();
+        cache.cleanUp();
+        return cache.asMap().keySet();
+    }
+
+    private StreamingSessionAgentManager streamingManagerWithToolSelectionEngine(ToolSelectionEngine selectionEngine) {
+        return new StreamingSessionAgentManager(
+                streamingChatModel,
+                toolRegistry,
+                sharedOrchestrationSupport,
+                selectionEngine,
+                scopedContentRetrieverFactory,
+                rolePromptResolver,
+                null,
+                30,
+                500,
+                50,
+                100);
+    }
+
+    private ToolSelectionEngine realToolSelectionEngine() {
+        return new ToolSelectionEngine(
+                toolRegistry,
+                exaWebSearchTool,
+                inventoryFacadeTool,
+                orderFacadeTool,
+                toolRegistryService,
+                sharedOrchestrationSupport,
+                3);
+    }
+
+    private static ToolMetadata inventoryToolMetadata() {
+        return new ToolMetadata(
+                UUID.randomUUID(),
+                "inventoryFacadeTool",
+                "Inventory",
+                "Inventory availability",
+                "inventory",
+                1.0,
+                "low",
+                200,
+                true,
+                "inventoryFacadeTool");
+    }
+
+    private static String ragScopeFor(java.util.Collection<?> tools) {
+        boolean hasInventory = tools.stream().anyMatch(InventoryFacadeTool.class::isInstance);
+        boolean hasOrder = tools.stream().anyMatch(OrderFacadeTool.class::isInstance);
+        if (hasInventory && !hasOrder) {
+            return "inventory";
         }
-
-        @BeforeEach
-        void setUp() {
-                // Return a fresh mutable list each invocation so buildAgent mutations don't
-                // bleed
-                when(toolRegistry.resolveDomainTools(any())).thenAnswer(inv -> new ArrayList<>());
-                when(toolRegistry.preloadableRoleIdentifiers()).thenReturn(Set.of("ROLE_CASHIER", "ROLE_MANAGER"));
-                lenient().when(rolePromptResolver.resolvePrompt(any())).thenReturn("Default role prompt");
-                lenient()
-                                .when(toolSelectionEngine.selectRoleTools(any(), any()))
-                                .thenReturn(new ToolSelectionEngine.ToolSelectionResult(List.of(), List.of()));
-                exaWebSearchTool = new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
-                inventoryFacadeTool = new InventoryFacadeTool(
-                                RestClient.builder(),
-                                "http://api-gateway",
-                                "/inventory/v1/inventory/stock/{sku}",
-                                "/inventory/v1/inventory/search?q={query}",
-                                "/inventory/v1/inventory/locations/{locationId}/stock");
-                orderFacadeTool = new OrderFacadeTool(
-                                RestClient.builder(),
-                                "http://api-gateway",
-                                "/order/v1/orders/{orderId}",
-                                "/order/v1/orders/search?q={query}");
-                sharedOrchestrationSupport = new SharedOrchestrationSupport();
-                ContentRetriever scopedRetriever = mock(ContentRetriever.class);
-                lenient().when(toolRegistry.sharedTools()).thenReturn(List.of());
-                lenient()
-                                .when(toolSelectionEngine.fullFallbackTools())
-                                .thenReturn(List.of(exaWebSearchTool, inventoryFacadeTool, orderFacadeTool));
-                lenient()
-                                .when(toolRegistry.resolveRagScopeForTools(anyCollection()))
-                                .thenAnswer(invocation -> ragScopeFor(invocation.getArgument(0)));
-                lenient()
-                                .when(scopedContentRetrieverFactory.create(anyString(), anyInt(), anyDouble()))
-                                .thenReturn(scopedRetriever);
-                manager = new StreamingSessionAgentManager(
-                                streamingChatModel,
-                                toolRegistry,
-                                sharedOrchestrationSupport,
-                                toolSelectionEngine,
-                                scopedContentRetrieverFactory,
-                                rolePromptResolver,
-                                null, // toolAuditService
-                                30,
-                                500,
-                                50,
-                                100);
-                clearInvocations(toolRegistry);
-                clearInvocations(toolSelectionEngine);
-                clearInvocations(scopedContentRetrieverFactory);
-                clearInvocations(rolePromptResolver);
+        if (hasOrder && !hasInventory) {
+            return "orders";
         }
+        return "master";
+    }
 
-        @Test
-        @DisplayName("manager no longer retains tool registry service state")
-        void manager_doesNotRetainToolRegistryServiceField() {
-                assertThat(java.util.Arrays.stream(StreamingSessionAgentManager.class.getDeclaredFields())
-                                .map(Member::getName)
-                                .toList())
-                                .doesNotContain("toolRegistryService");
-        }
-
-        @Test
-        @DisplayName("streamChat returns a non-null Flux")
-        void streamChat_returnsNonNullFlux() {
-                Flux<String> result = manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "hello");
-
-                assertThat(result).isNotNull();
-        }
-
-        @Test
-        @DisplayName("streamChat reuses cached agent for same userId+role")
-        void streamChat_cachesAgentForSameUser() {
-                manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "first message");
-                manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "second message");
-
-                verify(toolRegistry, never()).resolveDomainTools("ROLE_CASHIER");
-        }
-
-        @Test
-        @DisplayName("evict removes cached agent so next streamChat rebuilds it")
-        void evict_removesFromCache() {
-                manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "first message");
-                manager.evict("user-1");
-                manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "after evict");
-
-                verify(toolRegistry, never()).resolveDomainTools("ROLE_CASHIER");
-        }
-
-        @Test
-        @DisplayName("streamChat rebuilds agent when role changes for same userId")
-        void streamChat_roleChange_rebuildsAgent() {
-                manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "first");
-                manager.streamChat(userContext("user-1", USER_ID, "ROLE_MANAGER"), "second");
-
-                verify(toolRegistry, never()).resolveDomainTools("ROLE_CASHIER");
-                verify(toolRegistry, never()).resolveDomainTools("ROLE_MANAGER");
-        }
-
-        @Test
-        @DisplayName("streamChat skips fallback tools already resolved for the role")
-        void streamChat_skipsDuplicateFallbackTool() {
-                when(toolSelectionEngine.selectRoleTools("ROLE_DUPLICATE", "hello"))
-                                .thenReturn(new ToolSelectionEngine.ToolSelectionResult(
-                                                List.of(exaWebSearchTool), List.of(exaWebSearchTool)));
-
-                Flux<String> result = manager.streamChat(userContext("user-with-role-tool", USER_ID, "ROLE_DUPLICATE"),
-                                "hello");
-
-                assertThat(result).isNotNull();
-                assertThat(roleAgentCacheKeys(manager)).contains("ROLE_DUPLICATE::ExaWebSearchTool");
-        }
-
-        // --- Phase 3: semantic tool selection through ToolSelectionEngine ---
-
-        @Test
-        @DisplayName("streamChat uses shared workflow derivation and tool narrowing")
-        void streamChat_semanticSelection_narrowsToolsWhenCandidatesReturned() {
-                String message = "show me inventory levels";
-                ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
-                when(toolRegistry.resolveDomainTools("ROLE_CASHIER"))
-                                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
-                when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
-                                .thenReturn(List.of(inventoryToolMetadata()));
-                when(toolRegistry.resolveDomainTools("ROLE_CASHIER", List.of("inventoryFacadeTool")))
-                                .thenReturn(List.of(inventoryFacadeTool));
-
-                StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(
-                                realToolSelectionEngine);
-                clearInvocations(toolRegistryService);
-                clearInvocations(scopedContentRetrieverFactory);
-
-                Flux<String> result = selectorManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"),
-                                message);
-
-                assertThat(result).isNotNull();
-                ArgumentCaptor<ToolSelectionContext> contextCaptor = ArgumentCaptor
-                                .forClass(ToolSelectionContext.class);
-                verify(toolRegistryService).resolveCandidateTools(contextCaptor.capture(), eq(3));
-                assertThat(contextCaptor.getValue().workflowState()).isEqualTo("READ");
-                assertThat(roleAgentCacheKeys(selectorManager)).contains("ROLE_CASHIER::InventoryFacadeTool");
-        }
-
-        @Test
-        @DisplayName("streamChat uses shared tool selection even when registry service is unavailable")
-        void streamChat_withoutRegistryService_usesSharedSelectionPath() {
-                String message = "latest internet sales report";
-                when(toolSelectionEngine.selectRoleTools("ROLE_CASHIER", message))
-                                .thenReturn(new ToolSelectionEngine.ToolSelectionResult(
-                                                List.of(orderFacadeTool),
-                                                List.of(exaWebSearchTool, inventoryFacadeTool)));
-
-                Flux<String> result = manager.streamChat(userContext("user-shared-path", USER_ID, "ROLE_CASHIER"),
-                                message);
-
-                assertThat(result).isNotNull();
-                verify(toolSelectionEngine).selectRoleTools("ROLE_CASHIER", message);
-                assertThat(roleAgentCacheKeys(manager))
-                                .contains("ROLE_CASHIER::ExaWebSearchTool+InventoryFacadeTool+OrderFacadeTool");
-        }
-
-        @Test
-        @DisplayName("streamChat falls back to shared full role selection when selector returns empty")
-        void streamChat_semanticSelection_fallsBackToFullRoleToolsOnEmptyResult() {
-                String message = "show sales orders";
-                ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
-                when(toolRegistry.resolveDomainTools("ROLE_CASHIER"))
-                                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
-                when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
-                                .thenReturn(List.of());
-
-                StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(
-                                realToolSelectionEngine);
-                clearInvocations(toolRegistryService);
-                clearInvocations(scopedContentRetrieverFactory);
-
-                Flux<String> result = selectorManager.streamChat(userContext("user-2", USER_ID, "ROLE_CASHIER"),
-                                message);
-
-                assertThat(result).isNotNull();
-                verify(toolRegistryService).resolveCandidateTools(any(ToolSelectionContext.class), eq(3));
-                assertThat(roleAgentCacheKeys(selectorManager))
-                                .contains("ROLE_CASHIER::InventoryFacadeTool+OrderFacadeTool");
-        }
-
-        @Test
-        @DisplayName("streamChat falls back to shared full role selection when selector throws")
-        void streamChat_semanticSelection_fallsBackToFullRoleToolsOnException() {
-                ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
-                when(toolRegistry.resolveDomainTools("ROLE_CASHIER"))
-                                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
-                when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
-                                .thenThrow(new IllegalStateException("selector unavailable"));
-
-                StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(
-                                realToolSelectionEngine);
-                clearInvocations(toolRegistryService);
-                clearInvocations(scopedContentRetrieverFactory);
-
-                Flux<String> result = selectorManager.streamChat(userContext("user-3", USER_ID, "ROLE_CASHIER"),
-                                "anything");
-
-                assertThat(result).isNotNull();
-                verify(toolRegistryService).resolveCandidateTools(any(ToolSelectionContext.class), eq(3));
-                assertThat(roleAgentCacheKeys(selectorManager))
-                                .contains("ROLE_CASHIER::InventoryFacadeTool+OrderFacadeTool");
-        }
-
-        @Test
-        @DisplayName("prebuild merges the full shared fallback tool set")
-        void constructor_prebuildRoleAgents_mergesFullSharedFallbackTools() {
-                SharedOrchestrationSupport sharedSupportSpy = spy(new SharedOrchestrationSupport());
-                when(toolRegistry.resolveDomainTools("ROLE_CASHIER")).thenReturn(new ArrayList<>());
-                when(toolRegistry.preloadableRoleIdentifiers()).thenReturn(Set.of("ROLE_CASHIER"));
-
-                new StreamingSessionAgentManager(
-                                streamingChatModel,
-                                toolRegistry,
-                                sharedSupportSpy,
-                                toolSelectionEngine,
-                                scopedContentRetrieverFactory,
-                                rolePromptResolver,
-                                null,
-                                30,
-                                500,
-                                50,
-                                100);
-
-                ArgumentCaptor<List<Object>> fallbackToolsCaptor = listCaptor();
-                verify(sharedSupportSpy, atLeastOnce())
-                                .mergeTools(argThat(Collection::isEmpty),
-                                                fallbackToolsCaptor.capture());
-                assertThat(fallbackToolsCaptor.getAllValues())
-                                .anySatisfy(fallbackTools -> assertThat(fallbackTools)
-                                                .containsExactly(exaWebSearchTool, inventoryFacadeTool,
-                                                                orderFacadeTool));
-                verify(scopedContentRetrieverFactory, atLeastOnce()).create("master", 10, 0.6);
-                verify(scopedContentRetrieverFactory, atLeastOnce()).create("master", 20, 0.55);
-        }
-
-        @Test
-        @DisplayName("streamChat applies shared inventory fallback selection")
-        void streamChat_withInventoryKeyword_includesInventoryFallbackTool() {
-                ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
-                when(toolRegistry.resolveDomainTools("ROLE_CASHIER")).thenReturn(new ArrayList<>());
-                when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
-                                .thenReturn(List.of());
-
-                StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(
-                                realToolSelectionEngine);
-
-                selectorManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "stock part 1234");
-
-                assertThat(roleAgentCacheKeys(selectorManager))
-                                .contains("ROLE_CASHIER::InventoryFacadeTool")
-                                .contains("ROLE_CASHIER::full");
-        }
-
-        @Test
-        @DisplayName("streamChat applies shared web fallback selection")
-        void streamChat_withWebKeyword_includesExaFallbackTool() {
-                ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
-                when(toolRegistry.resolveDomainTools("ROLE_CASHIER")).thenReturn(new ArrayList<>());
-                when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
-                                .thenReturn(List.of());
-
-                StreamingSessionAgentManager selectorManager = streamingManagerWithToolSelectionEngine(
-                                realToolSelectionEngine);
-
-                selectorManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "latest internet news");
-
-                assertThat(roleAgentCacheKeys(selectorManager))
-                                .contains("ROLE_CASHIER::ExaWebSearchTool")
-                                .contains("ROLE_CASHIER::full");
-        }
-
-        @Test
-        @DisplayName("streamChat rebuilds agent after cache TTL expiry")
-        void streamChat_rebuildsAgentAfterCacheTtlExpiry() {
-                StreamingSessionAgentManager expiringManager = new StreamingSessionAgentManager(
-                                streamingChatModel,
-                                toolRegistry,
-                                sharedOrchestrationSupport,
-                                toolSelectionEngine,
-                                scopedContentRetrieverFactory,
-                                rolePromptResolver,
-                                null,
-                                0,
-                                500,
-                                50,
-                                100);
-                clearInvocations(toolRegistry);
-
-                expiringManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "first");
-                expiringManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "second");
-
-                verify(toolSelectionEngine, times(3)).selectRoleTools(eq("ROLE_CASHIER"), any());
-        }
-
-        @SuppressWarnings("unchecked")
-        private static Set<String> roleAgentCacheKeys(StreamingSessionAgentManager selectorManager) {
-                Cache<String, ?> cache = (Cache<String, ?>) ReflectionTestUtils.getField(selectorManager,
-                                "roleAgentCache");
-                assertThat(cache).isNotNull();
-                cache.cleanUp();
-                return cache.asMap().keySet();
-        }
-
-        private StreamingSessionAgentManager streamingManagerWithToolSelectionEngine(
-                        ToolSelectionEngine selectionEngine) {
-                return new StreamingSessionAgentManager(
-                                streamingChatModel,
-                                toolRegistry,
-                                sharedOrchestrationSupport,
-                                selectionEngine,
-                                scopedContentRetrieverFactory,
-                                rolePromptResolver,
-                                null,
-                                30,
-                                500,
-                                50,
-                                100);
-        }
-
-        private ToolSelectionEngine realToolSelectionEngine() {
-                return new ToolSelectionEngine(
-                                toolRegistry,
-                                exaWebSearchTool,
-                                inventoryFacadeTool,
-                                orderFacadeTool,
-                                toolRegistryService,
-                                sharedOrchestrationSupport,
-                                3);
-        }
-
-        private static ToolMetadata inventoryToolMetadata() {
-                return new ToolMetadata(
-                                UUID.randomUUID(),
-                                "inventoryFacadeTool",
-                                "Inventory",
-                                "Inventory availability",
-                                "inventory",
-                                1.0,
-                                "low",
-                                200,
-                                true,
-                                "inventoryFacadeTool");
-        }
-
-        private static String ragScopeFor(java.util.Collection<?> tools) {
-                boolean hasInventory = tools.stream().anyMatch(InventoryFacadeTool.class::isInstance);
-                boolean hasOrder = tools.stream().anyMatch(OrderFacadeTool.class::isInstance);
-                if (hasInventory && !hasOrder) {
-                        return "inventory";
-                }
-                if (hasOrder && !hasInventory) {
-                        return "orders";
-                }
-                return "master";
-        }
-
-        private static CurrentUserContext userContext(String username, UUID userId, String primaryRole) {
-                return new CurrentUserContext(
-                                username, userId, primaryRole, Set.of(primaryRole),
-                                Set.of(primaryRole, "mcp:chat:stream"));
-        }
+    private static CurrentUserContext userContext(String username, UUID userId, String primaryRole) {
+        return new CurrentUserContext(
+                username, userId, primaryRole, Set.of(primaryRole), Set.of(primaryRole, "mcp:chat:stream"));
+    }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -163,6 +163,7 @@ class StreamingSessionAgentManagerTest {
                 clearInvocations(toolRegistry);
                 clearInvocations(toolSelectionEngine);
                 clearInvocations(scopedContentRetrieverFactory);
+                clearInvocations(rolePromptResolver);
         }
 
         @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/rag/ScopedContentRetrieverFactoryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/rag/ScopedContentRetrieverFactoryTest.java
@@ -21,7 +21,8 @@ import org.springframework.context.annotation.Bean;
 class ScopedContentRetrieverFactoryTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withUserConfiguration(ScopedContentRetrieverFactory.class, ScopedContentRetrieverFactoryContextTestConfig.class);
+            .withUserConfiguration(
+                    ScopedContentRetrieverFactory.class, ScopedContentRetrieverFactoryContextTestConfig.class);
 
     @Test
     void createsRetrieverFilteredToNormalizedRagScope() throws Exception {
@@ -34,8 +35,10 @@ class ScopedContentRetrieverFactoryTest {
         EmbeddingStoreContentRetriever embeddingRetriever = (EmbeddingStoreContentRetriever) retriever;
         assertThat(filterProvider(embeddingRetriever).apply(Query.from("stock")))
                 .isEqualTo(metadataKey("rag_scope").isEqualTo("inventory"));
-        assertThat(maxResultsProvider(embeddingRetriever).apply(Query.from("stock"))).isEqualTo(7);
-        assertThat(minScoreProvider(embeddingRetriever).apply(Query.from("stock"))).isEqualTo(0.42);
+        assertThat(maxResultsProvider(embeddingRetriever).apply(Query.from("stock")))
+                .isEqualTo(7);
+        assertThat(minScoreProvider(embeddingRetriever).apply(Query.from("stock")))
+                .isEqualTo(0.42);
     }
 
     @Test
@@ -49,8 +52,10 @@ class ScopedContentRetrieverFactoryTest {
         EmbeddingStoreContentRetriever embeddingRetriever = (EmbeddingStoreContentRetriever) retriever;
         assertThat(filterProvider(embeddingRetriever).apply(Query.from("anything")))
                 .isEqualTo(metadataKey("rag_scope").isEqualTo("master"));
-        assertThat(maxResultsProvider(embeddingRetriever).apply(Query.from("anything"))).isEqualTo(3);
-        assertThat(minScoreProvider(embeddingRetriever).apply(Query.from("anything"))).isEqualTo(0.21);
+        assertThat(maxResultsProvider(embeddingRetriever).apply(Query.from("anything")))
+                .isEqualTo(3);
+        assertThat(minScoreProvider(embeddingRetriever).apply(Query.from("anything")))
+                .isEqualTo(0.21);
     }
 
     @Test
@@ -77,7 +82,8 @@ class ScopedContentRetrieverFactoryTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static Function<Query, Integer> maxResultsProvider(EmbeddingStoreContentRetriever retriever) throws Exception {
+    private static Function<Query, Integer> maxResultsProvider(EmbeddingStoreContentRetriever retriever)
+            throws Exception {
         Field field = EmbeddingStoreContentRetriever.class.getDeclaredField("maxResultsProvider");
         field.setAccessible(true);
         return (Function<Query, Integer>) field.get(retriever);

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/DocumentEmbeddingIngestorTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/DocumentEmbeddingIngestorTest.java
@@ -8,62 +8,55 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
 import java.util.List;
 import java.util.Map;
-import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class DocumentEmbeddingIngestorTest {
 
-        @SuppressWarnings({ "rawtypes", "unchecked" })
-        private static <T> ArgumentCaptor<List<T>> listCaptor() {
-                return (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
-        }
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static <T> ArgumentCaptor<List<T>> listCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
+    }
 
-        @Test
-        void addsNormalizedRagScopeToSegmentMetadata() {
-                Map<String, Object> metadata = Map.of("document_id", "inventory.stock", "rag_scope", " INVENTORY ");
+    @Test
+    void addsNormalizedRagScopeToSegmentMetadata() {
+        Map<String, Object> metadata = Map.of("document_id", "inventory.stock", "rag_scope", " INVENTORY ");
 
-                PgVectorEmbeddingStore embeddingStore = mock(PgVectorEmbeddingStore.class);
-                EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
-                when(embeddingModel.embedAll(anyList()))
-                                .thenReturn(Response.from(List.of(Embedding.from(new float[] { 1.0f }))));
-                DocumentEmbeddingIngestor ingestor = new DocumentEmbeddingIngestor(embeddingStore, embeddingModel,
-                                false, 2000,
-                                200);
+        PgVectorEmbeddingStore embeddingStore = mock(PgVectorEmbeddingStore.class);
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+        when(embeddingModel.embedAll(anyList())).thenReturn(Response.from(List.of(Embedding.from(new float[] {1.0f}))));
+        DocumentEmbeddingIngestor ingestor =
+                new DocumentEmbeddingIngestor(embeddingStore, embeddingModel, false, 2000, 200);
 
-                assertEquals(1, ingestor.ingestDocument("stock policy", metadata));
+        assertEquals(1, ingestor.ingestDocument("stock policy", metadata));
 
-                ArgumentCaptor<List<TextSegment>> segmentCaptor = listCaptor();
-                verify(embeddingStore).addAll(anyList(), segmentCaptor.capture());
-                assertTrue(
-                                segmentCaptor.getValue().stream()
-                                                .allMatch(segment -> "inventory"
-                                                                .equals(segment.metadata().getString("rag_scope"))));
-        }
+        ArgumentCaptor<List<TextSegment>> segmentCaptor = listCaptor();
+        verify(embeddingStore).addAll(anyList(), segmentCaptor.capture());
+        assertTrue(segmentCaptor.getValue().stream()
+                .allMatch(segment -> "inventory".equals(segment.metadata().getString("rag_scope"))));
+    }
 
-        @Test
-        void replacesExistingDocumentWithinSameRagScopeOnly() {
-                PgVectorEmbeddingStore embeddingStore = mock(PgVectorEmbeddingStore.class);
-                EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
-                when(embeddingModel.embedAll(anyList()))
-                                .thenReturn(Response.from(List.of(Embedding.from(new float[] { 1.0f }))));
-                DocumentEmbeddingIngestor ingestor = new DocumentEmbeddingIngestor(embeddingStore, embeddingModel,
-                                false, 2000,
-                                200);
+    @Test
+    void replacesExistingDocumentWithinSameRagScopeOnly() {
+        PgVectorEmbeddingStore embeddingStore = mock(PgVectorEmbeddingStore.class);
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+        when(embeddingModel.embedAll(anyList())).thenReturn(Response.from(List.of(Embedding.from(new float[] {1.0f}))));
+        DocumentEmbeddingIngestor ingestor =
+                new DocumentEmbeddingIngestor(embeddingStore, embeddingModel, false, 2000, 200);
 
-                ingestor.ingestDocument("stock policy",
-                                Map.of("document_id", "inventory.stock", "rag_scope", "inventory"));
+        ingestor.ingestDocument("stock policy", Map.of("document_id", "inventory.stock", "rag_scope", "inventory"));
 
-                verify(embeddingStore)
-                                .removeAll(new And(
-                                                metadataKey("document_id").isEqualTo("inventory.stock"),
-                                                metadataKey("rag_scope").isEqualTo("inventory")));
-        }
+        verify(embeddingStore)
+                .removeAll(new And(
+                        metadataKey("document_id").isEqualTo("inventory.stock"),
+                        metadataKey("rag_scope").isEqualTo("inventory")));
+    }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/DocumentIngestionServiceImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/DocumentIngestionServiceImplTest.java
@@ -71,7 +71,8 @@ class DocumentIngestionServiceImplTest {
     @DisplayName("submitDocument persists pending job and processes it in the background")
     void submitDocument_persistsPendingJobAndProcesses() {
         when(documentEmbeddingIngestor.ingestDocument(
-                        eq("policy text"), eq(Map.of("source", "manual", "document_id", "policy-1", "rag_scope", "master"))))
+                        eq("policy text"),
+                        eq(Map.of("source", "manual", "document_id", "policy-1", "rag_scope", "master"))))
                 .thenReturn(2);
 
         var accepted = service.submitDocument("policy text", Map.of("source", "manual", "document_id", "policy-1"));
@@ -117,9 +118,8 @@ class DocumentIngestionServiceImplTest {
     @DisplayName("ingestDocuments passes metadata through to the ingestor")
     void ingestDocuments_normalizesRagScope() {
         List<String> contents = List.of("one", "two");
-        List<Map<String, Object>> metadata = List.of(
-                Map.of("document_id", "doc-1", "rag_scope", " INVENTORY "),
-                Map.of("document_id", "doc-2"));
+        List<Map<String, Object>> metadata =
+                List.of(Map.of("document_id", "doc-1", "rag_scope", " INVENTORY "), Map.of("document_id", "doc-2"));
 
         service.ingestDocuments(contents, metadata);
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/McpRoleResolverImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/McpRoleResolverImplTest.java
@@ -33,7 +33,8 @@ class McpRoleResolverImplTest {
     }
 
     private void givenAuthorities(String... roles) {
-        Collection<? extends GrantedAuthority> authorities = Stream.of(roles).map(SimpleGrantedAuthority::new).toList();
+        Collection<? extends GrantedAuthority> authorities =
+                Stream.of(roles).map(SimpleGrantedAuthority::new).toList();
         when(authentication.getAuthorities()).thenAnswer(inv -> authorities);
     }
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/RagScopeMigrationScriptsTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/RagScopeMigrationScriptsTest.java
@@ -13,8 +13,7 @@ class RagScopeMigrationScriptsTest {
     void postgresMigrationBackfillsLegacyEmbeddingMetadataWithMasterScope() throws IOException {
         String sql = new String(
                 Objects.requireNonNull(
-                                getClass()
-                                        .getResourceAsStream("/db/migration/V16__backfill_embedding_rag_scope.sql"))
+                                getClass().getResourceAsStream("/db/migration/V16__backfill_embedding_rag_scope.sql"))
                         .readAllBytes(),
                 UTF_8);
 
@@ -28,9 +27,8 @@ class RagScopeMigrationScriptsTest {
     @Test
     void h2MigrationExistsForFlywayVersionAlignment() throws IOException {
         String sql = new String(
-                Objects.requireNonNull(
-                                getClass()
-                                        .getResourceAsStream("/db/h2-migration/V16__backfill_embedding_rag_scope.sql"))
+                Objects.requireNonNull(getClass()
+                                .getResourceAsStream("/db/h2-migration/V16__backfill_embedding_rag_scope.sql"))
                         .readAllBytes(),
                 UTF_8);
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/RolePromptResolverImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/RolePromptResolverImplTest.java
@@ -19,8 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class RolePromptResolverImplTest {
 
-    private static final String ROLE_NAME = SystemPromptDefaults.ROLE_SERVICE_ADVISOR_PROMPT_NAME;
-    private static final String DEFAULT_NAME = SystemPromptDefaults.DEFAULT_PROMPT_NAME;
+    private static final String AGENT_NAME = "inventory";
+    private static final String MASTER_NAME = "master";
 
     @Mock
     private SystemPromptRepository systemPromptRepository;
@@ -40,46 +40,46 @@ class RolePromptResolverImplTest {
     // ─── resolvePrompt ──────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("resolvePrompt returns role content when role name exists")
-    void resolvePrompt_roleExists_returnsRoleContent() {
-        SystemPrompt rolePrompt = buildPrompt(ROLE_NAME, "You are a service advisor assistant.");
-        when(systemPromptRepository.findByName(ROLE_NAME)).thenReturn(Optional.of(rolePrompt));
+    @DisplayName("resolvePrompt returns agent content when agent prompt exists")
+    void resolvePrompt_agentPromptExists_returnsAgentContent() {
+        SystemPrompt agentPrompt = buildPrompt(AGENT_NAME, "You are the inventory domain agent.");
+        when(systemPromptRepository.findByName(AGENT_NAME)).thenReturn(Optional.of(agentPrompt));
 
-        String result = resolver.resolvePrompt(ROLE_NAME);
+        String result = resolver.resolvePrompt(AGENT_NAME);
 
-        assertThat(result).isEqualTo("You are a service advisor assistant.");
+        assertThat(result).isEqualTo("You are the inventory domain agent.");
     }
 
     @Test
-    @DisplayName("resolvePrompt returns default content when role not found but default exists")
-    void resolvePrompt_roleNotFound_defaultExists_returnsDefaultContent() {
-        SystemPrompt defaultPrompt = buildPrompt(DEFAULT_NAME, "You are a default assistant.");
-        when(systemPromptRepository.findByName(ROLE_NAME)).thenReturn(Optional.empty());
-        when(systemPromptRepository.findByName(DEFAULT_NAME)).thenReturn(Optional.of(defaultPrompt));
+    @DisplayName("resolvePrompt falls back to master prompt when agent prompt is missing")
+    void resolvePrompt_agentPromptMissing_masterExists_returnsMasterContent() {
+        SystemPrompt masterPrompt = buildPrompt(MASTER_NAME, "You are the master orchestration agent.");
+        when(systemPromptRepository.findByName(AGENT_NAME)).thenReturn(Optional.empty());
+        when(systemPromptRepository.findByName(MASTER_NAME)).thenReturn(Optional.of(masterPrompt));
 
-        String result = resolver.resolvePrompt(ROLE_NAME);
+        String result = resolver.resolvePrompt(AGENT_NAME);
 
-        assertThat(result).isEqualTo("You are a default assistant.");
+        assertThat(result).isEqualTo("You are the master orchestration agent.");
     }
 
     @Test
-    @DisplayName("resolvePrompt returns built-in prompt when neither role nor default exists")
+    @DisplayName("resolvePrompt returns built-in prompt when neither agent nor master prompt exists")
     void resolvePrompt_neitherFound_returnsBuiltIn() {
-        when(systemPromptRepository.findByName(ROLE_NAME)).thenReturn(Optional.empty());
-        when(systemPromptRepository.findByName(DEFAULT_NAME)).thenReturn(Optional.empty());
+        when(systemPromptRepository.findByName(AGENT_NAME)).thenReturn(Optional.empty());
+        when(systemPromptRepository.findByName(MASTER_NAME)).thenReturn(Optional.empty());
 
-        String result = resolver.resolvePrompt(ROLE_NAME);
+        String result = resolver.resolvePrompt(AGENT_NAME);
 
         assertThat(result).contains("concise POS assistant");
     }
 
     @Test
-    @DisplayName("resolvePrompt returns shared default text when neither role nor default prompt exists")
-    void resolvePrompt_noPromptFoundForRoleOrDefault_returnsSharedDefaultText() {
-        when(systemPromptRepository.findByName(ROLE_NAME)).thenReturn(Optional.empty());
-        when(systemPromptRepository.findByName(DEFAULT_NAME)).thenReturn(Optional.empty());
+    @DisplayName("resolvePrompt returns shared default text when neither agent nor master prompt exists")
+    void resolvePrompt_noPromptFoundForAgentOrMaster_returnsSharedDefaultText() {
+        when(systemPromptRepository.findByName(AGENT_NAME)).thenReturn(Optional.empty());
+        when(systemPromptRepository.findByName(MASTER_NAME)).thenReturn(Optional.empty());
 
-        String result = resolver.resolvePrompt(ROLE_NAME);
+        String result = resolver.resolvePrompt(AGENT_NAME);
 
         assertThat(result).isEqualTo(SystemPromptDefaults.DEFAULT_PROMPT_TEXT);
     }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/StaticRagPreloadServiceImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/StaticRagPreloadServiceImplTest.java
@@ -157,8 +157,7 @@ class StaticRagPreloadServiceImplTest {
                 .thenReturn(Optional.of(loadedRecord(TEST_DOC_ID, hash)));
         when(ragPreloadRecordRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        StaticRagPreloadServiceImpl service =
-                createService(List.of(docEntry(TEST_DOC_ID)));
+        StaticRagPreloadServiceImpl service = createService(List.of(docEntry(TEST_DOC_ID)));
 
         service.preloadAll();
 
@@ -189,8 +188,7 @@ class StaticRagPreloadServiceImplTest {
         when(documentIngestionService.submitDocument(anyString(), any())).thenReturn(stubJob(TEST_DOC_ID));
         when(ragPreloadRecordRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        StaticRagPreloadServiceImpl service =
-                createService(List.of(docEntry(TEST_DOC_ID)));
+        StaticRagPreloadServiceImpl service = createService(List.of(docEntry(TEST_DOC_ID)));
 
         service.preloadAll();
 
@@ -199,8 +197,9 @@ class StaticRagPreloadServiceImplTest {
         verify(ragPreloadRecordRepository).save(captor.capture());
         assertThat(captor.getValue().getStatus()).isEqualTo(RagPreloadStatus.QUEUED);
         assertThat(captor.getValue().getRagScope()).isEqualTo(TEST_RAG_SCOPE);
-        verify(ragPreloadRecordRepository, never()).findFirstByDocumentIdAndRagScopeAndStatusOrderByLoadedAtDesc(
-                TEST_DOC_ID, "master", RagPreloadStatus.LOADED);
+        verify(ragPreloadRecordRepository, never())
+                .findFirstByDocumentIdAndRagScopeAndStatusOrderByLoadedAtDesc(
+                        TEST_DOC_ID, "master", RagPreloadStatus.LOADED);
     }
 
     @Test
@@ -215,8 +214,7 @@ class StaticRagPreloadServiceImplTest {
         when(documentIngestionService.submitDocument(anyString(), any())).thenReturn(stubJob(TEST_DOC_ID));
         when(ragPreloadRecordRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        StaticRagPreloadServiceImpl service =
-                createService(List.of(docEntry(TEST_DOC_ID)));
+        StaticRagPreloadServiceImpl service = createService(List.of(docEntry(TEST_DOC_ID)));
 
         service.preloadAll();
 
@@ -242,8 +240,7 @@ class StaticRagPreloadServiceImplTest {
         when(documentIngestionService.submitDocument(anyString(), any())).thenReturn(stubJob(TEST_DOC_ID));
         when(ragPreloadRecordRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        StaticRagPreloadServiceImpl service =
-                createService(List.of(docEntry(TEST_DOC_ID)));
+        StaticRagPreloadServiceImpl service = createService(List.of(docEntry(TEST_DOC_ID)));
 
         service.preloadAll();
 
@@ -300,16 +297,18 @@ class StaticRagPreloadServiceImplTest {
         when(documentIngestionService.submitDocument(anyString(), any())).thenReturn(stubJob(TEST_DOC_ID));
         when(ragPreloadRecordRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        StaticRagPreloadServiceImpl service = createService(List.of(
-                new StaticRagPreloadProperties.StaticDocEntry(TEST_DOC_ID, TEST_SOURCE_PATH, " INVENTORY ")));
+        StaticRagPreloadServiceImpl service = createService(
+                List.of(new StaticRagPreloadProperties.StaticDocEntry(TEST_DOC_ID, TEST_SOURCE_PATH, " INVENTORY ")));
 
         service.preloadAll();
 
         verify(documentIngestionService)
-                .submitDocument(anyString(), eq(java.util.Map.of(
-                        "document_id", TEST_DOC_ID,
-                        "source_path", TEST_SOURCE_PATH,
-                        "rag_scope", "inventory")));
+                .submitDocument(
+                        anyString(),
+                        eq(java.util.Map.of(
+                                "document_id", TEST_DOC_ID,
+                                "source_path", TEST_SOURCE_PATH,
+                                "rag_scope", "inventory")));
     }
 
     @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SystemPromptDefaultsTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SystemPromptDefaultsTest.java
@@ -1,0 +1,105 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SystemPromptDefaults}: prompt name resolution and delegation
+ * to RagScope normalization.
+ *
+ * <p>
+ * Tests verify that:
+ * <ul>
+ * <li>promptNameForRagScope() delegates to RagScope.normalize()</li>
+ * <li>"shared" scope is correctly mapped to MASTER_PROMPT_NAME</li>
+ * <li>Edge cases (null, blank, mixed case, trimming) are handled</li>
+ * </ul>
+ */
+class SystemPromptDefaultsTest {
+
+    @Test
+    @DisplayName("promptNameForRagScope delegates to RagScope.normalize for non-shared scopes")
+    void promptNameForRagScope_delegatesToRagScopeNormalize() {
+        // RagScope.normalize() lowercases and trims
+        assertThat(SystemPromptDefaults.promptNameForRagScope("INVENTORY")).isEqualTo("inventory");
+        assertThat(SystemPromptDefaults.promptNameForRagScope("ORDER")).isEqualTo("order");
+        assertThat(SystemPromptDefaults.promptNameForRagScope("CataLog")).isEqualTo("catalog");
+    }
+
+    @Test
+    @DisplayName("promptNameForRagScope handles leading/trailing whitespace")
+    void promptNameForRagScope_handlesWhitespace() {
+        // RagScope.normalize() trims before lowercasing
+        assertThat(SystemPromptDefaults.promptNameForRagScope(" inventory ")).isEqualTo("inventory");
+        assertThat(SystemPromptDefaults.promptNameForRagScope("\torder\n")).isEqualTo("order");
+        assertThat(SystemPromptDefaults.promptNameForRagScope("   CATALOG   ")).isEqualTo("catalog");
+    }
+
+    @Test
+    @DisplayName("promptNameForRagScope maps 'shared' to MASTER_PROMPT_NAME")
+    void promptNameForRagScope_mapsSharedToMaster() {
+        assertThat(SystemPromptDefaults.promptNameForRagScope("shared"))
+                .isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+        assertThat(SystemPromptDefaults.promptNameForRagScope("SHARED"))
+                .isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+        assertThat(SystemPromptDefaults.promptNameForRagScope(" shared "))
+                .isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+    }
+
+    @Test
+    @DisplayName("promptNameForRagScope maps null to MASTER_PROMPT_NAME")
+    void promptNameForRagScope_mapsNullToMaster() {
+        // RagScope.normalize(null) returns "master"
+        // promptNameForRagScope then checks if normalized value is "shared"
+        // In this case, it's not, so it returns the normalized value "master"
+        assertThat(SystemPromptDefaults.promptNameForRagScope(null)).isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+    }
+
+    @Test
+    @DisplayName("promptNameForRagScope maps blank string to MASTER_PROMPT_NAME")
+    void promptNameForRagScope_mapsBlankToMaster() {
+        // RagScope.normalize("") returns "master" (via isEmpty check)
+        assertThat(SystemPromptDefaults.promptNameForRagScope("")).isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+        assertThat(SystemPromptDefaults.promptNameForRagScope("   "))
+                .isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+        assertThat(SystemPromptDefaults.promptNameForRagScope("\t\n"))
+                .isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+    }
+
+    @Test
+    @DisplayName("promptNameForRagScope handles all normalized cases consistently")
+    void promptNameForRagScope_handlesAllCasesConsistently() {
+        // Verify the complete behavior matrix for normalization + "shared" check
+        assertThat(SystemPromptDefaults.promptNameForRagScope("master")).isEqualTo("master");
+        assertThat(SystemPromptDefaults.promptNameForRagScope("MASTER")).isEqualTo("master");
+        assertThat(SystemPromptDefaults.promptNameForRagScope(" MASTER ")).isEqualTo("master");
+
+        assertThat(SystemPromptDefaults.promptNameForRagScope("shared"))
+                .isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+        assertThat(SystemPromptDefaults.promptNameForRagScope("SHARED"))
+                .isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+        assertThat(SystemPromptDefaults.promptNameForRagScope(" SHARED "))
+                .isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+
+        // Other scopes pass through after normalization
+        assertThat(SystemPromptDefaults.promptNameForRagScope("inventory")).isEqualTo("inventory");
+        assertThat(SystemPromptDefaults.promptNameForRagScope("INVENTORY")).isEqualTo("inventory");
+    }
+
+    @Test
+    @DisplayName("promptNameForRagScope distinguishes 'master' from 'shared'")
+    void promptNameForRagScope_distinguishesMasterFromShared() {
+        // "master" should NOT be mapped to MASTER_PROMPT_NAME by the if check
+        // (it's already the master by default, no remapping needed)
+        assertThat(SystemPromptDefaults.promptNameForRagScope("master")).isEqualTo("master");
+
+        // "shared" should be explicitly mapped to MASTER_PROMPT_NAME by the if check
+        assertThat(SystemPromptDefaults.promptNameForRagScope("shared"))
+                .isEqualTo(SystemPromptDefaults.MASTER_PROMPT_NAME);
+
+        // Both should equal the same value (since MASTER_PROMPT_NAME is "master")
+        assertThat(SystemPromptDefaults.MASTER_PROMPT_NAME).isEqualTo("master");
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SystemPromptSeedRunnerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SystemPromptSeedRunnerTest.java
@@ -40,6 +40,7 @@ class SystemPromptSeedRunnerTest {
                         SystemPromptDefaults.ROLE_ADMIN_PROMPT_NAME,
                         SystemPromptDefaults.ROLE_SYSTEM_ADMINISTRATOR_PROMPT_NAME,
                         SystemPromptDefaults.ROLE_SERVICE_ADVISOR_PROMPT_NAME);
+        assertThat(seedPrompts.get("shop-manager")).contains("Stay inside shop-manager scope");
     }
 
     @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SystemPromptSeedRunnerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SystemPromptSeedRunnerTest.java
@@ -30,6 +30,20 @@ class SystemPromptSeedRunnerTest {
   private ApplicationArguments applicationArguments;
 
   @Test
+  @DisplayName("seedPrompts uses master and domain agent prompt names")
+  void seedPrompts_usesMasterAndDomainAgentPromptNames() {
+    Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
+
+    assertThat(seedPrompts)
+        .containsKeys("master", "inventory", "order", "customer", "workorder", "admin");
+    assertThat(seedPrompts)
+        .doesNotContainKeys(
+            SystemPromptDefaults.ROLE_ADMIN_PROMPT_NAME,
+            SystemPromptDefaults.ROLE_SYSTEM_ADMINISTRATOR_PROMPT_NAME,
+            SystemPromptDefaults.ROLE_SERVICE_ADVISOR_PROMPT_NAME);
+  }
+
+  @Test
   @DisplayName("run seeds missing prompts")
   void run_whenPromptMissing_seedsPrompt() {
     Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
@@ -52,7 +66,7 @@ class SystemPromptSeedRunnerTest {
   void run_whenPromptExistsWithDifferentContent_updatesPrompt() {
     Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
     Map<String, SystemPrompt> existingByName = existingPromptsWithSameContent(seedPrompts);
-    existingByName.get(SystemPromptDefaults.DEFAULT_PROMPT_NAME).setContent("stale default content");
+    existingByName.get("master").setContent("stale master content");
 
     when(systemPromptRepository.findByName(anyString()))
         .thenAnswer(invocation -> Optional.ofNullable(existingByName.get(invocation.getArgument(0))));
@@ -64,9 +78,8 @@ class SystemPromptSeedRunnerTest {
 
     ArgumentCaptor<SystemPrompt> promptCaptor = ArgumentCaptor.forClass(SystemPrompt.class);
     verify(systemPromptRepository).save(promptCaptor.capture());
-    assertThat(promptCaptor.getValue().getName()).isEqualTo(SystemPromptDefaults.DEFAULT_PROMPT_NAME);
-    assertThat(promptCaptor.getValue().getContent())
-        .isEqualTo(seedPrompts.get(SystemPromptDefaults.DEFAULT_PROMPT_NAME));
+    assertThat(promptCaptor.getValue().getName()).isEqualTo("master");
+    assertThat(promptCaptor.getValue().getContent()).isEqualTo(seedPrompts.get("master"));
   }
 
   @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SystemPromptSeedRunnerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SystemPromptSeedRunnerTest.java
@@ -23,88 +23,86 @@ import org.springframework.boot.ApplicationArguments;
 @ExtendWith(MockitoExtension.class)
 class SystemPromptSeedRunnerTest {
 
-  @Mock
-  private SystemPromptRepository systemPromptRepository;
+    @Mock
+    private SystemPromptRepository systemPromptRepository;
 
-  @Mock
-  private ApplicationArguments applicationArguments;
+    @Mock
+    private ApplicationArguments applicationArguments;
 
-  @Test
-  @DisplayName("seedPrompts uses master and domain agent prompt names")
-  void seedPrompts_usesMasterAndDomainAgentPromptNames() {
-    Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
+    @Test
+    @DisplayName("seedPrompts uses master and domain agent prompt names")
+    void seedPrompts_usesMasterAndDomainAgentPromptNames() {
+        Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
 
-    assertThat(seedPrompts)
-        .containsKeys("master", "inventory", "order", "customer", "workorder", "admin");
-    assertThat(seedPrompts)
-        .doesNotContainKeys(
-            SystemPromptDefaults.ROLE_ADMIN_PROMPT_NAME,
-            SystemPromptDefaults.ROLE_SYSTEM_ADMINISTRATOR_PROMPT_NAME,
-            SystemPromptDefaults.ROLE_SERVICE_ADVISOR_PROMPT_NAME);
-  }
-
-  @Test
-  @DisplayName("run seeds missing prompts")
-  void run_whenPromptMissing_seedsPrompt() {
-    Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
-    when(systemPromptRepository.findByName(anyString())).thenReturn(Optional.empty());
-    when(systemPromptRepository.save(any(SystemPrompt.class)))
-        .thenAnswer(invocation -> invocation.getArgument(0));
-
-    var runner = new SystemPromptSeedRunner(systemPromptRepository);
-    runner.run(applicationArguments);
-
-    ArgumentCaptor<SystemPrompt> promptCaptor = ArgumentCaptor.forClass(SystemPrompt.class);
-    verify(systemPromptRepository, org.mockito.Mockito.times(seedPrompts.size())).save(promptCaptor.capture());
-    assertThat(promptCaptor.getAllValues())
-        .extracting(SystemPrompt::getName)
-        .containsExactlyInAnyOrderElementsOf(seedPrompts.keySet());
-  }
-
-  @Test
-  @DisplayName("run updates prompt when DB content differs from code source of truth")
-  void run_whenPromptExistsWithDifferentContent_updatesPrompt() {
-    Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
-    Map<String, SystemPrompt> existingByName = existingPromptsWithSameContent(seedPrompts);
-    existingByName.get("master").setContent("stale master content");
-
-    when(systemPromptRepository.findByName(anyString()))
-        .thenAnswer(invocation -> Optional.ofNullable(existingByName.get(invocation.getArgument(0))));
-    when(systemPromptRepository.save(any(SystemPrompt.class)))
-        .thenAnswer(invocation -> invocation.getArgument(0));
-
-    var runner = new SystemPromptSeedRunner(systemPromptRepository);
-    runner.run(applicationArguments);
-
-    ArgumentCaptor<SystemPrompt> promptCaptor = ArgumentCaptor.forClass(SystemPrompt.class);
-    verify(systemPromptRepository).save(promptCaptor.capture());
-    assertThat(promptCaptor.getValue().getName()).isEqualTo("master");
-    assertThat(promptCaptor.getValue().getContent()).isEqualTo(seedPrompts.get("master"));
-  }
-
-  @Test
-  @DisplayName("run does not update prompts when DB content already matches code")
-  void run_whenPromptExistsWithSameContent_doesNotSave() {
-    Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
-    Map<String, SystemPrompt> existingByName = existingPromptsWithSameContent(seedPrompts);
-
-    when(systemPromptRepository.findByName(anyString()))
-        .thenAnswer(invocation -> Optional.ofNullable(existingByName.get(invocation.getArgument(0))));
-
-    var runner = new SystemPromptSeedRunner(systemPromptRepository);
-    runner.run(applicationArguments);
-
-    verify(systemPromptRepository, never()).save(any(SystemPrompt.class));
-  }
-
-  private static Map<String, SystemPrompt> existingPromptsWithSameContent(Map<String, String> seedPrompts) {
-    Map<String, SystemPrompt> prompts = new HashMap<>();
-    for (Map.Entry<String, String> entry : seedPrompts.entrySet()) {
-      var prompt = new SystemPrompt();
-      prompt.setName(entry.getKey());
-      prompt.setContent(entry.getValue());
-      prompts.put(entry.getKey(), prompt);
+        assertThat(seedPrompts).containsKeys("master", "inventory", "order", "customer", "workorder", "admin");
+        assertThat(seedPrompts)
+                .doesNotContainKeys(
+                        SystemPromptDefaults.ROLE_ADMIN_PROMPT_NAME,
+                        SystemPromptDefaults.ROLE_SYSTEM_ADMINISTRATOR_PROMPT_NAME,
+                        SystemPromptDefaults.ROLE_SERVICE_ADVISOR_PROMPT_NAME);
     }
-    return prompts;
-  }
+
+    @Test
+    @DisplayName("run seeds missing prompts")
+    void run_whenPromptMissing_seedsPrompt() {
+        Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
+        when(systemPromptRepository.findByName(anyString())).thenReturn(Optional.empty());
+        when(systemPromptRepository.save(any(SystemPrompt.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var runner = new SystemPromptSeedRunner(systemPromptRepository);
+        runner.run(applicationArguments);
+
+        ArgumentCaptor<SystemPrompt> promptCaptor = ArgumentCaptor.forClass(SystemPrompt.class);
+        verify(systemPromptRepository, org.mockito.Mockito.times(seedPrompts.size()))
+                .save(promptCaptor.capture());
+        assertThat(promptCaptor.getAllValues())
+                .extracting(SystemPrompt::getName)
+                .containsExactlyInAnyOrderElementsOf(seedPrompts.keySet());
+    }
+
+    @Test
+    @DisplayName("run updates prompt when DB content differs from code source of truth")
+    void run_whenPromptExistsWithDifferentContent_updatesPrompt() {
+        Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
+        Map<String, SystemPrompt> existingByName = existingPromptsWithSameContent(seedPrompts);
+        existingByName.get("master").setContent("stale master content");
+
+        when(systemPromptRepository.findByName(anyString()))
+                .thenAnswer(invocation -> Optional.ofNullable(existingByName.get(invocation.getArgument(0))));
+        when(systemPromptRepository.save(any(SystemPrompt.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var runner = new SystemPromptSeedRunner(systemPromptRepository);
+        runner.run(applicationArguments);
+
+        ArgumentCaptor<SystemPrompt> promptCaptor = ArgumentCaptor.forClass(SystemPrompt.class);
+        verify(systemPromptRepository).save(promptCaptor.capture());
+        assertThat(promptCaptor.getValue().getName()).isEqualTo("master");
+        assertThat(promptCaptor.getValue().getContent()).isEqualTo(seedPrompts.get("master"));
+    }
+
+    @Test
+    @DisplayName("run does not update prompts when DB content already matches code")
+    void run_whenPromptExistsWithSameContent_doesNotSave() {
+        Map<String, String> seedPrompts = SystemPromptSeedRunner.seedPrompts();
+        Map<String, SystemPrompt> existingByName = existingPromptsWithSameContent(seedPrompts);
+
+        when(systemPromptRepository.findByName(anyString()))
+                .thenAnswer(invocation -> Optional.ofNullable(existingByName.get(invocation.getArgument(0))));
+
+        var runner = new SystemPromptSeedRunner(systemPromptRepository);
+        runner.run(applicationArguments);
+
+        verify(systemPromptRepository, never()).save(any(SystemPrompt.class));
+    }
+
+    private static Map<String, SystemPrompt> existingPromptsWithSameContent(Map<String, String> seedPrompts) {
+        Map<String, SystemPrompt> prompts = new HashMap<>();
+        for (Map.Entry<String, String> entry : seedPrompts.entrySet()) {
+            var prompt = new SystemPrompt();
+            prompt.setName(entry.getKey());
+            prompt.setContent(entry.getValue());
+            prompts.put(entry.getKey(), prompt);
+        }
+        return prompts;
+    }
 }


### PR DESCRIPTION
## Summary
- resolve system prompts by agent scope instead of user role
- seed standalone master and domain prompts with higher-quality operational guidance
- update prompt resolver and orchestration tests for agent-scoped fallback behavior

## Test Plan
- [x] ./mvnw -q -pl pos-mcp-server -DskipTests=false test