### PR TITLE
test(security): fix catalog guard tests for CATALOG_VERSION 11 (#700 follow-up)

### DIFF
--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1164,13 +1164,13 @@ class SecurityGatewayConfigTest {
         // ── Task-2: new catalog version + extended array tests ───────────────────
 
         @Test
-        @DisplayName("CATALOG_VERSION is 10")
-        void catalogVersionIsTen() {
-                assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(10);
+        @DisplayName("CATALOG_VERSION is 11")
+        void catalogVersionIsEleven() {
+                assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(11);
         }
 
         @Test
-        @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 327")
+        @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 337")
         void authorityByBitCoversNewEntries() {
                 // batch-2: previously missing (bits 241-261)
                 assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1190,8 +1190,15 @@ class SecurityGatewayConfigTest {
                                 .isEqualTo("PERM_accounting:credit-memo:create");
                 assertThat(GatewayPermissionCatalog.authorityForBit(327))
                                 .isEqualTo("PERM_workorder:operationalContext:override");
+                // catalog v11: Promotion + TimeEntry + people:timekeeping (bits 328-337)
+                assertThat(GatewayPermissionCatalog.authorityForBit(328)).isEqualTo("PERM_Promotion:Apply");
+                assertThat(GatewayPermissionCatalog.authorityForBit(333)).isEqualTo("PERM_TimeEntry:Approve");
+                assertThat(GatewayPermissionCatalog.authorityForBit(335))
+                                .isEqualTo("PERM_people:timekeeping:approve");
+                assertThat(GatewayPermissionCatalog.authorityForBit(337))
+                                .isEqualTo("PERM_people:timekeeping:view");
                 // beyond array must return null
-                assertThat(GatewayPermissionCatalog.authorityForBit(328)).isNull();
+                assertThat(GatewayPermissionCatalog.authorityForBit(338)).isNull();
         }
 
         @Test

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,16 +32,16 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 328;
-    private static final int EXPECTED_CATALOG_VERSION = 10;
+    private static final int EXPECTED_PERMISSION_COUNT = 338;
+    private static final int EXPECTED_CATALOG_VERSION = 11;
 
     // -------------------------------------------------------------------------
-    // AC-1: Catalog size — 328 entries
+    // AC-1: Catalog size — 338 entries
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("catalog contains exactly 328 permissions")
-    void catalogContainsExactly328Permissions() {
+    @DisplayName("catalog contains exactly 338 permissions")
+    void catalogContainsExpectedPermissions() {
         assertThat(PermissionCode.values()).hasSize(EXPECTED_PERMISSION_COUNT);
     }
 
@@ -60,12 +60,12 @@ class PermissionCodeTest {
     }
 
     @Test
-    @DisplayName("bit indexes span from 0 to 327 with no gaps")
-    void bitIndexesSpanFrom0To327WithNoGaps() {
+    @DisplayName("bit indexes span from 0 to 337 with no gaps")
+    void bitIndexesSpanContiguouslyWithNoGaps() {
         Set<Integer> bitIndexes = Arrays.stream(PermissionCode.values())
                 .map(PermissionCode::bitIndex)
                 .collect(Collectors.toSet());
-        // Issue PERM-001: every index 0..327 must be present
+        // Issue PERM-001: every index 0..(count-1) must be present
         for (int i = 0; i < EXPECTED_PERMISSION_COUNT; i++) {
             assertThat(bitIndexes).as("bit index %d must be assigned", i).contains(i);
         }


### PR DESCRIPTION
#700 bumped the perm-bits catalog (CATALOG_VERSION 10→11, 328→338 permissions) to register `people:timekeeping:*` (+ already-merged Promotion/TimeEntry perms), but left guard tests pinned to the old values → CI red ([run 27760244941](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/27760244941)).

## Fixes
- **pos-api-gateway** `SecurityGatewayConfigTest`: `catalogVersionIsTen`→`catalogVersionIsEleven` (assert 11); `authorityByBitCoversNewEntries` now covers bits 328–337 (Promotion:Apply, TimeEntry:Approve, people:timekeeping:approve/view) and moves the null boundary 328→338.
- **pos-security-service** `PermissionCodeTest`: `EXPECTED_PERMISSION_COUNT` 328→338, `EXPECTED_CATALOG_VERSION` 10→11; refreshed stale display names/comments.

No production code change — guard tests catching up to the catalog. Assertions use the constants; only pinned literals + labels updated.

## Tests (clean builds)
- `SecurityGatewayConfigTest` 49/49
- `PermissionCodeTest` 11/11
- `pos-security-common` 16/16 (unaffected, re-confirmed earlier)