### PR TITLE
hotfix(customer): replace JOIN FETCH contactPoints with @BatchSize to fix 500 on contacts endpoint

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/entity/PersonParty.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/entity/PersonParty.java
@@ -12,7 +12,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
-import org.hibernate.annotations.BatchSize;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -25,6 +24,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**

--- a/pos-customer/src/main/java/com/positivity/customer/internal/entity/PersonParty.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/entity/PersonParty.java
@@ -12,6 +12,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import org.hibernate.annotations.BatchSize;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -67,6 +68,7 @@ public class PersonParty extends AbstractParty {
     private PreferredContactMethod preferredContactMethod = PreferredContactMethod.NONE;
 
     @OneToMany(mappedBy = "person", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 20)
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
     @Schema(description = "Contact points (emails, phones) for this person")

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/PartyRelationshipRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/PartyRelationshipRepository.java
@@ -62,8 +62,7 @@ public interface PartyRelationshipRepository extends JpaRepository<PartyRelation
             + "WHERE pr.toPerson.partyId = :personPartyId "
             + "AND (pr.effectiveEndDate IS NULL OR pr.effectiveEndDate >= :today)")
     List<PartyRelationship> findActiveByToPersonPartyId(
-            @Param("personPartyId") @NonNull UUID personPartyId,
-            @Param("today") @NonNull LocalDate today);
+            @Param("personPartyId") @NonNull UUID personPartyId, @Param("today") @NonNull LocalDate today);
 
     /**
      * Find the primary billing contact relationship for a party.

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/PartyRelationshipRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/PartyRelationshipRepository.java
@@ -36,8 +36,7 @@ public interface PartyRelationshipRepository extends JpaRepository<PartyRelation
      * @return list of active relationships
      */
     @Query("SELECT pr FROM PartyRelationship pr "
-            + "JOIN FETCH pr.toPerson p "
-            + "JOIN FETCH p.contactPoints "
+            + "JOIN FETCH pr.toPerson "
             + "WHERE pr.fromParty.partyId = :partyId "
             + "AND (pr.effectiveEndDate IS NULL OR pr.effectiveEndDate >= :today)")
     List<PartyRelationship> findActiveByFromPartyId(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
@@ -183,8 +183,8 @@ public class PersonPartyServiceImpl implements CustomerService {
      */
     private PersonParty toEntity(CustomerDTO dto) {
         PersonParty entity = createEntityByType(dto.getCustomerType());
-        UUID canonicalPersonId = peopleClient.resolveOrCreatePersonId(
-                null, null, dto.getLastName(), dto.getFirstName());
+        UUID canonicalPersonId =
+                peopleClient.resolveOrCreatePersonId(null, null, dto.getLastName(), dto.getFirstName());
         entity.setPersonId(canonicalPersonId);
         entity.setCustomerNumber(dto.getCustomerNumber());
         entity.setLastName(dto.getLastName());

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonServiceImpl.java
@@ -309,9 +309,8 @@ public class PersonServiceImpl implements PersonService {
                         .isPrimary(cp.isPrimary())
                         .build())
                 .toList();
-        List<PartyRelationship> commercialRelationships =
-                partyRelationshipRepository.findActiveByToPersonPartyId(
-                        person.getPersonPartyId(), LocalDate.now(clock));
+        List<PartyRelationship> commercialRelationships = partyRelationshipRepository.findActiveByToPersonPartyId(
+                person.getPersonPartyId(), LocalDate.now(clock));
         int commercialAccountCount = (int) commercialRelationships.stream()
                 .map(rel -> rel.getFromParty().getPartyId())
                 .distinct()

--- a/pos-customer/src/test/java/com/positivity/customer/PersonServiceContractBehaviorIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/PersonServiceContractBehaviorIT.java
@@ -16,8 +16,8 @@ import com.positivity.customer.internal.repository.CommercialPartyRepository;
 import com.positivity.customer.internal.repository.ContactPointRepository;
 import com.positivity.customer.internal.repository.PartyRelationshipRepository;
 import com.positivity.customer.internal.repository.PersonPartyRepository;
-import java.time.LocalDate;
 import com.positivity.customer.service.PersonService;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -354,7 +354,8 @@ class PersonServiceContractBehaviorIT extends BaseContractIntegrationTest {
         party.setDisplayName("Acme Logistics");
         commercialPartyRepository.save(party);
 
-        PersonParty personParty = personRepository.findByPersonId(created.getPersonId()).orElseThrow();
+        PersonParty personParty =
+                personRepository.findByPersonId(created.getPersonId()).orElseThrow();
         PartyRelationship relationship = new PartyRelationship();
         relationship.setFromParty(party);
         relationship.setToPerson(personParty);

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -88,7 +88,12 @@ class PartyServiceImplTest {
     @BeforeEach
     void setUp() {
         service = new PartyServiceImpl(
-                TEST_CLOCK, partyRepository, partyRelationshipRepository, cacheManager, peopleClient, vehicleInventoryClient);
+                TEST_CLOCK,
+                partyRepository,
+                partyRelationshipRepository,
+                cacheManager,
+                peopleClient,
+                vehicleInventoryClient);
     }
 
     private CommercialParty party(UUID id) {


### PR DESCRIPTION
## Summary

- `findActiveByFromPartyId` had `JOIN FETCH p.contactPoints` which conflicts with the EAGER `@ElementCollection roles` on `PartyRelationship` — Hibernate throws a runtime exception when asked to simultaneously fetch two collections for the same root entity in one query
- Fix: remove `JOIN FETCH p.contactPoints` from the query; add `@BatchSize(size=20)` on `PersonParty.contactPoints` — Hibernate batches contactPoints loads into one `IN(...)` query per 20 persons, avoiding both the N+1 pattern and the Cartesian product exception
- Introduced by the N+1 fix in #669; caught on deploy to durionpos.org

## Test plan

- [x] `mvn test -pl pos-customer` — 115 tests pass
- [ ] Re-verify `/app/crm/party/{partyId}` contacts section shows contacts after deploy

Closes post-deploy issue from #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)