### PR TITLE
docs(openapi): @Schema + validation on pos-location DTOs (#699 Wave 1)

### DIFF
--- a/pos-location/openapi.yaml
+++ b/pos-location/openapi.yaml
@@ -1387,372 +1387,671 @@ components:
   schemas:
     CoverageRuleResponse:
       type: object
+      description: Response payload describing a mobile unit coverage rule
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the coverage rule
+          example: 01960003-0000-7000-8000-000000000001
         mobileUnitId:
           type: string
           format: uuid
+          description: Identifier of the mobile unit this rule belongs to
+          example: 01960003-0000-7000-8000-000000000002
         serviceAreaId:
           type: string
           format: uuid
+          description: Identifier of the service area this rule applies to
+          example: 01960003-0000-7000-8000-000000000003
         ruleType:
           type: string
+          description: Type of coverage rule
+          example: INCLUDE
         priority:
           type: integer
           format: int32
+          description: Evaluation priority of the rule (lower is evaluated first)
+          example: 1
         validFrom:
           type: string
           format: date
+          description: Date from which the rule is effective
+          example: 2026-06-18
         validTo:
           type: string
           format: date
+          description: Date until which the rule is effective
+          example: 2026-12-31
         maxDistance:
           type: number
+          description: Maximum service distance in kilometres covered by the rule
+          example: 25.5
+      required:
+      - id
+      - mobileUnitId
+      - serviceAreaId
     HolidayClosureRequest:
       type: object
+      description: A single holiday closure entry for a location
       properties:
         date:
           type: string
           format: date
+          description: Date on which the location is closed
+          example: 2026-12-25
         reason:
           type: string
+          description: Human-readable reason for the closure
+          example: Christmas Day
+      required:
+      - date
     LocationRequestDTO:
       type: object
       description: Location object to be created
       properties:
         name:
           type: string
+          description: Display name of the location
+          example: Downtown Service Center
           minLength: 1
         code:
           type: string
+          description: Unique business code of the location
+          example: LOC-001
           minLength: 1
         geographicalLocationId:
           type: string
           format: uuid
+          description: Identifier of the associated geographical location
+          example: 01960003-0000-7000-8000-000000000001
         addressLine1:
           type: string
+          description: First line of the street address
+          example: 123 Main St
         addressLine2:
           type: string
+          description: Second line of the street address
+          example: Suite 200
         city:
           type: string
+          description: City of the location
+          example: Springfield
         state:
           type: string
+          description: State or province of the location
+          example: IL
         postalCode:
           type: string
+          description: Postal or ZIP code of the location
+          example: '62704'
         country:
           type: string
+          description: Country of the location
+          example: US
         mailingAddress:
           type: string
+          description: Mailing address of the location
+          example: PO Box 100
         active:
           type: boolean
+          description: Whether the location is active
+          example: true
         responsiblePersonId:
           type: integer
           format: int64
+          description: Identifier of the person responsible for the location
+          example: 1001
         timezone:
           type: string
+          description: IANA timezone identifier for the location
+          example: America/Chicago
         operatingHours:
           type: array
+          description: Weekly operating hours for the location
           items:
             $ref: '#/components/schemas/OperatingHoursRequest'
         holidayClosures:
           type: array
+          description: Holiday closures for the location
           items:
             $ref: '#/components/schemas/HolidayClosureRequest'
         checkInBufferMinutes:
           type: integer
           format: int32
+          description: Buffer minutes reserved before appointments for check-in
+          example: 15
         cleanupBufferMinutes:
           type: integer
           format: int32
+          description: Buffer minutes reserved after appointments for cleanup
+          example: 10
         type:
           $ref: '#/components/schemas/LocationTypeDTO'
         parents:
           type: object
+          description: Map of parent relationships keyed by relationship type
+          example:
+            ORGANIZATIONAL: 01960003-0000-7000-8000-000000000002
       required:
       - code
       - name
       - type
     LocationTypeDTO:
       type: object
+      description: Location type classification reference
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the location type
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Name of the location type
+          example: STORE
         description:
           type: string
+          description: Description of the location type
+          example: Retail storefront with point-of-sale operations
     OperatingHoursRequest:
       type: object
+      description: A single operating-hours entry for a day of the week
       properties:
         dayOfWeek:
           type: string
+          description: Day of week the hours apply to
+          example: MONDAY
+          minLength: 1
         openTime:
           type: string
+          description: Opening time (local time)
+          example: 08:00
         closeTime:
           type: string
+          description: Closing time (local time)
+          example: 1020
+      required:
+      - dayOfWeek
     LocationResponseDTO:
       type: object
+      description: Response payload describing a location
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the location
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Display name of the location
+          example: Downtown Service Center
         code:
           type: string
+          description: Unique business code of the location
+          example: LOC-001
         geographicalLocationId:
           type: string
           format: uuid
+          description: Identifier of the associated geographical location
+          example: 01960003-0000-7000-8000-000000000002
         addressLine1:
           type: string
+          description: First line of the street address
+          example: 123 Main St
         addressLine2:
           type: string
+          description: Second line of the street address
+          example: Suite 200
         city:
           type: string
+          description: City of the location
+          example: Springfield
         state:
           type: string
+          description: State or province of the location
+          example: IL
         postalCode:
           type: string
+          description: Postal or ZIP code of the location
+          example: '62704'
         country:
           type: string
+          description: Country of the location
+          example: US
         mailingAddress:
           type: string
+          description: Mailing address of the location
+          example: PO Box 100
         active:
           type: boolean
+          description: Whether the location is active
+          example: true
         responsiblePersonId:
           type: integer
           format: int64
+          description: Identifier of the person responsible for the location
+          example: 1001
         type:
           $ref: '#/components/schemas/LocationTypeDTO'
+      required:
+      - active
+      - id
+      - name
     SiteDefaultsRequest:
       type: object
+      description: Request payload for configuring default storage locations for a site
       properties:
         defaultStagingLocationId:
           type: string
           format: uuid
+          description: Identifier of the default staging storage location
+          example: 01960003-0000-7000-8000-000000000001
         defaultQuarantineLocationId:
           type: string
           format: uuid
+          description: Identifier of the default quarantine storage location
+          example: 01960003-0000-7000-8000-000000000002
     SiteDefaultsResponse:
       type: object
+      description: Response payload describing default storage location configuration for a site
       properties:
         siteId:
           type: string
           format: uuid
+          description: Identifier of the site
+          example: 01960003-0000-7000-8000-000000000001
         defaultStagingLocationId:
           type: string
           format: uuid
+          description: Identifier of the default staging storage location
+          example: 01960003-0000-7000-8000-000000000002
         defaultQuarantineLocationId:
           type: string
           format: uuid
+          description: Identifier of the default quarantine storage location
+          example: 01960003-0000-7000-8000-000000000003
+      required:
+      - siteId
     TravelBufferPolicyRequest:
       type: object
+      description: Request payload for creating or updating a travel buffer policy
       properties:
         name:
           type: string
+          description: Display name of the travel buffer policy
+          example: Standard Metro Buffer
+          minLength: 1
         bufferType:
           type: string
+          description: Type of buffer the policy applies
+          example: FIXED_MINUTES
+          minLength: 1
         bufferValue:
           type: number
+          description: Numeric value of the buffer (interpretation depends on buffer type)
+          example: 30
         notes:
           type: string
+          description: Free-text notes about the policy
+          example: Applies during peak hours only
+      required:
+      - bufferType
+      - name
     TravelBufferPolicyResponse:
       type: object
+      description: Response payload describing a travel buffer policy
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the travel buffer policy
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Display name of the travel buffer policy
+          example: Standard Metro Buffer
         bufferType:
           type: string
+          description: Type of buffer the policy applies
+          example: FIXED_MINUTES
         bufferValue:
           type: number
+          description: Numeric value of the buffer (interpretation depends on buffer type)
+          example: 30
         notes:
           type: string
+          description: Free-text notes about the policy
+          example: Applies during peak hours only
         createdAt:
           type: string
           format: date-time
+          description: Timestamp when the policy was created (ISO 8601)
+          example: 2026-06-18 08:00:00+00:00
         updatedAt:
           type: string
           format: date-time
+          description: Timestamp when the policy was last updated (ISO 8601)
+          example: 2026-06-18 08:00:00+00:00
+      required:
+      - id
     PostalCodeEntry:
       type: object
+      description: A postal code entry within a service area
       properties:
         postalCode:
           type: string
+          description: Postal or ZIP code
+          example: '62704'
+          minLength: 1
         countryCode:
           type: string
+          description: ISO 3166-1 alpha-2 country code
+          example: US
+      required:
+      - postalCode
     ServiceAreaRequest:
       type: object
+      description: Request payload for creating or updating a service area
       properties:
         name:
           type: string
+          description: Display name of the service area
+          example: North Metro
+          minLength: 1
         description:
           type: string
+          description: Description of the service area
+          example: Northern metropolitan coverage zone
         active:
           type: boolean
+          description: Whether the service area is active
+          example: true
         postalCodes:
           type: array
+          description: Postal codes included in the service area
           items:
             $ref: '#/components/schemas/PostalCodeEntry'
+      required:
+      - name
     ServiceAreaResponse:
       type: object
+      description: Response payload describing a service area
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the service area
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Display name of the service area
+          example: North Metro
         description:
           type: string
+          description: Description of the service area
+          example: Northern metropolitan coverage zone
         active:
           type: boolean
+          description: Whether the service area is active
+          example: true
         postalCodes:
           type: array
+          description: Postal codes included in the service area
           items:
             $ref: '#/components/schemas/PostalCodeEntry'
         createdAt:
           type: string
           format: date-time
+          description: Timestamp when the service area was created (ISO 8601)
+          example: 2026-06-18 08:00:00+00:00
         updatedAt:
           type: string
           format: date-time
+          description: Timestamp when the service area was last updated (ISO 8601)
+          example: 2026-06-18 08:00:00+00:00
+      required:
+      - id
     CoverageRuleRequest:
       type: object
+      description: Request payload defining a coverage rule for a mobile unit
       properties:
         serviceAreaId:
           type: string
           format: uuid
+          description: Identifier of the service area this rule applies to
+          example: 01960003-0000-7000-8000-000000000001
         ruleType:
           type: string
+          description: Type of coverage rule
+          example: INCLUDE
+          minLength: 1
         priority:
           type: integer
           format: int32
+          description: Evaluation priority of the rule (lower is evaluated first)
+          example: 1
         validFrom:
           type: string
           format: date
+          description: Date from which the rule is effective
+          example: 2026-06-18
         validTo:
           type: string
           format: date
+          description: Date until which the rule is effective
+          example: 2026-12-31
         maxDistance:
           type: number
+          description: Maximum service distance in kilometres covered by the rule
+          example: 25.5
+      required:
+      - ruleType
+      - serviceAreaId
     MobileUnitRequest:
       type: object
       description: Mobile unit creation request body
       properties:
         name:
           type: string
+          description: Display name of the mobile unit
+          example: Van 7
+          minLength: 1
         baseLocationId:
           type: string
           format: uuid
+          description: Identifier of the base location the mobile unit operates from
+          example: 01960003-0000-7000-8000-000000000001
         status:
           type: string
+          description: Operational status of the mobile unit
+          example: ACTIVE
         travelBufferPolicyId:
           type: string
           format: uuid
+          description: Identifier of the travel buffer policy applied to the mobile unit
+          example: 01960003-0000-7000-8000-000000000002
         notes:
           type: string
+          description: Free-text notes about the mobile unit
+          example: Equipped with hydraulic lift
         capabilityIds:
           type: array
+          description: Identifiers of capabilities the mobile unit can perform
+          example:
+          - 01960003-0000-7000-8000-000000000010
           items:
             type: string
         coverageRules:
           type: array
+          description: Coverage rules defining where the mobile unit can operate
           items:
             $ref: '#/components/schemas/CoverageRuleRequest'
+      required:
+      - name
     MobileUnitResponse:
       type: object
+      description: Response payload describing a mobile unit
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the mobile unit
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Display name of the mobile unit
+          example: Van 7
         baseLocationId:
           type: string
           format: uuid
+          description: Identifier of the base location the mobile unit operates from
+          example: 01960003-0000-7000-8000-000000000002
         status:
           type: string
+          description: Operational status of the mobile unit
+          example: ACTIVE
         travelBufferPolicyId:
           type: string
           format: uuid
+          description: Identifier of the travel buffer policy applied to the mobile unit
+          example: 01960003-0000-7000-8000-000000000003
         notes:
           type: string
+          description: Free-text notes about the mobile unit
+          example: Equipped with hydraulic lift
         capabilityIds:
           type: array
+          description: Identifiers of capabilities the mobile unit can perform
+          example:
+          - 01960003-0000-7000-8000-000000000010
           items:
             type: string
         createdAt:
           type: string
           format: date-time
+          description: Timestamp when the mobile unit was created (ISO 8601)
+          example: 2026-06-18 08:00:00+00:00
         updatedAt:
           type: string
           format: date-time
+          description: Timestamp when the mobile unit was last updated (ISO 8601)
+          example: 2026-06-18 08:00:00+00:00
+      required:
+      - id
     StorageLocationRequest:
       type: object
+      description: Request payload for creating a storage location
       properties:
         name:
           type: string
+          description: Display name of the storage location
+          example: Aisle 3 Bin 12
+          minLength: 1
         barcode:
           type: string
+          description: Barcode identifying the storage location
+          example: SL-000312
         type:
           type: string
+          description: Type classification of the storage location
           enum:
           - FLOOR
           - SHELF
           - BIN
           - CAGE
           - TRUCK
+          example: BIN
         parentStorageLocationId:
           type: string
           format: uuid
+          description: Identifier of the parent storage location
+          example: 01960003-0000-7000-8000-000000000001
         capacity:
           type: object
+          description: Capacity attributes of the storage location
+          example:
+            maxUnits: 100
         temperature:
           type: object
+          description: Temperature attributes of the storage location
+          example:
+            min: 2
+            max: 8
+            unit: C
+      required:
+      - name
+      - type
     StorageLocationResponse:
       type: object
+      description: Response payload describing a storage location
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the storage location
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Display name of the storage location
+          example: Aisle 3 Bin 12
         barcode:
           type: string
+          description: Barcode identifying the storage location
+          example: SL-000312
         type:
           type: string
+          description: Type classification of the storage location
           enum:
           - FLOOR
           - SHELF
           - BIN
           - CAGE
           - TRUCK
+          example: BIN
         status:
           type: string
+          description: Operational status of the storage location
+          example: ACTIVE
         siteId:
           type: string
           format: uuid
+          description: Identifier of the site that owns the storage location
+          example: 01960003-0000-7000-8000-000000000002
         parentStorageLocationId:
           type: string
           format: uuid
+          description: Identifier of the parent storage location
+          example: 01960003-0000-7000-8000-000000000003
         capacity:
           type: object
+          description: Capacity attributes of the storage location
+          example:
+            maxUnits: 100
         temperature:
           type: object
+          description: Temperature attributes of the storage location
+          example:
+            min: 2
+            max: 8
+            unit: C
         inventoryCount:
           type: integer
           format: int32
+          description: Count of inventory items stored at the location
+          example: 42
+      required:
+      - id
+      - inventoryCount
     BayCapacityRequest:
       type: object
+      description: Capacity configuration for a service bay
       properties:
         maxConcurrentVehicles:
           type: integer
           format: int32
+          description: Maximum number of vehicles that can be serviced concurrently in the bay
+          example: 2
           minimum: 1
       required:
       - maxConcurrentVehicles
@@ -1762,75 +2061,130 @@ components:
       properties:
         name:
           type: string
+          description: Display name of the bay
+          example: Bay A1
           minLength: 1
         bayType:
           type: string
+          description: Type classification of the bay
+          example: LIFT
           minLength: 1
         capacity:
           $ref: '#/components/schemas/BayCapacityRequest'
         maxConcurrentVehicles:
           type: integer
           format: int32
+          description: Maximum number of vehicles that can be serviced concurrently in the bay
+          example: 2
+          minimum: 1
         serviceCapabilityIds:
           type: array
+          description: Identifiers of service capabilities supported by the bay
+          example:
+          - 01960003-0000-7000-8000-000000000010
           items:
             type: string
         skillRequirementIds:
           type: array
+          description: Identifiers of skills required to operate the bay
+          example:
+          - 01960003-0000-7000-8000-000000000020
           items:
             type: string
         status:
           type: string
+          description: Operational status of the bay
+          example: ACTIVE
       required:
       - bayType
       - capacity
       - name
     BayResponse:
       type: object
+      description: Response payload describing a service bay
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the bay
+          example: 01960003-0000-7000-8000-000000000001
         locationId:
           type: string
           format: uuid
+          description: Identifier of the location that owns the bay
+          example: 01960003-0000-7000-8000-000000000002
         name:
           type: string
+          description: Display name of the bay
+          example: Bay A1
         bayType:
           type: string
+          description: Type classification of the bay
+          example: LIFT
         status:
           type: string
+          description: Operational status of the bay
+          example: ACTIVE
         maxConcurrentVehicles:
           type: integer
           format: int32
+          description: Maximum number of vehicles that can be serviced concurrently in the bay
+          example: 2
         serviceCapabilityIds:
           type: array
+          description: Identifiers of service capabilities supported by the bay
+          example:
+          - 01960003-0000-7000-8000-000000000010
           items:
             type: string
         skillRequirementIds:
           type: array
+          description: Identifiers of skills required to operate the bay
+          example:
+          - 01960003-0000-7000-8000-000000000020
           items:
             type: string
         createdAt:
           type: string
           format: date-time
+          description: Timestamp when the bay was created (ISO 8601)
+          example: 2026-06-18 08:00:00+00:00
         lastModifiedAt:
           type: string
           format: date-time
+          description: Timestamp when the bay was last modified (ISO 8601)
+          example: 2026-06-18 08:00:00+00:00
+      required:
+      - id
+      - locationId
+      - name
     LocationParentResponseDTO:
       type: object
+      description: Response payload describing a parent relationship of a location
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the parent relationship record
+          example: 01960003-0000-7000-8000-000000000001
         parentId:
           type: string
           format: uuid
+          description: Identifier of the parent location
+          example: 01960003-0000-7000-8000-000000000002
         childId:
           type: string
           format: uuid
+          description: Identifier of the child location
+          example: 01960003-0000-7000-8000-000000000003
         parentType:
           type: string
+          description: Type of the parent relationship
+          example: ORGANIZATIONAL
+      required:
+      - childId
+      - id
+      - parentId
     BulkIngestRequestLocationBulkIngestRecord:
       type: object
       properties:
@@ -1853,31 +2207,54 @@ components:
       - records
     LocationBulkIngestRecord:
       type: object
+      description: A single location record within a bulk ingest request
       properties:
         name:
           type: string
+          description: Display name of the location
+          example: Downtown Service Center
           minLength: 1
         code:
           type: string
+          description: Unique business code of the location
+          example: LOC-001
           minLength: 1
         addressLine1:
           type: string
+          description: First line of the street address
+          example: 123 Main St
         addressLine2:
           type: string
+          description: Second line of the street address
+          example: Suite 200
         city:
           type: string
+          description: City of the location
+          example: Springfield
         stateOrProvince:
           type: string
+          description: State or province of the location
+          example: IL
         postalCode:
           type: string
+          description: Postal or ZIP code of the location
+          example: '62704'
         countryCode:
           type: string
+          description: ISO 3166-1 alpha-2 country code
+          example: US
         phoneNumber:
           type: string
+          description: Primary phone number for the location
+          example: +1-217-555-0100
         active:
           type: boolean
+          description: Whether the location is active
+          example: true
         locationTypeName:
           type: string
+          description: Name of the location type to resolve during ingest
+          example: STORE
       required:
       - code
       - name
@@ -1914,90 +2291,152 @@ components:
           type: string
     StorageLocationPatchRequest:
       type: object
+      description: Partial update payload for a storage location; null fields are left unchanged
       properties:
         name:
           type: string
+          description: Display name of the storage location
+          example: Aisle 3 Bin 12
         barcode:
           type: string
+          description: Barcode identifying the storage location
+          example: SL-000312
         status:
           type: string
+          description: Operational status of the storage location
           enum:
           - ACTIVE
           - INACTIVE
           - MAINTENANCE
           - QUARANTINED
+          example: ACTIVE
         parentStorageLocationId:
           type: string
           format: uuid
+          description: Identifier of the parent storage location
+          example: 01960003-0000-7000-8000-000000000001
         destinationStorageLocationId:
           type: string
           format: uuid
+          description: Identifier of the destination storage location for relocation operations
+          example: 01960003-0000-7000-8000-000000000002
         capacity:
           type: object
+          description: Capacity attributes of the storage location
+          example:
+            maxUnits: 100
         temperature:
           type: object
+          description: Temperature attributes of the storage location
+          example:
+            min: 2
+            max: 8
+            unit: C
     LocationPatchRequest:
       type: object
       description: Partial location payload
       properties:
         name:
           type: string
+          description: Display name of the location
+          example: Downtown Service Center
         status:
           type: string
+          description: Operational status of the location
+          example: ACTIVE
         timezone:
           type: string
+          description: IANA timezone identifier for the location
+          example: America/Chicago
         operatingHours:
           type: array
+          description: Weekly operating hours for the location
           items:
             $ref: '#/components/schemas/OperatingHoursRequest'
         holidayClosures:
           type: array
+          description: Holiday closures for the location
           items:
             $ref: '#/components/schemas/HolidayClosureRequest'
         checkInBufferMinutes:
           type: integer
           format: int32
+          description: Buffer minutes reserved before appointments for check-in
+          example: 15
         cleanupBufferMinutes:
           type: integer
           format: int32
+          description: Buffer minutes reserved after appointments for cleanup
+          example: 10
     BayPatchRequest:
       type: object
+      description: Partial update payload for a service bay; null fields are left unchanged
       properties:
         name:
           type: string
+          description: Display name of the bay
+          example: Bay A1
         bayType:
           type: string
+          description: Type classification of the bay
+          example: LIFT
         status:
           type: string
+          description: Operational status of the bay
+          example: ACTIVE
         maxConcurrentVehicles:
           type: integer
           format: int32
+          description: Maximum number of vehicles that can be serviced concurrently in the bay
+          example: 2
+          minimum: 1
         capacity:
           $ref: '#/components/schemas/BayCapacityRequest'
         serviceCapabilityIds:
           type: array
+          description: Identifiers of service capabilities supported by the bay
+          example:
+          - 01960003-0000-7000-8000-000000000010
           items:
             type: string
         skillRequirementIds:
           type: array
+          description: Identifiers of skills required to operate the bay
+          example:
+          - 01960003-0000-7000-8000-000000000020
           items:
             type: string
     StorageLocationValidationResponseDTO:
       type: object
+      description: Validation result for a storage location lookup
       properties:
         storageLocationId:
           type: string
           format: uuid
+          description: Identifier of the storage location that was validated
+          example: 01960003-0000-7000-8000-000000000001
         siteId:
           type: string
           format: uuid
+          description: Identifier of the site that owns the storage location
+          example: 01960003-0000-7000-8000-000000000002
         exists:
           type: boolean
+          description: Whether the storage location exists
+          example: true
         active:
           type: boolean
+          description: Whether the storage location is active
+          example: true
         maxUnitCapacity:
           type: integer
           format: int32
+          description: Maximum unit capacity of the storage location
+          example: 100
+      required:
+      - active
+      - exists
+      - storageLocationId
     PageMobileUnitResponse:
       type: object
       properties:
@@ -2059,18 +2498,29 @@ components:
           type: boolean
     EligibleMobileUnitResponse:
       type: object
+      description: Response payload describing a mobile unit eligible to cover a request
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the mobile unit
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Display name of the mobile unit
+          example: Van 7
         baseLocationId:
           type: string
           format: uuid
+          description: Identifier of the base location the mobile unit operates from
+          example: 01960003-0000-7000-8000-000000000002
         priority:
           type: integer
           format: int32
+          description: Coverage priority of the mobile unit for the requested area (lower is preferred)
+          example: 1
+      required:
+      - id
     Pageable:
       type: object
       properties:
@@ -2120,73 +2570,130 @@ components:
           type: boolean
     StorageLocationTopologyResponse:
       type: object
+      description: Lightweight flat projection of a storage location for topology consumers
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the storage location
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Display name of the storage location
+          example: Aisle 3 Bin 12
         type:
           type: string
+          description: Type classification of the storage location
           enum:
           - FLOOR
           - SHELF
           - BIN
           - CAGE
           - TRUCK
+          example: BIN
         status:
           type: string
+          description: Operational status of the storage location
+          example: ACTIVE
         parentStorageLocationId:
           type: string
           format: uuid
+          description: Identifier of the parent storage location
+          example: 01960003-0000-7000-8000-000000000002
+      required:
+      - id
     LocationValidationResponseDTO:
       type: object
+      description: Validation result for a location lookup
       properties:
         locationId:
           type: string
           format: uuid
+          description: Identifier of the location that was validated
+          example: 01960003-0000-7000-8000-000000000001
         exists:
           type: boolean
+          description: Whether the location exists
+          example: true
         active:
           type: boolean
+          description: Whether the location is active
+          example: true
+      required:
+      - active
+      - exists
+      - locationId
     PersonDTO:
       type: object
+      description: Person reference associated with a location
       properties:
         id:
           type: integer
           format: int64
+          description: Unique identifier of the person
+          example: 1001
         firstName:
           type: string
+          description: First name of the person
+          example: Jane
         lastName:
           type: string
+          description: Last name of the person
+          example: Doe
         primaryEmail:
           type: string
+          description: Primary email address of the person
+          example: jane.doe@example.com
         secondaryEmail:
           type: string
+          description: Secondary email address of the person
+          example: jane.d@example.com
         phoneNumbers:
           type: array
+          description: Phone numbers associated with the person
+          example:
+          - +1-217-555-0100
           items:
             type: string
         username:
           type: string
+          description: Login username of the person
+          example: jdoe
     LocationDescendantResponseDTO:
       type: object
+      description: Flat projection of a descendant location within a hierarchy traversal
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the descendant location
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Display name of the location
+          example: Downtown Service Center
         code:
           type: string
+          description: Unique business code of the location
+          example: LOC-001
         status:
           type: string
+          description: Operational status of the location
+          example: ACTIVE
         parentId:
           type: string
           format: uuid
+          description: Identifier of the immediate parent of this location within the traversed chain
+          example: 01960003-0000-7000-8000-000000000002
         depth:
           type: integer
           format: int32
+          description: Distance from the requested root location (1 = direct child)
+          example: 2
+      required:
+      - depth
+      - id
+      - name
     PageBayResponse:
       type: object
       properties:
@@ -2221,21 +2728,36 @@ components:
           type: boolean
     LocationRef:
       type: object
+      description: Lightweight location reference for reconciliation roster consumers
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the location
+          example: 01960003-0000-7000-8000-000000000001
         name:
           type: string
+          description: Display name of the location
+          example: Downtown Service Center
         code:
           type: string
+          description: Unique business code of the location
+          example: LOC-001
         status:
           type: string
+          description: Operational status of the location
+          example: ACTIVE
         hrLocationId:
           type: string
+          description: Identifier of the location in the HR system of record
+          example: HR-1001
         updatedAt:
           type: string
           format: date-time
+          description: Timestamp when the location was last updated (ISO 8601)
+          example: 2026-06-18 08:00:00+00:00
+      required:
+      - id
     PageLocationRef:
       type: object
       properties:

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/BayCapacityRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/BayCapacityRequest.java
@@ -1,5 +1,8 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -16,8 +19,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Capacity configuration for a service bay")
 public class BayCapacityRequest {
 
+    @Schema(
+            description = "Maximum number of vehicles that can be serviced concurrently in the bay",
+            example = "2",
+            requiredMode = REQUIRED)
     @NotNull
     @Min(1)
     private Integer maxConcurrentVehicles;

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/BayPatchRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/BayPatchRequest.java
@@ -1,6 +1,11 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,13 +22,38 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Partial update payload for a service bay; null fields are left unchanged")
 public class BayPatchRequest {
 
+    @Schema(description = "Display name of the bay", example = "Bay A1", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(description = "Type classification of the bay", example = "LIFT", requiredMode = NOT_REQUIRED)
     private String bayType;
+
+    @Schema(description = "Operational status of the bay", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
+
+    @Schema(
+            description = "Maximum number of vehicles that can be serviced concurrently in the bay",
+            example = "2",
+            requiredMode = NOT_REQUIRED)
+    @Min(1)
     private Integer maxConcurrentVehicles;
+
+    @Schema(description = "Capacity configuration for the bay", requiredMode = NOT_REQUIRED)
+    @Valid
     private BayCapacityRequest capacity;
+
+    @Schema(
+            description = "Identifiers of service capabilities supported by the bay",
+            example = "[\"01960003-0000-7000-8000-000000000010\"]",
+            requiredMode = NOT_REQUIRED)
     private List<String> serviceCapabilityIds;
+
+    @Schema(
+            description = "Identifiers of skills required to operate the bay",
+            example = "[\"01960003-0000-7000-8000-000000000020\"]",
+            requiredMode = NOT_REQUIRED)
     private List<String> skillRequirementIds;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/BayRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/BayRequest.java
@@ -1,7 +1,12 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -20,20 +25,41 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Request payload for creating a service bay")
 public class BayRequest {
 
+    @Schema(description = "Display name of the bay", example = "Bay A1", requiredMode = REQUIRED)
     @NotBlank
     private String name;
 
+    @Schema(description = "Type classification of the bay", example = "LIFT", requiredMode = REQUIRED)
     @NotBlank
     private String bayType;
 
+    @Schema(description = "Capacity configuration for the bay", requiredMode = REQUIRED)
     @NotNull
     @Valid
     private BayCapacityRequest capacity;
 
+    @Schema(
+            description = "Maximum number of vehicles that can be serviced concurrently in the bay",
+            example = "2",
+            requiredMode = NOT_REQUIRED)
+    @Min(1)
     private Integer maxConcurrentVehicles;
+
+    @Schema(
+            description = "Identifiers of service capabilities supported by the bay",
+            example = "[\"01960003-0000-7000-8000-000000000010\"]",
+            requiredMode = NOT_REQUIRED)
     private List<String> serviceCapabilityIds;
+
+    @Schema(
+            description = "Identifiers of skills required to operate the bay",
+            example = "[\"01960003-0000-7000-8000-000000000020\"]",
+            requiredMode = NOT_REQUIRED)
     private List<String> skillRequirementIds;
+
+    @Schema(description = "Operational status of the bay", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/BayResponse.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/BayResponse.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -17,16 +22,60 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Response payload describing a service bay")
 public class BayResponse {
 
+    @Schema(
+            description = "Unique identifier of the bay",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(
+            description = "Identifier of the location that owns the bay",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID locationId;
+
+    @Schema(description = "Display name of the bay", example = "Bay A1", requiredMode = REQUIRED)
+    @NotNull
     private String name;
+
+    @Schema(description = "Type classification of the bay", example = "LIFT", requiredMode = NOT_REQUIRED)
     private String bayType;
+
+    @Schema(description = "Operational status of the bay", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
+
+    @Schema(
+            description = "Maximum number of vehicles that can be serviced concurrently in the bay",
+            example = "2",
+            requiredMode = NOT_REQUIRED)
     private Integer maxConcurrentVehicles;
+
+    @Schema(
+            description = "Identifiers of service capabilities supported by the bay",
+            example = "[\"01960003-0000-7000-8000-000000000010\"]",
+            requiredMode = NOT_REQUIRED)
     private List<String> serviceCapabilityIds;
+
+    @Schema(
+            description = "Identifiers of skills required to operate the bay",
+            example = "[\"01960003-0000-7000-8000-000000000020\"]",
+            requiredMode = NOT_REQUIRED)
     private List<String> skillRequirementIds;
+
+    @Schema(
+            description = "Timestamp when the bay was created (ISO 8601)",
+            example = "2026-06-18T08:00:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant createdAt;
+
+    @Schema(
+            description = "Timestamp when the bay was last modified (ISO 8601)",
+            example = "2026-06-18T08:00:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant lastModifiedAt;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/CoverageRuleRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/CoverageRuleRequest.java
@@ -1,5 +1,12 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -17,12 +24,43 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Request payload defining a coverage rule for a mobile unit")
 public class CoverageRuleRequest {
 
+    @Schema(
+            description = "Identifier of the service area this rule applies to",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID serviceAreaId;
+
+    @Schema(description = "Type of coverage rule", example = "INCLUDE", requiredMode = REQUIRED)
+    @NotBlank
     private String ruleType;
+
+    @Schema(
+            description = "Evaluation priority of the rule (lower is evaluated first)",
+            example = "1",
+            requiredMode = NOT_REQUIRED)
+    @PositiveOrZero
     private Integer priority;
+
+    @Schema(
+            description = "Date from which the rule is effective",
+            example = "2026-06-18",
+            requiredMode = NOT_REQUIRED)
     private LocalDate validFrom;
+
+    @Schema(
+            description = "Date until which the rule is effective",
+            example = "2026-12-31",
+            requiredMode = NOT_REQUIRED)
     private LocalDate validTo;
+
+    @Schema(
+            description = "Maximum service distance in kilometres covered by the rule",
+            example = "25.5",
+            requiredMode = NOT_REQUIRED)
+    @PositiveOrZero
     private BigDecimal maxDistance;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/CoverageRuleResponse.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/CoverageRuleResponse.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -17,14 +22,54 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Response payload describing a mobile unit coverage rule")
 public class CoverageRuleResponse {
 
+    @Schema(
+            description = "Unique identifier of the coverage rule",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(
+            description = "Identifier of the mobile unit this rule belongs to",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID mobileUnitId;
+
+    @Schema(
+            description = "Identifier of the service area this rule applies to",
+            example = "01960003-0000-7000-8000-000000000003",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID serviceAreaId;
+
+    @Schema(description = "Type of coverage rule", example = "INCLUDE", requiredMode = NOT_REQUIRED)
     private String ruleType;
+
+    @Schema(
+            description = "Evaluation priority of the rule (lower is evaluated first)",
+            example = "1",
+            requiredMode = NOT_REQUIRED)
     private Integer priority;
+
+    @Schema(
+            description = "Date from which the rule is effective",
+            example = "2026-06-18",
+            requiredMode = NOT_REQUIRED)
     private LocalDate validFrom;
+
+    @Schema(
+            description = "Date until which the rule is effective",
+            example = "2026-12-31",
+            requiredMode = NOT_REQUIRED)
     private LocalDate validTo;
+
+    @Schema(
+            description = "Maximum service distance in kilometres covered by the rule",
+            example = "25.5",
+            requiredMode = NOT_REQUIRED)
     private BigDecimal maxDistance;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/EligibleMobileUnitResponse.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/EligibleMobileUnitResponse.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,10 +20,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Response payload describing a mobile unit eligible to cover a request")
 public class EligibleMobileUnitResponse {
 
+    @Schema(
+            description = "Unique identifier of the mobile unit",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(description = "Display name of the mobile unit", example = "Van 7", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(
+            description = "Identifier of the base location the mobile unit operates from",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID baseLocationId;
+
+    @Schema(
+            description = "Coverage priority of the mobile unit for the requested area (lower is preferred)",
+            example = "1",
+            requiredMode = NOT_REQUIRED)
     private Integer priority;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/HolidayClosureRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/HolidayClosureRequest.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +20,19 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "A single holiday closure entry for a location")
 public class HolidayClosureRequest {
+
+    @Schema(
+            description = "Date on which the location is closed",
+            example = "2026-12-25",
+            requiredMode = REQUIRED)
+    @NotNull
     private LocalDate date;
+
+    @Schema(
+            description = "Human-readable reason for the closure",
+            example = "Christmas Day",
+            requiredMode = NOT_REQUIRED)
     private String reason;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/LocationBulkIngestRecord.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/LocationBulkIngestRecord.java
@@ -1,24 +1,51 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
+/**
+ * Single record within a bulk location ingest request.
+ */
 @Data
+@Schema(description = "A single location record within a bulk ingest request")
 public class LocationBulkIngestRecord {
 
+    @Schema(description = "Display name of the location", example = "Downtown Service Center", requiredMode = REQUIRED)
     @NotBlank
     private String name;
 
+    @Schema(description = "Unique business code of the location", example = "LOC-001", requiredMode = REQUIRED)
     @NotBlank
     private String code;
 
+    @Schema(description = "First line of the street address", example = "123 Main St", requiredMode = NOT_REQUIRED)
     private String addressLine1;
+
+    @Schema(description = "Second line of the street address", example = "Suite 200", requiredMode = NOT_REQUIRED)
     private String addressLine2;
+
+    @Schema(description = "City of the location", example = "Springfield", requiredMode = NOT_REQUIRED)
     private String city;
+
+    @Schema(description = "State or province of the location", example = "IL", requiredMode = NOT_REQUIRED)
     private String stateOrProvince;
+
+    @Schema(description = "Postal or ZIP code of the location", example = "62704", requiredMode = NOT_REQUIRED)
     private String postalCode;
+
+    @Schema(description = "ISO 3166-1 alpha-2 country code", example = "US", requiredMode = NOT_REQUIRED)
     private String countryCode;
+
+    @Schema(description = "Primary phone number for the location", example = "+1-217-555-0100", requiredMode = NOT_REQUIRED)
     private String phoneNumber;
+
+    @Schema(description = "Whether the location is active", example = "true", requiredMode = NOT_REQUIRED)
     private Boolean active;
+
+    @Schema(description = "Name of the location type to resolve during ingest", example = "STORE", requiredMode = NOT_REQUIRED)
     private String locationTypeName;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/LocationDescendantResponseDTO.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/LocationDescendantResponseDTO.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,16 +21,37 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Flat projection of a descendant location within a hierarchy traversal")
 public class LocationDescendantResponseDTO {
 
+    @Schema(
+            description = "Unique identifier of the descendant location",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(description = "Display name of the location", example = "Downtown Service Center", requiredMode = REQUIRED)
+    @NotNull
     private String name;
+
+    @Schema(description = "Unique business code of the location", example = "LOC-001", requiredMode = NOT_REQUIRED)
     private String code;
+
+    @Schema(description = "Operational status of the location", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
 
     /** Immediate parent of this location within the traversed chain. */
+    @Schema(
+            description = "Identifier of the immediate parent of this location within the traversed chain",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID parentId;
 
     /** Distance from the requested root location (1 = direct child). */
+    @Schema(
+            description = "Distance from the requested root location (1 = direct child)",
+            example = "2",
+            requiredMode = REQUIRED)
     private int depth;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/LocationParentResponseDTO.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/LocationParentResponseDTO.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,9 +15,30 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Response payload describing a parent relationship of a location")
 public class LocationParentResponseDTO {
+
+    @Schema(
+            description = "Unique identifier of the parent relationship record",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(
+            description = "Identifier of the parent location",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID parentId;
+
+    @Schema(
+            description = "Identifier of the child location",
+            example = "01960003-0000-7000-8000-000000000003",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID childId;
+
+    @Schema(description = "Type of the parent relationship", example = "ORGANIZATIONAL", requiredMode = NOT_REQUIRED)
     private String parentType;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/LocationPatchRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/LocationPatchRequest.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,12 +20,37 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Partial update payload for a location; null fields are left unchanged")
 public class LocationPatchRequest {
+
+    @Schema(description = "Display name of the location", example = "Downtown Service Center", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(description = "Operational status of the location", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
+
+    @Schema(description = "IANA timezone identifier for the location", example = "America/Chicago", requiredMode = NOT_REQUIRED)
     private String timezone;
+
+    @Schema(description = "Weekly operating hours for the location", requiredMode = NOT_REQUIRED)
+    @Valid
     private List<OperatingHoursRequest> operatingHours;
+
+    @Schema(description = "Holiday closures for the location", requiredMode = NOT_REQUIRED)
+    @Valid
     private List<HolidayClosureRequest> holidayClosures;
+
+    @Schema(
+            description = "Buffer minutes reserved before appointments for check-in",
+            example = "15",
+            requiredMode = NOT_REQUIRED)
+    @PositiveOrZero
     private Integer checkInBufferMinutes;
+
+    @Schema(
+            description = "Buffer minutes reserved after appointments for cleanup",
+            example = "10",
+            requiredMode = NOT_REQUIRED)
+    @PositiveOrZero
     private Integer cleanupBufferMinutes;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/LocationRef.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/LocationRef.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -16,12 +21,34 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Lightweight location reference for reconciliation roster consumers")
 public class LocationRef {
 
+    @Schema(
+            description = "Unique identifier of the location",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(description = "Display name of the location", example = "Downtown Service Center", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(description = "Unique business code of the location", example = "LOC-001", requiredMode = NOT_REQUIRED)
     private String code;
+
+    @Schema(description = "Operational status of the location", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
+
+    @Schema(
+            description = "Identifier of the location in the HR system of record",
+            example = "HR-1001",
+            requiredMode = NOT_REQUIRED)
     private String hrLocationId;
+
+    @Schema(
+            description = "Timestamp when the location was last updated (ISO 8601)",
+            example = "2026-06-18T08:00:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant updatedAt;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/LocationRequestDTO.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/LocationRequestDTO.java
@@ -1,8 +1,14 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -16,31 +22,86 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Request payload for creating or updating a location")
 public class LocationRequestDTO {
+
+    @Schema(description = "Display name of the location", example = "Downtown Service Center", requiredMode = REQUIRED)
     @NotBlank(message = "name is required")
     private String name;
 
+    @Schema(description = "Unique business code of the location", example = "LOC-001", requiredMode = REQUIRED)
     @NotBlank(message = "code is required")
     private String code;
 
+    @Schema(
+            description = "Identifier of the associated geographical location",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
     private UUID geographicalLocationId;
+
+    @Schema(description = "First line of the street address", example = "123 Main St", requiredMode = NOT_REQUIRED)
     private String addressLine1;
+
+    @Schema(description = "Second line of the street address", example = "Suite 200", requiredMode = NOT_REQUIRED)
     private String addressLine2;
+
+    @Schema(description = "City of the location", example = "Springfield", requiredMode = NOT_REQUIRED)
     private String city;
+
+    @Schema(description = "State or province of the location", example = "IL", requiredMode = NOT_REQUIRED)
     private String state;
+
+    @Schema(description = "Postal or ZIP code of the location", example = "62704", requiredMode = NOT_REQUIRED)
     private String postalCode;
+
+    @Schema(description = "Country of the location", example = "US", requiredMode = NOT_REQUIRED)
     private String country;
+
+    @Schema(description = "Mailing address of the location", example = "PO Box 100", requiredMode = NOT_REQUIRED)
     private String mailingAddress;
+
+    @Schema(description = "Whether the location is active", example = "true", requiredMode = NOT_REQUIRED)
     private Boolean active;
+
+    @Schema(
+            description = "Identifier of the person responsible for the location",
+            example = "1001",
+            requiredMode = NOT_REQUIRED)
     private Long responsiblePersonId;
+
+    @Schema(description = "IANA timezone identifier for the location", example = "America/Chicago", requiredMode = NOT_REQUIRED)
     private String timezone;
+
+    @Schema(description = "Weekly operating hours for the location", requiredMode = NOT_REQUIRED)
+    @Valid
     private List<OperatingHoursRequest> operatingHours;
+
+    @Schema(description = "Holiday closures for the location", requiredMode = NOT_REQUIRED)
+    @Valid
     private List<HolidayClosureRequest> holidayClosures;
+
+    @Schema(
+            description = "Buffer minutes reserved before appointments for check-in",
+            example = "15",
+            requiredMode = NOT_REQUIRED)
+    @PositiveOrZero
     private Integer checkInBufferMinutes;
+
+    @Schema(
+            description = "Buffer minutes reserved after appointments for cleanup",
+            example = "10",
+            requiredMode = NOT_REQUIRED)
+    @PositiveOrZero
     private Integer cleanupBufferMinutes;
 
+    @Schema(description = "Type classification of the location", requiredMode = REQUIRED)
     @NotNull(message = "type is required")
+    @Valid
     private LocationTypeDTO type;
 
+    @Schema(
+            description = "Map of parent relationships keyed by relationship type",
+            example = "{\"ORGANIZATIONAL\": \"01960003-0000-7000-8000-000000000002\"}",
+            requiredMode = NOT_REQUIRED)
     private Map<String, Object> parents;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/LocationResponseDTO.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/LocationResponseDTO.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,19 +15,59 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Response payload describing a location")
 public class LocationResponseDTO {
+
+    @Schema(
+            description = "Unique identifier of the location",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(description = "Display name of the location", example = "Downtown Service Center", requiredMode = REQUIRED)
+    @NotNull
     private String name;
+
+    @Schema(description = "Unique business code of the location", example = "LOC-001", requiredMode = NOT_REQUIRED)
     private String code;
+
+    @Schema(
+            description = "Identifier of the associated geographical location",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID geographicalLocationId;
+
+    @Schema(description = "First line of the street address", example = "123 Main St", requiredMode = NOT_REQUIRED)
     private String addressLine1;
+
+    @Schema(description = "Second line of the street address", example = "Suite 200", requiredMode = NOT_REQUIRED)
     private String addressLine2;
+
+    @Schema(description = "City of the location", example = "Springfield", requiredMode = NOT_REQUIRED)
     private String city;
+
+    @Schema(description = "State or province of the location", example = "IL", requiredMode = NOT_REQUIRED)
     private String state;
+
+    @Schema(description = "Postal or ZIP code of the location", example = "62704", requiredMode = NOT_REQUIRED)
     private String postalCode;
+
+    @Schema(description = "Country of the location", example = "US", requiredMode = NOT_REQUIRED)
     private String country;
+
+    @Schema(description = "Mailing address of the location", example = "PO Box 100", requiredMode = NOT_REQUIRED)
     private String mailingAddress;
+
+    @Schema(description = "Whether the location is active", example = "true", requiredMode = REQUIRED)
     private boolean active;
+
+    @Schema(
+            description = "Identifier of the person responsible for the location",
+            example = "1001",
+            requiredMode = NOT_REQUIRED)
     private Long responsiblePersonId;
+
+    @Schema(description = "Type classification of the location", requiredMode = NOT_REQUIRED)
     private LocationTypeDTO type;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/LocationTypeDTO.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/LocationTypeDTO.java
@@ -1,6 +1,9 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,8 +15,21 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Location type classification reference")
 public class LocationTypeDTO {
+
+    @Schema(
+            description = "Unique identifier of the location type",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
     private UUID id;
+
+    @Schema(description = "Name of the location type", example = "STORE", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(
+            description = "Description of the location type",
+            example = "Retail storefront with point-of-sale operations",
+            requiredMode = NOT_REQUIRED)
     private String description;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/LocationValidationResponseDTO.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/LocationValidationResponseDTO.java
@@ -1,5 +1,9 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,8 +14,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Validation result for a location lookup")
 public class LocationValidationResponseDTO {
+
+    @Schema(
+            description = "Identifier of the location that was validated",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID locationId;
+
+    @Schema(description = "Whether the location exists", example = "true", requiredMode = REQUIRED)
     private boolean exists;
+
+    @Schema(description = "Whether the location is active", example = "true", requiredMode = REQUIRED)
     private boolean active;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/MobileUnitRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/MobileUnitRequest.java
@@ -1,6 +1,12 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -18,13 +24,38 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Request payload for creating or updating a mobile unit")
 public class MobileUnitRequest {
 
+    @Schema(description = "Display name of the mobile unit", example = "Van 7", requiredMode = REQUIRED)
+    @NotBlank
     private String name;
+
+    @Schema(
+            description = "Identifier of the base location the mobile unit operates from",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
     private UUID baseLocationId;
+
+    @Schema(description = "Operational status of the mobile unit", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
+
+    @Schema(
+            description = "Identifier of the travel buffer policy applied to the mobile unit",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID travelBufferPolicyId;
+
+    @Schema(description = "Free-text notes about the mobile unit", example = "Equipped with hydraulic lift", requiredMode = NOT_REQUIRED)
     private String notes;
+
+    @Schema(
+            description = "Identifiers of capabilities the mobile unit can perform",
+            example = "[\"01960003-0000-7000-8000-000000000010\"]",
+            requiredMode = NOT_REQUIRED)
     private List<String> capabilityIds;
+
+    @Schema(description = "Coverage rules defining where the mobile unit can operate", requiredMode = NOT_REQUIRED)
+    @Valid
     private List<CoverageRuleRequest> coverageRules;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/MobileUnitResponse.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/MobileUnitResponse.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -17,15 +22,52 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Response payload describing a mobile unit")
 public class MobileUnitResponse {
 
+    @Schema(
+            description = "Unique identifier of the mobile unit",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(description = "Display name of the mobile unit", example = "Van 7", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(
+            description = "Identifier of the base location the mobile unit operates from",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID baseLocationId;
+
+    @Schema(description = "Operational status of the mobile unit", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
+
+    @Schema(
+            description = "Identifier of the travel buffer policy applied to the mobile unit",
+            example = "01960003-0000-7000-8000-000000000003",
+            requiredMode = NOT_REQUIRED)
     private UUID travelBufferPolicyId;
+
+    @Schema(description = "Free-text notes about the mobile unit", example = "Equipped with hydraulic lift", requiredMode = NOT_REQUIRED)
     private String notes;
+
+    @Schema(
+            description = "Identifiers of capabilities the mobile unit can perform",
+            example = "[\"01960003-0000-7000-8000-000000000010\"]",
+            requiredMode = NOT_REQUIRED)
     private List<String> capabilityIds;
+
+    @Schema(
+            description = "Timestamp when the mobile unit was created (ISO 8601)",
+            example = "2026-06-18T08:00:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant createdAt;
+
+    @Schema(
+            description = "Timestamp when the mobile unit was last updated (ISO 8601)",
+            example = "2026-06-18T08:00:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant updatedAt;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/OperatingHoursRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/OperatingHoursRequest.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,8 +20,16 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "A single operating-hours entry for a day of the week")
 public class OperatingHoursRequest {
+
+    @Schema(description = "Day of week the hours apply to", example = "MONDAY", requiredMode = REQUIRED)
+    @NotBlank
     private String dayOfWeek;
+
+    @Schema(description = "Opening time (local time)", example = "08:00", requiredMode = NOT_REQUIRED)
     private LocalTime openTime;
+
+    @Schema(description = "Closing time (local time)", example = "17:00", requiredMode = NOT_REQUIRED)
     private LocalTime closeTime;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/PersonDTO.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/PersonDTO.java
@@ -1,15 +1,36 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Data;
 
 @Data
+@Schema(description = "Person reference associated with a location")
 public class PersonDTO {
+
+    @Schema(description = "Unique identifier of the person", example = "1001", requiredMode = NOT_REQUIRED)
     private Long id;
+
+    @Schema(description = "First name of the person", example = "Jane", requiredMode = NOT_REQUIRED)
     private String firstName;
+
+    @Schema(description = "Last name of the person", example = "Doe", requiredMode = NOT_REQUIRED)
     private String lastName;
+
+    @Schema(description = "Primary email address of the person", example = "jane.doe@example.com", requiredMode = NOT_REQUIRED)
     private String primaryEmail;
+
+    @Schema(description = "Secondary email address of the person", example = "jane.d@example.com", requiredMode = NOT_REQUIRED)
     private String secondaryEmail;
+
+    @Schema(
+            description = "Phone numbers associated with the person",
+            example = "[\"+1-217-555-0100\"]",
+            requiredMode = NOT_REQUIRED)
     private List<String> phoneNumbers;
+
+    @Schema(description = "Login username of the person", example = "jdoe", requiredMode = NOT_REQUIRED)
     private String username;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/ServiceAreaRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/ServiceAreaRequest.java
@@ -1,6 +1,12 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,19 +23,35 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Request payload for creating or updating a service area")
 public class ServiceAreaRequest {
 
+    @Schema(description = "Display name of the service area", example = "North Metro", requiredMode = REQUIRED)
+    @NotBlank
     private String name;
+
+    @Schema(description = "Description of the service area", example = "Northern metropolitan coverage zone", requiredMode = NOT_REQUIRED)
     private String description;
+
+    @Schema(description = "Whether the service area is active", example = "true", requiredMode = NOT_REQUIRED)
     private Boolean active;
+
+    @Schema(description = "Postal codes included in the service area", requiredMode = NOT_REQUIRED)
+    @Valid
     private List<PostalCodeEntry> postalCodes;
 
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @Schema(description = "A postal code entry within a service area")
     public static class PostalCodeEntry {
+
+        @Schema(description = "Postal or ZIP code", example = "62704", requiredMode = REQUIRED)
+        @NotBlank
         private String postalCode;
+
+        @Schema(description = "ISO 3166-1 alpha-2 country code", example = "US", requiredMode = NOT_REQUIRED)
         private String countryCode;
     }
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/ServiceAreaResponse.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/ServiceAreaResponse.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -17,13 +22,37 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Response payload describing a service area")
 public class ServiceAreaResponse {
 
+    @Schema(
+            description = "Unique identifier of the service area",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(description = "Display name of the service area", example = "North Metro", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(description = "Description of the service area", example = "Northern metropolitan coverage zone", requiredMode = NOT_REQUIRED)
     private String description;
+
+    @Schema(description = "Whether the service area is active", example = "true", requiredMode = NOT_REQUIRED)
     private Boolean active;
+
+    @Schema(description = "Postal codes included in the service area", requiredMode = NOT_REQUIRED)
     private List<ServiceAreaRequest.PostalCodeEntry> postalCodes;
+
+    @Schema(
+            description = "Timestamp when the service area was created (ISO 8601)",
+            example = "2026-06-18T08:00:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant createdAt;
+
+    @Schema(
+            description = "Timestamp when the service area was last updated (ISO 8601)",
+            example = "2026-06-18T08:00:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant updatedAt;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/SiteDefaultsRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/SiteDefaultsRequest.java
@@ -1,5 +1,8 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,8 +18,18 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Request payload for configuring default storage locations for a site")
 public class SiteDefaultsRequest {
 
+    @Schema(
+            description = "Identifier of the default staging storage location",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
     private UUID defaultStagingLocationId;
+
+    @Schema(
+            description = "Identifier of the default quarantine storage location",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID defaultQuarantineLocationId;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/SiteDefaultsResponse.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/SiteDefaultsResponse.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,9 +20,25 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Response payload describing default storage location configuration for a site")
 public class SiteDefaultsResponse {
 
+    @Schema(
+            description = "Identifier of the site",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID siteId;
+
+    @Schema(
+            description = "Identifier of the default staging storage location",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID defaultStagingLocationId;
+
+    @Schema(
+            description = "Identifier of the default quarantine storage location",
+            example = "01960003-0000-7000-8000-000000000003",
+            requiredMode = NOT_REQUIRED)
     private UUID defaultQuarantineLocationId;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationPatchRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationPatchRequest.java
@@ -1,7 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.positivity.location.internal.enums.StorageLocationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -19,13 +22,39 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Partial update payload for a storage location; null fields are left unchanged")
 public class StorageLocationPatchRequest {
 
+    @Schema(description = "Display name of the storage location", example = "Aisle 3 Bin 12", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(description = "Barcode identifying the storage location", example = "SL-000312", requiredMode = NOT_REQUIRED)
     private String barcode;
+
+    @Schema(description = "Operational status of the storage location", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private StorageLocationStatus status;
+
+    @Schema(
+            description = "Identifier of the parent storage location",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
     private UUID parentStorageLocationId;
+
+    @Schema(
+            description = "Identifier of the destination storage location for relocation operations",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID destinationStorageLocationId;
+
+    @Schema(
+            description = "Capacity attributes of the storage location",
+            example = "{\"maxUnits\": 100}",
+            requiredMode = NOT_REQUIRED)
     private Map<String, Object> capacity;
+
+    @Schema(
+            description = "Temperature attributes of the storage location",
+            example = "{\"min\": 2, \"max\": 8, \"unit\": \"C\"}",
+            requiredMode = NOT_REQUIRED)
     private Map<String, Object> temperature;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationRequest.java
@@ -1,7 +1,13 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.positivity.location.internal.enums.StorageLocationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -19,12 +25,35 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Request payload for creating a storage location")
 public class StorageLocationRequest {
 
+    @Schema(description = "Display name of the storage location", example = "Aisle 3 Bin 12", requiredMode = REQUIRED)
+    @NotBlank
     private String name;
+
+    @Schema(description = "Barcode identifying the storage location", example = "SL-000312", requiredMode = NOT_REQUIRED)
     private String barcode;
+
+    @Schema(description = "Type classification of the storage location", example = "BIN", requiredMode = REQUIRED)
+    @NotNull
     private StorageLocationType type;
+
+    @Schema(
+            description = "Identifier of the parent storage location",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
     private UUID parentStorageLocationId;
+
+    @Schema(
+            description = "Capacity attributes of the storage location",
+            example = "{\"maxUnits\": 100}",
+            requiredMode = NOT_REQUIRED)
     private Map<String, Object> capacity;
+
+    @Schema(
+            description = "Temperature attributes of the storage location",
+            example = "{\"min\": 2, \"max\": 8, \"unit\": \"C\"}",
+            requiredMode = NOT_REQUIRED)
     private Map<String, Object> temperature;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationResponse.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationResponse.java
@@ -1,6 +1,11 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.positivity.location.internal.enums.StorageLocationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -17,16 +22,52 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Response payload describing a storage location")
 public class StorageLocationResponse {
 
+    @Schema(
+            description = "Unique identifier of the storage location",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(description = "Display name of the storage location", example = "Aisle 3 Bin 12", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(description = "Barcode identifying the storage location", example = "SL-000312", requiredMode = NOT_REQUIRED)
     private String barcode;
+
+    @Schema(description = "Type classification of the storage location", example = "BIN", requiredMode = NOT_REQUIRED)
     private StorageLocationType type;
+
+    @Schema(description = "Operational status of the storage location", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
+
+    @Schema(
+            description = "Identifier of the site that owns the storage location",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID siteId;
+
+    @Schema(
+            description = "Identifier of the parent storage location",
+            example = "01960003-0000-7000-8000-000000000003",
+            requiredMode = NOT_REQUIRED)
     private UUID parentStorageLocationId;
+
+    @Schema(
+            description = "Capacity attributes of the storage location",
+            example = "{\"maxUnits\": 100}",
+            requiredMode = NOT_REQUIRED)
     private Map<String, Object> capacity;
+
+    @Schema(
+            description = "Temperature attributes of the storage location",
+            example = "{\"min\": 2, \"max\": 8, \"unit\": \"C\"}",
+            requiredMode = NOT_REQUIRED)
     private Map<String, Object> temperature;
+
+    @Schema(description = "Count of inventory items stored at the location", example = "42", requiredMode = REQUIRED)
     private int inventoryCount;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationTopologyResponse.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationTopologyResponse.java
@@ -1,6 +1,11 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.positivity.location.internal.enums.StorageLocationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,11 +22,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Lightweight flat projection of a storage location for topology consumers")
 public class StorageLocationTopologyResponse {
 
+    @Schema(
+            description = "Unique identifier of the storage location",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(description = "Display name of the storage location", example = "Aisle 3 Bin 12", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(description = "Type classification of the storage location", example = "BIN", requiredMode = NOT_REQUIRED)
     private StorageLocationType type;
+
+    @Schema(description = "Operational status of the storage location", example = "ACTIVE", requiredMode = NOT_REQUIRED)
     private String status;
+
+    @Schema(
+            description = "Identifier of the parent storage location",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID parentStorageLocationId;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationValidationResponseDTO.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/StorageLocationValidationResponseDTO.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,10 +15,31 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Validation result for a storage location lookup")
 public class StorageLocationValidationResponseDTO {
+
+    @Schema(
+            description = "Identifier of the storage location that was validated",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID storageLocationId;
+
+    @Schema(
+            description = "Identifier of the site that owns the storage location",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = NOT_REQUIRED)
     private UUID siteId;
+
+    @Schema(description = "Whether the storage location exists", example = "true", requiredMode = REQUIRED)
     private boolean exists;
+
+    @Schema(description = "Whether the storage location is active", example = "true", requiredMode = REQUIRED)
     private boolean active;
+
+    @Schema(
+            description = "Maximum unit capacity of the storage location",
+            example = "100",
+            requiredMode = NOT_REQUIRED)
     private Integer maxUnitCapacity;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/TravelBufferPolicyRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/TravelBufferPolicyRequest.java
@@ -1,6 +1,12 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,10 +23,24 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Request payload for creating or updating a travel buffer policy")
 public class TravelBufferPolicyRequest {
 
+    @Schema(description = "Display name of the travel buffer policy", example = "Standard Metro Buffer", requiredMode = REQUIRED)
+    @NotBlank
     private String name;
+
+    @Schema(description = "Type of buffer the policy applies", example = "FIXED_MINUTES", requiredMode = REQUIRED)
+    @NotBlank
     private String bufferType;
+
+    @Schema(
+            description = "Numeric value of the buffer (interpretation depends on buffer type)",
+            example = "30",
+            requiredMode = NOT_REQUIRED)
+    @PositiveOrZero
     private BigDecimal bufferValue;
+
+    @Schema(description = "Free-text notes about the policy", example = "Applies during peak hours only", requiredMode = NOT_REQUIRED)
     private String notes;
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/TravelBufferPolicyResponse.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/TravelBufferPolicyResponse.java
@@ -1,5 +1,10 @@
 package com.positivity.location.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
@@ -17,13 +22,40 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Response payload describing a travel buffer policy")
 public class TravelBufferPolicyResponse {
 
+    @Schema(
+            description = "Unique identifier of the travel buffer policy",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
     private UUID id;
+
+    @Schema(description = "Display name of the travel buffer policy", example = "Standard Metro Buffer", requiredMode = NOT_REQUIRED)
     private String name;
+
+    @Schema(description = "Type of buffer the policy applies", example = "FIXED_MINUTES", requiredMode = NOT_REQUIRED)
     private String bufferType;
+
+    @Schema(
+            description = "Numeric value of the buffer (interpretation depends on buffer type)",
+            example = "30",
+            requiredMode = NOT_REQUIRED)
     private BigDecimal bufferValue;
+
+    @Schema(description = "Free-text notes about the policy", example = "Applies during peak hours only", requiredMode = NOT_REQUIRED)
     private String notes;
+
+    @Schema(
+            description = "Timestamp when the policy was created (ISO 8601)",
+            example = "2026-06-18T08:00:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant createdAt;
+
+    @Schema(
+            description = "Timestamp when the policy was last updated (ISO 8601)",
+            example = "2026-06-18T08:00:00Z",
+            requiredMode = NOT_REQUIRED)
     private Instant updatedAt;
 }


### PR DESCRIPTION
First module of #699. All 32 pos-location DTOs annotated (class + every field) with `@Schema` (description/example/requiredMode) + jakarta validation on requests. Regenerated openapi.yaml: descriptions 144→375, examples 13→208. Tests 185/185. Pairs with SDK + frontend PRs (newly-required fields cascade). See #699 plan.