### PR TITLE
feat(inventory): add list-inventory-items endpoint for a storage location

### DIFF
--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -2542,6 +2542,45 @@ paths:
         - inventory:on_hand:view
       x-required-permissions:
       - inventory:on_hand:view
+  /v1/inventory/locations/{locationId}/inventory-items:
+    get:
+      tags:
+      - Inventory Locations
+      summary: List location inventory contents
+      description: Returns the on-hand stock items (positive quantity) at a storage location.
+      operationId: listLocationInventoryItems
+      parameters:
+      - name: locationId
+        in: path
+        description: Storage location identifier
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Location inventory contents returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationInventoryItemsResponse'
+        '400':
+          description: Invalid location identifier
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationInventoryItemsResponse'
+        '403':
+          description: User lacks required on-hand view authority
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - inventory:on_hand:view
+      x-required-permissions:
+      - inventory:on_hand:view
   /v1/inventory/locations/{locationId}/inventory-inquiry:
     get:
       tags:
@@ -5172,6 +5211,38 @@ components:
       required:
       - siteId
       - totals
+    Item:
+      type: object
+      description: A single on-hand stock item line
+      properties:
+        stockItemId:
+          type: string
+          description: Stock item identifier (product SKU)
+          example: MICH-XC2-0001
+        onHandQuantity:
+          type: integer
+          format: int64
+          description: On-hand quantity of this stock item at the location
+          example: 24
+      required:
+      - onHandQuantity
+      - stockItemId
+    LocationInventoryItemsResponse:
+      type: object
+      description: On-hand inventory contents for a storage location
+      properties:
+        locationId:
+          type: string
+          format: uuid
+          description: Storage location identifier
+        items:
+          type: array
+          description: Stock items currently on hand at the location
+          items:
+            $ref: '#/components/schemas/Item'
+      required:
+      - items
+      - locationId
     LocationInventoryInquiryResponse:
       type: object
       description: Inventory summary for a storage location

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -2569,7 +2569,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LocationInventoryItemsResponse'
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: User lacks required on-hand view authority
           content:
@@ -5211,7 +5211,7 @@ components:
       required:
       - siteId
       - totals
-    Item:
+    LocationInventoryItem:
       type: object
       description: A single on-hand stock item line
       properties:
@@ -5239,7 +5239,7 @@ components:
           type: array
           description: Stock items currently on hand at the location
           items:
-            $ref: '#/components/schemas/Item'
+            $ref: '#/components/schemas/LocationInventoryItem'
       required:
       - items
       - locationId

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryInquiryController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryInquiryController.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.controller;
 
 import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
+import com.positivity.inventory.internal.dto.LocationInventoryItemsResponse;
 import com.positivity.inventory.service.LocationInventoryInquiryService;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
