### PR TITLE
fix(people): pin contact-point 'primary' JSON name both directions — fixes contact write

### DIFF
--- a/pos-people/src/main/java/com/positivity/people/internal/dto/Person.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/dto/Person.java
@@ -1,5 +1,6 @@
 package com.positivity.people.internal.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.positivity.people.internal.enums.ContactPointType;
 import com.positivity.people.internal.enums.EmployeeStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -110,6 +111,11 @@ public class Person {
     public static class ContactPointDto {
         private ContactPointType contactType;
         private String value;
+
+        // Pin the JSON name to "primary" for BOTH directions. The isPrimary() getter
+        // serializes as "primary", but without this the field deserializes from
+        // "isPrimary" — an asymmetry that 400'd the contact-point write endpoint.
+        @JsonProperty("primary")
         private boolean isPrimary;
 
         public ContactPointDto() {}

--- a/pos-people/src/test/java/com/positivity/people/internal/dto/PersonContactPointDtoTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/dto/PersonContactPointDtoTest.java
@@ -1,0 +1,47 @@
+package com.positivity.people.internal.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.people.internal.enums.ContactPointType;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Locks the JSON wire name of the contact-point primary flag to "primary" in BOTH
+ * directions. The getter serialized as "primary" while the field deserialized from
+ * "isPrimary" — an asymmetry that 400'd PUT /v1/people/{id}/contact-points and broke
+ * the pos-customer dual-write.
+ */
+class PersonContactPointDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serializesPrimaryFlagAsPrimary() {
+        String json =
+                mapper.writeValueAsString(new Person.ContactPointDto(ContactPointType.EMAIL, "g@example.com", true));
+
+        assertThat(json).contains("\"primary\":true");
+        assertThat(json).doesNotContain("isPrimary");
+    }
+
+    @Test
+    void deserializesFromPrimaryField() {
+        Person.ContactPointDto dto = mapper.readValue(
+                "{\"contactType\":\"EMAIL\",\"value\":\"g@example.com\",\"primary\":true}",
+                Person.ContactPointDto.class);
+
+        assertThat(dto.getContactType()).isEqualTo(ContactPointType.EMAIL);
+        assertThat(dto.getValue()).isEqualTo("g@example.com");
+        assertThat(dto.isPrimary()).isTrue();
+    }
+
+    @Test
+    void deserializesPrimaryFalse() {
+        Person.ContactPointDto dto = mapper.readValue(
+                "{\"contactType\":\"PHONE_WORK\",\"value\":\"704-555-1\",\"primary\":false}",
+                Person.ContactPointDto.class);
+
+        assertThat(dto.isPrimary()).isFalse();
+    }
+}


### PR DESCRIPTION
Found live while verifying #681's dual-write: a newly-created person had **empty `contactPoints`** in pos-people. Isolated it:

| PUT body flag | result |
|---|---|
| `"isPrimary":true` | 204 |
| `"primary":true` | **400 Malformed JSON** |

## Root cause — mirror of #679
`Person.ContactPointDto` is **asymmetric**: the `isPrimary()` getter serializes the flag as `"primary"`, but the field deserializes from `"isPrimary"`. So `PUT /v1/people/{id}/contact-points` rejects the canonical `"primary"` payload that pos-customer's dual-write (#681) sends (and that pos-people itself emits, and that #679 reads). The best-effort dual-write swallowed the 400 → contact points never persisted.

## Fix
`@JsonProperty("primary")` on the field so serialization **and** deserialization agree on `"primary"`. Round-trip unit tests lock it.

Contract: additive `Person` DTO read field only; behavior of the existing PUT endpoint now accepts the documented `"primary"` flag — see `BACKEND_CONTRACT_GUIDE.md` (people domain). No breaking change.

Same class of bug as #679 — both from the untested cross-service wire format. (Flyway-on + wire-contract test profile would catch these in CI; flagged as a follow-up.)

## Test plan
- [x] `mvn test -pl pos-people` — `PersonContactPointDtoTest` passes
- [ ] Deploy → create individual w/ contacts → pos-people `by-ids` shows non-empty `contactPoints`

🤖 Generated with [Claude Code](https://claude.com/claude-code)