### PR TITLE
fix(people): employee directory filters gate on employee_number

### DIFF
--- a/pos-people/src/main/java/com/positivity/people/internal/repository/PersonSpecifications.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/PersonSpecifications.java
@@ -16,14 +16,24 @@ public final class PersonSpecifications {
             List<Predicate> predicates = new ArrayList<>();
 
             if (type != null) {
+                // employee_number is the discriminator for "is an employee". The person
+                // table also holds customer individuals and commercial contacts (ADR-0015
+                // person unification), so status alone is not sufficient — those records
+                // may carry an EmployeeStatus without being employees.
                 switch (type.toUpperCase()) {
-                    case "EMPLOYEE" -> predicates.add(root.get("status").isNotNull());
-                    case "ACTIVE" -> predicates.add(cb.equal(root.get("status"), EmployeeStatus.ACTIVE));
-                    case "INACTIVE" -> predicates.add(root.get("status").in(
-                            EmployeeStatus.ON_LEAVE,
-                            EmployeeStatus.SUSPENDED,
-                            EmployeeStatus.TERMINATED,
-                            EmployeeStatus.DISABLED));
+                    case "EMPLOYEE" -> predicates.add(cb.isNotNull(root.get("employeeNumber")));
+                    case "ACTIVE" -> {
+                        predicates.add(cb.isNotNull(root.get("employeeNumber")));
+                        predicates.add(cb.equal(root.get("status"), EmployeeStatus.ACTIVE));
+                    }
+                    case "INACTIVE" -> {
+                        predicates.add(cb.isNotNull(root.get("employeeNumber")));
+                        predicates.add(root.get("status").in(
+                                EmployeeStatus.ON_LEAVE,
+                                EmployeeStatus.SUSPENDED,
+                                EmployeeStatus.TERMINATED,
+                                EmployeeStatus.DISABLED));
+                    }
                     default -> { /* ALL or unrecognised — no predicate */ }
                 }
             }

--- a/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
@@ -122,6 +122,17 @@ ON CONFLICT (id) DO NOTHING;
 -- matching pos-customer person_party rows are removed by pos-customer V9.
 -- =========================================================================
 
+-- ADR-0015: the person table also holds customer individuals (Group A) and
+-- commercial contacts (Group B), which are NOT employees. EmployeeStatus is an
+-- employment lifecycle value and must not be set on non-employees, otherwise the
+-- people directory's employee filters surface them. employee_number is the
+-- authoritative employee discriminator, so clear status wherever it is absent.
+UPDATE person
+   SET status = NULL,
+       status_effective_at = NULL
+ WHERE employee_number IS NULL
+   AND status IS NOT NULL;
+
 -- user_person_links (guarded by person table existence; person rows inserted above)
 DO $$
 BEGIN

--- a/pos-people/src/test/java/com/positivity/people/internal/repository/PersonSpecificationsTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/repository/PersonSpecificationsTest.java
@@ -1,0 +1,76 @@
+package com.positivity.people.internal.repository;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.internal.entity.Person;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the people directory employee filters discriminate on employee_number,
+ * not status. After ADR-0015 person unification the person table also holds
+ * customer individuals / commercial contacts that may carry an EmployeeStatus.
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+class PersonSpecificationsTest {
+
+    private Root<Person> mockRoot() {
+        Root<Person> root = mock(Root.class);
+        when(root.get(any(String.class))).thenReturn(mock(Path.class));
+        return root;
+    }
+
+    private CriteriaBuilder mockCb() {
+        CriteriaBuilder cb = mock(CriteriaBuilder.class);
+        when(cb.isNotNull(any())).thenReturn(mock(Predicate.class));
+        when(cb.equal(any(), any())).thenReturn(mock(Predicate.class));
+        when(cb.and(any(Predicate[].class))).thenReturn(mock(Predicate.class));
+        when(cb.conjunction()).thenReturn(mock(Predicate.class));
+        return cb;
+    }
+
+    @Test
+    void employeeFilter_gatesOnEmployeeNumber_notStatus() {
+        Root<Person> root = mockRoot();
+        CriteriaBuilder cb = mockCb();
+
+        PersonSpecifications.directoryFilter("EMPLOYEE", null)
+                .toPredicate(root, mock(CriteriaQuery.class), cb);
+
+        verify(root).get("employeeNumber");
+        verify(cb).isNotNull(any());
+        verify(root, never()).get("status");
+    }
+
+    @Test
+    void activeFilter_requiresEmployeeNumberAndActiveStatus() {
+        Root<Person> root = mockRoot();
+        CriteriaBuilder cb = mockCb();
+
+        PersonSpecifications.directoryFilter("ACTIVE", null)
+                .toPredicate(root, mock(CriteriaQuery.class), cb);
+
+        verify(root).get("employeeNumber");
+        verify(root).get("status");
+    }
+
+    @Test
+    void allFilter_addsNoTypePredicate() {
+        Root<Person> root = mockRoot();
+        CriteriaBuilder cb = mockCb();
+
+        PersonSpecifications.directoryFilter("ALL", null)
+                .toPredicate(root, mock(CriteriaQuery.class), cb);
+
+        verify(root, never()).get("employeeNumber");
+        verify(root, never()).get("status");
+    }
+}


### PR DESCRIPTION
## Summary
The people directory `Employees` filter (`/app/people/directory`) showed non-employees. Root cause: after ADR-0015 person unification, the `person` table holds employees **and** customer individuals / commercial contacts. The EMPLOYEE filter tested `status IS NOT NULL`, but seed data set `EmployeeStatus.ACTIVE` on those non-employees, so they matched.

## Diagnosis: both filter + data
- **Filter:** `status` is the employment lifecycle, not the is-employee flag. `employee_number` is the authoritative discriminator (only employees have one).
- **Data:** `EmployeeStatus.ACTIVE` should never be set on non-employee persons.

## Changes (`pos-people`)
- `PersonSpecifications.directoryFilter` — `EMPLOYEE`/`ACTIVE`/`INACTIVE` now require `employee_number IS NOT NULL`; `ACTIVE`/`INACTIVE` also match on status. `ALL` unchanged.
- `R__seed_people_operational_data.sql` — idempotent `UPDATE` clearing `status` on any person without an `employee_number` (corrects fresh and existing rows via the repeatable migration).
- `PersonSpecificationsTest` — 3 cases (employee gating, active gating, ALL no-op).

## Verification
`mvn -pl pos-people test -Dtest=PersonSpecificationsTest` → 3 passing, BUILD SUCCESS. Backend-only; filter param values unchanged, so no SDK/frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)