@@ -55,5 +56,32 @@ public class LocationInventoryInquiryController {
             @Parameter(description = "Storage location identifier", required = true) @PathVariable UUID locationId,
             @Parameter(description = "Product SKU filter") @RequestParam(required = false) String sku) {
         return ResponseEntity.ok(locationInventoryInquiryService.getLocationInventory(locationId, sku));
+    }
+
+    @GetMapping("/{locationId}/inventory-items")
+    @PreAuthorize("hasAuthority('inventory:on_hand:view')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:on_hand:view"})
+    @Operation(
+            operationId = "listLocationInventoryItems",
+            summary = "List location inventory contents",
+            description = "Returns the on-hand stock items (positive quantity) at a storage location.",
+            tags = {"Inventory Locations"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Location inventory contents returned",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LocationInventoryItemsResponse.class)))
+    @ApiResponse(responseCode = "400", description = "Invalid location identifier")
+    @ApiResponse(
+            responseCode = "403",
+            description = "User lacks required on-hand view authority",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<LocationInventoryItemsResponse> listLocationInventoryItems(
+            @Parameter(description = "Storage location identifier", required = true) @PathVariable UUID locationId) {
+        return ResponseEntity.ok(locationInventoryInquiryService.listLocationInventoryItems(locationId));
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryInquiryController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/LocationInventoryInquiryController.java
@@ -75,7 +75,10 @@ public class LocationInventoryInquiryController {
                     @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = LocationInventoryItemsResponse.class)))
-    @ApiResponse(responseCode = "400", description = "Invalid location identifier")
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid location identifier",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @ApiResponse(
             responseCode = "403",
             description = "User lacks required on-hand view authority",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryItemsResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryItemsResponse.java
@@ -28,7 +28,7 @@ public class LocationInventoryItemsResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    @Schema(description = "A single on-hand stock item line")
+    @Schema(name = "LocationInventoryItem", description = "A single on-hand stock item line")
     public static class Item {
 
         @Schema(description = "Stock item identifier (product SKU)", example = "MICH-XC2-0001",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryItemsResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryItemsResponse.java
@@ -1,0 +1,42 @@
+package com.positivity.inventory.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * On-hand inventory contents (per stock item) for a single storage location.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "On-hand inventory contents for a storage location")
+public class LocationInventoryItemsResponse {
+
+    @Schema(description = "Storage location identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID locationId;
+
+    @Schema(description = "Stock items currently on hand at the location", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<Item> items;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "A single on-hand stock item line")
+    public static class Item {
+
+        @Schema(description = "Stock item identifier (product SKU)", example = "MICH-XC2-0001",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private String stockItemId;
+
+        @Schema(description = "On-hand quantity of this stock item at the location", example = "24",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private long onHandQuantity;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
+import com.positivity.inventory.internal.dto.LocationInventoryItemsResponse;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
@@ -50,6 +51,25 @@ public class LocationInventoryInquiryServiceImpl implements LocationInventoryInq
                 .locationId(locationId)
                 .onHandQuantity(resolvedOnHandQuantity)
                 .availableToPromiseQuantity(resolvedOnHandQuantity - outstandingAllocations)
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @NonNull
+    public LocationInventoryItemsResponse listLocationInventoryItems(@NonNull UUID locationId) {
+        List<LocationInventoryItemsResponse.Item> items = inventoryLedgerEntryRepository
+                .findPositiveOnHandByLocation(locationId, ON_HAND_EVENT_TYPES)
+                .stream()
+                .map(row -> LocationInventoryItemsResponse.Item.builder()
+                        .stockItemId(row.getStockItemId())
+                        .onHandQuantity(row.getOnHandQuantity() == null ? 0L : row.getOnHandQuantity())
+                        .build())
+                .toList();
+
+        return LocationInventoryItemsResponse.builder()
+                .locationId(locationId)
+                .items(items)
                 .build();
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/LocationInventoryInquiryService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/LocationInventoryInquiryService.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.service;
 
 import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
+import com.positivity.inventory.internal.dto.LocationInventoryItemsResponse;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -18,4 +19,14 @@ public interface LocationInventoryInquiryService {
      */
     @NonNull
     LocationInventoryInquiryResponse getLocationInventory(@NonNull UUID locationId, @Nullable String sku);
+
+    /**
+     * Lists the on-hand stock items (with positive quantity) at the given
+     * storage location.
+     *
+     * @param locationId storage location identifier
+     * @return per-stock-item on-hand contents for the location
+     */
+    @NonNull
+    LocationInventoryItemsResponse listLocationInventoryItems(@NonNull UUID locationId);
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryInquiryServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryInquiryServiceImplTest.java
@@ -1,0 +1,83 @@
+package com.positivity.inventory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.dto.LocationInventoryItemsResponse;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository.LocationOnHand;
+import com.positivity.inventory.internal.service.LocationInventoryInquiryServiceImpl;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link LocationInventoryInquiryServiceImpl#listLocationInventoryItems}.
+ */
+@ExtendWith(MockitoExtension.class)
+class LocationInventoryInquiryServiceImplTest {
+
+    private static final UUID LOCATION_ID = UUID.fromString("01960004-0001-7000-8000-000000000047");
+
+    @Mock
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    private LocationOnHand onHand(String sku, Long qty) {
+        return new LocationOnHand() {
+            @Override
+            public String getStockItemId() {
+                return sku;
+            }
+
+            @Override
+            public Long getOnHandQuantity() {
+                return qty;
+            }
+        };
+    }
+
+    @Test
+    void listLocationInventoryItems_mapsPositiveOnHandRowsToItems() {
+        var service = new LocationInventoryInquiryServiceImpl(ledgerRepository);
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(LOCATION_ID), any()))
+                .thenReturn(List.of(onHand("MICH-XC2-0001", 24L), onHand("MICH-DEF-0002", 8L)));
+
+        LocationInventoryItemsResponse response = service.listLocationInventoryItems(LOCATION_ID);
+
+        assertThat(response.getLocationId()).isEqualTo(LOCATION_ID);
+        assertThat(response.getItems())
+                .extracting(LocationInventoryItemsResponse.Item::getStockItemId)
+                .containsExactly("MICH-XC2-0001", "MICH-DEF-0002");
+        assertThat(response.getItems())
+                .extracting(LocationInventoryItemsResponse.Item::getOnHandQuantity)
+                .containsExactly(24L, 8L);
+    }
+
+    @Test
+    void listLocationInventoryItems_returnsEmptyListForLocationWithoutStock() {
+        var service = new LocationInventoryInquiryServiceImpl(ledgerRepository);
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(LOCATION_ID), any())).thenReturn(List.of());
+
+        LocationInventoryItemsResponse response = service.listLocationInventoryItems(LOCATION_ID);
+
+        assertThat(response.getLocationId()).isEqualTo(LOCATION_ID);
+        assertThat(response.getItems()).isEmpty();
+    }
+
+    @Test
+    void listLocationInventoryItems_treatsNullQuantityAsZero() {
+        var service = new LocationInventoryInquiryServiceImpl(ledgerRepository);
+        when(ledgerRepository.findPositiveOnHandByLocation(eq(LOCATION_ID), any()))
+                .thenReturn(List.of(onHand("WIXF-XP57356", null)));
+
+        LocationInventoryItemsResponse response = service.listLocationInventoryItems(LOCATION_ID);
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getOnHandQuantity()).isZero();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `GET /v1/inventory/locations/{locationId}/inventory-items` — on-hand stock items (positive quantity) at a single storage location, so callers can show the **contents** of one bin/shelf/rack.

## Changes

- `LocationInventoryItemsResponse` (nested schema named `LocationInventoryItem`).
- `LocationInventoryInquiryService.listLocationInventoryItems` maps the existing `findPositiveOnHandByLocation` ledger aggregation; no new query.
- Controller endpoint mirrors the inquiry endpoint (`inventory:on_hand:view`, OpenAPI, `ApiError` for 400/403).
- Regenerated `openapi.yaml`; 3 unit tests.

## Contract

No curated contract change required for this read endpoint; the generated OpenAPI is the source of truth and `BACKEND_CONTRACT_GUIDE.md` for the inventory domain is unaffected (no new business rule — it surfaces existing ledger on-hand per location).

## Validation

- [x] `LocationInventoryInquiryServiceImplTest` 3/3
- [x] `openapi.yaml` regenerated (new path; nested schema `LocationInventoryItem`; 400 → `ApiError`)

## Dependencies

- Pairs with bin-level seed (#693) and the storage-page contents UI (frontend #43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
