### PR TITLE
feat(people,customer): person-unification finale prep — dedup, contact write-API, reconcile hardening

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonLinkReconciliationServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonLinkReconciliationServiceImpl.java
@@ -25,7 +25,16 @@ public class PersonLinkReconciliationServiceImpl implements PersonLinkReconcilia
     @Transactional(readOnly = true)
     public PersonLinkReport reconcile() {
         List<UUID> linkedIds = personPartyRepository.findDistinctPersonIds();
-        Map<UUID, PeopleClient.PersonIdentity> resolved = peopleClient.fetchPersonIdentities(linkedIds);
+
+        Map<UUID, PeopleClient.PersonIdentity> resolved;
+        try {
+            resolved = peopleClient.fetchPersonIdentities(linkedIds);
+        } catch (Exception exception) {
+            // pos-people unreachable — report degraded rather than 500. I1 cannot be
+            // verified right now; counts are not meaningful.
+            log.warn("Person-link reconciliation could not reach pos-people: {}", exception.getMessage());
+            return new PersonLinkReport(linkedIds.size(), 0, List.of(), false);
+        }
 
         List<UUID> unresolved =
                 linkedIds.stream().filter(id -> !resolved.containsKey(id)).toList();
@@ -36,6 +45,6 @@ public class PersonLinkReconciliationServiceImpl implements PersonLinkReconcilia
                     unresolved.size(),
                     linkedIds.size());
         }
-        return new PersonLinkReport(linkedIds.size(), resolved.size(), unresolved);
+        return new PersonLinkReport(linkedIds.size(), resolved.size(), unresolved, true);
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/service/PersonLinkReconciliationService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/service/PersonLinkReconciliationService.java
@@ -25,11 +25,13 @@ public interface PersonLinkReconciliationService {
      * @param totalLinks          distinct linked person ids
      * @param resolved            ids that exist in pos-people
      * @param unresolvedPersonIds ids with no matching pos-people person (orphans)
+     * @param posPeopleReachable  false if pos-people could not be reached, in which
+     *                            case the resolved/unresolved counts are not meaningful
      */
     record PersonLinkReport(
-            int totalLinks, int resolved, @NonNull List<UUID> unresolvedPersonIds) {
+            int totalLinks, int resolved, @NonNull List<UUID> unresolvedPersonIds, boolean posPeopleReachable) {
         public boolean isHealthy() {
-            return unresolvedPersonIds.isEmpty();
+            return posPeopleReachable && unresolvedPersonIds.isEmpty();
         }
     }
 }

--- a/pos-customer/src/main/resources/db/migration/V8__dedupe_party_relationships.sql
+++ b/pos-customer/src/main/resources/db/migration/V8__dedupe_party_relationships.sql
@@ -1,0 +1,39 @@
+-- V8: Remove duplicate party_relationship rows.
+--
+-- V6 (contact-table decommission) created party_relationship rows from the legacy
+-- contact table. When V6 ran before the repeatable seed in the same Flyway cycle,
+-- the seed's (from_party_id, to_person_id) relationships did not yet exist, so V6's
+-- NOT EXISTS guard matched nothing and inserted overlapping rows. The repeatable
+-- seed then inserted its own rows (different ids, ON CONFLICT only on the PK), so a
+-- party ended up with two relationships to the same contact person.
+--
+-- Keep the earliest relationship per (from_party_id, to_person_id) and delete the
+-- rest, including their role rows. Idempotent: on a clean DB there is nothing to
+-- remove. This only removes exact duplicate pairs; genuinely distinct contacts
+-- (different to_person_id) are preserved.
+
+-- Role rows for relationships that will be deleted.
+DELETE FROM party_relationship_role
+WHERE party_relationship_id IN (
+    SELECT pr.party_relationship_id
+    FROM party_relationship pr
+    WHERE pr.party_relationship_id <> (
+        SELECT keep.party_relationship_id
+        FROM party_relationship keep
+        WHERE keep.from_party_id = pr.from_party_id
+          AND keep.to_person_id = pr.to_person_id
+        ORDER BY keep.effective_start_date ASC, keep.created_at ASC, keep.party_relationship_id ASC
+        LIMIT 1
+    )
+);
+
+-- The duplicate relationships themselves.
+DELETE FROM party_relationship pr
+WHERE pr.party_relationship_id <> (
+    SELECT keep.party_relationship_id
+    FROM party_relationship keep
+    WHERE keep.from_party_id = pr.from_party_id
+      AND keep.to_person_id = pr.to_person_id
+    ORDER BY keep.effective_start_date ASC, keep.created_at ASC, keep.party_relationship_id ASC
+    LIMIT 1
+);

--- a/pos-customer/src/test/java/com/positivity/customer/service/PersonLinkReconciliationServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PersonLinkReconciliationServiceImplTest.java
@@ -77,5 +77,21 @@ class PersonLinkReconciliationServiceImplTest {
 
         assertThat(report.totalLinks()).isZero();
         assertThat(report.isHealthy()).isTrue();
+        assertThat(report.posPeopleReachable()).isTrue();
+    }
+
+    @Test
+    void reconcile_posPeopleUnreachable_reportsDegradedWithoutThrowing() {
+        UUID a = id("a1");
+        when(personPartyRepository.findDistinctPersonIds()).thenReturn(List.of(a));
+        when(peopleClient.fetchPersonIdentities(List.of(a)))
+                .thenThrow(new IllegalStateException("No instances available for people"));
+
+        PersonLinkReport report = service.reconcile();
+
+        assertThat(report.posPeopleReachable()).isFalse();
+        assertThat(report.isHealthy()).isFalse();
+        assertThat(report.totalLinks()).isEqualTo(1);
+        assertThat(report.unresolvedPersonIds()).isEmpty();
     }
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/PersonController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/PersonController.java
@@ -86,6 +86,23 @@ public class PersonController {
         return personService.getPeopleByIds(ids);
     }
 
