### PR TITLE
feat: add aggregate-first MCP OpenAPI discovery

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/McpServerProperties.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/McpServerProperties.java
@@ -14,7 +14,9 @@ public record McpServerProperties(
         @NonNull String openApiPath,
         Duration discoveryTimeout,
         @NonNull List<String> includedServices,
-        @NonNull List<String> includedPathPrefixes) {
+        @NonNull List<String> includedPathPrefixes,
+        String aggregateSpecUrl,
+        @NonNull List<String> excludedPathFragments) {
     public McpServerProperties {
         if (baseUrl == null) {
             baseUrl = "http://localhost:8080";
@@ -37,6 +39,9 @@ public record McpServerProperties(
         if (includedPathPrefixes == null) {
             includedPathPrefixes = List.of();
         }
+        if (excludedPathFragments == null) {
+            excludedPathFragments = List.of();
+        }
     }
 
     public boolean includesService(@NonNull String serviceId) {
@@ -51,5 +56,9 @@ public record McpServerProperties(
             return true;
         }
         return includedPathPrefixes.stream().anyMatch(path::startsWith);
+    }
+
+    public boolean excludesPath(@NonNull String path) {
+        return excludedPathFragments.stream().anyMatch(path::contains);
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
@@ -34,6 +34,41 @@ public class OpenApiDocumentFetcher {
         this.properties = properties;
     }
 
+    public @NonNull Mono<DiscoveredOpenApi> fetchAggregateSpec() {
+        String specUrl = properties.aggregateSpecUrl();
+        if (specUrl == null || specUrl.isBlank()) {
+            return Mono.empty();
+        }
+        URI specUri = URI.create(specUrl);
+        URI baseUri = URI.create(specUri.getScheme() + "://" + specUri.getAuthority());
+        long fetchStartNanos = System.nanoTime();
+
+        return webClient
+                .get()
+                .uri(specUri)
+                .retrieve()
+                .bodyToMono(String.class)
+                .timeout(properties.discoveryTimeout())
+                .doOnNext(raw -> log.info(
+                        "Fetched aggregate OpenAPI from {} in {} ms ({} bytes)",
+                        specUri,
+                        elapsedMs(fetchStartNanos),
+                        raw.length()))
+                .map(raw -> deserialize("aggregate", raw))
+                .flatMap(result -> {
+                    OpenAPI openAPI = result.getOpenAPI();
+                    if (openAPI == null) {
+                        log.warn("Failed to parse aggregate OpenAPI from {}: {}", specUri, result.getMessages());
+                        return Mono.<DiscoveredOpenApi>empty();
+                    }
+                    return Mono.just(new DiscoveredOpenApi("aggregate", baseUri, openAPI));
+                })
+                .onErrorResume(ex -> {
+                    log.warn("Could not fetch aggregate OpenAPI from {}: {}", specUri, ex.getMessage());
+                    return Mono.empty();
+                });
+    }
+
     public @NonNull Mono<DiscoveredOpenApi> fetchForService(@NonNull String serviceId) {
         var instance = pickInstance(serviceId);
         if (instance.isEmpty()) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
@@ -41,13 +41,50 @@ public class OpenApiDocumentFetcher {
         if (specUrl == null || specUrl.isBlank()) {
             return Mono.empty();
         }
-        URI specUri = URI.create(specUrl);
+        URI specUri;
+        try {
+            specUri = URI.create(specUrl);
+        } catch (IllegalArgumentException ex) {
+            log.warn("Malformed mcp.server.aggregate-spec-url '{}', skipping aggregate discovery: {}",
+                    specUrl, ex.getMessage());
+            return Mono.empty();
+        }
         if (!specUri.isAbsolute()) {
             URI gatewayBase = resolveGatewayBase();
             return fetchAggregateSpecFrom(gatewayBase.resolve(specUri), gatewayBase);
         }
-        URI baseUri = URI.create(specUri.getScheme() + "://" + specUri.getAuthority());
+        URI baseUri = deriveBaseUri(specUri);
         return fetchAggregateSpecFrom(specUri, baseUri);
+    }
+
+    /**
+     * Derives the routing base URI from an absolute spec URL by stripping the configured
+     * {@code openApiPath} suffix (e.g. {@code /v3/api-docs}) from the spec URL path. This
+     * preserves any context-path prefix the gateway may have.
+     *
+     * <p>Examples (with {@code openApiPath=/v3/api-docs}):
+     * <ul>
+     *   <li>{@code http://gateway.test/v3/api-docs} → {@code http://gateway.test}
+     *   <li>{@code https://gateway.example/mcp/v3/api-docs} → {@code https://gateway.example/mcp}
+     * </ul>
+     *
+     * <p>If the spec URL does not end with the configured {@code openApiPath}, the last path
+     * segment is stripped as a fallback.
+     */
+    private URI deriveBaseUri(URI specUri) {
+        String specPath = specUri.getPath();
+        String openApiPath = properties.openApiPath();
+        String basePath;
+        if (specPath != null && specPath.endsWith(openApiPath)) {
+            basePath = specPath.substring(0, specPath.length() - openApiPath.length());
+        } else {
+            int lastSlash = specPath != null ? specPath.lastIndexOf('/') : -1;
+            basePath = lastSlash > 0 ? specPath.substring(0, lastSlash) : "";
+        }
+        if (basePath.isEmpty() || basePath.equals("/")) {
+            return URI.create(specUri.getScheme() + "://" + specUri.getAuthority());
+        }
+        return URI.create(specUri.getScheme() + "://" + specUri.getAuthority() + basePath);
     }
 
     private URI resolveGatewayBase() {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
@@ -51,7 +51,7 @@ public class OpenApiDocumentFetcher {
         }
         if (!specUri.isAbsolute()) {
             URI gatewayBase = resolveGatewayBase();
-            return fetchAggregateSpecFrom(gatewayBase.resolve(specUri), gatewayBase);
+            return fetchAggregateSpecFrom(resolveRelativeSpecUri(gatewayBase, specUri), gatewayBase);
         }
         URI baseUri = deriveBaseUri(specUri);
         return fetchAggregateSpecFrom(specUri, baseUri);
@@ -93,6 +93,41 @@ public class OpenApiDocumentFetcher {
             return instances.getFirst().getUri();
         }
         return LOCAL_GATEWAY_FALLBACK;
+    }
+
+    private URI resolveRelativeSpecUri(URI gatewayBase, URI relativeSpecUri) {
+        String gatewayPath = normalizeBasePath(gatewayBase.getPath());
+        String specPath = normalizeSpecPath(relativeSpecUri.getPath());
+        String resolvedPath = gatewayPath + specPath;
+        if (resolvedPath.isEmpty()) {
+            resolvedPath = "/";
+        }
+        try {
+            return new URI(
+                    gatewayBase.getScheme(),
+                    gatewayBase.getUserInfo(),
+                    gatewayBase.getHost(),
+                    gatewayBase.getPort(),
+                    resolvedPath,
+                    relativeSpecUri.getQuery(),
+                    relativeSpecUri.getFragment());
+        } catch (java.net.URISyntaxException ex) {
+            throw new IllegalArgumentException("Invalid aggregate spec URI path: " + relativeSpecUri, ex);
+        }
+    }
+
+    private String normalizeBasePath(String gatewayPath) {
+        if (gatewayPath == null || gatewayPath.isBlank() || "/".equals(gatewayPath)) {
+            return "";
+        }
+        return gatewayPath.endsWith("/") ? gatewayPath.substring(0, gatewayPath.length() - 1) : gatewayPath;
+    }
+
+    private String normalizeSpecPath(String specPath) {
+        if (specPath == null || specPath.isBlank()) {
+            return "";
+        }
+        return specPath.startsWith("/") ? specPath : "/" + specPath;
     }
 
     private Mono<DiscoveredOpenApi> fetchAggregateSpecFrom(URI specUri, URI baseUri) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
@@ -20,6 +20,8 @@ import reactor.core.publisher.Mono;
 public class OpenApiDocumentFetcher {
 
     private static final Logger log = LoggerFactory.getLogger(OpenApiDocumentFetcher.class);
+    private static final String GATEWAY_SERVICE_ID = "pos-api-gateway";
+    private static final URI LOCAL_GATEWAY_FALLBACK = URI.create("http://localhost:8080");
 
     private final DiscoveryClient discoveryClient;
     private final WebClient webClient;
@@ -40,9 +42,24 @@ public class OpenApiDocumentFetcher {
             return Mono.empty();
         }
         URI specUri = URI.create(specUrl);
+        if (!specUri.isAbsolute()) {
+            URI gatewayBase = resolveGatewayBase();
+            return fetchAggregateSpecFrom(gatewayBase.resolve(specUri), gatewayBase);
+        }
         URI baseUri = URI.create(specUri.getScheme() + "://" + specUri.getAuthority());
-        long fetchStartNanos = System.nanoTime();
+        return fetchAggregateSpecFrom(specUri, baseUri);
+    }
 
+    private URI resolveGatewayBase() {
+        var instances = discoveryClient.getInstances(GATEWAY_SERVICE_ID);
+        if (!instances.isEmpty()) {
+            return instances.getFirst().getUri();
+        }
+        return LOCAL_GATEWAY_FALLBACK;
+    }
+
+    private Mono<DiscoveredOpenApi> fetchAggregateSpecFrom(URI specUri, URI baseUri) {
+        long fetchStartNanos = System.nanoTime();
         return webClient
                 .get()
                 .uri(specUri)

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
@@ -52,6 +52,72 @@ public class OpenApiToolMapper {
         return specs;
     }
 
+    /**
+     * Maps aggregate OpenAPI operations to tool specifications using the gateway base URI directly.
+     * Tool names are derived as {@code {domain}_{operationId}} where the domain is the first
+     * non-version path segment (e.g. {@code /v1/accounting/invoices} → {@code accounting}).
+     * Paths matching any configured {@code excludedPathFragments} are skipped.
+     */
+    @NonNull
+    public List<McpServerFeatures.AsyncToolSpecification> toAggregateToolSpecifications(
+            @NonNull URI gatewayBaseUri, @NonNull OpenAPI openApi) {
+        var specs = new ArrayList<McpServerFeatures.AsyncToolSpecification>();
+        if (openApi.getPaths() == null) {
+            return specs;
+        }
+        openApi.getPaths().forEach((path, pathItem) -> {
+            if (properties.excludesPath(path)) {
+                return;
+            }
+            addAggregateOperation(specs, gatewayBaseUri, path, pathItem.getGet(), HttpMethod.GET);
+            addAggregateOperation(specs, gatewayBaseUri, path, pathItem.getPost(), HttpMethod.POST);
+            addAggregateOperation(specs, gatewayBaseUri, path, pathItem.getPut(), HttpMethod.PUT);
+            addAggregateOperation(specs, gatewayBaseUri, path, pathItem.getDelete(), HttpMethod.DELETE);
+            addAggregateOperation(specs, gatewayBaseUri, path, pathItem.getPatch(), HttpMethod.PATCH);
+        });
+        return specs;
+    }
+
+    private void addAggregateOperation(
+            @NonNull List<McpServerFeatures.AsyncToolSpecification> specs,
+            @NonNull URI gatewayBaseUri,
+            @NonNull String path,
+            Operation operation,
+            @NonNull HttpMethod method) {
+        if (operation == null) {
+            return;
+        }
+        String domain = extractDomain(path);
+        String operationId = buildOperationId(operation);
+        String toolName = sanitizeName(domain + "_" + operationId);
+        String title = Optional.ofNullable(operation.getSummary()).orElse(operationId);
+        String description = Optional.ofNullable(operation.getDescription()).orElse(title);
+
+        var inputSchema = buildInputSchema(method, path, operation);
+        var tool = McpSchema.Tool.builder()
+                .name(toolName)
+                .title(title)
+                .description(description)
+                .inputSchema(inputSchema)
+                .build();
+
+        var handler = proxyFactory.handlerForBaseUri(gatewayBaseUri, method, path);
+        specs.add(McpServerFeatures.AsyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler(handler)
+                .build());
+    }
+
+    static String extractDomain(@NonNull String path) {
+        for (String segment : path.split("/")) {
+            if (segment.isBlank() || segment.matches("v\\d+")) {
+                continue;
+            }
+            return segment;
+        }
+        return "unknown";
+    }
+
     private void addOperation(
             @NonNull List<McpServerFeatures.AsyncToolSpecification> specs,
             @NonNull String serviceId,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
@@ -66,7 +66,7 @@ public class OpenApiToolMapper {
             return specs;
         }
         openApi.getPaths().forEach((path, pathItem) -> {
-            if (properties.excludesPath(path)) {
+            if (!properties.includesPath(path) || properties.excludesPath(path)) {
                 return;
             }
             addAggregateOperation(specs, gatewayBaseUri, path, pathItem.getGet(), HttpMethod.GET);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OperationProxyFactory.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OperationProxyFactory.java
@@ -64,38 +64,60 @@ public class OperationProxyFactory {
                 return Mono.just(errorResult("No instance available for service " + serviceId));
             }
 
-            URI targetUri = buildUri(instance, pathTemplate, pathParams, queryParams);
-            var requestSpec = webClient.method(method).uri(targetUri);
-            headers.forEach((key, value) -> requestSpec.header(key, String.valueOf(value)));
-            if (body != null) {
-                requestSpec.contentType(MediaType.APPLICATION_JSON);
-            }
-
-            return requestSpec
-                    .body(body != null ? BodyInserters.fromValue(body) : BodyInserters.empty())
-                    .retrieve()
-                    .toEntity(String.class)
-                    .map(responseEntity -> successResult(responseEntity.getBody()))
-                    .onErrorResume(ex -> {
-                        log.warn(
-                                "Tool proxy failed for service {} {} {}: {}",
-                                serviceId,
-                                method,
-                                targetUri,
-                                ex.getMessage());
-                        return Mono.just(errorResult(ex.getMessage()));
-                    });
+            URI targetUri = buildUriFromBase(instance.getUri(), pathTemplate, pathParams, queryParams);
+            return executeRequest(method, targetUri, headers, body, serviceId + " " + pathTemplate);
         };
     }
 
-    private URI buildUri(
-            @NonNull ServiceInstance instance,
+    /**
+     * Returns a handler that invokes the given gateway base URI directly, bypassing load-balancer
+     * resolution. Used for aggregate-discovered tools where the gateway base URI is known at
+     * mapping time and does not need per-request service lookup.
+     */
+    @NonNull
+    BiFunction<McpAsyncServerExchange, McpSchema.CallToolRequest, Mono<McpSchema.CallToolResult>> handlerForBaseUri(
+            @NonNull URI baseUri, @NonNull HttpMethod method, @NonNull String pathTemplate) {
+        return (exchange, request) -> {
+            var arguments = Optional.ofNullable(request.arguments()).orElse(Map.of());
+            Map<String, Object> pathParams = asMap(arguments.get("pathParams"));
+            Map<String, Object> queryParams = asMap(arguments.get("queryParams"));
+            Map<String, Object> headers = asMap(arguments.get("headers"));
+            Object body = arguments.get("body");
+
+            URI targetUri = buildUriFromBase(baseUri, pathTemplate, pathParams, queryParams);
+            return executeRequest(method, targetUri, headers, body, baseUri + " " + pathTemplate);
+        };
+    }
+
+    private Mono<McpSchema.CallToolResult> executeRequest(
+            @NonNull HttpMethod method,
+            @NonNull URI targetUri,
+            @NonNull Map<String, Object> headers,
+            Object body,
+            @NonNull String logContext) {
+        var requestSpec = webClient.method(method).uri(targetUri);
+        headers.forEach((key, value) -> requestSpec.header(key, String.valueOf(value)));
+        if (body != null) {
+            requestSpec.contentType(MediaType.APPLICATION_JSON);
+        }
+        return requestSpec
+                .body(body != null ? BodyInserters.fromValue(body) : BodyInserters.empty())
+                .retrieve()
+                .toEntity(String.class)
+                .map(responseEntity -> successResult(responseEntity.getBody()))
+                .onErrorResume(ex -> {
+                    log.warn("Tool proxy failed for {} {}: {}", logContext, targetUri, ex.getMessage());
+                    return Mono.just(errorResult(ex.getMessage()));
+                });
+    }
+
+    private URI buildUriFromBase(
+            @NonNull URI baseUri,
             @NonNull String pathTemplate,
             @NonNull Map<String, Object> pathParams,
             @NonNull Map<String, Object> queryParams) {
         String resolvedPath = resolvePath(pathTemplate, pathParams);
-        UriComponentsBuilder builder =
-                UriComponentsBuilder.fromUri(instance.getUri()).path(resolvedPath);
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUri(baseUri).path(resolvedPath);
         queryParams.forEach((key, value) -> {
             if (value instanceof List<?> list) {
                 list.forEach(item -> builder.queryParam(key, item));

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/ToolBootstrapRunner.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/ToolBootstrapRunner.java
@@ -21,7 +21,7 @@ public class ToolBootstrapRunner implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
-        log.info("Discovering services and registering MCP tools via Eureka");
+        log.info("Registering MCP tools from gateway aggregate OpenAPI spec");
         toolRegistrationService.registerDiscoveredTools().blockOptional();
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
@@ -41,8 +41,10 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
         warnIfIncludedServicesDeprecated();
         return openApiDocumentFetcher
                 .fetchAggregateSpec()
-                .switchIfEmpty(Mono.fromRunnable(() -> log.warn(
-                        "Aggregate OpenAPI spec unavailable — skipping auto-discovered tool registration")))
+                .switchIfEmpty(Mono.defer(() -> {
+                    log.warn("Aggregate OpenAPI spec unavailable — skipping auto-discovered tool registration");
+                    return Mono.empty();
+                }))
                 .flatMap(discovered -> {
                     var specifications =
                             openApiToolMapper.toAggregateToolSpecifications(discovered.baseUri(), discovered.openApi());

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
@@ -6,12 +6,10 @@ import com.positivity.mcp.internal.discovery.OpenApiToolMapper;
 import com.positivity.mcp.service.ToolRegistrationService;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
-import java.util.List;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -21,19 +19,16 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
 
     private static final Logger log = LoggerFactory.getLogger(ToolRegistrationServiceImpl.class);
 
-    private final DiscoveryClient discoveryClient;
     private final McpServerProperties properties;
     private final OpenApiDocumentFetcher openApiDocumentFetcher;
     private final OpenApiToolMapper openApiToolMapper;
     private final McpAsyncServer mcpAsyncServer;
 
     public ToolRegistrationServiceImpl(
-            @NonNull DiscoveryClient discoveryClient,
             @NonNull McpServerProperties properties,
             @NonNull OpenApiDocumentFetcher openApiDocumentFetcher,
             @NonNull OpenApiToolMapper openApiToolMapper,
             @NonNull McpAsyncServer mcpAsyncServer) {
-        this.discoveryClient = discoveryClient;
         this.properties = properties;
         this.openApiDocumentFetcher = openApiDocumentFetcher;
         this.openApiToolMapper = openApiToolMapper;
@@ -43,42 +38,36 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
     @Override
     public @NonNull Mono<Void> registerDiscoveredTools() {
         long totalStartNanos = System.nanoTime();
-        return Flux.defer(() -> {
-                    List<String> services = discoveryClient.getServices();
-                    log.info("Discovered {} services before MCP tool filtering: {}", services.size(), services);
-                    return Flux.fromIterable(services);
-                })
-                .filter(service -> !"mcp-server".equalsIgnoreCase(service))
-                .filter(properties::includesService)
-                .flatMap(openApiDocumentFetcher::fetchForService)
-                .flatMap(discovered -> Flux.fromIterable(openApiToolMapper.toToolSpecifications(
-                        discovered.serviceId(), discovered.baseUri(), discovered.openApi())))
-                .collectList()
-                .flatMap(specifications -> {
+        return openApiDocumentFetcher
+                .fetchAggregateSpec()
+                .switchIfEmpty(Mono.fromRunnable(() -> log.warn(
+                        "Aggregate OpenAPI spec unavailable — skipping auto-discovered tool registration")))
+                .flatMap(discovered -> {
+                    var specifications =
+                            openApiToolMapper.toAggregateToolSpecifications(discovered.baseUri(), discovered.openApi());
                     if (specifications.isEmpty()) {
                         log.warn(
-                                "No MCP tools matched the configured discovery allowlist. Services: {}, path prefixes: {}",
-                                properties.includedServices(),
+                                "No MCP tools matched the configured allowlist in the aggregate spec. Path prefixes: {}",
                                 properties.includedPathPrefixes());
-                        return Mono.empty();
+                        return Mono.<Void>empty();
                     }
 
                     String toolNames = specifications.stream()
                             .map(specification -> specification.tool().name())
                             .collect(Collectors.joining(", "));
 
-                    log.info("Registering {} MCP tools: {}", specifications.size(), toolNames);
+                    log.info("Registering {} MCP tools from gateway aggregate spec: {}", specifications.size(), toolNames);
 
                     return Flux.fromIterable(specifications)
                             .flatMap(this::addToolWithTiming)
                             .then(mcpAsyncServer.notifyToolsListChanged())
                             .doOnSuccess(ignored -> log.info(
-                                    "Registered MCP tools for discovered services in {} ms",
+                                    "Registered MCP tools from gateway aggregate spec in {} ms",
                                     elapsedMs(totalStartNanos)));
                 })
                 .onErrorResume(ex -> {
                     log.warn(
-                            "Failed to register discovered tools after {} ms: {}",
+                            "Failed to register tools from gateway aggregate spec after {} ms: {}",
                             elapsedMs(totalStartNanos),
                             ex.getMessage());
                     return Mono.empty();

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
@@ -38,6 +38,7 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
     @Override
     public @NonNull Mono<Void> registerDiscoveredTools() {
         long totalStartNanos = System.nanoTime();
+        warnIfIncludedServicesDeprecated();
         return openApiDocumentFetcher
                 .fetchAggregateSpec()
                 .switchIfEmpty(Mono.fromRunnable(() -> log.warn(
@@ -72,6 +73,17 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
                             ex.getMessage());
                     return Mono.empty();
                 });
+    }
+
+    private void warnIfIncludedServicesDeprecated() {
+        if (!properties.includedServices().isEmpty()
+                && properties.aggregateSpecUrl() != null
+                && !properties.aggregateSpecUrl().isBlank()) {
+            log.warn(
+                    "mcp.server.included-services is configured but has no effect in aggregate-first discovery mode "
+                            + "(aggregate-spec-url is set). included-services is deprecated for aggregate-first "
+                            + "discovery; use mcp.server.included-path-prefixes instead.");
+        }
     }
 
     private @NonNull Mono<Void> addToolWithTiming(McpServerFeatures.AsyncToolSpecification specification) {

--- a/pos-mcp-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/pos-mcp-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -31,7 +31,11 @@
     {
       "name": "mcp.server.included-services",
       "type": "java.util.List<java.lang.String>",
-      "description": "Optional allowlist of services to include as MCP tools."
+      "description": "Deprecated. This property has no effect in aggregate-first discovery mode (when mcp.server.aggregate-spec-url is set). Use mcp.server.included-path-prefixes to filter which API paths are exposed as MCP tools.",
+      "deprecation": {
+        "reason": "Has no effect in aggregate-first discovery mode. Use included-path-prefixes instead.",
+        "replacement": "mcp.server.included-path-prefixes"
+      }
     },
     {
       "name": "mcp.server.included-path-prefixes",
@@ -648,7 +652,7 @@
     {
       "name": "langchain4j.ollama.chat-model.temperature",
       "type": "java.lang.Double",
-      "description": "Sampling temperature for the Ollama chat model (0.0–1.0).",
+      "description": "Sampling temperature for the Ollama chat model (0.0\u20131.0).",
       "defaultValue": 0.2
     },
     {
@@ -700,7 +704,7 @@
     {
       "name": "langchain4j.ollama.streaming-chat-model.temperature",
       "type": "java.lang.Double",
-      "description": "Sampling temperature for the Ollama streaming chat model (0.0–1.0).",
+      "description": "Sampling temperature for the Ollama streaming chat model (0.0\u20131.0).",
       "defaultValue": 0.2
     },
     {

--- a/pos-mcp-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/pos-mcp-server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -39,6 +39,17 @@
       "description": "Optional allowlist of API path prefixes to include as MCP tools."
     },
     {
+      "name": "mcp.server.aggregate-spec-url",
+      "type": "java.lang.String",
+      "description": "URL of the API gateway aggregate OpenAPI spec used for aggregate-first discovery.",
+      "defaultValue": "http://localhost:8080/v3/api-docs"
+    },
+    {
+      "name": "mcp.server.excluded-path-fragments",
+      "type": "java.util.List<java.lang.String>",
+      "description": "Path fragment substrings that exclude matching API paths from aggregate MCP tool discovery."
+    },
+    {
       "name": "mcp.security.permit-all-transport",
       "type": "java.lang.Boolean",
       "description": "Allow all MCP transport requests without authentication when enabled.",

--- a/pos-mcp-server/src/main/resources/application-alpha.yml
+++ b/pos-mcp-server/src/main/resources/application-alpha.yml
@@ -48,6 +48,9 @@ langchain4j:
       timeout: ${OLLAMA_STREAMING_CHAT_TIMEOUT:${OLLAMA_CHAT_TIMEOUT:180s}}
 
 mcp:
+  server:
+    aggregate-spec-url: ${MCP_AGGREGATE_SPEC_URL:http://pos-api-gateway/v3/api-docs}
+    excluded-path-fragments: ${MCP_EXCLUDED_PATH_FRAGMENTS:}
   rag:
     table-name: mcp_document_embedding
     dimension: 768

--- a/pos-mcp-server/src/main/resources/application-alpha.yml
+++ b/pos-mcp-server/src/main/resources/application-alpha.yml
@@ -50,7 +50,10 @@ langchain4j:
 mcp:
   server:
     aggregate-spec-url: ${MCP_AGGREGATE_SPEC_URL:http://pos-api-gateway/v3/api-docs}
-    excluded-path-fragments: ${MCP_EXCLUDED_PATH_FRAGMENTS:}
+    excluded-path-fragments:
+      - /admin/
+      - /actuator/
+      - /internal/
   rag:
     table-name: mcp_document_embedding
     dimension: 768

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -13,7 +13,10 @@ mcp:
     open-api-path: /v3/api-docs
     discovery-timeout: 5s
     aggregate-spec-url: ${MCP_AGGREGATE_SPEC_URL:http://localhost:8080/v3/api-docs}
-    excluded-path-fragments: []
+    excluded-path-fragments:
+      - /admin/
+      - /actuator/
+      - /internal/
     included-services:
       - event-receiver
     included-path-prefixes:

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -17,8 +17,6 @@ mcp:
       - /admin/
       - /actuator/
       - /internal/
-    included-services:
-      - event-receiver
     included-path-prefixes:
       - /v1/events/summary
   security:

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -12,6 +12,8 @@ mcp:
     sse-endpoint: /mcp/sse
     open-api-path: /v3/api-docs
     discovery-timeout: 5s
+    aggregate-spec-url: ${MCP_AGGREGATE_SPEC_URL:http://localhost:8080/v3/api-docs}
+    excluded-path-fragments: []
     included-services:
       - event-receiver
     included-path-prefixes:

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/McpServerPropertiesDefaultsTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/McpServerPropertiesDefaultsTest.java
@@ -1,0 +1,46 @@
+package com.positivity.mcp.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.env.PropertySource;
+
+class McpServerPropertiesDefaultsTest {
+
+    @Configuration
+    @EnableConfigurationProperties(McpServerProperties.class)
+    static class Config {}
+
+    @Test
+    @DisplayName("excluded-path-fragments defaults in application.yml include /admin/, /actuator/, /internal/")
+    void excludedPathFragments_defaultToAdminActuatorInternal() {
+        new ApplicationContextRunner()
+                .withInitializer(ctx -> {
+                    YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+                    try {
+                        List<PropertySource<?>> sources =
+                                loader.load("application", new ClassPathResource("application.yml"));
+                        for (PropertySource<?> source : sources) {
+                            ctx.getEnvironment().getPropertySources().addLast(source);
+                        }
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                })
+                .withUserConfiguration(Config.class)
+                .run(ctx -> {
+                    McpServerProperties props = ctx.getBean(McpServerProperties.class);
+                    assertThat(props.excludedPathFragments())
+                            .containsExactlyInAnyOrder("/admin/", "/actuator/", "/internal/");
+                });
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherTest.java
@@ -134,6 +134,35 @@ class OpenApiDocumentFetcherTest {
     }
 
     @Test
+    @DisplayName("fetchAggregateSpec preserves discovered gateway context path for relative aggregate URL")
+    void fetchAggregateSpec_preservesGatewayContextPath_whenConfigIsRelativeAndGatewayHasContextPath() {
+        String yaml = loadClasspathResource("openapi/aggregate/minimal-aggregate.yaml");
+        DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+        ServiceInstance gatewayInstance = mock(ServiceInstance.class);
+        when(gatewayInstance.getUri()).thenReturn(URI.create("http://gateway.local:8080/mcp"));
+        when(discoveryClient.getInstances("pos-api-gateway")).thenReturn(List.of(gatewayInstance));
+
+        List<URI> requestedUris = new ArrayList<>();
+        WebClient trackingClient = WebClient.builder()
+                .exchangeFunction(request -> {
+                    requestedUris.add(request.url());
+                    return Mono.just(ClientResponse.create(HttpStatus.OK).body(yaml).build());
+                })
+                .build();
+
+        OpenApiDocumentFetcher fetcher = fetcherWith(discoveryClient, trackingClient, "/v3/api-docs");
+
+        OpenApiDocumentFetcher.DiscoveredOpenApi result =
+                fetcher.fetchAggregateSpec().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNotNull();
+        assertThat(result.baseUri()).isEqualTo(URI.create("http://gateway.local:8080/mcp"));
+        assertThat(requestedUris).hasSize(1);
+        assertThat(requestedUris.getFirst().toString())
+                .isEqualTo("http://gateway.local:8080/mcp/v3/api-docs");
+    }
+
+    @Test
     @DisplayName("fetchAggregateSpec falls back to http://localhost:8080 when path-only and gateway not discoverable")
     void fetchAggregateSpec_resolvesPathAgainstLocalDefault_whenConfigIsPathOnlyAndGatewayNotDiscoverable() {
         String yaml = loadClasspathResource("openapi/aggregate/minimal-aggregate.yaml");

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherTest.java
@@ -69,6 +69,31 @@ class OpenApiDocumentFetcherTest {
     }
 
     @Test
+    @DisplayName("fetchAggregateSpec derives context-path-aware base URI when absolute URL includes a context path")
+    void fetchAggregateSpec_derivesContextPathAwareBaseUri_whenSpecUrlIncludesContextPath() {
+        String yaml = loadClasspathResource("openapi/aggregate/minimal-aggregate.yaml");
+        String specUrlWithContextPath = "http://gateway.example/mcp/v3/api-docs";
+        OpenApiDocumentFetcher fetcher = fetcherWith(webClientReturning(yaml), specUrlWithContextPath);
+
+        OpenApiDocumentFetcher.DiscoveredOpenApi result =
+                fetcher.fetchAggregateSpec().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNotNull();
+        assertThat(result.baseUri()).isEqualTo(URI.create("http://gateway.example/mcp"));
+    }
+
+    @Test
+    @DisplayName("fetchAggregateSpec returns empty Mono when aggregateSpecUrl is malformed")
+    void fetchAggregateSpec_returnsEmpty_whenAggregateSpecUrlIsMalformed() {
+        OpenApiDocumentFetcher fetcher = fetcherWith(webClientReturning("irrelevant"), "not a valid url {}");
+
+        OpenApiDocumentFetcher.DiscoveredOpenApi result =
+                fetcher.fetchAggregateSpec().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
     @DisplayName("fetchAggregateSpec returns empty Mono when aggregateSpecUrl is not configured")
     void fetchAggregateSpec_returnsEmpty_whenAggregateSpecUrlIsBlank() {
         OpenApiDocumentFetcher fetcher = fetcherWith(webClientReturning("irrelevant"), null);

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherTest.java
@@ -1,0 +1,109 @@
+package com.positivity.mcp.internal.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.positivity.mcp.internal.config.McpServerProperties;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+class OpenApiDocumentFetcherTest {
+
+    private static final String AGGREGATE_URL = "http://gateway.test/v3/api-docs";
+    private static final URI EXPECTED_BASE_URI = URI.create("http://gateway.test");
+
+    @Test
+    @DisplayName("fetchAggregateSpec returns gateway base URI and parsed OpenAPI for valid YAML")
+    void fetchAggregateSpec_returnsGatewayBaseUriAndParsedOpenApi_whenYamlIsValid() {
+        String yaml = loadClasspathResource("openapi/aggregate/minimal-aggregate.yaml");
+        OpenApiDocumentFetcher fetcher = fetcherWith(webClientReturning(yaml), AGGREGATE_URL);
+
+        OpenApiDocumentFetcher.DiscoveredOpenApi result =
+                fetcher.fetchAggregateSpec().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNotNull();
+        assertThat(result.baseUri()).isEqualTo(EXPECTED_BASE_URI);
+        assertThat(result.openApi()).isNotNull();
+        assertThat(result.openApi().getInfo().getTitle()).isEqualTo("Positivity API Gateway");
+    }
+
+    @Test
+    @DisplayName("fetchAggregateSpec returns empty Mono when YAML cannot be parsed as OpenAPI")
+    void fetchAggregateSpec_returnsEmpty_whenYamlIsInvalid() {
+        String yaml = loadClasspathResource("openapi/aggregate/invalid-aggregate.yaml");
+        OpenApiDocumentFetcher fetcher = fetcherWith(webClientReturning(yaml), AGGREGATE_URL);
+
+        OpenApiDocumentFetcher.DiscoveredOpenApi result =
+                fetcher.fetchAggregateSpec().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("fetchAggregateSpec returns empty Mono when HTTP fetch fails")
+    void fetchAggregateSpec_returnsEmpty_whenFetchFails() {
+        WebClient errorClient = WebClient.builder()
+                .exchangeFunction(request -> Mono.error(new RuntimeException("connection refused")))
+                .build();
+        OpenApiDocumentFetcher fetcher = fetcherWith(errorClient, AGGREGATE_URL);
+
+        OpenApiDocumentFetcher.DiscoveredOpenApi result =
+                fetcher.fetchAggregateSpec().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("fetchAggregateSpec returns empty Mono when aggregateSpecUrl is not configured")
+    void fetchAggregateSpec_returnsEmpty_whenAggregateSpecUrlIsBlank() {
+        OpenApiDocumentFetcher fetcher = fetcherWith(webClientReturning("irrelevant"), null);
+
+        OpenApiDocumentFetcher.DiscoveredOpenApi result =
+                fetcher.fetchAggregateSpec().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNull();
+    }
+
+    // --- helpers ---
+
+    private static OpenApiDocumentFetcher fetcherWith(WebClient webClient, String aggregateSpecUrl) {
+        McpServerProperties props = new McpServerProperties(
+                "http://localhost:8086",
+                "/mcp/message",
+                "/mcp/sse",
+                "/v3/api-docs",
+                Duration.ofSeconds(5),
+                List.of(),
+                List.of(),
+                aggregateSpecUrl,
+                List.of());
+        return new OpenApiDocumentFetcher(mock(DiscoveryClient.class), webClient, props);
+    }
+
+    private static WebClient webClientReturning(String body) {
+        ExchangeFunction exchange = request -> Mono.just(
+                ClientResponse.create(HttpStatus.OK).body(body).build());
+        return WebClient.builder().exchangeFunction(exchange).build();
+    }
+
+    private static String loadClasspathResource(String path) {
+        try {
+            return StreamUtils.copyToString(
+                    new ClassPathResource(path).getInputStream(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not load test resource: " + path, e);
+        }
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherTest.java
@@ -2,14 +2,17 @@ package com.positivity.mcp.internal.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.positivity.mcp.internal.config.McpServerProperties;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
@@ -76,9 +79,68 @@ class OpenApiDocumentFetcherTest {
         assertThat(result).isNull();
     }
 
+    @Test
+    @DisplayName("fetchAggregateSpec resolves path-only URL against gateway service from discovery")
+    void fetchAggregateSpec_resolvesPathAgainstGatewayFromDiscovery_whenConfigIsPathOnly() {
+        String yaml = loadClasspathResource("openapi/aggregate/minimal-aggregate.yaml");
+        DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+        ServiceInstance gatewayInstance = mock(ServiceInstance.class);
+        when(gatewayInstance.getUri()).thenReturn(URI.create("http://gateway.local:8080"));
+        when(discoveryClient.getInstances("pos-api-gateway")).thenReturn(List.of(gatewayInstance));
+
+        List<URI> requestedUris = new ArrayList<>();
+        WebClient trackingClient = WebClient.builder()
+                .exchangeFunction(request -> {
+                    requestedUris.add(request.url());
+                    return Mono.just(ClientResponse.create(HttpStatus.OK).body(yaml).build());
+                })
+                .build();
+
+        OpenApiDocumentFetcher fetcher = fetcherWith(discoveryClient, trackingClient, "/v3/api-docs");
+
+        OpenApiDocumentFetcher.DiscoveredOpenApi result =
+                fetcher.fetchAggregateSpec().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNotNull();
+        assertThat(result.baseUri()).isEqualTo(URI.create("http://gateway.local:8080"));
+        assertThat(requestedUris).hasSize(1);
+        assertThat(requestedUris.getFirst().toString())
+                .isEqualTo("http://gateway.local:8080/v3/api-docs");
+    }
+
+    @Test
+    @DisplayName("fetchAggregateSpec falls back to http://localhost:8080 when path-only and gateway not discoverable")
+    void fetchAggregateSpec_resolvesPathAgainstLocalDefault_whenConfigIsPathOnlyAndGatewayNotDiscoverable() {
+        String yaml = loadClasspathResource("openapi/aggregate/minimal-aggregate.yaml");
+        DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+        when(discoveryClient.getInstances("pos-api-gateway")).thenReturn(List.of());
+
+        List<URI> requestedUris = new ArrayList<>();
+        WebClient trackingClient = WebClient.builder()
+                .exchangeFunction(request -> {
+                    requestedUris.add(request.url());
+                    return Mono.just(ClientResponse.create(HttpStatus.OK).body(yaml).build());
+                })
+                .build();
+
+        OpenApiDocumentFetcher fetcher = fetcherWith(discoveryClient, trackingClient, "/v3/api-docs");
+
+        OpenApiDocumentFetcher.DiscoveredOpenApi result =
+                fetcher.fetchAggregateSpec().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNotNull();
+        assertThat(result.baseUri()).isEqualTo(URI.create("http://localhost:8080"));
+        assertThat(requestedUris.getFirst().toString()).isEqualTo("http://localhost:8080/v3/api-docs");
+    }
+
     // --- helpers ---
 
     private static OpenApiDocumentFetcher fetcherWith(WebClient webClient, String aggregateSpecUrl) {
+        return fetcherWith(mock(DiscoveryClient.class), webClient, aggregateSpecUrl);
+    }
+
+    private static OpenApiDocumentFetcher fetcherWith(
+            DiscoveryClient discoveryClient, WebClient webClient, String aggregateSpecUrl) {
         McpServerProperties props = new McpServerProperties(
                 "http://localhost:8086",
                 "/mcp/message",
@@ -89,7 +151,7 @@ class OpenApiDocumentFetcherTest {
                 List.of(),
                 aggregateSpecUrl,
                 List.of());
-        return new OpenApiDocumentFetcher(mock(DiscoveryClient.class), webClient, props);
+        return new OpenApiDocumentFetcher(discoveryClient, webClient, props);
     }
 
     private static WebClient webClientReturning(String body) {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiToolMapperTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiToolMapperTest.java
@@ -90,6 +90,25 @@ class OpenApiToolMapperTest {
         assertThat(specs).isEmpty();
     }
 
+    @Test
+    @DisplayName("toAggregateToolSpecifications excludes paths not matching configured included-path-prefixes allowlist")
+    void toAggregateToolSpecifications_excludesPaths_whenNotInAllowlist() {
+        OperationProxyFactory mockFactory = mock(OperationProxyFactory.class);
+        when(mockFactory.handlerForBaseUri(any(), any(), any())).thenReturn((ex, req) -> Mono.empty());
+
+        McpServerProperties props = propertiesWithPrefixesAndExclusions(List.of("/v1/accounting/"), List.of());
+        OpenApiToolMapper mapper = new OpenApiToolMapper(props, mockFactory);
+        OpenAPI openApi = openApiWith(Map.of(
+                "/v1/accounting/invoices", getItem("listInvoices", "List invoices"),
+                "/v1/orders/items", getItem("listItems", "List items")));
+
+        List<McpServerFeatures.AsyncToolSpecification> specs =
+                mapper.toAggregateToolSpecifications(GATEWAY_URI, openApi);
+
+        assertThat(specs).hasSize(1);
+        assertThat(specs.getFirst().tool().name()).isEqualTo("accounting_listinvoices");
+    }
+
     // --- helpers ---
 
     private static McpServerProperties propertiesWithExclusions(List<String> excludedFragments) {
@@ -101,6 +120,20 @@ class OpenApiToolMapperTest {
                 Duration.ofSeconds(5),
                 List.of(),
                 List.of(),
+                null,
+                excludedFragments);
+    }
+
+    private static McpServerProperties propertiesWithPrefixesAndExclusions(
+            List<String> includedPrefixes, List<String> excludedFragments) {
+        return new McpServerProperties(
+                "http://localhost:8086",
+                "/mcp/message",
+                "/mcp/sse",
+                "/v3/api-docs",
+                Duration.ofSeconds(5),
+                List.of(),
+                includedPrefixes,
                 null,
                 excludedFragments);
     }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiToolMapperTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiToolMapperTest.java
@@ -1,0 +1,124 @@
+package com.positivity.mcp.internal.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.config.McpServerProperties;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+class OpenApiToolMapperTest {
+
+    private static final URI GATEWAY_URI = URI.create("http://gateway.test");
+
+    @Test
+    @DisplayName("toAggregateToolSpecifications derives domain from first non-version path segment and names tool {domain}_{operationId}")
+    void toAggregateToolSpecifications_generatesDomainPrefixedToolName_forVersionedPath() {
+        OperationProxyFactory mockFactory = mock(OperationProxyFactory.class);
+        when(mockFactory.handlerForBaseUri(any(), any(), any())).thenReturn((ex, req) -> Mono.empty());
+
+        OpenApiToolMapper mapper = new OpenApiToolMapper(propertiesWithExclusions(List.of()), mockFactory);
+        OpenAPI openApi = openApiWith(Map.of("/v1/accounting/invoices", getItem("listInvoices", "List invoices")));
+
+        List<McpServerFeatures.AsyncToolSpecification> specs =
+                mapper.toAggregateToolSpecifications(GATEWAY_URI, openApi);
+
+        assertThat(specs).hasSize(1);
+        assertThat(specs.getFirst().tool().name()).isEqualTo("accounting_listinvoices");
+    }
+
+    @Test
+    @DisplayName("toAggregateToolSpecifications uses first non-version segment when path starts with domain prefix before version")
+    void toAggregateToolSpecifications_usesFirstSegment_whenDomainPrecedesVersion() {
+        OperationProxyFactory mockFactory = mock(OperationProxyFactory.class);
+        when(mockFactory.handlerForBaseUri(any(), any(), any())).thenReturn((ex, req) -> Mono.empty());
+
+        OpenApiToolMapper mapper = new OpenApiToolMapper(propertiesWithExclusions(List.of()), mockFactory);
+        OpenAPI openApi =
+                openApiWith(Map.of("/catalog/v1/catalog/products/{productId}", getItem("getProduct", "Get product")));
+
+        List<McpServerFeatures.AsyncToolSpecification> specs =
+                mapper.toAggregateToolSpecifications(GATEWAY_URI, openApi);
+
+        assertThat(specs).hasSize(1);
+        assertThat(specs.getFirst().tool().name()).isEqualTo("catalog_getproduct");
+    }
+
+    @Test
+    @DisplayName("toAggregateToolSpecifications excludes paths containing configured excluded-path-fragments")
+    void toAggregateToolSpecifications_excludesPaths_whenFragmentsConfigured() {
+        OperationProxyFactory mockFactory = mock(OperationProxyFactory.class);
+        when(mockFactory.handlerForBaseUri(any(), any(), any())).thenReturn((ex, req) -> Mono.empty());
+
+        McpServerProperties props = propertiesWithExclusions(List.of("/admin/", "/actuator/", "/internal/"));
+        OpenApiToolMapper mapper = new OpenApiToolMapper(props, mockFactory);
+        OpenAPI openApi = openApiWith(Map.of(
+                "/v1/accounting/invoices", getItem("listInvoices", "List invoices"),
+                "/v1/admin/users", getItem("listUsers", "List users"),
+                "/actuator/health", getItem("health", "Health check"),
+                "/v1/internal/config", getItem("getConfig", "Get config")));
+
+        List<McpServerFeatures.AsyncToolSpecification> specs =
+                mapper.toAggregateToolSpecifications(GATEWAY_URI, openApi);
+
+        assertThat(specs).hasSize(1);
+        assertThat(specs.getFirst().tool().name()).isEqualTo("accounting_listinvoices");
+    }
+
+    @Test
+    @DisplayName("toAggregateToolSpecifications returns empty list when OpenAPI has no paths")
+    void toAggregateToolSpecifications_returnsEmpty_whenNoPaths() {
+        OperationProxyFactory mockFactory = mock(OperationProxyFactory.class);
+        OpenApiToolMapper mapper = new OpenApiToolMapper(propertiesWithExclusions(List.of()), mockFactory);
+        OpenAPI openApi = new OpenAPI();
+
+        List<McpServerFeatures.AsyncToolSpecification> specs =
+                mapper.toAggregateToolSpecifications(GATEWAY_URI, openApi);
+
+        assertThat(specs).isEmpty();
+    }
+
+    // --- helpers ---
+
+    private static McpServerProperties propertiesWithExclusions(List<String> excludedFragments) {
+        return new McpServerProperties(
+                "http://localhost:8086",
+                "/mcp/message",
+                "/mcp/sse",
+                "/v3/api-docs",
+                Duration.ofSeconds(5),
+                List.of(),
+                List.of(),
+                null,
+                excludedFragments);
+    }
+
+    private static OpenAPI openApiWith(Map<String, PathItem> pathItems) {
+        Paths paths = new Paths();
+        pathItems.forEach(paths::addPathItem);
+        OpenAPI openApi = new OpenAPI();
+        openApi.setPaths(paths);
+        return openApi;
+    }
+
+    private static PathItem getItem(String operationId, String summary) {
+        Operation op = new Operation();
+        op.setOperationId(operationId);
+        op.setSummary(summary);
+        PathItem item = new PathItem();
+        item.setGet(op);
+        return item;
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImplTest.java
@@ -1,0 +1,135 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.config.McpServerProperties;
+import com.positivity.mcp.internal.discovery.OpenApiDocumentFetcher;
+import com.positivity.mcp.internal.discovery.OpenApiToolMapper;
+import io.modelcontextprotocol.server.McpAsyncServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.swagger.v3.oas.models.OpenAPI;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+class ToolRegistrationServiceImplTest {
+
+    @Mock
+    private OpenApiDocumentFetcher openApiDocumentFetcher;
+
+    @Mock
+    private OpenApiToolMapper openApiToolMapper;
+
+    @Mock
+    private McpAsyncServer mcpAsyncServer;
+
+    private static final URI GATEWAY_BASE_URI = URI.create("http://gateway.test");
+
+    @Test
+    @DisplayName("registerDiscoveredTools fetches aggregate spec and registers tools via addTool")
+    void registerDiscoveredTools_fetchesAggregateSpec_andRegistersTools() {
+        McpServerFeatures.AsyncToolSpecification spec = toolSpec("accounting_listinvoices");
+        OpenApiDocumentFetcher.DiscoveredOpenApi discovered =
+                new OpenApiDocumentFetcher.DiscoveredOpenApi("aggregate", GATEWAY_BASE_URI, new OpenAPI());
+
+        when(openApiDocumentFetcher.fetchAggregateSpec()).thenReturn(Mono.just(discovered));
+        when(openApiToolMapper.toAggregateToolSpecifications(GATEWAY_BASE_URI, discovered.openApi()))
+                .thenReturn(List.of(spec));
+        when(mcpAsyncServer.addTool(spec)).thenReturn(Mono.empty());
+        when(mcpAsyncServer.notifyToolsListChanged()).thenReturn(Mono.empty());
+
+        ToolRegistrationServiceImpl service = serviceUnderTest();
+        service.registerDiscoveredTools().block(Duration.ofSeconds(5));
+
+        verify(openApiDocumentFetcher).fetchAggregateSpec();
+        verify(openApiToolMapper).toAggregateToolSpecifications(GATEWAY_BASE_URI, discovered.openApi());
+        verify(mcpAsyncServer).addTool(spec);
+        verify(mcpAsyncServer).notifyToolsListChanged();
+    }
+
+    @Test
+    @DisplayName("registerDiscoveredTools does not register tools and returns empty when aggregate fetch returns empty")
+    void registerDiscoveredTools_skipsRegistration_whenAggregateFetchReturnsEmpty() {
+        when(openApiDocumentFetcher.fetchAggregateSpec()).thenReturn(Mono.empty());
+
+        ToolRegistrationServiceImpl service = serviceUnderTest();
+        Void result = service.registerDiscoveredTools().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNull();
+        verify(openApiDocumentFetcher).fetchAggregateSpec();
+        verify(openApiToolMapper, never()).toAggregateToolSpecifications(any(), any());
+        verify(mcpAsyncServer, never()).addTool(any());
+    }
+
+    @Test
+    @DisplayName("registerDiscoveredTools skips registration and completes normally when aggregate fetch errors")
+    void registerDiscoveredTools_completesNormally_whenAggregateFetchErrors() {
+        when(openApiDocumentFetcher.fetchAggregateSpec())
+                .thenReturn(Mono.error(new RuntimeException("connection refused")));
+
+        ToolRegistrationServiceImpl service = serviceUnderTest();
+        Void result = service.registerDiscoveredTools().block(Duration.ofSeconds(5));
+
+        assertThat(result).isNull();
+        verify(mcpAsyncServer, never()).addTool(any());
+        verify(mcpAsyncServer, never()).notifyToolsListChanged();
+    }
+
+    @Test
+    @DisplayName("registerDiscoveredTools returns empty without calling addTool when mapper returns no specs")
+    void registerDiscoveredTools_skipsAddTool_whenMapperReturnsNoSpecs() {
+        OpenApiDocumentFetcher.DiscoveredOpenApi discovered =
+                new OpenApiDocumentFetcher.DiscoveredOpenApi("aggregate", GATEWAY_BASE_URI, new OpenAPI());
+
+        when(openApiDocumentFetcher.fetchAggregateSpec()).thenReturn(Mono.just(discovered));
+        when(openApiToolMapper.toAggregateToolSpecifications(GATEWAY_BASE_URI, discovered.openApi()))
+                .thenReturn(List.of());
+
+        ToolRegistrationServiceImpl service = serviceUnderTest();
+        service.registerDiscoveredTools().block(Duration.ofSeconds(5));
+
+        verify(mcpAsyncServer, never()).addTool(any());
+        verify(mcpAsyncServer, never()).notifyToolsListChanged();
+    }
+
+    // --- helpers ---
+
+    private ToolRegistrationServiceImpl serviceUnderTest() {
+        McpServerProperties properties = new McpServerProperties(
+                "http://localhost:8086",
+                "/mcp/message",
+                "/mcp/sse",
+                "/v3/api-docs",
+                Duration.ofSeconds(5),
+                List.of(),
+                List.of(),
+                "http://gateway.test/v3/api-docs",
+                List.of());
+        return new ToolRegistrationServiceImpl(
+                properties, openApiDocumentFetcher, openApiToolMapper, mcpAsyncServer);
+    }
+
+    private static McpServerFeatures.AsyncToolSpecification toolSpec(String name) {
+        var tool = McpSchema.Tool.builder()
+                .name(name)
+                .description("test tool")
+                .inputSchema(new McpSchema.JsonSchema("object", null, null, null, null, null))
+                .build();
+        return McpServerFeatures.AsyncToolSpecification.builder()
+                .tool(tool)
+                .callHandler((exchange, req) -> Mono.empty())
+                .build();
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImplTest.java
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.positivity.mcp.internal.config.McpServerProperties;
 import com.positivity.mcp.internal.discovery.OpenApiDocumentFetcher;
 import com.positivity.mcp.internal.discovery.OpenApiToolMapper;
@@ -21,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 @ExtendWith(MockitoExtension.class)
@@ -104,6 +108,27 @@ class ToolRegistrationServiceImplTest {
         verify(mcpAsyncServer, never()).notifyToolsListChanged();
     }
 
+    @Test
+    @DisplayName("registerDiscoveredTools logs a WARN when included-services is configured in aggregate-first mode")
+    void registerDiscoveredTools_logsWarning_whenIncludedServicesConfiguredInAggregateFirstMode() {
+        when(openApiDocumentFetcher.fetchAggregateSpec()).thenReturn(Mono.empty());
+
+        ListAppender<ILoggingEvent> logAppender = attachLogAppender();
+        try {
+            ToolRegistrationServiceImpl service = serviceWithIncludedServices(List.of("event-receiver"));
+            service.registerDiscoveredTools().block(Duration.ofSeconds(5));
+
+            boolean hasDeprecationWarning = logAppender.list.stream()
+                    .filter(e -> e.getLevel() == Level.WARN)
+                    .anyMatch(e -> e.getFormattedMessage().contains("included-services"));
+            assertThat(hasDeprecationWarning)
+                    .as("Expected a WARN log mentioning 'included-services' when it is set in aggregate-first mode")
+                    .isTrue();
+        } finally {
+            detachLogAppender(logAppender);
+        }
+    }
+
     // --- helpers ---
 
     private ToolRegistrationServiceImpl serviceUnderTest() {
@@ -119,6 +144,36 @@ class ToolRegistrationServiceImplTest {
                 List.of());
         return new ToolRegistrationServiceImpl(
                 properties, openApiDocumentFetcher, openApiToolMapper, mcpAsyncServer);
+    }
+
+    private ToolRegistrationServiceImpl serviceWithIncludedServices(List<String> includedServices) {
+        McpServerProperties properties = new McpServerProperties(
+                "http://localhost:8086",
+                "/mcp/message",
+                "/mcp/sse",
+                "/v3/api-docs",
+                Duration.ofSeconds(5),
+                includedServices,
+                List.of(),
+                "http://gateway.test/v3/api-docs",
+                List.of());
+        return new ToolRegistrationServiceImpl(
+                properties, openApiDocumentFetcher, openApiToolMapper, mcpAsyncServer);
+    }
+
+    private static ListAppender<ILoggingEvent> attachLogAppender() {
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger)
+                LoggerFactory.getLogger(ToolRegistrationServiceImpl.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        return appender;
+    }
+
+    private static void detachLogAppender(ListAppender<ILoggingEvent> appender) {
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger)
+                LoggerFactory.getLogger(ToolRegistrationServiceImpl.class);
+        logger.detachAppender(appender);
     }
 
     private static McpServerFeatures.AsyncToolSpecification toolSpec(String name) {

--- a/pos-mcp-server/src/test/resources/openapi/aggregate/invalid-aggregate.yaml
+++ b/pos-mcp-server/src/test/resources/openapi/aggregate/invalid-aggregate.yaml
@@ -1,0 +1,4 @@
+this is not valid openapi yaml:
+  - missing required openapi version
+  - missing info block
+  broken: [unclosed bracket

--- a/pos-mcp-server/src/test/resources/openapi/aggregate/minimal-aggregate.yaml
+++ b/pos-mcp-server/src/test/resources/openapi/aggregate/minimal-aggregate.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.3"
+info:
+  title: Positivity API Gateway
+  version: "1.0"
+paths:
+  /catalog/v1/catalog/products/{productId}:
+    get:
+      operationId: getProduct
+      summary: Get product by ID
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Product found


### PR DESCRIPTION
## Summary
- switch pos-mcp-server auto-discovery from per-service iteration to gateway aggregate-first registration
- add aggregate OpenAPI fetch, mapping, routing, and fail-soft handling for malformed or unavailable aggregate specs
- preserve gateway context paths for absolute and relative aggregate spec URLs and warn when deprecated included-services is configured

## Test Plan
- [x] ./mvnw -q -pl pos-mcp-server -DskipTests=false -Dtest=OpenApiDocumentFetcherTest,OpenApiToolMapperTest,ToolRegistrationServiceImplTest test
- [x] ./mvnw -q -pl pos-mcp-server -DskipTests=false test