### PR TITLE
[CAP:663] Customer-vehicle association endpoints, partyId + search

### DIFF
--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -484,7 +484,7 @@ paths:
       tags:
       - Customer API
       summary: Get all customers
-      description: Retrieve a paginated list of customers by type (PERSON or COMMERCIAL). Defaults to PERSON customers if no type specified.
+      description: Retrieve a paginated list of customers by type (PERSON or COMMERCIAL). Defaults to PERSON customers if no type specified. When a name and/or email filter is supplied, performs a server-side search instead of an unfiltered listing (scalable typeahead).
       operationId: getAllCustomers
       parameters:
       - name: customerType
@@ -495,6 +495,20 @@ paths:
           type: string
           default: PERSON
         example: PERSON
+      - name: name
+        in: query
+        description: Case-insensitive partial name filter for typeahead search
+        required: false
+        schema:
+          type: string
+        example: doe
+      - name: email
+        in: query
+        description: Case-insensitive email filter for typeahead search
+        required: false
+        schema:
+          type: string
+        example: jdoe@acme.com
       - name: pageable
         in: query
         description: Pagination parameters (page, size, sort)
@@ -538,6 +552,38 @@ paths:
       x-required-permissions:
       - crm:party:create
   /v1/crm/{customerId}/vehicles:
+    get:
+      tags:
+      - CRM Vehicles
+      summary: List vehicles for customer
+      description: Retrieve all vehicle summaries (vehicleId, VIN, make/model/year) associated with a customer. Returns the vehicle UUIDs the frontend needs to build estimates for a given Durion customer.
+      operationId: listVehiclesForCustomer
+      parameters:
+      - name: customerId
+        in: path
+        description: Customer ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Vehicles listed (possibly empty)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VehicleSummary'
+        '403':
+          description: Forbidden - insufficient permissions
+        '404':
+          description: Customer not found
+      security:
+      - bearerAuth:
+        - crm:vehicle:view
+      x-required-permissions:
+      - crm:vehicle:view
     post:
       tags:
       - CRM Vehicles
@@ -1616,6 +1662,11 @@ components:
           type: string
           format: uuid
           description: Unique identifier of the customer
+          example: 01960003-0000-7000-8000-000000000001
+        partyId:
+          type: string
+          format: uuid
+          description: CRM party identifier. Equal to id; exposed explicitly so callers can pass it to the CRM snapshot endpoints (GET /v1/crm/snapshot/party/{partyId}) without assuming the id mapping.
           example: 01960003-0000-7000-8000-000000000001
         customerNumber:
           type: string
@@ -3102,6 +3153,37 @@ components:
           type: boolean
         unsorted:
           type: boolean
+    VehicleSummary:
+      type: object
+      description: Vehicle summary within a CRM snapshot
+      properties:
+        vehicleId:
+          type: string
+          description: Identifier of the vehicle
+          example: 01960003-0000-7000-8000-000000000030
+        vin:
+          type: string
+          description: Vehicle Identification Number
+          example: 1HGCM82633A004352
+        licensePlate:
+          type: string
+          description: License plate
+          example: ABC-1234
+        make:
+          type: string
+          description: Vehicle make
+          example: Ford
+        model:
+          type: string
+          description: Vehicle model
+          example: Transit 250
+        year:
+          type: integer
+          format: int32
+          description: Model year
+          example: 2019
+      required:
+      - vehicleId
     AccountSummary:
       type: object
       description: Account summary surfaced in a CRM snapshot
@@ -3315,37 +3397,6 @@ components:
       - snapshotId
       - stale
       - version
