### PR TITLE
Issue 647 customer directory browse

### DIFF
--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -899,7 +899,7 @@ paths:
       tags:
       - CRM Accounts
       summary: Browse parties
-      description: Browse parties with paging and sorting. Default sort is legalName,asc then partyId,asc; legalName sorting is case-insensitive.
+      description: Browse parties with paging and sorting. If sort is omitted, the service uses legalName,asc and appends partyId,asc as a stable tie-breaker; legalName sorting is case-insensitive.
       operationId: browseParties
       parameters:
       - name: page
@@ -920,7 +920,7 @@ paths:
           default: 20
       - name: sort
         in: query
-        description: Repeat to override sorting. Defaults to legalName,asc and partyId,asc; legalName sorting is case-insensitive.
+        description: Repeat to override sorting. If omitted, the service uses legalName,asc and appends partyId,asc as a stable tie-breaker; legalName sorting is case-insensitive.
         schema:
           type: array
           items:

--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -899,7 +899,7 @@ paths:
       tags:
       - CRM Accounts
       summary: Browse parties
-      description: Browse parties with paging and sorting. If sort is omitted, the service uses legalName,asc and appends partyId,asc as a stable tie-breaker; legalName sorting is case-insensitive.
+      description: Browse parties with paging and sorting. The service sorts by legalName ascending by default, appends partyId ascending as a stable tie-breaker whenever the requested sort list does not explicitly include partyId, and applies case-insensitive legalName sorting.
       operationId: browseParties
       parameters:
       - name: page
@@ -920,7 +920,7 @@ paths:
           default: 20
       - name: sort
         in: query
-        description: Repeat to override sorting. If omitted, the service uses legalName,asc and appends partyId,asc as a stable tie-breaker; legalName sorting is case-insensitive.
+        description: Repeat to override sorting. The service uses legalName,asc by default and appends partyId,asc as a stable tie-breaker whenever the requested sort list does not explicitly include partyId; legalName sorting is case-insensitive.
         schema:
           type: array
           items:

--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -895,6 +895,55 @@ paths:
       x-required-permissions:
       - crm:party:view
   /v1/crm/accounts/parties:
+    get:
+      tags:
+      - CRM Accounts
+      summary: Browse parties
+      description: Browse parties with paging and sorting. Default sort is legalName,asc then partyId,asc; legalName sorting is case-insensitive.
+      operationId: browseParties
+      parameters:
+      - name: page
+        in: query
+        description: Zero-based page index
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
+      - name: size
+        in: query
+        description: Page size
+        schema:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 20
+      - name: sort
+        in: query
+        description: Repeat to override sorting. Defaults to legalName,asc and partyId,asc; legalName sorting is case-insensitive.
+        schema:
+          type: array
+          items:
+            type: string
+          default:
+          - legalName,asc
+          - partyId,asc
+        style: form
+        explode: true
+      responses:
+        '200':
+          description: Browse results returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchPartiesResponse'
+        '403':
+          description: Forbidden - insufficient permissions
+      security:
+      - bearerAuth:
+        - crm:party:view
+      x-required-permissions:
+      - crm:party:view
     post:
       tags:
       - CRM Accounts

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/EventTypes.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/EventTypes.java
@@ -14,7 +14,7 @@ public final class EventTypes {
 
     /**
      * All event type registrations for the customer module.
-     * Total: 35 event types.
+     * Total: 36 event types.
      */
     public static List<EventTypeRegistration> all() {
         return List.of(
@@ -28,7 +28,7 @@ public final class EventTypes {
                 EventTypeRegistration.write("CUSTOMER_BULK_INGEST", "Bulk import customer records")
                         .build(),
 
-                // CrmAccountsController - 8 events
+                // CrmAccountsController - 11 events
                 EventTypeRegistration.fastRead(
                                 "CUSTOMER_ACCOUNT_TIER_GET", "Retrieve the tier level for a specific account")
                         .build(),
@@ -37,6 +37,8 @@ public final class EventTypes {
                                 "Resolve or compute the account tier based on business rules")
                         .build(),
                 EventTypeRegistration.write("CUSTOMER_PARTY_CREATE", "Create a new commercial party/account")
+                        .build(),
+                EventTypeRegistration.fastRead("CUSTOMER_PARTY_BROWSE", "Browse parties with paging and sorting")
                         .build(),
                 EventTypeRegistration.search("CUSTOMER_PARTY_SEARCH", "Search for parties based on various criteria")
                         .build(),

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
@@ -191,11 +191,34 @@ public class CrmAccountsController {
 
     // --- Party Search and Merge (Issue #173) ---
 
+    @Operation(
+            summary = "Browse parties",
+            description =
+                    "Browse parties with paging and sorting. Default sort is legalName ascending, then partyId "
+                            + "ascending for stable tie-breaking; legalName sorting is case-insensitive.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Browse results returned",
+                        content = @Content(schema = @Schema(implementation = SearchPartiesResponse.class))),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "Forbidden - insufficient permissions",
+                        content = @Content)
+            })
     @GetMapping("/parties")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {CrmPermissionRegistry.PARTY_VIEW})
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
     @EmitEvent(id = "CUSTOMER_PARTY_BROWSE", apiVersion = "1")
     public ResponseEntity<SearchPartiesResponse> browseParties(
-            @PageableDefault(size = 20, sort = "legalName") Pageable pageable) {
+            @Parameter(
+                            description = "Pagination parameters (page, size, sort). Default sort is legalName,asc "
+                                    + "then partyId,asc; legalName sorting is case-insensitive.")
+                    @PageableDefault(size = 20, sort = {"legalName", "partyId"})
+                    Pageable pageable) {
         log.info("browseParties pageable={}", pageable);
         return ResponseEntity.ok(partyService.browseParties(pageable));
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
@@ -194,9 +194,9 @@ public class CrmAccountsController {
     @Operation(
             summary = "Browse parties",
             description =
-                    "Browse parties with paging and sorting. Default sort is legalName ascending, and when "
-                            + "partyId is not explicitly supplied the service appends partyId ascending as a "
-                            + "stable tie-breaker; legalName sorting is case-insensitive.")
+                    "Browse parties with paging and sorting. The service sorts by legalName ascending by default, "
+                            + "appends partyId ascending as a stable tie-breaker whenever the requested sort list "
+                            + "does not explicitly include partyId, and applies case-insensitive legalName sorting.")
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -216,9 +216,10 @@ public class CrmAccountsController {
     @EmitEvent(id = "CUSTOMER_PARTY_BROWSE", apiVersion = "1")
     public ResponseEntity<SearchPartiesResponse> browseParties(
             @Parameter(
-                            description = "Pagination parameters (page, size, sort). If sort is omitted, the "
-                                    + "service uses legalName,asc and appends partyId,asc as a stable "
-                                    + "tie-breaker; legalName sorting is case-insensitive.")
+                            description = "Pagination parameters (page, size, sort). The service uses legalName,asc "
+                                    + "by default and appends partyId,asc as a stable tie-breaker whenever the "
+                                    + "requested sort list does not explicitly include partyId; legalName sorting "
+                                    + "is case-insensitive.")
                     @PageableDefault(size = 20, sort = {"legalName", "partyId"})
                     Pageable pageable) {
         log.info("browseParties pageable={}", pageable);

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
@@ -35,6 +35,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -188,6 +190,28 @@ public class CrmAccountsController {
     }
 
     // --- Party Search and Merge (Issue #173) ---
+
+    @Operation(summary = "Browse parties", description = "Browse parties with paging and sorting")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Browse results returned",
+                        content = @Content(schema = @Schema(implementation = SearchPartiesResponse.class))),
+                @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+            })
+    @GetMapping("/parties")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {CrmPermissionRegistry.PARTY_VIEW})
+    @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
+    @EmitEvent(id = "CUSTOMER_PARTY_BROWSE", apiVersion = "1")
+    public ResponseEntity<SearchPartiesResponse> browseParties(
+            @Parameter(description = "Pagination parameters (page, size, sort)") @PageableDefault(size = 20, sort = "legalName")
+                    Pageable pageable) {
+        log.info("browseParties pageable={}", pageable);
+        return ResponseEntity.ok(partyService.browseParties(pageable));
+    }
 
     @Operation(summary = "Search parties", description = "Search for parties based on various criteria")
     @ApiResponses(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
@@ -194,8 +194,9 @@ public class CrmAccountsController {
     @Operation(
             summary = "Browse parties",
             description =
-                    "Browse parties with paging and sorting. Default sort is legalName ascending, then partyId "
-                            + "ascending for stable tie-breaking; legalName sorting is case-insensitive.")
+                    "Browse parties with paging and sorting. Default sort is legalName ascending, and when "
+                            + "partyId is not explicitly supplied the service appends partyId ascending as a "
+                            + "stable tie-breaker; legalName sorting is case-insensitive.")
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -215,8 +216,9 @@ public class CrmAccountsController {
     @EmitEvent(id = "CUSTOMER_PARTY_BROWSE", apiVersion = "1")
     public ResponseEntity<SearchPartiesResponse> browseParties(
             @Parameter(
-                            description = "Pagination parameters (page, size, sort). Default sort is legalName,asc "
-                                    + "then partyId,asc; legalName sorting is case-insensitive.")
+                            description = "Pagination parameters (page, size, sort). If sort is omitted, the "
+                                    + "service uses legalName,asc and appends partyId,asc as a stable "
+                                    + "tie-breaker; legalName sorting is case-insensitive.")
                     @PageableDefault(size = 20, sort = {"legalName", "partyId"})
                     Pageable pageable) {
         log.info("browseParties pageable={}", pageable);

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
@@ -191,24 +191,11 @@ public class CrmAccountsController {
 
     // --- Party Search and Merge (Issue #173) ---
 
-    @Operation(summary = "Browse parties", description = "Browse parties with paging and sorting")
-    @ApiResponses(
-            value = {
-                @ApiResponse(
-                        responseCode = "200",
-                        description = "Browse results returned",
-                        content = @Content(schema = @Schema(implementation = SearchPartiesResponse.class))),
-                @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
-            })
     @GetMapping("/parties")
-    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {CrmPermissionRegistry.PARTY_VIEW})
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
     @EmitEvent(id = "CUSTOMER_PARTY_BROWSE", apiVersion = "1")
     public ResponseEntity<SearchPartiesResponse> browseParties(
-            @Parameter(description = "Pagination parameters (page, size, sort)") @PageableDefault(size = 20, sort = "legalName")
-                    Pageable pageable) {
+            @PageableDefault(size = 20, sort = "legalName") Pageable pageable) {
         log.info("browseParties pageable={}", pageable);
         return ResponseEntity.ok(partyService.browseParties(pageable));
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -222,10 +222,15 @@ public class PartyServiceImpl implements PartyService {
 
         return SearchPartiesResponse.builder()
                 .results(summaries)
-                .totalCount(Math.toIntExact(page.getTotalElements()))
+                .totalCount(safeTotalCount(page.getTotalElements()))
                 .pageNumber(normalizedPageable.getPageNumber())
                 .pageSize(normalizedPageable.getPageSize())
                 .build();
+    }
+
+    private int safeTotalCount(long totalElements) {
+        // Response schema exposes int32; cap large totals to avoid overflow exceptions.
+        return totalElements > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) totalElements;
     }
 
     @Override

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -48,6 +48,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.http.HttpStatus;
@@ -205,6 +207,21 @@ public class PartyServiceImpl implements PartyService {
     private String buildContactName(Contact contact) {
         return (contact.getFirstName() != null ? contact.getFirstName() : "") + " "
                 + (contact.getLastName() != null ? contact.getLastName() : "");
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @NonNull
+    public SearchPartiesResponse browseParties(@NonNull Pageable pageable) {
+        Sort.Order order = pageable.getSort().isSorted() ? pageable.getSort().iterator().next() : null;
+        SearchPartiesRequest request = SearchPartiesRequest.builder()
+                .pageNumber(pageable.getPageNumber() + 1)
+                .pageSize(pageable.getPageSize())
+                .sortField(order != null ? order.getProperty() : null)
+                .sortOrder(order != null ? (order.isDescending() ? Sort.Direction.DESC.name() : Sort.Direction.ASC.name())
+                        : null)
+                .build();
+        return searchParties(request);
     }
 
     @Override

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -48,6 +48,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.cache.Cache;
@@ -213,15 +215,17 @@ public class PartyServiceImpl implements PartyService {
     @Transactional(readOnly = true)
     @NonNull
     public SearchPartiesResponse browseParties(@NonNull Pageable pageable) {
-        Sort.Order order = pageable.getSort().isSorted() ? pageable.getSort().iterator().next() : null;
-        SearchPartiesRequest request = SearchPartiesRequest.builder()
-                .pageNumber(pageable.getPageNumber() + 1)
-                .pageSize(pageable.getPageSize())
-                .sortField(order != null ? order.getProperty() : null)
-                .sortOrder(order != null ? (order.isDescending() ? Sort.Direction.DESC.name() : Sort.Direction.ASC.name())
-                        : null)
+        Pageable normalizedPageable = normalizeBrowsePageable(pageable);
+        Page<CommercialParty> page = partyRepository.findAll(normalizedPageable);
+        List<SearchPartiesResponse.PartySummary> summaries =
+                page.getContent().stream().map(this::mapToPartySummary).toList();
+
+        return SearchPartiesResponse.builder()
+                .results(summaries)
+                .totalCount(Math.toIntExact(page.getTotalElements()))
+                .pageNumber(normalizedPageable.getPageNumber())
+                .pageSize(normalizedPageable.getPageSize())
                 .build();
-        return searchParties(request);
     }
 
     @Override
@@ -452,6 +456,37 @@ public class PartyServiceImpl implements PartyService {
                 .status(party.getStatus().toString())
                 .createdAt(party.getCreatedAt() != null ? ISO_FORMATTER.format(party.getCreatedAt()) : null)
                 .build();
+    }
+
+    private Pageable normalizeBrowsePageable(@Nullable Pageable pageable) {
+        Sort normalizedSort = normalizeBrowseSort(pageable != null ? pageable.getSort() : Sort.unsorted());
+        if (pageable == null || pageable.isUnpaged()) {
+            return PageRequest.of(0, 20, normalizedSort);
+        }
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), normalizedSort);
+    }
+
+    private Sort normalizeBrowseSort(@NonNull Sort requestedSort) {
+        if (requestedSort.isUnsorted()) {
+            return Sort.by(Sort.Order.asc("legalName").ignoreCase(), Sort.Order.asc("partyId"));
+        }
+
+        List<Sort.Order> orders = new ArrayList<>();
+        requestedSort.forEach(order -> {
+            if ("legalName".equals(order.getProperty())) {
+                Sort.Order normalizedOrder = order.isDescending()
+                        ? Sort.Order.desc("legalName")
+                        : Sort.Order.asc("legalName");
+                orders.add(normalizedOrder.ignoreCase());
+            } else {
+                orders.add(order);
+            }
+        });
+        boolean hasPartyIdSort = orders.stream().anyMatch(order -> "partyId".equals(order.getProperty()));
+        if (!hasPartyIdSort) {
+            orders.add(Sort.Order.asc("partyId"));
+        }
+        return Sort.by(orders);
     }
 
     @Override

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -474,10 +474,7 @@ public class PartyServiceImpl implements PartyService {
         List<Sort.Order> orders = new ArrayList<>();
         requestedSort.forEach(order -> {
             if ("legalName".equals(order.getProperty())) {
-                Sort.Order normalizedOrder = order.isDescending()
-                        ? Sort.Order.desc("legalName")
-                        : Sort.Order.asc("legalName");
-                orders.add(normalizedOrder.ignoreCase());
+                orders.add(order.ignoreCase());
             } else {
                 orders.add(order);
             }

--- a/pos-customer/src/main/java/com/positivity/customer/service/PartyService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/service/PartyService.java
@@ -35,9 +35,7 @@ public interface PartyService {
     GetContactsWithRolesResponse getContactsWithRoles(UUID partyId);
 
     @NonNull
-    default SearchPartiesResponse browseParties(@NonNull Pageable pageable) {
-        throw new UnsupportedOperationException("browseParties is not implemented yet");
-    }
+    SearchPartiesResponse browseParties(@NonNull Pageable pageable);
 
     SearchPartiesResponse searchParties(SearchPartiesRequest request);
 

--- a/pos-customer/src/main/java/com/positivity/customer/service/PartyService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/service/PartyService.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Pageable;
 
 public interface PartyService {
 
@@ -32,6 +33,11 @@ public interface PartyService {
     GetPartyResponse getParty(UUID partyId);
 
     GetContactsWithRolesResponse getContactsWithRoles(UUID partyId);
+
+    @NonNull
+    default SearchPartiesResponse browseParties(@NonNull Pageable pageable) {
+        throw new UnsupportedOperationException("browseParties is not implemented yet");
+    }
 
     SearchPartiesResponse searchParties(SearchPartiesRequest request);
 

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/EventTypesTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/EventTypesTest.java
@@ -1,0 +1,32 @@
+package com.positivity.customer.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.events.EventTypeRegistration;
+import org.junit.jupiter.api.Test;
+
+class EventTypesTest {
+
+    @Test
+    void all_includesBrowseEventAsDistinctFastReadRegistration() {
+        assertThat(EventTypes.all())
+                .extracting(EventTypeRegistration::getTypeCode)
+                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
+
+        EventTypeRegistration browseRegistration = EventTypes.all().stream()
+                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
+                .findFirst()
+                .orElseThrow();
+
+        EventTypeRegistration searchRegistration = EventTypes.all().stream()
+                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
+        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
+        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
+        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
+        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/EventTypesTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/EventTypesTest.java
@@ -12,6 +12,10 @@ class EventTypesTest {
         assertThat(EventTypes.all())
                 .extracting(EventTypeRegistration::getTypeCode)
                 .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
+        assertThat(EventTypes.all().stream()
+                        .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
+                        .count())
+                .isEqualTo(1);
 
         EventTypeRegistration browseRegistration = EventTypes.all().stream()
                 .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/EventTypesTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/EventTypesTest.java
@@ -3,26 +3,25 @@ package com.positivity.customer.internal.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.positivity.events.EventTypeRegistration;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class EventTypesTest {
 
     @Test
     void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        assertThat(EventTypes.all())
+        List<EventTypeRegistration> registrations = EventTypes.all();
+        assertThat(registrations)
                 .extracting(EventTypeRegistration::getTypeCode)
+                .doesNotHaveDuplicates()
                 .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-        assertThat(EventTypes.all().stream()
-                        .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                        .count())
-                .isEqualTo(1);
 
-        EventTypeRegistration browseRegistration = EventTypes.all().stream()
+        EventTypeRegistration browseRegistration = registrations.stream()
                 .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
                 .findFirst()
                 .orElseThrow();
 
-        EventTypeRegistration searchRegistration = EventTypes.all().stream()
+        EventTypeRegistration searchRegistration = registrations.stream()
                 .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
                 .findFirst()
                 .orElseThrow();

--- a/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
@@ -2,7 +2,10 @@ package com.positivity.customer.internal.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -20,11 +23,13 @@ import com.positivity.customer.service.PartyService;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -136,14 +141,28 @@ class CrmAccountsControllerTest {
                 .pageSize(20)
                 .build();
 
-        when(partyService.browseParties(any())).thenReturn(response);
+        when(partyService.browseParties(any(Pageable.class))).thenReturn(response);
 
         mockMvc.perform(get("/v1/crm/accounts/parties").header("X-Authorities", "crm:party:view"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results").isArray())
+                .andExpect(jsonPath("$.results.length()").value(1))
                 .andExpect(jsonPath("$.results[0].partyId").value(PARTY_ID.toString()))
+                .andExpect(jsonPath("$.results[0].legalName").value("Acme Corp"))
+                .andExpect(jsonPath("$.results[0].displayName").value("Acme"))
+                .andExpect(jsonPath("$.results[0].partyType").value("COMMERCIAL"))
+                .andExpect(jsonPath("$.results[0].status").value("ACTIVE"))
+                .andExpect(jsonPath("$.results[0].createdAt").value("2024-01-01T00:00:00Z"))
                 .andExpect(jsonPath("$.totalCount").value(1))
                 .andExpect(jsonPath("$.pageNumber").value(0))
                 .andExpect(jsonPath("$.pageSize").value(20));
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(partyService).browseParties(pageableCaptor.capture());
+        assertEquals(0, pageableCaptor.getValue().getPageNumber());
+        assertEquals(20, pageableCaptor.getValue().getPageSize());
+        assertTrue(pageableCaptor.getValue().getSort().isSorted());
+        assertEquals("legalName", pageableCaptor.getValue().getSort().iterator().next().getProperty());
     }
 
     @Test

--- a/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.positivity.customer.config.WebMvcTestSecurityConfig;
 import com.positivity.customer.internal.config.CrmExceptionHandler;
 import com.positivity.customer.internal.dto.DuplicateCheckResponse;
+import com.positivity.customer.internal.dto.SearchPartiesResponse;
 import com.positivity.customer.internal.dto.UpsertBillingRulesRequest;
 import com.positivity.customer.internal.dto.snapshot.BillingRuleRef;
 import com.positivity.customer.service.AccountTierService;
@@ -115,6 +116,40 @@ class CrmAccountsControllerTest {
     @DisplayName("B-21: GET duplicate-check without crm:party:search authority → 403")
     void checkPartyDuplicates_returns403_whenUnauthorized() throws Exception {
         mockMvc.perform(get("/v1/crm/accounts/parties/duplicate-check").param("legalName", "Acme"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("browseParties returns 200 with shared response when authorized")
+    void listParties_returns200WithSharedResponse_whenAuthorized() throws Exception {
+        SearchPartiesResponse response = SearchPartiesResponse.builder()
+                .results(List.of(SearchPartiesResponse.PartySummary.builder()
+                        .partyId(PARTY_ID.toString())
+                        .legalName("Acme Corp")
+                        .displayName("Acme")
+                        .partyType("COMMERCIAL")
+                        .status("ACTIVE")
+                        .createdAt("2024-01-01T00:00:00Z")
+                        .build()))
+                .totalCount(1)
+                .pageNumber(0)
+                .pageSize(20)
+                .build();
+
+        when(partyService.browseParties(any())).thenReturn(response);
+
+        mockMvc.perform(get("/v1/crm/accounts/parties").header("X-Authorities", "crm:party:view"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results[0].partyId").value(PARTY_ID.toString()))
+                .andExpect(jsonPath("$.totalCount").value(1))
+                .andExpect(jsonPath("$.pageNumber").value(0))
+                .andExpect(jsonPath("$.pageSize").value(20));
+    }
+
+    @Test
+    @DisplayName("browseParties returns 403 when unauthorized")
+    void listParties_returns403_whenUnauthorized() throws Exception {
+        mockMvc.perform(get("/v1/crm/accounts/parties"))
                 .andExpect(status().isForbidden());
     }
 

--- a/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Pageable;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
@@ -162,7 +163,13 @@ class CrmAccountsControllerTest {
         assertEquals(0, pageableCaptor.getValue().getPageNumber());
         assertEquals(20, pageableCaptor.getValue().getPageSize());
         assertTrue(pageableCaptor.getValue().getSort().isSorted());
-        assertEquals("legalName", pageableCaptor.getValue().getSort().iterator().next().getProperty());
+        var sortIterator = pageableCaptor.getValue().getSort().iterator();
+        var legalNameOrder = sortIterator.next();
+        assertEquals("legalName", legalNameOrder.getProperty());
+        assertEquals(Sort.Direction.ASC, legalNameOrder.getDirection());
+        var partyIdOrder = sortIterator.next();
+        assertEquals("partyId", partyIdOrder.getProperty());
+        assertEquals(Sort.Direction.ASC, partyIdOrder.getDirection());
     }
 
     @Test

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -53,6 +53,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.server.ResponseStatusException;
 
 @ExtendWith(MockitoExtension.class)
@@ -491,6 +495,56 @@ class PartyServiceImplTest {
         assertThat(response.getTotalCount()).isEqualTo(1);
         assertThat(response.getResults()).hasSize(1);
         assertThat(response.getResults().getFirst().getLegalName()).isEqualTo("Acme Industrial");
+    }
+
+    @Test
+    void browseParties_usesDefaultPageAndSort_whenPageableIsUnpaged() {
+        CommercialParty first = party(UUID.fromString("00000000-0000-0000-0000-000000000101"));
+        first.setLegalName("Acme Corp");
+
+        PageRequest expectedPageable = PageRequest.of(
+                0, 20, Sort.by(Sort.Order.asc("legalName").ignoreCase(), Sort.Order.asc("partyId")));
+
+        when(partyRepository.findAll(expectedPageable)).thenReturn(new PageImpl<>(List.of(first), expectedPageable, 1));
+
+        SearchPartiesResponse response = service.browseParties(Pageable.unpaged());
+
+        assertThat(response.getTotalCount()).isEqualTo(1);
+        assertThat(response.getPageNumber()).isEqualTo(0);
+        assertThat(response.getPageSize()).isEqualTo(20);
+        assertThat(response.getResults())
+                .extracting(SearchPartiesResponse.PartySummary::getLegalName)
+                .containsExactly("Acme Corp");
+    }
+
+    @Test
+    void browseParties_returnsEmptyResultsWithPagingMetadata() {
+        PageRequest expectedPageable = PageRequest.of(
+                0, 20, Sort.by(Sort.Order.asc("legalName").ignoreCase(), Sort.Order.asc("partyId")));
+
+        when(partyRepository.findAll(expectedPageable)).thenReturn(new PageImpl<>(List.of(), expectedPageable, 0));
+
+        SearchPartiesResponse response = service.browseParties(Pageable.unpaged());
+
+        assertThat(response.getResults()).isEmpty();
+        assertThat(response.getTotalCount()).isZero();
+        assertThat(response.getPageNumber()).isEqualTo(0);
+        assertThat(response.getPageSize()).isEqualTo(20);
+    }
+
+    @Test
+    void browseParties_normalizesControllerDefaultSortToIgnoreCaseAndStableTieBreaker() {
+        PageRequest requestedPageable = PageRequest.of(0, 20, Sort.by(Sort.Order.asc("legalName")));
+        PageRequest expectedPageable = PageRequest.of(
+                0, 20, Sort.by(Sort.Order.asc("legalName").ignoreCase(), Sort.Order.asc("partyId")));
+
+        when(partyRepository.findAll(expectedPageable)).thenReturn(new PageImpl<>(List.of(), expectedPageable, 0));
+
+        SearchPartiesResponse response = service.browseParties(requestedPageable);
+
+        assertThat(response.getResults()).isEmpty();
+        assertThat(response.getPageNumber()).isEqualTo(0);
+        assertThat(response.getPageSize()).isEqualTo(20);
     }
 
     @Test


### PR DESCRIPTION
 ## Summary
 
 Implements the backend browse API for Customer Directory in support of #647.
 
 This PR adds a dedicated paged `GET /v1/crm/accounts/parties` endpoint so the UI can load a normal customer list when no search criteria is present, instead of relying on criteria search semantics.
 
 ## What changed
 
 - Added `PartyService.browseParties(Pageable)` and controller support in `CrmAccountsController`
 - Added paged browse behavior backed by `CommercialPartyRepository.findAll(...)`
 - Standardized browse responses on the existing `SearchPartiesResponse` shape
 - Documented the new browse contract in `pos-customer/openapi.yaml`
 - Registered a distinct `CUSTOMER_PARTY_BROWSE` event type for observability
 - Added coverage for controller, service, and event-type registration behavior
 
 ## Browse contract
 
 - **Endpoint:** `GET /v1/crm/accounts/parties`
 - **Auth:** `crm:party:view`
 - **Default paging:** `page=0`, `size=20`
 - **Default sort:** `legalName,asc`
 - **Stable tie-breaker:** `partyId,asc` is appended when not explicitly requested
 - **Sorting behavior:** `legalName` sorting is case-insensitive
 - **Empty result behavior:** returns `200 OK` with an empty `results` array plus paging metadata
 
 ## Why
 
 Customer Directory needs dedicated browse semantics for the empty-query state. This separates:
 - **Browse** → paged list endpoint
 - **Search** → criteria-based search endpoint
 
 That keeps the API contract explicit and gives the frontend a stable response shape for initial directory loads.
 
 ## Testing
 
 - `CrmAccountsControllerTest`
 - `PartyServiceImplTest`
 - `EventTypesTest`