+    @Operation(
+            summary = "Replace a person's contact points",
+            description = "Replaces all typed contact points (email/phone) for a person. pos-people is the source of"
+                    + " truth for contacts (ADR-0015).")
+    @ApiResponse(responseCode = "204", description = "Contact points replaced.")
+    @PutMapping("/{personId}/contact-points")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people:person:edit"})
+    @PreAuthorize("hasAuthority('people:person:edit')")
+    public ResponseEntity<Void> replaceContactPoints(
+            @Parameter(description = "Person id") @PathVariable UUID personId,
+            @RequestBody List<Person.ContactPointDto> contactPoints) {
+        personService.replaceContactPoints(personId, contactPoints);
+        return ResponseEntity.noContent().build();
+    }
+
     @Operation(summary = "Create a new person", description = "Add a new person to the system.")
     @ApiResponse(responseCode = "201", description = "Person created successfully.")
     @EmitEvent(id = "PEOPLE_PERSON_CREATE", apiVersion = "1")

--- a/pos-people/src/main/java/com/positivity/people/internal/repository/PersonContactPointRepository.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/PersonContactPointRepository.java
@@ -18,4 +18,6 @@ public interface PersonContactPointRepository extends JpaRepository<PersonContac
     List<PersonContactPoint> findByPersonId(@NonNull UUID personId);
 
     List<PersonContactPoint> findByPersonIdIn(@NonNull Collection<UUID> personIds);
+
+    void deleteByPersonId(@NonNull UUID personId);
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PersonServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PersonServiceImpl.java
@@ -88,6 +88,25 @@ public class PersonServiceImpl implements PersonService {
 
     @Override
     @Transactional
+    public void replaceContactPoints(@NonNull UUID personId, @NonNull List<Person.ContactPointDto> contactPoints) {
+        personContactPointRepository.deleteByPersonId(personId);
+        if (contactPoints.isEmpty()) {
+            return;
+        }
+        List<PersonContactPoint> entities = contactPoints.stream()
+                .filter(cp -> cp.getContactType() != null && cp.getValue() != null)
+                .map(cp -> PersonContactPoint.builder()
+                        .personId(personId)
+                        .contactType(cp.getContactType())
+                        .value(cp.getValue())
+                        .isPrimary(cp.isPrimary())
+                        .build())
+                .toList();
+        personContactPointRepository.saveAll(entities);
+    }
+
+    @Override
+    @Transactional
     @NonNull
     public Person savePerson(@NonNull Person person) {
         if (person.getUsername() != null

--- a/pos-people/src/main/java/com/positivity/people/service/PersonService.java
+++ b/pos-people/src/main/java/com/positivity/people/service/PersonService.java
@@ -34,6 +34,16 @@ public interface PersonService {
     @NonNull
     List<Person> getPeopleByIds(@NonNull Collection<UUID> ids);
 
+    /**
+     * Replace all typed contact points for a person (pos-people is the source of
+     * truth for contacts, ADR-0015 I2). Existing points are removed and replaced
+     * with the supplied set.
+     *
+     * @param personId the canonical person id
+     * @param contactPoints the contact points to persist (may be empty)
+     */
+    void replaceContactPoints(@NonNull UUID personId, @NonNull List<Person.ContactPointDto> contactPoints);
+
     @NonNull
     Person savePerson(@NonNull Person person);
 


### PR DESCRIPTION
Prep for the gated drops. Three independent pieces, all verified-safe by the live reconcile (`90/90 resolved, 0 orphans` → I1 holds).

## V8 dedup (pos-customer)
Removes duplicate `party_relationship` rows from the V6-vs-seed Flyway ordering bug (a party linked to the same contact person twice — the "3 contacts" you saw). Keeps the earliest per `(from_party_id, to_person_id)`, deletes the rest + their role rows. Idempotent; preserves genuinely distinct contacts. (The `01960026` *billing* contact is a distinct person/pair, so it survives dedup — flag if you want it removed too; that's a domain call.)

## Contact write-API (pos-people)
`PUT /v1/people/{personId}/contact-points` replaces a person's typed contact points (`PersonService.replaceContactPoints`, repo `deleteByPersonId`). The prerequisite for moving contact writes off `pos-customer.contact_point` before dropping it (2c.3).

## Reconcile hardening (pos-customer)
`PersonLinkReport` adds `posPeopleReachable`; reconcile degrades to a non-healthy report instead of 500 when pos-people is unreachable. Belt-and-suspenders — the by-ids deser fix (#679) already stopped the throw.

Contract: additive write endpoint on `PersonController`; see `BACKEND_CONTRACT_GUIDE.md` (people domain).

## Test plan
- [x] `mvn test -pl pos-people,pos-customer` — 77 + 125 pass
- [ ] Deploy → party shows 1 contact (dedup); reconcile still `healthy`; `PUT .../contact-points` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)