### PR TITLE
fix(people,customer): remove redundant 01960026 billing-contact duplicates

### DIFF
--- a/pos-customer/src/main/resources/db/migration/V9__remove_billing_contact_duplicates.sql
+++ b/pos-customer/src/main/resources/db/migration/V9__remove_billing_contact_duplicates.sql
@@ -1,0 +1,33 @@
+-- V9: Remove redundant commercial billing-contact persons (namespace 01960026-*).
+--
+-- The 01960026-* "billing contacts" were migrated from the legacy contact table and
+-- are duplicate persons of the 01960025-* primary contacts (same human, same party).
+-- The domain model keeps a single primary contact per commercial account, so the
+-- billing duplicates are removed here along with their full dependency chain. Leaving
+-- the person_party rows would resurface them as standalone "individual customers".
+--
+-- Namespace-scoped, one-time seed-data cleanup. Idempotent: nothing to delete on a
+-- database that never had the legacy billing contacts.
+
+-- 1. Roles for the billing-contact relationships.
+DELETE FROM party_relationship_role
+WHERE party_relationship_id IN (
+    SELECT party_relationship_id FROM party_relationship
+    WHERE to_person_id >= '01960026-0000-0000-0000-000000000000'::uuid
+      AND to_person_id <  '01960027-0000-0000-0000-000000000000'::uuid
+);
+
+-- 2. The billing-contact relationships.
+DELETE FROM party_relationship
+WHERE to_person_id >= '01960026-0000-0000-0000-000000000000'::uuid
+  AND to_person_id <  '01960027-0000-0000-0000-000000000000'::uuid;
+
+-- 3. Their contact points.
+DELETE FROM contact_point
+WHERE person_id >= '01960026-0000-0000-0000-000000000000'::uuid
+  AND person_id <  '01960027-0000-0000-0000-000000000000'::uuid;
+
+-- 4. The person_party rows themselves.
+DELETE FROM person_party
+WHERE customer_id >= '01960026-0000-0000-0000-000000000000'::uuid
+  AND customer_id <  '01960027-0000-0000-0000-000000000000'::uuid;

--- a/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
@@ -116,36 +116,11 @@ VALUES
 ON CONFLICT (id) DO NOTHING;
 
 -- =========================================================================
--- Group C: 20 commercial billing contact persons (01960026-*) — contact.person_id in pos-customer
---          Represents the org-level billing/admin inbox preserved from commercial_party.email.
+-- Group C (REMOVED): the 20 commercial billing contacts (01960026-*) were
+-- duplicate persons of the 01960025-* primary contacts. They are deleted by
+-- migration V5__remove_billing_contact_duplicates.sql and no longer seeded; the
+-- matching pos-customer person_party rows are removed by pos-customer V9.
 -- =========================================================================
