### PR TITLE
feat(customer): createPerson mirrors contact points to pos-people (dual-write)

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/client/PeopleClient.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/client/PeopleClient.java
@@ -122,6 +122,36 @@ public class PeopleClient {
     }
 
     /**
+     * Mirror a person's contact points to pos-people (source of truth, ADR-0015 I2).
+     * Best-effort: failures are logged and swallowed so the local contact_point copy
+     * still serves reads (we are dual-writing during the transition).
+     *
+     * @param personId the canonical person id
+     * @param contactPoints the contact points to persist (replaces existing)
+     */
+    public void setContactPoints(@NonNull UUID personId, @NonNull List<ContactPointUpsert> contactPoints) {
+        try {
+            restClient
+                    .put()
+                    .uri("/v1/people/{personId}/contact-points", personId)
+                    .header("X-User", "pos-customer")
+                    .header("X-Authorities", "people:person:edit")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(contactPoints)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception exception) {
+            log.warn(
+                    "Failed to mirror contact points to pos-people for personId={}: {}",
+                    personId,
+                    exception.getMessage());
+        }
+    }
+
+    /** Contact point to upsert into pos-people. Serializes the flag as "primary". */
+    public record ContactPointUpsert(String contactType, String value, boolean primary) {}
+
+    /**
      * Resilient variant of {@link #fetchPersonIdentities} for display read paths:
      * if pos-people is unreachable, returns an empty map instead of throwing, so
      * callers transparently fall back to the local person_party name copy rather

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonServiceImpl.java
@@ -152,6 +152,16 @@ public class PersonServiceImpl implements PersonService {
                     savedPerson.getPersonPartyId());
         }
 
+        // Mirror contact points to pos-people (source of truth, ADR-0015 I2). Dual-write:
+        // the local contact_point rows remain as a read fallback. Non-fatal if pos-people
+        // is unreachable — local data still serves reads.
+        peopleClient.setContactPoints(
+                peoplePersonId,
+                contactPoints.stream()
+                        .map(cp -> new PeopleClient.ContactPointUpsert(
+                                cp.getContactType().name(), cp.getValue(), cp.isPrimary()))
+                        .toList());
+
         log.info(
                 "Successfully created person personId={} personPartyId={} with {} contact points",
                 savedPerson.getPersonId(),

--- a/pos-customer/src/test/java/com/positivity/customer/internal/client/CustomerClientUriTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/client/CustomerClientUriTest.java
@@ -153,6 +153,45 @@ class CustomerClientUriTest {
         mockServer.verify();
     }
 
+    @Test
+    void peopleClient_setContactPoints_putsToContactPointsUrl_withPrimaryField() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer mockServer = MockRestServiceServer.bindTo(builder).build();
+        PeopleClient client = new PeopleClient(builder, "people");
+
+        UUID personId = UUID.fromString("01960025-0000-7000-8000-000000000001");
+        mockServer
+                .expect(requestTo("http://people/v1/people/" + personId + "/contact-points"))
+                .andExpect(method(HttpMethod.PUT))
+                .andExpect(header("X-Authorities", "people:person:edit"))
+                .andExpect(org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath(
+                        "$[0].primary", org.hamcrest.Matchers.is(true)))
+                .andRespond(withSuccess());
+
+        client.setContactPoints(
+                personId, java.util.List.of(new PeopleClient.ContactPointUpsert("EMAIL", "g@example.com", true)));
+
+        mockServer.verify();
+    }
+
+    @Test
+    void peopleClient_setContactPoints_swallowsErrors() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer mockServer = MockRestServiceServer.bindTo(builder).build();
+        PeopleClient client = new PeopleClient(builder, "people");
+
+        UUID personId = UUID.fromString("01960025-0000-7000-8000-000000000002");
+        mockServer
+                .expect(requestTo("http://people/v1/people/" + personId + "/contact-points"))
+                .andRespond(withServerError());
+
+        // Best-effort dual-write: must not throw even if pos-people errors.
+        client.setContactPoints(
+                personId, java.util.List.of(new PeopleClient.ContactPointUpsert("EMAIL", "g@example.com", true)));
+
+        mockServer.verify();
+    }
+
     // -----------------------------------------------------------------------
     // VehicleInventoryClient
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Builds on #680's pos-people contact write-API. Makes pos-people the source of truth for **new** contact data while keeping the local fallback (per the "hold the drops" decision).

## What
`createPerson`, after saving local `contact_point` rows, now also pushes the points to pos-people via `PUT /v1/people/{id}/contact-points` (`PeopleClient.setContactPoints`).

- **Dual-write**: local `contact_point` retained as a read fallback — no resilience lost.
- **Best-effort**: the mirror is wrapped in try/catch; a pos-people hiccup logs a warning and never fails person creation.
- `ContactPointUpsert` serializes the flag as `"primary"` to match pos-people's DTO (the same field-name lesson as #679).

## Why this, not the drops
Per the decision after pos-people broke 3× today: build the write path (non-destructive), **hold** the `DROP contact_point` / name-column migrations until pos-people proves stable. This PR is that write path. The drops stay queued for an explicit go.

Service/client only; no contract surface change — see `BACKEND_CONTRACT_GUIDE.md`.

## Test plan
- [x] `mvn test -pl pos-customer` — 127 pass (incl. PUT URL/auth, `"primary"` field, error-swallowing)
- [ ] Deploy → create an individual with contacts → `GET /v1/people/by-ids` shows the contact points in pos-people

🤖 Generated with [Claude Code](https://claude.com/claude-code)