### PR TITLE
fix(security): scope perm-bits catalog to people:timekeeping (fix #700 over-reach)

### DIFF
--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -343,17 +343,10 @@ public final class GatewayPermissionCatalog {
         "PERM_people:timeException:view",                    // 326
         "PERM_workorder:operationalContext:override",        // 327
 
-        // ── New batch (bits 328–337) ──────────────────────────────────────────
-        "PERM_Promotion:Apply",                              // 328
-        "PERM_Promotion:Manage",                             // 329
-        "PERM_Promotion:RecordRedemption",                   // 330
-        "PERM_Promotion:View",                               // 331
-        "PERM_Promotion:ViewRedemption",                     // 332
-        "PERM_TimeEntry:Approve",                            // 333
-        "PERM_TimeEntry:Reject",                             // 334
-        "PERM_people:timekeeping:approve",                   // 335
-        "PERM_people:timekeeping:reject",                    // 336
-        "PERM_people:timekeeping:view"                      // 337
+        // ── People timekeeping approval (bits 328–330) ────────────────────────
+        "PERM_people:timekeeping:approve",                   // 328
+        "PERM_people:timekeeping:reject",                    // 329
+        "PERM_people:timekeeping:view"                      // 330
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1170,7 +1170,7 @@ class SecurityGatewayConfigTest {
         }
 
         @Test
-        @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 337")
+        @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 330")
         void authorityByBitCoversNewEntries() {
                 // batch-2: previously missing (bits 241-261)
                 assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1190,15 +1190,15 @@ class SecurityGatewayConfigTest {
                                 .isEqualTo("PERM_accounting:credit-memo:create");
                 assertThat(GatewayPermissionCatalog.authorityForBit(327))
                                 .isEqualTo("PERM_workorder:operationalContext:override");
-                // catalog v11: Promotion + TimeEntry + people:timekeeping (bits 328-337)
-                assertThat(GatewayPermissionCatalog.authorityForBit(328)).isEqualTo("PERM_Promotion:Apply");
-                assertThat(GatewayPermissionCatalog.authorityForBit(333)).isEqualTo("PERM_TimeEntry:Approve");
-                assertThat(GatewayPermissionCatalog.authorityForBit(335))
+                // catalog v11: people:timekeeping approval (bits 328-330)
+                assertThat(GatewayPermissionCatalog.authorityForBit(328))
                                 .isEqualTo("PERM_people:timekeeping:approve");
-                assertThat(GatewayPermissionCatalog.authorityForBit(337))
+                assertThat(GatewayPermissionCatalog.authorityForBit(329))
+                                .isEqualTo("PERM_people:timekeeping:reject");
+                assertThat(GatewayPermissionCatalog.authorityForBit(330))
                                 .isEqualTo("PERM_people:timekeeping:view");
                 // beyond array must return null
-                assertThat(GatewayPermissionCatalog.authorityForBit(338)).isNull();
+                assertThat(GatewayPermissionCatalog.authorityForBit(331)).isNull();
         }
 
         @Test

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -368,17 +368,10 @@ public final class DownstreamPermissionCatalog {
         "PERM_people:timeException:view",                    // 326
         "PERM_workorder:operationalContext:override",         // 327
 
-        // ── New batch (bits 328–337) ──────────────────────────────────────────
-        "PERM_Promotion:Apply",                              // 328
-        "PERM_Promotion:Manage",                             // 329
-        "PERM_Promotion:RecordRedemption",                   // 330
-        "PERM_Promotion:View",                               // 331
-        "PERM_Promotion:ViewRedemption",                     // 332
-        "PERM_TimeEntry:Approve",                            // 333
-        "PERM_TimeEntry:Reject",                             // 334
-        "PERM_people:timekeeping:approve",                   // 335
-        "PERM_people:timekeeping:reject",                    // 336
-        "PERM_people:timekeeping:view"                      // 337
+        // ── People timekeeping approval (bits 328–330) ────────────────────────
+        "PERM_people:timekeeping:approve",                   // 328
+        "PERM_people:timekeeping:reject",                    // 329
+        "PERM_people:timekeeping:view"                      // 330
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -421,21 +421,10 @@ public enum PermissionCode {
 
     // ── Workorder (new) ────────────────────────────────────────────────────────
     WORKORDER__OPERATIONALCONTEXT__OVERRIDE(327, "workorder:operationalContext:override"),
-    // ── Promotion (new) ────────────────────────────────────────────────────────
-    PROMOTION__APPLY(328, "Promotion:Apply"),
-    PROMOTION__MANAGE(329, "Promotion:Manage"),
-    PROMOTION__RECORDREDEMPTION(330, "Promotion:RecordRedemption"),
-    PROMOTION__VIEW(331, "Promotion:View"),
-    PROMOTION__VIEWREDEMPTION(332, "Promotion:ViewRedemption"),
-
-    // ── Timeentry (new) ────────────────────────────────────────────────────────
-    TIMEENTRY__APPROVE(333, "TimeEntry:Approve"),
-    TIMEENTRY__REJECT(334, "TimeEntry:Reject"),
-
-    // ── People (new) ───────────────────────────────────────────────────────────
-    PEOPLE__TIMEKEEPING__APPROVE(335, "people:timekeeping:approve"),
-    PEOPLE__TIMEKEEPING__REJECT(336, "people:timekeeping:reject"),
-    PEOPLE__TIMEKEEPING__VIEW(337, "people:timekeeping:view");
+    // ── People timekeeping approval (new) ────────────────────────────────────────
+    PEOPLE__TIMEKEEPING__APPROVE(328, "people:timekeeping:approve"),
+    PEOPLE__TIMEKEEPING__REJECT(329, "people:timekeeping:reject"),
+    PEOPLE__TIMEKEEPING__VIEW(330, "people:timekeeping:view");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 338;
+    private static final int EXPECTED_PERMISSION_COUNT = 331;
     private static final int EXPECTED_CATALOG_VERSION = 11;
 
     // -------------------------------------------------------------------------
-    // AC-1: Catalog size — 338 entries
+    // AC-1: Catalog size — 331 entries
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("catalog contains exactly 338 permissions")
+    @DisplayName("catalog contains exactly 331 permissions")
     void catalogContainsExpectedPermissions() {
         assertThat(PermissionCode.values()).hasSize(EXPECTED_PERMISSION_COUNT);
     }
@@ -60,7 +60,7 @@ class PermissionCodeTest {
     }
 
     @Test
-    @DisplayName("bit indexes span from 0 to 337 with no gaps")
+    @DisplayName("bit indexes span from 0 to 330 with no gaps")
     void bitIndexesSpanContiguouslyWithNoGaps() {
         Set<Integer> bitIndexes = Arrays.stream(PermissionCode.values())
                 .map(PermissionCode::bitIndex)


### PR DESCRIPTION
## Problem
#700's `generate-permissions.py --sync` appended **10** permissions to the catalog, but 7 (`Promotion:*` ×5, `TimeEntry:Approve/Reject`) are PascalCase cross-domain refs scraped from `@PreAuthorize` that **no module's `permissions.yaml` owns/registers**. That broke `PermissionBitIndexTest.allCatalogPermissionsGetCorrectBitIndexWhenRegistered` — registering all `PermissionCode.values()` yielded 331 successes of 338 (the 7 orphans fail registration). CI red ([run 27760951706](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/27760951706)).

## Fix
Keep only the 3 permissions this work actually needs and that ARE registered (pos-people `permissions.yaml`): `people:timekeeping:approve/reject/view` at bits **328–330**. `CATALOG_VERSION` stays **11** (328→331 perms). Removed the 7 orphan entries from `PermissionCode`, `GatewayPermissionCatalog`, `DownstreamPermissionCatalog`; updated the guard tests.

The `Promotion:*` / `TimeEntry:*` `@PreAuthorize` refs stay uncataloged — a **pre-existing** inconsistency (those endpoints already 403'd before #700, and pre-#700 CI was green with them absent). Out of scope; worth a separate cleanup issue.

## Tests (clean builds)
- pos-api-gateway `SecurityGatewayConfigTest` ✓
- pos-security-common 16/16
- pos-security-service `PermissionCodeTest` + `PermissionBitIndexTest` 22/22

## Deploy
Unchanged from #700: `CATALOG_VERSION` 10→11 is fleet-coordinated (api-gateway + all pos-* together; fail-closed on version mismatch).