### PR TITLE
fix(customer): deserialize pos-people contact-point 'primary' flag — fixes contact reads

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/client/PeopleClient.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/client/PeopleClient.java
@@ -1,5 +1,6 @@
 package com.positivity.customer.internal.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.positivity.shared.id.UUIDv7Generator;
 import java.util.Collection;
 import java.util.HashMap;
@@ -215,6 +216,10 @@ public class PeopleClient {
     private static class ContactPointView {
         private String contactType;
         private String value;
+
+        // pos-people serializes this flag as JSON "primary" (its isPrimary() getter);
+        // map it explicitly so deserialization does not bind null to a primitive boolean.
+        @JsonProperty("primary")
         private boolean isPrimary;
     }
 }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/client/CustomerClientUriTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/client/CustomerClientUriTest.java
@@ -49,6 +49,38 @@ class CustomerClientUriTest {
         mockServer.verify();
     }
 
+    @Test
+    void peopleClient_fetchPersonIdentities_deserializesPosPeopleContactPoints() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer mockServer = MockRestServiceServer.bindTo(builder).build();
+
+        PeopleClient client = new PeopleClient(builder, "people");
+
+        // pos-people serializes the contact-point flag as JSON "primary" (not "isPrimary").
+        // Regression: a primitive-boolean field mapped from the wrong name bound null and
+        // threw MismatchedInputException, collapsing all contact reads to local fallback.
+        UUID personId = UUID.fromString("01960025-0000-7000-8000-000000000001");
+        String json = "[{\"id\":\"" + personId + "\",\"firstName\":\"Greg\",\"lastName\":\"Whitfield\","
+                + "\"primaryEmail\":\"g.whitfield@example.com\",\"contactPoints\":["
+                + "{\"contactType\":\"EMAIL\",\"value\":\"g.whitfield@example.com\",\"primary\":true},"
+                + "{\"contactType\":\"PHONE_WORK\",\"value\":\"704-555-3001\",\"primary\":false}]}]";
+
+        mockServer
+                .expect(requestTo("http://people/v1/people/by-ids"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("X-Authorities", "people:person:view"))
+                .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+        var identities = client.fetchPersonIdentities(java.util.List.of(personId));
+
+        assertThat(identities).containsKey(personId);
+        var identity = identities.get(personId);
+        assertThat(identity.displayName()).isEqualTo("Greg Whitfield");
+        assertThat(identity.emails()).containsExactly("g.whitfield@example.com");
+        assertThat(identity.phones()).containsExactly("704-555-3001");
+        mockServer.verify();
+    }
+
     // -----------------------------------------------------------------------
     // VehicleInventoryClient
     // -----------------------------------------------------------------------

