### PR TITLE
fix(crm): surface primary contact in party directory listings

### DIFF
--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -2417,7 +2417,6 @@ components:
           $ref: '#/components/schemas/PrimaryContact'
     PrimaryContact:
       type: object
-      description: Lightweight primary-contact projection for directory rows.
       properties:
         name:
           type: string

--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -2413,6 +2413,18 @@ components:
           type: string
         createdAt:
           type: string
+        primaryContact:
+          $ref: '#/components/schemas/PrimaryContact'
+    PrimaryContact:
+      type: object
+      description: Lightweight primary-contact projection for directory rows.
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        phone:
+          type: string
     SearchPartiesResponse:
       type: object
       properties:

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/SearchPartiesResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/SearchPartiesResponse.java
@@ -53,5 +53,25 @@ public class SearchPartiesResponse {
         private String partyType;
         private String status;
         private String createdAt;
+
+        /**
+         * Primary contact for the party, surfaced so the customer directory can render
+         * it without a per-row fetch. Null when the party has no resolvable contact.
+         */
+        private PrimaryContact primaryContact;
+    }
+
+    /**
+     * Lightweight primary-contact projection for directory rows.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class PrimaryContact {
+        private String name;
+        private String email;
+        private String phone;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -201,6 +201,24 @@ public class PartyServiceImpl implements PartyService {
                 .partyType(person.getPartyType().toString())
                 .status(person.getStatus() != null ? person.getStatus().toString() : null)
                 .createdAt(person.getCreatedAt() != null ? ISO_FORMATTER.format(person.getCreatedAt()) : null)
+                .primaryContact(resolvePersonPrimaryContact(person, displayName, identities))
+                .build();
+    }
+
+    /**
+     * For a standalone individual customer the party's primary contact is the person
+     * themselves: name plus their first email/phone (pos-people source of truth).
+     */
+    private SearchPartiesResponse.PrimaryContact resolvePersonPrimaryContact(
+            PersonParty person, String displayName, Map<UUID, PeopleClient.PersonIdentity> identities) {
+        PeopleClient.PersonIdentity identity =
+                person.getPersonId() != null ? identities.get(person.getPersonId()) : null;
+        List<String> emails = resolveEmails(person, identity);
+        List<String> phones = resolvePhones(person, identity);
+        return SearchPartiesResponse.PrimaryContact.builder()
+                .name(displayName)
+                .email(emails.isEmpty() ? null : emails.get(0))
+                .phone(phones.isEmpty() ? null : phones.get(0))
                 .build();
     }
 
