### PR TITLE
feat(customer): person-unification phase 3 step 2a — source person names from pos-people

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -40,12 +40,16 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -161,8 +165,11 @@ public class PartyServiceImpl implements PartyService {
         // window at this tier (see ADR-0026 / OQ3 in PLAN-person-unification).
         List<SearchPartiesResponse.PartySummary> all = new ArrayList<>();
         partyRepository.findAll().stream().map(this::mapToPartySummary).forEach(all::add);
-        personPartyRepository.findIndividualCustomers().stream()
-                .map(this::mapPersonToPartySummary)
+
+        List<PersonParty> individuals = personPartyRepository.findIndividualCustomers();
+        Map<UUID, PeopleClient.PersonIdentity> identities = fetchIdentitiesFor(individuals);
+        individuals.stream()
+                .map(person -> mapPersonToPartySummary(person, identities))
                 .forEach(all::add);
 
         all.sort(Comparator.comparing(
@@ -184,15 +191,43 @@ public class PartyServiceImpl implements PartyService {
                 .build();
     }
 
-    private SearchPartiesResponse.PartySummary mapPersonToPartySummary(PersonParty person) {
+    private SearchPartiesResponse.PartySummary mapPersonToPartySummary(
+            PersonParty person, Map<UUID, PeopleClient.PersonIdentity> identities) {
+        String displayName = resolveDisplayName(person, identities);
         return SearchPartiesResponse.PartySummary.builder()
                 .partyId(String.valueOf(person.getPartyId()))
-                .legalName(person.getDisplayName())
-                .displayName(person.getDisplayName())
+                .legalName(displayName)
+                .displayName(displayName)
                 .partyType(person.getPartyType().toString())
                 .status(person.getStatus() != null ? person.getStatus().toString() : null)
                 .createdAt(person.getCreatedAt() != null ? ISO_FORMATTER.format(person.getCreatedAt()) : null)
                 .build();
+    }
+
+    /**
+     * Batch-load canonical identities from pos-people (source of truth, ADR-0015 I2)
+     * for the given person parties, keyed by the canonical person id.
+     */
+    private Map<UUID, PeopleClient.PersonIdentity> fetchIdentitiesFor(Collection<PersonParty> persons) {
+        Set<UUID> personIds = persons.stream()
+                .map(PersonParty::getPersonId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        return peopleClient.fetchPersonIdentities(personIds);
+    }
+
+    /**
+     * Resolve a person's display name from pos-people (source of truth), falling
+     * back to the local person_party copy while the thin-link migration is in
+     * progress (e.g. an orphan link not yet reconciled).
+     */
+    private String resolveDisplayName(PersonParty person, Map<UUID, PeopleClient.PersonIdentity> identities) {
+        PeopleClient.PersonIdentity identity =
+                (identities != null && person.getPersonId() != null) ? identities.get(person.getPersonId()) : null;
+        if (identity != null && !identity.displayName().isBlank()) {
+            return identity.displayName();
+        }
+        return person.getDisplayName();
     }
 
     private int safeTotalCount(long totalElements) {
@@ -638,15 +673,20 @@ public class PartyServiceImpl implements PartyService {
         LocalDate today = LocalDate.now(clock);
         List<PartyRelationship> relationships =
                 partyRelationshipRepository.findActiveByFromPartyId(party.getPartyId(), today);
-        return relationships.stream().map(this::convertRelationshipToSummary).toList();
+        Map<UUID, PeopleClient.PersonIdentity> identities = fetchIdentitiesFor(
+                relationships.stream().map(PartyRelationship::getToPerson).toList());
+        return relationships.stream()
+                .map(rel -> convertRelationshipToSummary(rel, identities))
+                .toList();
     }
 
-    private ContactSummary convertRelationshipToSummary(PartyRelationship rel) {
+    private ContactSummary convertRelationshipToSummary(
+            PartyRelationship rel, Map<UUID, PeopleClient.PersonIdentity> identities) {
         PersonParty person = rel.getToPerson();
         ContactSummary summary = new ContactSummary();
         summary.setContactId(rel.getPartyRelationshipId().toString());
         summary.setPrimary(rel.isPrimaryBillingContact());
-        summary.setName(person.getDisplayName());
+        summary.setName(resolveDisplayName(person, identities));
         summary.setRoles(Collections.emptyList());
         summary.setPhoneNumbers(person.getContactPoints().stream()
                 .filter(cp -> cp.getContactType() == ContactPointType.PHONE_MOBILE

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -477,6 +477,29 @@ class PartyServiceImplTest {
     }
 
     @Test
+    void browseParties_individualName_sourcedFromPosPeople_overridesLocalCopy() {
+        UUID canonicalPersonId = UUID.fromString("00000000-0000-0000-0000-0000000000d4");
+        PersonParty individual = new PersonParty();
+        individual.setPartyId(UUID.fromString("00000000-0000-0000-0000-0000000000a2"));
+        individual.setPersonId(canonicalPersonId);
+        individual.setFirstName("Stale");
+        individual.setLastName("Local");
+        individual.setStatus(AccountStatus.ACTIVE);
+
+        when(partyRepository.findAll()).thenReturn(List.of());
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of(individual));
+        when(peopleClient.fetchPersonIdentities(java.util.Set.of(canonicalPersonId)))
+                .thenReturn(java.util.Map.of(
+                        canonicalPersonId,
+                        new PeopleClient.PersonIdentity(canonicalPersonId, "Fresh", "Canonical", "f@x.com")));
+
+        SearchPartiesResponse response = service.browseParties(Pageable.unpaged());
+
+        // Name comes from pos-people (source of truth), not the local person_party copy.
+        assertThat(response.getResults().get(0).getDisplayName()).isEqualTo("Fresh Canonical");
+    }
+
+    @Test
     void searchParties_filtersByPartyTypeAndStatus_caseInsensitive() {
         CommercialParty match = party(UUID.fromString("00000000-0000-0000-0000-000000000003"));
         match.setPartyType(PartyType.COMMERCIAL);


### PR DESCRIPTION
Phase 3 **step 2a** of [PLAN-person-unification](https://github.com/louisburroughs/durion/blob/master/docs/capabilities/PLAN-person-unification.md). Builds on step 1's `PeopleClient.fetchPersonIdentities` (#673).

## What
Route person **display-name** reads through pos-people (source of truth, ADR-0015 I2) instead of the local `person_party` name columns — batched to avoid N+1:

- `browseParties` (individual customers) and `buildContactSummaries` / CRM snapshot contacts resolve names via `fetchPersonIdentities`, keyed by the **canonical `person_id`** (not the local PK).
- `resolveDisplayName` falls back to the local `person_party` copy when an id doesn't resolve (orphan not yet reconciled) — reads never break mid-migration.
- Finally uses the previously-dead `peopleClient` field.

## Scope (deliberately narrow)
**Names only.** Email/phone still come from `contact_point`. Remaining read sites (`PersonServiceImpl`, `ContactRoleServiceImpl`, `PartyRelationshipServiceImpl`) and contact attributes follow in **step 2b**, before the `person_party` name columns are dropped (**step 4**). No behavior change visible to users (names match) — this shifts the *source*, not the values.

No controller/DTO/contract surface changed (service-layer only); see `BACKEND_CONTRACT_GUIDE.md` for the people/customer domains.

## Test plan
- [x] `mvn test -pl pos-customer` — 119 pass, incl. new `browseParties_individualName_sourcedFromPosPeople_overridesLocalCopy` (proves pos-people name overrides a stale local copy)
- [ ] Deploy → Customer Directory + CRM snapshot names unchanged (now sourced from pos-people)

🤖 Generated with [Claude Code](https://claude.com/claude-code)