### PR TITLE
fix(security): add people:timekeeping to perm-bits catalog (fixes Time Approval 403)

### DIFF
--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 10;
+    public static final int CATALOG_VERSION = 11;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -341,7 +341,19 @@ public final class GatewayPermissionCatalog {
         "PERM_people:timeException:create",                  // 324
         "PERM_people:timeException:resolve",                 // 325
         "PERM_people:timeException:view",                    // 326
-        "PERM_workorder:operationalContext:override"        // 327
+        "PERM_workorder:operationalContext:override",        // 327
+
+        // ── New batch (bits 328–337) ──────────────────────────────────────────
+        "PERM_Promotion:Apply",                              // 328
+        "PERM_Promotion:Manage",                             // 329
+        "PERM_Promotion:RecordRedemption",                   // 330
+        "PERM_Promotion:View",                               // 331
+        "PERM_Promotion:ViewRedemption",                     // 332
+        "PERM_TimeEntry:Approve",                            // 333
+        "PERM_TimeEntry:Reject",                             // 334
+        "PERM_people:timekeeping:approve",                   // 335
+        "PERM_people:timekeeping:reject",                    // 336
+        "PERM_people:timekeeping:view"                      // 337
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 10;
+    public static final int CATALOG_VERSION = 11;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -366,7 +366,19 @@ public final class DownstreamPermissionCatalog {
         "PERM_people:timeException:create",                  // 324
         "PERM_people:timeException:resolve",                 // 325
         "PERM_people:timeException:view",                    // 326
-        "PERM_workorder:operationalContext:override"         // 327
+        "PERM_workorder:operationalContext:override",         // 327
+
+        // ── New batch (bits 328–337) ──────────────────────────────────────────
+        "PERM_Promotion:Apply",                              // 328
+        "PERM_Promotion:Manage",                             // 329
+        "PERM_Promotion:RecordRedemption",                   // 330
+        "PERM_Promotion:View",                               // 331
+        "PERM_Promotion:ViewRedemption",                     // 332
+        "PERM_TimeEntry:Approve",                            // 333
+        "PERM_TimeEntry:Reject",                             // 334
+        "PERM_people:timekeeping:approve",                   // 335
+        "PERM_people:timekeeping:reject",                    // 336
+        "PERM_people:timekeeping:view"                      // 337
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -420,13 +420,28 @@ public enum PermissionCode {
     PEOPLE__TIMEEXCEPTION__VIEW(326, "people:timeException:view"),
 
     // ── Workorder (new) ────────────────────────────────────────────────────────
-    WORKORDER__OPERATIONALCONTEXT__OVERRIDE(327, "workorder:operationalContext:override");
+    WORKORDER__OPERATIONALCONTEXT__OVERRIDE(327, "workorder:operationalContext:override"),
+    // ── Promotion (new) ────────────────────────────────────────────────────────
+    PROMOTION__APPLY(328, "Promotion:Apply"),
+    PROMOTION__MANAGE(329, "Promotion:Manage"),
+    PROMOTION__RECORDREDEMPTION(330, "Promotion:RecordRedemption"),
+    PROMOTION__VIEW(331, "Promotion:View"),
+    PROMOTION__VIEWREDEMPTION(332, "Promotion:ViewRedemption"),
+
+    // ── Timeentry (new) ────────────────────────────────────────────────────────
+    TIMEENTRY__APPROVE(333, "TimeEntry:Approve"),
+    TIMEENTRY__REJECT(334, "TimeEntry:Reject"),
+
+    // ── People (new) ───────────────────────────────────────────────────────────
+    PEOPLE__TIMEKEEPING__APPROVE(335, "people:timekeeping:approve"),
+    PEOPLE__TIMEKEEPING__REJECT(336, "people:timekeeping:reject"),
+    PEOPLE__TIMEKEEPING__VIEW(337, "people:timekeeping:view");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 10;
+    public static final int CATALOG_VERSION = 11;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));


### PR DESCRIPTION
## Problem
The Time Approval page (`/app/people/timekeeping/approval`) returns **403** for `admin.alpha` (ROLE_ADMIN) on:
```
GET /api/people/v1/people/timekeeping/approvals/people => 403
GET /api/people/v1/people/timekeeping/time-periods     => 403
```
The endpoints exist and are deployed (403, not 404 — #664 is complete).

## Root cause
Authorization is transmitted gateway→service via the compact `X-Perm-Bits` header:
- pos-api-gateway expands a user's roles to authorities and encodes them as bits against `GatewayPermissionCatalog`.
- Downstream services decode against `DownstreamPermissionCatalog` (`GatewayAuthoritiesFilter`).

`people:timekeeping:view/approve/reject` were **never added to either catalog**, despite #686 granting them to ROLE_ADMIN and pos-people registering them in `permissions.yaml`. With no bit, the gateway silently drops the authority → `@PreAuthorize("hasAuthority('people:timekeeping:view')")` fails → 403. #686 was incomplete.

## Fix
Ran `scripts/generate-permissions.py --sync`, which appended the 10 registered-but-uncataloged permissions and bumped `CATALOG_VERSION` 10→11 across the three synced files:
- `people:timekeeping:approve/reject/view` (bits 335–337) — the actual fix.
- `Promotion:*`, `TimeEntry:Approve/Reject` — already-merged endpoints with the same latent 403; the generator catalogs all drift in one pass.

Bit indices are append-only; existing bits unchanged. `permissions.yaml` files were already up to date (no per-module changes).

## Tests
`pos-security-common` 16/16 on a clean build (incl. `GatewayAuthoritiesFilterTest`, `DownstreamPermissionCatalogTest`). Gateway catalog tests green.

## ⚠️ Deploy — fleet-coordinated
`CATALOG_VERSION` 10→11 is a breaking handshake. `GatewayAuthoritiesFilter` **fails closed** when `X-Perm-Ver != local CATALOG_VERSION`. So **api-gateway + every pos-\* service must deploy together**; any service left on v10 will 403 all perm-bits requests until upgraded. Pairs with the pending #687 pos-people deploy.

## Verify after deploy
1. Time Approval page loads employees + pay periods (no 403).
2. approve/reject a period works.