### PR TITLE
feat(customer): @Schema + Jakarta validation on DTOs; enrich account response

### DIFF
--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -2075,7 +2075,6 @@ components:
           minLength: 0
         email:
           type: string
-          format: email
           description: Email address of the customer
           example: jane@acme.com
           maxLength: 254
@@ -2084,7 +2083,7 @@ components:
           type: string
           description: Phone number of the customer
           example: +1-555-0142
-          maxLength: 32
+          maxLength: 64
           minLength: 0
         primaryAddress:
           type: string

--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -1580,33 +1580,44 @@ components:
           type: string
           format: uuid
           description: Unique identifier of the customer
-          example: 123e4567-e89b-12d3-a456-426614174000
+          example: 01960003-0000-7000-8000-000000000001
         customerNumber:
           type: string
           description: Unique customer number
           example: CUST-1001
+          maxLength: 50
+          minLength: 0
         lastName:
           type: string
           description: Last name of the customer
           example: Doe
-          minLength: 1
+          maxLength: 100
+          minLength: 0
         firstName:
           type: string
           description: First name of the customer
           example: John
-          minLength: 1
+          maxLength: 100
+          minLength: 0
         primaryAddress:
           type: string
           description: Primary address label or identifier for the customer
           example: 123 Main St, Springfield
+          maxLength: 255
+          minLength: 0
         vehicleVins:
           type: array
           description: List of vehicle VINs associated with the customer
+          example:
+          - 1HGCM82633A004352
           items:
             type: string
         customerType:
           type: string
           description: Type of customer (e.g., 'retail', 'commercial')
+          example: retail
+          maxLength: 50
+          minLength: 0
       required:
       - firstName
       - lastName
@@ -1616,14 +1627,36 @@ components:
       properties:
         vinNumber:
           type: string
+          description: Vehicle Identification Number (uniqueness scope global or per-party)
+          example: 1HGCM82633A004352
+          maxLength: 17
+          minLength: 0
         unitNumber:
           type: string
+          description: Unit number or internal reference
+          example: UNIT-42
+          maxLength: 64
+          minLength: 0
         description:
           type: string
+          description: Vehicle description
+          example: 2019 Ford Transit 250 cargo van
+          maxLength: 255
+          minLength: 0
         licensePlate:
           type: string
+          description: License plate (single string or plate plus region)
+          example: ABC-1234
+          maxLength: 32
+          minLength: 0
         licensePlateRegion:
           type: string
+          description: License plate region/state
+          example: CA
+          maxLength: 64
+          minLength: 0
+      required:
+      - vinNumber
     VehicleResponse:
       type: object
       description: Vehicle response payload.
@@ -1712,38 +1745,79 @@ components:
       properties:
         targetCustomerId:
           type: string
+          description: Target customer ID to transfer the vehicle to
+          example: 01960003-0000-7000-8000-000000000001
+          maxLength: 100
+          minLength: 0
         notes:
           type: string
+          description: Optional notes about the transfer
+          example: Vehicle reassigned to fleet account
+          maxLength: 1000
+          minLength: 0
+      required:
+      - targetCustomerId
     RoleAssignment:
       type: object
+      description: Single role assignment detail
       properties:
         roleCode:
           type: string
+          description: Role code (BILLING|APPROVER|DRIVER)
+          example: BILLING
+          maxLength: 40
+          minLength: 0
         isPrimary:
           type: boolean
+          description: 'Flag: set this contact as primary for this role'
+          example: true
+      required:
+      - roleCode
     UpdateContactRolesRequest:
       type: object
       description: Role assignment request
       properties:
         version:
           type: string
+          description: Optimistic locking version; required when the backend enforces optimistic locking
+          example: '7'
+          maxLength: 100
+          minLength: 0
         roles:
           type: array
+          description: List of roles to assign to this contact
           items:
             $ref: '#/components/schemas/RoleAssignment'
+      required:
+      - roles
     UpdateContactRolesResponse:
       type: object
+      description: Response after updating contact role assignments
       properties:
         partyId:
           type: string
+          description: Identifier of the party that owns the contact
+          example: 01960003-0000-7000-8000-000000000001
         contactId:
           type: string
+          description: Identifier of the contact that was updated
+          example: 01960003-0000-7000-8000-000000000002
         version:
           type: string
+          description: Updated version for optimistic locking conflict resolution
+          example: '8'
         status:
           type: string
+          description: Update status (SUCCESS|CONFLICT)
+          example: SUCCESS
         updatedAt:
           type: string
+          description: Timestamp of update (ISO 8601)
+          example: 2026-01-15 09:30:00+00:00
+      required:
+      - contactId
+      - partyId
+      - status
     UpsertBillingRulesRequest:
       type: object
       description: Request to upsert billing rules for a commercial party
@@ -1832,33 +1906,54 @@ components:
           type: object
     RecordRedemptionRequest:
       type: object
+      description: Request to record a promotion redemption for a customer
       properties:
         promotionId:
           type: string
           format: uuid
+          description: Identifier of the promotion being redeemed
+          example: 01960003-0000-7000-8000-000000000002
         customerId:
           type: string
           format: uuid
+          description: Identifier of the customer redeeming the promotion
+          example: 01960003-0000-7000-8000-000000000003
         workorderId:
           type: string
           format: uuid
+          description: Identifier of the workorder the redemption applies to
+          example: 01960003-0000-7000-8000-000000000004
         invoiceId:
           type: string
           format: uuid
+          description: Identifier of the invoice the redemption applies to, if any
+          example: 01960003-0000-7000-8000-000000000005
         discountAmount:
           type: number
+          description: Discount amount to record for the redemption
+          example: 25.0
           minimum: 0.0
         discountType:
           type: string
-          minLength: 1
+          description: Type of discount being recorded
+          example: PERCENTAGE
+          maxLength: 50
+          minLength: 0
         promotionCode:
           type: string
-          minLength: 1
+          description: Promotion code being redeemed
+          example: SUMMER25
+          maxLength: 100
+          minLength: 0
         recordedOverLimit:
           type: boolean
+          description: Whether the redemption is being recorded over the configured usage limit
+          example: false
         redemptionTimestamp:
           type: string
           format: date-time
+          description: Timestamp when the redemption occurred
+          example: 2026-02-20 14:45:00
       required:
       - customerId
       - discountAmount
@@ -1868,43 +1963,80 @@ components:
       - workorderId
     PromotionRedemptionResponse:
       type: object
+      description: Result of recording a promotion redemption for a customer
       properties:
         promotionRedemptionId:
           type: string
           format: uuid
+          description: Unique identifier of the promotion redemption record
+          example: 01960003-0000-7000-8000-000000000001
         promotionId:
           type: string
           format: uuid
+          description: Identifier of the redeemed promotion
+          example: 01960003-0000-7000-8000-000000000002
         customerId:
           type: string
           format: uuid
+          description: Identifier of the customer who redeemed the promotion
+          example: 01960003-0000-7000-8000-000000000003
         workorderId:
           type: string
           format: uuid
+          description: Identifier of the workorder the redemption was applied to
+          example: 01960003-0000-7000-8000-000000000004
         invoiceId:
           type: string
           format: uuid
+          description: Identifier of the invoice the redemption was applied to, if any
+          example: 01960003-0000-7000-8000-000000000005
         discountAmount:
           type: number
+          description: Discount amount applied by the redemption
+          example: 25.0
         discountType:
           type: string
+          description: Type of discount applied
+          example: PERCENTAGE
         promotionCode:
           type: string
+          description: Promotion code that was redeemed
+          example: SUMMER25
         recordedBy:
           type: string
+          description: Identifier of the actor who recorded the redemption
+          example: 01960003-0000-7000-8000-000000000006
         recordedOverLimit:
           type: boolean
+          description: Whether the redemption was recorded over the configured usage limit
+          example: false
         status:
           type: string
+          description: Current status of the redemption
           enum:
           - RECORDED
           - RECORDED_OVER_LIMIT
+          example: RECORDED
         redemptionTimestamp:
           type: string
           format: date-time
+          description: Timestamp when the redemption occurred
+          example: 2026-02-20 14:45:00
         createdAt:
           type: string
           format: date-time
+          description: Timestamp when the redemption record was created
+          example: 2026-02-20 14:45:01
+      required:
+      - createdAt
+      - customerId
+      - discountAmount
+      - discountType
+      - promotionCode
+      - promotionId
+      - promotionRedemptionId
+      - status
+      - workorderId
     BulkIngestRequestCustomerBulkIngestRecord:
       type: object
       properties:
@@ -1927,21 +2059,45 @@ components:
       - records
     CustomerBulkIngestRecord:
       type: object
+      description: A single customer record submitted as part of a bulk ingest request
       properties:
         firstName:
           type: string
-          minLength: 1
+          description: First name of the customer
+          example: Jane
+          maxLength: 100
+          minLength: 0
         lastName:
           type: string
-          minLength: 1
+          description: Last name of the customer
+          example: Doe
+          maxLength: 100
+          minLength: 0
         email:
           type: string
+          format: email
+          description: Email address of the customer
+          example: jane@acme.com
+          maxLength: 254
+          minLength: 0
         phoneNumber:
           type: string
+          description: Phone number of the customer
+          example: +1-555-0142
+          maxLength: 32
+          minLength: 0
         primaryAddress:
           type: string
+          description: Primary address of the customer
+          example: 123 Main St, Springfield
+          maxLength: 255
+          minLength: 0
         customerNumber:
           type: string
+          description: Existing customer number, if known
+          example: CUST-1001
+          maxLength: 50
+          minLength: 0
       required:
       - firstName
       - lastName
@@ -1984,12 +2140,14 @@ components:
           type: string
           description: First name of the person
           example: John
-          minLength: 1
+          maxLength: 255
+          minLength: 0
         lastName:
           type: string
           description: Last name of the person
           example: Doe
-          minLength: 1
+          maxLength: 255
+          minLength: 0
         preferredContactMethod:
           type: string
           description: Preferred method of contact
@@ -2022,7 +2180,8 @@ components:
           format: email
           description: Email address
           example: john.doe@example.com
-          minLength: 1
+          maxLength: 255
+          minLength: 0
         primary:
           type: boolean
       required:
@@ -2035,7 +2194,8 @@ components:
           type: string
           description: Phone number
           example: +1-555-123-4567
-          minLength: 1
+          maxLength: 64
+          minLength: 0
         type:
           type: string
           description: Phone type
@@ -2080,45 +2240,101 @@ components:
           type: integer
           format: int32
           description: Number of contact points created
+          example: 2
         createdAt:
           type: string
           format: date-time
           description: Timestamp when the person was created
+          example: 2026-01-01 12:00:00+00:00
+      required:
+      - contactPointsCreated
+      - createdAt
+      - firstName
+      - lastName
+      - personId
+      - preferredContactMethod
     UpsertCommunicationPreferencesRequest:
       type: object
       description: Communication preferences to set
       properties:
         version:
           type: string
+          description: Optimistic locking version; required for updates, omitted for creates
+          example: '5'
+          maxLength: 100
+          minLength: 0
         emailPreference:
           type: string
+          description: Email preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)
+          example: OPT_IN
+          maxLength: 40
+          minLength: 0
         smsPreference:
           type: string
+          description: SMS preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)
+          example: OPT_OUT
+          maxLength: 40
+          minLength: 0
         phonePreference:
           type: string
+          description: Phone preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)
+          example: OPT_IN
+          maxLength: 40
+          minLength: 0
         marketingPreference:
           type: string
+          description: Marketing communications preference (OPT_IN|OPT_OUT)
+          example: OPT_OUT
+          maxLength: 40
+          minLength: 0
         consentFlags:
           type: object
           additionalProperties:
             type: boolean
+          description: Consent flags keyed by consent type; field names depend on legal requirements
+          example:
+            gdpr: true
+            ccpa: false
         preferencesNote:
           type: string
+          description: User-provided note or preferences summary
+          example: Prefers email contact only on weekdays
+          maxLength: 1000
+          minLength: 0
         updateSource:
           type: string
+          description: Source of update (APP|API|ADMIN)
+          example: APP
+          maxLength: 40
+          minLength: 0
     UpsertCommunicationPreferencesResponse:
       type: object
+      description: Response after upserting communication preferences
       properties:
         partyId:
           type: string
+          description: Identifier of the party that was updated
+          example: 01960003-0000-7000-8000-000000000001
         version:
           type: string
+          description: Updated version for optimistic locking
+          example: '6'
         operationType:
           type: string
+          description: Operation type (CREATED|UPDATED)
+          example: UPDATED
         status:
           type: string
+          description: Update status (SUCCESS|CONFLICT)
+          example: SUCCESS
         updatedAt:
           type: string
+          description: Timestamp of update (ISO 8601)
+          example: 2026-01-15 09:30:00+00:00
+      required:
+      - operationType
+      - partyId
+      - status
     CreatePartyRelationshipRequest:
       type: object
       description: Request to create a relationship between a commercial account and an individual
@@ -2169,16 +2385,22 @@ components:
           type: string
           format: uuid
           description: Unique identifier of the relationship
+          example: 01960003-0000-7000-8000-000000000010
         partyId:
           type: string
           description: ID of the commercial account
