### PR TITLE
feat(security): grant people:timekeeping authorities to admin and managers

### DIFF
--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RoleAuthorityServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RoleAuthorityServiceImpl.java
@@ -150,6 +150,7 @@ public class RoleAuthorityServiceImpl implements RoleAuthorityService {
         set.addAll(appointmentAuthorities());
         set.addAll(invoiceAuthorities());
         set.addAll(timekeepingAuthorities());
+        set.addAll(timekeepingApprovalAuthorities());
         set.addAll(nltiAuthorities());
         set.addAll(productLifecycleAuthorities());
         set.addAll(mcpAuthorities());
@@ -167,6 +168,8 @@ public class RoleAuthorityServiceImpl implements RoleAuthorityService {
     private Set<String> managerAuthorities() {
         Set<String> authorities = new HashSet<>(interactiveChatAuthorities());
         authorities.addAll(List.of("security:role:view", "security:role:assign", "security:permission:view"));
+        // Managers review, approve, and reject pay-period timekeeping for their staff.
+        authorities.addAll(timekeepingApprovalAuthorities());
         return authorities;
     }
 
@@ -356,6 +359,8 @@ public class RoleAuthorityServiceImpl implements RoleAuthorityService {
 
     private Set<String> locationManagerAuthorities() {
         Set<String> authorities = new HashSet<>(serviceAdvisorAuthorities());
+        // Shop/location managers approve and reject their staff's pay-period timekeeping.
+        authorities.addAll(timekeepingApprovalAuthorities());
         authorities.addAll(List.of(
                 "people:availability:view",
                 // Time management (self-service + team approval)
@@ -590,6 +595,16 @@ public class RoleAuthorityServiceImpl implements RoleAuthorityService {
                 "timekeeping:work_session:break_start",
                 "timekeeping:work_session:break_stop",
                 "timekeeping:overlap_override"));
+    }
+
+    /**
+     * Pay-period timekeeping approval authorities required by TimekeepingApprovalController
+     * (people:timekeeping:*). Separate from the employee-facing work_session authorities above:
+     * view lists every employee's entries; approve/reject are manager decisions.
+     */
+    private Set<String> timekeepingApprovalAuthorities() {
+        return new HashSet<>(List.of(
+                "people:timekeeping:view", "people:timekeeping:approve", "people:timekeeping:reject"));
     }
 
     private Set<String> shopAuthorities() {

--- a/pos-security-service/src/test/java/com/positivity/securityservice/service/RoleAuthorityServiceTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/service/RoleAuthorityServiceTest.java
@@ -172,6 +172,7 @@ class RoleAuthorityServiceTest {
                 .contains("workorder:workorder:assign-technician")
                 .contains("workorder:change_request:emergency_override")
                 .contains("timekeeping:overlap_override")
+                .contains("people:timekeeping:view", "people:timekeeping:approve", "people:timekeeping:reject")
                 .doesNotContain("security:user:edit")
                 .contains(MCP_CHAT_EXECUTE);
     }
@@ -187,6 +188,7 @@ class RoleAuthorityServiceTest {
                 .contains("workorder:workorder:generate_invoice")
                 .contains("invoice:finalize")
                 .doesNotContain("workorder:workorder:assign-technician")
+                .doesNotContain("people:timekeeping:approve", "people:timekeeping:reject")
                 .contains(MCP_CHAT_EXECUTE);
     }
 
@@ -201,7 +203,24 @@ class RoleAuthorityServiceTest {
                 .contains("inventory:pick_list:execute")
                 .contains("timekeeping:work_session:create")
                 .doesNotContain("invoice:finalize")
+                .doesNotContain("people:timekeeping:approve", "people:timekeeping:reject")
                 .contains(MCP_CHAT_EXECUTE);
+    }
+
+    @Test
+    void expandRolesToAuthorities_timekeepingApprovalGrantedToApproversNotStaff() {
+        // Approver-tier roles can view/approve/reject pay-period timekeeping.
+        for (String role : Set.of("ADMIN", "MANAGER", "GENERAL_MANAGER", "LOCATION_MANAGER")) {
+            assertThat(roleAuthorityService.expandRolesToAuthorities(Set.of(role)))
+                    .as("role %s timekeeping approval grant", role)
+                    .contains("people:timekeeping:view", "people:timekeeping:approve", "people:timekeeping:reject");
+        }
+        // Staff-tier roles must never receive approve/reject.
+        for (String role : Set.of("SERVICE_ADVISOR", "TECHNICIAN", "CSR")) {
+            assertThat(roleAuthorityService.expandRolesToAuthorities(Set.of(role)))
+                    .as("role %s must not approve/reject timekeeping", role)
+                    .doesNotContain("people:timekeeping:approve", "people:timekeeping:reject");
+        }
     }
 
     @Test


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## Capability & Traceability
- Capability: `cap:<not-provided>`
- Parent STORY (durion): louisburroughs/durion#<not-provided>
- Child issue: louisburroughs/durion-positivity-backend#<not-provided>
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entries (durion): N/A — change is service-layer only. No Controller/DTO/OpenAPI changes, so the contract-sync gate does not apply.
- Durion contract PR (if applicable): N/A

## Scope
- What changed: `RoleAuthorityServiceImpl` — added helper `timekeepingApprovalAuthorities()` returning `people:timekeeping:view`, `people:timekeeping:approve`, `people:timekeeping:reject`. Wired into `adminAuthorities` (ADMIN), `managerAuthorities` (MANAGER, GENERAL_MANAGER), and `locationManagerAuthorities` (LOCATION_MANAGER). Kept separate from the employee-facing `timekeeping:work_session:*` authorities.
- Why: `TimekeepingApprovalController` requires `people:timekeeping:view/approve/reject`, but no role — including ADMIN — was granted them, so every Time Approval endpoint returned 403 even via the correct gateway path. Confirmed live on durionpos.org: corrected path returned 403 Access Denied prior to this change.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated (backend)
- [ ] Consumer/UI tests added/updated (frontend)
- How to run: `mvn -pl pos-security-service test -Dtest=RoleAuthorityServiceTest` (18/18 pass)

## Risk & Rollback
- Risk level: Medium (security authority grants)
- Rollback plan: Revert the commit; authorities are computed at token-mint time, so there is no persisted data to migrate.

## Deploy Note
- Requires `pos-security-service` redeploy and token re-issue (authorities are JWT-baked). Existing tokens stay 403 until re-login.

## Related
- Frontend companion PR fixes the gateway path (branch `fix/people-timekeeping-approval-path` in `durion-positivity-frontend`).

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, capability ID not provided; branch is `feat/timekeeping-approval-authorities`.
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, capability ID not provided.
- [ ] Links to parent + child issues are present — capability/story IDs not supplied in runtime context.
- [x] Contract guide updated (when contract semantics changed) — N/A, no contract semantics changed.
- [x] Required CI checks passing — `RoleAuthorityServiceTest` 18/18 pass locally.