@@ -465,7 +483,36 @@ public class PartyServiceImpl implements PartyService {
                 .partyType(party.getPartyType().toString())
                 .status(party.getStatus().toString())
                 .createdAt(party.getCreatedAt() != null ? ISO_FORMATTER.format(party.getCreatedAt()) : null)
+                .primaryContact(resolvePrimaryContact(party))
                 .build();
+    }
+
+    /**
+     * Resolve the primary contact for a commercial party from its active
+     * relationships: the contact flagged primary, else the first active contact.
+     * Returns null when the party has no active contacts.
+     */
+    private SearchPartiesResponse.PrimaryContact resolvePrimaryContact(CommercialParty party) {
+        List<ContactSummary> contacts = buildContactSummaries(party);
+        if (contacts.isEmpty()) {
+            return null;
+        }
+        ContactSummary primary = contacts.stream()
+                .filter(ContactSummary::isPrimary)
+                .findFirst()
+                .orElse(contacts.get(0));
+        return SearchPartiesResponse.PrimaryContact.builder()
+                .name(primary.getName())
+                .email(firstContactValue(primary.getEmailAddresses(), ContactSummary.EmailAddressDTO::getAddress))
+                .phone(firstContactValue(primary.getPhoneNumbers(), ContactSummary.PhoneNumberDTO::getNumber))
+                .build();
+    }
+
+    private <T> String firstContactValue(List<T> values, java.util.function.Function<T, String> extractor) {
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        return extractor.apply(values.get(0));
     }
 
     private Pageable normalizeBrowsePageable(@Nullable Pageable pageable) {

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -501,6 +501,69 @@ class PartyServiceImplTest {
     }
 
     @Test
+    void browseParties_populatesPrimaryContact_forCommercialParty() {
+        UUID partyId = UUID.fromString("00000000-0000-0000-0000-0000000000c2");
+        UUID relId = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+        CommercialParty commercial = party(partyId);
+        commercial.setLegalName("Acme Corp");
+        commercial.setDisplayName("Acme Corp");
+
+        PersonParty contact = new PersonParty();
+        contact.setFirstName("Jane");
+        contact.setLastName("Doe");
+        ContactPoint phone = new ContactPoint();
+        phone.setContactType(ContactPointType.PHONE_MOBILE);
+        phone.setValue("555-1234");
+        ContactPoint email = new ContactPoint();
+        email.setContactType(ContactPointType.EMAIL);
+        email.setValue("jane@acme.com");
+        contact.setContactPoints(new ArrayList<>(List.of(phone, email)));
+
+        PartyRelationship rel = new PartyRelationship();
+        rel.setPartyRelationshipId(relId);
+        rel.setToPerson(contact);
+        rel.setPrimaryBillingContact(true);
+
+        when(partyRepository.findAll()).thenReturn(List.of(commercial));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of());
+        when(partyRelationshipRepository.findActiveByFromPartyId(partyId, LocalDate.of(2024, 1, 1)))
+                .thenReturn(List.of(rel));
+
+        SearchPartiesResponse response = service.browseParties(Pageable.unpaged());
+
+        SearchPartiesResponse.PrimaryContact primary =
+                response.getResults().getFirst().getPrimaryContact();
+        assertThat(primary).isNotNull();
+        assertThat(primary.getName()).isEqualTo("Jane Doe");
+        assertThat(primary.getEmail()).isEqualTo("jane@acme.com");
+        assertThat(primary.getPhone()).isEqualTo("555-1234");
+    }
+
+    @Test
+    void browseParties_populatesPrimaryContact_forIndividualCustomer() {
+        PersonParty individual = new PersonParty();
+        individual.setPartyId(UUID.fromString("00000000-0000-0000-0000-0000000000a3"));
+        individual.setFirstName("Alice");
+        individual.setLastName("Anders");
+        individual.setStatus(AccountStatus.ACTIVE);
+        ContactPoint email = new ContactPoint();
+        email.setContactType(ContactPointType.EMAIL);
+        email.setValue("alice@example.com");
+        individual.setContactPoints(new ArrayList<>(List.of(email)));
+
+        when(partyRepository.findAll()).thenReturn(List.of());
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of(individual));
+
+        SearchPartiesResponse response = service.browseParties(Pageable.unpaged());
+
+        SearchPartiesResponse.PrimaryContact primary =
+                response.getResults().getFirst().getPrimaryContact();
+        assertThat(primary).isNotNull();
+        assertThat(primary.getName()).isEqualTo("Alice Anders");
+        assertThat(primary.getEmail()).isEqualTo("alice@example.com");
+    }
+
+    @Test
     void searchParties_filtersByPartyTypeAndStatus_caseInsensitive() {
         CommercialParty match = party(UUID.fromString("00000000-0000-0000-0000-000000000003"));
         match.setPartyType(PartyType.COMMERCIAL);


### PR DESCRIPTION
## Summary
The customer directory (`/app/crm/customers`) showed no primary contact. Server-side paging (#33) changed browse/search to return `PartySummary`, which carried no contact data, so the frontend had nothing to render.

## Changes (`pos-customer`)
- `SearchPartiesResponse` — add nested `PrimaryContact{name,email,phone}` and a `primaryContact` field on `PartySummary`.
- `PartyServiceImpl` — populate primary contact in both directory mappers:
  - commercial parties: resolved from active relationships (primary-flagged contact, else first active contact)
  - individual customers: resolved from the person's own name/email/phone (pos-people source of truth, with local fallback)
- `openapi.yaml` — add `PrimaryContact` schema + `$ref` from `PartySummary`.

## Contract
Additive, backward-compatible change to the CRM party search/browse contract. See `domains/crm/.business-rules/BACKEND_CONTRACT_GUIDE.md` — the curated guide does not enumerate `PartySummary` field-level schema, so no guide content change is required; the authoritative schema lives in `pos-customer/openapi.yaml`.

## Tests
- `PartyServiceImplTest` — +2 cases (commercial relationship contact; individual customer). Full class: 36 passing, BUILD SUCCESS.

## Follow-up
The published `@durion-sdk/customer` `PartySummary` needs regeneration from this openapi to type `primaryContact`. The frontend consumes the field via its own `PartyDetail` model in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