+          example: 01960003-0000-7000-8000-000000000001
         personId:
           type: string
           format: uuid
           description: ID of the individual person
+          example: 550e8400-e29b-41d4-a716-446655440000
         roles:
           type: array
           description: Roles assigned to this relationship
+          example:
+          - BILLING
+          - APPROVER
           items:
             type: string
             description: Role type for party relationships
@@ -2193,19 +2415,31 @@ components:
           type: string
           format: date
           description: Effective start date
+          example: 2026-01-01
         effectiveEndDate:
           type: string
           format: date
           description: Effective end date (null if active)
+          example: 2026-12-31
         createdAt:
           type: string
           format: date-time
           description: Timestamp when the relationship was created
+          example: 2026-01-01 12:00:00+00:00
         previousPrimaryDemoted:
           type: boolean
           description: Whether a previous primary billing contact was demoted
+          example: false
         primaryBillingContact:
           type: boolean
+      required:
+      - createdAt
+      - effectiveStartDate
+      - partyId
+      - personId
+      - previousPrimaryDemoted
+      - relationshipId
+      - roles
     ResolveAccountTierRequest:
       type: object
       description: Tier resolution request
@@ -2213,7 +2447,9 @@ components:
         accountId:
           type: string
           description: Account/party identifier
-          example: 123e4567-e89b-12d3-a456-426614174000
+          example: 01960003-0000-7000-8000-000000000001
+          maxLength: 64
+          minLength: 0
         annualRevenue:
           type: number
           description: Annual revenue or spending for tier calculation
@@ -2222,16 +2458,22 @@ components:
           type: integer
           format: int32
           description: Number of active contracts or subscriptions
+          example: 3
         accountAgeMonths:
           type: integer
           format: int32
           description: Account age in months
+          example: 18
         applyTier:
           type: boolean
           description: Whether to apply the resolved tier or just return the recommendation
+          example: false
         forceRecalculation:
           type: boolean
           description: Force recalculation even if tier was manually set
+          example: false
+      required:
+      - accountId
     ResolveAccountTierResponse:
       type: object
       description: Account tier resolution result
@@ -2239,7 +2481,8 @@ components:
         accountId:
           type: string
           description: Account/party identifier
-          example: 123e4567-e89b-12d3-a456-426614174000
+          example: 01960003-0000-7000-8000-000000000001
+          minLength: 1
         currentTier:
           type: string
           description: Currently assigned tier (before resolution)
@@ -2265,184 +2508,424 @@ components:
         tierApplied:
           type: boolean
           description: Whether the tier was applied to the account
+          example: true
         manualOverrideActive:
           type: boolean
           description: Whether the current tier was manually set and blocked auto-update
+          example: false
         resolutionReason:
           type: string
           description: Explanation of why this tier was recommended
+          example: Annual revenue exceeds GOLD threshold of 100000.00
         tierScore:
           type: integer
           format: int32
           description: Score or metric used for tier calculation
+          example: 82
+      required:
+      - accountId
+      - currentTier
+      - manualOverrideActive
+      - recommendedTier
+      - tierApplied
     CreateCommercialAccountRequest:
       type: object
       description: Commercial account creation request
       properties:
         legalName:
           type: string
+          description: Legal business name
+          example: Acme Industrial Supply, LLC
+          maxLength: 255
+          minLength: 0
         displayName:
           type: string
+          description: Display/trading name
+          example: Acme Supply
+          maxLength: 255
+          minLength: 0
         taxId:
           type: string
+          description: Tax identification number (required for certain jurisdictions)
+          example: 12-3456789
+          maxLength: 64
+          minLength: 0
         partyType:
           type: string
+          description: Party type (ORGANIZATION|INDIVIDUAL; default ORGANIZATION for commercial accounts)
+          example: ORGANIZATION
+          maxLength: 32
+          minLength: 0
         billingTermsId:
           type: string
+          description: Billing terms ID (foreign key to Billing domain)
+          example: 01960003-0000-7000-8000-000000000001
         externalIdentifiers:
           type: object
           additionalProperties:
             type: string
+          description: External identifiers (system-specific IDs from upstream systems)
+          example:
+            erp: CUST-00123
         contactFirstName:
           type: string
+          description: Primary contact first name
+          example: Jane
+          maxLength: 255
+          minLength: 0
         contactLastName:
           type: string
+          description: Primary contact last name
+          example: Smith
+          maxLength: 255
+          minLength: 0
         email:
           type: string
+          format: email
+          description: Contact email
+          example: jane@acme.com
+          maxLength: 255
+          minLength: 0
         phone:
           type: string
+          description: Contact phone
+          example: +1-555-123-4567
+          maxLength: 64
+          minLength: 0
+      required:
+      - legalName
     CreateCommercialAccountResponse:
       type: object
+      description: Response after creating a commercial account
       properties:
         partyId:
           type: string
+          description: Newly created party ID (canonical CRM identifier)
+          example: 01960003-0000-7000-8000-000000000001
         legalName:
           type: string
+          description: Legal name of created party
+          example: Acme Industrial Supply, LLC
         status:
           type: string
+          description: Status (ACTIVE|PENDING|SUSPENDED)
+          example: ACTIVE
+        customerNumber:
+          type: string
+          description: Human-readable customer/account number (party number) for display and lookup
+          example: CUST-000123
+        displayName:
+          type: string
+          description: Display name of the account, if provided (falls back to legal name in UI)
+          example: Acme Industrial
+        partyType:
+          type: string
+          description: Party type discriminator
+          example: COMMERCIAL
+        taxId:
+          type: string
+          description: Tax identifier, if provided
+          example: 12-3456789
+        billingTermsId:
+          type: string
+          description: Billing terms identifier associated with the account, if set
+          example: NET30
+        primaryAddress:
+          type: string
+          description: Primary address for display, if available
+          example: 100 Trade Street, Charlotte, NC 28202
         createdAt:
           type: string
           format: date-time
+          description: Timestamp of creation
+          example: 2026-01-01 12:00:00+00:00
         duplicateCandidates:
           type: array
+          description: List of duplicate candidates found during creation. If present, frontend should prompt user for confirmation. Contains summary fields only (partyId, legalName, matchReason).
           items:
             $ref: '#/components/schemas/DuplicateCandidate'
+      required:
+      - createdAt
+      - customerNumber
+      - legalName
+      - partyId
+      - status
     DuplicateCandidate:
       type: object
+      description: Duplicate candidate summary returned on 409 or as advisory in 201
       properties:
         partyId:
           type: string
+          description: Candidate party ID
+          example: 01960003-0000-7000-8000-000000000002
         legalName:
           type: string
+          description: Candidate legal name
+          example: Acme Industrial Supply Co.
         matchReason:
           type: string
+          description: Reason this candidate matched
+          example: LEGAL_NAME_SIMILARITY
+      required:
+      - legalName
+      - matchReason
+      - partyId
     CreateVehicleForPartyResponse:
       type: object
+      description: Response returned after creating a vehicle record for a party
       properties:
         vehicleId:
           type: string
+          description: Newly created vehicle identifier
+          example: 01960003-0000-7000-8000-000000000001
+          minLength: 1
         partyId:
           type: string
+          description: Party identifier of the vehicle owner
+          example: 01960003-0000-7000-8000-000000000002
+          minLength: 1
         vinNumber:
           type: string
+          description: Vehicle Identification Number
+          example: 1HGCM82633A004352
         unitNumber:
           type: string
+          description: Unit number or internal reference
+          example: UNIT-204
         description:
           type: string
+          description: Human-readable vehicle description
+          example: 2020 Ford F-150 XLT
         licensePlate:
           type: string
+          description: License plate
+          example: ABC-1234
         status:
           type: string
+          description: Vehicle status
+          enum:
+          - ACTIVE
+          - INACTIVE
+          example: ACTIVE
+          minLength: 1
         createdAt:
           type: string
+          description: Timestamp of creation (ISO 8601)
+          example: 2026-06-17 10:15:30+00:00
+      required:
+      - partyId
+      - status
+      - vehicleId
     MergePartiesRequest:
       type: object
       description: Merge request with source party IDs
       properties:
         survivorPartyId:
           type: string
+          description: ID of the party to merge into (survivor party). Sourced from the URL path.
+          example: 01960003-0000-7000-8000-000000000001
         losingPartyId:
           type: string
+          description: ID of the party to be merged away (losing party)
+          example: 01960003-0000-7000-8000-000000000002
+          minLength: 1
         justification:
           type: string
+          description: Justification for the merge
+          example: Duplicate party created during onboarding; consolidating records.
+          maxLength: 1000
+          minLength: 0
+      required:
+      - justification
+      - losingPartyId
     MergePartiesResponse:
       type: object
+      description: Result of a party merge operation
       properties:
         mergeAuditId:
           type: string
+          description: Merge audit record ID (for traceability)
+          example: 01960003-0000-7000-8000-000000000003
+          minLength: 1
         survivorPartyId:
           type: string
+          description: Survivor party ID (canonical identifier for merged entity)
+          example: 01960003-0000-7000-8000-000000000001
+          minLength: 1
         losingPartyId:
           type: string
+          description: Losing party ID (now merged away)
+          example: 01960003-0000-7000-8000-000000000002
+          minLength: 1
         mergedPartyAlias:
           type: string
+          description: Alias/redirect ID for the losing party, pointing to the survivor
+          example: 01960003-0000-7000-8000-000000000001
         status:
           type: string
+          description: Merge status
+          example: COMPLETED
+          minLength: 1
         completedAt:
           type: string
+          description: Timestamp of merge completion (ISO 8601)
+          example: 2026-02-20 14:45:00+00:00
+      required:
+      - losingPartyId
+      - mergeAuditId
+      - status
+      - survivorPartyId
     SearchPartiesRequest:
       type: object
       description: Search criteria
       properties:
         name:
           type: string
+          description: Party name search term (matches legalName or displayName)
+          example: Acme Corporation
+          maxLength: 200
+          minLength: 0
         email:
           type: string
+          description: Search by email address
+          example: jane@acme.com
+          maxLength: 254
+          minLength: 0
         phone:
           type: string
+          description: Search by phone number
+          example: +1-555-0100
+          maxLength: 50
+          minLength: 0
         taxId:
           type: string
+          description: Search by tax ID
+          example: 12-3456789
+          maxLength: 50
+          minLength: 0
         partyType:
           type: string
+          description: Filter by party type (ORGANIZATION|INDIVIDUAL)
+          example: ORGANIZATION
+          maxLength: 40
+          minLength: 0
         status:
           type: string
+          description: Filter by status (ACTIVE|PENDING|SUSPENDED|INACTIVE)
+          example: ACTIVE
+          maxLength: 40
+          minLength: 0
         includeMerged:
           type: boolean
+          description: Include merged parties in results (default false); admin-only troubleshooting toggle
+          example: false
         pageNumber:
           type: integer
           format: int32
+          description: 'Pagination: page number (1-indexed, default 1)'
+          example: 1
+          minimum: 1
         pageSize:
           type: integer
           format: int32
+          description: 'Pagination: items per page (default 20, max 100)'
+          example: 20
+          maximum: 100
+          minimum: 1
         sortField:
           type: string
+          description: Sort field (legalName|createdAt|modifiedAt)
+          example: legalName
+          maxLength: 40
+          minLength: 0
         sortOrder:
           type: string
+          description: Sort order (ASC|DESC)
+          example: ASC
+          maxLength: 4
+          minLength: 0
     PartySummary:
       type: object
+      description: Party summary record for a directory row
       properties:
         partyId:
           type: string
+          description: Unique identifier of the party
+          example: 01960003-0000-7000-8000-000000000001
         legalName:
           type: string
+          description: Legal name of the party
+          example: Acme Corporation
         displayName:
           type: string
+          description: Display name of the party
+          example: Acme
         partyType:
           type: string
+          description: Party type (ORGANIZATION|INDIVIDUAL)
+          example: ORGANIZATION
         status:
           type: string
+          description: Party status (ACTIVE|PENDING|SUSPENDED|INACTIVE)
+          example: ACTIVE
         createdAt:
           type: string
+          description: Creation timestamp (ISO 8601)
+          example: 2026-01-15 09:30:00+00:00
         primaryContact:
           $ref: '#/components/schemas/PrimaryContact'
         vehicleCount:
           type: integer
           format: int32
+          description: Number of vehicles associated with the party (defaults to 0)
+          example: 3
+      required:
+      - partyId
     PrimaryContact:
       type: object
+      description: Lightweight primary-contact projection for directory rows
       properties:
         name:
           type: string
+          description: Contact name
+          example: Jane Doe
         email:
           type: string
+          description: Contact email address
+          example: jane@acme.com
         phone:
           type: string
+          description: Contact phone number
+          example: +1-555-0100
     SearchPartiesResponse:
       type: object
+      description: Paged response of matching party summaries
       properties:
         results:
           type: array
+          description: List of party summary records
           items:
             $ref: '#/components/schemas/PartySummary'
         totalCount:
           type: integer
           format: int32
+          description: Total number of matching records
+          example: 42
         pageNumber:
           type: integer
           format: int32