--- a/pos-customer/src/test/java/com/positivity/customer/internal/client/CustomerClientUriTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/client/CustomerClientUriTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.positivity.shared.dto.CreateVehicleRequest;
@@ -78,6 +79,77 @@ class CustomerClientUriTest {
         assertThat(identity.displayName()).isEqualTo("Greg Whitfield");
         assertThat(identity.emails()).containsExactly("g.whitfield@example.com");
         assertThat(identity.phones()).containsExactly("704-555-3001");
+        mockServer.verify();
+    }
+
+    @Test
+    void peopleClient_fetchPersonIdentities_emptyContactPoints_fallsBackToPrimaryEmail() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer mockServer = MockRestServiceServer.bindTo(builder).build();
+        PeopleClient client = new PeopleClient(builder, "people");
+
+        UUID personId = UUID.fromString("01960024-0000-7000-8000-000000000001");
+        String json = "[{\"id\":\"" + personId + "\",\"firstName\":\"Marcus\",\"lastName\":\"Patterson\","
+                + "\"primaryEmail\":\"marcus@example.com\",\"contactPoints\":[]}]";
+
+        mockServer
+                .expect(requestTo("http://people/v1/people/by-ids"))
+                .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+        var identity = client.fetchPersonIdentities(java.util.List.of(personId)).get(personId);
+
+        assertThat(identity.contactPoints()).isEmpty();
+        assertThat(identity.emails()).containsExactly("marcus@example.com"); // falls back to primaryEmail
+        assertThat(identity.phones()).isEmpty();
+        mockServer.verify();
+    }
+
+    @Test
+    void peopleClient_fetchPersonIdentities_toleratesUnknownPosPeopleFields() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer mockServer = MockRestServiceServer.bindTo(builder).build();
+        PeopleClient client = new PeopleClient(builder, "people");
+
+        UUID personId = UUID.fromString("01960024-0000-7000-8000-000000000002");
+        // Full pos-people Person payload with fields PersonView does not declare.
+        String json = "[{\"id\":\"" + personId + "\",\"firstName\":\"Jane\",\"lastName\":\"Smith\","
+                + "\"primaryEmail\":\"jane@example.com\",\"secondaryEmail\":\"j2@example.com\","
+                + "\"phoneNumbers\":[\"555-1\"],\"username\":\"jsmith\",\"employeeStatus\":\"ACTIVE\","
+                + "\"contactPoints\":[{\"contactType\":\"EMAIL\",\"value\":\"jane@example.com\",\"primary\":true}]}]";
+
+        mockServer
+                .expect(requestTo("http://people/v1/people/by-ids"))
+                .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+        var identity = client.fetchPersonIdentities(java.util.List.of(personId)).get(personId);
+
+        assertThat(identity.displayName()).isEqualTo("Jane Smith");
+        assertThat(identity.emails()).containsExactly("jane@example.com");
+        mockServer.verify();
+    }
+
+    @Test
+    void peopleClient_fetchPersonIdentities_emptyInput_makesNoCall() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer mockServer = MockRestServiceServer.bindTo(builder).build();
+        PeopleClient client = new PeopleClient(builder, "people");
+
+        assertThat(client.fetchPersonIdentities(java.util.List.of())).isEmpty();
+        mockServer.verify(); // no request expected
+    }
+
+    @Test
+    void peopleClient_fetchPersonIdentitiesQuietly_returnsEmptyOnServerError() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer mockServer = MockRestServiceServer.bindTo(builder).build();
+        PeopleClient client = new PeopleClient(builder, "people");
+
+        UUID personId = UUID.fromString("01960025-0000-7000-8000-000000000001");
+        mockServer.expect(requestTo("http://people/v1/people/by-ids")).andRespond(withServerError());
+
+        // Quiet variant degrades to empty instead of throwing (display read paths).
+        assertThat(client.fetchPersonIdentitiesQuietly(java.util.List.of(personId)))
+                .isEmpty();
         mockServer.verify();
     }
 


### PR DESCRIPTION
## The bug behind "2c.2 looks deployed but inert"

pos-customer **is** running the new image (`sha-f7a12e4`), but every contact/name read from pos-people silently fell back to local data, and `/person-links/reconcile` 500'd. Root cause from the pos-customer log:

```
MismatchedInputException: Cannot map `null` into type `boolean`
  PersonView["contactPoints"] → ArrayList[0] → ContactPointView["isPrimary"]
```

pos-people serializes the flag as JSON **`"primary"`** (`ContactPointDto.isPrimary()` getter → property `primary`), but `PeopleClient.ContactPointView` expected **`"isPrimary"`**. The property is absent → null → can't bind to a primitive `boolean` → throws on any person that has contact points. `fetchPersonIdentitiesQuietly` swallowed it (→ local fallback everywhere); the strict path (reconcile) 500'd.

## Fix
- `@JsonProperty("primary")` on `ContactPointView.isPrimary`.
- **Regression test** (`MockRestServiceServer`) deserializing the actual pos-people `by-ids` payload (`"primary":true`). This cross-service deserialization path had **no test** — the gap that let it ship (pos-people ITs run Flyway-off; nothing exercised the wire format).

## Test plan
- [x] `mvn test -pl pos-customer` — 120 pass incl. new `peopleClient_fetchPersonIdentities_deserializesPosPeopleContactPoints`
- [ ] Deploy → `01960026` contact reads "Greg Whitfield" (pos-people) not "General Piedmont Freight"; reconcile returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)