-    VehicleSummary:
-      type: object
-      description: Vehicle summary within a CRM snapshot
-      properties:
-        vehicleId:
-          type: string
-          description: Identifier of the vehicle
-          example: 01960003-0000-7000-8000-000000000030
-        vin:
-          type: string
-          description: Vehicle Identification Number
-          example: 1HGCM82633A004352
-        licensePlate:
-          type: string
-          description: License plate
-          example: ABC-1234
-        make:
-          type: string
-          description: Vehicle make
-          example: Ford
-        model:
-          type: string
-          description: Vehicle model
-          example: Transit 250
-        year:
-          type: integer
-          format: int32
-          description: Model year
-          example: 2019
-      required:
-      - vehicleId
     ContactPointDto:
       type: object
       description: Contact point details

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmVehiclesController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmVehiclesController.java
@@ -156,6 +156,46 @@ public class CrmVehiclesController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "List vehicles for customer",
+            description = "Retrieve all vehicle summaries (vehicleId, VIN, make/model/year) associated with a customer."
+                    + " Returns the vehicle UUIDs the frontend needs to build estimates for a given Durion customer.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Vehicles listed (possibly empty)",
+                        content =
+                                @Content(
+                                        array =
+                                                @io.swagger.v3.oas.annotations.media.ArraySchema(
+                                                        schema =
+                                                                @Schema(
+                                                                        implementation =
+                                                                                com.positivity.customer.internal.dto
+                                                                                        .snapshot.CrmSnapshotDTO
+                                                                                        .VehicleSummary.class)))),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "Forbidden - insufficient permissions",
+                        content = @Content),
+                @ApiResponse(responseCode = "404", description = "Customer not found", content = @Content)
+            })
+    @GetMapping("/{customerId}/vehicles")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {CrmPermissionRegistry.VEHICLE_VIEW})
+    @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.VEHICLE_VIEW + "')")
+    public ResponseEntity<java.util.List<com.positivity.customer.internal.dto.snapshot.CrmSnapshotDTO.VehicleSummary>>
+            listVehiclesForCustomer(
+                    @Parameter(description = "Customer ID", required = true) @PathVariable UUID customerId) {
+        log.info("Listing vehicles for customer: {}", customerId);
+        return crmVehicleService
+                .findVehiclesForCustomer(customerId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     @Operation(summary = "Get vehicle for customer", description = "Retrieve a specific vehicle for a given customer")
     @ApiResponses(
             value = {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerController.java
@@ -46,7 +46,9 @@ public class CustomerController {
     @Operation(
             summary = "Get all customers",
             description =
-                    "Retrieve a paginated list of customers by type (PERSON or COMMERCIAL). Defaults to PERSON customers if no type specified.")
+                    "Retrieve a paginated list of customers by type (PERSON or COMMERCIAL). Defaults to PERSON customers"
+                            + " if no type specified. When a name and/or email filter is supplied, performs a"
+                            + " server-side search instead of an unfiltered listing (scalable typeahead).")
     @ApiResponse(responseCode = "200", description = "Page of customers returned successfully.")
     @GetMapping
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -57,16 +59,25 @@ public class CustomerController {
             @Parameter(description = "Customer type filter: PERSON or COMMERCIAL", example = "PERSON")
                     @RequestParam(required = false, defaultValue = "PERSON")
                     String customerType,
+            @Parameter(description = "Case-insensitive partial name filter for typeahead search", example = "doe")
+                    @RequestParam(required = false)
+                    String name,
+            @Parameter(description = "Case-insensitive email filter for typeahead search", example = "jdoe@acme.com")
+                    @RequestParam(required = false)
+                    String email,
             @Parameter(description = "Pagination parameters (page, size, sort)")
                     @PageableDefault(size = 20, sort = "customerNumber")
                     Pageable pageable) {
-        log.info("Fetching customers of type: {} with paging: {}", customerType, pageable);
+        CustomerService service = COMMERCIAL.equalsIgnoreCase(customerType) ? commercialService : personService;
 
-        if (COMMERCIAL.equalsIgnoreCase(customerType)) {
-            return commercialService.getAllCustomers(pageable);
-        } else {
-            return personService.getAllCustomers(pageable);
+        boolean searching = (name != null && !name.isBlank()) || (email != null && !email.isBlank());
+        if (searching) {
+            log.info("Searching {} customers by name={} email={} with paging: {}", customerType, name, email, pageable);
+            return service.searchCustomers(name, email, pageable);
         }
+
+        log.info("Fetching customers of type: {} with paging: {}", customerType, pageable);
+        return service.getAllCustomers(pageable);
     }
 
     @Operation(summary = "Get customer by ID", description = "Retrieve a customer by their unique ID.")

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerDTO.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerDTO.java
@@ -28,6 +28,13 @@ public class CustomerDTO {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private UUID id;
 
+    @Schema(
+            description = "CRM party identifier. Equal to id; exposed explicitly so callers can pass it to the CRM"
+                    + " snapshot endpoints (GET /v1/crm/snapshot/party/{partyId}) without assuming the id mapping.",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private UUID partyId;
+
     @Size(max = 50)
     @Schema(
             description = "Unique customer number",
@@ -37,18 +44,12 @@ public class CustomerDTO {
 
     @NotBlank
     @Size(max = 100)
-    @Schema(
-            description = "Last name of the customer",
-            example = "Doe",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Last name of the customer", example = "Doe", requiredMode = Schema.RequiredMode.REQUIRED)
     private String lastName;
 
     @NotBlank
     @Size(max = 100)
-    @Schema(
-            description = "First name of the customer",
-            example = "John",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "First name of the customer", example = "John", requiredMode = Schema.RequiredMode.REQUIRED)
     private String firstName;
 
     @Size(max = 255)

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
@@ -80,6 +80,26 @@ public class CommercialPartyServiceImpl implements CustomerService {
     }
 
     /**
+     * Searches commercial customers by legal name. Commercial parties hold no local
+     * email, so an email-only query yields an empty page.
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CustomerDTO> searchCustomers(String name, String email, @NonNull Pageable pageable) {
+        boolean hasName = name != null && !name.isBlank();
+        if (!hasName) {
+            // Commercial parties have no locally-searchable email; nothing to match.
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+        List<CustomerDTO> matches = commercialRepository.findByLegalNameContaining(name.trim()).stream()
+                .map(this::toDTO)
+                .toList();
+        int from = Math.min((int) pageable.getOffset(), matches.size());
+        int to = Math.min(from + pageable.getPageSize(), matches.size());
+        return new PageImpl<>(matches.subList(from, to), pageable, matches.size());
+    }
+
+    /**
      * Retrieves a customer by ID as DTO.
      *
      * @param id the customer ID
@@ -181,6 +201,7 @@ public class CommercialPartyServiceImpl implements CustomerService {
         PartyType customerType = determineCustomerType(entity);
         return CustomerDTO.builder()
                 .id(entity.getPartyId())
+                .partyId(entity.getPartyId())
                 .customerNumber(entity.getCustomerNumber())
                 .lastName(entity.getLegalName())
                 .firstName(entity.getDisplayName())

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CrmVehicleServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CrmVehicleServiceImpl.java
@@ -353,6 +353,31 @@ public class CrmVehicleServiceImpl implements CrmVehicleService {
     @Override
     public java.util.List<com.positivity.customer.internal.dto.snapshot.CrmSnapshotDTO.VehicleSummary>
             collectVehiclesForParty(CommercialParty party) {
+        return collectVehicleSummaries(party);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<java.util.List<com.positivity.customer.internal.dto.snapshot.CrmSnapshotDTO.VehicleSummary>>
+            findVehiclesForCustomer(@NonNull UUID customerId) {
+        log.debug("Listing vehicles for customer: {}", customerId);
+        AbstractParty party = personPartyRepository
+                .findById(customerId)
+                .map(p -> (AbstractParty) p)
+                .or(() -> commercialPartyRepository.findById(customerId).map(p -> (AbstractParty) p))
+                .orElse(null);
+        if (party == null) {
+            return Optional.empty();
+        }
+        return Optional.of(collectVehicleSummaries(party));
+    }
+
+    /**
+     * Resolves the VIN set of any party to vehicle summaries, dropping VINs the
+     * vehicle-inventory service cannot resolve.
+     */
+    private java.util.List<com.positivity.customer.internal.dto.snapshot.CrmSnapshotDTO.VehicleSummary>
+            collectVehicleSummaries(AbstractParty party) {
         return party.getVehicleVins().stream()
                 .map(this::fetchVehicleSummaryByVin)
                 .filter(java.util.Objects::nonNull)

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
@@ -63,6 +63,42 @@ public class PersonPartyServiceImpl implements CustomerService {
     }
 
     /**
+     * Searches person customers by name and/or email. Names and emails live in
+     * pos-people (ADR-0015 I2; issue #684), so the search delegates to
+     * {@link PeopleClient#searchPersons(String)} and maps the resolved person ids
+     * back to local person parties. Email filtering is applied client-side against
+     * the resolved identities.
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CustomerDTO> searchCustomers(String name, String email, @NonNull Pageable pageable) {
+        boolean hasName = name != null && !name.isBlank();
+        boolean hasEmail = email != null && !email.isBlank();
+        String query = hasName ? name.trim() : (hasEmail ? email.trim() : null);
+        if (query == null) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        String emailNeedle = hasEmail ? email.trim().toLowerCase() : null;
+        List<CustomerDTO> matches = new ArrayList<>();
+        for (PeopleClient.PersonIdentity identity : peopleClient.searchPersons(query)) {
+            if (identity.id() == null) {
+                continue;
+            }
+            if (emailNeedle != null
+                    && identity.emails().stream()
+                            .noneMatch(e -> e != null && e.toLowerCase().contains(emailNeedle))) {
+                continue;
+            }
+            customerRepository.findByPersonId(identity.id()).ifPresent(party -> matches.add(toDTO(party, identity)));
+        }
+
+        int from = Math.min((int) pageable.getOffset(), matches.size());
+        int to = Math.min(from + pageable.getPageSize(), matches.size());
+        return new PageImpl<>(matches.subList(from, to), pageable, matches.size());
+    }
+
+    /**
      * Retrieves a customer by ID as DTO.
      *
      * @param id the customer ID
@@ -167,15 +203,24 @@ public class PersonPartyServiceImpl implements CustomerService {
      * @return the customer DTO
      */
     private CustomerDTO toDTO(PersonParty entity) {
-        PartyType customerType = determineCustomerType(entity);
         // Names from pos-people (sole source of truth, ADR-0015 I2; issue #684).
         PeopleClient.PersonIdentity identity = entity.getPersonId() != null
                 ? peopleClient
                         .fetchPersonIdentitiesQuietly(Set.of(entity.getPersonId()))
                         .get(entity.getPersonId())
                 : null;
+        return toDTO(entity, identity);
+    }
+
+    /**
+     * Builds a DTO from an entity and an already-resolved pos-people identity,
+     * avoiding a redundant identity fetch (used by name/email search).
+     */
+    private CustomerDTO toDTO(PersonParty entity, PeopleClient.PersonIdentity identity) {
+        PartyType customerType = determineCustomerType(entity);
         return CustomerDTO.builder()
                 .id(entity.getPartyId())
+                .partyId(entity.getPartyId())
                 .customerNumber(entity.getCustomerNumber())
                 .lastName(identity != null ? identity.lastName() : null)
                 .firstName(identity != null ? identity.firstName() : null)

--- a/pos-customer/src/main/java/com/positivity/customer/service/CrmVehicleService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/service/CrmVehicleService.java
@@ -46,4 +46,16 @@ public interface CrmVehicleService {
 
     java.util.List<com.positivity.customer.internal.dto.snapshot.CrmSnapshotDTO.VehicleSummary> collectVehiclesForParty(
             CommercialParty party);
+
+    /**
+     * Lists vehicle summaries for any customer (person or commercial), resolved by
+     * the Durion customer/party id. Returns {@link Optional#empty()} when the
+     * customer does not exist (so the caller can answer 404); a present list may be
+     * empty when the customer has no associated vehicles.
+     *
+     * @param customerId the Durion customer (party) id
+     * @return optional list of vehicle summaries; empty when the customer is unknown
+     */
+    Optional<java.util.List<com.positivity.customer.internal.dto.snapshot.CrmSnapshotDTO.VehicleSummary>>
+            findVehiclesForCustomer(UUID customerId);
 }

--- a/pos-customer/src/main/java/com/positivity/customer/service/CustomerService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/service/CustomerService.java
@@ -25,6 +25,19 @@ public interface CustomerService {
     Page<CustomerDTO> getAllCustomers(Pageable pageable);
 
     /**
+     * Searches customers by name and/or email for scalable server-side typeahead.
+     * At least one of {@code name}/{@code email} should be non-blank; when both are
+     * blank the implementation returns an empty page (callers should use
+     * {@link #getAllCustomers(Pageable)} for an unfiltered listing).
+     *
+     * @param name     case-insensitive partial name filter (nullable)
+     * @param email    case-insensitive email filter (nullable)
+     * @param pageable pagination information
+     * @return page of matching customers as DTOs
+     */
+    Page<CustomerDTO> searchCustomers(String name, String email, Pageable pageable);
+
+    /**
      * Retrieves a customer by ID as DTO.
      *
      * @param id the customer ID

--- a/pos-customer/src/test/java/com/positivity/customer/service/CommercialPartyServiceImplSearchTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/CommercialPartyServiceImplSearchTest.java
@@ -1,0 +1,69 @@
+package com.positivity.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.CustomerDTO;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.enums.PartyType;
+import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import com.positivity.customer.internal.service.CommercialPartyServiceImpl;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class CommercialPartyServiceImplSearchTest {
+
+    @Mock
+    private CommercialPartyRepository commercialRepository;
+
+    private CommercialPartyServiceImpl service() {
+        return new CommercialPartyServiceImpl(commercialRepository);
+    }
+
+    private CommercialParty party(UUID id, String legalName) {
+        CommercialParty p = new CommercialParty();
+        p.setPartyId(id);
+        p.setPartyNumber("PARTY-" + id.toString().substring(0, 8));
+        p.setCustomerNumber("CUST-" + id.toString().substring(0, 8));
+        p.setLegalName(legalName);
+        p.setDisplayName("Acme");
+        p.setPartyType(PartyType.COMMERCIAL);
+        p.setVehicleVins(new HashSet<>());
+        return p;
+    }
+
+    @Test
+    void searchCustomers_byName_returnsMatch_withPartyIdEqualToId() {
+        UUID id = UUID.fromString("00000000-0000-0000-0000-000000000111");
+        when(commercialRepository.findByLegalNameContaining("acme")).thenReturn(List.of(party(id, "Acme Corp")));
+
+        Page<CustomerDTO> page = service().searchCustomers("acme", null, PageRequest.of(0, 20));
+
+        assertThat(page.getTotalElements()).isEqualTo(1);
+        CustomerDTO dto = page.getContent().get(0);
+        assertThat(dto.getId()).isEqualTo(id);
+        assertThat(dto.getPartyId()).isEqualTo(id);
+        assertThat(dto.getLastName()).isEqualTo("Acme Corp");
+    }
+
+    @Test
+    void searchCustomers_emailOnly_returnsEmptyPage() {
+        Page<CustomerDTO> page = service().searchCustomers(null, "x@acme.com", PageRequest.of(0, 20));
+        assertThat(page.getTotalElements()).isZero();
+        assertThat(page.getContent()).isEmpty();
+    }
+
+    @Test
+    void searchCustomers_blankName_returnsEmptyPage() {
+        Page<CustomerDTO> page = service().searchCustomers("  ", null, PageRequest.of(0, 20));
+        assertThat(page.getContent()).isEmpty();
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/service/CrmVehicleServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/CrmVehicleServiceImplTest.java
@@ -342,4 +342,51 @@ class CrmVehicleServiceImplTest {
         verify(personPartyRepository).save(person);
         verify(commercialPartyRepository, never()).save(any());
     }
+
+    @Test
+    void findVehiclesForCustomer_returnsEmptyOptional_whenCustomerUnknown() {
+        UUID customerId = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
+        when(personPartyRepository.findById(customerId)).thenReturn(Optional.empty());
+        when(commercialPartyRepository.findById(customerId)).thenReturn(Optional.empty());
+
+        assertThat(service.findVehiclesForCustomer(customerId)).isEmpty();
+        verify(vehicleInventoryClient, never()).getVehicleByVin(any());
+    }
+
+    @Test
+    void findVehiclesForCustomer_returnsSummaries_forCommercialPartyVins() {
+        UUID customerId = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
+        UUID vehicleId = UUID.fromString("00000000-0000-0000-0000-0000000000cc");
+        CommercialParty party = commercialParty(customerId);
+        party.getVehicleVins().add("VIN-OWNED");
+
+        when(personPartyRepository.findById(customerId)).thenReturn(Optional.empty());
+        when(commercialPartyRepository.findById(customerId)).thenReturn(Optional.of(party));
+        when(vehicleInventoryClient.getVehicleByVin("VIN-OWNED"))
+                .thenReturn(Optional.of(vehicle(vehicleId, "VIN-OWNED")));
+
+        Optional<List<CrmSnapshotDTO.VehicleSummary>> result = service.findVehiclesForCustomer(customerId);
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).hasSize(1);
+        CrmSnapshotDTO.VehicleSummary summary = result.get().get(0);
+        assertThat(summary.getVehicleId()).isEqualTo(vehicleId.toString());
+        assertThat(summary.getVin()).isEqualTo("VIN-OWNED");
+        assertThat(summary.getMake()).isEqualTo("Ford");
+        assertThat(summary.getModel()).isEqualTo("F-150");
+        assertThat(summary.getYear()).isEqualTo(2022);
+    }
+
+    @Test
+    void findVehiclesForCustomer_resolvesPersonParty_andReturnsEmptyListWhenNoVins() {
+        UUID customerId = UUID.fromString("00000000-0000-0000-0000-0000000000dd");
+        PersonParty person = personParty(customerId);
+        when(personPartyRepository.findById(customerId)).thenReturn(Optional.of(person));
+
+        Optional<List<CrmSnapshotDTO.VehicleSummary>> result = service.findVehiclesForCustomer(customerId);
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEmpty();
+        verify(commercialPartyRepository, never()).findById(any());
+    }
 }

--- a/pos-customer/src/test/java/com/positivity/customer/service/PersonPartyServiceImplSearchTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PersonPartyServiceImplSearchTest.java
@@ -1,0 +1,89 @@
+package com.positivity.customer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.client.PeopleClient;
+import com.positivity.customer.internal.dto.CustomerDTO;
+import com.positivity.customer.internal.entity.PersonParty;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.customer.internal.service.PersonPartyServiceImpl;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class PersonPartyServiceImplSearchTest {
+
+    @Mock
+    private PersonPartyRepository personPartyRepository;
+
+    @Mock
+    private PeopleClient peopleClient;
+
+    private PersonPartyServiceImpl service() {
+        return new PersonPartyServiceImpl(personPartyRepository, peopleClient);
+    }
+
+    private PersonParty person(UUID partyId, UUID personId) {
+        PersonParty p = new PersonParty();
+        p.setPartyId(partyId);
+        p.setPersonId(personId);
+        p.setCustomerNumber("CUST-" + partyId.toString().substring(0, 8));
+        p.setVehicleVins(new HashSet<>());
+        return p;
+    }
+
+    private PeopleClient.PersonIdentity identity(UUID personId, String first, String last, String email) {
+        return new PeopleClient.PersonIdentity(
+                personId, first, last, email, List.of(new PeopleClient.ContactPoint("EMAIL", email, true)));
+    }
+
+    @Test
+    void searchCustomers_byName_mapsIdentityToDto_withPartyId() {
+        UUID partyId = UUID.fromString("00000000-0000-0000-0000-000000000221");
+        UUID personId = UUID.fromString("00000000-0000-0000-0000-000000000222");
+        when(peopleClient.searchPersons("doe")).thenReturn(List.of(identity(personId, "John", "Doe", "jd@x.com")));
+        when(personPartyRepository.findByPersonId(personId)).thenReturn(Optional.of(person(partyId, personId)));
+
+        Page<CustomerDTO> page = service().searchCustomers("doe", null, PageRequest.of(0, 20));
+
+        assertThat(page.getTotalElements()).isEqualTo(1);
+        CustomerDTO dto = page.getContent().get(0);
+        assertThat(dto.getId()).isEqualTo(partyId);
+        assertThat(dto.getPartyId()).isEqualTo(partyId);
+        assertThat(dto.getFirstName()).isEqualTo("John");
+        assertThat(dto.getLastName()).isEqualTo("Doe");
+    }
+
+    @Test
+    void searchCustomers_emailFilter_excludesNonMatchingIdentities() {
+        UUID personA = UUID.fromString("00000000-0000-0000-0000-0000000002a1");
+        UUID personB = UUID.fromString("00000000-0000-0000-0000-0000000002b1");
+        UUID partyB = UUID.fromString("00000000-0000-0000-0000-0000000002b2");
+        when(peopleClient.searchPersons("jd@acme.com"))
+                .thenReturn(List.of(
+                        identity(personA, "Jane", "Smith", "jane@other.com"),
+                        identity(personB, "John", "Doe", "jd@acme.com")));
+        when(personPartyRepository.findByPersonId(personB)).thenReturn(Optional.of(person(partyB, personB)));
+
+        Page<CustomerDTO> page = service().searchCustomers(null, "jd@acme.com", PageRequest.of(0, 20));
+
+        assertThat(page.getTotalElements()).isEqualTo(1);
+        assertThat(page.getContent().get(0).getPartyId()).isEqualTo(partyB);
+    }
+
+    @Test
+    void searchCustomers_blank_returnsEmptyPage() {
+        Page<CustomerDTO> page = service().searchCustomers(null, null, PageRequest.of(0, 20));
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
+    }
+}


### PR DESCRIPTION
Closes #663.

Unblocks the estimate-create vehicle typeahead (`durion-positivity-frontend@2e15b08`). Implements all four resolution paths the issue called for.

## Changes

**A — vehicles list endpoint**
- `GET /v1/crm/{customerId}/vehicles` → `VehicleSummary[]` (vehicleId UUID + VIN + make/model/year).
- New `CrmVehicleService.findVehiclesForCustomer(UUID)` resolves any party type (person or commercial), returns `404` when the customer is unknown, `200` + empty list when it has no vehicles. Reuses the existing `fetchVehicleSummaryByVin` path; generalized the VIN-collection helper from `CommercialParty` to `AbstractParty`.

**B — expose CRM `partyId` on `CustomerDTO`**
- New `partyId` field (equal to `id`) so the frontend can call `GET /v1/crm/snapshot/party/{partyId}` without assuming the id mapping.

**Search — `name`/`email` on `GET /v1/crm`**
- Scalable server-side typeahead. Commercial → `findByLegalNameContaining`. Person → delegates to `pos-people` (`PeopleClient.searchPersons`, ADR-0015 names live in pos-people) and maps resolved identities back to local person parties; email filtered client-side against the identities.

**C — `vehicleVins` population (no change required; verified)**
- Validated, not assumed. `toEntity`/`updateEntityFromDTO` already copy `vehicleVins`, and `createVehicle` associates the VIN on the party — the code path is correct.
- The seed is also correct: `R__seed_customer_operational_data.sql` Section 10 populates `customer_vehicle` (party→VIN), with `customer_id` namespaces (`01960020-*` person / `01960021-*` commercial) matching the seeded parties, so `AbstractParty.vehicleVins` is populated for all seeded customers (~329 vehicles across 50 persons + commercial parties).
- The empty-`vehicleVins` symptom in #663 was a real gap **only at filing time (2026-06-15)**; the association seed was added the next day in `d19d8249` (#685, 2026-06-16). Nothing outstanding for C.

## Contract chain
Regenerated `pos-customer/openapi.yaml` and the `@durion-sdk/customer` Angular SDK (controller → OpenAPI → SDK). SDK now exposes `listVehiclesForCustomer`, `getAllCustomers(..., name?, email?)`, and `CustomerDTO.partyId`. SDK regen: durion-positivity-sdk-angular PR #10.

**Contract guide:** additive surface only (new endpoint + DTO field + query params); no curated content change to the CRM domain `BACKEND_CONTRACT_GUIDE.md`. OpenAPI spec regenerated and committed.

## Tests
- `CrmVehicleServiceImplTest` (+3): unknown customer → empty Optional; commercial VINs → summaries; person party → empty list.
- `CommercialPartyServiceImplSearchTest` (new, 3): name match w/ partyId, email-only empty, blank empty.
- `PersonPartyServiceImplSearchTest` (new, 3): name→DTO mapping, email filter excludes non-matches, blank empty.
- Full pos-customer unit suite: **163 tests, 0 failures** (incl. ArchUnit boundary rules — new code under `internal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)