+          description: Current page number
+          example: 1
         pageSize:
           type: integer
           format: int32
+          description: Items per page
+          example: 20
+      required:
+      - pageNumber
+      - pageSize
+      - results
+      - totalCount
     Pageable:
       type: object
       properties:
@@ -2650,6 +3133,7 @@ components:
           type: string
           format: uuid
           description: Contact point ID
+          example: 01960003-0000-7000-8000-000000000002
         contactType:
           type: string
           description: Type of contact point
@@ -2666,6 +3150,10 @@ components:
           example: john.doe@example.com
         primary:
           type: boolean
+      required:
+      - contactPointId
+      - contactType
+      - value
     GetPersonResponse:
       type: object
       description: Person details response
@@ -2674,7 +3162,7 @@ components:
           type: string
           format: uuid
           description: Unique identifier of the person
-          example: 550e8400-e29b-41d4-a716-446655440000
+          example: 01960003-0000-7000-8000-000000000001
         firstName:
           type: string
           description: First name
@@ -2718,72 +3206,172 @@ components:
           type: string
           format: date-time
           description: Timestamp when the person was created
+          example: 2026-01-15 10:30:00+00:00
         updatedAt:
           type: string
           format: date-time
           description: Timestamp when the person was last updated
+          example: 2026-02-20 14:45:00+00:00
+      required:
+      - commercialAccountCount
+      - commercialContact
+      - createdAt
+      - firstName
+      - individualCustomer
+      - lastName
+      - personId
     AssignedRole:
       type: object
+      description: An assigned role with its primary flag
       properties:
         roleCode:
           type: string
+          description: Role code
+          enum:
+          - BILLING
+          - APPROVER
+          - DRIVER
+          example: BILLING
+          minLength: 1
         roleLabel:
           type: string
+          description: Role display label
+          example: Billing Contact
         isPrimary:
           type: boolean
+          description: Whether this contact is primary for this role
+          example: true
+      required:
+      - roleCode
     ContactWithRoles:
       type: object
+      description: A single contact with its assigned roles
       properties:
         contactId:
           type: string
+          description: Contact point identifier (person/contact)
+          example: 01960003-0000-7000-8000-000000000020
+          minLength: 1
         contactName:
           type: string
+          description: Contact name
+          example: Jane Doe
         email:
           type: string
+          description: Email address
+          example: jane@acme.com
         phone:
           type: string
+          description: Phone number
+          example: +1-555-0142
         hasPrimaryEmail:
           type: boolean
+          description: Whether the contact has at least one primary email on file
+          example: true
         roles:
           type: array
+          description: Assigned roles for this contact
           items:
             $ref: '#/components/schemas/AssignedRole'
         invoiceDeliveryMethod:
           type: string
+          description: Invoice delivery method for this contact
+          enum:
+          - EMAIL
+          - PHONE
+          - NONE
+          example: EMAIL
+      required:
+      - contactId
+      - contactName
     GetContactsWithRolesResponse:
       type: object
+      description: Contacts with their assigned roles and primary flags for a party
       properties:
         partyId:
           type: string
+          description: Party identifier the contacts belong to
+          example: 01960003-0000-7000-8000-000000000001
+          minLength: 1
         contacts:
           type: array
+          description: List of contacts with assigned roles
           items:
             $ref: '#/components/schemas/ContactWithRoles'
+      required:
+      - contacts
+      - partyId
     GetCommunicationPreferencesResponse:
       type: object
+      description: Communication preferences and consent flags for a party
       properties:
         partyId:
           type: string
+          description: Party identifier the preferences belong to
+          example: 01960003-0000-7000-8000-000000000001
+          minLength: 1
         version:
           type: string
+          description: Optimistic locking version token for concurrent updates
+          example: '3'
         emailPreference:
           type: string
+          description: Email communication preference
+          enum:
+          - OPT_IN
+          - OPT_OUT
+          - NOT_APPLICABLE
+          example: OPT_IN
         smsPreference:
           type: string
+          description: SMS communication preference
+          enum:
+          - OPT_IN
+          - OPT_OUT
+          - NOT_APPLICABLE
+          example: OPT_OUT
         phonePreference:
           type: string
+          description: Phone communication preference
+          enum:
+          - OPT_IN
+          - OPT_OUT
+          - NOT_APPLICABLE
+          example: OPT_IN
         marketingPreference:
           type: string
+          description: Marketing communications preference
+          enum:
+          - OPT_IN
+          - OPT_OUT
+          example: OPT_OUT
         consentFlags:
           type: object
           additionalProperties:
             type: boolean
+          description: Consent flags keyed by consent type
+          example:
+            gdpr: true
+            tcpa: false
         preferencesNote:
           type: string
+          description: User-provided note or preferences summary
+          example: Prefers contact after 5pm
         updatedAt:
           type: string
+          description: Last update timestamp (ISO 8601)
+          example: 2026-06-17 10:15:30+00:00
         updateSource:
           type: string
+          description: Source of the last update
+          enum:
+          - APP
+          - API
+          - ADMIN
+          - IMPORT
+          example: API
+      required:
+      - partyId
     ContactWithRole:
       type: object
       description: Contact information with role assignments
@@ -2792,13 +3380,17 @@ components:
           type: string
           format: uuid
           description: Relationship ID
+          example: 01960003-0000-7000-8000-000000000010
         individualId:
           type: string
           format: uuid
           description: Individual person ID
+          example: 01960003-0000-7000-8000-000000000011
         roles:
           type: array
           description: Roles assigned to this contact
+          example:
+          - BILLING
           items:
             type: string
             description: Role type for party relationships
@@ -2817,14 +3409,20 @@ components:
           type: string
           format: date
           description: Effective start date
+          example: 2026-01-01
         effectiveTo:
           type: string
           format: date
           description: Effective end date (null if active)
+          example: 2026-12-31
         individual:
           $ref: '#/components/schemas/IndividualDetails'
         primaryBilling:
           type: boolean
+      required:
+      - individualId
+      - relationshipId
+      - status
     GetCommercialAccountContactsResponse:
       type: object
       description: Contacts with roles for a commercial account
@@ -2832,11 +3430,15 @@ components:
         commercialAccountId:
           type: string
           description: ID of the commercial account
+          example: 01960003-0000-7000-8000-000000000001
         contacts:
           type: array
           description: List of contacts with their roles
           items:
             $ref: '#/components/schemas/ContactWithRole'
+      required:
+      - commercialAccountId
+      - contacts
     IndividualDetails:
       type: object
       description: Individual person details
@@ -2848,9 +3450,13 @@ components:
         email:
           type: string
           description: Primary email address
+          example: john.doe@acme.com
         phone:
           type: string
           description: Primary phone number
+          example: +1-555-0142
+      required:
+      - displayName
     BillingTermsRef:
       type: object
       description: Billing term reference entry
@@ -2859,15 +3465,21 @@ components:
           type: string
           description: Billing term code identifier
           example: NET_30
+          minLength: 1
         label:
           type: string
           description: Human-readable label
           example: Net 30
+          minLength: 1
         netDays:
           type: integer
           format: int32
           description: Net payment days. Negative values indicate prepayment is required.
           example: 30
+      required:
+      - code
+      - label
+      - netDays
     PersonLinkReport:
       type: object
       properties:
@@ -2893,7 +3505,7 @@ components:
         accountId:
           type: string
           description: Account/party identifier
-          example: 123e4567-e89b-12d3-a456-426614174000
+          example: 01960003-0000-7000-8000-000000000001
         tier:
           type: string
           description: Current tier level
@@ -2913,36 +3525,74 @@ components:
           type: string
           format: date-time
           description: When the tier was last assigned or updated
+          example: 2026-06-17 10:15:30+00:00
         tierAssignedBy:
           type: string
           description: Who assigned or last modified the tier
+          example: user-admin
         notes:
           type: string
           description: Optional notes about tier assignment or status
+          example: Upgraded after Q2 spend review
         manualOverride:
           type: boolean
           description: Whether tier was manually assigned or auto-calculated
+          example: false
+      required:
+      - accountId
+      - manualOverride
+      - tier
+      - tierDisplayName
     GetPartyResponse:
       type: object
+      description: Party details for a commercial account or individual party
       properties:
         partyId:
           type: string
+          description: Party ID (canonical CRM identifier)
+          example: 01960003-0000-7000-8000-000000000001
+          minLength: 1
         partyType:
           type: string
+          description: Party type discriminator
+          example: ORGANIZATION
+          minLength: 1
         legalName:
           type: string
+          description: Legal name of the party
+          example: Acme Industrial Supply LLC
+          minLength: 1
         displayName:
           type: string
+          description: Display/trading name
+          example: Acme Supply
         taxId:
           type: string
+          description: Tax identification number
+          example: 82-1234567
         status:
           type: string
+          description: Current status of the party
+          example: ACTIVE
+          minLength: 1
         billingTermsId:
           type: string
+          description: Billing terms ID
+          example: 01960003-0000-7000-8000-000000000010
         createdAt:
           type: string
+          description: Party creation timestamp (ISO 8601)
+          example: 2026-01-15 10:30:00+00:00
         modifiedAt:
           type: string
+          description: Last modification timestamp (ISO 8601)
+          example: 2026-02-20 14:45:00+00:00
+      required:
+      - createdAt
+      - legalName
+      - partyId
+      - partyType
+      - status
     DuplicateCheckResponse:
       type: object
       description: Response containing potential duplicate party matches
@@ -2954,12 +3604,15 @@ components:
         exactMatchPartyId:
           type: string
           description: ID of exact-match party, if any
-          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          example: 01960003-0000-7000-8000-000000000001
         potentialDuplicates:
           type: array
           description: List of potential duplicate matches
           items:
             $ref: '#/components/schemas/PartyMatch'
+      required:
+      - duplicatesFound
+      - potentialDuplicates
     PartyMatch:
       type: object
       description: A single potential duplicate party match
@@ -2967,7 +3620,8 @@ components:
         partyId:
           type: string
           description: Party ID
-          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          example: 01960003-0000-7000-8000-000000000001
+          minLength: 1
         legalName:
           type: string
           description: Legal name of the party
@@ -2984,6 +3638,11 @@ components:
           - EXACT
           - FUZZY
           example: EXACT
