### PR TITLE
fix(customer): tolerate duplicate primary contact points — fix 500 on contacts endpoint

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/ContactPointRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/ContactPointRepository.java
@@ -32,13 +32,18 @@ public interface ContactPointRepository extends JpaRepository<ContactPoint, UUID
     List<ContactPoint> findByPersonPartyIdAndContactType(@NonNull UUID personId, @NonNull ContactPointType contactType);
 
     /**
-     * Find primary contact point of a specific type for a person.
+     * Find the primary contact point of a specific type for a person.
+     *
+     * <p>Returns the earliest-created primary if more than one exists, tolerating
+     * legacy data where a person may carry multiple primaries of the same type
+     * (e.g. one from migration and one from seed). Avoids
+     * {@code NonUniqueResultException}.
      *
      * @param personId    the person ID
      * @param contactType the contact type
-     * @return the primary contact point, if exists
+     * @return the primary contact point, or {@code null} if none exists
      */
-    ContactPoint findByPersonPartyIdAndContactTypeAndIsPrimaryTrue(
+    ContactPoint findFirstByPersonPartyIdAndContactTypeAndIsPrimaryTrueOrderByCreatedAtAsc(
             @NonNull UUID personId, @NonNull ContactPointType contactType);
 
     /**

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/ContactRoleServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/ContactRoleServiceImpl.java
@@ -97,17 +97,19 @@ public class ContactRoleServiceImpl implements ContactRoleService {
                         .build();
 
                 // Get email and phone from contact points
-                var emailOpt =
-                        Optional.ofNullable(contactPointRepository.findByPersonPartyIdAndContactTypeAndIsPrimaryTrue(
-                                person.getPersonPartyId(),
-                                com.positivity.customer.internal.enums.ContactPointType.EMAIL));
+                var emailOpt = Optional.ofNullable(
+                        contactPointRepository
+                                .findFirstByPersonPartyIdAndContactTypeAndIsPrimaryTrueOrderByCreatedAtAsc(
+                                        person.getPersonPartyId(),
+                                        com.positivity.customer.internal.enums.ContactPointType.EMAIL));
                 emailOpt.ifPresent(cp -> contactDto.setEmail(cp.getValue()));
                 contactDto.setHasPrimaryEmail(emailOpt.isPresent());
 
-                var phoneOpt =
-                        Optional.ofNullable(contactPointRepository.findByPersonPartyIdAndContactTypeAndIsPrimaryTrue(
-                                person.getPersonPartyId(),
-                                com.positivity.customer.internal.enums.ContactPointType.PHONE_MOBILE));
+                var phoneOpt = Optional.ofNullable(
+                        contactPointRepository
+                                .findFirstByPersonPartyIdAndContactTypeAndIsPrimaryTrueOrderByCreatedAtAsc(
+                                        person.getPersonPartyId(),
+                                        com.positivity.customer.internal.enums.ContactPointType.PHONE_MOBILE));
                 phoneOpt.ifPresent(cp -> contactDto.setPhone(cp.getValue()));
 
                 // Map role assignments

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyRelationshipServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyRelationshipServiceImpl.java
@@ -305,7 +305,9 @@ public class PartyRelationshipServiceImpl implements PartyRelationshipService {
     }
 
     private String getPrimaryContactValue(UUID personId, ContactPointType type) {
-        ContactPoint primary = contactPointRepository.findByPersonPartyIdAndContactTypeAndIsPrimaryTrue(personId, type);
+        ContactPoint primary =
+                contactPointRepository.findFirstByPersonPartyIdAndContactTypeAndIsPrimaryTrueOrderByCreatedAtAsc(
+                        personId, type);
         if (primary != null) {
             return primary.getValue();
         }

--- a/pos-customer/src/main/resources/db/migration/V7__dedupe_primary_contact_points.sql
+++ b/pos-customer/src/main/resources/db/migration/V7__dedupe_primary_contact_points.sql
@@ -1,0 +1,35 @@
+-- V7: Repair duplicate primary contact points and prevent recurrence.
+--
+-- On a database that ran V6 (legacy contact migration) AND the repeatable seed,
+-- a person could end up with two is_primary contact points of the same type:
+-- one inserted by V6 from the old contact table, one by the seed (the seed only
+-- guards ON CONFLICT (contact_point_id), so a different id slips through).
+-- This made the single-result primary lookup throw NonUniqueResultException and
+-- 500 the GET /v1/crm/commercial-accounts/{partyId}/contacts endpoint.
+--
+-- The read path now tolerates it (findFirst...OrderByCreatedAtAsc), but the data
+-- is repaired here and a partial unique index prevents the condition recurring.
+-- On a fresh database V6 is a no-op, so no duplicates exist and the UPDATE is a
+-- no-op; the index still applies.
+
+SET TIME ZONE 'UTC';
+
+-- Demote every primary except the earliest-created one per (person_id, contact_type).
+UPDATE contact_point cp
+SET is_primary = false,
+    updated_at = NOW()
+WHERE cp.is_primary = true
+  AND cp.contact_point_id <> (
+      SELECT keep.contact_point_id
+      FROM contact_point keep
+      WHERE keep.person_id = cp.person_id
+        AND keep.contact_type = cp.contact_type
+        AND keep.is_primary = true
+      ORDER BY keep.created_at ASC, keep.contact_point_id ASC
+      LIMIT 1
+  );
+
+-- Enforce at most one primary contact point per person and contact type.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_contact_point_one_primary_per_type
+    ON contact_point (person_id, contact_type)
+    WHERE is_primary;


### PR DESCRIPTION
## Summary

`GET /v1/crm/commercial-accounts/{partyId}/contacts` returned **500** in production:

```
NonUniqueResultException: Query did not return a unique result: 2 results were returned
  at PartyRelationshipServiceImpl.getPrimaryContactValue(:308)
  → findByPersonPartyIdAndContactTypeAndIsPrimaryTrue
```

### Root cause
On a database that ran **V6** (legacy `contact` migration) **and** the repeatable seed, a person can carry **two `is_primary` contact points of the same type**: V6 inserts one from the old `contact` table, the seed inserts another. The seed only guards `ON CONFLICT (contact_point_id)`, so a row with a different id slips through. The single-result lookup then throws.

This is **not** the JOIN FETCH / `@BatchSize` issue addressed in #669/#670 — those were on a different path. The deployed build (`0.1.256-SNAPSHOT`) is current; this is a distinct data+query defect.

### Fix
- Repository lookup → `findFirstByPersonPartyIdAndContactTypeAndIsPrimaryTrueOrderByCreatedAtAsc` (LIMIT 1, deterministic, NonUnique-safe). Updated all 3 callers (`PartyRelationshipServiceImpl`, `ContactRoleServiceImpl` ×2).
- **V7 migration**: demotes all but the earliest primary per `(person_id, contact_type)`; adds partial unique index `ux_contact_point_one_primary_per_type` so it cannot recur. No-op on a fresh DB.

## Test plan

- [x] `mvn test -pl pos-customer` — 115 pass, Spotless clean
- [ ] Deploy → `GET /v1/crm/commercial-accounts/{partyId}/contacts` returns 200 with contacts
- [ ] Verify CRM party page contacts section renders on durionpos.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)