-
--- Commercial-account contact persons. These are real individuals, not employees,
--- so status is NULL per the People Directory contract (null = non-employee person).
--- Names mirror the matching CUST-CPC contacts in pos-customer person_party.
-INSERT INTO person (id, first_name, last_name, primary_email, status, created_at, updated_at)
-VALUES
-    ('01960026-0000-7000-8000-000000000001'::uuid, 'Greg',      'Whitfield',   'info@piedmontfreight.example.com',           NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000002'::uuid, 'Teresa',    'Mullen',      'accounts@carolinaconcrete.example.com',      NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000003'::uuid, 'Darnell',   'Okafor',      'billing@qcwaste.example.com',                NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000004'::uuid, 'Brittany',  'Norris',      'fleet@blueridgelandscaping.example.com',     NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000005'::uuid, 'Marcus',    'Tillman',     'ops@tarheellogistics.example.com',           NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000006'::uuid, 'Christine', 'Walters',     'dispatch@meckplumbing.example.com',          NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000007'::uuid, 'Donald',    'Frazier',     'fleet@piedmontreadymix.example.com',         NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000008'::uuid, 'Alicia',    'Stephens',    'service@carolinapower.example.com',          NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000009'::uuid, 'Keith',     'Burnham',     'accounts@bluestoneaggregate.example.com',    NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000a'::uuid, 'Tamara',    'McPherson',   'billing@cabarruscleaning.example.com',       NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000b'::uuid, 'Wesley',    'Parrish',     'ops@sedelivery.example.com',                 NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000c'::uuid, 'Renee',     'Holt',        'fleet@carolinascrane.example.com',           NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000d'::uuid, 'Calvin',    'Dunmore',     'service@lknpropane.example.com',             NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000e'::uuid, 'Latasha',   'Gooden',      'accounts@rowanroad.example.com',             NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-00000000000f'::uuid, 'Bryan',     'Cantrell',    'dispatch@carolinafresh.example.com',         NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000010'::uuid, 'Monica',    'Byrd',        'billing@piedmontmetals.example.com',         NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000011'::uuid, 'Cedric',    'Blackwell',   'ops@uniongrading.example.com',               NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000012'::uuid, 'Veronica',  'Pratt',       'service@carolinaseptic.example.com',         NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000013'::uuid, 'Jonathon',  'Culpepper',   'fleet@mecktree.example.com',                 NULL, NOW(), NOW()),
-    ('01960026-0000-7000-8000-000000000014'::uuid, 'Sheryl',    'Davenport',   'billing@highlandmoving.example.com',         NULL, NOW(), NOW())
-ON CONFLICT (id) DO NOTHING;
 
 -- user_person_links (guarded by person table existence; person rows inserted above)
 DO $$

--- a/pos-people/src/main/resources/db/migration/V5__remove_billing_contact_duplicates.sql
+++ b/pos-people/src/main/resources/db/migration/V5__remove_billing_contact_duplicates.sql
@@ -1,0 +1,19 @@
+-- V5: Remove redundant commercial billing-contact persons (namespace 01960026-*).
+--
+-- These were duplicate persons of the 01960025-* primary contacts (same human),
+-- migrated from the legacy contact taxonomy. They are no longer seeded (Group C
+-- removed from the repeatable seed); the matching pos-customer person_party rows
+-- are removed in pos-customer V9. Delete dependent rows first to satisfy the
+-- person foreign keys. Idempotent; namespace-scoped one-time cleanup.
+
+DELETE FROM person_contact_point
+WHERE person_id >= '01960026-0000-0000-0000-000000000000'::uuid
+  AND person_id <  '01960027-0000-0000-0000-000000000000'::uuid;
+
+DELETE FROM person_phone_numbers
+WHERE person_id >= '01960026-0000-0000-0000-000000000000'::uuid
+  AND person_id <  '01960027-0000-0000-0000-000000000000'::uuid;
+
+DELETE FROM person
+WHERE id >= '01960026-0000-0000-0000-000000000000'::uuid
+  AND id <  '01960027-0000-0000-0000-000000000000'::uuid;


### PR DESCRIPTION
Task (2) from the verification follow-up: remove the `01960026` billing-contact duplicates left after V8 dedup.

## Why
The `01960026-*` "billing contacts" are duplicate **persons** of the `01960025-*` primary contacts (same human, same commercial account) — migrated from the legacy contact taxonomy. They show as a second identical "Greg Whitfield" contact per party (and as duplicate persons in the People Directory).

## What
- **pos-customer V9** — delete the full chain for the `01960026` namespace: `party_relationship_role` → `party_relationship` → `contact_point` → `person_party`. (Deleting only the relationship would orphan `person_party` → they'd resurface as standalone *individual customers*.)
- **pos-people V5** — delete the `01960026` persons (+ `person_contact_point`, `person_phone_numbers`); **remove the Group C seed block** so they aren't re-seeded on the next repeatable run.

## Validation
Both migrations **run against a throwaway Postgres** with a `01960025`-keep + `01960026`-delete fixture: correct deletes, FK-safe order, idempotent on re-run. (Not relying on CI — Flyway is off in tests.)

## Test plan
- [x] Postgres dry-run: `01960025` preserved, `01960026` fully removed both sides, idempotent
- [ ] Deploy → party shows **1 contact**; People Directory has no duplicate billing-contact persons; reconcile `healthy` (totalLinks drops 90 → 70)

🤖 Generated with [Claude Code](https://claude.com/claude-code)