### PR TITLE
feat(customer,people): person-unification phases 1–2

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/PersonPartyRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/PersonPartyRepository.java
@@ -17,6 +17,17 @@ import org.springframework.stereotype.Repository;
 public interface PersonPartyRepository extends JpaRepository<PersonParty, UUID> {
     Optional<PersonParty> findByPersonId(@NonNull UUID personId);
 
+    /**
+     * Find individual-customer persons: person parties that are NOT acting as a
+     * commercial-account contact (i.e. not referenced by any party relationship).
+     * These are the standalone individual customers shown in the customer directory.
+     *
+     * @return list of individual-customer person parties
+     */
+    @Query("SELECT p FROM PersonParty p WHERE p.partyId NOT IN "
+            + "(SELECT pr.toPerson.partyId FROM PartyRelationship pr)")
+    List<PersonParty> findIndividualCustomers();
+
     List<PersonParty> findByLastNameIgnoreCase(@NonNull String lastName);
 
     List<PersonParty> findByFirstNameIgnoreCaseAndLastNameIgnoreCase(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -31,6 +31,7 @@ import com.positivity.customer.internal.enums.ContactPointType;
 import com.positivity.customer.internal.enums.PartyType;
 import com.positivity.customer.internal.repository.CommercialPartyRepository;
 import com.positivity.customer.internal.repository.PartyRelationshipRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.customer.service.PartyService;
 import com.positivity.shared.dto.VehicleResponse;
 import com.positivity.shared.id.UUIDv7Generator;
@@ -40,6 +41,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -50,7 +52,6 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -70,6 +71,7 @@ public class PartyServiceImpl implements PartyService {
     private final Clock clock;
 
     private final CommercialPartyRepository partyRepository;
+    private final PersonPartyRepository personPartyRepository;
     private final PartyRelationshipRepository partyRelationshipRepository;
     private final CacheManager cacheManager;
     private final PeopleClient peopleClient;
@@ -152,15 +154,44 @@ public class PartyServiceImpl implements PartyService {
     @NonNull
     public SearchPartiesResponse browseParties(@NonNull Pageable pageable) {
         Pageable normalizedPageable = normalizeBrowsePageable(pageable);
-        Page<CommercialParty> page = partyRepository.findAll(normalizedPageable);
-        List<SearchPartiesResponse.PartySummary> summaries =
-                page.getContent().stream().map(this::mapToPartySummary).toList();
+
+        // Unified customer directory: commercial parties plus standalone individual
+        // customers (person parties that are not commercial-account contacts).
+        // Merged and paged in-memory; customer volumes are well within a single
+        // window at this tier (see ADR-0026 / OQ3 in PLAN-person-unification).
+        List<SearchPartiesResponse.PartySummary> all = new ArrayList<>();
+        partyRepository.findAll().stream().map(this::mapToPartySummary).forEach(all::add);
+        personPartyRepository.findIndividualCustomers().stream()
+                .map(this::mapPersonToPartySummary)
+                .forEach(all::add);
+
+        all.sort(Comparator.comparing(
+                        (SearchPartiesResponse.PartySummary s) ->
+                                s.getDisplayName() != null ? s.getDisplayName() : s.getLegalName(),
+                        Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
+                .thenComparing(SearchPartiesResponse.PartySummary::getPartyId));
+
+        int total = all.size();
+        int from = Math.min(normalizedPageable.getPageNumber() * normalizedPageable.getPageSize(), total);
+        int to = Math.min(from + normalizedPageable.getPageSize(), total);
+        List<SearchPartiesResponse.PartySummary> window = all.subList(from, to);
 
         return SearchPartiesResponse.builder()
-                .results(summaries)
-                .totalCount(safeTotalCount(page.getTotalElements()))
+                .results(window)
+                .totalCount(safeTotalCount(total))
                 .pageNumber(normalizedPageable.getPageNumber())
                 .pageSize(normalizedPageable.getPageSize())
+                .build();
+    }
+
+    private SearchPartiesResponse.PartySummary mapPersonToPartySummary(PersonParty person) {
+        return SearchPartiesResponse.PartySummary.builder()
+                .partyId(String.valueOf(person.getPartyId()))
+                .legalName(person.getDisplayName())
+                .displayName(person.getDisplayName())
+                .partyType(person.getPartyType().toString())
+                .status(person.getStatus() != null ? person.getStatus().toString() : null)
+                .createdAt(person.getCreatedAt() != null ? ISO_FORMATTER.format(person.getCreatedAt()) : null)
                 .build();
     }
 

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -34,6 +34,7 @@ import com.positivity.customer.internal.enums.InvoiceDeliveryMethod;
 import com.positivity.customer.internal.enums.PartyType;
 import com.positivity.customer.internal.repository.CommercialPartyRepository;
 import com.positivity.customer.internal.repository.PartyRelationshipRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.customer.internal.service.PartyServiceImpl;
 import com.positivity.shared.dto.VehicleResponse;
 import java.time.Clock;
@@ -55,10 +56,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.web.server.ResponseStatusException;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,6 +65,9 @@ class PartyServiceImplTest {
 
     @Mock
     private CommercialPartyRepository partyRepository;
+
+    @Mock
+    private PersonPartyRepository personPartyRepository;
 
     @Mock
     private PartyRelationshipRepository partyRelationshipRepository;
@@ -90,6 +91,7 @@ class PartyServiceImplTest {
         service = new PartyServiceImpl(
                 TEST_CLOCK,
                 partyRepository,
+                personPartyRepository,
                 partyRelationshipRepository,
                 cacheManager,
                 peopleClient,
@@ -421,11 +423,10 @@ class PartyServiceImplTest {
     void browseParties_usesDefaultPageAndSort_whenPageableIsUnpaged() {
         CommercialParty first = party(UUID.fromString("00000000-0000-0000-0000-000000000101"));
         first.setLegalName("Acme Corp");
+        first.setDisplayName("Acme Corp");
 
-        PageRequest expectedPageable =
-                PageRequest.of(0, 20, Sort.by(Sort.Order.asc("legalName").ignoreCase(), Sort.Order.asc("partyId")));
-
-        when(partyRepository.findAll(expectedPageable)).thenReturn(new PageImpl<>(List.of(first), expectedPageable, 1));
+        when(partyRepository.findAll()).thenReturn(List.of(first));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of());
 
         SearchPartiesResponse response = service.browseParties(Pageable.unpaged());
 
@@ -439,10 +440,8 @@ class PartyServiceImplTest {
 
     @Test
     void browseParties_returnsEmptyResultsWithPagingMetadata() {
-        PageRequest expectedPageable =
-                PageRequest.of(0, 20, Sort.by(Sort.Order.asc("legalName").ignoreCase(), Sort.Order.asc("partyId")));
-
-        when(partyRepository.findAll(expectedPageable)).thenReturn(new PageImpl<>(List.of(), expectedPageable, 0));
+        when(partyRepository.findAll()).thenReturn(List.of());
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of());
 
         SearchPartiesResponse response = service.browseParties(Pageable.unpaged());
 
@@ -453,18 +452,28 @@ class PartyServiceImplTest {
     }
 
     @Test
-    void browseParties_normalizesControllerDefaultSortToIgnoreCaseAndStableTieBreaker() {
-        PageRequest requestedPageable = PageRequest.of(0, 20, Sort.by(Sort.Order.asc("legalName")));
-        PageRequest expectedPageable =
-                PageRequest.of(0, 20, Sort.by(Sort.Order.asc("legalName").ignoreCase(), Sort.Order.asc("partyId")));
+    void browseParties_mergesCommercialAndIndividualCustomers_sortedByDisplayName() {
+        CommercialParty commercial = party(UUID.fromString("00000000-0000-0000-0000-0000000000c1"));
+        commercial.setLegalName("Zenith Freight LLC");
+        commercial.setDisplayName("Zenith Freight LLC");
 
-        when(partyRepository.findAll(expectedPageable)).thenReturn(new PageImpl<>(List.of(), expectedPageable, 0));
+        PersonParty individual = new PersonParty();
+        individual.setPartyId(UUID.fromString("00000000-0000-0000-0000-0000000000a1"));
+        individual.setFirstName("Alice");
+        individual.setLastName("Anders");
+        individual.setStatus(AccountStatus.ACTIVE);
 
-        SearchPartiesResponse response = service.browseParties(requestedPageable);
+        when(partyRepository.findAll()).thenReturn(List.of(commercial));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of(individual));
 
-        assertThat(response.getResults()).isEmpty();
-        assertThat(response.getPageNumber()).isEqualTo(0);
-        assertThat(response.getPageSize()).isEqualTo(20);
+        SearchPartiesResponse response = service.browseParties(Pageable.unpaged());
+
+        assertThat(response.getTotalCount()).isEqualTo(2);
+        // Sorted case-insensitively by display name: "Alice Anders" before "Zenith Freight LLC"
+        assertThat(response.getResults())
+                .extracting(SearchPartiesResponse.PartySummary::getPartyType)
+                .containsExactly(PartyType.PERSON.toString(), PartyType.COMMERCIAL.toString());
+        assertThat(response.getResults().get(0).getDisplayName()).isEqualTo("Alice Anders");
     }
 
     @Test

--- a/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
@@ -120,28 +120,31 @@ ON CONFLICT (id) DO NOTHING;
 --          Represents the org-level billing/admin inbox preserved from commercial_party.email.
 -- =========================================================================
 
+-- Commercial-account contact persons. These are real individuals, not employees,
+-- so status is NULL per the People Directory contract (null = non-employee person).
+-- Names mirror the matching CUST-CPC contacts in pos-customer person_party.
 INSERT INTO person (id, first_name, last_name, primary_email, status, created_at, updated_at)
 VALUES
-    ('01960026-0000-7000-8000-000000000001'::uuid, 'General',    'Piedmont Freight',      'info@piedmontfreight.example.com',           'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000002'::uuid, 'Accounts',   'Carolina Concrete',     'accounts@carolinaconcrete.example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000003'::uuid, 'Billing',    'QC Waste',              'billing@qcwaste.example.com',                'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000004'::uuid, 'Fleet',      'Blue Ridge Landscaping','fleet@blueridgelandscaping.example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000005'::uuid, 'Operations', 'Tarheel Logistics',     'ops@tarheellogistics.example.com',           'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000006'::uuid, 'Dispatch',   'Meck Plumbing',         'dispatch@meckplumbing.example.com',          'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000007'::uuid, 'Fleet',      'Piedmont Ready Mix',    'fleet@piedmontreadymix.example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000008'::uuid, 'Service',    'Carolina Power',        'service@carolinapower.example.com',          'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000009'::uuid, 'Accounts',   'Blue Stone Aggregate',  'accounts@bluestoneaggregate.example.com',    'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000a'::uuid, 'Billing',    'Cabarrus Cleaning',     'billing@cabarruscleaning.example.com',       'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000b'::uuid, 'Operations', 'SE Delivery',           'ops@sedelivery.example.com',                 'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000c'::uuid, 'Fleet',      'Carolinas Crane',       'fleet@carolinascrane.example.com',           'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000d'::uuid, 'Service',    'LKN Propane',           'service@lknpropane.example.com',             'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000e'::uuid, 'Accounts',   'Rowan Road Services',   'accounts@rowanroad.example.com',             'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000f'::uuid, 'Dispatch',   'Carolina Fresh',        'dispatch@carolinafresh.example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000010'::uuid, 'Billing',    'Piedmont Metals',       'billing@piedmontmetals.example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000011'::uuid, 'Operations', 'Union Grading',         'ops@uniongrading.example.com',               'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000012'::uuid, 'Service',    'Carolina Septic',       'service@carolinaseptic.example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000013'::uuid, 'Fleet',      'Meck Tree',             'fleet@mecktree.example.com',                 'ACTIVE', NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000014'::uuid, 'Billing',    'Highland Moving',       'billing@highlandmoving.example.com',         'ACTIVE', NOW(), NOW())
+    ('01960026-0000-7000-8000-000000000001'::uuid, 'Greg',      'Whitfield',   'info@piedmontfreight.example.com',           NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000002'::uuid, 'Teresa',    'Mullen',      'accounts@carolinaconcrete.example.com',      NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000003'::uuid, 'Darnell',   'Okafor',      'billing@qcwaste.example.com',                NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000004'::uuid, 'Brittany',  'Norris',      'fleet@blueridgelandscaping.example.com',     NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000005'::uuid, 'Marcus',    'Tillman',     'ops@tarheellogistics.example.com',           NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000006'::uuid, 'Christine', 'Walters',     'dispatch@meckplumbing.example.com',          NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000007'::uuid, 'Donald',    'Frazier',     'fleet@piedmontreadymix.example.com',         NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000008'::uuid, 'Alicia',    'Stephens',    'service@carolinapower.example.com',          NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000009'::uuid, 'Keith',     'Burnham',     'accounts@bluestoneaggregate.example.com',    NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-00000000000a'::uuid, 'Tamara',    'McPherson',   'billing@cabarruscleaning.example.com',       NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-00000000000b'::uuid, 'Wesley',    'Parrish',     'ops@sedelivery.example.com',                 NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-00000000000c'::uuid, 'Renee',     'Holt',        'fleet@carolinascrane.example.com',           NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-00000000000d'::uuid, 'Calvin',    'Dunmore',     'service@lknpropane.example.com',             NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-00000000000e'::uuid, 'Latasha',   'Gooden',      'accounts@rowanroad.example.com',             NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-00000000000f'::uuid, 'Bryan',     'Cantrell',    'dispatch@carolinafresh.example.com',         NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000010'::uuid, 'Monica',    'Byrd',        'billing@piedmontmetals.example.com',         NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000011'::uuid, 'Cedric',    'Blackwell',   'ops@uniongrading.example.com',               NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000012'::uuid, 'Veronica',  'Pratt',       'service@carolinaseptic.example.com',         NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000013'::uuid, 'Jonathon',  'Culpepper',   'fleet@mecktree.example.com',                 NULL, NOW(), NOW()),
+    ('01960026-0000-7000-8000-000000000014'::uuid, 'Sheryl',    'Davenport',   'billing@highlandmoving.example.com',         NULL, NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 -- user_person_links (guarded by person table existence; person rows inserted above)

--- a/pos-people/src/main/resources/db/migration/V3__fix_commercial_contact_person_names.sql
+++ b/pos-people/src/main/resources/db/migration/V3__fix_commercial_contact_person_names.sql
@@ -1,0 +1,33 @@
+-- V3: Repair commercial-account contact persons.
+--
+-- These rows (namespace 01960026) were seeded with department+company names
+-- (e.g. 'General Piedmont Freight') and status='ACTIVE', which made them read as
+-- companies/employees in the People Directory. They are real, non-employee
+-- contacts. Rename to the matching CUST-CPC individuals (as held in pos-customer
+-- person_party) and clear status so the directory categorizes them as
+-- non-employee persons (status IS NULL).
+--
+-- The repeatable seed uses ON CONFLICT (id) DO NOTHING, so existing rows are not
+-- updated by the seed; this versioned migration repairs them once. On a fresh DB
+-- the seed already carries the corrected values and these UPDATEs are no-ops.
+
+UPDATE person SET first_name = 'Greg',      last_name = 'Whitfield',  status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000001'::uuid;
+UPDATE person SET first_name = 'Teresa',    last_name = 'Mullen',     status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000002'::uuid;
+UPDATE person SET first_name = 'Darnell',   last_name = 'Okafor',     status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000003'::uuid;
+UPDATE person SET first_name = 'Brittany',  last_name = 'Norris',     status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000004'::uuid;
+UPDATE person SET first_name = 'Marcus',    last_name = 'Tillman',    status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000005'::uuid;
+UPDATE person SET first_name = 'Christine', last_name = 'Walters',    status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000006'::uuid;
+UPDATE person SET first_name = 'Donald',    last_name = 'Frazier',    status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000007'::uuid;
+UPDATE person SET first_name = 'Alicia',    last_name = 'Stephens',   status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000008'::uuid;
+UPDATE person SET first_name = 'Keith',     last_name = 'Burnham',    status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000009'::uuid;
+UPDATE person SET first_name = 'Tamara',    last_name = 'McPherson',  status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-00000000000a'::uuid;
+UPDATE person SET first_name = 'Wesley',    last_name = 'Parrish',    status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-00000000000b'::uuid;
+UPDATE person SET first_name = 'Renee',     last_name = 'Holt',       status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-00000000000c'::uuid;
+UPDATE person SET first_name = 'Calvin',    last_name = 'Dunmore',    status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-00000000000d'::uuid;
+UPDATE person SET first_name = 'Latasha',   last_name = 'Gooden',     status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-00000000000e'::uuid;
+UPDATE person SET first_name = 'Bryan',     last_name = 'Cantrell',   status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-00000000000f'::uuid;
+UPDATE person SET first_name = 'Monica',    last_name = 'Byrd',       status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000010'::uuid;
+UPDATE person SET first_name = 'Cedric',    last_name = 'Blackwell',  status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000011'::uuid;
+UPDATE person SET first_name = 'Veronica',  last_name = 'Pratt',      status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000012'::uuid;
+UPDATE person SET first_name = 'Jonathon',  last_name = 'Culpepper',  status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000013'::uuid;
+UPDATE person SET first_name = 'Sheryl',    last_name = 'Davenport',  status = NULL, updated_at = NOW() WHERE id = '01960026-0000-7000-8000-000000000014'::uuid;


### PR DESCRIPTION
Implements Phases 1 and 2 of [PLAN-person-unification](https://github.com/louisburroughs/durion/blob/master/docs/capabilities/PLAN-person-unification.md). Realizes ADR-0015 invariants I3 and I4.

## Phase 1 — Customer Directory shows all customers (I3)
Previously `browseParties` queried only `commercial_party`, so individual person-customers never appeared.

- `PersonPartyRepository.findIndividualCustomers()` — person parties **not** acting as a commercial-account contact (not referenced by any `party_relationship`).
- `PartyServiceImpl.browseParties` now merges commercial parties + individual customers, tags each by `partyType`, sorts by display name, pages in-memory (OQ3: customer volumes fit one window at this tier).
- Tests updated; merge test added.

## Phase 2 — Fix commercial-contact person names in pos-people (I4)
pos-people rows `01960026-*` were seeded as `department + company` (`"General Piedmont Freight"`) with `status='ACTIVE'`, so they read as companies/employees in the People Directory.

- Seed renamed to the real CUST-CPC individuals (mirroring pos-customer `person_party`); `status = NULL` → categorized as non-employee persons.
- **V3 migration** repairs existing rows (seed `ON CONFLICT (id) DO NOTHING` won't update them). No-op on fresh DB.

## Out of scope
Phase 3 (pos-people as single source of truth; `person_party` demotion — invariants I1/I2) is gated on decision **OD1** (thin-link vs event-synced cache).

## Test plan
- [x] `mvn test -pl pos-customer` — 115 pass, Spotless clean
- [ ] Deploy → Customer Directory lists individuals + commercial; People Directory shows real contact names

🤖 Generated with [Claude Code](https://claude.com/claude-code)