### PR TITLE
fix(crm): surface vehicle count in party directory listings

### DIFF
--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -2415,6 +2415,9 @@ components:
           type: string
         primaryContact:
           $ref: '#/components/schemas/PrimaryContact'
+        vehicleCount:
+          type: integer
+          format: int32
     PrimaryContact:
       type: object
       properties:

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/SearchPartiesResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/SearchPartiesResponse.java
@@ -59,6 +59,12 @@ public class SearchPartiesResponse {
          * it without a per-row fetch. Null when the party has no resolvable contact.
          */
         private PrimaryContact primaryContact;
+
+        /**
+         * Number of vehicles associated with the party, surfaced so the directory can
+         * show a count without a per-row fetch. Defaults to 0.
+         */
+        private Integer vehicleCount;
     }
 
     /**

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -24,6 +24,7 @@ import com.positivity.customer.internal.dto.snapshot.CrmSnapshotDTO;
 import com.positivity.customer.internal.dto.snapshot.SnapshotMetadata;
 import com.positivity.customer.internal.entity.BillingRulesEmbeddable;
 import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.entity.Party;
 import com.positivity.customer.internal.entity.PartyRelationship;
 import com.positivity.customer.internal.entity.PersonParty;
 import com.positivity.customer.internal.enums.AccountStatus;
@@ -202,6 +203,7 @@ public class PartyServiceImpl implements PartyService {
                 .status(person.getStatus() != null ? person.getStatus().toString() : null)
                 .createdAt(person.getCreatedAt() != null ? ISO_FORMATTER.format(person.getCreatedAt()) : null)
                 .primaryContact(resolvePersonPrimaryContact(person, displayName, identities))
+                .vehicleCount(vehicleCount(person))
                 .build();
     }
 
@@ -484,7 +486,13 @@ public class PartyServiceImpl implements PartyService {
                 .status(party.getStatus().toString())
                 .createdAt(party.getCreatedAt() != null ? ISO_FORMATTER.format(party.getCreatedAt()) : null)
                 .primaryContact(resolvePrimaryContact(party))
+                .vehicleCount(vehicleCount(party))
                 .build();
+    }
+
+    /** Vehicle count for a party; 0 when none. */
+    private int vehicleCount(Party party) {
+        return party.getVehicleVins() != null ? party.getVehicleVins().size() : 0;
     }
 
     /**

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -564,6 +564,32 @@ class PartyServiceImplTest {
     }
 
     @Test
+    void browseParties_populatesVehicleCount_fromPartyVins() {
+        CommercialParty commercial = party(UUID.fromString("00000000-0000-0000-0000-0000000000c3"));
+        commercial.setLegalName("Fleet Co");
+        commercial.setDisplayName("Fleet Co");
+        commercial.setVehicleVins(new java.util.HashSet<>(List.of("VIN1", "VIN2", "VIN3")));
+
+        PersonParty individual = new PersonParty();
+        individual.setPartyId(UUID.fromString("00000000-0000-0000-0000-0000000000a4"));
+        individual.setFirstName("No");
+        individual.setLastName("Vehicles");
+        individual.setStatus(AccountStatus.ACTIVE);
+
+        when(partyRepository.findAll()).thenReturn(List.of(commercial));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of(individual));
+
+        SearchPartiesResponse response = service.browseParties(Pageable.unpaged());
+
+        java.util.Map<String, Integer> countByName = response.getResults().stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        SearchPartiesResponse.PartySummary::getDisplayName,
+                        SearchPartiesResponse.PartySummary::getVehicleCount));
+        assertThat(countByName.get("Fleet Co")).isEqualTo(3);
+        assertThat(countByName.get("No Vehicles")).isZero();
+    }
+
+    @Test
     void searchParties_filtersByPartyTypeAndStatus_caseInsensitive() {
         CommercialParty match = party(UUID.fromString("00000000-0000-0000-0000-000000000003"));
         match.setPartyType(PartyType.COMMERCIAL);


### PR DESCRIPTION
## Summary
The customer directory (`/app/crm/customers`) always showed 0 vehicles. Browse/search return `PartySummary`, which carried no vehicle data.

## Changes (`pos-customer`)
- `SearchPartiesResponse.PartySummary` — add `vehicleCount` (int32).
- `PartyServiceImpl` — populate from `getVehicleVins().size()` for commercial and individual parties.
- `openapi.yaml` — add `vehicleCount`.

## Contract
Additive, backward-compatible change to the CRM party search/browse contract. See `domains/crm/.business-rules/BACKEND_CONTRACT_GUIDE.md`; field-level schema is authoritative in `pos-customer/openapi.yaml`.

## Tests
- `PartyServiceImplTest` — +1 case. Full class: 37 passing, BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
