### PR TITLE
[CAP:218] Site and parent-location inventory rollup with allocation ledger events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ pos-mcp-server/src/main/resources/exa.prompt.md
 .superpowers/
 .flattened-pom.xml
 
+.tokensave
+repomix-output.*

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/client/StorageLocationTopologyClient.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/client/StorageLocationTopologyClient.java
@@ -62,9 +62,43 @@ public class StorageLocationTopologyClient {
     }
 
     /**
+     * Fetches the flat list of descendant locations of a parent location
+     * along the given typed parent chain (CAP-214 #655 descendants contract).
+     *
+     * @param parentType pos-location {@code ParentType} name, e.g. {@code PHYSICAL}
+     * @throws LocationNotFoundException when pos-location reports the location does not exist
+     * @throws LocationServiceUnavailableException when pos-location is unreachable or errors
+     */
+    @NonNull
+    public List<LocationDescendant> fetchDescendants(@NonNull UUID locationId, @NonNull String parentType) {
+        try {
+            List<LocationDescendant> descendants = restClient
+                    .get()
+                    .uri("/v1/locations/{locationId}/descendants?parentType={parentType}", locationId, parentType)
+                    .header("X-User", "pos-inventory")
+                    .header("X-Authorities", "location:read")
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<>() {});
+            return descendants == null ? List.of() : descendants;
+        } catch (HttpClientErrorException.NotFound ex) {
+            throw new LocationNotFoundException(locationId);
+        } catch (HttpServerErrorException | ResourceAccessException ex) {
+            log.warn("pos-location descendants fetch failed for location {}: {}", locationId, ex.getMessage());
+            throw new LocationServiceUnavailableException(
+                    "Location service unavailable while fetching descendants", ex);
+        }
+    }
+
+    /**
      * Consumer-side projection of the pos-location topology contract.
      * Fields pinned by the CAP-214 #655 contract tests:
      * id, name, type, status, parentStorageLocationId.
      */
     public record StorageLocationNode(UUID id, String name, String type, String status, UUID parentStorageLocationId) {}
+
+    /**
+     * Consumer-side projection of the pos-location descendants contract
+     * (CAP-214 #655): id, name, code, status, parentId, depth.
+     */
+    public record LocationDescendant(UUID id, String name, String code, String status, UUID parentId, int depth) {}
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/client/StorageLocationTopologyClient.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/client/StorageLocationTopologyClient.java
@@ -1,0 +1,70 @@
+package com.positivity.inventory.internal.client;
+
+import com.positivity.inventory.internal.exception.LocationNotFoundException;
+import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Client for fetching the storage-location topology of a site from
+ * pos-location (source of truth, ADR-0016). Consumes the unpaginated
+ * topology contract introduced by CAP-214 #655.
+ */
+@Component
+public class StorageLocationTopologyClient {
+
+    private static final Logger log = LoggerFactory.getLogger(StorageLocationTopologyClient.class);
+
+    private final RestClient restClient;
+
+    public StorageLocationTopologyClient(
+            @Qualifier("loadBalancedRestClientBuilder") RestClient.Builder restClientBuilder,
+            @Value("${pos.location.service-id:location}") String locationServiceId) {
+        this.restClient =
+                restClientBuilder.baseUrl("http://" + locationServiceId).build();
+    }
+
+    /**
+     * Fetches the complete flat storage-location topology for a site.
+     *
+     * @throws LocationNotFoundException when pos-location reports the site does not exist
+     * @throws LocationServiceUnavailableException when pos-location is unreachable or errors
+     */
+    @NonNull
+    public List<StorageLocationNode> fetchSiteTopology(@NonNull UUID siteId) {
+        try {
+            List<StorageLocationNode> nodes = restClient
+                    .get()
+                    .uri("/v1/locations/{siteId}/storage-locations/topology", siteId)
+                    .header("X-User", "pos-inventory")
+                    .header("X-Authorities", "location:read")
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<>() {});
+            return nodes == null ? List.of() : nodes;
+        } catch (HttpClientErrorException.NotFound ex) {
+            throw new LocationNotFoundException(siteId);
+        } catch (HttpServerErrorException | ResourceAccessException ex) {
+            log.warn("pos-location topology fetch failed for site {}: {}", siteId, ex.getMessage());
+            throw new LocationServiceUnavailableException(
+                    "Location service unavailable while fetching site topology", ex);
+        }
+    }
+
+    /**
+     * Consumer-side projection of the pos-location topology contract.
+     * Fields pinned by the CAP-214 #655 contract tests:
+     * id, name, type, status, parentStorageLocationId.
+     */
+    public record StorageLocationNode(UUID id, String name, String type, String status, UUID parentStorageLocationId) {}
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -25,6 +25,7 @@ import com.positivity.inventory.internal.exception.ReceivingSessionNotFoundExcep
 import com.positivity.inventory.internal.exception.RecountLimitExceededException;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.exception.ReturnQuantityExceededException;
+import com.positivity.inventory.internal.exception.RollupExpansionTooLargeException;
 import com.positivity.inventory.internal.exception.SourceDocumentAlreadyReceivedException;
 import com.positivity.inventory.internal.exception.SourceDocumentNotFoundException;
 import com.positivity.inventory.internal.exception.TaskNotFoundException;
