### PR TITLE
feat(people,customer): person-unification phase 3 step 1 — identity read + link reconciliation

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/client/PeopleClient.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/client/PeopleClient.java
@@ -1,6 +1,10 @@
 package com.positivity.customer.internal.client;
 
 import com.positivity.shared.id.UUIDv7Generator;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -75,6 +79,49 @@ public class PeopleClient {
         }
     }
 
+    /**
+     * Batch-resolve canonical person identities from pos-people (the source of
+     * truth, ADR-0015 I2). Unknown ids are simply absent from the returned map.
+     *
+     * @param personIds the canonical person ids to fetch
+     * @return map of personId to identity for ids that exist in pos-people
+     */
+    @NonNull
+    public Map<UUID, PersonIdentity> fetchPersonIdentities(@NonNull Collection<UUID> personIds) {
+        if (personIds.isEmpty()) {
+            return Map.of();
+        }
+        PersonView[] people = restClient
+                .post()
+                .uri("/v1/people/by-ids")
+                .header("X-User", "pos-customer")
+                .header("X-Authorities", "people:person:view")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(List.copyOf(personIds))
+                .retrieve()
+                .body(PersonView[].class);
+
+        if (people == null) {
+            return Map.of();
+        }
+        Map<UUID, PersonIdentity> result = new HashMap<>();
+        for (PersonView p : people) {
+            if (p.getId() != null) {
+                result.put(
+                        p.getId(),
+                        new PersonIdentity(p.getId(), p.getFirstName(), p.getLastName(), p.getPrimaryEmail()));
+            }
+        }
+        return result;
+    }
+
+    /** Canonical person identity sourced from pos-people. */
+    public record PersonIdentity(UUID id, String firstName, String lastName, String primaryEmail) {
+        public String displayName() {
+            return ((firstName != null ? firstName : "") + " " + (lastName != null ? lastName : "")).trim();
+        }
+    }
+
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
@@ -91,5 +138,15 @@ public class PeopleClient {
     @AllArgsConstructor
     private static class ResolvePersonResponse {
         private UUID personId;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class PersonView {
+        private UUID id;
+        private String firstName;
+        private String lastName;
+        private String primaryEmail;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/PersonLinkReconciliationController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/PersonLinkReconciliationController.java
@@ -1,0 +1,40 @@
+package com.positivity.customer.internal.controller;
+
+import com.positivity.customer.internal.security.CrmPermissionRegistry;
+import com.positivity.customer.service.PersonLinkReconciliationService;
+import com.positivity.customer.service.PersonLinkReconciliationService.PersonLinkReport;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Read-only person-link reconciliation (ADR-0015 I1). Reports any
+ * {@code person_party.person_id} that does not resolve to a pos-people person,
+ * the integrity precondition for demoting person_party to a thin link (Phase 3).
+ */
+@Tag(name = "CRM Person-Link Reconciliation", description = "Verify person_party links resolve in pos-people")
+@RestController
+@RequestMapping("/v1/crm/admin/person-links")
+public class PersonLinkReconciliationController {
+
+    private final PersonLinkReconciliationService reconciliationService;
+
+    public PersonLinkReconciliationController(PersonLinkReconciliationService reconciliationService) {
+        this.reconciliationService = reconciliationService;
+    }
+
+    @Operation(
+            summary = "Reconcile person links",
+            description = "Verify every person_party.person_id resolves to a pos-people person (ADR-0015 I1).")
+    @ApiResponse(responseCode = "200", description = "Reconciliation report returned")
+    @GetMapping("/reconcile")
+    @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
+    public ResponseEntity<PersonLinkReport> reconcile() {
+        return ResponseEntity.ok(reconciliationService.reconcile());
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/PersonPartyRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/PersonPartyRepository.java
@@ -28,6 +28,15 @@ public interface PersonPartyRepository extends JpaRepository<PersonParty, UUID> 
             + "(SELECT pr.toPerson.partyId FROM PartyRelationship pr)")
     List<PersonParty> findIndividualCustomers();
 
+    /**
+     * Distinct canonical person ids linked from person parties. Used by person-link
+     * reconciliation to verify every link resolves in pos-people (ADR-0015 I1).
+     *
+     * @return distinct non-null person ids
+     */
+    @Query("SELECT DISTINCT p.personId FROM PersonParty p WHERE p.personId IS NOT NULL")
+    List<UUID> findDistinctPersonIds();
+
     List<PersonParty> findByLastNameIgnoreCase(@NonNull String lastName);
 
     List<PersonParty> findByFirstNameIgnoreCaseAndLastNameIgnoreCase(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonLinkReconciliationServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonLinkReconciliationServiceImpl.java
@@ -1,0 +1,41 @@
+package com.positivity.customer.internal.service;
+
+import com.positivity.customer.internal.client.PeopleClient;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.customer.service.PersonLinkReconciliationService;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PersonLinkReconciliationServiceImpl implements PersonLinkReconciliationService {
+
+    private final PersonPartyRepository personPartyRepository;
+    private final PeopleClient peopleClient;
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public PersonLinkReport reconcile() {
+        List<UUID> linkedIds = personPartyRepository.findDistinctPersonIds();
+        Map<UUID, PeopleClient.PersonIdentity> resolved = peopleClient.fetchPersonIdentities(linkedIds);
+
+        List<UUID> unresolved =
+                linkedIds.stream().filter(id -> !resolved.containsKey(id)).toList();
+
+        if (!unresolved.isEmpty()) {
+            log.warn(
+                    "Person-link reconciliation found {} orphan person_party.person_id of {} links (ADR-0015 I1)",
+                    unresolved.size(),
+                    linkedIds.size());
+        }
+        return new PersonLinkReport(linkedIds.size(), resolved.size(), unresolved);
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/service/PersonLinkReconciliationService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/service/PersonLinkReconciliationService.java
@@ -1,0 +1,35 @@
+package com.positivity.customer.service;
+
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Verifies invariant ADR-0015 I1: every {@code person_party.person_id} references
+ * an existing {@code pos-people.person.id}. Read-only; reports orphan links so
+ * they can be remediated before person_party is demoted to a thin link (Phase 3).
+ */
+public interface PersonLinkReconciliationService {
+
+    /**
+     * Check all linked person ids against pos-people.
+     *
+     * @return reconciliation report
+     */
+    @NonNull
+    PersonLinkReport reconcile();
+
+    /**
+     * Outcome of a reconciliation pass.
+     *
+     * @param totalLinks          distinct linked person ids
+     * @param resolved            ids that exist in pos-people
+     * @param unresolvedPersonIds ids with no matching pos-people person (orphans)
+     */
+    record PersonLinkReport(
+            int totalLinks, int resolved, @NonNull List<UUID> unresolvedPersonIds) {
+        public boolean isHealthy() {
+            return unresolvedPersonIds.isEmpty();
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/service/PersonLinkReconciliationServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PersonLinkReconciliationServiceImplTest.java
@@ -1,0 +1,79 @@
+package com.positivity.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.client.PeopleClient;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.customer.internal.service.PersonLinkReconciliationServiceImpl;
+import com.positivity.customer.service.PersonLinkReconciliationService.PersonLinkReport;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PersonLinkReconciliationServiceImplTest {
+
+    @Mock
+    private PersonPartyRepository personPartyRepository;
+
+    @Mock
+    private PeopleClient peopleClient;
+
+    @InjectMocks
+    private PersonLinkReconciliationServiceImpl service;
+
+    private static UUID id(String suffix) {
+        return UUID.fromString("00000000-0000-0000-0000-0000000000" + suffix);
+    }
+
+    @Test
+    void reconcile_allLinksResolve_reportsHealthy() {
+        UUID a = id("a1");
+        UUID b = id("b2");
+        when(personPartyRepository.findDistinctPersonIds()).thenReturn(List.of(a, b));
+        when(peopleClient.fetchPersonIdentities(List.of(a, b)))
+                .thenReturn(Map.of(
+                        a, new PeopleClient.PersonIdentity(a, "Greg", "Whitfield", "g@x.com"),
+                        b, new PeopleClient.PersonIdentity(b, "Teresa", "Mullen", "t@x.com")));
+
+        PersonLinkReport report = service.reconcile();
+
+        assertThat(report.totalLinks()).isEqualTo(2);
+        assertThat(report.resolved()).isEqualTo(2);
+        assertThat(report.unresolvedPersonIds()).isEmpty();
+        assertThat(report.isHealthy()).isTrue();
+    }
+
+    @Test
+    void reconcile_orphanLink_reportedAsUnresolved() {
+        UUID linked = id("a1");
+        UUID orphan = id("c3");
+        when(personPartyRepository.findDistinctPersonIds()).thenReturn(List.of(linked, orphan));
+        when(peopleClient.fetchPersonIdentities(List.of(linked, orphan)))
+                .thenReturn(Map.of(linked, new PeopleClient.PersonIdentity(linked, "Greg", "Whitfield", "g@x.com")));
+
+        PersonLinkReport report = service.reconcile();
+
+        assertThat(report.totalLinks()).isEqualTo(2);
+        assertThat(report.resolved()).isEqualTo(1);
+        assertThat(report.unresolvedPersonIds()).containsExactly(orphan);
+        assertThat(report.isHealthy()).isFalse();
+    }
+
+    @Test
+    void reconcile_noLinks_reportsHealthy() {
+        when(personPartyRepository.findDistinctPersonIds()).thenReturn(List.of());
+        when(peopleClient.fetchPersonIdentities(List.of())).thenReturn(Map.of());
+
+        PersonLinkReport report = service.reconcile();
+
+        assertThat(report.totalLinks()).isZero();
+        assertThat(report.isHealthy()).isTrue();
+    }
+}

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/PersonController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/PersonController.java
@@ -37,7 +37,9 @@ public class PersonController {
     private final PersonService personService;
 
     @Operation(summary = "Get all people", description = "Retrieve people with optional type and text filters.")
-    @Parameter(name = "type", description = "Filter by person type: EMPLOYEE, ACTIVE, INACTIVE, or ALL (default).",
+    @Parameter(
+            name = "type",
+            description = "Filter by person type: EMPLOYEE, ACTIVE, INACTIVE, or ALL (default).",
             schema = @Schema(allowableValues = {"ALL", "EMPLOYEE", "ACTIVE", "INACTIVE"}))
     @Parameter(name = "q", description = "Case-insensitive text search on firstName, lastName, primaryEmail, username.")
     @ApiResponse(responseCode = "200", description = "List of people returned successfully.")
@@ -68,6 +70,20 @@ public class PersonController {
                 .getPersonById(personId)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @Operation(
+            summary = "Get people by IDs",
+            description = "Batch-resolve persons by id in one request. Unknown ids are omitted; the result may be"
+                    + " smaller than the request. Used for cross-service identity reads (ADR-0015).")
+    @ApiResponse(responseCode = "200", description = "Persons resolved.")
+    @PostMapping("/by-ids")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people:person:view"})
+    @PreAuthorize("hasAuthority('people:person:view')")
+    public List<Person> getPeopleByIds(@Parameter(description = "Person ids to resolve") @RequestBody List<UUID> ids) {
+        return personService.getPeopleByIds(ids);
     }
 
     @Operation(summary = "Create a new person", description = "Add a new person to the system.")

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PersonServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PersonServiceImpl.java
@@ -8,6 +8,7 @@ import com.positivity.people.internal.repository.PersonRepository;
 import com.positivity.people.internal.repository.PersonSpecifications;
 import com.positivity.people.service.PersonService;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -47,9 +48,7 @@ public class PersonServiceImpl implements PersonService {
     @Override
     @NonNull
     public List<Person> getAllPeople(@Nullable String type, @Nullable String q) {
-        return personRepository
-                .findAll(PersonSpecifications.directoryFilter(type, q))
-                .stream()
+        return personRepository.findAll(PersonSpecifications.directoryFilter(type, q)).stream()
                 .map(this::toDto)
                 .toList();
     }
@@ -58,6 +57,15 @@ public class PersonServiceImpl implements PersonService {
     @NonNull
     public Optional<Person> getPersonById(@NonNull UUID id) {
         return personRepository.findById(id).map(this::toDto);
+    }
+
+    @Override
+    @NonNull
+    public List<Person> getPeopleByIds(@NonNull Collection<UUID> ids) {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        return personRepository.findAllById(ids).stream().map(this::toDto).toList();
     }
 
     @Override

--- a/pos-people/src/main/java/com/positivity/people/service/PersonService.java
+++ b/pos-people/src/main/java/com/positivity/people/service/PersonService.java
@@ -3,6 +3,7 @@ package com.positivity.people.service;
 import com.positivity.people.internal.dto.Person;
 import com.positivity.people.internal.dto.ResolvePersonRequest;
 import com.positivity.people.internal.dto.ResolvePersonResponse;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,6 +22,17 @@ public interface PersonService {
 
     @NonNull
     Optional<Person> getPersonById(@NonNull UUID id);
+
+    /**
+     * Resolve many persons by id in one round trip. Unknown ids are omitted from
+     * the result (no error). Supports cross-service identity reads where
+     * pos-people is the source of truth for person attributes (ADR-0015 I2).
+     *
+     * @param ids the person ids to fetch
+     * @return persons that exist, in no guaranteed order
+     */
+    @NonNull
+    List<Person> getPeopleByIds(@NonNull Collection<UUID> ids);
 
     @NonNull
     Person savePerson(@NonNull Person person);


### PR DESCRIPTION
Foundation for the Phase 3 thin-link refactor ([PLAN-person-unification](https://github.com/louisburroughs/durion/blob/master/docs/capabilities/PLAN-person-unification.md), ADR-0015 I1/I2). **Additive, no breaking changes, no column drops.**

## What
**pos-people**
- `POST /v1/people/by-ids` — batch-resolve persons by id (`PersonService.getPeopleByIds`). Unknown ids omitted. Foundation for cross-service identity reads (Step 2–3).

**pos-customer**
- `PeopleClient.fetchPersonIdentities(ids) → Map<UUID, PersonIdentity>` — calls the new endpoint.
- `PersonPartyRepository.findDistinctPersonIds()`.
- `PersonLinkReconciliationService` + `GET /v1/crm/admin/person-links/reconcile` — read-only; reports `person_party.person_id` values that don't resolve in pos-people (orphans from any `allow-local-fallback`). This is the I1 integrity precondition before `person_party` can be demoted to a thin link.

## Contract
New endpoints are **additive read APIs**, fully annotated with springdoc (`@Operation`/`@ApiResponse`), so the live `/v3/api-docs` reflects them. Domain contract guidance: `BACKEND_CONTRACT_GUIDE.md` (people + customer domains). No breaking changes to existing contracts. **Follow-up:** regenerate the static `openapi.yaml` snapshots (the app-boot springdoc generation needs the full infra profile; deferred — not required for these additive endpoints).

## Key finding (corrects an earlier assumption)
Seed data **already satisfies I1**. `person_party.person_id` = `01960024-*` (individuals) / `01960025-*` (contacts) — all resolve in pos-people (verified live on durionpos.org). The earlier "broken link `01960025` vs `01960026`" was a misread: `01960025` = primary contacts, `01960026` = billing contacts (two separate person sets). So **no destructive id reconciliation is needed** — the remaining Phase 3 work is rerouting reads (Step 2/3) and dropping duplicated columns (Step 4).

## Next (this PR unblocks)
- Step 2: reroute pos-customer identity reads through `fetchPersonIdentities`.
- Step 4: drop `person_party` name/contact columns.
- Separate cleanup: `01960025`/`01960026` are duplicate persons for the same contact — dedup candidate.

## Test plan
- [x] `mvn test -pl pos-people,pos-customer` — 118 pass (incl. 3 reconciliation tests; orphan-detection path exercised)
- [ ] Deploy → `GET /v1/crm/admin/person-links/reconcile` returns healthy (0 unresolved) on seed data

🤖 Generated with [Claude Code](https://claude.com/claude-code)