### PR TITLE
fix(security): accept camelCase permission names + CI catalog drift gate

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -73,6 +73,26 @@ jobs:
             fi
           done
 
+  validate-permissions:
+    name: Validate Permission Catalog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Check @PreAuthorize permissions are registered in the catalog
+        run: |
+          # Fails if any @PreAuthorize permission is missing from PermissionCode /
+          # GatewayPermissionCatalog / DownstreamPermissionCatalog. Run
+          # `scripts/generate-permissions.sh --sync` locally and commit the result
+          # (note: a catalog change bumps CATALOG_VERSION = fleet-coordinated deploy).
+          scripts/generate-permissions.sh --sync --check
+
   pr-comment:
     name: PR Summary Comment
     runs-on: ubuntu-latest

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 11;
+    public static final int CATALOG_VERSION = 12;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -346,7 +346,16 @@ public final class GatewayPermissionCatalog {
         // ── People timekeeping approval (bits 328–330) ────────────────────────
         "PERM_people:timekeeping:approve",                   // 328
         "PERM_people:timekeeping:reject",                    // 329
-        "PERM_people:timekeeping:view"                      // 330
+        "PERM_people:timekeeping:view",                      // 330
+
+        // ── New batch (bits 331–337) ──────────────────────────────────────────
+        "PERM_Promotion:Apply",                              // 331
+        "PERM_Promotion:Manage",                             // 332
+        "PERM_Promotion:RecordRedemption",                   // 333
+        "PERM_Promotion:View",                               // 334
+        "PERM_Promotion:ViewRedemption",                     // 335
+        "PERM_TimeEntry:Approve",                            // 336
+        "PERM_TimeEntry:Reject"                             // 337
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1164,13 +1164,13 @@ class SecurityGatewayConfigTest {
         // ── Task-2: new catalog version + extended array tests ───────────────────
 
         @Test
-        @DisplayName("CATALOG_VERSION is 11")
-        void catalogVersionIsEleven() {
-                assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(11);
+        @DisplayName("CATALOG_VERSION is 12")
+        void catalogVersionIsTwelve() {
+                assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(12);
         }
 
         @Test
-        @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 330")
+        @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 337")
         void authorityByBitCoversNewEntries() {
                 // batch-2: previously missing (bits 241-261)
                 assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1190,15 +1190,15 @@ class SecurityGatewayConfigTest {
                                 .isEqualTo("PERM_accounting:credit-memo:create");
                 assertThat(GatewayPermissionCatalog.authorityForBit(327))
                                 .isEqualTo("PERM_workorder:operationalContext:override");
-                // catalog v11: people:timekeeping approval (bits 328-330)
+                // catalog v12: people:timekeeping (328-330), Promotion/TimeEntry (331-337)
                 assertThat(GatewayPermissionCatalog.authorityForBit(328))
                                 .isEqualTo("PERM_people:timekeeping:approve");
-                assertThat(GatewayPermissionCatalog.authorityForBit(329))
-                                .isEqualTo("PERM_people:timekeeping:reject");
                 assertThat(GatewayPermissionCatalog.authorityForBit(330))
                                 .isEqualTo("PERM_people:timekeeping:view");
+                assertThat(GatewayPermissionCatalog.authorityForBit(331)).isEqualTo("PERM_Promotion:Apply");
+                assertThat(GatewayPermissionCatalog.authorityForBit(337)).isEqualTo("PERM_TimeEntry:Reject");
                 // beyond array must return null
-                assertThat(GatewayPermissionCatalog.authorityForBit(331)).isNull();
+                assertThat(GatewayPermissionCatalog.authorityForBit(338)).isNull();
         }
 
         @Test

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 11;
+    public static final int CATALOG_VERSION = 12;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -371,7 +371,16 @@ public final class DownstreamPermissionCatalog {
         // ── People timekeeping approval (bits 328–330) ────────────────────────
         "PERM_people:timekeeping:approve",                   // 328
         "PERM_people:timekeeping:reject",                    // 329
-        "PERM_people:timekeeping:view"                      // 330
+        "PERM_people:timekeeping:view",                      // 330
+
+        // ── New batch (bits 331–337) ──────────────────────────────────────────
+        "PERM_Promotion:Apply",                              // 331
+        "PERM_Promotion:Manage",                             // 332
+        "PERM_Promotion:RecordRedemption",                   // 333
+        "PERM_Promotion:View",                               // 334
+        "PERM_Promotion:ViewRedemption",                     // 335
+        "PERM_TimeEntry:Approve",                            // 336
+        "PERM_TimeEntry:Reject"                             // 337
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -424,13 +424,23 @@ public enum PermissionCode {
     // ── People timekeeping approval (new) ────────────────────────────────────────
     PEOPLE__TIMEKEEPING__APPROVE(328, "people:timekeeping:approve"),
     PEOPLE__TIMEKEEPING__REJECT(329, "people:timekeeping:reject"),
-    PEOPLE__TIMEKEEPING__VIEW(330, "people:timekeeping:view");
+    PEOPLE__TIMEKEEPING__VIEW(330, "people:timekeeping:view"),
+    // ── Promotion (new) ────────────────────────────────────────────────────────
+    PROMOTION__APPLY(331, "Promotion:Apply"),
+    PROMOTION__MANAGE(332, "Promotion:Manage"),
+    PROMOTION__RECORDREDEMPTION(333, "Promotion:RecordRedemption"),
+    PROMOTION__VIEW(334, "Promotion:View"),
+    PROMOTION__VIEWREDEMPTION(335, "Promotion:ViewRedemption"),
+
+    // ── Timeentry (new) ────────────────────────────────────────────────────────
+    TIMEENTRY__APPROVE(336, "TimeEntry:Approve"),
+    TIMEENTRY__REJECT(337, "TimeEntry:Reject");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 11;
+    public static final int CATALOG_VERSION = 12;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PermissionRegistryServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PermissionRegistryServiceImpl.java
@@ -37,11 +37,12 @@ public class PermissionRegistryServiceImpl implements PermissionRegistryService 
     /**
      * Pattern for validating permission names: domain:resource:action (3-segment)
      * or domain:action (2-segment legacy format).
-     * Segments must start lowercase and may then include mixed-case alphanumeric
-     * characters, underscores, and hyphens.
+     * Each segment starts with a letter (lower- or upper-case, so camelCase and
+     * PascalCase domains like {@code Promotion:Apply} are accepted) and may then
+     * include mixed-case alphanumeric characters, underscores, and hyphens.
      */
     public static final Pattern PERMISSION_PATTERN =
-            Pattern.compile("^[a-z][A-Za-z0-9_-]*:[a-z][A-Za-z0-9_-]*(:[a-z][A-Za-z0-9_-]*)?$");
+            Pattern.compile("^[A-Za-z][A-Za-z0-9_-]*:[A-Za-z][A-Za-z0-9_-]*(:[A-Za-z][A-Za-z0-9_-]*)?$");
 
     /**
      * Register or update permissions from a service manifest.
@@ -115,7 +116,7 @@ public class PermissionRegistryServiceImpl implements PermissionRegistryService 
             ProcessingCounters counters) {
         errors.add(
                 "Invalid permission name format: " + permDef.getName()
-                        + " (must match 'domain:resource:action' or legacy 'domain:action' format; each segment must start lowercase and may include mixed-case letters, digits, underscores, and hyphens)");
+                        + " (must match 'domain:resource:action' or legacy 'domain:action' format; each segment must start with a letter and may include mixed-case letters, digits, underscores, and hyphens)");
         return incrementSkipped(counters);
     }
 

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 331;
-    private static final int EXPECTED_CATALOG_VERSION = 11;
+    private static final int EXPECTED_PERMISSION_COUNT = 338;
+    private static final int EXPECTED_CATALOG_VERSION = 12;
 
     // -------------------------------------------------------------------------
-    // AC-1: Catalog size — 331 entries
+    // AC-1: Catalog size — 338 entries
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("catalog contains exactly 331 permissions")
+    @DisplayName("catalog contains exactly 338 permissions")
     void catalogContainsExpectedPermissions() {
         assertThat(PermissionCode.values()).hasSize(EXPECTED_PERMISSION_COUNT);
     }
@@ -60,7 +60,7 @@ class PermissionCodeTest {
     }
 
     @Test
-    @DisplayName("bit indexes span from 0 to 330 with no gaps")
+    @DisplayName("bit indexes span from 0 to 337 with no gaps")
     void bitIndexesSpanContiguouslyWithNoGaps() {
         Set<Integer> bitIndexes = Arrays.stream(PermissionCode.values())
                 .map(PermissionCode::bitIndex)

--- a/pos-security-service/src/test/java/com/positivity/securityservice/service/PermissionRegistryServiceImplTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/service/PermissionRegistryServiceImplTest.java
@@ -78,6 +78,11 @@ class PermissionRegistryServiceImplTest {
                 .isTrue();
         assertThat(permissionRegistryService.isValidPermissionName("people:userLink:view"))
                 .isTrue();
+        // PascalCase/camelCase domains are accepted (e.g. Promotion:Apply, TimeEntry:Approve)
+        assertThat(permissionRegistryService.isValidPermissionName("Promotion:Apply"))
+                .isTrue();
+        assertThat(permissionRegistryService.isValidPermissionName("TimeEntry:Approve"))
+                .isTrue();
         assertThat(permissionRegistryService.isValidPermissionName("INVALID")).isFalse();
         assertThat(permissionRegistryService.getPermissionsByDomain("pricing")).hasSize(1);
         assertThat(permissionRegistryService.getAllPermissions()).hasSize(1);


### PR DESCRIPTION
Follow-up to #700/#702. Makes the permission tooling self-managing so catalog drift can't silently reach prod (the cause of the `people:timekeeping` 403).

## 1. Accept camelCase/PascalCase permission names
`PermissionRegistryServiceImpl.PERMISSION_PATTERN` required every segment to **start lowercase** (`^[a-z]…`), so the registration validator rejected `Promotion:Apply` / `TimeEntry:Approve`. That's why those 7 `@PreAuthorize` perms failed to register and #702 had to exclude them from the catalog. Relaxed to `^[A-Za-z]…` per segment — PascalCase/camelCase domains are now valid (lowercase still valid; `INVALID`/empty/null still rejected).

## 2. Re-sync the catalog
`generate-permissions.py --sync` re-adds the 7 now-valid perms: `Promotion:*` (bits 331–335), `TimeEntry:Approve/Reject` (336–337). **CATALOG_VERSION 11 → 12.** `people:timekeeping` stays 328–330.

## 3. CI drift gate
New `validate-permissions` job in `pr-checks.yml` runs `scripts/generate-permissions.sh --sync --check` — **fails the PR if any `@PreAuthorize` permission isn't in the catalog.** This is the guard that was missing: `generate-openapi.sh` only runs the generator *without* `--sync` (refreshes `permissions.yaml` but not the bit catalog / version), so additions like `people:timekeeping` silently never got a bit. The gate closes that loop without auto-bumping the version (which stays a deliberate, reviewed, fleet-coordinated action).

## Tests (clean builds)
- pos-security-service `PermissionCodeTest` + `PermissionBitIndexTest` + `PermissionRegistryServiceImplTest` **34/34** (registration now succeeds for all 338)
- pos-api-gateway `SecurityGatewayConfigTest` **49/49**
- pos-security-common **16/16**
- `--sync --check` gate passes locally (exit 0)

## Deploy
`CATALOG_VERSION` → **12**, fleet-coordinated (api-gateway + all pos-* together; fail-closed on version mismatch). Supersedes the pending v11 deploy from #700/#702 — deploy once at v12.