### PR TITLE
feat(customer): server-side filter + sort on customer directory browse

### DIFF
--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -867,6 +867,42 @@ paths:
         required: true
         schema:
           $ref: '#/components/schemas/Pageable'
+      - name: name
+        in: query
+        description: Filter by name (case-insensitive contains on legal/display name)
+        required: false
+        schema:
+          type: string
+      - name: status
+        in: query
+        description: Filter by account status (ACTIVE|PENDING|SUSPENDED|INACTIVE)
+        required: false
+        schema:
+          type: string
+      - name: partyType
+        in: query
+        description: Filter by party type (ORGANIZATION|INDIVIDUAL)
+        required: false
+        schema:
+          type: string
+      - name: customerNumber
+        in: query
+        description: Filter by customer number (case-insensitive contains)
+        required: false
+        schema:
+          type: string
+      - name: sortField
+        in: query
+        description: 'Sort field: name (default) or customerNumber'
+        required: false
+        schema:
+          type: string
+      - name: sortOrder
+        in: query
+        description: 'Sort order: asc (default) or desc'
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Browse results returned

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
@@ -220,9 +220,30 @@ public class CrmAccountsController {
                     @PageableDefault(
                             size = 20,
                             sort = {"legalName", "partyId"})
-                    Pageable pageable) {
-        log.info("browseParties pageable={}", pageable);
-        return ResponseEntity.ok(partyService.browseParties(pageable));
+                    Pageable pageable,
+            @Parameter(description = "Filter by name (case-insensitive contains on legal/display name)")
+                    @RequestParam(required = false) String name,
+            @Parameter(description = "Filter by account status (ACTIVE|PENDING|SUSPENDED|INACTIVE)")
+                    @RequestParam(required = false) String status,
+            @Parameter(description = "Filter by party type (ORGANIZATION|INDIVIDUAL)")
+                    @RequestParam(required = false) String partyType,
+            @Parameter(description = "Filter by customer number (case-insensitive contains)")
+                    @RequestParam(required = false) String customerNumber,
+            @Parameter(description = "Sort field: name (default) or customerNumber")
+                    @RequestParam(required = false) String sortField,
+            @Parameter(description = "Sort order: asc (default) or desc")
+                    @RequestParam(required = false) String sortOrder) {
+        log.info(
+                "browseParties pageable={} name={} status={} partyType={} customerNumber={} sortField={} sortOrder={}",
+                pageable,
+                name,
+                status,
+                partyType,
+                customerNumber,
+                sortField,
+                sortOrder);
+        return ResponseEntity.ok(
+                partyService.browseParties(pageable, name, status, partyType, customerNumber, sortField, sortOrder));
     }
 
     @Operation(summary = "Search parties", description = "Search for parties based on various criteria")

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -164,12 +164,25 @@ public class PartyServiceImpl implements PartyService {
     @Transactional(readOnly = true)
     @NonNull
     public SearchPartiesResponse browseParties(@NonNull Pageable pageable) {
+        return browseParties(pageable, null, null, null, null, null, null);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SearchPartiesResponse browseParties(
+            @NonNull Pageable pageable,
+            String name,
+            String status,
+            String partyType,
+            String customerNumber,
+            String sortField,
+            String sortOrder) {
         Pageable normalizedPageable = normalizeBrowsePageable(pageable);
 
         // Unified customer directory: commercial parties plus standalone individual
         // customers (person parties that are not commercial-account contacts).
-        // Merged and paged in-memory; customer volumes are well within a single
-        // window at this tier (see ADR-0026 / OQ3 in PLAN-person-unification).
+        // Merged, filtered, sorted, and paged in-memory; customer volumes are well
+        // within a single window at this tier (see ADR-0026 / OQ3 in PLAN-person-unification).
         List<SearchPartiesResponse.PartySummary> all = new ArrayList<>();
         partyRepository.findAll().stream().map(this::mapToPartySummary).forEach(all::add);
 
@@ -179,23 +192,68 @@ public class PartyServiceImpl implements PartyService {
                 .map(person -> mapPersonToPartySummary(person, identities))
                 .forEach(all::add);
 
-        all.sort(Comparator.comparing(
-                        (SearchPartiesResponse.PartySummary s) ->
-                                s.getDisplayName() != null ? s.getDisplayName() : s.getLegalName(),
-                        Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
-                .thenComparing(SearchPartiesResponse.PartySummary::getPartyId));
+        List<SearchPartiesResponse.PartySummary> filtered = all.stream()
+                .filter(s -> matchesBrowseFilter(s, name, status, partyType, customerNumber))
+                .sorted(browseComparator(sortField, sortOrder))
+                .toList();
 
-        int total = all.size();
+        int total = filtered.size();
         int from = Math.min(normalizedPageable.getPageNumber() * normalizedPageable.getPageSize(), total);
         int to = Math.min(from + normalizedPageable.getPageSize(), total);
-        List<SearchPartiesResponse.PartySummary> window = all.subList(from, to);
+        List<SearchPartiesResponse.PartySummary> window = filtered.subList(from, to);
 
         return SearchPartiesResponse.builder()
-                .results(window)
+                .results(new ArrayList<>(window))
                 .totalCount(safeTotalCount(total))
                 .pageNumber(normalizedPageable.getPageNumber())
                 .pageSize(normalizedPageable.getPageSize())
                 .build();
+    }
+
+    private boolean matchesBrowseFilter(
+            SearchPartiesResponse.PartySummary s,
+            String name,
+            String status,
+            String partyType,
+            String customerNumber) {
+        if (StringUtils.hasText(name)) {
+            String needle = name.toLowerCase(java.util.Locale.ROOT);
+            String legal = s.getLegalName() != null ? s.getLegalName().toLowerCase(java.util.Locale.ROOT) : "";
+            String display = s.getDisplayName() != null ? s.getDisplayName().toLowerCase(java.util.Locale.ROOT) : "";
+            if (!legal.contains(needle) && !display.contains(needle)) {
+                return false;
+            }
+        }
+        if (StringUtils.hasText(status) && !status.equalsIgnoreCase(s.getStatus())) {
+            return false;
+        }
+        if (StringUtils.hasText(partyType) && !partyType.equalsIgnoreCase(s.getPartyType())) {
+            return false;
+        }
+        if (StringUtils.hasText(customerNumber)) {
+            String cn = s.getCustomerNumber() != null ? s.getCustomerNumber().toLowerCase(java.util.Locale.ROOT) : "";
+            return cn.contains(customerNumber.toLowerCase(java.util.Locale.ROOT));
+        }
+        return true;
+    }
+
+    private Comparator<SearchPartiesResponse.PartySummary> browseComparator(String sortField, String sortOrder) {
+        Comparator<SearchPartiesResponse.PartySummary> base;
+        if ("customerNumber".equalsIgnoreCase(sortField)) {
+            base = Comparator.comparing(
+                    SearchPartiesResponse.PartySummary::getCustomerNumber,
+                    Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+        } else {
+            base = Comparator.comparing(
+                    (SearchPartiesResponse.PartySummary s) ->
+                            s.getDisplayName() != null ? s.getDisplayName() : s.getLegalName(),
+                    Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+        }
+        if ("desc".equalsIgnoreCase(sortOrder)) {
+            base = base.reversed();
+        }
+        // Stable tie-breaker so paging is deterministic.
+        return base.thenComparing(SearchPartiesResponse.PartySummary::getPartyId);
     }
 
     private SearchPartiesResponse.PartySummary mapPersonToPartySummary(

--- a/pos-customer/src/main/java/com/positivity/customer/service/PartyService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/service/PartyService.java
@@ -30,6 +30,21 @@ public interface PartyService {
     @NonNull
     SearchPartiesResponse browseParties(@NonNull Pageable pageable);
 
+    /**
+     * Browse the unified customer directory with optional server-side filtering
+     * (name, status, party type, customer number) and sorting (by name or
+     * customer number), paged.
+     */
+    @NonNull
+    SearchPartiesResponse browseParties(
+            @NonNull Pageable pageable,
+            String name,
+            String status,
+            String partyType,
+            String customerNumber,
+            String sortField,
+            String sortOrder);
+
     SearchPartiesResponse searchParties(SearchPartiesRequest request);
 
     MergePartiesResponse mergeParties(UUID survivorPartyId, MergePartiesRequest request);

--- a/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
@@ -176,6 +176,39 @@ class CrmAccountsControllerTest {
     }
 
     @Test
+    @DisplayName("browseParties forwards filter and sort query params to the service")
+    void browsePartiesForwardsFilterSortParams() throws Exception {
+        SearchPartiesResponse response = SearchPartiesResponse.builder()
+                .results(List.of())
+                .totalCount(0)
+                .pageNumber(0)
+                .pageSize(20)
+                .build();
+        when(partyService.browseParties(
+                        any(Pageable.class), any(), any(), any(), any(), any(), any()))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/v1/crm/accounts/parties")
+                        .param("name", "acme")
+                        .param("status", "ACTIVE")
+                        .param("partyType", "ORGANIZATION")
+                        .param("customerNumber", "CUST-1")
+                        .param("sortField", "customerNumber")
+                        .param("sortOrder", "desc")
+                        .header("X-Authorities", "crm:party:view"))
+                .andExpect(status().isOk());
+
+        verify(partyService).browseParties(
+                any(Pageable.class),
+                eq("acme"),
+                eq("ACTIVE"),
+                eq("ORGANIZATION"),
+                eq("CUST-1"),
+                eq("customerNumber"),
+                eq("desc"));
+    }
+
+    @Test
     @DisplayName("browseParties returns 403 when unauthorized")
     void listParties_returns403_whenUnauthorized() throws Exception {
         mockMvc.perform(get("/v1/crm/accounts/parties")).andExpect(status().isForbidden());

--- a/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
@@ -142,7 +142,9 @@ class CrmAccountsControllerTest {
                 .pageSize(20)
                 .build();
 
-        when(partyService.browseParties(any(Pageable.class))).thenReturn(response);
+        when(partyService.browseParties(
+                        any(Pageable.class), any(), any(), any(), any(), any(), any()))
+                .thenReturn(response);
 
         mockMvc.perform(get("/v1/crm/accounts/parties").header("X-Authorities", "crm:party:view"))
                 .andExpect(status().isOk())
@@ -159,7 +161,8 @@ class CrmAccountsControllerTest {
                 .andExpect(jsonPath("$.pageSize").value(20));
 
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        verify(partyService).browseParties(pageableCaptor.capture());
+        verify(partyService).browseParties(
+                pageableCaptor.capture(), any(), any(), any(), any(), any(), any());
         assertEquals(0, pageableCaptor.getValue().getPageNumber());
         assertEquals(20, pageableCaptor.getValue().getPageSize());
         assertTrue(pageableCaptor.getValue().getSort().isSorted());

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -56,6 +56,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -474,6 +475,92 @@ class PartyServiceImplTest {
                 .extracting(SearchPartiesResponse.PartySummary::getPartyType)
                 .containsExactly(PartyType.PERSON.toString(), PartyType.COMMERCIAL.toString());
         assertThat(response.getResults().get(0).getDisplayName()).isEqualTo("Alice Anders");
+    }
+
+    private CommercialParty browseable(String idSuffix, String legalName, String customerNumber,
+            AccountStatus status) {
+        CommercialParty p = party(UUID.fromString("00000000-0000-0000-0000-0000000000" + idSuffix));
+        p.setLegalName(legalName);
+        p.setDisplayName(legalName);
+        p.setCustomerNumber(customerNumber);
+        p.setStatus(status);
+        return p;
+    }
+
+    @Test
+    void browseParties_filtersByName_caseInsensitiveContainsOnDisplayOrLegal() {
+        when(partyRepository.findAll()).thenReturn(List.of(
+                browseable("01", "Acme Industrial", "CUST-1", AccountStatus.ACTIVE),
+                browseable("02", "Beta Supplies", "CUST-2", AccountStatus.ACTIVE)));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of());
+
+        SearchPartiesResponse response =
+                service.browseParties(Pageable.unpaged(), "acme", null, null, null, null, null);
+
+        assertThat(response.getTotalCount()).isEqualTo(1);
+        assertThat(response.getResults()).extracting(SearchPartiesResponse.PartySummary::getLegalName)
+                .containsExactly("Acme Industrial");
+    }
+
+    @Test
+    void browseParties_filtersByStatusAndCustomerNumber() {
+        when(partyRepository.findAll()).thenReturn(List.of(
+                browseable("01", "Acme", "CUST-100", AccountStatus.ACTIVE),
+                browseable("02", "Beta", "CUST-200", AccountStatus.INACTIVE)));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of());
+
+        assertThat(service.browseParties(Pageable.unpaged(), null, "INACTIVE", null, null, null, null)
+                        .getResults())
+                .extracting(SearchPartiesResponse.PartySummary::getLegalName)
+                .containsExactly("Beta");
+
+        assertThat(service.browseParties(Pageable.unpaged(), null, null, null, "cust-100", null, null)
+                        .getResults())
+                .extracting(SearchPartiesResponse.PartySummary::getCustomerNumber)
+                .containsExactly("CUST-100");
+    }
+
+    @Test
+    void browseParties_filterAppliedBeforePaging_totalCountReflectsFilteredSize() {
+        when(partyRepository.findAll()).thenReturn(List.of(
+                browseable("01", "Acme One", "C1", AccountStatus.ACTIVE),
+                browseable("02", "Acme Two", "C2", AccountStatus.ACTIVE),
+                browseable("03", "Other Co", "C3", AccountStatus.ACTIVE)));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of());
+
+        SearchPartiesResponse response = service.browseParties(
+                PageRequest.of(0, 1), "acme", null, null, null, null, null);
+
+        // 2 match the filter; page size 1 -> one row, but totalCount is the filtered count.
+        assertThat(response.getTotalCount()).isEqualTo(2);
+        assertThat(response.getResults()).hasSize(1);
+    }
+
+    @Test
+    void browseParties_sortsByCustomerNumber_descending() {
+        when(partyRepository.findAll()).thenReturn(List.of(
+                browseable("01", "Acme", "CUST-001", AccountStatus.ACTIVE),
+                browseable("02", "Beta", "CUST-003", AccountStatus.ACTIVE),
+                browseable("03", "Gamma", "CUST-002", AccountStatus.ACTIVE)));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of());
+
+        SearchPartiesResponse response = service.browseParties(
+                Pageable.unpaged(), null, null, null, null, "customerNumber", "desc");
+
+        assertThat(response.getResults()).extracting(SearchPartiesResponse.PartySummary::getCustomerNumber)
+                .containsExactly("CUST-003", "CUST-002", "CUST-001");
+    }
+
+    @Test
+    void browseParties_nullFilterFields_doNotMatchOrThrow() {
+        CommercialParty noCustNo = browseable("01", "Acme", null, AccountStatus.ACTIVE);
+        when(partyRepository.findAll()).thenReturn(List.of(noCustNo));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of());
+
+        // filtering by customerNumber excludes the row whose customerNumber is null, no NPE
+        assertThat(service.browseParties(Pageable.unpaged(), null, null, null, "C", null, null)
+                        .getResults())
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds optional server-side filtering (name, status, partyType, customerNumber) and sorting (name|customerNumber, asc|desc) to `GET /v1/crm/accounts/parties`, applied to the unified commercial+individual list before paging. Powers the customer-directory rework (real paging + sort + filter).

## Changes

- `browseParties(pageable, name, status, partyType, customerNumber, sortField, sortOrder)` on `PartyService` + impl; filter/sort helpers operate on the unified `PartySummary` list (covers both party types). No-arg overload delegates.
- Controller adds the 6 filter/sort query params; `openapi.yaml` regenerated.
- Tests: service-level filter/sort coverage + controller param-forwarding; `CrmAccountsControllerTest` updated to the new signature.

## Contract

Read endpoint enhancement; no curated contract-rule change — the domain `BACKEND_CONTRACT_GUIDE.md` is unaffected (no new business rule, just additional optional query params surfaced in the generated OpenAPI). Downstream `@durion-sdk/customer` regenerated (sdk-angular #6) and revendored in the frontend (#49).

## Validation

- [x] compiles; pos-customer suites pass (42 service, 12 controller incl. new filter/sort + param-forwarding tests)
- [x] openapi regenerated with all 6 params

🤖 Generated with [Claude Code](https://claude.com/claude-code)