+      required:
+      - legalName
+      - matchType
+      - partyId
+      - score
   securitySchemes:
     bearerAuth:
       type: http

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/BillingTermsRef.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/BillingTermsRef.java
@@ -1,6 +1,7 @@
 package com.positivity.customer.internal.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -20,12 +21,20 @@ import lombok.NoArgsConstructor;
 @Schema(description = "Billing term reference entry")
 public class BillingTermsRef {
 
-    @Schema(description = "Billing term code identifier", example = "NET_30")
+    @NotBlank
+    @Schema(
+            description = "Billing term code identifier",
+            example = "NET_30",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
-    @Schema(description = "Human-readable label", example = "Net 30")
+    @NotBlank
+    @Schema(description = "Human-readable label", example = "Net 30", requiredMode = Schema.RequiredMode.REQUIRED)
     private String label;
 
-    @Schema(description = "Net payment days. Negative values indicate prepayment is required.", example = "30")
+    @Schema(
+            description = "Net payment days. Negative values indicate prepayment is required.",
+            example = "30",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private int netDays;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreateCommercialAccountRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreateCommercialAccountRequest.java
@@ -1,6 +1,10 @@
 package com.positivity.customer.internal.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,57 +20,76 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Request to create a commercial account (party)")
 public class CreateCommercialAccountRequest {
 
-    /**
-     * Legal business name (required)
-     */
+    @NotBlank(message = "legalName is required")
+    @Size(max = 255)
+    @Schema(
+            description = "Legal business name",
+            example = "Acme Industrial Supply, LLC",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String legalName;
 
-    /**
-     * Display/trading name (optional)
-     */
+    @Size(max = 255)
+    @Schema(
+            description = "Display/trading name",
+            example = "Acme Supply",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String displayName;
 
-    /**
-     * Tax identification number (optional, but required for certain jurisdictions)
-     */
+    @Size(max = 64)
+    @Schema(
+            description = "Tax identification number (required for certain jurisdictions)",
+            example = "12-3456789",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String taxId;
 
-    /**
-     * Party type (ORGANIZATION|INDIVIDUAL; default ORGANIZATION for commercial
-     * accounts)
-     */
+    @Size(max = 32)
+    @Schema(
+            description = "Party type (ORGANIZATION|INDIVIDUAL; default ORGANIZATION for commercial accounts)",
+            example = "ORGANIZATION",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String partyType;
 
-    /**
-     * Billing terms ID (foreign key to Billing domain)
-     */
+    @Schema(
+            description = "Billing terms ID (foreign key to Billing domain)",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String billingTermsId;
 
-    /**
-     * External identifiers (system-specific IDs from upstream systems).
-     * Format TBD: fixed set vs key/value map.
-     */
+    @Schema(
+            description = "External identifiers (system-specific IDs from upstream systems)",
+            example = "{\"erp\": \"CUST-00123\"}",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Map<String, String> externalIdentifiers;
 
-    /**
-     * Primary contact first name (optional)
-     */
+    @Size(max = 255)
+    @Schema(
+            description = "Primary contact first name",
+            example = "Jane",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String contactFirstName;
 
-    /**
-     * Primary contact last name (optional)
-     */
+    @Size(max = 255)
+    @Schema(
+            description = "Primary contact last name",
+            example = "Smith",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String contactLastName;
 
-    /**
-     * Contact email (optional)
-     */
+    @Email
+    @Size(max = 255)
+    @Schema(
+            description = "Contact email",
+            example = "jane@acme.com",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String email;
 
-    /**
-     * Contact phone (optional)
-     */
+    @Size(max = 64)
+    @Schema(
+            description = "Contact phone",
+            example = "+1-555-123-4567",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String phone;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreateCommercialAccountResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreateCommercialAccountResponse.java
@@ -1,6 +1,8 @@
 package com.positivity.customer.internal.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -17,33 +19,78 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Response after creating a commercial account")
 public class CreateCommercialAccountResponse {
 
-    /**
-     * Newly created party ID (canonical CRM identifier)
-     */
+    @NotNull
+    @Schema(
+            description = "Newly created party ID (canonical CRM identifier)",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String partyId;
 
-    /**
-     * Legal name of created party
-     */
+    @NotNull
+    @Schema(
+            description = "Legal name of created party",
+            example = "Acme Industrial Supply, LLC",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String legalName;
 
-    /**
-     * Status (ACTIVE|PENDING|SUSPENDED)
-     */
+    @NotNull
+    @Schema(
+            description = "Status (ACTIVE|PENDING|SUSPENDED)",
+            example = "ACTIVE",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String status;
 
-    /**
-     * Timestamp of creation
-     */
+    @NotNull
+    @Schema(
+            description = "Human-readable customer/account number (party number) for display and lookup",
+            example = "CUST-000123",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String customerNumber;
+
+    @Schema(
+            description = "Display name of the account, if provided (falls back to legal name in UI)",
+            example = "Acme Industrial",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String displayName;
+
+    @Schema(
+            description = "Party type discriminator",
+            example = "COMMERCIAL",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String partyType;
+
+    @Schema(
+            description = "Tax identifier, if provided",
+            example = "12-3456789",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String taxId;
+
+    @Schema(
+            description = "Billing terms identifier associated with the account, if set",
+            example = "NET30",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String billingTermsId;
+
+    @Schema(
+            description = "Primary address for display, if available",
+            example = "100 Trade Street, Charlotte, NC 28202",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String primaryAddress;
+
+    @NotNull
+    @Schema(
+            description = "Timestamp of creation",
+            example = "2026-01-01T12:00:00Z",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Instant createdAt;
 
-    /**
-     * List of duplicate candidates found during creation.
-     * If present, frontend should prompt user for confirmation.
-     * Contains summary fields only (partyId, legalName, matchReason).
-     */
+    @Schema(
+            description = "List of duplicate candidates found during creation. If present, frontend should prompt"
+                    + " user for confirmation. Contains summary fields only (partyId, legalName, matchReason).",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<DuplicateCandidate> duplicateCandidates;
 
     /**
@@ -53,9 +100,27 @@ public class CreateCommercialAccountResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @Schema(description = "Duplicate candidate summary returned on 409 or as advisory in 201")
     public static class DuplicateCandidate {
+        @NotNull
+        @Schema(
+                description = "Candidate party ID",
+                example = "01960003-0000-7000-8000-000000000002",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String partyId;
+
+        @NotNull
+        @Schema(
+                description = "Candidate legal name",
+                example = "Acme Industrial Supply Co.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String legalName;
+
+        @NotNull
+        @Schema(
+                description = "Reason this candidate matched",
+                example = "LEGAL_NAME_SIMILARITY",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String matchReason;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreatePartyRelationshipRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreatePartyRelationshipRequest.java
@@ -40,7 +40,10 @@ public class CreatePartyRelationshipRequest {
             requiredMode = Schema.RequiredMode.REQUIRED)
     private Set<PartyRelationshipRole> roles;
 
-    @Schema(description = "Whether this should be the primary billing contact", example = "true")
+    @Schema(
+            description = "Whether this should be the primary billing contact",
+            example = "true",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private boolean isPrimaryBillingContact;
 
     @NotNull(message = "effectiveStartDate is required")
@@ -50,6 +53,9 @@ public class CreatePartyRelationshipRequest {
             requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDate effectiveStartDate;
 
-    @Schema(description = "Date when this relationship ends (null means no end date)", example = "2026-12-31")
+    @Schema(
+            description = "Date when this relationship ends (null means no end date)",
+            example = "2026-12-31",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private LocalDate effectiveEndDate;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreatePartyRelationshipResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreatePartyRelationshipResponse.java
@@ -2,6 +2,7 @@ package com.positivity.customer.internal.dto;
 
 import com.positivity.customer.internal.enums.PartyRelationshipRole;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Set;
@@ -25,30 +26,63 @@ import lombok.NoArgsConstructor;
 @Schema(description = "Response after creating a party relationship")
 public class CreatePartyRelationshipResponse {
 
-    @Schema(description = "Unique identifier of the relationship")
+    @NotNull
+    @Schema(
+            description = "Unique identifier of the relationship",
+            example = "01960003-0000-7000-8000-000000000010",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private UUID relationshipId;
 
-    @Schema(description = "ID of the commercial account")
+    @NotNull
+    @Schema(
+            description = "ID of the commercial account",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String partyId;
 
-    @Schema(description = "ID of the individual person")
+    @NotNull
+    @Schema(
+            description = "ID of the individual person",
+            example = "550e8400-e29b-41d4-a716-446655440000",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private UUID personId;
 
-    @Schema(description = "Roles assigned to this relationship")
+    @NotNull
+    @Schema(
+            description = "Roles assigned to this relationship",
+            example = "[\"BILLING\", \"APPROVER\"]",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Set<PartyRelationshipRole> roles;
 
-    @Schema(description = "Whether this is the primary billing contact")
+    @Schema(
+            description = "Whether this is the primary billing contact",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean isPrimaryBillingContact;
 
-    @Schema(description = "Effective start date")
+    @NotNull
+    @Schema(
+            description = "Effective start date",
+            example = "2026-01-01",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDate effectiveStartDate;
 
-    @Schema(description = "Effective end date (null if active)")
+    @Schema(
+            description = "Effective end date (null if active)",
+            example = "2026-12-31",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private LocalDate effectiveEndDate;
 
-    @Schema(description = "Timestamp when the relationship was created")
+    @NotNull
+    @Schema(
+            description = "Timestamp when the relationship was created",
+            example = "2026-01-01T12:00:00Z",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Instant createdAt;
 
-    @Schema(description = "Whether a previous primary billing contact was demoted")
+    @Schema(
+            description = "Whether a previous primary billing contact was demoted",
+            example = "false",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean previousPrimaryDemoted;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreatePersonRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreatePersonRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,10 +29,12 @@ import lombok.NoArgsConstructor;
 public class CreatePersonRequest {
 
     @NotBlank(message = "firstName is required")
+    @Size(max = 255)
     @Schema(description = "First name of the person", example = "John", requiredMode = Schema.RequiredMode.REQUIRED)
     private String firstName;
 
     @NotBlank(message = "lastName is required")
+    @Size(max = 255)
     @Schema(description = "Last name of the person", example = "Doe", requiredMode = Schema.RequiredMode.REQUIRED)
     private String lastName;
 
@@ -40,11 +43,11 @@ public class CreatePersonRequest {
     private PreferredContactMethod preferredContactMethod;
 
     @Valid
-    @Schema(description = "Email addresses for this person")
+    @Schema(description = "Email addresses for this person", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<EmailInput> emails;
 
     @Valid
-    @Schema(description = "Phone numbers for this person")
+    @Schema(description = "Phone numbers for this person", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<PhoneInput> phones;
 
     /**
@@ -58,10 +61,17 @@ public class CreatePersonRequest {
     public static class EmailInput {
         @NotBlank(message = "email value is required")
         @Email(message = "Invalid email format")
-        @Schema(description = "Email address", example = "john.doe@example.com")
+        @Size(max = 255)
+        @Schema(
+                description = "Email address",
+                example = "john.doe@example.com",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String value;
 
-        @Schema(description = "Whether this is the primary email", example = "true")
+        @Schema(
+                description = "Whether this is the primary email",
+                example = "true",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private boolean isPrimary;
     }
 
@@ -75,13 +85,23 @@ public class CreatePersonRequest {
     @Schema(description = "Phone number input")
     public static class PhoneInput {
         @NotBlank(message = "phone value is required")
-        @Schema(description = "Phone number", example = "+1-555-123-4567")
+        @Size(max = 64)
+        @Schema(
+                description = "Phone number",
+                example = "+1-555-123-4567",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String value;
 
-        @Schema(description = "Phone type", example = "PHONE_MOBILE")
+        @Schema(
+                description = "Phone type",
+                example = "PHONE_MOBILE",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private ContactPointType type;
 
-        @Schema(description = "Whether this is the primary phone", example = "true")
+        @Schema(
+                description = "Whether this is the primary phone",
+                example = "true",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private boolean isPrimary;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreatePersonResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreatePersonResponse.java
@@ -3,6 +3,7 @@ package com.positivity.customer.internal.dto;
 import com.positivity.customer.internal.entity.PersonParty;
 import com.positivity.customer.internal.enums.PreferredContactMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -24,22 +25,39 @@ import lombok.NoArgsConstructor;
 @Schema(description = "Response after creating a person record")
 public class CreatePersonResponse {
 
-    @Schema(description = "Unique identifier of the created person", example = "550e8400-e29b-41d4-a716-446655440000")
+    @NotNull
+    @Schema(
+            description = "Unique identifier of the created person",
+            example = "550e8400-e29b-41d4-a716-446655440000",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private UUID personId;
 
-    @Schema(description = "First name", example = "John")
+    @NotNull
+    @Schema(description = "First name", example = "John", requiredMode = Schema.RequiredMode.REQUIRED)
     private String firstName;
 
-    @Schema(description = "Last name", example = "Doe")
+    @NotNull
+    @Schema(description = "Last name", example = "Doe", requiredMode = Schema.RequiredMode.REQUIRED)
     private String lastName;
 
-    @Schema(description = "Preferred contact method", example = "EMAIL")
+    @NotNull
+    @Schema(
+            description = "Preferred contact method",
+            example = "EMAIL",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private PreferredContactMethod preferredContactMethod;
 
-    @Schema(description = "Number of contact points created")
+    @Schema(
+            description = "Number of contact points created",
+            example = "2",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private int contactPointsCreated;
 
-    @Schema(description = "Timestamp when the person was created")
+    @NotNull
+    @Schema(
+            description = "Timestamp when the person was created",
+            example = "2026-01-01T12:00:00Z",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Instant createdAt;
 
     /**

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreateVehicleForPartyRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreateVehicleForPartyRequest.java
@@ -1,6 +1,9 @@
 package com.positivity.customer.internal.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,32 +18,42 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Request to create a vehicle record for a party")
 public class CreateVehicleForPartyRequest {
 
-    /**
-     * Vehicle Identification Number (required, uniqueness scope TBD: global or
-     * per-party)
-     */
+    @NotBlank(message = "vinNumber is required")
+    @Size(max = 17)
+    @Schema(
+            description = "Vehicle Identification Number (uniqueness scope global or per-party)",
+            example = "1HGCM82633A004352",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String vinNumber;
 
-    /**
-     * Unit number or internal reference (optional)
-     */
+    @Size(max = 64)
+    @Schema(
+            description = "Unit number or internal reference",
+            example = "UNIT-42",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String unitNumber;
 
-    /**
-     * Vehicle description (optional)
-     */
+    @Size(max = 255)
+    @Schema(
+            description = "Vehicle description",
+            example = "2019 Ford Transit 250 cargo van",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String description;
 
-    /**
-     * License plate (optional).
-     * Format TBD: single string or plate + region (state/province/country).
-     */
+    @Size(max = 32)
+    @Schema(
+            description = "License plate (single string or plate plus region)",
+            example = "ABC-1234",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String licensePlate;
 
-    /**
-     * License plate region/state (optional, if separate field required)
-     */
+    @Size(max = 64)
+    @Schema(
+            description = "License plate region/state",
+            example = "CA",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String licensePlateRegion;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreateVehicleForPartyResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CreateVehicleForPartyResponse.java
@@ -1,6 +1,8 @@
 package com.positivity.customer.internal.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,45 +17,82 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Response returned after creating a vehicle record for a party")
 public class CreateVehicleForPartyResponse {
 
     /**
      * Newly created vehicle ID
      */
+    @NotBlank
+    @Schema(
+            description = "Newly created vehicle identifier",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String vehicleId;
 
     /**
      * Party ID (owner) of the vehicle
      */
+    @NotBlank
+    @Schema(
+            description = "Party identifier of the vehicle owner",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String partyId;
 
     /**
      * Vehicle Identification Number
      */
+    @Schema(
+            description = "Vehicle Identification Number",
+            example = "1HGCM82633A004352",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String vinNumber;
 
     /**
      * Unit number or internal reference
      */
+    @Schema(
+            description = "Unit number or internal reference",
+            example = "UNIT-204",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String unitNumber;
 
     /**
      * Vehicle description
      */
+    @Schema(
+            description = "Human-readable vehicle description",
+            example = "2020 Ford F-150 XLT",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String description;
 
     /**
      * License plate
      */
+    @Schema(
+            description = "License plate",
+            example = "ABC-1234",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String licensePlate;
 
     /**
      * Vehicle status (ACTIVE|INACTIVE)
      */
+    @NotBlank
+    @Schema(
+            description = "Vehicle status",
+            example = "ACTIVE",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            allowableValues = {"ACTIVE", "INACTIVE"})
     private String status;
 
     /**
      * Timestamp of creation (ISO 8601)
      */
+    @Schema(
+            description = "Timestamp of creation (ISO 8601)",
+            example = "2026-06-17T10:15:30Z",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String createdAt;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerBulkIngestRecord.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerBulkIngestRecord.java
@@ -1,22 +1,57 @@
 package com.positivity.customer.internal.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
+@Schema(description = "A single customer record submitted as part of a bulk ingest request")
 public class CustomerBulkIngestRecord {
 
     @NotBlank
+    @Size(max = 100)
+    @Schema(
+            description = "First name of the customer",
+            example = "Jane",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String firstName;
 
     @NotBlank
+    @Size(max = 100)
+    @Schema(
+            description = "Last name of the customer",
+            example = "Doe",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String lastName;
 
+    @Email
+    @Size(max = 254)
+    @Schema(
+            description = "Email address of the customer",
+            example = "jane@acme.com",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String email;
 
+    @Size(max = 32)
+    @Schema(
+            description = "Phone number of the customer",
+            example = "+1-555-0142",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String phoneNumber;
 
+    @Size(max = 255)
+    @Schema(
+            description = "Primary address of the customer",
+            example = "123 Main St, Springfield",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String primaryAddress;
 
+    @Size(max = 50)
+    @Schema(
+            description = "Existing customer number, if known",
+            example = "CUST-1001",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String customerNumber;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerBulkIngestRecord.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerBulkIngestRecord.java
@@ -1,7 +1,6 @@
 package com.positivity.customer.internal.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -26,7 +25,9 @@ public class CustomerBulkIngestRecord {
             requiredMode = Schema.RequiredMode.REQUIRED)
     private String lastName;
 
-    @Email
+    // Bulk ingest tolerates dirty legacy data — length-bounded only, no strict
+    // @Email format check, so a malformed value flags per-record rather than
+    // 400-ing the whole batch.
     @Size(max = 254)
     @Schema(
             description = "Email address of the customer",
@@ -34,7 +35,7 @@ public class CustomerBulkIngestRecord {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String email;
 
-    @Size(max = 32)
+    @Size(max = 64)
     @Schema(
             description = "Phone number of the customer",
             example = "+1-555-0142",

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerDTO.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerDTO.java
@@ -2,6 +2,7 @@ package com.positivity.customer.internal.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -21,27 +22,53 @@ import lombok.NoArgsConstructor;
 @Schema(description = "Customer data transfer object for API operations")
 public class CustomerDTO {
 
-    @Schema(description = "Unique identifier of the customer", example = "123e4567-e89b-12d3-a456-426614174000")
+    @Schema(
+            description = "Unique identifier of the customer",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private UUID id;
 
-    @Schema(description = "Unique customer number", example = "CUST-1001")
+    @Size(max = 50)
+    @Schema(
+            description = "Unique customer number",
+            example = "CUST-1001",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String customerNumber;
 
     @NotBlank
-    @Schema(description = "Last name of the customer", example = "Doe")
+    @Size(max = 100)
+    @Schema(
+            description = "Last name of the customer",
+            example = "Doe",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String lastName;
 
     @NotBlank
-    @Schema(description = "First name of the customer", example = "John")
+    @Size(max = 100)
+    @Schema(
+            description = "First name of the customer",
+            example = "John",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String firstName;
 
-    @Schema(description = "Primary address label or identifier for the customer", example = "123 Main St, Springfield")
+    @Size(max = 255)
+    @Schema(
+            description = "Primary address label or identifier for the customer",
+            example = "123 Main St, Springfield",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String primaryAddress;
 
     @Builder.Default
-    @Schema(description = "List of vehicle VINs associated with the customer")
+    @Schema(
+            description = "List of vehicle VINs associated with the customer",
+            example = "[\"1HGCM82633A004352\"]",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<String> vehicleVins = new ArrayList<>();
 
-    @Schema(description = "Type of customer (e.g., 'retail', 'commercial')")
+    @Size(max = 50)
+    @Schema(
+            description = "Type of customer (e.g., 'retail', 'commercial')",
+            example = "retail",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String customerType;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/DuplicateCheckResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/DuplicateCheckResponse.java
@@ -1,6 +1,9 @@
 package com.positivity.customer.internal.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
@@ -10,13 +13,23 @@ import lombok.Data;
 @Schema(description = "Response containing potential duplicate party matches")
 public class DuplicateCheckResponse {
 
-    @Schema(description = "Whether any duplicate matches were found", example = "true")
+    @Schema(
+            description = "Whether any duplicate matches were found",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean duplicatesFound;
 
-    @Schema(description = "ID of exact-match party, if any", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+    @Schema(
+            description = "ID of exact-match party, if any",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String exactMatchPartyId;
 
-    @Schema(description = "List of potential duplicate matches")
+    @Valid
+    @NotNull
+    @Schema(
+            description = "List of potential duplicate matches",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<PartyMatch> potentialDuplicates;
 
     @Data
@@ -24,18 +37,29 @@ public class DuplicateCheckResponse {
     @Schema(description = "A single potential duplicate party match")
     public static class PartyMatch {
 
-        @Schema(description = "Party ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+        @NotBlank
+        @Schema(
+                description = "Party ID",
+                example = "01960003-0000-7000-8000-000000000001",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String partyId;
 
-        @Schema(description = "Legal name of the party", example = "Acme Corporation")
+        @Schema(
+                description = "Legal name of the party",
+                example = "Acme Corporation",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String legalName;
 
-        @Schema(description = "Match confidence score (0.0-1.0)", example = "0.95")
+        @Schema(
+                description = "Match confidence score (0.0-1.0)",
+                example = "0.95",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private double score;
 
         @Schema(
                 description = "Type of match",
                 example = "EXACT",
+                requiredMode = Schema.RequiredMode.REQUIRED,
                 allowableValues = {"EXACT", "FUZZY"})
         private String matchType;
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetAccountTierResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetAccountTierResponse.java
@@ -23,30 +23,45 @@ import org.jspecify.annotations.Nullable;
 @Schema(description = "Account tier information response")
 public class GetAccountTierResponse {
 
-    @Schema(description = "Account/party identifier", example = "123e4567-e89b-12d3-a456-426614174000")
+    @Schema(
+            description = "Account/party identifier",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     @NonNull
     private String accountId;
 
-    @Schema(description = "Current tier level", example = "GOLD")
+    @Schema(description = "Current tier level", example = "GOLD", requiredMode = Schema.RequiredMode.REQUIRED)
     @NonNull
     private AccountTier tier;
 
-    @Schema(description = "Display name of the tier", example = "Gold")
+    @Schema(description = "Display name of the tier", example = "Gold", requiredMode = Schema.RequiredMode.REQUIRED)
     @NonNull
     private String tierDisplayName;
 
-    @Schema(description = "When the tier was last assigned or updated")
+    @Schema(
+            description = "When the tier was last assigned or updated",
+            example = "2026-06-17T10:15:30Z",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @Nullable
     private Instant tierAssignedAt;
 
-    @Schema(description = "Who assigned or last modified the tier")
+    @Schema(
+            description = "Who assigned or last modified the tier",
+            example = "user-admin",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @Nullable
     private String tierAssignedBy;
 
-    @Schema(description = "Optional notes about tier assignment or status")
+    @Schema(
+            description = "Optional notes about tier assignment or status",
+            example = "Upgraded after Q2 spend review",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @Nullable
     private String notes;
 
-    @Schema(description = "Whether tier was manually assigned or auto-calculated")
+    @Schema(
+            description = "Whether tier was manually assigned or auto-calculated",
+            example = "false",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean manualOverride;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetCommercialAccountContactsResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetCommercialAccountContactsResponse.java
@@ -2,6 +2,8 @@ package com.positivity.customer.internal.dto;
 
 import com.positivity.customer.internal.enums.PartyRelationshipRole;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
@@ -26,10 +28,18 @@ import lombok.NoArgsConstructor;
 @Schema(description = "Contacts with roles for a commercial account")
 public class GetCommercialAccountContactsResponse {
 
-    @Schema(description = "ID of the commercial account")
+    @NotNull
+    @Schema(
+            description = "ID of the commercial account",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String commercialAccountId;
 
-    @Schema(description = "List of contacts with their roles")
+    @Valid
+    @NotNull
+    @Schema(
+            description = "List of contacts with their roles",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ContactWithRole> contacts;
 
     /**
@@ -42,28 +52,54 @@ public class GetCommercialAccountContactsResponse {
     @Schema(description = "Contact information with role assignments")
     public static class ContactWithRole {
 
-        @Schema(description = "Relationship ID")
+        @NotNull
+        @Schema(
+                description = "Relationship ID",
+                example = "01960003-0000-7000-8000-000000000010",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private UUID relationshipId;
 
-        @Schema(description = "Individual person ID")
+        @NotNull
+        @Schema(
+                description = "Individual person ID",
+                example = "01960003-0000-7000-8000-000000000011",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private UUID individualId;
 
-        @Schema(description = "Roles assigned to this contact")
+        @Schema(
+                description = "Roles assigned to this contact",
+                example = "[\"BILLING\"]",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private Set<PartyRelationshipRole> roles;
 
-        @Schema(description = "Whether this is the primary billing contact")
+        @Schema(
+                description = "Whether this is the primary billing contact",
+                example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private boolean isPrimaryBilling;
 
-        @Schema(description = "Status of the relationship", example = "ACTIVE")
+        @Schema(
+                description = "Status of the relationship",
+                example = "ACTIVE",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String status;
 
-        @Schema(description = "Effective start date")
+        @Schema(
+                description = "Effective start date",
+                example = "2026-01-01",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private LocalDate effectiveFrom;
 
-        @Schema(description = "Effective end date (null if active)")
+        @Schema(
+                description = "Effective end date (null if active)",
+                example = "2026-12-31",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private LocalDate effectiveTo;
 
-        @Schema(description = "Individual person details")
+        @Valid
+        @Schema(
+                description = "Individual person details",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private IndividualDetails individual;
     }
 
@@ -77,13 +113,22 @@ public class GetCommercialAccountContactsResponse {
     @Schema(description = "Individual person details")
     public static class IndividualDetails {
 
-        @Schema(description = "Display name", example = "John Doe")
+        @Schema(
+                description = "Display name",
+                example = "John Doe",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String displayName;
 
-        @Schema(description = "Primary email address")
+        @Schema(
+                description = "Primary email address",
+                example = "john.doe@acme.com",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String email;
 
-        @Schema(description = "Primary phone number")
+        @Schema(
+                description = "Primary phone number",
+                example = "+1-555-0142",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String phone;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetCommunicationPreferencesResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetCommunicationPreferencesResponse.java
@@ -1,6 +1,8 @@
 package com.positivity.customer.internal.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,56 +18,103 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Communication preferences and consent flags for a party")
 public class GetCommunicationPreferencesResponse {
 
     /**
      * Party ID queried
      */
+    @NotBlank
+    @Schema(
+            description = "Party identifier the preferences belong to",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String partyId;
 
     /**
      * Optimistic locking version field (name TBD: version|lastUpdatedStamp|ETag)
      */
+    @Schema(
+            description = "Optimistic locking version token for concurrent updates",
+            example = "3",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String version;
 
     /**
      * Email preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)
      */
+    @Schema(
+            description = "Email communication preference",
+            example = "OPT_IN",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+            allowableValues = {"OPT_IN", "OPT_OUT", "NOT_APPLICABLE"})
     private String emailPreference;
 
     /**
      * SMS preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)
      */
+    @Schema(
+            description = "SMS communication preference",
+            example = "OPT_OUT",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+            allowableValues = {"OPT_IN", "OPT_OUT", "NOT_APPLICABLE"})
     private String smsPreference;
 
     /**
      * Phone preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)
      */
+    @Schema(
+            description = "Phone communication preference",
+            example = "OPT_IN",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+            allowableValues = {"OPT_IN", "OPT_OUT", "NOT_APPLICABLE"})
     private String phonePreference;
 
     /**
      * Marketing communications preference (OPT_IN|OPT_OUT)
      */
+    @Schema(
+            description = "Marketing communications preference",
+            example = "OPT_OUT",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+            allowableValues = {"OPT_IN", "OPT_OUT"})
     private String marketingPreference;
 
     /**
      * Consent flags (field names TBD based on legal requirements)
      * Can be separate ConsentRecord entity or stored here.
      */
+    @Schema(
+            description = "Consent flags keyed by consent type",
+            example = "{\"gdpr\":true,\"tcpa\":false}",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Map<String, Boolean> consentFlags;
 
     /**
      * User-provided note or preferences summary
      */
+    @Schema(
+            description = "User-provided note or preferences summary",
+            example = "Prefers contact after 5pm",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String preferencesNote;
 
     /**
      * Last update timestamp (ISO 8601)
      */
+    @Schema(
+            description = "Last update timestamp (ISO 8601)",
+            example = "2026-06-17T10:15:30Z",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String updatedAt;
 
     /**
      * Source of last update (APP|API|ADMIN|IMPORT)
      */
+    @Schema(
+            description = "Source of the last update",
+            example = "API",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+            allowableValues = {"APP", "API", "ADMIN", "IMPORT"})
     private String updateSource;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetContactsWithRolesResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetContactsWithRolesResponse.java
@@ -1,6 +1,10 @@
 package com.positivity.customer.internal.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,16 +20,27 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Contacts with their assigned roles and primary flags for a party")
 public class GetContactsWithRolesResponse {
 
     /**
      * Party ID queried
      */
+    @NotBlank
+    @Schema(
+            description = "Party identifier the contacts belong to",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String partyId;
 
     /**
      * List of contacts with assigned roles
      */
+    @Valid
+    @NotNull
+    @Schema(
+            description = "List of contacts with assigned roles",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ContactWithRoles> contacts;
 
     /**
@@ -36,41 +51,72 @@ public class GetContactsWithRolesResponse {
     @AllArgsConstructor
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "A single contact with its assigned roles")
     public static class ContactWithRoles {
 
         /**
          * Contact point ID (person/contact identifier)
          */
+        @NotBlank
+        @Schema(
+                description = "Contact point identifier (person/contact)",
+                example = "01960003-0000-7000-8000-000000000020",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String contactId;
 
         /**
          * Contact name
          */
+        @Schema(
+                description = "Contact name",
+                example = "Jane Doe",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String contactName;
 
         /**
          * Email address
          */
+        @Schema(
+                description = "Email address",
+                example = "jane@acme.com",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String email;
 
         /**
          * Phone number
          */
+        @Schema(
+                description = "Phone number",
+                example = "+1-555-0142",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String phone;
 
         /**
          * Flag: contact has at least one primary email on file
          */
+        @Schema(
+                description = "Whether the contact has at least one primary email on file",
+                example = "true",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private Boolean hasPrimaryEmail;
 
         /**
          * Assigned roles (BILLING|APPROVER|DRIVER or dynamic list)
          */
+        @Valid
+        @Schema(
+                description = "Assigned roles for this contact",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private List<AssignedRole> roles;
 
         /**
          * Invoice delivery method for this contact (EMAIL|PHONE|NONE)
          */
+        @Schema(
+                description = "Invoice delivery method for this contact",
+                example = "EMAIL",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+                allowableValues = {"EMAIL", "PHONE", "NONE"})
         private String invoiceDeliveryMethod;
     }
 
@@ -82,21 +128,36 @@ public class GetContactsWithRolesResponse {
     @AllArgsConstructor
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "An assigned role with its primary flag")
     public static class AssignedRole {
 
         /**
          * Role code (BILLING|APPROVER|DRIVER)
          */
+        @NotBlank
+        @Schema(
+                description = "Role code",
+                example = "BILLING",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"BILLING", "APPROVER", "DRIVER"})
         private String roleCode;
 
         /**
          * Role display label
          */
+        @Schema(
+                description = "Role display label",
+                example = "Billing Contact",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String roleLabel;
 
         /**
          * Flag: this contact is primary for this role
          */
+        @Schema(
+                description = "Whether this contact is primary for this role",
+                example = "true",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private Boolean isPrimary;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetPartyResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetPartyResponse.java
@@ -1,6 +1,12 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,50 +21,92 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Party details for a commercial account or individual party")
 public class GetPartyResponse {
 
     /**
      * Party ID (canonical CRM identifier)
      */
+    @Schema(
+            description = "Party ID (canonical CRM identifier)",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotBlank
     private String partyId;
 
     /**
      * Party type (ORGANIZATION|INDIVIDUAL)
      */
+    @Schema(
+            description = "Party type discriminator",
+            example = "ORGANIZATION",
+            requiredMode = REQUIRED)
+    @NotBlank
     private String partyType;
 
     /**
      * Legal name
      */
+    @Schema(
+            description = "Legal name of the party",
+            example = "Acme Industrial Supply LLC",
+            requiredMode = REQUIRED)
+    @NotBlank
     private String legalName;
 
     /**
      * Display/trading name
      */
+    @Schema(
+            description = "Display/trading name",
+            example = "Acme Supply",
+            requiredMode = NOT_REQUIRED)
     private String displayName;
 
     /**
      * Tax identification number
      */
+    @Schema(
+            description = "Tax identification number",
+            example = "82-1234567",
+            requiredMode = NOT_REQUIRED)
     private String taxId;
 
     /**
      * Current status (ACTIVE|PENDING|SUSPENDED|INACTIVE)
      */
+    @Schema(
+            description = "Current status of the party",
+            example = "ACTIVE",
+            requiredMode = REQUIRED)
+    @NotBlank
     private String status;
 
     /**
      * Billing terms ID
      */
+    @Schema(
+            description = "Billing terms ID",
+            example = "01960003-0000-7000-8000-000000000010",
+            requiredMode = NOT_REQUIRED)
     private String billingTermsId;
 
     /**
      * Party creation timestamp (ISO 8601)
      */
+    @Schema(
+            description = "Party creation timestamp (ISO 8601)",
+            example = "2026-01-15T10:30:00Z",
+            requiredMode = REQUIRED)
+    @NotNull
     private String createdAt;
 
     /**
      * Last modification timestamp (ISO 8601)
      */
+    @Schema(
+            description = "Last modification timestamp (ISO 8601)",
+            example = "2026-02-20T14:45:00Z",
+            requiredMode = NOT_REQUIRED)
     private String modifiedAt;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetPersonResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/GetPersonResponse.java
@@ -1,8 +1,13 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.positivity.customer.internal.enums.ContactPointType;
 import com.positivity.customer.internal.enums.PreferredContactMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -25,39 +30,61 @@ import lombok.NoArgsConstructor;
 @Schema(description = "Person details response")
 public class GetPersonResponse {
 
-    @Schema(description = "Unique identifier of the person", example = "550e8400-e29b-41d4-a716-446655440000")
+    @Schema(
+            description = "Unique identifier of the person",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID personId;
 
-    @Schema(description = "First name", example = "John")
+    @Schema(description = "First name", example = "John", requiredMode = REQUIRED)
     private String firstName;
 
-    @Schema(description = "Last name", example = "Doe")
+    @Schema(description = "Last name", example = "Doe", requiredMode = REQUIRED)
     private String lastName;
 
-    @Schema(description = "Display name", example = "John Doe")
+    @Schema(description = "Display name", example = "John Doe", requiredMode = NOT_REQUIRED)
     private String displayName;
 
-    @Schema(description = "Preferred contact method", example = "EMAIL")
+    @Schema(
+            description = "Preferred contact method",
+            example = "EMAIL",
+            requiredMode = NOT_REQUIRED)
     private PreferredContactMethod preferredContactMethod;
 
-    @Schema(description = "Contact points (emails, phones)")
+    @Schema(description = "Contact points (emails, phones)", requiredMode = NOT_REQUIRED)
+    @Valid
     private List<ContactPointDto> contactPoints;
 
-    @Schema(description = "Whether this CRM record represents an individual customer", example = "true")
+    @Schema(
+            description = "Whether this CRM record represents an individual customer",
+            example = "true",
+            requiredMode = REQUIRED)
     private boolean individualCustomer;
 
     @Schema(
             description = "Whether this person is an active contact on one or more commercial accounts",
-            example = "false")
+            example = "false",
+            requiredMode = REQUIRED)
     private boolean commercialContact;
 
-    @Schema(description = "Number of active commercial accounts where this person is a contact", example = "0")
+    @Schema(
+            description = "Number of active commercial accounts where this person is a contact",
+            example = "0",
+            requiredMode = REQUIRED)
     private int commercialAccountCount;
 
-    @Schema(description = "Timestamp when the person was created")
+    @Schema(
+            description = "Timestamp when the person was created",
+            example = "2026-01-15T10:30:00Z",
+            requiredMode = REQUIRED)
+    @NotNull
     private Instant createdAt;
 
-    @Schema(description = "Timestamp when the person was last updated")
+    @Schema(
+            description = "Timestamp when the person was last updated",
+            example = "2026-02-20T14:45:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant updatedAt;
 
     /**
@@ -69,16 +96,30 @@ public class GetPersonResponse {
     @AllArgsConstructor
     @Schema(description = "Contact point details")
     public static class ContactPointDto {
-        @Schema(description = "Contact point ID")
+        @Schema(
+                description = "Contact point ID",
+                example = "01960003-0000-7000-8000-000000000002",
+                requiredMode = REQUIRED)
+        @NotNull
         private UUID contactPointId;
 
-        @Schema(description = "Type of contact point", example = "EMAIL")
+        @Schema(
+                description = "Type of contact point",
+                example = "EMAIL",
+                requiredMode = REQUIRED)
+        @NotNull
         private ContactPointType contactType;
 
-        @Schema(description = "Contact value", example = "john.doe@example.com")
+        @Schema(
+                description = "Contact value",
+                example = "john.doe@example.com",
+                requiredMode = REQUIRED)
         private String value;
 
-        @Schema(description = "Whether this is the primary contact of its type")
+        @Schema(
+                description = "Whether this is the primary contact of its type",
+                example = "true",
+                requiredMode = REQUIRED)
         private boolean isPrimary;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/MergePartiesRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/MergePartiesRequest.java
@@ -1,6 +1,12 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,23 +21,39 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Request to merge a duplicate (losing) party into a survivor party")
 public class MergePartiesRequest {
 
     /**
      * ID of the party to merge into (survivor party).
      * Extracted from URL path: /parties/{partyId}/merge
      */
+    @Schema(
+            description = "ID of the party to merge into (survivor party). Sourced from the URL path.",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
     private String survivorPartyId;
 
     /**
      * ID of the party to be merged away (losing party).
      * Must be provided in request body.
      */
+    @Schema(
+            description = "ID of the party to be merged away (losing party)",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = REQUIRED)
+    @NotBlank
     private String losingPartyId;
 
     /**
      * Justification for merge (required).
      * Min/max length TBD.
      */
+    @Schema(
+            description = "Justification for the merge",
+            example = "Duplicate party created during onboarding; consolidating records.",
+            requiredMode = REQUIRED)
+    @NotBlank
+    @Size(max = 1000)
     private String justification;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/MergePartiesResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/MergePartiesResponse.java
@@ -1,6 +1,12 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,21 +21,37 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Result of a party merge operation")
 public class MergePartiesResponse {
 
     /**
      * Merge audit record ID (for traceability)
      */
+    @Schema(
+            description = "Merge audit record ID (for traceability)",
+            example = "01960003-0000-7000-8000-000000000003",
+            requiredMode = REQUIRED)
+    @NotBlank
     private String mergeAuditId;
 
     /**
      * Survivor party ID (canonical identifier for merged entity)
      */
+    @Schema(
+            description = "Survivor party ID (canonical identifier for merged entity)",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotBlank
     private String survivorPartyId;
 
     /**
      * Losing party ID (now merged away)
      */
+    @Schema(
+            description = "Losing party ID (now merged away)",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = REQUIRED)
+    @NotBlank
     private String losingPartyId;
 
     /**
@@ -37,15 +59,28 @@ public class MergePartiesResponse {
      * When clients query the losing party ID, they should be redirected to
      * survivor.
      */
+    @Schema(
+            description = "Alias/redirect ID for the losing party, pointing to the survivor",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
     private String mergedPartyAlias;
 
     /**
      * Merge status (COMPLETED|PENDING)
      */
+    @Schema(
+            description = "Merge status",
+            example = "COMPLETED",
+            requiredMode = REQUIRED)
+    @NotBlank
     private String status;
 
     /**
      * Timestamp of merge completion (ISO 8601)
      */
+    @Schema(
+            description = "Timestamp of merge completion (ISO 8601)",
+            example = "2026-02-20T14:45:00Z",
+            requiredMode = NOT_REQUIRED)
     private String completedAt;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/PromotionRedemptionResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/PromotionRedemptionResponse.java
@@ -1,7 +1,12 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.positivity.customer.internal.enums.RedemptionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -13,19 +18,93 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Result of recording a promotion redemption for a customer")
 public class PromotionRedemptionResponse {
 
+    @Schema(
+            description = "Unique identifier of the promotion redemption record",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID promotionRedemptionId;
+
+    @Schema(
+            description = "Identifier of the redeemed promotion",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID promotionId;
+
+    @Schema(
+            description = "Identifier of the customer who redeemed the promotion",
+            example = "01960003-0000-7000-8000-000000000003",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID customerId;
+
+    @Schema(
+            description = "Identifier of the workorder the redemption was applied to",
+            example = "01960003-0000-7000-8000-000000000004",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID workorderId;
+
+    @Schema(
+            description = "Identifier of the invoice the redemption was applied to, if any",
+            example = "01960003-0000-7000-8000-000000000005",
+            requiredMode = NOT_REQUIRED)
     private UUID invoiceId;
+
+    @Schema(
+            description = "Discount amount applied by the redemption",
+            example = "25.00",
+            requiredMode = REQUIRED)
+    @NotNull
     private BigDecimal discountAmount;
+
+    @Schema(
+            description = "Type of discount applied",
+            example = "PERCENTAGE",
+            requiredMode = REQUIRED)
+    @NotNull
     private String discountType;
+
+    @Schema(
+            description = "Promotion code that was redeemed",
+            example = "SUMMER25",
+            requiredMode = REQUIRED)
+    @NotNull
     private String promotionCode;
+
+    @Schema(
+            description = "Identifier of the actor who recorded the redemption",
+            example = "01960003-0000-7000-8000-000000000006",
+            requiredMode = NOT_REQUIRED)
     private String recordedBy;
+
+    @Schema(
+            description = "Whether the redemption was recorded over the configured usage limit",
+            example = "false",
+            requiredMode = NOT_REQUIRED)
     private Boolean recordedOverLimit;
+
+    @Schema(
+            description = "Current status of the redemption",
+            example = "RECORDED",
+            requiredMode = REQUIRED)
+    @NotNull
     private RedemptionStatus status;
+
+    @Schema(
+            description = "Timestamp when the redemption occurred",
+            example = "2026-02-20T14:45:00",
+            requiredMode = NOT_REQUIRED)
     private LocalDateTime redemptionTimestamp;
+
+    @Schema(
+            description = "Timestamp when the redemption record was created",
+            example = "2026-02-20T14:45:01",
+            requiredMode = REQUIRED)
+    @NotNull
     private LocalDateTime createdAt;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/RecordRedemptionRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/RecordRedemptionRequest.java
@@ -1,8 +1,13 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -14,33 +19,72 @@ import org.jspecify.annotations.Nullable;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Request to record a promotion redemption for a customer")
 public class RecordRedemptionRequest {
 
+    @Schema(
+            description = "Identifier of the promotion being redeemed",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = REQUIRED)
     @NotNull
     private UUID promotionId;
 
+    @Schema(
+            description = "Identifier of the customer redeeming the promotion",
+            example = "01960003-0000-7000-8000-000000000003",
+            requiredMode = REQUIRED)
     @NotNull
     private UUID customerId;
 
+    @Schema(
+            description = "Identifier of the workorder the redemption applies to",
+            example = "01960003-0000-7000-8000-000000000004",
+            requiredMode = REQUIRED)
     @NotNull
     private UUID workorderId;
 
+    @Schema(
+            description = "Identifier of the invoice the redemption applies to, if any",
+            example = "01960003-0000-7000-8000-000000000005",
+            requiredMode = NOT_REQUIRED)
     @Nullable
     private UUID invoiceId;
 
+    @Schema(
+            description = "Discount amount to record for the redemption",
+            example = "25.00",
+            requiredMode = REQUIRED)
     @NotNull
     @DecimalMin("0.00")
     private BigDecimal discountAmount;
 
+    @Schema(
+            description = "Type of discount being recorded",
+            example = "PERCENTAGE",
+            requiredMode = REQUIRED)
     @NotBlank
+    @Size(max = 50)
     private String discountType;
 
+    @Schema(
+            description = "Promotion code being redeemed",
+            example = "SUMMER25",
+            requiredMode = REQUIRED)
     @NotBlank
+    @Size(max = 100)
     private String promotionCode;
 
+    @Schema(
+            description = "Whether the redemption is being recorded over the configured usage limit",
+            example = "false",
+            requiredMode = NOT_REQUIRED)
     @Nullable
     private Boolean recordedOverLimit;
 
+    @Schema(
+            description = "Timestamp when the redemption occurred",
+            example = "2026-02-20T14:45:00",
+            requiredMode = NOT_REQUIRED)
     @Nullable
     private LocalDateTime redemptionTimestamp;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/ResolveAccountTierRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/ResolveAccountTierRequest.java
@@ -1,6 +1,12 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,27 +29,50 @@ import org.jspecify.annotations.Nullable;
 @Schema(description = "Request to compute account tier based on business rules")
 public class ResolveAccountTierRequest {
 
-    @Schema(description = "Account/party identifier", example = "123e4567-e89b-12d3-a456-426614174000")
+    @Schema(
+            description = "Account/party identifier",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
     @NonNull
+    @NotBlank
+    @Size(max = 64)
     private String accountId;
 
-    @Schema(description = "Annual revenue or spending for tier calculation", example = "125000.00")
+    @Schema(
+            description = "Annual revenue or spending for tier calculation",
+            example = "125000.00",
+            requiredMode = NOT_REQUIRED)
     @Nullable
+    @PositiveOrZero
     private BigDecimal annualRevenue;
 
-    @Schema(description = "Number of active contracts or subscriptions")
+    @Schema(
+            description = "Number of active contracts or subscriptions",
+            example = "3",
+            requiredMode = NOT_REQUIRED)
     @Nullable
+    @PositiveOrZero
     private Integer activeContractCount;
 
-    @Schema(description = "Account age in months")
+    @Schema(
+            description = "Account age in months",
+            example = "18",
+            requiredMode = NOT_REQUIRED)
     @Nullable
+    @PositiveOrZero
     private Integer accountAgeMonths;
 
-    @Schema(description = "Whether to apply the resolved tier or just return the recommendation")
+    @Schema(
+            description = "Whether to apply the resolved tier or just return the recommendation",
+            example = "false",
+            requiredMode = NOT_REQUIRED)
     @Builder.Default
     private boolean applyTier = false;
 
-    @Schema(description = "Force recalculation even if tier was manually set")
+    @Schema(
+            description = "Force recalculation even if tier was manually set",
+            example = "false",
+            requiredMode = NOT_REQUIRED)
     @Builder.Default
     private boolean forceRecalculation = false;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/ResolveAccountTierResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/ResolveAccountTierResponse.java
@@ -1,7 +1,12 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.positivity.customer.internal.enums.AccountTier;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -22,29 +27,53 @@ import org.jspecify.annotations.Nullable;
 @Schema(description = "Account tier resolution result")
 public class ResolveAccountTierResponse {
 
-    @Schema(description = "Account/party identifier", example = "123e4567-e89b-12d3-a456-426614174000")
+    @Schema(
+            description = "Account/party identifier",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
     @NonNull
+    @NotBlank
     private String accountId;
 
-    @Schema(description = "Currently assigned tier (before resolution)", example = "SILVER")
+    @Schema(
+            description = "Currently assigned tier (before resolution)",
+            example = "SILVER",
+            requiredMode = REQUIRED)
     @NonNull
+    @NotNull
     private AccountTier currentTier;
 
-    @Schema(description = "Recommended/resolved tier based on business rules", example = "GOLD")
+    @Schema(
+            description = "Recommended/resolved tier based on business rules",
+            example = "GOLD",
+            requiredMode = REQUIRED)
     @NonNull
+    @NotNull
     private AccountTier recommendedTier;
 
-    @Schema(description = "Whether the tier was applied to the account")
+    @Schema(
+            description = "Whether the tier was applied to the account",
+            example = "true",
+            requiredMode = REQUIRED)
     private boolean tierApplied;
 
-    @Schema(description = "Whether the current tier was manually set and blocked auto-update")
+    @Schema(
+            description = "Whether the current tier was manually set and blocked auto-update",
+            example = "false",
+            requiredMode = REQUIRED)
     private boolean manualOverrideActive;
 
-    @Schema(description = "Explanation of why this tier was recommended")
+    @Schema(
+            description = "Explanation of why this tier was recommended",
+            example = "Annual revenue exceeds GOLD threshold of 100000.00",
+            requiredMode = NOT_REQUIRED)
     @Nullable
     private String resolutionReason;
 
-    @Schema(description = "Score or metric used for tier calculation")
+    @Schema(
+            description = "Score or metric used for tier calculation",
+            example = "82",
+            requiredMode = NOT_REQUIRED)
     @Nullable
     private Integer tierScore;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/SearchPartiesRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/SearchPartiesRequest.java
@@ -1,6 +1,12 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,62 +21,106 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Request to search parties with optional filters and pagination")
 public class SearchPartiesRequest {
 
     /**
      * Party name search term (matches legalName or displayName).
      * Search type (exact|prefix|contains) TBD.
      */
+    @Schema(
+            description = "Party name search term (matches legalName or displayName)",
+            example = "Acme Corporation",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 200)
     private String name;
 
     /**
      * Search by email address
      */
+    @Schema(description = "Search by email address", example = "jane@acme.com", requiredMode = NOT_REQUIRED)
+    @Size(max = 254)
     private String email;
 
     /**
      * Search by phone number
      */
+    @Schema(description = "Search by phone number", example = "+1-555-0100", requiredMode = NOT_REQUIRED)
+    @Size(max = 50)
     private String phone;
 
     /**
      * Search by tax ID
      */
+    @Schema(description = "Search by tax ID", example = "12-3456789", requiredMode = NOT_REQUIRED)
+    @Size(max = 50)
     private String taxId;
 
     /**
      * Filter by party type (ORGANIZATION|INDIVIDUAL)
      */
+    @Schema(
+            description = "Filter by party type (ORGANIZATION|INDIVIDUAL)",
+            example = "ORGANIZATION",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 40)
     private String partyType;
 
     /**
      * Filter by status (ACTIVE|PENDING|SUSPENDED|INACTIVE)
      */
+    @Schema(
+            description = "Filter by status (ACTIVE|PENDING|SUSPENDED|INACTIVE)",
+            example = "ACTIVE",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 40)
     private String status;
 
     /**
      * Include merged parties in results (default false).
      * Admin-only toggle for troubleshooting.
      */
+    @Schema(
+            description = "Include merged parties in results (default false); admin-only troubleshooting toggle",
+            example = "false",
+            requiredMode = NOT_REQUIRED)
     private Boolean includeMerged;
 
     /**
      * Pagination: page number (1-indexed, default 1)
      */
+    @Schema(
+            description = "Pagination: page number (1-indexed, default 1)",
+            example = "1",
+            requiredMode = NOT_REQUIRED)
+    @Min(1)
     private Integer pageNumber;
 
     /**
      * Pagination: items per page (default 20, max 100)
      */
+    @Schema(
+            description = "Pagination: items per page (default 20, max 100)",
+            example = "20",
+            requiredMode = NOT_REQUIRED)
+    @Min(1)
+    @Max(100)
     private Integer pageSize;
 
     /**
      * Sort field (legalName|createdAt|modifiedAt)
      */
+    @Schema(
+            description = "Sort field (legalName|createdAt|modifiedAt)",
+            example = "legalName",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 40)
     private String sortField;
 
     /**
      * Sort order (ASC|DESC)
      */
+    @Schema(description = "Sort order (ASC|DESC)", example = "ASC", requiredMode = NOT_REQUIRED)
+    @Size(max = 4)
     private String sortOrder;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/SearchPartiesResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/SearchPartiesResponse.java
@@ -1,6 +1,12 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,26 +22,36 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Paged response of matching party summaries")
 public class SearchPartiesResponse {
 
     /**
      * List of party summary records
      */
+    @Schema(description = "List of party summary records", requiredMode = REQUIRED)
+    @NotNull
+    @Valid
     private List<PartySummary> results;
 
     /**
      * Total number of matching records
      */
+    @Schema(description = "Total number of matching records", example = "42", requiredMode = REQUIRED)
+    @NotNull
     private Integer totalCount;
 
     /**
      * Current page number
      */
+    @Schema(description = "Current page number", example = "1", requiredMode = REQUIRED)
+    @NotNull
     private Integer pageNumber;
 
     /**
      * Items per page
      */
+    @Schema(description = "Items per page", example = "20", requiredMode = REQUIRED)
+    @NotNull
     private Integer pageSize;
 
     /**
@@ -46,24 +62,49 @@ public class SearchPartiesResponse {
     @AllArgsConstructor
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "Party summary record for a directory row")
     public static class PartySummary {
+
+        @Schema(
+                description = "Unique identifier of the party",
+                example = "01960003-0000-7000-8000-000000000001",
+                requiredMode = REQUIRED)
+        @NotNull
         private String partyId;
+
+        @Schema(description = "Legal name of the party", example = "Acme Corporation", requiredMode = NOT_REQUIRED)
         private String legalName;
+
+        @Schema(description = "Display name of the party", example = "Acme", requiredMode = NOT_REQUIRED)
         private String displayName;
+
+        @Schema(description = "Party type (ORGANIZATION|INDIVIDUAL)", example = "ORGANIZATION", requiredMode = NOT_REQUIRED)
         private String partyType;
+
+        @Schema(description = "Party status (ACTIVE|PENDING|SUSPENDED|INACTIVE)", example = "ACTIVE", requiredMode = NOT_REQUIRED)
         private String status;
+
+        @Schema(description = "Creation timestamp (ISO 8601)", example = "2026-01-15T09:30:00Z", requiredMode = NOT_REQUIRED)
         private String createdAt;
 
         /**
          * Primary contact for the party, surfaced so the customer directory can render
          * it without a per-row fetch. Null when the party has no resolvable contact.
          */
+        @Schema(
+                description = "Primary contact for the party; null when none is resolvable",
+                requiredMode = NOT_REQUIRED)
+        @Valid
         private PrimaryContact primaryContact;
 
         /**
          * Number of vehicles associated with the party, surfaced so the directory can
          * show a count without a per-row fetch. Defaults to 0.
          */
+        @Schema(
+                description = "Number of vehicles associated with the party (defaults to 0)",
+                example = "3",
+                requiredMode = NOT_REQUIRED)
         private Integer vehicleCount;
     }
 
@@ -75,9 +116,16 @@ public class SearchPartiesResponse {
     @AllArgsConstructor
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "Lightweight primary-contact projection for directory rows")
     public static class PrimaryContact {
+
+        @Schema(description = "Contact name", example = "Jane Doe", requiredMode = NOT_REQUIRED)
         private String name;
+
+        @Schema(description = "Contact email address", example = "jane@acme.com", requiredMode = NOT_REQUIRED)
         private String email;
+
+        @Schema(description = "Contact phone number", example = "+1-555-0100", requiredMode = NOT_REQUIRED)
         private String phone;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpdateContactRolesRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpdateContactRolesRequest.java
@@ -1,6 +1,14 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,17 +24,26 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Request to update the set of role assignments for a contact")
 public class UpdateContactRolesRequest {
 
     /**
      * Optimistic locking version field (name TBD: version|lastUpdatedStamp|ETag)
      * Required if backend enforces optimistic locking.
      */
+    @Schema(
+            description = "Optimistic locking version; required when the backend enforces optimistic locking",
+            example = "7",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 100)
     private String version;
 
     /**
      * List of roles to assign to this contact
      */
+    @Schema(description = "List of roles to assign to this contact", requiredMode = REQUIRED)
+    @NotNull
+    @Valid
     private List<RoleAssignment> roles;
 
     /**
@@ -37,16 +54,24 @@ public class UpdateContactRolesRequest {
     @AllArgsConstructor
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "Single role assignment detail")
     public static class RoleAssignment {
 
         /**
          * Role code (BILLING|APPROVER|DRIVER)
          */
+        @Schema(description = "Role code (BILLING|APPROVER|DRIVER)", example = "BILLING", requiredMode = REQUIRED)
+        @NotBlank
+        @Size(max = 40)
         private String roleCode;
 
         /**
          * Flag: set this contact as primary for this role
          */
+        @Schema(
+                description = "Flag: set this contact as primary for this role",
+                example = "true",
+                requiredMode = NOT_REQUIRED)
         private Boolean isPrimary;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpdateContactRolesResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpdateContactRolesResponse.java
@@ -1,6 +1,11 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,30 +20,51 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Response after updating contact role assignments")
 public class UpdateContactRolesResponse {
 
     /**
      * Party ID
      */
+    @Schema(
+            description = "Identifier of the party that owns the contact",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private String partyId;
 
     /**
      * Contact ID that was updated
      */
+    @Schema(
+            description = "Identifier of the contact that was updated",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = REQUIRED)
+    @NotNull
     private String contactId;
 
     /**
      * Updated version (for optimistic locking conflict resolution)
      */
+    @Schema(
+            description = "Updated version for optimistic locking conflict resolution",
+            example = "8",
+            requiredMode = NOT_REQUIRED)
     private String version;
 
     /**
      * Update status (SUCCESS|CONFLICT)
      */
+    @Schema(description = "Update status (SUCCESS|CONFLICT)", example = "SUCCESS", requiredMode = REQUIRED)
+    @NotNull
     private String status;
 
     /**
      * Timestamp of update (ISO 8601)
      */
+    @Schema(
+            description = "Timestamp of update (ISO 8601)",
+            example = "2026-01-15T09:30:00Z",
+            requiredMode = NOT_REQUIRED)
     private String updatedAt;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpsertBillingRulesRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpsertBillingRulesRequest.java
@@ -1,5 +1,7 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
 import com.positivity.customer.internal.enums.InvoiceDeliveryMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
@@ -20,42 +22,57 @@ import org.jspecify.annotations.Nullable;
 @Schema(description = "Request to upsert billing rules for a commercial party")
 public class UpsertBillingRulesRequest {
 
-    @Schema(description = "Payment terms string", example = "Net 30")
+    @Schema(description = "Payment terms string", example = "Net 30", requiredMode = NOT_REQUIRED)
     @Nullable
     @Size(max = 100)
     private String paymentTerms;
 
-    @Schema(description = "Maximum credit limit; null means no configured limit", example = "10000.00")
+    @Schema(
+            description = "Maximum credit limit; null means no configured limit",
+            example = "10000.00",
+            requiredMode = NOT_REQUIRED)
     @Nullable
     @DecimalMin("0.00")
     private BigDecimal creditLimit;
 
-    @Schema(description = "ISO-4217 currency code", example = "USD")
+    @Schema(description = "ISO-4217 currency code", example = "USD", requiredMode = NOT_REQUIRED)
     @Nullable
     @Pattern(regexp = "^[A-Z]{3}$", message = "Currency must be a 3-letter ISO-4217 code")
     private String currency;
 
-    @Schema(description = "Whether the account is tax-exempt", example = "false")
+    @Schema(description = "Whether the account is tax-exempt", example = "false", requiredMode = NOT_REQUIRED)
     private boolean taxExempt;
 
-    @Schema(description = "Whether a PO number is required before order can be finalized", example = "false")
+    @Schema(
+            description = "Whether a PO number is required before order can be finalized",
+            example = "false",
+            requiredMode = NOT_REQUIRED)
     private boolean poRequired;
 
-    @Schema(description = "Whether the account is on a credit hold", example = "false")
+    @Schema(description = "Whether the account is on a credit hold", example = "false", requiredMode = NOT_REQUIRED)
     private boolean creditHold;
 
-    @Schema(description = "Whether auto-pay is enabled for this account", example = "false")
+    @Schema(
+            description = "Whether auto-pay is enabled for this account",
+            example = "false",
+            requiredMode = NOT_REQUIRED)
     private boolean autoPayEnabled;
 
-    @Schema(description = "Preferred invoice delivery method")
+    @Schema(description = "Preferred invoice delivery method", requiredMode = NOT_REQUIRED)
     @Nullable
     private InvoiceDeliveryMethod invoiceDeliveryMethod;
 
-    @Schema(description = "Billing address ID", example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+    @Schema(
+            description = "Billing address ID",
+            example = "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            requiredMode = NOT_REQUIRED)
     @Nullable
     private UUID billingAddressId;
 
-    @Schema(description = "Optional reference to a discount policy", example = "DISC-GOLD-001")
+    @Schema(
+            description = "Optional reference to a discount policy",
+            example = "DISC-GOLD-001",
+            requiredMode = NOT_REQUIRED)
     @Nullable
     @Size(max = 200)
     private String discountPolicyRef;

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpsertCommunicationPreferencesRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpsertCommunicationPreferencesRequest.java
@@ -1,6 +1,10 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,48 +20,88 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Request to upsert communication preferences and consent flags for a party")
 public class UpsertCommunicationPreferencesRequest {
 
     /**
      * Optimistic locking version field (name TBD: version|lastUpdatedStamp|ETag)
      * Required for updates, omitted for creates.
      */
+    @Schema(
+            description = "Optimistic locking version; required for updates, omitted for creates",
+            example = "5",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 100)
     private String version;
 
     /**
      * Email preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)
      */
+    @Schema(
+            description = "Email preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)",
+            example = "OPT_IN",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 40)
     private String emailPreference;
 
     /**
      * SMS preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)
      */
+    @Schema(
+            description = "SMS preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)",
+            example = "OPT_OUT",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 40)
     private String smsPreference;
 
     /**
      * Phone preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)
      */
+    @Schema(
+            description = "Phone preference (OPT_IN|OPT_OUT|NOT_APPLICABLE)",
+            example = "OPT_IN",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 40)
     private String phonePreference;
 
     /**
      * Marketing communications preference (OPT_IN|OPT_OUT)
      */
+    @Schema(
+            description = "Marketing communications preference (OPT_IN|OPT_OUT)",
+            example = "OPT_OUT",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 40)
     private String marketingPreference;
 
     /**
      * Consent flags (field names TBD based on legal requirements)
      * Can be separate ConsentRecord entity or stored here.
      */
+    @Schema(
+            description = "Consent flags keyed by consent type; field names depend on legal requirements",
+            example = "{\"gdpr\": true, \"ccpa\": false}",
+            requiredMode = NOT_REQUIRED)
     private Map<String, Boolean> consentFlags;
 
     /**
      * User-provided note or preferences summary
      */
+    @Schema(
+            description = "User-provided note or preferences summary",
+            example = "Prefers email contact only on weekdays",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 1000)
     private String preferencesNote;
 
     /**
      * Source of update (frontend sends constant or backend infers from context).
      * TBD: frontend sends (APP|API|ADMIN) or backend always sets to APP if client.
      */
+    @Schema(
+            description = "Source of update (APP|API|ADMIN)",
+            example = "APP",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 40)
     private String updateSource;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpsertCommunicationPreferencesResponse.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/UpsertCommunicationPreferencesResponse.java
@@ -1,6 +1,11 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,30 +20,48 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Response after upserting communication preferences")
 public class UpsertCommunicationPreferencesResponse {
 
     /**
      * Party ID updated
      */
+    @Schema(
+            description = "Identifier of the party that was updated",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private String partyId;
 
     /**
      * Updated version (for optimistic locking)
      */
+    @Schema(
+            description = "Updated version for optimistic locking",
+            example = "6",
+            requiredMode = NOT_REQUIRED)
     private String version;
 
     /**
      * Operation type (CREATED|UPDATED)
      */
+    @Schema(description = "Operation type (CREATED|UPDATED)", example = "UPDATED", requiredMode = REQUIRED)
+    @NotNull
     private String operationType;
 
     /**
      * Update status (SUCCESS|CONFLICT)
      */
+    @Schema(description = "Update status (SUCCESS|CONFLICT)", example = "SUCCESS", requiredMode = REQUIRED)
+    @NotNull
     private String status;
 
     /**
      * Timestamp of update (ISO 8601)
      */
+    @Schema(
+            description = "Timestamp of update (ISO 8601)",
+            example = "2026-01-15T09:30:00Z",
+            requiredMode = NOT_REQUIRED)
     private String updatedAt;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/VehicleTransferRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/VehicleTransferRequest.java
@@ -1,5 +1,11 @@
 package com.positivity.customer.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,16 +19,28 @@ import org.jspecify.annotations.NonNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Request to transfer vehicle ownership between customers")
 public class VehicleTransferRequest {
 
     /**
      * Target customer ID to transfer the vehicle to.
      */
+    @Schema(
+            description = "Target customer ID to transfer the vehicle to",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
     @NonNull
+    @NotBlank
+    @Size(max = 100)
     private String targetCustomerId;
 
     /**
      * Optional notes about the transfer.
      */
+    @Schema(
+            description = "Optional notes about the transfer",
+            example = "Vehicle reassigned to fleet account",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 1000)
     private String notes;
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -118,6 +118,12 @@ public class PartyServiceImpl implements PartyService {
                 .partyId(String.valueOf(saved.getPartyId()))
                 .legalName(saved.getLegalName())
                 .status(saved.getStatus().toString())
+                .customerNumber(saved.getPartyNumber())
+                .displayName(saved.getDisplayName())
+                .partyType(saved.getPartyType() != null ? saved.getPartyType().toString() : null)
+                .taxId(saved.getTaxId())
+                .billingTermsId(saved.getBillingTermsId())
+                .primaryAddress(saved.getPrimaryAddress())
                 .createdAt(saved.getCreatedAt())
                 .duplicateCandidates(new ArrayList<>())
                 .build();


### PR DESCRIPTION
## Summary

Adds OpenAPI `@Schema` annotations and Jakarta Bean Validation across all `pos-customer` DTOs, and enriches the create-commercial-account response with display fields.

## Changes

- **All request/response DTOs** (`internal/dto/`): `@Schema` (description/example/`requiredMode`) on classes + fields; Jakarta validation (`@NotNull`/`@NotBlank`/`@Size`/`@Email`/`@Positive`/`@Valid`) — requests get functional validation, responses document the contract.
- **`CreateCommercialAccountResponse`**: add `customerNumber` (party number, required) + display fields `displayName`, `partyType`, `taxId`, `billingTermsId`, `primaryAddress`; populated in `PartyServiceImpl` from the saved party (null-safe).
- **`openapi.yaml`** regenerated to reflect the enriched schemas.

## Validation

- [x] `pos-customer` compiles
- [x] All **17 test suites pass**
- [x] `openapi.yaml` regenerated (`customerNumber` in the response's required list)

## Contract chain

Propagated per `BACKEND_CONTRACT_GUIDE.md` conventions: OpenAPI regenerated here; `@durion-sdk/customer` regenerated in durion-positivity-sdk-angular #4; vendored tarball refreshed in frontend #45. **Merge order:** this PR → SDK #4 → frontend #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