@@ -129,6 +130,11 @@ public class InventoryGlobalExceptionHandler {
     @ExceptionHandler(LocationServiceUnavailableException.class)
     public ResponseEntity<ApiError> handleLocationServiceUnavailable(LocationServiceUnavailableException ex) {
         return build(HttpStatus.SERVICE_UNAVAILABLE, "LOCATION_SERVICE_UNAVAILABLE", ex.getMessage());
+    }
+
+    @ExceptionHandler(RollupExpansionTooLargeException.class)
+    public ResponseEntity<ApiError> handleRollupExpansionTooLarge(RollupExpansionTooLargeException ex) {
+        return build(HttpStatus.valueOf(422), "ROLLUP_EXPANSION_TOO_LARGE", ex.getMessage());
     }
 
     @ExceptionHandler(InvalidCountQuantityException.class)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import com.positivity.inventory.internal.exception.InvalidPoReferenceException;
 import com.positivity.inventory.internal.exception.LocationAtCapacityException;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.LocationNotValidForSkuException;
+import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
 import com.positivity.inventory.internal.exception.NoOnHandAtSourceLocationException;
 import com.positivity.inventory.internal.exception.OverReceiptNotPermittedException;
 import com.positivity.inventory.internal.exception.PartMatchPermissionException;
@@ -123,6 +124,11 @@ public class InventoryGlobalExceptionHandler {
     })
     public ResponseEntity<ApiError> handleResourceNotFound(RuntimeException ex) {
         return build(HttpStatus.NOT_FOUND, NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(LocationServiceUnavailableException.class)
+    public ResponseEntity<ApiError> handleLocationServiceUnavailable(LocationServiceUnavailableException ex) {
+        return build(HttpStatus.SERVICE_UNAVAILABLE, "LOCATION_SERVICE_UNAVAILABLE", ex.getMessage());
     }
 
     @ExceptionHandler(InvalidCountQuantityException.class)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryRollupController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryRollupController.java
@@ -1,0 +1,105 @@
+package com.positivity.inventory.internal.controller;
+
+import com.positivity.inventory.internal.dto.rollup.LocationInventoryRollupResponse;
+import com.positivity.inventory.service.LocationInventoryRollupService;
+import com.positivity.shared.error.ApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/inventory/locations")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Inventory Rollup", description = "Inventory quantities rolled up along the storage-location hierarchy")
+public class LocationInventoryRollupController {
+
+    private static final String EXPAND_TREE = "tree";
+
+    private final LocationInventoryRollupService locationInventoryRollupService;
+
+    @GetMapping("/{locationId}/inventory-rollup")
+    @PreAuthorize("hasAuthority('inventory:on_hand:view')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:on_hand:view"})
+    @Operation(
+            operationId = "getLocationInventoryRollup",
+            summary = "Get parent-location inventory rollup",
+            description = "Aggregates inventory totals across all descendant sites of a parent location"
+                    + " (building/place/region) along a typed parent chain (default PHYSICAL, ADR-0016)."
+                    + " Returns per-site summaries plus a grand total. With expand=tree, each site entry"
+                    + " inlines its full storage-location rollup tree; expansion is rejected with 422 when"
+                    + " the descendant site count exceeds the configured cap"
+                    + " (pos.inventory.rollup.expand-site-cap, default 25).",
+            tags = {"Inventory Rollup"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Rollup returned (empty sites list when the location has no descendants)",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LocationInventoryRollupResponse.class)))
+    @ApiResponse(responseCode = "400", description = "Invalid parameters (unknown parentType, bad expand value)")
+    @ApiResponse(
+            responseCode = "403",
+            description = "User lacks required on-hand view authority",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Location not found",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "expand=tree rejected: descendant site count exceeds the configured cap",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "503",
+            description = "Location service unavailable; retry later",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<LocationInventoryRollupResponse> getLocationInventoryRollup(
+            @Parameter(description = "Parent location identifier (building/place/region)", required = true)
+                    @PathVariable
+                    UUID locationId,
+            @Parameter(description = "Typed parent chain to walk (default PHYSICAL)") @RequestParam(required = false)
+                    String parentType,
+            @Parameter(description = "Optional product SKU filter") @RequestParam(required = false) String sku,
+            @Parameter(description = "Set to 'tree' to inline each site's full rollup tree")
+                    @RequestParam(required = false)
+                    String expand,
+            @Parameter(description = "Maximum per-site tree depth (only with expand=tree)")
+                    @RequestParam(required = false)
+                    @Min(1)
+                    Integer depth,
+            @Parameter(description = "Include all-zero tree nodes (only with expand=tree)")
+                    @RequestParam(required = false, defaultValue = "false")
+                    boolean includeEmpty) {
+        boolean expandTree = resolveExpand(expand);
+        return ResponseEntity.ok(locationInventoryRollupService.getLocationInventoryRollup(
+                locationId, parentType, sku, expandTree, depth, includeEmpty));
+    }
+
+    private boolean resolveExpand(String expand) {
+        if (expand == null || expand.isBlank()) {
+            return false;
+        }
+        if (EXPAND_TREE.equalsIgnoreCase(expand.trim())) {
+            return true;
+        }
+        throw new IllegalArgumentException("Unsupported expand value '" + expand + "'; only 'tree' is supported");
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryRollupController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryRollupController.java
@@ -45,7 +45,9 @@ public class LocationInventoryRollupController {
                     + " Returns per-site summaries plus a grand total. With expand=tree, each site entry"
                     + " inlines its full storage-location rollup tree; expansion is rejected with 422 when"
                     + " the descendant site count exceeds the configured cap"
-                    + " (pos.inventory.rollup.expand-site-cap, default 25).",
+                    + " (pos.inventory.rollup.expand-site-cap, default 25). Without expand, summaries are computed"
+                    + " sequentially for every descendant regardless of count; prefer narrow parent locations"
+                    + " for large hierarchies.",
             tags = {"Inventory Rollup"})
     @ApiResponse(
             responseCode = "200",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReservationController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReservationController.java
@@ -83,7 +83,10 @@ public class ReservationController {
     @PreAuthorize("hasAuthority('inventory:adjustment:create')")
     @Operation(
             summary = "Promote allocation to hard",
-            description = "Promotes an existing allocation to HARD state when ATP is sufficient",
+            description = "Promotes an existing allocation to HARD state when ATP is sufficient. Requires a"
+                    + " storageLocationId; the hardened allocation is pinned to that storage location and an"
+                    + " ALLOCATION_CREATED ledger event is recorded against it. A repeat promote of an"
+                    + " already-HARD allocation keeps its original location and writes no duplicate event.",
             tags = {"Inventory Reservations"})
     @ApiResponse(
             responseCode = "200",
@@ -102,7 +105,7 @@ public class ReservationController {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @ApiResponse(
             responseCode = "404",
-            description = "Allocation or reservation not found",
+            description = "Allocation, reservation, or storage location not found",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @ApiResponse(
             responseCode = "422",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/SiteInventoryRollupController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/SiteInventoryRollupController.java
@@ -1,0 +1,79 @@
+package com.positivity.inventory.internal.controller;
+
+import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
+import com.positivity.inventory.service.SiteInventoryRollupService;
+import com.positivity.shared.error.ApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/inventory/sites")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Inventory Rollup", description = "Inventory quantities rolled up along the storage-location hierarchy")
+public class SiteInventoryRollupController {
+
+    private final SiteInventoryRollupService siteInventoryRollupService;
+
+    @GetMapping("/{siteId}/inventory-rollup")
+    @PreAuthorize("hasAuthority('inventory:on_hand:view')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:on_hand:view"})
+    @Operation(
+            operationId = "getSiteInventoryRollup",
+            summary = "Get site inventory rollup",
+            description = "Returns on-hand, allocated, and available quantities grouped and subtotaled along the"
+                    + " storage-location hierarchy of a site. Each node carries its own quantities and the rolled-up"
+                    + " sum of itself plus all descendants. Topology comes from pos-location at request time"
+                    + " (ADR-0016). Ledger rows at location ids unknown to the site are excluded in v1 (no"
+                    + " 'unassigned' bucket).",
+            tags = {"Inventory Rollup"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Rollup returned (empty nodes list when the site has no storage locations)",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SiteInventoryRollupResponse.class)))
+    @ApiResponse(responseCode = "400", description = "Invalid parameters")
+    @ApiResponse(
+            responseCode = "403",
+            description = "User lacks required on-hand view authority",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Site not found",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "503",
+            description = "Location service unavailable; retry later",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<SiteInventoryRollupResponse> getSiteInventoryRollup(
+            @Parameter(description = "Site (Location) identifier", required = true) @PathVariable UUID siteId,
+            @Parameter(description = "Optional product SKU filter") @RequestParam(required = false) String sku,
+            @Parameter(description = "Maximum tree depth to return (1 = root storage locations only)")
+                    @RequestParam(required = false)
+                    @Min(1)
+                    Integer depth,
+            @Parameter(description = "Include storage locations with zero on-hand and zero allocations")
+                    @RequestParam(required = false, defaultValue = "false")
+                    boolean includeEmpty) {
+        return ResponseEntity.ok(siteInventoryRollupService.getSiteInventoryRollup(siteId, sku, depth, includeEmpty));
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/PromoteAllocationRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/PromoteAllocationRequest.java
@@ -1,5 +1,8 @@
 package com.positivity.inventory.internal.dto.reservation;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,5 +12,17 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PromoteAllocationRequest {
 
+    /**
+     * Storage location where the hardened allocation pins physical stock.
+     * Required: a HARD allocation must be location-attributable so the
+     * ALLOCATION_CREATED ledger event can be recorded against it (CAP-218 #656).
+     */
+    @NotNull
+    @Schema(
+            description = "Storage location identifier where the hardened allocation pins stock",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID storageLocationId;
+
+    @Schema(description = "Reason the allocation is being hardened")
     private String hardenedReason;
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/LocationInventoryRollupResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/LocationInventoryRollupResponse.java
@@ -1,0 +1,28 @@
+package com.positivity.inventory.internal.dto.rollup;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Parent-location inventory rollup: site totals aggregated across all
+ * descendant sites of a location along a typed parent chain (CAP-218 #659).
+ */
+public record LocationInventoryRollupResponse(
+        @Schema(
+                description = "Parent location identifier (building/place/region)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID locationId,
+
+        @Schema(
+                description = "Parent chain type used for descendant resolution",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String parentType,
+
+        @Schema(description = "Grand total across all descendant sites", requiredMode = Schema.RequiredMode.REQUIRED)
+        RollupQuantities totals,
+
+        @Schema(
+                description = "Per-site summaries (trees inlined with expand=tree)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<SiteRollupSummary> sites) {}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/RollupQuantities.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/RollupQuantities.java
@@ -1,0 +1,35 @@
+package com.positivity.inventory.internal.dto.rollup;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Quantity triple used at every rollup node. {@code available} is
+ * {@code onHand - allocated} and is intentionally NOT clamped — negative
+ * available is a real over-allocation signal (CAP-218 #658).
+ */
+public record RollupQuantities(
+        @Schema(description = "On-hand quantity", requiredMode = Schema.RequiredMode.REQUIRED)
+        long onHand,
+
+        @Schema(description = "Outstanding allocated quantity", requiredMode = Schema.RequiredMode.REQUIRED)
+        long allocated,
+
+        @Schema(
+                description = "Available to promise: onHand - allocated (may be negative)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        long available) {
+
+    public static final RollupQuantities ZERO = new RollupQuantities(0, 0, 0);
+
+    public static RollupQuantities of(long onHand, long allocated) {
+        return new RollupQuantities(onHand, allocated, onHand - allocated);
+    }
+
+    public RollupQuantities plus(RollupQuantities other) {
+        return of(onHand + other.onHand, allocated + other.allocated);
+    }
+
+    public boolean isEmpty() {
+        return onHand == 0 && allocated == 0;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/SiteInventoryRollupResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/SiteInventoryRollupResponse.java
@@ -1,0 +1,27 @@
+package com.positivity.inventory.internal.dto.rollup;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Site inventory rollup: quantities grouped and subtotaled along the
+ * storage-location hierarchy (CAP-218 #658).
+ *
+ * <p>Ledger rows recorded against location ids that pos-location does not
+ * list under this site (orphans) are excluded from this response in v1; an
+ * {@code unassigned} bucket is deferred to v2.
+ */
+public record SiteInventoryRollupResponse(
+        @Schema(description = "Site (Location) identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID siteId,
+
+        @Schema(
+                description = "Site-wide totals (sum of root nodes' rolledUp quantities)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        RollupQuantities totals,
+
+        @Schema(
+                description = "Root storage locations of the site topology",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<StorageLocationRollupNode> nodes) {}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/SiteRollupSummary.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/SiteRollupSummary.java
@@ -1,0 +1,26 @@
+package com.positivity.inventory.internal.dto.rollup;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Per-site entry of a parent-location rollup (CAP-218 #659). {@code nodes}
+ * is present only when {@code expand=tree} was requested.
+ */
+public record SiteRollupSummary(
+        @Schema(description = "Site (Location) identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID siteId,
+
+        @Schema(description = "Site name from the location hierarchy")
+        String siteName,
+
+        @Schema(
+                description = "Site totals (sum of the site's root storage locations)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        RollupQuantities totals,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "Full storage-location rollup tree; present only with expand=tree")
+        List<StorageLocationRollupNode> nodes) {}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/StorageLocationRollupNode.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/StorageLocationRollupNode.java
@@ -1,0 +1,32 @@
+package com.positivity.inventory.internal.dto.rollup;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * One storage location in the site rollup tree.
+ *
+ * <p>{@code own} is the quantity recorded directly against this storage
+ * location; {@code rolledUp} is {@code own} plus all descendants' {@code own}.
+ */
+public record StorageLocationRollupNode(
+        @Schema(description = "Storage location identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID storageLocationId,
+
+        @Schema(description = "Storage location name") String name,
+
+        @Schema(description = "Storage location type (e.g. FLOOR, SHELF, BIN)")
+        String type,
+
+        @Schema(description = "Storage location status") String status,
+
+        @Schema(
+                description = "Quantities recorded directly at this location",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        RollupQuantities own,
+
+        @Schema(description = "Own quantities plus all descendants", requiredMode = Schema.RequiredMode.REQUIRED)
+        RollupQuantities rolledUp,
+
+        @Schema(description = "Child storage locations") List<StorageLocationRollupNode> children) {}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryLedgerEntry.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryLedgerEntry.java
@@ -9,6 +9,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -25,7 +26,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
  * Immutable ledger entry representing a single inventory transaction.
  */
 @Entity
-@Table(name = "inventory_ledger_entry")
+@Table(
+        name = "inventory_ledger_entry",
+        indexes = {@Index(name = "idx_inventory_ledger_entry_location_event", columnList = "location_id, event_type")})
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/InventoryLedgerEventType.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/InventoryLedgerEventType.java
@@ -151,6 +151,11 @@ public enum InventoryLedgerEventType {
      * Hard allocation created for picking/packing.
      * Direction: NEUTRAL
      * Affects On-Hand: NO (affects ATP only)
+     *
+     * <p>Written when an allocation is promoted to HARD with an assigned storage
+     * location. Invariant (CAP-218 #656): per allocation, CREATED quantities −
+     * RELEASED quantities ∈ {0, allocatedQuantity}; a repeat promote must not
+     * write a duplicate CREATED.
      */
     ALLOCATION_CREATED(EventDirection.NEUTRAL, false),
 
@@ -158,6 +163,11 @@ public enum InventoryLedgerEventType {
      * Hard allocation cancelled or released.
      * Direction: NEUTRAL
      * Affects On-Hand: NO (affects ATP only)
+     *
+     * <p>Written when a located HARD allocation is released. Invariant
+     * (CAP-218 #656): whichever flow posts {@link #WORKORDER_CONSUMPTION} for
+     * allocated stock MUST also close the allocation with ALLOCATION_RELEASED,
+     * otherwise outstanding allocations double-count consumed stock.
      */
     ALLOCATION_RELEASED(EventDirection.NEUTRAL, false),
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LocationServiceUnavailableException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LocationServiceUnavailableException.java
@@ -1,0 +1,12 @@
+package com.positivity.inventory.internal.exception;
+
+/**
+ * Raised when pos-location cannot be reached or returns a server error while
+ * pos-inventory needs authoritative topology data. Rollup reads must never
+ * fabricate partial topology (CAP-218 #658).
+ */
+public class LocationServiceUnavailableException extends RuntimeException {
+    public LocationServiceUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/RollupExpansionTooLargeException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/RollupExpansionTooLargeException.java
@@ -1,0 +1,13 @@
+package com.positivity.inventory.internal.exception;
+
+/**
+ * Raised when {@code expand=tree} is requested on a parent-location rollup
+ * whose descendant site count exceeds the configured cap — prevents unbounded
+ * fan-out of topology fetches and grouped queries (CAP-218 #659).
+ */
+public class RollupExpansionTooLargeException extends RuntimeException {
+    public RollupExpansionTooLargeException(int siteCount, int cap) {
+        super("expand=tree rejected: " + siteCount + " descendant sites exceed the cap of " + cap
+                + "; call the per-site rollup endpoint instead");
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
@@ -3,9 +3,12 @@ package com.positivity.inventory.internal.repository;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -104,5 +107,102 @@ public interface InventoryLedgerEntryRepository
         String getStockItemId();
 
         Long getOnHandQuantity();
+    }
+
+    /**
+     * Maximum number of location ids passed to a single {@code IN} clause.
+     */
+    int LOCATION_ID_CHUNK_SIZE = 1000;
+
+    @Query("""
+                        SELECT e.locationId AS locationId, COALESCE(SUM(e.changeInQuantity), 0) AS quantity
+                        FROM InventoryLedgerEntry e
+                        WHERE e.locationId IN :locationIds
+                          AND e.eventType IN :eventTypes
+                        GROUP BY e.locationId
+                        """)
+    List<LocationQuantity> sumQuantityByLocation(
+            @Param("locationIds") Collection<UUID> locationIds,
+            @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
+
+    @Query("""
+                        SELECT e.locationId AS locationId, COALESCE(SUM(e.changeInQuantity), 0) AS quantity
+                        FROM InventoryLedgerEntry e
+                        WHERE e.stockItemId = :stockItemId
+                          AND e.locationId IN :locationIds
+                          AND e.eventType IN :eventTypes
+                        GROUP BY e.locationId
+                        """)
+    List<LocationQuantity> sumQuantityByLocationForSku(
+            @Param("stockItemId") String stockItemId,
+            @Param("locationIds") Collection<UUID> locationIds,
+            @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
+
+    /**
+     * Chunk-safe grouped sum of {@code changeInQuantity} per location for the given event types.
+     *
+     * <p>Locations without matching ledger entries are absent from the result (treat as 0).
+     * An empty {@code locationIds} collection short-circuits to an empty map without executing SQL.
+     */
+    default Map<UUID, Long> sumQuantityByLocationChunked(
+            Collection<UUID> locationIds, Collection<InventoryLedgerEventType> eventTypes) {
+        if (eventTypes == null || eventTypes.isEmpty()) {
+            return Map.of();
+        }
+        return sumChunked(locationIds, chunk -> sumQuantityByLocation(chunk, eventTypes));
+    }
+
+    /**
+     * Chunk-safe grouped sum of {@code changeInQuantity} per location for a single stock item.
+     *
+     * <p>Same semantics as {@link #sumQuantityByLocationChunked(Collection, Collection)}.
+     */
+    default Map<UUID, Long> sumQuantityByLocationForSkuChunked(
+            String stockItemId, Collection<UUID> locationIds, Collection<InventoryLedgerEventType> eventTypes) {
+        if (eventTypes == null || eventTypes.isEmpty()) {
+            return Map.of();
+        }
+        return sumChunked(locationIds, chunk -> sumQuantityByLocationForSku(stockItemId, chunk, eventTypes));
+    }
+
+    /**
+     * Outstanding allocations per location: sum(ALLOCATION_CREATED) - sum(ALLOCATION_RELEASED).
+     *
+     * <p>Mirrors the single-location semantics of
+     * {@code LocationInventoryInquiryServiceImpl#calculateOutstandingAllocations}. Locations without
+     * allocation entries are absent from the result (treat as 0).
+     */
+    default Map<UUID, Long> calculateOutstandingAllocationsByLocation(Collection<UUID> locationIds) {
+        Map<UUID, Long> created =
+                sumQuantityByLocationChunked(locationIds, List.of(InventoryLedgerEventType.ALLOCATION_CREATED));
+        Map<UUID, Long> released =
+                sumQuantityByLocationChunked(locationIds, List.of(InventoryLedgerEventType.ALLOCATION_RELEASED));
+
+        Map<UUID, Long> outstanding = new HashMap<>(created);
+        released.forEach((locationId, quantity) -> outstanding.merge(locationId, -quantity, Long::sum));
+        return Map.copyOf(outstanding);
+    }
+
+    private Map<UUID, Long> sumChunked(
+            Collection<UUID> locationIds, Function<List<UUID>, List<LocationQuantity>> query) {
+        if (locationIds == null || locationIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<UUID> distinctIds = locationIds.stream().distinct().toList();
+        Map<UUID, Long> totals = new HashMap<>();
+        for (int start = 0; start < distinctIds.size(); start += LOCATION_ID_CHUNK_SIZE) {
+            List<UUID> chunk = distinctIds.subList(start, Math.min(start + LOCATION_ID_CHUNK_SIZE, distinctIds.size()));
+            for (LocationQuantity row : query.apply(chunk)) {
+                totals.merge(row.getLocationId(), row.getQuantity(), Long::sum);
+            }
+        }
+        return Map.copyOf(totals);
+    }
+
+    interface LocationQuantity {
+        UUID getLocationId();
+
+        long getQuantity();
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
@@ -110,6 +110,22 @@ public interface InventoryLedgerEntryRepository
     }
 
     /**
+     * Sum of {@code changeInQuantity} for one event type attributed to a source
+     * transaction (allocation ledger events carry the allocation id as
+     * {@code sourceTransactionId}). Used to derive how much of an allocation
+     * has already been released (CAP-218 #662).
+     */
+    @Query("""
+                        SELECT COALESCE(SUM(e.changeInQuantity), 0)
+                        FROM InventoryLedgerEntry e
+                        WHERE e.sourceTransactionId = :sourceTransactionId
+                          AND e.eventType = :eventType
+                        """)
+    int sumChangeBySourceTransactionIdAndEventType(
+            @Param("sourceTransactionId") String sourceTransactionId,
+            @Param("eventType") InventoryLedgerEventType eventType);
+
+    /**
      * Maximum number of location ids passed to a single {@code IN} clause.
      */
     int LOCATION_ID_CHUNK_SIZE = 1000;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
@@ -3,27 +3,48 @@ package com.positivity.inventory.internal.service;
 import com.positivity.inventory.internal.dto.consumption.ConsumeItemLine;
 import com.positivity.inventory.internal.dto.consumption.ConsumeItemsRequest;
 import com.positivity.inventory.internal.dto.consumption.ConsumptionResponse;
+import com.positivity.inventory.internal.entity.AllocationEntity;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.entity.PickTaskEntity;
+import com.positivity.inventory.internal.entity.ReservationEntity;
+import com.positivity.inventory.internal.enums.AllocationState;
+import com.positivity.inventory.internal.enums.AllocationStatus;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.enums.PickTaskStatus;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.exception.WorkorderConsumptionException;
+import com.positivity.inventory.internal.repository.AllocationRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.PickTaskRepository;
+import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.service.ConsumptionService;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.shared.id.UUIDv7Generator;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Consumes picked items to a workorder, posting {@code WORKORDER_CONSUMPTION}
+ * ledger entries and closing the originating allocations with
+ * {@code ALLOCATION_RELEASED} in the same transaction (CAP-218 #662).
+ *
+ * <p>Allocations are resolved deterministically: pick task →
+ * {@code workorderLineId} → reservation → located HARD allocations. Consumed
+ * quantity is applied to allocations oldest-first; each portion releases at
+ * most the allocation's un-released remainder (derived from the ledger via
+ * {@code sourceTransactionId}), preserving the per-allocation
+ * CREATED − RELEASED ∈ {0, allocatedQuantity} invariant. Consumption of
+ * unallocated stock writes no allocation events.
+ */
 @Service
 @Transactional
 public class ConsumptionServiceImpl implements ConsumptionService {
@@ -31,14 +52,20 @@ public class ConsumptionServiceImpl implements ConsumptionService {
 
     private final PickTaskRepository pickTaskRepository;
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+    private final ReservationRepository reservationRepository;
+    private final AllocationRepository allocationRepository;
 
     public ConsumptionServiceImpl(
             PickTaskRepository pickTaskRepository,
             InventoryLedgerEntryRepository inventoryLedgerEntryRepository,
+            ReservationRepository reservationRepository,
+            AllocationRepository allocationRepository,
             Clock clock) {
         this.clock = clock;
         this.pickTaskRepository = pickTaskRepository;
         this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
+        this.reservationRepository = reservationRepository;
+        this.allocationRepository = allocationRepository;
     }
 
     @Override
@@ -65,7 +92,8 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                         "Requested quantity exceeds picked quantity for task: " + item.getPickTaskId());
             }
 
-            entriesToSave.add(buildLedgerEntry(request, item));
+            entriesToSave.add(buildConsumptionEntry(request, item));
+            entriesToSave.addAll(closeAllocations(request, item, task));
         }
 
         List<InventoryLedgerEntry> savedEntries = inventoryLedgerEntryRepository.saveAll(entriesToSave);
@@ -86,7 +114,74 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                 ledgerEntryIds);
     }
 
-    private InventoryLedgerEntry buildLedgerEntry(ConsumeItemsRequest request, ConsumeItemLine item) {
+    /**
+     * Closes located HARD allocations for the consumed quantity, oldest first.
+     * Returns the {@code ALLOCATION_RELEASED} entries to persist; transitions
+     * fully released allocations to {@link AllocationStatus#RELEASED}.
+     */
+    private List<InventoryLedgerEntry> closeAllocations(
+            ConsumeItemsRequest request, ConsumeItemLine item, PickTaskEntity task) {
+        if (task.getWorkorderLineId() == null) {
+            return List.of();
+        }
+        Optional<ReservationEntity> reservation =
+                reservationRepository.findByWorkorderLineId(task.getWorkorderLineId());
+        if (reservation.isEmpty()) {
+            return List.of();
+        }
+
+        List<AllocationEntity> locatedHard = allocationRepository.findByReservation(reservation.get()).stream()
+                .filter(allocation -> allocation.getAllocationState() == AllocationState.HARD)
+                .filter(allocation -> allocation.getLocationId() != null)
+                .filter(allocation -> allocation.getStatus() != AllocationStatus.RELEASED)
+                .sorted(Comparator.comparing(
+                        AllocationEntity::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+        if (locatedHard.isEmpty()) {
+            return List.of();
+        }
+
+        UUID stockItemId = reservation.get().getStockItemId();
+        int netOnHand = Optional.ofNullable(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
+                .orElse(0);
+
+        List<InventoryLedgerEntry> releases = new ArrayList<>();
+        int remainingToClose = item.getQuantity();
+        for (AllocationEntity allocation : locatedHard) {
+            if (remainingToClose <= 0) {
+                break;
+            }
+            int alreadyReleased = inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                    allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED);
+            int allocationRemaining = allocation.getAllocatedQuantity() - alreadyReleased;
+            if (allocationRemaining <= 0) {
+                continue;
+            }
+
+            int release = Math.min(remainingToClose, allocationRemaining);
+            releases.add(InventoryLedgerEntry.builder()
+                    .stockItemId(stockItemId.toString())
+                    .eventType(InventoryLedgerEventType.ALLOCATION_RELEASED)
+                    .changeInQuantity(release)
+                    .quantityAfter(netOnHand)
+                    .transactionUserId(SecurityContextHelper.getCurrentUsernameOrDefault("system"))
+                    .locationId(allocation.getLocationId())
+                    .sourceTransactionId(allocation.getAllocationId().toString())
+                    .notes("Closed by consumption of pick task " + item.getPickTaskId() + " for workorder "
+                            + request.getWorkorderId())
+                    .timestamp(Instant.now(clock))
+                    .build());
+
+            if (release == allocationRemaining) {
+                allocation.setStatus(AllocationStatus.RELEASED);
+                allocationRepository.save(allocation);
+            }
+            remainingToClose -= release;
+        }
+        return releases;
+    }
+
+    private InventoryLedgerEntry buildConsumptionEntry(ConsumeItemsRequest request, ConsumeItemLine item) {
         return InventoryLedgerEntry.builder()
                 .stockItemId(item.getSkuId() == null ? "" : item.getSkuId().toString())
                 .eventType(InventoryLedgerEventType.WORKORDER_CONSUMPTION)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
@@ -24,7 +24,9 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -77,6 +79,10 @@ public class ConsumptionServiceImpl implements ConsumptionService {
         List<ConsumeItemLine> items = request.getItems() == null ? List.of() : request.getItems();
 
         List<InventoryLedgerEntry> entriesToSave = new ArrayList<>();
+        // Releases accumulated in this request are not yet visible to the
+        // ledger-derived "already released" lookup; track them per allocation
+        // so multi-item requests cannot over-release (PR #661 re-review finding 1).
+        Map<UUID, Integer> releasedInBatch = new HashMap<>();
         for (ConsumeItemLine item : items) {
             PickTaskEntity task = pickTaskRepository
                     .findById(item.getPickTaskId())
@@ -93,7 +99,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
             }
 
             entriesToSave.add(buildConsumptionEntry(request, item));
-            entriesToSave.addAll(closeAllocations(request, item, task));
+            entriesToSave.addAll(closeAllocations(request, item, task, releasedInBatch));
         }
 
         List<InventoryLedgerEntry> savedEntries = inventoryLedgerEntryRepository.saveAll(entriesToSave);
@@ -120,7 +126,10 @@ public class ConsumptionServiceImpl implements ConsumptionService {
      * fully released allocations to {@link AllocationStatus#RELEASED}.
      */
     private List<InventoryLedgerEntry> closeAllocations(
-            ConsumeItemsRequest request, ConsumeItemLine item, PickTaskEntity task) {
+            ConsumeItemsRequest request,
+            ConsumeItemLine item,
+            PickTaskEntity task,
+            Map<UUID, Integer> releasedInBatch) {
         if (task.getWorkorderLineId() == null) {
             return List.of();
         }
@@ -135,7 +144,9 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                 .filter(allocation -> allocation.getLocationId() != null)
                 .filter(allocation -> allocation.getStatus() != AllocationStatus.RELEASED)
                 .sorted(Comparator.comparing(
-                        AllocationEntity::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                                AllocationEntity::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(
+                                AllocationEntity::getAllocationId, Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList();
         if (locatedHard.isEmpty()) {
             return List.of();
@@ -147,12 +158,14 @@ public class ConsumptionServiceImpl implements ConsumptionService {
 
         List<InventoryLedgerEntry> releases = new ArrayList<>();
         int remainingToClose = item.getQuantity();
+        int totalReleasedForReservation = 0;
         for (AllocationEntity allocation : locatedHard) {
             if (remainingToClose <= 0) {
                 break;
             }
             int alreadyReleased = inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
-                    allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED);
+                            allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED)
+                    + releasedInBatch.getOrDefault(allocation.getAllocationId(), 0);
             int allocationRemaining = allocation.getAllocatedQuantity() - alreadyReleased;
             if (allocationRemaining <= 0) {
                 continue;
@@ -172,11 +185,21 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                     .timestamp(Instant.now(clock))
                     .build());
 
+            releasedInBatch.merge(allocation.getAllocationId(), release, Integer::sum);
             if (release == allocationRemaining) {
                 allocation.setStatus(AllocationStatus.RELEASED);
                 allocationRepository.save(allocation);
             }
             remainingToClose -= release;
+            totalReleasedForReservation += release;
+        }
+        if (totalReleasedForReservation > 0) {
+            // PR #661 re-review finding 2: AllocationReallocationServiceImpl pools
+            // reservation.allocatedQuantity as reallocatable stock; consumed stock
+            // is physically gone and must leave that pool.
+            ReservationEntity owning = reservation.get();
+            owning.setAllocatedQuantity(Math.max(0, owning.getAllocatedQuantity() - totalReleasedForReservation));
+            reservationRepository.save(owning);
         }
         return releases;
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryRollupServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryRollupServiceImpl.java
@@ -1,0 +1,98 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.client.StorageLocationTopologyClient;
+import com.positivity.inventory.internal.client.StorageLocationTopologyClient.LocationDescendant;
+import com.positivity.inventory.internal.dto.rollup.LocationInventoryRollupResponse;
+import com.positivity.inventory.internal.dto.rollup.RollupQuantities;
+import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
+import com.positivity.inventory.internal.dto.rollup.SiteRollupSummary;
+import com.positivity.inventory.internal.exception.RollupExpansionTooLargeException;
+import com.positivity.inventory.service.LocationInventoryRollupService;
+import com.positivity.inventory.service.SiteInventoryRollupService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Parent-location rollup (CAP-218 #659): resolves descendant locations via
+ * pos-location's typed-parent descendants contract, computes the site rollup
+ * per descendant, and aggregates a grand total. Descendants with no storage
+ * locations contribute zero totals.
+ *
+ * <p>{@code expand=tree} fan-out is capped: every expanded site costs one
+ * topology fetch plus grouped ledger queries, so over-cap requests are
+ * rejected with 422 rather than degrading the service.
+ */
+@Service
+public class LocationInventoryRollupServiceImpl implements LocationInventoryRollupService {
+
+    private static final String DEFAULT_PARENT_TYPE = "PHYSICAL";
+
+    /**
+     * Consumer-side pin of pos-location's {@code ParentType} value set
+     * (ADR-0016). Kept in sync via the CAP-214 contract guide.
+     */
+    private static final Set<String> VALID_PARENT_TYPES = Set.of(
+            "HOME_OFFICE", "HEADQUARTERS", "REGION", "DISTRICT", "PHYSICAL", "ORGANIZATIONAL", "FINANCIAL", "SHIPPING");
+
+    private final StorageLocationTopologyClient topologyClient;
+    private final SiteInventoryRollupService siteInventoryRollupService;
+    private final int expandSiteCap;
+
+    public LocationInventoryRollupServiceImpl(
+            StorageLocationTopologyClient topologyClient,
+            SiteInventoryRollupService siteInventoryRollupService,
+            @Value("${pos.inventory.rollup.expand-site-cap:25}") int expandSiteCap) {
+        this.topologyClient = topologyClient;
+        this.siteInventoryRollupService = siteInventoryRollupService;
+        this.expandSiteCap = expandSiteCap;
+    }
+
+    @Override
+    @NonNull
+    public LocationInventoryRollupResponse getLocationInventoryRollup(
+            @NonNull UUID locationId,
+            @Nullable String parentType,
+            @Nullable String sku,
+            boolean expandTree,
+            @Nullable Integer depth,
+            boolean includeEmpty) {
+        String resolvedParentType = resolveParentType(parentType);
+
+        List<LocationDescendant> descendants = topologyClient.fetchDescendants(locationId, resolvedParentType);
+
+        if (expandTree && descendants.size() > expandSiteCap) {
+            throw new RollupExpansionTooLargeException(descendants.size(), expandSiteCap);
+        }
+
+        List<SiteRollupSummary> sites = new ArrayList<>(descendants.size());
+        RollupQuantities grandTotal = RollupQuantities.ZERO;
+        for (LocationDescendant descendant : descendants) {
+            SiteInventoryRollupResponse siteRollup =
+                    siteInventoryRollupService.getSiteInventoryRollup(descendant.id(), sku, depth, includeEmpty);
+            grandTotal = grandTotal.plus(siteRollup.totals());
+            sites.add(new SiteRollupSummary(
+                    descendant.id(), descendant.name(), siteRollup.totals(), expandTree ? siteRollup.nodes() : null));
+        }
+
+        return new LocationInventoryRollupResponse(locationId, resolvedParentType, grandTotal, List.copyOf(sites));
+    }
+
+    private String resolveParentType(@Nullable String parentType) {
+        if (parentType == null || parentType.isBlank()) {
+            return DEFAULT_PARENT_TYPE;
+        }
+        String normalized = parentType.trim().toUpperCase(Locale.ROOT);
+        if (!VALID_PARENT_TYPES.contains(normalized)) {
+            throw new IllegalArgumentException(
+                    "Unknown parentType '" + parentType + "'; expected one of " + VALID_PARENT_TYPES);
+        }
+        return normalized;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
@@ -13,6 +13,7 @@ import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.enums.ReservationStatus;
 import com.positivity.inventory.internal.exception.InsufficientAtpException;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
+import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.repository.AllocationRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
@@ -84,6 +85,13 @@ public class ReservationServiceImpl implements ReservationService {
         boolean ledgerEventRequired =
                 allocation.getAllocationState() != AllocationState.HARD || allocation.getLocationId() == null;
 
+        // PR #661 review finding 6: surface a conflict instead of silently
+        // discarding a relocation request on an already-located HARD allocation.
+        if (!ledgerEventRequired && !allocation.getLocationId().equals(storageLocationId)) {
+            throw new IllegalStateException("Allocation " + allocationId + " is already hardened at location "
+                    + allocation.getLocationId() + "; relocation via promote is not supported");
+        }
+
         allocation.setAllocationState(AllocationState.HARD);
         if (ledgerEventRequired) {
             allocation.setLocationId(storageLocationId);
@@ -153,8 +161,14 @@ public class ReservationServiceImpl implements ReservationService {
             throw new IllegalArgumentException("storageLocationId is required to promote an allocation to HARD");
         }
 
-        StorageLocationValidationClient.StorageLocationValidation validation =
-                storageLocationValidationClient.getStorageLocationValidation(storageLocationId.toString());
+        StorageLocationValidationClient.StorageLocationValidation validation;
+        try {
+            validation = storageLocationValidationClient.getStorageLocationValidation(storageLocationId.toString());
+        } catch (org.springframework.web.client.HttpServerErrorException
+                | org.springframework.web.client.ResourceAccessException ex) {
+            throw new LocationServiceUnavailableException(
+                    "Location service unavailable while validating storage location", ex);
+        }
         if (!validation.isExists()) {
             throw new LocationNotFoundException(storageLocationId);
         }
@@ -183,6 +197,19 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
     private ReservationEntity updateExistingReservation(ReservationEntity existing, CreateReservationRequest request) {
+        // PR #661 review finding 4: a located HARD allocation has an
+        // ALLOCATION_CREATED ledger event recorded under the current SKU;
+        // changing the SKU afterwards would skew per-SKU CREATED-RELEASED math.
+        if (!existing.getStockItemId().equals(request.getStockItemId())) {
+            boolean hasLocatedHard = allocationRepository.findByReservation(existing).stream()
+                    .anyMatch(allocation -> allocation.getAllocationState() == AllocationState.HARD
+                            && allocation.getLocationId() != null
+                            && allocation.getStatus() != AllocationStatus.RELEASED);
+            if (hasLocatedHard) {
+                throw new IllegalStateException(
+                        "Cannot change stock item on a reservation with located HARD allocations; cancel first");
+            }
+        }
         existing.setStockItemId(request.getStockItemId());
         existing.setRequiredQuantity(request.getRequiredQuantity());
         return reservationRepository.save(existing);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
@@ -1,14 +1,18 @@
 package com.positivity.inventory.internal.service;
 
+import com.positivity.inventory.internal.client.StorageLocationValidationClient;
 import com.positivity.inventory.internal.dto.reservation.CreateReservationRequest;
 import com.positivity.inventory.internal.dto.reservation.PromoteAllocationRequest;
 import com.positivity.inventory.internal.dto.reservation.ReservationResponse;
 import com.positivity.inventory.internal.entity.AllocationEntity;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.entity.ReservationEntity;
 import com.positivity.inventory.internal.enums.AllocationState;
 import com.positivity.inventory.internal.enums.AllocationStatus;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.enums.ReservationStatus;
 import com.positivity.inventory.internal.exception.InsufficientAtpException;
+import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.repository.AllocationRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
@@ -33,6 +37,7 @@ public class ReservationServiceImpl implements ReservationService {
     private final ReservationRepository reservationRepository;
     private final AllocationRepository allocationRepository;
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+    private final StorageLocationValidationClient storageLocationValidationClient;
 
     @Override
     public @NonNull ReservationResponse createOrUpdateReservation(@NonNull CreateReservationRequest request) {
@@ -50,6 +55,8 @@ public class ReservationServiceImpl implements ReservationService {
         AllocationEntity allocation = allocationRepository
                 .findById(allocationId)
                 .orElseThrow(() -> new ResourceNotFoundException("Allocation", allocationId.toString()));
+
+        UUID storageLocationId = requireValidStorageLocation(request);
 
         ReservationEntity reservation = allocation.getReservation();
         UUID stockItemId = reservation.getStockItemId();
@@ -71,11 +78,24 @@ public class ReservationServiceImpl implements ReservationService {
             throw new InsufficientAtpException(allocationId, allocation.getAllocatedQuantity(), availableAtp);
         }
 
+        // A repeat promote of an already-HARD allocation with a recorded location
+        // must not write a duplicate ALLOCATION_CREATED ledger event, and must keep
+        // the location the existing CREATED event was recorded against (CAP-218 #656).
+        boolean ledgerEventRequired =
+                allocation.getAllocationState() != AllocationState.HARD || allocation.getLocationId() == null;
+
         allocation.setAllocationState(AllocationState.HARD);
+        if (ledgerEventRequired) {
+            allocation.setLocationId(storageLocationId);
+        }
         allocation.setHardenedAt(Instant.now(clock));
         allocation.setHardenedBy(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
         allocation.setHardenedReason(request.getHardenedReason());
         allocationRepository.save(allocation);
+
+        if (ledgerEventRequired) {
+            writeAllocationLedgerEntry(InventoryLedgerEventType.ALLOCATION_CREATED, allocation, stockItemId, netOnHand);
+        }
 
         List<AllocationEntity> allocations = allocationRepository.findByReservation(reservation);
         int totalAllocated = allocations.stream()
@@ -98,12 +118,68 @@ public class ReservationServiceImpl implements ReservationService {
                 .orElseThrow(() -> new ResourceNotFoundException("Reservation", workorderLineId.toString()));
 
         List<AllocationEntity> allocations = allocationRepository.findByReservation(reservation);
+
+        // Only located HARD allocations had a matching ALLOCATION_CREATED ledger
+        // event; releasing anything else would break the CREATED − RELEASED
+        // invariant (CAP-218 #656).
+        List<AllocationEntity> ledgerReleasable = allocations.stream()
+                .filter(allocation -> allocation.getStatus() != AllocationStatus.RELEASED)
+                .filter(allocation -> allocation.getAllocationState() == AllocationState.HARD)
+                .filter(allocation -> allocation.getLocationId() != null)
+                .toList();
+
         allocations.forEach(allocation -> allocation.setStatus(AllocationStatus.RELEASED));
         allocationRepository.saveAll(allocations);
+
+        if (!ledgerReleasable.isEmpty()) {
+            int netOnHand = calculateNetOnHand(reservation.getStockItemId());
+            for (AllocationEntity allocation : ledgerReleasable) {
+                writeAllocationLedgerEntry(
+                        InventoryLedgerEventType.ALLOCATION_RELEASED,
+                        allocation,
+                        reservation.getStockItemId(),
+                        netOnHand);
+            }
+        }
 
         reservation.setAllocatedQuantity(0);
         reservation.setStatus(ReservationStatus.CANCELLED);
         reservationRepository.save(reservation);
+    }
+
+    private UUID requireValidStorageLocation(PromoteAllocationRequest request) {
+        UUID storageLocationId = request.getStorageLocationId();
+        if (storageLocationId == null) {
+            throw new IllegalArgumentException("storageLocationId is required to promote an allocation to HARD");
+        }
+
+        StorageLocationValidationClient.StorageLocationValidation validation =
+                storageLocationValidationClient.getStorageLocationValidation(storageLocationId.toString());
+        if (!validation.isExists()) {
+            throw new LocationNotFoundException(storageLocationId);
+        }
+        if (!validation.isActive()) {
+            throw new IllegalArgumentException("Storage location is not active: " + storageLocationId);
+        }
+        return storageLocationId;
+    }
+
+    private void writeAllocationLedgerEntry(
+            InventoryLedgerEventType eventType, AllocationEntity allocation, UUID stockItemId, int netOnHand) {
+        InventoryLedgerEntry entry = InventoryLedgerEntry.builder()
+                .stockItemId(stockItemId.toString())
+                .eventType(eventType)
+                .changeInQuantity(allocation.getAllocatedQuantity())
+                .quantityAfter(netOnHand)
+                .transactionUserId(SecurityContextHelper.getCurrentUsernameOrDefault("system"))
+                .locationId(allocation.getLocationId())
+                .sourceTransactionId(
+                        allocation.getAllocationId() == null
+                                ? null
+                                : allocation.getAllocationId().toString())
+                .timestamp(Instant.now(clock))
+                .build();
+        inventoryLedgerEntryRepository.save(entry);
     }
 
     private ReservationEntity updateExistingReservation(ReservationEntity existing, CreateReservationRequest request) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
@@ -102,7 +102,12 @@ public class ReservationServiceImpl implements ReservationService {
         allocationRepository.save(allocation);
 
         if (ledgerEventRequired) {
-            writeAllocationLedgerEntry(InventoryLedgerEventType.ALLOCATION_CREATED, allocation, stockItemId, netOnHand);
+            writeAllocationLedgerEntry(
+                    InventoryLedgerEventType.ALLOCATION_CREATED,
+                    allocation,
+                    stockItemId,
+                    netOnHand,
+                    allocation.getAllocatedQuantity());
         }
 
         List<AllocationEntity> allocations = allocationRepository.findByReservation(reservation);
@@ -142,11 +147,20 @@ public class ReservationServiceImpl implements ReservationService {
         if (!ledgerReleasable.isEmpty()) {
             int netOnHand = calculateNetOnHand(reservation.getStockItemId());
             for (AllocationEntity allocation : ledgerReleasable) {
-                writeAllocationLedgerEntry(
-                        InventoryLedgerEventType.ALLOCATION_RELEASED,
-                        allocation,
-                        reservation.getStockItemId(),
-                        netOnHand);
+                // CAP-218 #662: partial consumption may already have released
+                // part of this allocation; release only the remainder so the
+                // per-allocation CREATED - RELEASED invariant holds.
+                int alreadyReleased = inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                        allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED);
+                int remaining = allocation.getAllocatedQuantity() - alreadyReleased;
+                if (remaining > 0) {
+                    writeAllocationLedgerEntry(
+                            InventoryLedgerEventType.ALLOCATION_RELEASED,
+                            allocation,
+                            reservation.getStockItemId(),
+                            netOnHand,
+                            remaining);
+                }
             }
         }
 
@@ -179,11 +193,15 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
     private void writeAllocationLedgerEntry(
-            InventoryLedgerEventType eventType, AllocationEntity allocation, UUID stockItemId, int netOnHand) {
+            InventoryLedgerEventType eventType,
+            AllocationEntity allocation,
+            UUID stockItemId,
+            int netOnHand,
+            int quantity) {
         InventoryLedgerEntry entry = InventoryLedgerEntry.builder()
                 .stockItemId(stockItemId.toString())
                 .eventType(eventType)
-                .changeInQuantity(allocation.getAllocatedQuantity())
+                .changeInQuantity(quantity)
                 .quantityAfter(netOnHand)
                 .transactionUserId(SecurityContextHelper.getCurrentUsernameOrDefault("system"))
                 .locationId(allocation.getLocationId())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryQuantityLoader.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryQuantityLoader.java
@@ -1,0 +1,68 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Loads bulk per-location quantity maps inside a single read-only
+ * transaction, keeping the remote topology fetch outside transactional
+ * scope (CAP-218 #658; see #657 handoff note on non-atomic grouped sums).
+ */
+@Component
+public class SiteInventoryQuantityLoader {
+
+    private static final List<InventoryLedgerEventType> ALLOCATION_CREATED_TYPES =
+            List.of(InventoryLedgerEventType.ALLOCATION_CREATED);
+    private static final List<InventoryLedgerEventType> ALLOCATION_RELEASED_TYPES =
+            List.of(InventoryLedgerEventType.ALLOCATION_RELEASED);
+
+    private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+
+    public SiteInventoryQuantityLoader(InventoryLedgerEntryRepository inventoryLedgerEntryRepository) {
+        this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
+    }
+
+    /**
+     * On-hand and outstanding-allocation quantities per location.
+     *
+     * @param sku optional stock item filter; null/blank = all stock items
+     */
+    @Transactional(readOnly = true)
+    @NonNull
+    public QuantitySnapshot load(@NonNull Collection<UUID> locationIds, @Nullable String sku) {
+        Collection<InventoryLedgerEventType> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes();
+
+        Map<UUID, Long> onHand;
+        Map<UUID, Long> allocated;
+        if (sku == null || sku.isBlank()) {
+            onHand = inventoryLedgerEntryRepository.sumQuantityByLocationChunked(locationIds, onHandTypes);
+            allocated = inventoryLedgerEntryRepository.calculateOutstandingAllocationsByLocation(locationIds);
+        } else {
+            onHand = inventoryLedgerEntryRepository.sumQuantityByLocationForSkuChunked(sku, locationIds, onHandTypes);
+            allocated = outstandingForSku(sku, locationIds);
+        }
+        return new QuantitySnapshot(onHand, allocated);
+    }
+
+    private Map<UUID, Long> outstandingForSku(String sku, Collection<UUID> locationIds) {
+        Map<UUID, Long> created = inventoryLedgerEntryRepository.sumQuantityByLocationForSkuChunked(
+                sku, locationIds, ALLOCATION_CREATED_TYPES);
+        Map<UUID, Long> released = inventoryLedgerEntryRepository.sumQuantityByLocationForSkuChunked(
+                sku, locationIds, ALLOCATION_RELEASED_TYPES);
+
+        Map<UUID, Long> outstanding = new HashMap<>(created);
+        released.forEach((locationId, quantity) -> outstanding.merge(locationId, -quantity, Long::sum));
+        return Map.copyOf(outstanding);
+    }
+
+    public record QuantitySnapshot(Map<UUID, Long> onHand, Map<UUID, Long> allocated) {}
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryRollupServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryRollupServiceImpl.java
@@ -1,0 +1,124 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.client.StorageLocationTopologyClient;
+import com.positivity.inventory.internal.client.StorageLocationTopologyClient.StorageLocationNode;
+import com.positivity.inventory.internal.dto.rollup.RollupQuantities;
+import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
+import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
+import com.positivity.inventory.service.SiteInventoryRollupService;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Computes the site inventory rollup tree: fetches the storage-location
+ * topology from pos-location (outside any transaction), loads bulk per-location
+ * quantities in one read-only transaction, then sums own quantities up the tree
+ * depth-first post-order.
+ *
+ * <p>Orphan handling (v1, CAP-218 #658): bulk queries are restricted to the
+ * site's known location ids, so ledger rows at unknown locations never enter
+ * the tree; no dedicated orphan scan is performed.
+ */
+@Service
+public class SiteInventoryRollupServiceImpl implements SiteInventoryRollupService {
+
+    private final StorageLocationTopologyClient storageLocationTopologyClient;
+    private final SiteInventoryQuantityLoader quantityLoader;
+
+    public SiteInventoryRollupServiceImpl(
+            StorageLocationTopologyClient storageLocationTopologyClient, SiteInventoryQuantityLoader quantityLoader) {
+        this.storageLocationTopologyClient = storageLocationTopologyClient;
+        this.quantityLoader = quantityLoader;
+    }
+
+    @Override
+    @NonNull
+    public SiteInventoryRollupResponse getSiteInventoryRollup(
+            @NonNull UUID siteId, @Nullable String sku, @Nullable Integer depth, boolean includeEmpty) {
+        List<StorageLocationNode> topology = storageLocationTopologyClient.fetchSiteTopology(siteId);
+        if (topology.isEmpty()) {
+            return new SiteInventoryRollupResponse(siteId, RollupQuantities.ZERO, List.of());
+        }
+
+        List<UUID> knownIds = topology.stream().map(StorageLocationNode::id).toList();
+        SiteInventoryQuantityLoader.QuantitySnapshot quantities = quantityLoader.load(knownIds, sku);
+
+        // Build mutable tree keyed by id; nodes whose parent id is absent from the
+        // site's set attach to root (defensive against partial topology data).
+        Map<UUID, MutableNode> byId = new HashMap<>();
+        for (StorageLocationNode node : topology) {
+            byId.put(
+                    node.id(),
+                    new MutableNode(
+                            node,
+                            RollupQuantities.of(
+                                    quantities.onHand().getOrDefault(node.id(), 0L),
+                                    quantities.allocated().getOrDefault(node.id(), 0L))));
+        }
+        List<MutableNode> roots = new ArrayList<>();
+        for (MutableNode node : byId.values()) {
+            UUID parentId = node.source.parentStorageLocationId();
+            MutableNode parent = parentId == null ? null : byId.get(parentId);
+            if (parent == null || parent == node) {
+                roots.add(node);
+            } else {
+                parent.children.add(node);
+            }
+        }
+
+        roots.forEach(MutableNode::computeRolledUp);
+
+        RollupQuantities totals =
+                roots.stream().map(node -> node.rolledUp).reduce(RollupQuantities.ZERO, RollupQuantities::plus);
+
+        int maxDepth = depth == null ? Integer.MAX_VALUE : Math.max(1, depth);
+        List<StorageLocationRollupNode> nodes = roots.stream()
+                .filter(node -> includeEmpty || !node.rolledUp.isEmpty())
+                .sorted(Comparator.comparing(node -> node.source.name(), Comparator.nullsLast(String::compareTo)))
+                .map(node -> node.toDto(1, maxDepth, includeEmpty))
+                .toList();
+
+        return new SiteInventoryRollupResponse(siteId, totals, nodes);
+    }
+
+    private static final class MutableNode {
+        private final StorageLocationNode source;
+        private final RollupQuantities own;
+        private final List<MutableNode> children = new ArrayList<>();
+        private RollupQuantities rolledUp;
+
+        private MutableNode(StorageLocationNode source, RollupQuantities own) {
+            this.source = source;
+            this.own = own;
+        }
+
+        private void computeRolledUp() {
+            RollupQuantities sum = own;
+            for (MutableNode child : children) {
+                child.computeRolledUp();
+                sum = sum.plus(child.rolledUp);
+            }
+            rolledUp = sum;
+        }
+
+        private StorageLocationRollupNode toDto(int currentDepth, int maxDepth, boolean includeEmpty) {
+            List<StorageLocationRollupNode> childDtos = currentDepth >= maxDepth
+                    ? List.of()
+                    : children.stream()
+                            .filter(child -> includeEmpty || !child.rolledUp.isEmpty())
+                            .sorted(Comparator.comparing(
+                                    child -> child.source.name(), Comparator.nullsLast(String::compareTo)))
+                            .map(child -> child.toDto(currentDepth + 1, maxDepth, includeEmpty))
+                            .toList();
+            return new StorageLocationRollupNode(
+                    source.id(), source.name(), source.type(), source.status(), own, rolledUp, childDtos);
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryRollupServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryRollupServiceImpl.java
@@ -29,6 +29,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class SiteInventoryRollupServiceImpl implements SiteInventoryRollupService {
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SiteInventoryRollupServiceImpl.class);
+
     private final StorageLocationTopologyClient storageLocationTopologyClient;
     private final SiteInventoryQuantityLoader quantityLoader;
 
@@ -73,6 +75,18 @@ public class SiteInventoryRollupServiceImpl implements SiteInventoryRollupServic
             }
         }
 
+        // PR #661 review finding 8: raw topology rows could theoretically contain
+        // a parent cycle (A<->B) leaving nodes unreachable from any root; their
+        // quantities would silently vanish from totals. Detect and warn.
+        int reachable = countReachable(roots);
+        if (reachable < byId.size()) {
+            log.warn(
+                    "Site {} topology has {} storage locations unreachable from any root (possible parent cycle);"
+                            + " their quantities are excluded from the rollup",
+                    siteId,
+                    byId.size() - reachable);
+        }
+
         roots.forEach(MutableNode::computeRolledUp);
 
         RollupQuantities totals =
@@ -86,6 +100,17 @@ public class SiteInventoryRollupServiceImpl implements SiteInventoryRollupServic
                 .toList();
 
         return new SiteInventoryRollupResponse(siteId, totals, nodes);
+    }
+
+    private static int countReachable(List<MutableNode> roots) {
+        int count = 0;
+        java.util.Deque<MutableNode> stack = new java.util.ArrayDeque<>(roots);
+        while (!stack.isEmpty()) {
+            MutableNode node = stack.pop();
+            count++;
+            stack.addAll(node.children);
+        }
+        return count;
     }
 
     private static final class MutableNode {

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/LocationInventoryRollupService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/LocationInventoryRollupService.java
@@ -1,0 +1,35 @@
+package com.positivity.inventory.service;
+
+import com.positivity.inventory.internal.dto.rollup.LocationInventoryRollupResponse;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Rolls inventory totals up beyond a single site to a parent Location
+ * (building/place/region) along a typed parent chain (CAP-218 #659).
+ */
+public interface LocationInventoryRollupService {
+
+    /**
+     * Computes per-site rollup summaries plus a grand total for all descendant
+     * sites of {@code locationId} along the {@code parentType} chain.
+     *
+     * @param locationId parent Location identifier (not a storage location)
+     * @param parentType pos-location parent chain type; null defaults to PHYSICAL
+     * @param sku optional stock item filter; blank treated as absent
+     * @param expandTree when true, each site entry carries its full rollup tree;
+     *        rejected when the descendant site count exceeds the configured cap
+     * @param depth optional per-site tree depth (only meaningful with expandTree)
+     * @param includeEmpty when false, all-zero tree nodes are pruned (only
+     *        meaningful with expandTree); site summaries are always returned
+     */
+    @NonNull
+    LocationInventoryRollupResponse getLocationInventoryRollup(
+            @NonNull UUID locationId,
+            @Nullable String parentType,
+            @Nullable String sku,
+            boolean expandTree,
+            @Nullable Integer depth,
+            boolean includeEmpty);
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/SiteInventoryRollupService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/SiteInventoryRollupService.java
@@ -1,0 +1,25 @@
+package com.positivity.inventory.service;
+
+import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Rolls up on-hand and outstanding-allocation quantities along the
+ * storage-location hierarchy of a site (CAP-218 #658).
+ */
+public interface SiteInventoryRollupService {
+
+    /**
+     * Computes the rollup tree for a site.
+     *
+     * @param siteId site (Location) identifier; resolved against pos-location
+     * @param sku optional stock item filter; blank treated as absent
+     * @param depth optional maximum tree depth to return (1 = roots only); null = full tree
+     * @param includeEmpty when false (default), nodes whose rolled-up quantities are all zero are pruned
+     */
+    @NonNull
+    SiteInventoryRollupResponse getSiteInventoryRollup(
+            @NonNull UUID siteId, @Nullable String sku, @Nullable Integer depth, boolean includeEmpty);
+}

--- a/pos-inventory/src/main/resources/db/migration/V3__add_inventory_ledger_entry_location_event_index.sql
+++ b/pos-inventory/src/main/resources/db/migration/V3__add_inventory_ledger_entry_location_event_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_inventory_ledger_entry_location_event ON inventory_ledger_entry USING btree (location_id, event_type);

--- a/pos-inventory/src/test/java/com/positivity/inventory/ArchitectureTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/ArchitectureTest.java
@@ -34,6 +34,17 @@ public class ArchitectureTest {
             };
 
     @ArchTest
+    static final ArchRule inventory_should_not_depend_on_pos_location_classes = noClasses()
+            .that()
+            .resideInAPackage("com.positivity.inventory..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("com.positivity.location..")
+            .allowEmptyShould(true)
+            .because("pos-inventory must consume pos-location only via REST contracts with"
+                    + " consumer-side DTOs (ADR-0016; CAP-218 #658)");
+
+    @ArchTest
     static final ArchRule controllers_should_not_access_repositories_directly = noClasses()
             .that()
             .resideInAPackage("..internal.controller..")

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/LocationInventoryRollupContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/LocationInventoryRollupContractBehaviorIT.java
@@ -1,0 +1,154 @@
+package com.positivity.inventory.contract;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.inventory.internal.dto.rollup.LocationInventoryRollupResponse;
+import com.positivity.inventory.internal.dto.rollup.RollupQuantities;
+import com.positivity.inventory.internal.dto.rollup.SiteRollupSummary;
+import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
+import com.positivity.inventory.internal.exception.LocationNotFoundException;
+import com.positivity.inventory.internal.exception.RollupExpansionTooLargeException;
+import com.positivity.inventory.service.LocationInventoryRollupService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Contract behavior integration tests for the parent-location inventory
+ * rollup API — CAP-218 #659.
+ *
+ * Issue: #659
+ */
+@DisplayName("Location Inventory Rollup Contract Behavior — CAP-218 #659")
+class LocationInventoryRollupContractBehaviorIT extends BaseContractIntegrationTest {
+
+    private static final UUID BUILDING_ID = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+    private static final UUID SITE_A = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LocationInventoryRollupService locationInventoryRollupService;
+
+    @Test
+    @DisplayName("GET /v1/inventory/locations/{locationId}/inventory-rollup → 200 with site summaries")
+    void contract_locationRollup_returns200Summaries() throws Exception {
+        // Issue #659: summaries only by default; nodes absent from JSON
+        LocationInventoryRollupResponse response = new LocationInventoryRollupResponse(
+                BUILDING_ID,
+                "PHYSICAL",
+                RollupQuantities.of(150, 15),
+                List.of(new SiteRollupSummary(SITE_A, "Main Workshop", RollupQuantities.of(150, 15), null)));
+        when(locationInventoryRollupService.getLocationInventoryRollup(
+                        eq(BUILDING_ID), isNull(), isNull(), eq(false), isNull(), eq(false)))
+                .thenReturn(response);
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/locations/{locationId}/inventory-rollup", BUILDING_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.locationId").value(BUILDING_ID.toString()))
+                .andExpect(jsonPath("$.parentType").value("PHYSICAL"))
+                .andExpect(jsonPath("$.totals.available").value(135))
+                .andExpect(jsonPath("$.sites[0].siteId").value(SITE_A.toString()))
+                .andExpect(jsonPath("$.sites[0].siteName").value("Main Workshop"))
+                .andExpect(jsonPath("$.sites[0].nodes").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup?expand=tree → 200 with inlined trees")
+    void contract_locationRollup_expandTree_returns200WithNodes() throws Exception {
+        // Issue #659: expand=tree inlines per-site nodes
+        StorageLocationRollupNode node = new StorageLocationRollupNode(
+                UUID.randomUUID(),
+                "Floor A",
+                "FLOOR",
+                "ACTIVE",
+                RollupQuantities.of(150, 15),
+                RollupQuantities.of(150, 15),
+                List.of());
+        LocationInventoryRollupResponse response = new LocationInventoryRollupResponse(
+                BUILDING_ID,
+                "PHYSICAL",
+                RollupQuantities.of(150, 15),
+                List.of(new SiteRollupSummary(SITE_A, "Main Workshop", RollupQuantities.of(150, 15), List.of(node))));
+        when(locationInventoryRollupService.getLocationInventoryRollup(
+                        eq(BUILDING_ID), isNull(), isNull(), eq(true), isNull(), eq(false)))
+                .thenReturn(response);
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/locations/{locationId}/inventory-rollup", BUILDING_ID)
+                        .param("expand", "tree")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sites[0].nodes[0].name").value("Floor A"));
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup?expand=bogus → 400")
+    void contract_locationRollup_invalidExpand_returns400() throws Exception {
+        // Issue #659: only expand=tree supported
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/locations/{locationId}/inventory-rollup", BUILDING_ID)
+                        .param("expand", "bogus")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup unknown parentType → 400 VALIDATION_ERROR")
+    void contract_locationRollup_unknownParentType_returns400() throws Exception {
+        // Issue #659: parentType validated against ParentType value set
+        when(locationInventoryRollupService.getLocationInventoryRollup(
+                        any(), eq("BOGUS"), any(), anyBoolean(), any(), anyBoolean()))
+                .thenThrow(new IllegalArgumentException("Unknown parentType 'BOGUS'"));
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/locations/{locationId}/inventory-rollup", BUILDING_ID)
+                        .param("parentType", "BOGUS")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup?expand=tree over site cap → 422 ROLLUP_EXPANSION_TOO_LARGE")
+    void contract_locationRollup_overCap_returns422() throws Exception {
+        // Issue #659: fan-out guard surfaces as 422 with guidance
+        when(locationInventoryRollupService.getLocationInventoryRollup(
+                        any(), any(), any(), eq(true), any(), anyBoolean()))
+                .thenThrow(new RollupExpansionTooLargeException(40, 25));
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/locations/{locationId}/inventory-rollup", BUILDING_ID)
+                        .param("expand", "tree")))
+                .andExpect(status().is(422))
+                .andExpect(jsonPath("$.code").value("ROLLUP_EXPANSION_TOO_LARGE"));
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup unknown location → 404 NOT_FOUND")
+    void contract_locationRollup_unknownLocation_returns404() throws Exception {
+        // Issue #659: pos-location 404 surfaces as 404 ApiError
+        when(locationInventoryRollupService.getLocationInventoryRollup(
+                        any(), any(), any(), anyBoolean(), any(), anyBoolean()))
+                .thenThrow(new LocationNotFoundException(BUILDING_ID));
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/locations/{locationId}/inventory-rollup", BUILDING_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup without on-hand view authority → 403")
+    void contract_locationRollup_missingAuthority_returns403() throws Exception {
+        // Issue #659: authz mirrors site rollup
+        mockMvc.perform(get("/v1/inventory/locations/{locationId}/inventory-rollup", BUILDING_ID)
+                        .header("X-User", "test-user")
+                        .header("X-Authorities", "unrelated:authority"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReservationContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReservationContractBehaviorIT.java
@@ -133,7 +133,8 @@ class ReservationContractBehaviorIT extends BaseContractIntegrationTest {
         when(reservationService.promoteToHard(eq(allocationId), any(PromoteAllocationRequest.class)))
                 .thenReturn(mockResponse);
 
-        String requestBody = objectMapper.writeValueAsString(new PromoteAllocationRequest("approved for workorder"));
+        String requestBody = objectMapper.writeValueAsString(new PromoteAllocationRequest(
+                UUID.fromString("00000000-0000-0000-0000-0000000000aa"), "approved for workorder"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/reservations/{allocationId}/promote", allocationId))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -141,6 +142,30 @@ class ReservationContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.reservationId").value(reservationId.toString()))
                 .andExpect(jsonPath("$.status").value("FULFILLED"));
+    }
+
+    // ─── contract_promoteWithoutStorageLocation_returns400 ──────────────────────
+
+    /**
+     * Verifies that POST /v1/inventory/reservations/{allocationId}/promote without
+     * the required {@code storageLocationId} returns 400 Bad Request per
+     * CAP-218 #656: a HARD allocation must be pinned to a storage location so the
+     * ALLOCATION_CREATED ledger event can be recorded against it.
+     *
+     * Issue: #656
+     */
+    @Test
+    @DisplayName("POST .../promote without storageLocationId → 400 Bad Request")
+    void contract_promoteWithoutStorageLocation_returns400() throws Exception {
+        // Issue #656: storageLocationId is mandatory on promotion
+        UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+        String requestBody = objectMapper.writeValueAsString(new PromoteAllocationRequest(null, "missing location"));
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/reservations/{allocationId}/promote", allocationId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
     }
 
     // ─── contract_cancelReservation_returns204 ──────────────────────────────────
@@ -192,7 +217,8 @@ class ReservationContractBehaviorIT extends BaseContractIntegrationTest {
         when(reservationService.promoteToHard(eq(allocationId), any(PromoteAllocationRequest.class)))
                 .thenThrow(new InsufficientAtpException(allocationId, 10, 3));
 
-        String requestBody = objectMapper.writeValueAsString(new PromoteAllocationRequest("urgent hardening"));
+        String requestBody = objectMapper.writeValueAsString(new PromoteAllocationRequest(
+                UUID.fromString("00000000-0000-0000-0000-0000000000aa"), "urgent hardening"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/reservations/{allocationId}/promote", allocationId))
                         .contentType(MediaType.APPLICATION_JSON)

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/SiteInventoryRollupContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/SiteInventoryRollupContractBehaviorIT.java
@@ -1,0 +1,133 @@
+package com.positivity.inventory.contract;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.inventory.internal.dto.rollup.RollupQuantities;
+import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
+import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
+import com.positivity.inventory.internal.exception.LocationNotFoundException;
+import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
+import com.positivity.inventory.service.SiteInventoryRollupService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Contract behavior integration tests for the site inventory rollup API —
+ * CAP-218 #658.
+ *
+ * <ul>
+ * <li>ADR-0011/0014: gateway auth headers required; 403 without authority</li>
+ * <li>ADR-0016: topology comes from pos-location; 404/503 surfaced</li>
+ * <li>ADR-0017: 200 / 400 / 403 / 404 / 503 response codes</li>
+ * <li>ADR-0023: no tenantId in request or response</li>
+ * </ul>
+ *
+ * Issue: #658
+ */
+@DisplayName("Site Inventory Rollup Contract Behavior — CAP-218 #658")
+class SiteInventoryRollupContractBehaviorIT extends BaseContractIntegrationTest {
+
+    private static final UUID SITE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID FLOOR_ID = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SiteInventoryRollupService siteInventoryRollupService;
+
+    @Test
+    @DisplayName("GET /v1/inventory/sites/{siteId}/inventory-rollup → 200 with totals and tree")
+    void contract_rollup_returns200WithTree() throws Exception {
+        // Issue #658: happy path returns siteId, totals, nodes with own/rolledUp
+        RollupQuantities own = RollupQuantities.of(0, 0);
+        RollupQuantities rolledUp = RollupQuantities.of(480, 30);
+        SiteInventoryRollupResponse response = new SiteInventoryRollupResponse(
+                SITE_ID,
+                rolledUp,
+                List.of(new StorageLocationRollupNode(
+                        FLOOR_ID, "Floor A", "FLOOR", "ACTIVE", own, rolledUp, List.of())));
+        when(siteInventoryRollupService.getSiteInventoryRollup(eq(SITE_ID), isNull(), isNull(), eq(false)))
+                .thenReturn(response);
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/sites/{siteId}/inventory-rollup", SITE_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.siteId").value(SITE_ID.toString()))
+                .andExpect(jsonPath("$.totals.onHand").value(480))
+                .andExpect(jsonPath("$.totals.allocated").value(30))
+                .andExpect(jsonPath("$.totals.available").value(450))
+                .andExpect(jsonPath("$.nodes[0].storageLocationId").value(FLOOR_ID.toString()))
+                .andExpect(jsonPath("$.nodes[0].type").value("FLOOR"))
+                .andExpect(jsonPath("$.nodes[0].rolledUp.onHand").value(480))
+                .andExpect(jsonPath("$.nodes[0].own.onHand").value(0));
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup passes sku, depth, includeEmpty through")
+    void contract_rollup_passesQueryParams() throws Exception {
+        // Issue #658: query params forwarded to service
+        when(siteInventoryRollupService.getSiteInventoryRollup(eq(SITE_ID), eq("SKU-1"), eq(2), eq(true)))
+                .thenReturn(new SiteInventoryRollupResponse(SITE_ID, RollupQuantities.ZERO, List.of()));
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/sites/{siteId}/inventory-rollup", SITE_ID)
+                        .param("sku", "SKU-1")
+                        .param("depth", "2")
+                        .param("includeEmpty", "true")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nodes").isEmpty());
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup with depth=0 → 400")
+    void contract_rollup_invalidDepth_returns400() throws Exception {
+        // Issue #658: depth must be >= 1
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/sites/{siteId}/inventory-rollup", SITE_ID)
+                        .param("depth", "0")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup unknown site → 404 NOT_FOUND")
+    void contract_rollup_unknownSite_returns404() throws Exception {
+        // Issue #658: pos-location 404 surfaces as 404 ApiError
+        when(siteInventoryRollupService.getSiteInventoryRollup(any(), any(), any(), eq(false)))
+                .thenThrow(new LocationNotFoundException(SITE_ID));
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/sites/{siteId}/inventory-rollup", SITE_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup when pos-location is down → 503 LOCATION_SERVICE_UNAVAILABLE")
+    void contract_rollup_locationServiceDown_returns503() throws Exception {
+        // Issue #658: never fabricate partial topology; surface 503 with retry hint
+        when(siteInventoryRollupService.getSiteInventoryRollup(any(), any(), any(), eq(false)))
+                .thenThrow(new LocationServiceUnavailableException("Location service unavailable", null));
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/sites/{siteId}/inventory-rollup", SITE_ID)))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.code").value("LOCATION_SERVICE_UNAVAILABLE"));
+    }
+
+    @Test
+    @DisplayName("GET .../inventory-rollup without on-hand view authority → 403")
+    void contract_rollup_missingAuthority_returns403() throws Exception {
+        // Issue #658: authz mirrors LocationInventoryInquiryController
+        mockMvc.perform(get("/v1/inventory/sites/{siteId}/inventory-rollup", SITE_ID)
+                        .header("X-User", "test-user")
+                        .header("X-Authorities", "unrelated:authority"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/client/StorageLocationTopologyClientTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/client/StorageLocationTopologyClientTest.java
@@ -1,0 +1,90 @@
+package com.positivity.inventory.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.inventory.internal.client.StorageLocationTopologyClient.StorageLocationNode;
+import com.positivity.inventory.internal.exception.LocationNotFoundException;
+import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link StorageLocationTopologyClient} — CAP-218 #658.
+ * Consumes the pos-location topology contract from CAP-214 #655.
+ */
+class StorageLocationTopologyClientTest {
+
+    private static final UUID SITE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    private record Fixture(MockRestServiceServer server, StorageLocationTopologyClient client) {}
+
+    private Fixture fixture() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        return new Fixture(server, new StorageLocationTopologyClient(builder, "location"));
+    }
+
+    @Test
+    void fetchSiteTopology_mapsContractFields() {
+        // Issue #658: consumer-side pin of id/name/type/status/parentStorageLocationId
+        Fixture f = fixture();
+        String body = """
+                [{"id":"00000000-0000-0000-0000-0000000000f1","name":"Floor A","type":"FLOOR",
+                  "status":"ACTIVE","parentStorageLocationId":null},
+                 {"id":"00000000-0000-0000-0000-0000000000e1","name":"Shelf A-1","type":"SHELF",
+                  "status":"INACTIVE","parentStorageLocationId":"00000000-0000-0000-0000-0000000000f1"}]
+                """;
+        f.server()
+                .expect(requestTo("http://location/v1/locations/" + SITE_ID + "/storage-locations/topology"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("X-User", "pos-inventory"))
+                .andExpect(header("X-Authorities", "location:read"))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        List<StorageLocationNode> nodes = f.client().fetchSiteTopology(SITE_ID);
+
+        assertThat(nodes).hasSize(2);
+        assertThat(nodes.getFirst().name()).isEqualTo("Floor A");
+        assertThat(nodes.getFirst().parentStorageLocationId()).isNull();
+        assertThat(nodes.getLast().status()).isEqualTo("INACTIVE");
+        assertThat(nodes.getLast().parentStorageLocationId())
+                .isEqualTo(UUID.fromString("00000000-0000-0000-0000-0000000000f1"));
+        f.server().verify();
+    }
+
+    @Test
+    void fetchSiteTopology_404_throwsLocationNotFound() {
+        // Issue #658: unknown site surfaces as LocationNotFoundException → 404
+        Fixture f = fixture();
+        f.server()
+                .expect(requestTo("http://location/v1/locations/" + SITE_ID + "/storage-locations/topology"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> f.client().fetchSiteTopology(SITE_ID)).isInstanceOf(LocationNotFoundException.class);
+    }
+
+    @Test
+    void fetchSiteTopology_5xx_throwsServiceUnavailable() {
+        // Issue #658: never fabricate partial topology on upstream failure
+        Fixture f = fixture();
+        f.server()
+                .expect(requestTo("http://location/v1/locations/" + SITE_ID + "/storage-locations/topology"))
+                .andRespond(withServerError());
+
+        assertThatThrownBy(() -> f.client().fetchSiteTopology(SITE_ID))
+                .isInstanceOf(LocationServiceUnavailableException.class);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/client/StorageLocationTopologyClientTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/client/StorageLocationTopologyClientTest.java
@@ -77,6 +77,42 @@ class StorageLocationTopologyClientTest {
     }
 
     @Test
+    void fetchDescendants_mapsContractFields() {
+        // Issue #659: consumer-side pin of id/name/code/status/parentId/depth
+        Fixture f = fixture();
+        String body = """
+                [{"id":"00000000-0000-0000-0000-0000000000a1","name":"Main Workshop","code":"MAIN-WS-001",
+                  "status":"ACTIVE","parentId":"00000000-0000-0000-0000-000000000001","depth":1}]
+                """;
+        f.server()
+                .expect(requestTo("http://location/v1/locations/" + SITE_ID + "/descendants?parentType=PHYSICAL"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("X-User", "pos-inventory"))
+                .andExpect(header("X-Authorities", "location:read"))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        var descendants = f.client().fetchDescendants(SITE_ID, "PHYSICAL");
+
+        assertThat(descendants).hasSize(1);
+        assertThat(descendants.getFirst().name()).isEqualTo("Main Workshop");
+        assertThat(descendants.getFirst().code()).isEqualTo("MAIN-WS-001");
+        assertThat(descendants.getFirst().depth()).isEqualTo(1);
+        f.server().verify();
+    }
+
+    @Test
+    void fetchDescendants_404_throwsLocationNotFound() {
+        // Issue #659: unknown parent location → LocationNotFoundException
+        Fixture f = fixture();
+        f.server()
+                .expect(requestTo("http://location/v1/locations/" + SITE_ID + "/descendants?parentType=PHYSICAL"))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThatThrownBy(() -> f.client().fetchDescendants(SITE_ID, "PHYSICAL"))
+                .isInstanceOf(LocationNotFoundException.class);
+    }
+
+    @Test
     void fetchSiteTopology_5xx_throwsServiceUnavailable() {
         // Issue #658: never fabricate partial topology on upstream failure
         Fixture f = fixture();

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepositoryTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepositoryTest.java
@@ -1,0 +1,170 @@
+package com.positivity.inventory.internal.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Repository tests for the bulk grouped on-hand and allocation queries (CAP-218 story #657).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class InventoryLedgerEntryRepositoryTest {
+
+    private static final String SKU_A = "SKU-A";
+    private static final String SKU_B = "SKU-B";
+
+    @Autowired
+    private InventoryLedgerEntryRepository repository;
+
+    private void seed(String stockItemId, UUID locationId, InventoryLedgerEventType eventType, int changeInQuantity) {
+        Instant now = Instant.now();
+        repository.save(InventoryLedgerEntry.builder()
+                .stockItemId(stockItemId)
+                .locationId(locationId)
+                .eventType(eventType)
+                .changeInQuantity(changeInQuantity)
+                .quantityAfter(0)
+                .transactionUserId("test-user")
+                .timestamp(now)
+                .createdAt(now)
+                .updatedAt(now)
+                .build());
+    }
+
+    @Test
+    @DisplayName("grouped sums are correct per location for mixed event types")
+    void sumQuantityByLocationChunkedGroupsAndFiltersByEventType() {
+        UUID locationA = UUID.randomUUID();
+        UUID locationB = UUID.randomUUID();
+        UUID locationC = UUID.randomUUID();
+
+        seed(SKU_A, locationA, InventoryLedgerEventType.GOODS_RECEIPT, 10);
+        seed(SKU_B, locationA, InventoryLedgerEventType.GOODS_ISSUE, -4);
+        seed(SKU_A, locationA, InventoryLedgerEventType.ALLOCATION_CREATED, 3); // not on-hand affecting
+        seed(SKU_A, locationB, InventoryLedgerEventType.TRANSFER_IN, 7);
+        seed(SKU_B, locationB, InventoryLedgerEventType.ADJUSTMENT_OUT, -2);
+
+        Set<InventoryLedgerEventType> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes();
+        Map<UUID, Long> result =
+                repository.sumQuantityByLocationChunked(List.of(locationA, locationB, locationC), onHandTypes);
+
+        assertThat(result).containsOnly(Map.entry(locationA, 6L), Map.entry(locationB, 5L));
+        assertThat(result).doesNotContainKey(locationC);
+
+        // grouped result matches the existing single-location aggregate for the same data
+        assertThat(result.get(locationA).intValue())
+                .isEqualTo(repository.calculateOnHandQuantityAtLocation(locationA, onHandTypes));
+        assertThat(result.get(locationB).intValue())
+                .isEqualTo(repository.calculateOnHandQuantityAtLocation(locationB, onHandTypes));
+    }
+
+    @Test
+    @DisplayName("SKU-filtered grouped sums only include the requested stock item")
+    void sumQuantityByLocationForSkuChunkedFiltersByStockItem() {
+        UUID locationA = UUID.randomUUID();
+        UUID locationB = UUID.randomUUID();
+
+        seed(SKU_A, locationA, InventoryLedgerEventType.GOODS_RECEIPT, 10);
+        seed(SKU_A, locationA, InventoryLedgerEventType.GOODS_ISSUE, -3);
+        seed(SKU_B, locationA, InventoryLedgerEventType.GOODS_RECEIPT, 50);
+        seed(SKU_A, locationB, InventoryLedgerEventType.GOODS_RECEIPT, 2);
+
+        Map<UUID, Long> result = repository.sumQuantityByLocationForSkuChunked(
+                SKU_A, List.of(locationA, locationB), InventoryLedgerEventType.onHandAffectingTypes());
+
+        assertThat(result).containsOnly(Map.entry(locationA, 7L), Map.entry(locationB, 2L));
+    }
+
+    @Test
+    @DisplayName("empty locationIds returns empty result without exception")
+    void emptyLocationIdsShortCircuit() {
+        seed(SKU_A, UUID.randomUUID(), InventoryLedgerEventType.GOODS_RECEIPT, 10);
+
+        assertThatCode(() -> {
+                    assertThat(repository.sumQuantityByLocationChunked(
+                                    List.of(), InventoryLedgerEventType.onHandAffectingTypes()))
+                            .isEmpty();
+                    assertThat(repository.sumQuantityByLocationForSkuChunked(
+                                    SKU_A, List.of(), InventoryLedgerEventType.onHandAffectingTypes()))
+                            .isEmpty();
+                    assertThat(repository.calculateOutstandingAllocationsByLocation(List.of()))
+                            .isEmpty();
+                })
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("chunking handles more than 1000 location ids and merges results")
+    void chunkingHandlesMoreThanOneThousandLocationIds() {
+        UUID firstLocation = UUID.randomUUID();
+        UUID lastLocation = UUID.randomUUID();
+
+        seed(SKU_A, firstLocation, InventoryLedgerEventType.GOODS_RECEIPT, 11);
+        seed(SKU_A, lastLocation, InventoryLedgerEventType.GOODS_RECEIPT, 22);
+        seed(SKU_A, lastLocation, InventoryLedgerEventType.GOODS_ISSUE, -2);
+
+        List<UUID> locationIds = new ArrayList<>();
+        locationIds.add(firstLocation); // lands in the first chunk
+        for (int i = 0; i < 999; i++) {
+            locationIds.add(UUID.randomUUID());
+        }
+        locationIds.add(lastLocation); // id #1001, lands in the second chunk
+        assertThat(locationIds).hasSize(1001);
+
+        Map<UUID, Long> result =
+                repository.sumQuantityByLocationChunked(locationIds, InventoryLedgerEventType.onHandAffectingTypes());
+
+        assertThat(result).containsOnly(Map.entry(firstLocation, 11L), Map.entry(lastLocation, 20L));
+    }
+
+    @Test
+    @DisplayName("outstanding allocations per location match single-location semantics")
+    void outstandingAllocationsMatchSingleLocationSemantics() {
+        UUID locationA = UUID.randomUUID();
+        UUID locationB = UUID.randomUUID();
+        UUID locationC = UUID.randomUUID();
+
+        seed(SKU_A, locationA, InventoryLedgerEventType.ALLOCATION_CREATED, 5);
+        seed(SKU_B, locationA, InventoryLedgerEventType.ALLOCATION_CREATED, 3);
+        seed(SKU_A, locationA, InventoryLedgerEventType.ALLOCATION_RELEASED, 2);
+        seed(SKU_A, locationB, InventoryLedgerEventType.ALLOCATION_CREATED, 4);
+        seed(SKU_A, locationC, InventoryLedgerEventType.GOODS_RECEIPT, 9); // no allocations
+
+        Map<UUID, Long> result =
+                repository.calculateOutstandingAllocationsByLocation(List.of(locationA, locationB, locationC));
+
+        // single-location semantics: sum(ALLOCATION_CREATED) - sum(ALLOCATION_RELEASED)
+        assertThat(result).containsOnly(Map.entry(locationA, 6L), Map.entry(locationB, 4L));
+        assertThat(result).doesNotContainKey(locationC);
+
+        // cross-check against the same ledger entries the single-location path reads
+        List<InventoryLedgerEntry> locationAEntries = repository.findByLocationIdAndEventTypeIn(
+                locationA,
+                List.of(InventoryLedgerEventType.ALLOCATION_CREATED, InventoryLedgerEventType.ALLOCATION_RELEASED));
+        long created = locationAEntries.stream()
+                .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_CREATED)
+                .mapToLong(InventoryLedgerEntry::getChangeInQuantity)
+                .sum();
+        long released = locationAEntries.stream()
+                .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
+                .mapToLong(InventoryLedgerEntry::getChangeInQuantity)
+                .sum();
+        assertThat(result.get(locationA)).isEqualTo(created - released);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
@@ -578,6 +578,8 @@ class ConsumptionServiceImplTest {
                 .mapToInt(InventoryLedgerEntry::getChangeInQuantity)
                 .sum();
         assertThat(totalReleased).isEqualTo(5); // capped at allocatedQuantity, not 8
+        // second item exhausts the remainder and closes the allocation
+        assertThat(allocation.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.RELEASED);
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
@@ -43,6 +43,12 @@ class ConsumptionServiceImplTest {
     @Mock
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
+    @Mock
+    private com.positivity.inventory.internal.repository.ReservationRepository reservationRepository;
+
+    @Mock
+    private com.positivity.inventory.internal.repository.AllocationRepository allocationRepository;
+
     @Captor
     private ArgumentCaptor<List<InventoryLedgerEntry>> entriesCaptor;
 
@@ -51,7 +57,12 @@ class ConsumptionServiceImplTest {
     }
 
     private ConsumptionServiceImpl persistentService() {
-        return new ConsumptionServiceImpl(pickTaskRepository, inventoryLedgerEntryRepository, FIXED_CLOCK);
+        return new ConsumptionServiceImpl(
+                pickTaskRepository,
+                inventoryLedgerEntryRepository,
+                reservationRepository,
+                allocationRepository,
+                FIXED_CLOCK);
     }
 
     // ─── CS1: consumePickedItems — valid picks → ConsumptionResponse fields ─────
@@ -296,5 +307,171 @@ class ConsumptionServiceImplTest {
         assertThatThrownBy(() -> service.consumePickedItems(request))
                 .isInstanceOf(WorkorderConsumptionException.class)
                 .hasMessageContaining("exceeds picked quantity");
+    }
+
+    // ─── CAP-218 #662: allocation closure on consumption ─────────────────────────
+
+    private static final UUID WO_LINE_ID = UUID.fromString("00000000-0000-0000-0000-00000000000c");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
+    private static final UUID STOCK_ITEM_ID = UUID.fromString("00000000-0000-0000-0000-0000000000dd");
+
+    private com.positivity.inventory.internal.entity.ReservationEntity reservationWithLine() {
+        return com.positivity.inventory.internal.entity.ReservationEntity.builder()
+                .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .workorderLineId(WO_LINE_ID)
+                .stockItemId(STOCK_ITEM_ID)
+                .requiredQuantity(5)
+                .allocatedQuantity(5)
+                .status(com.positivity.inventory.internal.enums.ReservationStatus.FULFILLED)
+                .build();
+    }
+
+    private com.positivity.inventory.internal.entity.AllocationEntity locatedHardAllocation(
+            com.positivity.inventory.internal.entity.ReservationEntity reservation, int quantity) {
+        return com.positivity.inventory.internal.entity.AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .reservation(reservation)
+                .locationId(LOCATION_ID)
+                .allocatedQuantity(quantity)
+                .allocationState(com.positivity.inventory.internal.enums.AllocationState.HARD)
+                .status(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED)
+                .build();
+    }
+
+    private PickTaskEntity pickedTaskWithLine(UUID pickTaskId) {
+        return PickTaskEntity.builder()
+                .pickTaskId(pickTaskId)
+                .workorderLineId(WO_LINE_ID)
+                .status(PickTaskStatus.PICKED)
+                .quantityPicked(5)
+                .build();
+    }
+
+    @Test
+    @DisplayName("#662: full consumption writes ALLOCATION_RELEASED and closes the allocation")
+    void consumePickedItems_fullConsumption_releasesAllocationAndClosesIt() {
+        ConsumptionServiceImpl service = persistentService();
+        UUID pickTaskId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        var reservation = reservationWithLine();
+        var allocation = locatedHardAllocation(reservation, 5);
+
+        when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(pickedTaskWithLine(pickTaskId)));
+        when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
+                .thenReturn(10);
+        when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                        allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
+                .thenReturn(0);
+        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        ConsumeItemsRequest request = new ConsumeItemsRequest(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                List.of(new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 5)));
+
+        service.consumePickedItems(request);
+
+        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        List<InventoryLedgerEntry> entries = entriesCaptor.getValue();
+        assertThat(entries).hasSize(2);
+        InventoryLedgerEntry released = entries.get(1);
+        assertThat(released.getEventType()).isEqualTo(InventoryLedgerEventType.ALLOCATION_RELEASED);
+        assertThat(released.getChangeInQuantity()).isEqualTo(5);
+        assertThat(released.getLocationId()).isEqualTo(LOCATION_ID);
+        assertThat(released.getStockItemId()).isEqualTo(STOCK_ITEM_ID.toString());
+        assertThat(released.getSourceTransactionId())
+                .isEqualTo(allocation.getAllocationId().toString());
+        assertThat(allocation.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.RELEASED);
+    }
+
+    @Test
+    @DisplayName("#662: partial consumption releases exactly the consumed quantity and keeps allocation open")
+    void consumePickedItems_partialConsumption_releasesConsumedQuantityOnly() {
+        ConsumptionServiceImpl service = persistentService();
+        UUID pickTaskId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        var reservation = reservationWithLine();
+        var allocation = locatedHardAllocation(reservation, 5);
+
+        when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(pickedTaskWithLine(pickTaskId)));
+        when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
+                .thenReturn(10);
+        when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                        allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
+                .thenReturn(0);
+        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+
+        ConsumeItemsRequest request = new ConsumeItemsRequest(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                List.of(new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 2)));
+
+        service.consumePickedItems(request);
+
+        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        InventoryLedgerEntry released = entriesCaptor.getValue().get(1);
+        assertThat(released.getChangeInQuantity()).isEqualTo(2);
+        assertThat(allocation.getStatus())
+                .isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED);
+        verify(allocationRepository, org.mockito.Mockito.never()).save(any());
+    }
+
+    @Test
+    @DisplayName("#662: consumption of unallocated stock writes no allocation events")
+    void consumePickedItems_noReservation_writesNoAllocationEvents() {
+        ConsumptionServiceImpl service = persistentService();
+        UUID pickTaskId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+
+        when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(pickedTaskWithLine(pickTaskId)));
+        when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.empty());
+        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+
+        ConsumeItemsRequest request = new ConsumeItemsRequest(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                List.of(new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 2)));
+
+        service.consumePickedItems(request);
+
+        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        assertThat(entriesCaptor.getValue()).hasSize(1);
+        assertThat(entriesCaptor.getValue().getFirst().getEventType())
+                .isEqualTo(InventoryLedgerEventType.WORKORDER_CONSUMPTION);
+    }
+
+    @Test
+    @DisplayName("#662: already partially released allocation only releases its remainder")
+    void consumePickedItems_partiallyReleasedAllocation_releasesRemainderOnly() {
+        ConsumptionServiceImpl service = persistentService();
+        UUID pickTaskId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        var reservation = reservationWithLine();
+        var allocation = locatedHardAllocation(reservation, 5);
+
+        when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(pickedTaskWithLine(pickTaskId)));
+        when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
+                .thenReturn(10);
+        when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                        allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
+                .thenReturn(3);
+        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        ConsumeItemsRequest request = new ConsumeItemsRequest(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                List.of(new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 4)));
+
+        service.consumePickedItems(request);
+
+        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        InventoryLedgerEntry released = entriesCaptor.getValue().get(1);
+        // invariant: total RELEASED never exceeds allocatedQuantity (3 + 2 = 5)
+        assertThat(released.getChangeInQuantity()).isEqualTo(2);
+        assertThat(allocation.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.RELEASED);
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
@@ -474,4 +474,160 @@ class ConsumptionServiceImplTest {
         assertThat(released.getChangeInQuantity()).isEqualTo(2);
         assertThat(allocation.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.RELEASED);
     }
+
+    @Test
+    @DisplayName("#662: multi-allocation reservation consumes oldest allocation first, spilling to the next")
+    void consumePickedItems_multiAllocation_oldestFirstWithSpill() {
+        ConsumptionServiceImpl service = persistentService();
+        UUID pickTaskId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        var reservation = reservationWithLine();
+        var older = com.positivity.inventory.internal.entity.AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .reservation(reservation)
+                .locationId(LOCATION_ID)
+                .allocatedQuantity(3)
+                .allocationState(com.positivity.inventory.internal.enums.AllocationState.HARD)
+                .status(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED)
+                .createdAt(java.time.Instant.parse("2024-01-01T00:00:00Z"))
+                .build();
+        UUID otherLocation = UUID.fromString("00000000-0000-0000-0000-0000000000ab");
+        var newer = com.positivity.inventory.internal.entity.AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000004"))
+                .reservation(reservation)
+                .locationId(otherLocation)
+                .allocatedQuantity(3)
+                .allocationState(com.positivity.inventory.internal.enums.AllocationState.HARD)
+                .status(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED)
+                .createdAt(java.time.Instant.parse("2024-02-01T00:00:00Z"))
+                .build();
+
+        when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(pickedTaskWithLine(pickTaskId)));
+        when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
+        // returned newest-first to prove the service sorts oldest-first itself
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(newer, older));
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
+                .thenReturn(10);
+        when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                        any(String.class),
+                        org.mockito.ArgumentMatchers.eq(InventoryLedgerEventType.ALLOCATION_RELEASED)))
+                .thenReturn(0);
+        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(reservationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        ConsumeItemsRequest request = new ConsumeItemsRequest(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                List.of(new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 4)));
+
+        service.consumePickedItems(request);
+
+        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        List<InventoryLedgerEntry> entries = entriesCaptor.getValue();
+        assertThat(entries).hasSize(3); // 1 consumption + 2 releases
+        InventoryLedgerEntry first = entries.get(1);
+        InventoryLedgerEntry second = entries.get(2);
+        assertThat(first.getSourceTransactionId())
+                .isEqualTo(older.getAllocationId().toString());
+        assertThat(first.getChangeInQuantity()).isEqualTo(3); // older exhausted
+        assertThat(first.getLocationId()).isEqualTo(LOCATION_ID);
+        assertThat(second.getSourceTransactionId())
+                .isEqualTo(newer.getAllocationId().toString());
+        assertThat(second.getChangeInQuantity()).isEqualTo(1); // spill
+        assertThat(second.getLocationId()).isEqualTo(otherLocation);
+        assertThat(older.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.RELEASED);
+        assertThat(newer.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED);
+        // reservation pool shrinks by total released (PR #661 re-review finding 2)
+        assertThat(reservation.getAllocatedQuantity()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("#662: two items on the same allocation in one request never release beyond allocatedQuantity")
+    void consumePickedItems_sameAllocationTwiceInOneRequest_neverOverReleases() {
+        // PR #661 re-review finding 1 regression: in-batch releases are
+        // invisible to the ledger sum; the in-batch map must cap the total
+        ConsumptionServiceImpl service = persistentService();
+        UUID pickTaskId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        var reservation = reservationWithLine();
+        var allocation = locatedHardAllocation(reservation, 5);
+
+        when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(pickedTaskWithLine(pickTaskId)));
+        when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
+                .thenReturn(10);
+        when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                        allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
+                .thenReturn(0);
+        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(reservationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        ConsumeItemsRequest request = new ConsumeItemsRequest(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                List.of(
+                        new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 4),
+                        new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 4)));
+
+        service.consumePickedItems(request);
+
+        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        int totalReleased = entriesCaptor.getValue().stream()
+                .filter(e -> e.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
+                .mapToInt(InventoryLedgerEntry::getChangeInQuantity)
+                .sum();
+        assertThat(totalReleased).isEqualTo(5); // capped at allocatedQuantity, not 8
+    }
+
+    @Test
+    @DisplayName("#662: pick task without workorderLineId writes no allocation events")
+    void consumePickedItems_noWorkorderLine_writesNoAllocationEvents() {
+        ConsumptionServiceImpl service = persistentService();
+        UUID pickTaskId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        PickTaskEntity task = PickTaskEntity.builder()
+                .pickTaskId(pickTaskId)
+                .status(PickTaskStatus.PICKED)
+                .quantityPicked(5)
+                .build();
+        when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(task));
+        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.consumePickedItems(new ConsumeItemsRequest(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                List.of(new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 2))));
+
+        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        assertThat(entriesCaptor.getValue()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("#662: reservation with only SOFT/unlocated allocations writes no allocation events")
+    void consumePickedItems_softOrUnlocatedOnly_writesNoAllocationEvents() {
+        ConsumptionServiceImpl service = persistentService();
+        UUID pickTaskId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        var reservation = reservationWithLine();
+        var soft = com.positivity.inventory.internal.entity.AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .reservation(reservation)
+                .locationId(null)
+                .allocatedQuantity(5)
+                .allocationState(com.positivity.inventory.internal.enums.AllocationState.SOFT)
+                .status(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED)
+                .build();
+
+        when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(pickedTaskWithLine(pickTaskId)));
+        when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(soft));
+        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.consumePickedItems(new ConsumeItemsRequest(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                List.of(new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 2))));
+
+        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        assertThat(entriesCaptor.getValue()).hasSize(1);
+    }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryRollupServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryRollupServiceImplTest.java
@@ -1,0 +1,181 @@
+package com.positivity.inventory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.client.StorageLocationTopologyClient;
+import com.positivity.inventory.internal.client.StorageLocationTopologyClient.LocationDescendant;
+import com.positivity.inventory.internal.dto.rollup.LocationInventoryRollupResponse;
+import com.positivity.inventory.internal.dto.rollup.RollupQuantities;
+import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
+import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
+import com.positivity.inventory.internal.exception.LocationNotFoundException;
+import com.positivity.inventory.internal.exception.RollupExpansionTooLargeException;
+import com.positivity.inventory.internal.service.LocationInventoryRollupServiceImpl;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link LocationInventoryRollupServiceImpl} — CAP-218 #659.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LocationInventoryRollupServiceImpl — CAP-218 #659 unit tests")
+class LocationInventoryRollupServiceImplTest {
+
+    private static final UUID BUILDING_ID = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+    private static final UUID SITE_A = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID SITE_B = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+
+    @Mock
+    private StorageLocationTopologyClient topologyClient;
+
+    @Mock
+    private SiteInventoryRollupService siteInventoryRollupService;
+
+    private LocationInventoryRollupServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LocationInventoryRollupServiceImpl(topologyClient, siteInventoryRollupService, 25);
+    }
+
+    private static LocationDescendant descendant(UUID id, String name, int depth) {
+        return new LocationDescendant(id, name, "CODE-" + name, "ACTIVE", BUILDING_ID, depth);
+    }
+
+    private static SiteInventoryRollupResponse siteRollup(UUID siteId, long onHand, long allocated) {
+        StorageLocationRollupNode node = new StorageLocationRollupNode(
+                UUID.randomUUID(),
+                "Floor",
+                "FLOOR",
+                "ACTIVE",
+                RollupQuantities.of(onHand, allocated),
+                RollupQuantities.of(onHand, allocated),
+                List.of());
+        return new SiteInventoryRollupResponse(siteId, RollupQuantities.of(onHand, allocated), List.of(node));
+    }
+
+    @Test
+    @DisplayName("grand total equals sum of site totals; summaries carry no trees by default")
+    void rollup_summaries_grandTotalIsSumOfSites() {
+        // Issue #659: per-site summaries plus grand total, nodes omitted without expand
+        when(topologyClient.fetchDescendants(BUILDING_ID, "PHYSICAL"))
+                .thenReturn(List.of(descendant(SITE_A, "Site A", 1), descendant(SITE_B, "Site B", 1)));
+        when(siteInventoryRollupService.getSiteInventoryRollup(SITE_A, null, null, false))
+                .thenReturn(siteRollup(SITE_A, 100, 10));
+        when(siteInventoryRollupService.getSiteInventoryRollup(SITE_B, null, null, false))
+                .thenReturn(siteRollup(SITE_B, 50, 5));
+
+        LocationInventoryRollupResponse response =
+                service.getLocationInventoryRollup(BUILDING_ID, null, null, false, null, false);
+
+        assertThat(response.locationId()).isEqualTo(BUILDING_ID);
+        assertThat(response.parentType()).isEqualTo("PHYSICAL");
+        assertThat(response.totals().onHand()).isEqualTo(150);
+        assertThat(response.totals().allocated()).isEqualTo(15);
+        assertThat(response.totals().available()).isEqualTo(135);
+        assertThat(response.sites()).hasSize(2);
+        assertThat(response.sites().getFirst().siteName()).isEqualTo("Site A");
+        assertThat(response.sites().getFirst().nodes()).isNull();
+    }
+
+    @Test
+    @DisplayName("expand=tree inlines per-site trees matching the site rollup output")
+    void rollup_expandTree_inlinesSiteTrees() {
+        // Issue #659: expand=tree carries full FR-1 trees per site
+        when(topologyClient.fetchDescendants(BUILDING_ID, "PHYSICAL"))
+                .thenReturn(List.of(descendant(SITE_A, "Site A", 1)));
+        SiteInventoryRollupResponse siteRollup = siteRollup(SITE_A, 100, 10);
+        when(siteInventoryRollupService.getSiteInventoryRollup(SITE_A, "SKU-1", 3, true))
+                .thenReturn(siteRollup);
+
+        LocationInventoryRollupResponse response =
+                service.getLocationInventoryRollup(BUILDING_ID, "PHYSICAL", "SKU-1", true, 3, true);
+
+        assertThat(response.sites().getFirst().nodes()).isEqualTo(siteRollup.nodes());
+    }
+
+    @Test
+    @DisplayName("expand=tree over the site cap → RollupExpansionTooLargeException, no site computation")
+    void rollup_expandTreeOverCap_throws422() {
+        // Issue #659: fan-out guard rejects before any per-site work
+        List<LocationDescendant> many = IntStream.range(0, 26)
+                .mapToObj(i -> descendant(UUID.randomUUID(), "Site " + i, 1))
+                .toList();
+        when(topologyClient.fetchDescendants(BUILDING_ID, "PHYSICAL")).thenReturn(many);
+
+        assertThatThrownBy(() -> service.getLocationInventoryRollup(BUILDING_ID, null, null, true, null, false))
+                .isInstanceOf(RollupExpansionTooLargeException.class)
+                .hasMessageContaining("26")
+                .hasMessageContaining("25");
+        verify(siteInventoryRollupService, never()).getSiteInventoryRollup(any(), any(), any(), eq(false));
+    }
+
+    @Test
+    @DisplayName("over the cap WITHOUT expand still returns summaries")
+    void rollup_overCapWithoutExpand_returnsSummaries() {
+        // Issue #659: cap applies to expand=tree only
+        List<LocationDescendant> many = IntStream.range(0, 26)
+                .mapToObj(i -> descendant(UUID.randomUUID(), "Site " + i, 1))
+                .toList();
+        when(topologyClient.fetchDescendants(BUILDING_ID, "PHYSICAL")).thenReturn(many);
+        when(siteInventoryRollupService.getSiteInventoryRollup(any(), any(), any(), eq(false)))
+                .thenAnswer(inv -> siteRollup(inv.getArgument(0), 1, 0));
+
+        LocationInventoryRollupResponse response =
+                service.getLocationInventoryRollup(BUILDING_ID, null, null, false, null, false);
+
+        assertThat(response.sites()).hasSize(26);
+        assertThat(response.totals().onHand()).isEqualTo(26);
+    }
+
+    @Test
+    @DisplayName("unknown parentType → IllegalArgumentException (400); case-insensitive accepted values")
+    void rollup_parentTypeValidation() {
+        // Issue #659: parentType validated against the ParentType value set
+        assertThatThrownBy(() -> service.getLocationInventoryRollup(BUILDING_ID, "BOGUS", null, false, null, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("BOGUS");
+
+        when(topologyClient.fetchDescendants(BUILDING_ID, "REGION")).thenReturn(List.of());
+        LocationInventoryRollupResponse response =
+                service.getLocationInventoryRollup(BUILDING_ID, "region", null, false, null, false);
+        assertThat(response.parentType()).isEqualTo("REGION");
+    }
+
+    @Test
+    @DisplayName("no descendants → 200 with empty sites and zero totals")
+    void rollup_noDescendants_returnsEmpty() {
+        // Issue #659: empty result, not an error
+        when(topologyClient.fetchDescendants(BUILDING_ID, "PHYSICAL")).thenReturn(List.of());
+
+        LocationInventoryRollupResponse response =
+                service.getLocationInventoryRollup(BUILDING_ID, null, null, false, null, false);
+
+        assertThat(response.sites()).isEmpty();
+        assertThat(response.totals()).isEqualTo(RollupQuantities.ZERO);
+    }
+
+    @Test
+    @DisplayName("unknown location propagates LocationNotFoundException from the client")
+    void rollup_unknownLocation_propagatesNotFound() {
+        // Issue #659: pos-location 404 → 404 at the controller
+        when(topologyClient.fetchDescendants(BUILDING_ID, "PHYSICAL"))
+                .thenThrow(new LocationNotFoundException(BUILDING_ID));
+
+        assertThatThrownBy(() -> service.getLocationInventoryRollup(BUILDING_ID, null, null, false, null, false))
+                .isInstanceOf(LocationNotFoundException.class);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
@@ -9,15 +9,19 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.positivity.inventory.internal.client.StorageLocationValidationClient;
 import com.positivity.inventory.internal.dto.reservation.CreateReservationRequest;
 import com.positivity.inventory.internal.dto.reservation.PromoteAllocationRequest;
 import com.positivity.inventory.internal.dto.reservation.ReservationResponse;
 import com.positivity.inventory.internal.entity.AllocationEntity;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.entity.ReservationEntity;
 import com.positivity.inventory.internal.enums.AllocationState;
 import com.positivity.inventory.internal.enums.AllocationStatus;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.enums.ReservationStatus;
 import com.positivity.inventory.internal.exception.InsufficientAtpException;
+import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.repository.AllocationRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
@@ -33,6 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -62,6 +67,8 @@ class ReservationServiceImplTest {
 
     private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
+    private static final UUID STORAGE_LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
+
     @Mock
     private ReservationRepository reservationRepository;
 
@@ -71,12 +78,29 @@ class ReservationServiceImplTest {
     @Mock
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
+    @Mock
+    private StorageLocationValidationClient storageLocationValidationClient;
+
     private ReservationServiceImpl service;
+
+    private static StorageLocationValidationClient.StorageLocationValidation validation(
+            boolean exists, boolean active) {
+        StorageLocationValidationClient.StorageLocationValidation result =
+                new StorageLocationValidationClient.StorageLocationValidation();
+        result.setStorageLocationId(STORAGE_LOCATION_ID);
+        result.setExists(exists);
+        result.setActive(active);
+        return result;
+    }
 
     @BeforeEach
     void setUp() {
         service = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
         // Default lenient stubs for the SC1–SC7 scaffold tests
         lenient().when(reservationRepository.findByWorkorderLineId(any())).thenReturn(Optional.empty());
         lenient().when(reservationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
@@ -107,6 +131,12 @@ class ReservationServiceImplTest {
         lenient()
                 .when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
                 .thenReturn(100);
+        lenient()
+                .when(storageLocationValidationClient.getStorageLocationValidation(any(String.class)))
+                .thenReturn(validation(true, true));
+        lenient()
+                .when(inventoryLedgerEntryRepository.save(any(InventoryLedgerEntry.class)))
+                .thenAnswer(i -> i.getArgument(0));
     }
 
     // ─── SC1: Create SOFT reservation ──────────────────────────────────────────
@@ -186,7 +216,8 @@ class ReservationServiceImplTest {
         // Issue #29: SC3 — SOFT → HARD promotion must record hardenedAt and hardenedBy
         // Arrange
         UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        PromoteAllocationRequest request = new PromoteAllocationRequest("approved for workorder completion");
+        PromoteAllocationRequest request =
+                new PromoteAllocationRequest(STORAGE_LOCATION_ID, "approved for workorder completion");
 
         // Act — RED: impl throws UnsupportedOperationException
         ReservationResponse result = service.promoteToHard(allocationId, request);
@@ -219,7 +250,7 @@ class ReservationServiceImplTest {
         // error code; reservation status must become BACKORDERED
         // Arrange
         UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        PromoteAllocationRequest request = new PromoteAllocationRequest("urgent");
+        PromoteAllocationRequest request = new PromoteAllocationRequest(STORAGE_LOCATION_ID, "urgent");
         // Force insufficient ATP so the exception is thrown
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
                 .thenReturn(1);
@@ -342,7 +373,11 @@ class ReservationServiceImplTest {
     @DisplayName("createOrUpdateReservation repository mode updates existing reservation by workorderLineId")
     void createOrUpdateReservation_repositoryMode_existingReservation_updatesRequiredQuantity() {
         ReservationServiceImpl repositoryService = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
 
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         ReservationEntity existing = ReservationEntity.builder()
@@ -369,7 +404,11 @@ class ReservationServiceImplTest {
     @DisplayName("createOrUpdateReservation repository mode creates reservation and SOFT allocation when absent")
     void createOrUpdateReservation_repositoryMode_missingReservation_createsSoftAllocation() {
         ReservationServiceImpl repositoryService = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
 
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         when(reservationRepository.findByWorkorderLineId(workorderLineId)).thenReturn(Optional.empty());
@@ -402,12 +441,16 @@ class ReservationServiceImplTest {
     @DisplayName("promoteToHard throws ResourceNotFoundException when allocationId does not exist")
     void promoteToHard_repositoryMode_allocationMissing_throwsResourceNotFound() {
         ReservationServiceImpl repositoryService = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
 
         UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         when(allocationRepository.findById(allocationId)).thenReturn(Optional.empty());
 
-        PromoteAllocationRequest request = new PromoteAllocationRequest("normal");
+        PromoteAllocationRequest request = new PromoteAllocationRequest(STORAGE_LOCATION_ID, "normal");
         assertThatThrownBy(() -> repositoryService.promoteToHard(allocationId, request))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Allocation not found");
@@ -417,7 +460,11 @@ class ReservationServiceImplTest {
     @DisplayName("promoteToHard sets BACKORDERED and throws InsufficientAtpException when ATP is insufficient")
     void promoteToHard_repositoryMode_insufficientAtp_setsBackorderedAndThrows() {
         ReservationServiceImpl repositoryService = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
 
         ReservationEntity reservation = ReservationEntity.builder()
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
@@ -445,7 +492,7 @@ class ReservationServiceImplTest {
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
         UUID targetAllocationId = allocation.getAllocationId();
-        PromoteAllocationRequest request = new PromoteAllocationRequest("urgent");
+        PromoteAllocationRequest request = new PromoteAllocationRequest(STORAGE_LOCATION_ID, "urgent");
 
         assertThatThrownBy(() -> repositoryService.promoteToHard(targetAllocationId, request))
                 .isInstanceOf(InsufficientAtpException.class)
@@ -459,7 +506,11 @@ class ReservationServiceImplTest {
     @DisplayName("promoteToHard transitions allocation to HARD and returns FULFILLED when ATP is sufficient")
     void promoteToHard_repositoryMode_sufficientAtp_transitionsToHard() {
         ReservationServiceImpl repositoryService = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
 
         ReservationEntity reservation = ReservationEntity.builder()
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
@@ -489,8 +540,8 @@ class ReservationServiceImplTest {
         when(reservationRepository.save(any(ReservationEntity.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        ReservationResponse response =
-                repositoryService.promoteToHard(allocation.getAllocationId(), new PromoteAllocationRequest("approved"));
+        ReservationResponse response = repositoryService.promoteToHard(
+                allocation.getAllocationId(), new PromoteAllocationRequest(STORAGE_LOCATION_ID, "approved"));
 
         assertThat(allocation.getAllocationState()).isEqualTo(AllocationState.HARD);
         assertThat(allocation.getHardenedAt()).isNotNull();
@@ -504,7 +555,11 @@ class ReservationServiceImplTest {
     @DisplayName("promoteToHard excludes current HARD allocation from ATP subtraction")
     void promoteToHard_repositoryMode_currentHardAllocation_excludesSelfFromExistingHard() {
         ReservationServiceImpl repositoryService = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
 
         ReservationEntity reservation = ReservationEntity.builder()
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
@@ -540,7 +595,7 @@ class ReservationServiceImplTest {
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
         UUID currentAllocationId = current.getAllocationId();
-        PromoteAllocationRequest promoteReq = new PromoteAllocationRequest("re-harden");
+        PromoteAllocationRequest promoteReq = new PromoteAllocationRequest(STORAGE_LOCATION_ID, "re-harden");
 
         assertThatThrownBy(() -> repositoryService.promoteToHard(currentAllocationId, promoteReq))
                 .isInstanceOf(InsufficientAtpException.class);
@@ -552,7 +607,11 @@ class ReservationServiceImplTest {
     @DisplayName("cancelReservation throws ResourceNotFoundException when reservation does not exist")
     void cancelReservation_repositoryMode_reservationMissing_throwsResourceNotFound() {
         ReservationServiceImpl repositoryService = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
 
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         when(reservationRepository.findByWorkorderLineId(workorderLineId)).thenReturn(Optional.empty());
@@ -566,7 +625,11 @@ class ReservationServiceImplTest {
     @DisplayName("cancelReservation handles empty allocation list and marks reservation CANCELLED")
     void cancelReservation_repositoryMode_emptyAllocationList_marksCancelled() {
         ReservationServiceImpl repositoryService = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
 
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         ReservationEntity reservation = ReservationEntity.builder()
@@ -595,7 +658,11 @@ class ReservationServiceImplTest {
     @DisplayName("cancelReservation releases both SOFT and HARD allocations")
     void cancelReservation_repositoryMode_releasesSoftAndHardAllocations() {
         ReservationServiceImpl repositoryService = new ReservationServiceImpl(
-                TEST_CLOCK, reservationRepository, allocationRepository, inventoryLedgerEntryRepository);
+                TEST_CLOCK,
+                reservationRepository,
+                allocationRepository,
+                inventoryLedgerEntryRepository,
+                storageLocationValidationClient);
 
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         ReservationEntity reservation = ReservationEntity.builder()
@@ -635,5 +702,183 @@ class ReservationServiceImplTest {
         assertThat(hardAllocation.getStatus()).isEqualTo(AllocationStatus.RELEASED);
         assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
         verify(allocationRepository).saveAll(any());
+    }
+
+    // ─── CAP-218 #656: allocation ledger events + location on hard promotion ────
+
+    @Test
+    @DisplayName("promoteToHard assigns storage location and writes ALLOCATION_CREATED ledger event")
+    void promoteToHard_softAllocation_assignsLocationAndWritesAllocationCreated() {
+        // Issue #656: hard promotion must pin a storage location and record
+        // an ALLOCATION_CREATED ledger event in the same transaction
+        ReservationEntity reservation = ReservationEntity.builder()
+                .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .requiredQuantity(5)
+                .allocatedQuantity(0)
+                .status(ReservationStatus.PENDING)
+                .build();
+        AllocationEntity allocation = AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .reservation(reservation)
+                .locationId(null)
+                .allocatedQuantity(5)
+                .allocationState(AllocationState.SOFT)
+                .status(AllocationStatus.ALLOCATED)
+                .build();
+
+        when(allocationRepository.findById(allocation.getAllocationId())).thenReturn(Optional.of(allocation));
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
+                .thenReturn(10);
+        when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
+                .thenReturn(List.of());
+        when(allocationRepository.save(any(AllocationEntity.class))).thenAnswer(i -> i.getArgument(0));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
+        when(reservationRepository.save(any(ReservationEntity.class))).thenAnswer(i -> i.getArgument(0));
+
+        service.promoteToHard(
+                allocation.getAllocationId(), new PromoteAllocationRequest(STORAGE_LOCATION_ID, "approved"));
+
+        assertThat(allocation.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);
+
+        ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
+        verify(inventoryLedgerEntryRepository).save(ledgerCaptor.capture());
+        InventoryLedgerEntry entry = ledgerCaptor.getValue();
+        assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.ALLOCATION_CREATED);
+        assertThat(entry.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);
+        assertThat(entry.getChangeInQuantity()).isEqualTo(5);
+        assertThat(entry.getStockItemId())
+                .isEqualTo(reservation.getStockItemId().toString());
+        assertThat(entry.getSourceTransactionId())
+                .isEqualTo(allocation.getAllocationId().toString());
+    }
+
+    @Test
+    @DisplayName("promoteToHard on already-HARD located allocation writes no duplicate CREATED and keeps location")
+    void promoteToHard_alreadyHardWithLocation_noDuplicateLedgerEventAndLocationUnchanged() {
+        // Issue #656: re-promote must not write a duplicate ALLOCATION_CREATED
+        // and must keep the location the original event was recorded against
+        UUID originalLocation = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
+        ReservationEntity reservation = ReservationEntity.builder()
+                .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .requiredQuantity(5)
+                .allocatedQuantity(5)
+                .status(ReservationStatus.FULFILLED)
+                .build();
+        AllocationEntity allocation = AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .reservation(reservation)
+                .locationId(originalLocation)
+                .allocatedQuantity(5)
+                .allocationState(AllocationState.HARD)
+                .status(AllocationStatus.ALLOCATED)
+                .build();
+
+        when(allocationRepository.findById(allocation.getAllocationId())).thenReturn(Optional.of(allocation));
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
+                .thenReturn(10);
+        when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
+                .thenReturn(List.of(allocation));
+        when(allocationRepository.save(any(AllocationEntity.class))).thenAnswer(i -> i.getArgument(0));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
+        when(reservationRepository.save(any(ReservationEntity.class))).thenAnswer(i -> i.getArgument(0));
+
+        service.promoteToHard(
+                allocation.getAllocationId(), new PromoteAllocationRequest(STORAGE_LOCATION_ID, "re-promote"));
+
+        assertThat(allocation.getLocationId()).isEqualTo(originalLocation);
+        verify(inventoryLedgerEntryRepository, never()).save(any(InventoryLedgerEntry.class));
+    }
+
+    @Test
+    @DisplayName("promoteToHard throws LocationNotFoundException when storage location does not exist")
+    void promoteToHard_storageLocationMissing_throwsLocationNotFound() {
+        // Issue #656: nonexistent storage location must fail before any state change
+        when(storageLocationValidationClient.getStorageLocationValidation(any(String.class)))
+                .thenReturn(validation(false, false));
+
+        UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        PromoteAllocationRequest request = new PromoteAllocationRequest(STORAGE_LOCATION_ID, "x");
+
+        assertThatThrownBy(() -> service.promoteToHard(allocationId, request))
+                .isInstanceOf(LocationNotFoundException.class);
+        verify(allocationRepository, never()).save(any(AllocationEntity.class));
+        verify(inventoryLedgerEntryRepository, never()).save(any(InventoryLedgerEntry.class));
+    }
+
+    @Test
+    @DisplayName("promoteToHard throws IllegalArgumentException when storage location is inactive")
+    void promoteToHard_storageLocationInactive_throwsIllegalArgument() {
+        // Issue #656: inactive storage location must be rejected
+        when(storageLocationValidationClient.getStorageLocationValidation(any(String.class)))
+                .thenReturn(validation(true, false));
+
+        UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        PromoteAllocationRequest request = new PromoteAllocationRequest(STORAGE_LOCATION_ID, "x");
+
+        assertThatThrownBy(() -> service.promoteToHard(allocationId, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not active");
+        verify(allocationRepository, never()).save(any(AllocationEntity.class));
+    }
+
+    @Test
+    @DisplayName("cancelReservation writes ALLOCATION_RELEASED only for located HARD allocations")
+    void cancelReservation_mixedAllocations_writesReleasedOnlyForLocatedHard() {
+        // Issue #656: SOFT and unlocated allocations had no CREATED event, so no
+        // RELEASED event may be written for them
+        UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        ReservationEntity reservation = ReservationEntity.builder()
+                .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .workorderLineId(workorderLineId)
+                .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .requiredQuantity(12)
+                .allocatedQuantity(12)
+                .status(ReservationStatus.PARTIALLY_FULFILLED)
+                .build();
+        AllocationEntity softAllocation = AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .reservation(reservation)
+                .locationId(null)
+                .allocatedQuantity(4)
+                .allocationState(AllocationState.SOFT)
+                .status(AllocationStatus.ALLOCATED)
+                .build();
+        AllocationEntity unlocatedHard = AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
+                .reservation(reservation)
+                .locationId(null)
+                .allocatedQuantity(3)
+                .allocationState(AllocationState.HARD)
+                .status(AllocationStatus.ALLOCATED)
+                .build();
+        AllocationEntity locatedHard = AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000004"))
+                .reservation(reservation)
+                .locationId(STORAGE_LOCATION_ID)
+                .allocatedQuantity(5)
+                .allocationState(AllocationState.HARD)
+                .status(AllocationStatus.ALLOCATED)
+                .build();
+
+        when(reservationRepository.findByWorkorderLineId(workorderLineId)).thenReturn(Optional.of(reservation));
+        when(allocationRepository.findByReservation(reservation))
+                .thenReturn(List.of(softAllocation, unlocatedHard, locatedHard));
+        when(allocationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(reservationRepository.save(any(ReservationEntity.class))).thenAnswer(i -> i.getArgument(0));
+
+        service.cancelReservation(workorderLineId);
+
+        ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
+        verify(inventoryLedgerEntryRepository).save(ledgerCaptor.capture());
+        InventoryLedgerEntry entry = ledgerCaptor.getValue();
+        assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.ALLOCATION_RELEASED);
+        assertThat(entry.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);
+        assertThat(entry.getChangeInQuantity()).isEqualTo(5);
+        assertThat(entry.getSourceTransactionId())
+                .isEqualTo(locatedHard.getAllocationId().toString());
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
@@ -914,6 +914,44 @@ class ReservationServiceImplTest {
     }
 
     @Test
+    @DisplayName("cancelReservation after partial consumption releases only the un-released remainder")
+    void cancelReservation_afterPartialRelease_releasesRemainderOnly() {
+        // Issue #662: ledger-derived remainder keeps CREATED - RELEASED within
+        // {0, allocatedQuantity} across promote -> partial consume -> cancel
+        UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        ReservationEntity reservation = ReservationEntity.builder()
+                .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .workorderLineId(workorderLineId)
+                .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .requiredQuantity(5)
+                .allocatedQuantity(5)
+                .status(ReservationStatus.FULFILLED)
+                .build();
+        AllocationEntity locatedHard = AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .reservation(reservation)
+                .locationId(STORAGE_LOCATION_ID)
+                .allocatedQuantity(5)
+                .allocationState(AllocationState.HARD)
+                .status(AllocationStatus.ALLOCATED)
+                .build();
+
+        when(reservationRepository.findByWorkorderLineId(workorderLineId)).thenReturn(Optional.of(reservation));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(locatedHard));
+        when(allocationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(reservationRepository.save(any(ReservationEntity.class))).thenAnswer(i -> i.getArgument(0));
+        when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                        locatedHard.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
+                .thenReturn(3);
+
+        service.cancelReservation(workorderLineId);
+
+        ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
+        verify(inventoryLedgerEntryRepository).save(ledgerCaptor.capture());
+        assertThat(ledgerCaptor.getValue().getChangeInQuantity()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("cancelReservation writes ALLOCATION_RELEASED only for located HARD allocations")
     void cancelReservation_mixedAllocations_writesReleasedOnlyForLocatedHard() {
         // Issue #656: SOFT and unlocated allocations had no CREATED event, so no

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
@@ -755,10 +755,47 @@ class ReservationServiceImplTest {
     }
 
     @Test
-    @DisplayName("promoteToHard on already-HARD located allocation writes no duplicate CREATED and keeps location")
-    void promoteToHard_alreadyHardWithLocation_noDuplicateLedgerEventAndLocationUnchanged() {
+    @DisplayName("promoteToHard re-promote at the SAME location writes no duplicate CREATED")
+    void promoteToHard_alreadyHardSameLocation_noDuplicateLedgerEvent() {
         // Issue #656: re-promote must not write a duplicate ALLOCATION_CREATED
-        // and must keep the location the original event was recorded against
+        ReservationEntity reservation = ReservationEntity.builder()
+                .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .requiredQuantity(5)
+                .allocatedQuantity(5)
+                .status(ReservationStatus.FULFILLED)
+                .build();
+        AllocationEntity allocation = AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .reservation(reservation)
+                .locationId(STORAGE_LOCATION_ID)
+                .allocatedQuantity(5)
+                .allocationState(AllocationState.HARD)
+                .status(AllocationStatus.ALLOCATED)
+                .build();
+
+        when(allocationRepository.findById(allocation.getAllocationId())).thenReturn(Optional.of(allocation));
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
+                .thenReturn(10);
+        when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
+                .thenReturn(List.of(allocation));
+        when(allocationRepository.save(any(AllocationEntity.class))).thenAnswer(i -> i.getArgument(0));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
+        when(reservationRepository.save(any(ReservationEntity.class))).thenAnswer(i -> i.getArgument(0));
+
+        service.promoteToHard(
+                allocation.getAllocationId(), new PromoteAllocationRequest(STORAGE_LOCATION_ID, "re-promote"));
+
+        assertThat(allocation.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);
+        verify(inventoryLedgerEntryRepository, never()).save(any(InventoryLedgerEntry.class));
+    }
+
+    @Test
+    @DisplayName("promoteToHard re-promote at a DIFFERENT location → IllegalStateException (409), location kept")
+    void promoteToHard_alreadyHardDifferentLocation_throwsConflictAndKeepsLocation() {
+        // PR #661 review finding 6: relocation via promote is rejected, not
+        // silently ignored
         UUID originalLocation = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
         ReservationEntity reservation = ReservationEntity.builder()
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
@@ -782,15 +819,66 @@ class ReservationServiceImplTest {
                 .thenReturn(10);
         when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
                 .thenReturn(List.of(allocation));
-        when(allocationRepository.save(any(AllocationEntity.class))).thenAnswer(i -> i.getArgument(0));
-        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
-        when(reservationRepository.save(any(ReservationEntity.class))).thenAnswer(i -> i.getArgument(0));
 
-        service.promoteToHard(
-                allocation.getAllocationId(), new PromoteAllocationRequest(STORAGE_LOCATION_ID, "re-promote"));
+        UUID targetAllocationId = allocation.getAllocationId();
+        PromoteAllocationRequest request = new PromoteAllocationRequest(STORAGE_LOCATION_ID, "re-promote");
+
+        assertThatThrownBy(() -> service.promoteToHard(targetAllocationId, request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already hardened");
 
         assertThat(allocation.getLocationId()).isEqualTo(originalLocation);
+        verify(allocationRepository, never()).save(any(AllocationEntity.class));
         verify(inventoryLedgerEntryRepository, never()).save(any(InventoryLedgerEntry.class));
+    }
+
+    @Test
+    @DisplayName("createOrUpdateReservation rejects SKU change while located HARD allocation exists")
+    void createOrUpdateReservation_skuChangeWithLocatedHard_throwsConflict() {
+        // PR #661 review finding 4: SKU change would skew per-SKU ledger math
+        UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        ReservationEntity existing = ReservationEntity.builder()
+                .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .workorderLineId(workorderLineId)
+                .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .requiredQuantity(5)
+                .allocatedQuantity(5)
+                .status(ReservationStatus.FULFILLED)
+                .build();
+        AllocationEntity locatedHard = AllocationEntity.builder()
+                .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .reservation(existing)
+                .locationId(STORAGE_LOCATION_ID)
+                .allocatedQuantity(5)
+                .allocationState(AllocationState.HARD)
+                .status(AllocationStatus.ALLOCATED)
+                .build();
+
+        when(reservationRepository.findByWorkorderLineId(workorderLineId)).thenReturn(Optional.of(existing));
+        when(allocationRepository.findByReservation(existing)).thenReturn(List.of(locatedHard));
+
+        CreateReservationRequest skuChange = new CreateReservationRequest(
+                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000099"), 5);
+
+        assertThatThrownBy(() -> service.createOrUpdateReservation(skuChange))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Cannot change stock item");
+        verify(reservationRepository, never()).save(any(ReservationEntity.class));
+    }
+
+    @Test
+    @DisplayName("promoteToHard surfaces 503-mapped exception when location validation service is down")
+    void promoteToHard_validationServiceDown_throwsLocationServiceUnavailable() {
+        // PR #661 review finding 5: outage must map to 503, not raw 500
+        when(storageLocationValidationClient.getStorageLocationValidation(any(String.class)))
+                .thenThrow(new org.springframework.web.client.ResourceAccessException("connection refused"));
+
+        UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        PromoteAllocationRequest request = new PromoteAllocationRequest(STORAGE_LOCATION_ID, "x");
+
+        assertThatThrownBy(() -> service.promoteToHard(allocationId, request))
+                .isInstanceOf(com.positivity.inventory.internal.exception.LocationServiceUnavailableException.class);
+        verify(allocationRepository, never()).save(any(AllocationEntity.class));
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/SiteInventoryRollupServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/SiteInventoryRollupServiceImplTest.java
@@ -1,0 +1,225 @@
+package com.positivity.inventory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.client.StorageLocationTopologyClient;
+import com.positivity.inventory.internal.client.StorageLocationTopologyClient.StorageLocationNode;
+import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
+import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.exception.LocationNotFoundException;
+import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.service.SiteInventoryQuantityLoader;
+import com.positivity.inventory.internal.service.SiteInventoryRollupServiceImpl;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link SiteInventoryRollupServiceImpl} — CAP-218 #658.
+ *
+ * <p>Topology client is mocked; quantities come through a real
+ * {@link SiteInventoryQuantityLoader} backed by a mocked repository so the
+ * loader's sku/no-sku branching is exercised too.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SiteInventoryRollupServiceImpl — CAP-218 #658 unit tests")
+class SiteInventoryRollupServiceImplTest {
+
+    private static final UUID SITE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID FLOOR_ID = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+    private static final UUID SHELF_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+    private static final UUID BIN_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+
+    @Mock
+    private StorageLocationTopologyClient topologyClient;
+
+    @Mock
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    private SiteInventoryRollupServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SiteInventoryRollupServiceImpl(topologyClient, new SiteInventoryQuantityLoader(ledgerRepository));
+    }
+
+    private static List<StorageLocationNode> threeLevelTopology() {
+        return List.of(
+                new StorageLocationNode(FLOOR_ID, "Floor A", "FLOOR", "ACTIVE", null),
+                new StorageLocationNode(SHELF_ID, "Shelf A-1", "SHELF", "ACTIVE", FLOOR_ID),
+                new StorageLocationNode(BIN_ID, "Bin A-1-1", "BIN", "ACTIVE", SHELF_ID));
+    }
+
+    @Test
+    @DisplayName("three-level tree: own vs rolledUp math and site totals are correct")
+    void rollup_threeLevelTree_correctOwnAndRolledUp() {
+        // Issue #658: rolledUp = own + sum of descendants' own, depth-first
+        when(topologyClient.fetchSiteTopology(SITE_ID)).thenReturn(threeLevelTopology());
+        when(ledgerRepository.sumQuantityByLocationChunked(any(), any()))
+                .thenReturn(Map.of(SHELF_ID, 120L, BIN_ID, 360L));
+        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any()))
+                .thenReturn(Map.of(SHELF_ID, 10L, BIN_ID, 20L));
+
+        SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, true);
+
+        assertThat(response.siteId()).isEqualTo(SITE_ID);
+        assertThat(response.totals().onHand()).isEqualTo(480);
+        assertThat(response.totals().allocated()).isEqualTo(30);
+        assertThat(response.totals().available()).isEqualTo(450);
+
+        StorageLocationRollupNode floor = response.nodes().getFirst();
+        assertThat(floor.storageLocationId()).isEqualTo(FLOOR_ID);
+        assertThat(floor.own().onHand()).isZero();
+        assertThat(floor.rolledUp().onHand()).isEqualTo(480);
+        assertThat(floor.rolledUp().available()).isEqualTo(450);
+
+        StorageLocationRollupNode shelf = floor.children().getFirst();
+        assertThat(shelf.own().onHand()).isEqualTo(120);
+        assertThat(shelf.rolledUp().onHand()).isEqualTo(480);
+
+        StorageLocationRollupNode bin = shelf.children().getFirst();
+        assertThat(bin.own().onHand()).isEqualTo(360);
+        assertThat(bin.rolledUp().onHand()).isEqualTo(360);
+        assertThat(bin.children()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("sku filter routes through SKU-scoped queries including CREATED-RELEASED allocation math")
+    void rollup_skuFilter_usesSkuScopedQueries() {
+        // Issue #658: when sku given, all quantities are for that SKU only
+        when(topologyClient.fetchSiteTopology(SITE_ID)).thenReturn(threeLevelTopology());
+        when(ledgerRepository.sumQuantityByLocationForSkuChunked(eq("SKU-1"), any(), any()))
+                .thenAnswer(invocation -> {
+                    Collection<InventoryLedgerEventType> types = invocation.getArgument(2);
+                    if (types.contains(InventoryLedgerEventType.ALLOCATION_CREATED)) {
+                        return Map.of(BIN_ID, 7L);
+                    }
+                    if (types.contains(InventoryLedgerEventType.ALLOCATION_RELEASED)) {
+                        return Map.of(BIN_ID, 2L);
+                    }
+                    return Map.of(BIN_ID, 50L); // on-hand types
+                });
+
+        SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, "SKU-1", null, true);
+
+        assertThat(response.totals().onHand()).isEqualTo(50);
+        assertThat(response.totals().allocated()).isEqualTo(5);
+        assertThat(response.totals().available()).isEqualTo(45);
+    }
+
+    @Test
+    @DisplayName("orphan parent id attaches node to root")
+    void rollup_orphanParentId_attachesToRoot() {
+        // Issue #658: node whose parent id is missing from the site set becomes a root
+        UUID ghostParent = UUID.fromString("00000000-0000-0000-0000-00000000dead");
+        when(topologyClient.fetchSiteTopology(SITE_ID))
+                .thenReturn(List.of(
+                        new StorageLocationNode(FLOOR_ID, "Floor A", "FLOOR", "ACTIVE", null),
+                        new StorageLocationNode(SHELF_ID, "Orphan Shelf", "SHELF", "ACTIVE", ghostParent)));
+        when(ledgerRepository.sumQuantityByLocationChunked(any(), any())).thenReturn(Map.of(SHELF_ID, 5L));
+        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any())).thenReturn(Map.of());
+
+        SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, true);
+
+        assertThat(response.nodes()).hasSize(2);
+        assertThat(response.totals().onHand()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("negative available passes through unclamped")
+    void rollup_overAllocated_negativeAvailableUnclamped() {
+        // Issue #658: available may be negative — real over-allocation signal
+        when(topologyClient.fetchSiteTopology(SITE_ID))
+                .thenReturn(List.of(new StorageLocationNode(BIN_ID, "Bin", "BIN", "ACTIVE", null)));
+        when(ledgerRepository.sumQuantityByLocationChunked(any(), any())).thenReturn(Map.of(BIN_ID, 3L));
+        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any())).thenReturn(Map.of(BIN_ID, 8L));
+
+        SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, true);
+
+        assertThat(response.totals().available()).isEqualTo(-5);
+    }
+
+    @Test
+    @DisplayName("includeEmpty=false prunes all-zero nodes; parents of non-empty children survive")
+    void rollup_includeEmptyFalse_prunesZeroNodes() {
+        // Issue #658: empty BIN pruned; FLOOR kept (rolledUp nonzero via SHELF)
+        UUID emptyBin = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+        when(topologyClient.fetchSiteTopology(SITE_ID))
+                .thenReturn(List.of(
+                        new StorageLocationNode(FLOOR_ID, "Floor A", "FLOOR", "ACTIVE", null),
+                        new StorageLocationNode(SHELF_ID, "Shelf A-1", "SHELF", "ACTIVE", FLOOR_ID),
+                        new StorageLocationNode(emptyBin, "Empty Bin", "BIN", "ACTIVE", FLOOR_ID)));
+        when(ledgerRepository.sumQuantityByLocationChunked(any(), any())).thenReturn(Map.of(SHELF_ID, 9L));
+        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any())).thenReturn(Map.of());
+
+        SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, false);
+
+        StorageLocationRollupNode floor = response.nodes().getFirst();
+        assertThat(response.nodes()).hasSize(1);
+        assertThat(floor.children()).hasSize(1);
+        assertThat(floor.children().getFirst().storageLocationId()).isEqualTo(SHELF_ID);
+    }
+
+    @Test
+    @DisplayName("depth=1 returns roots only; totals remain full-tree")
+    void rollup_depthOne_truncatesChildrenButKeepsFullTotals() {
+        // Issue #658: depth truncates the returned tree, not the math
+        when(topologyClient.fetchSiteTopology(SITE_ID)).thenReturn(threeLevelTopology());
+        when(ledgerRepository.sumQuantityByLocationChunked(any(), any())).thenReturn(Map.of(BIN_ID, 360L));
+        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any())).thenReturn(Map.of());
+
+        SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, 1, true);
+
+        StorageLocationRollupNode floor = response.nodes().getFirst();
+        assertThat(floor.children()).isEmpty();
+        assertThat(floor.rolledUp().onHand()).isEqualTo(360);
+        assertThat(response.totals().onHand()).isEqualTo(360);
+    }
+
+    @Test
+    @DisplayName("site with no storage locations returns empty nodes and zero totals")
+    void rollup_emptySite_returnsEmptyResponse() {
+        // Issue #658: 200 with empty nodes, not 404
+        when(topologyClient.fetchSiteTopology(SITE_ID)).thenReturn(List.of());
+
+        SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, false);
+
+        assertThat(response.nodes()).isEmpty();
+        assertThat(response.totals().onHand()).isZero();
+        assertThat(response.totals().allocated()).isZero();
+    }
+
+    @Test
+    @DisplayName("unknown site propagates LocationNotFoundException from the topology client")
+    void rollup_unknownSite_propagatesNotFound() {
+        // Issue #658: pos-location 404 → 404 ProblemDetail at the controller
+        when(topologyClient.fetchSiteTopology(SITE_ID)).thenThrow(new LocationNotFoundException(SITE_ID));
+
+        assertThatThrownBy(() -> service.getSiteInventoryRollup(SITE_ID, null, null, false))
+                .isInstanceOf(LocationNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("pos-location outage propagates LocationServiceUnavailableException")
+    void rollup_locationOutage_propagatesUnavailable() {
+        // Issue #658: never fabricate partial topology; surface 503
+        when(topologyClient.fetchSiteTopology(SITE_ID))
+                .thenThrow(new LocationServiceUnavailableException("down", null));
+
+        assertThatThrownBy(() -> service.getSiteInventoryRollup(SITE_ID, null, null, false))
+                .isInstanceOf(LocationServiceUnavailableException.class);
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:218`
- Parent STORY (durion): louisburroughs/durion#218
- Child issues:
  - louisburroughs/durion-positivity-backend#656 — Allocation: write allocation ledger events and assign location on hard promotion
  - louisburroughs/durion-positivity-backend#657 — Inventory: bulk grouped on-hand and allocation queries by location set
  - louisburroughs/durion-positivity-backend#658 — Inventory: site inventory rollup by storage location hierarchy
  - louisburroughs/durion-positivity-backend#659 — Inventory: parent-location inventory rollup with optional per-site trees
- Domain: `domain:inventory`

## Contract References
- Contract guide entries (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` → Story #656, #658, #659 behavioral assertion blocks under CAP-218
- Spec: durion `domains/inventory/SPEC-inventory-location-rollup.md` (FR-1, FR-2, FR-5–FR-9)
- Implementation log: durion `docs/capabilities/CAP-218/CAP-218-backend-implementation.md`

## Scope
- What changed (4 commits, one per story):
  - **#656 (`1c4b529`):** `PromoteAllocationRequest` now requires `storageLocationId`; `promoteToHard` validates it against pos-location and pins the allocation; `ALLOCATION_CREATED` ledger event written in-transaction on promotion (no duplicate on re-promote); `cancelReservation` writes `ALLOCATION_RELEASED` for located HARD allocations only; consumption-closure invariant documented. Fixes a live gap: these event types previously had readers but no writers, so ATP silently equalled on-hand.
  - **#657 (`68c87ff`):** grouped ledger queries by location set (`LocationQuantity` projection), chunk-safe (≤1000 ids) empty-guarded default methods, outstanding-allocations helper (CREATED − RELEASED), index on `(location_id, event_type)` via Flyway V3 + entity `@Index`.
  - **#658 (`63676bd`):** `GET /v1/inventory/sites/{siteId}/inventory-rollup?sku&depth&includeEmpty` — storage-location tree with `own` vs `rolledUp` quantities and site totals; `StorageLocationTopologyClient` consuming the CAP-214 topology contract; bulk quantities loaded in one read-only transaction; 503 `LOCATION_SERVICE_UNAVAILABLE` on pos-location outage; orphan ledger rows excluded (v1).
  - **#659 (`7ee1d9a`):** `GET /v1/inventory/locations/{locationId}/inventory-rollup?parentType&sku&expand&depth&includeEmpty` — per-site summaries + grand total across descendant sites via the CAP-214 descendants contract; `expand=tree` inlines per-site trees, capped by `pos.inventory.rollup.expand-site-cap` (default 25) → 422 `ROLLUP_EXPANSION_TOO_LARGE`.
- Why: enables viewing inventory with storage locations rolled up under building/place locations (capability goal), with the ledger as trustworthy source of truth for outstanding allocations.

## Tests
- [x] Unit tests added/updated (service, repository, client)
- [x] Integration tests added/updated (contract ITs for reservation, site rollup, location rollup)
- [x] Provider behavioral contract tests added/updated (backend)
- [ ] Consumer/UI tests added/updated (frontend) — N/A
- How to run: `./mvnw -pl pos-inventory test` (306/306 pass incl. ArchUnit)

## Risk & Rollback
- Risk level: Medium — `PromoteAllocationRequest` gains a required field (`storageLocationId`), a breaking API change for promote callers (pre-production policy: no compatibility shim). New endpoints are additive. One Flyway migration (index only, no data change).
- Rollback plan: revert the 4 commits; drop index `idx_inventory_ledger_entry_location_event` if migration already applied (no data impact). Ledger events written post-deploy remain but are inert without readers.

## Checklist
- [x] Branch name matches `cap/218`
- [x] PR title starts with `[CAP:218]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (durion commits a8bbd58, bb2c22f, f530a36)
- [ ] Required CI checks passing

**Depends on:** louisburroughs/durion-positivity-backend cap/CAP214 PR (CAP-214 #655) — the topology client consumes its `/topology` and `/descendants` contracts at runtime. Merge that PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
