### PR TITLE
[CAP:120] Add work-session submit endpoint (#687)

### DIFF
--- a/pos-people/openapi.yaml
+++ b/pos-people/openapi.yaml
@@ -504,6 +504,51 @@ paths:
         - people:role:assign
       x-required-permissions:
       - people:role:assign
+  /v1/people/workSessions/{id}/submit:
+    post:
+      tags:
+      - Work Sessions API
+      summary: Submit work session
+      description: Submit an ended work session with its billable and break totals for approval.
+      operationId: submitWorkSession
+      parameters:
+      - name: id
+        in: path
+        description: Work session ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+        example: 7b1f5a9d-0c2b-4c6d-9a5a-5f8e7c3a9b1c
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkSessionSubmitRequest'
+        required: true
+      responses:
+        '200':
+          description: Work session submitted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkSessionDto'
+        '404':
+          description: Work session not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkSessionDto'
+        '409':
+          description: Work session is not in a submittable state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkSessionDto'
+      security:
+      - bearerAuth: []
+      x-required-permissions:
+      - AUTHENTICATED
   /v1/people/workSessions/{id}/breaks/stop:
     post:
       tags:
@@ -2339,6 +2384,52 @@ components:
           format: uri
         properties:
           type: object
+    WorkSessionSubmitRequest:
+      type: object
+      description: Work session submit request body
+      properties:
+        billableMinutes:
+          type: integer
+          format: int32
+          description: Total billable minutes for the session
+        breakMinutes:
+          type: integer
+          format: int32
+          description: Total break minutes for the session
+        submittedAt:
+          type: string
+          format: date-time
+          description: Timestamp the session was submitted
+      required:
+      - billableMinutes
+      - breakMinutes
+      - submittedAt
+    WorkSessionDto:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          format: uuid
+        personId:
+          type: string
+          format: uuid
+        status:
+          type: string
+        startedAt:
+          type: string
+          format: date-time
+        endedAt:
+          type: string
+          format: date-time
+        billableMinutes:
+          type: integer
+          format: int32
+        breakMinutes:
+          type: integer
+          format: int32
+        submittedAt:
+          type: string
+          format: date-time
     BreakDto:
       type: object
       properties:
@@ -2364,23 +2455,6 @@ components:
           description: Actor performing the action
       required:
       - personId
-    WorkSessionDto:
-      type: object
-      properties:
-        sessionId:
-          type: string
-          format: uuid
-        personId:
-          type: string
-          format: uuid
-        status:
-          type: string
-        startedAt:
-          type: string
-          format: date-time
-        endedAt:
-          type: string
-          format: date-time
     LinkUserToPersonRequest:
       type: object
       properties:

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/WorkSessionController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/WorkSessionController.java
@@ -4,6 +4,7 @@ import com.positivity.events.EmitEvent;
 import com.positivity.people.internal.dto.BreakDto;
 import com.positivity.people.internal.dto.WorkSessionDto;
 import com.positivity.people.internal.dto.WorkSessionRequest;
+import com.positivity.people.internal.dto.WorkSessionSubmitRequest;
 import com.positivity.people.service.WorkSessionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -83,6 +84,27 @@ public class WorkSessionController {
                     UUID id) {
         log.info("Stopping break for work session ID(mask): {}", maskForLog(id));
         BreakDto response = workSessionService.stopBreak(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "Submit work session",
+            description = "Submit an ended work session with its billable and break totals for approval.")
+    @ApiResponse(responseCode = "200", description = "Work session submitted successfully.")
+    @ApiResponse(responseCode = "404", description = "Work session not found.")
+    @ApiResponse(responseCode = "409", description = "Work session is not in a submittable state.")
+    @EmitEvent(id = "PEOPLE_WORK_SESSION_SUBMIT", apiVersion = "1")
+    @PostMapping("/{id}/submit")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<WorkSessionDto> submitWorkSession(
+            @Parameter(description = "Work session ID", example = "7b1f5a9d-0c2b-4c6d-9a5a-5f8e7c3a9b1c")
+                    @PathVariable
+                    @NonNull
+                    UUID id,
+            @Parameter(description = "Work session submit request body") @Valid @RequestBody @NonNull
+                    WorkSessionSubmitRequest request) {
+        log.info("Submitting work session ID(mask): {}", maskForLog(id));
+        WorkSessionDto response = workSessionService.submitSession(id, request);
         return ResponseEntity.ok(response);
     }
 

--- a/pos-people/src/main/java/com/positivity/people/internal/dto/WorkSessionDto.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/dto/WorkSessionDto.java
@@ -15,6 +15,12 @@ public class WorkSessionDto {
 
     private Instant endedAt;
 
+    private Integer billableMinutes;
+
+    private Integer breakMinutes;
+
+    private Instant submittedAt;
+
     public WorkSessionDto() {}
 
     public WorkSessionDto(UUID sessionId, UUID personId, String status, Instant startedAt, Instant endedAt) {
@@ -63,5 +69,29 @@ public class WorkSessionDto {
 
     public void setEndedAt(Instant endedAt) {
         this.endedAt = endedAt;
+    }
+
+    public Integer getBillableMinutes() {
+        return billableMinutes;
+    }
+
+    public void setBillableMinutes(Integer billableMinutes) {
+        this.billableMinutes = billableMinutes;
+    }
+
+    public Integer getBreakMinutes() {
+        return breakMinutes;
+    }
+
+    public void setBreakMinutes(Integer breakMinutes) {
+        this.breakMinutes = breakMinutes;
+    }
+
+    public Instant getSubmittedAt() {
+        return submittedAt;
+    }
+
+    public void setSubmittedAt(Instant submittedAt) {
+        this.submittedAt = submittedAt;
     }
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/dto/WorkSessionSubmitRequest.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/dto/WorkSessionSubmitRequest.java
@@ -1,0 +1,47 @@
+package com.positivity.people.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.Instant;
+
+public class WorkSessionSubmitRequest {
+
+    @NotNull(message = "billableMinutes is required")
+    @PositiveOrZero(message = "billableMinutes must be zero or greater")
+    @Schema(description = "Total billable minutes for the session", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Integer billableMinutes;
+
+    @NotNull(message = "breakMinutes is required")
+    @PositiveOrZero(message = "breakMinutes must be zero or greater")
+    @Schema(description = "Total break minutes for the session", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Integer breakMinutes;
+
+    @NotNull(message = "submittedAt is required")
+    @Schema(description = "Timestamp the session was submitted", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Instant submittedAt;
+
+    public Integer getBillableMinutes() {
+        return billableMinutes;
+    }
+
+    public void setBillableMinutes(Integer billableMinutes) {
+        this.billableMinutes = billableMinutes;
+    }
+
+    public Integer getBreakMinutes() {
+        return breakMinutes;
+    }
+
+    public void setBreakMinutes(Integer breakMinutes) {
+        this.breakMinutes = breakMinutes;
+    }
+
+    public Instant getSubmittedAt() {
+        return submittedAt;
+    }
+
+    public void setSubmittedAt(Instant submittedAt) {
+        this.submittedAt = submittedAt;
+    }
+}

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/WorkSession.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/WorkSession.java
@@ -50,6 +50,15 @@ public class WorkSession {
     @Column(name = "actor", length = 128)
     private String actor;
 
+    @Column(name = "billable_minutes")
+    private Integer billableMinutes;
+
+    @Column(name = "break_minutes")
+    private Integer breakMinutes;
+
+    @Column(name = "submitted_at")
+    private Instant submittedAt;
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private Instant createdAt;

--- a/pos-people/src/main/java/com/positivity/people/internal/service/WorkSessionServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/WorkSessionServiceImpl.java
@@ -2,6 +2,7 @@ package com.positivity.people.internal.service;
 
 import com.positivity.people.internal.dto.BreakDto;
 import com.positivity.people.internal.dto.WorkSessionDto;
+import com.positivity.people.internal.dto.WorkSessionSubmitRequest;
 import com.positivity.people.internal.entity.WorkSession;
 import com.positivity.people.internal.entity.WorkSessionBreak;
 import com.positivity.people.internal.exception.WorkSessionNotFoundException;
@@ -28,6 +29,8 @@ public class WorkSessionServiceImpl implements WorkSessionService {
     private static final String STATUS_ACTIVE = "ACTIVE";
 
     private static final String STATUS_ENDED = "ENDED";
+
+    private static final String STATUS_SUBMITTED = "SUBMITTED";
 
     private static final String SYSTEM_USER = "system";
 
@@ -148,6 +151,30 @@ public class WorkSessionServiceImpl implements WorkSessionService {
         return toBreakDto(saved);
     }
 
+    @Override
+    public WorkSessionDto submitSession(@NonNull UUID sessionId, @NonNull WorkSessionSubmitRequest request) {
+        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        Objects.requireNonNull(request, "request must not be null");
+        String resolvedActor = resolveActorFromSecurityContext();
+
+        WorkSession session = workSessionRepository
+                .findById(sessionId)
+                .orElseThrow(() -> new WorkSessionNotFoundException("No work session found for sessionId=" + sessionId));
+
+        if (!STATUS_ENDED.equals(session.getStatus())) {
+            throw new IllegalStateException(
+                    "Only an ENDED session can be submitted; sessionId=" + sessionId + " status=" + session.getStatus());
+        }
+
+        session.setStatus(STATUS_SUBMITTED);
+        session.setBillableMinutes(request.getBillableMinutes());
+        session.setBreakMinutes(request.getBreakMinutes());
+        session.setSubmittedAt(request.getSubmittedAt());
+        session.setActor(resolvedActor);
+
+        return toWorkSessionDto(workSessionRepository.save(session));
+    }
+
     private String resolveActorFromSecurityContext() {
         return SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_USER);
     }
@@ -159,6 +186,9 @@ public class WorkSessionServiceImpl implements WorkSessionService {
         dto.setStatus(session.getStatus());
         dto.setStartedAt(session.getStartedAt());
         dto.setEndedAt(session.getEndedAt());
+        dto.setBillableMinutes(session.getBillableMinutes());
+        dto.setBreakMinutes(session.getBreakMinutes());
+        dto.setSubmittedAt(session.getSubmittedAt());
         return dto;
     }
 

--- a/pos-people/src/main/java/com/positivity/people/service/WorkSessionService.java
+++ b/pos-people/src/main/java/com/positivity/people/service/WorkSessionService.java
@@ -2,6 +2,7 @@ package com.positivity.people.service;
 
 import com.positivity.people.internal.dto.BreakDto;
 import com.positivity.people.internal.dto.WorkSessionDto;
+import com.positivity.people.internal.dto.WorkSessionSubmitRequest;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 
@@ -18,4 +19,7 @@ public interface WorkSessionService {
 
     @NonNull
     BreakDto stopBreak(@NonNull UUID sessionId);
+
+    @NonNull
+    WorkSessionDto submitSession(@NonNull UUID sessionId, @NonNull WorkSessionSubmitRequest request);
 }

--- a/pos-people/src/main/resources/db/migration/V6__add_work_session_submission.sql
+++ b/pos-people/src/main/resources/db/migration/V6__add_work_session_submission.sql
@@ -1,0 +1,4 @@
+-- Work-session submission (issue #687): persist submitted totals + timestamp.
+ALTER TABLE work_session ADD COLUMN billable_minutes integer;
+ALTER TABLE work_session ADD COLUMN break_minutes integer;
+ALTER TABLE work_session ADD COLUMN submitted_at timestamp(6) with time zone;

--- a/pos-people/src/test/java/com/positivity/people/contract/WorkSessionContractIT.java
+++ b/pos-people/src/test/java/com/positivity/people/contract/WorkSessionContractIT.java
@@ -230,6 +230,34 @@ class WorkSessionContractIT extends BaseContractIntegrationTest {
                 .andExpect(status().isConflict());
     }
 
+    @Test
+    @DisplayName("VE-120-005: submitting negative billableMinutes returns 400")
+    void VE_120_005_submitWorkSession_negativeMinutes_returns400() throws Exception {
+        String response = mockMvc.perform(withAuth(post("/v1/people/workSessions/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(START_PAYLOAD)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String sessionId = objectMapper.readTree(response).get("sessionId").asText();
+
+        String invalidPayload =
+                """
+				{
+				  "billableMinutes": -1,
+				  "breakMinutes": 0,
+				  "submittedAt": "2026-01-01T16:05:00Z"
+				}
+				""";
+
+        mockMvc.perform(withAuth(post("/v1/people/workSessions/" + sessionId + "/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidPayload)))
+                .andExpect(status().isBadRequest());
+    }
+
     private void ensurePersonExists(UUID personId, String firstName, String lastName) {
         if (personRepository.existsById(personId)) {
             return;

--- a/pos-people/src/test/java/com/positivity/people/contract/WorkSessionContractIT.java
+++ b/pos-people/src/test/java/com/positivity/people/contract/WorkSessionContractIT.java
@@ -146,6 +146,90 @@ class WorkSessionContractIT extends BaseContractIntegrationTest {
                 .andExpect(status().isNotFound());
     }
 
+    @Test
+    @DisplayName("CP-120-005: submit an ended work session returns 200 with SUBMITTED status and totals")
+    void CP_120_005_submitWorkSession_returns200() throws Exception {
+        mockMvc.perform(withAuth(post("/v1/people/workSessions/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(START_PAYLOAD)))
+                .andExpect(status().isOk());
+
+        String stopResponse = mockMvc.perform(withAuth(post("/v1/people/workSessions/stop")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(START_PAYLOAD)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String sessionId = objectMapper.readTree(stopResponse).get("sessionId").asText();
+
+        String submitPayload =
+                """
+				{
+				  "billableMinutes": 450,
+				  "breakMinutes": 30,
+				  "submittedAt": "2026-01-01T16:05:00Z"
+				}
+				""";
+
+        mockMvc.perform(withAuth(post("/v1/people/workSessions/" + sessionId + "/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitPayload)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUBMITTED"))
+                .andExpect(jsonPath("$.billableMinutes").value(450))
+                .andExpect(jsonPath("$.breakMinutes").value(30));
+    }
+
+    @Test
+    @DisplayName("VE-120-003: submitting a non-existent session returns 404")
+    void VE_120_003_submitWorkSession_nonExistentSession_returns404() throws Exception {
+        String submitPayload =
+                """
+				{
+				  "billableMinutes": 60,
+				  "breakMinutes": 0,
+				  "submittedAt": "2026-01-01T16:05:00Z"
+				}
+				""";
+
+        mockMvc.perform(withAuth(post(
+                                "/v1/people/workSessions/{id}/submit",
+                                UUID.fromString("99999999-9999-9999-9999-999999999999"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitPayload)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("VE-120-004: submitting an active (not ended) session returns 409")
+    void VE_120_004_submitWorkSession_notEnded_returns409() throws Exception {
+        String startResponse = mockMvc.perform(withAuth(post("/v1/people/workSessions/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(START_PAYLOAD)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String sessionId = objectMapper.readTree(startResponse).get("sessionId").asText();
+
+        String submitPayload =
+                """
+				{
+				  "billableMinutes": 60,
+				  "breakMinutes": 0,
+				  "submittedAt": "2026-01-01T16:05:00Z"
+				}
+				""";
+
+        mockMvc.perform(withAuth(post("/v1/people/workSessions/" + sessionId + "/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitPayload)))
+                .andExpect(status().isConflict());
+    }
+
     private void ensurePersonExists(UUID personId, String firstName, String lastName) {
         if (personRepository.existsById(personId)) {
             return;

--- a/pos-people/src/test/java/com/positivity/people/service/WorkSessionServiceTest.java
+++ b/pos-people/src/test/java/com/positivity/people/service/WorkSessionServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.positivity.people.internal.dto.BreakDto;
 import com.positivity.people.internal.dto.WorkSessionDto;
+import com.positivity.people.internal.dto.WorkSessionSubmitRequest;
 import com.positivity.people.internal.entity.Person;
 import com.positivity.people.internal.entity.WorkSession;
 import com.positivity.people.internal.entity.WorkSessionBreak;
@@ -277,6 +278,83 @@ class WorkSessionServiceTest {
             assertThat(result.getStatus()).isEqualTo("ENDED");
             verify(workSessionBreakRepository).save(any(WorkSessionBreak.class));
             assertThat(activeBreak.getEndedAt()).isNotNull();
+        }
+    }
+
+    @Test
+    void submitSession_whenSessionEnded_transitionsToSubmittedAndPersistsTotals() {
+        UUID sessionId = UUID.fromString("33333333-3333-3333-3333-333333333333");
+        WorkSession ended = new WorkSession();
+        ended.setSessionId(sessionId);
+        ended.setPerson(Person.builder().id(personId).build());
+        ended.setStatus("ENDED");
+        ended.setStartedAt(Instant.parse("2026-01-01T08:00:00Z"));
+        ended.setEndedAt(Instant.parse("2026-01-01T16:00:00Z"));
+
+        WorkSessionSubmitRequest request = new WorkSessionSubmitRequest();
+        request.setBillableMinutes(450);
+        request.setBreakMinutes(30);
+        request.setSubmittedAt(Instant.parse("2026-01-01T16:05:00Z"));
+
+        when(workSessionRepository.findById(sessionId)).thenReturn(Optional.of(ended));
+        when(workSessionRepository.save(any(WorkSession.class))).thenAnswer(i -> i.getArgument(0));
+
+        try (MockedStatic<SecurityContextHelper> helperMock = Mockito.mockStatic(SecurityContextHelper.class)) {
+            helperMock
+                    .when(() -> SecurityContextHelper.getCurrentUsernameOrDefault("system"))
+                    .thenReturn("worker.user");
+
+            WorkSessionDto result = service.submitSession(sessionId, request);
+
+            assertThat(result.getStatus()).isEqualTo("SUBMITTED");
+            assertThat(result.getBillableMinutes()).isEqualTo(450);
+            assertThat(result.getBreakMinutes()).isEqualTo(30);
+            assertThat(result.getSubmittedAt()).isEqualTo(Instant.parse("2026-01-01T16:05:00Z"));
+            verify(workSessionRepository).save(any(WorkSession.class));
+        }
+    }
+
+    @Test
+    void submitSession_whenSessionMissing_throwsWorkSessionNotFoundException() {
+        UUID missingId = UUID.fromString("44444444-4444-4444-4444-444444444444");
+        WorkSessionSubmitRequest request = new WorkSessionSubmitRequest();
+        request.setBillableMinutes(10);
+        request.setBreakMinutes(0);
+        request.setSubmittedAt(Instant.parse("2026-01-01T16:05:00Z"));
+        when(workSessionRepository.findById(missingId)).thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityContextHelper> helperMock = Mockito.mockStatic(SecurityContextHelper.class)) {
+            helperMock
+                    .when(() -> SecurityContextHelper.getCurrentUsernameOrDefault("system"))
+                    .thenReturn("worker.user");
+
+            assertThatThrownBy(() -> service.submitSession(missingId, request))
+                    .isInstanceOf(WorkSessionNotFoundException.class);
+        }
+    }
+
+    @Test
+    void submitSession_whenSessionNotEnded_throwsIllegalState() {
+        UUID sessionId = UUID.fromString("55555555-5555-5555-5555-555555555556");
+        WorkSession active = new WorkSession();
+        active.setSessionId(sessionId);
+        active.setPerson(Person.builder().id(personId).build());
+        active.setStatus("ACTIVE");
+
+        WorkSessionSubmitRequest request = new WorkSessionSubmitRequest();
+        request.setBillableMinutes(10);
+        request.setBreakMinutes(0);
+        request.setSubmittedAt(Instant.parse("2026-01-01T16:05:00Z"));
+        when(workSessionRepository.findById(sessionId)).thenReturn(Optional.of(active));
+
+        try (MockedStatic<SecurityContextHelper> helperMock = Mockito.mockStatic(SecurityContextHelper.class)) {
+            helperMock
+                    .when(() -> SecurityContextHelper.getCurrentUsernameOrDefault("system"))
+                    .thenReturn("worker.user");
+
+            assertThatThrownBy(() -> service.submitSession(sessionId, request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("ENDED");
         }
     }
 }


### PR DESCRIPTION
Closes #687.

## Problem
`WorkSessionController` exposed only `/start`, `/stop`, `/{id}/breaks/start|stop` — no `POST /{id}/submit`. The frontend work-session submit page (`PeopleService.submitWorkSession`) called a non-existent endpoint and 404'd.

## Change
- **`POST /v1/people/workSessions/{id}/submit`** — transitions an `ENDED` session to `SUBMITTED`, persisting `billableMinutes`, `breakMinutes`, `submittedAt`.
- `@PreAuthorize("isAuthenticated()")` — matches the sibling self-service start/stop/breaks endpoints (the worker submits their own session). Per #688 confirmation, period-level approval authorities (`people:timekeeping:*`) are separate and unchanged.
- `404` when the session does not exist, `409` when it is not `ENDED` (existing `PeopleExceptionHandler` mappings).
- Entity + **`V6__add_work_session_submission.sql`** add the three columns. `WorkSessionSubmitRequest` DTO has `@Schema` + jakarta validation; `WorkSessionDto` returns the submitted totals.
- Regenerated `pos-people/openapi.yaml`. SDK + frontend re-point follow.

## Tests
- `WorkSessionServiceTest` +3 (submit happy path, 404, 409).
- `WorkSessionContractIT` +3 (CP-120-005 submit 200, VE-120-003 404, VE-120-004 409). Full file green (9/9).

## Contract chain
Controller → OpenAPI regenerated (this PR) → SDK regen + frontend re-point tracked next. See BACKEND_CONTRACT_GUIDE.md.