### PR TITLE
[CAP:714] Reconcile check: active users on inactive persons (ADR-0015 §4)

### DIFF
--- a/pos-people/openapi.yaml
+++ b/pos-people/openapi.yaml
@@ -1572,6 +1572,25 @@ paths:
         - people:userLink:view
       x-required-permissions:
       - people:userLink:view
+  /v1/people/user-links/inactive-person-active-user:
+    get:
+      tags:
+      - User-Person Linking API
+      summary: List active users linked to inactive persons
+      description: 'Compliance check (ADR-0015 §4): returns every ACTIVE user-person link whose linked person is in an inactive status (SUSPENDED, TERMINATED, DISABLED). Each row is a user that should have been disabled when the person was disabled/archived. Returns an empty list when none.'
+      operationId: findActiveUsersForInactivePersons
+      responses:
+        '200':
+          description: Offending links returned (possibly empty)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InactivePersonActiveUserResponse'
+      security:
+      - bearerAuth:
+        - people:userLink:view
+      x-required-permissions:
+      - people:userLink:view
   /v1/people/timekeeping/timekeeping-entries:
     get:
       tags:
@@ -3264,6 +3283,45 @@ components:
           example: jane.smith
       required:
       - id
+    InactivePersonActiveUserResponse:
+      type: object
+      description: An active user-person link whose linked person is in an inactive status (ADR-0015 §4 violation)
+      properties:
+        linkId:
+          type: string
+          format: uuid
+          description: User-person link identifier
+          example: 01960012-0000-7000-8000-000000000001
+        userId:
+          type: string
+          format: uuid
+          description: User account identifier with the still-active link
+          example: 01960010-0000-7000-8000-000000000001
+        personId:
+          type: string
+          format: uuid
+          description: Person identifier in an inactive status
+          example: 01960011-0000-7000-8000-000000000001
+        personStatus:
+          type: string
+          description: Inactive status of the linked person
+          enum:
+          - ACTIVE
+          - ON_LEAVE
+          - SUSPENDED
+          - TERMINATED
+          - DISABLED
+          example: TERMINATED
+        personStatusEffectiveAt:
+          type: string
+          format: date-time
+          description: When the person's status last became effective
+          example: 2026-01-15 09:30:00+00:00
+      required:
+      - linkId
+      - personId
+      - personStatus
+      - userId
     TimekeepingEntryDto:
       type: object
       description: Timekeeping entry summarizing a worked session pending or resolved for approval

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/UserPersonLinkController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/UserPersonLinkController.java
@@ -2,6 +2,7 @@ package com.positivity.people.internal.controller;
 
 import com.positivity.events.EmitEvent;
 import com.positivity.people.internal.dto.CreateUserLinkRequest;
+import com.positivity.people.internal.dto.InactivePersonActiveUserResponse;
 import com.positivity.people.internal.dto.LinkUserToPersonRequest;
 import com.positivity.people.internal.dto.PersonResponse;
 import com.positivity.people.internal.dto.UserPersonLinkResponse;
@@ -136,6 +137,24 @@ public class UserPersonLinkController {
 
         List<UUID> userIds = linkService.findUserIdsByPersonId(personId);
         return ResponseEntity.ok(userIds);
+    }
+
+    @GetMapping("/user-links/inactive-person-active-user")
+    @Operation(
+            summary = "List active users linked to inactive persons",
+            description = "Compliance check (ADR-0015 §4): returns every ACTIVE user-person link whose linked person"
+                    + " is in an inactive status (SUSPENDED, TERMINATED, DISABLED). Each row is a user that should"
+                    + " have been disabled when the person was disabled/archived. Returns an empty list when none.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Offending links returned (possibly empty)",
+            content = @Content(schema = @Schema(implementation = InactivePersonActiveUserResponse.class)))
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people:userLink:view"})
+    @PreAuthorize("hasAuthority('people:userLink:view')")
+    public ResponseEntity<List<InactivePersonActiveUserResponse>> findActiveUsersForInactivePersons() {
+        return ResponseEntity.ok(linkService.findActiveUsersForInactivePersons());
     }
 
     @GetMapping("/user-links/{personId}")

--- a/pos-people/src/main/java/com/positivity/people/internal/dto/InactivePersonActiveUserResponse.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/dto/InactivePersonActiveUserResponse.java
@@ -1,0 +1,49 @@
+package com.positivity.people.internal.dto;
+
+import com.positivity.people.internal.enums.EmployeeStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Compliance finding: an ACTIVE user linked to a person whose status is inactive
+ * (SUSPENDED, TERMINATED, or DISABLED). Per ADR-0015 §4, disabling/archiving a
+ * person must disable their active user, so each row is a violation to remediate.
+ */
+@Data
+@Builder
+@Schema(description = "An active user-person link whose linked person is in an inactive status (ADR-0015 §4 violation)")
+public class InactivePersonActiveUserResponse {
+
+    @Schema(
+            description = "User-person link identifier",
+            example = "01960012-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID linkId;
+
+    @Schema(
+            description = "User account identifier with the still-active link",
+            example = "01960010-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID userId;
+
+    @Schema(
+            description = "Person identifier in an inactive status",
+            example = "01960011-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID personId;
+
+    @Schema(
+            description = "Inactive status of the linked person",
+            example = "TERMINATED",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private EmployeeStatus personStatus;
+
+    @Schema(
+            description = "When the person's status last became effective",
+            example = "2026-01-15T09:30:00Z",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Instant personStatusEffectiveAt;
+}

--- a/pos-people/src/main/java/com/positivity/people/internal/repository/UserPersonLinkRepository.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/UserPersonLinkRepository.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserPersonLinkRepository extends JpaRepository<UserPersonLink, UUID> {
 
@@ -19,12 +21,18 @@ public interface UserPersonLinkRepository extends JpaRepository<UserPersonLink, 
      * linked person sits in an inactive status. These represent users that should
      * have been disabled when the person was disabled/archived.
      *
+     * <p>Fetches the person in the same query (JOIN FETCH) so the response mapping
+     * does not trigger per-row lazy loads (N+1).
+     *
      * @param status         the link status to match (ACTIVE)
      * @param personStatuses the person statuses considered inactive
      * @return offending links (active user, inactive person)
      */
+    @Query("SELECT l FROM UserPersonLink l JOIN FETCH l.person p "
+            + "WHERE l.status = :status AND p.status IN :personStatuses")
     List<UserPersonLink> findByStatusAndPerson_StatusIn(
-            @NonNull UserLinkStatus status, @NonNull Collection<EmployeeStatus> personStatuses);
+            @Param("status") @NonNull UserLinkStatus status,
+            @Param("personStatuses") @NonNull Collection<EmployeeStatus> personStatuses);
 
     List<UserPersonLink> findByPerson_Id(@NonNull UUID personId);
 

--- a/pos-people/src/main/java/com/positivity/people/internal/repository/UserPersonLinkRepository.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/UserPersonLinkRepository.java
@@ -1,7 +1,9 @@
 package com.positivity.people.internal.repository;
 
 import com.positivity.people.internal.entity.UserPersonLink;
+import com.positivity.people.internal.enums.EmployeeStatus;
 import com.positivity.people.internal.enums.UserLinkStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -11,6 +13,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserPersonLinkRepository extends JpaRepository<UserPersonLink, UUID> {
 
     Optional<UserPersonLink> findByUserId(@NonNull UUID userId);
+
+    /**
+     * Compliance check (ADR-0015 §4): links whose user is still ACTIVE but whose
+     * linked person sits in an inactive status. These represent users that should
+     * have been disabled when the person was disabled/archived.
+     *
+     * @param status         the link status to match (ACTIVE)
+     * @param personStatuses the person statuses considered inactive
+     * @return offending links (active user, inactive person)
+     */
+    List<UserPersonLink> findByStatusAndPerson_StatusIn(
+            @NonNull UserLinkStatus status, @NonNull Collection<EmployeeStatus> personStatuses);
 
     List<UserPersonLink> findByPerson_Id(@NonNull UUID personId);
 

--- a/pos-people/src/main/java/com/positivity/people/internal/service/UserPersonLinkServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/UserPersonLinkServiceImpl.java
@@ -1,10 +1,13 @@
 package com.positivity.people.internal.service;
 
+import com.positivity.people.internal.dto.InactivePersonActiveUserResponse;
 import com.positivity.people.internal.dto.LinkUserToPersonRequest;
 import com.positivity.people.internal.dto.PersonResponse;
 import com.positivity.people.internal.dto.UserPersonLinkResponse;
 import com.positivity.people.internal.entity.Person;
 import com.positivity.people.internal.entity.UserPersonLink;
+import com.positivity.people.internal.enums.EmployeeStatus;
+import com.positivity.people.internal.enums.UserLinkStatus;
 import com.positivity.people.internal.exception.PersonNotFoundException;
 import com.positivity.people.internal.exception.UserAlreadyLinkedException;
 import com.positivity.people.internal.exception.UserPersonLinkNotFoundException;
@@ -12,7 +15,9 @@ import com.positivity.people.internal.repository.PersonRepository;
 import com.positivity.people.internal.repository.UserPersonLinkRepository;
 import com.positivity.people.service.UserPersonLinkService;
 import com.positivity.security.common.SecurityContextHelper;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -24,6 +29,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserPersonLinkServiceImpl implements UserPersonLinkService {
 
     private static final String SYSTEM_USER = "system";
+
+    /** Person statuses that should NOT retain an active user (ADR-0015 §4). */
+    private static final Set<EmployeeStatus> INACTIVE_PERSON_STATUSES =
+            EnumSet.of(EmployeeStatus.SUSPENDED, EmployeeStatus.TERMINATED, EmployeeStatus.DISABLED);
 
     private final UserPersonLinkRepository linkRepository;
 
@@ -152,6 +161,26 @@ public class UserPersonLinkServiceImpl implements UserPersonLinkService {
                 .orElseThrow(() -> new UserPersonLinkNotFoundException(personId));
 
         return toResponse(link);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @NonNull
+    public List<InactivePersonActiveUserResponse> findActiveUsersForInactivePersons() {
+        return linkRepository.findByStatusAndPerson_StatusIn(UserLinkStatus.ACTIVE, INACTIVE_PERSON_STATUSES).stream()
+                .map(this::toInactivePersonResponse)
+                .toList();
+    }
+
+    private InactivePersonActiveUserResponse toInactivePersonResponse(UserPersonLink link) {
+        Person person = link.getPerson();
+        return InactivePersonActiveUserResponse.builder()
+                .linkId(link.getId())
+                .userId(link.getUserId())
+                .personId(link.getPersonId())
+                .personStatus(person != null ? person.getStatus() : null)
+                .personStatusEffectiveAt(person != null ? person.getStatusEffectiveAt() : null)
+                .build();
     }
 
     private UserPersonLinkResponse toResponse(UserPersonLink link) {

--- a/pos-people/src/main/java/com/positivity/people/service/UserPersonLinkService.java
+++ b/pos-people/src/main/java/com/positivity/people/service/UserPersonLinkService.java
@@ -1,5 +1,6 @@
 package com.positivity.people.service;
 
+import com.positivity.people.internal.dto.InactivePersonActiveUserResponse;
 import com.positivity.people.internal.dto.LinkUserToPersonRequest;
 import com.positivity.people.internal.dto.PersonResponse;
 import com.positivity.people.internal.dto.UserPersonLinkResponse;
@@ -32,4 +33,14 @@ public interface UserPersonLinkService {
 
     @NonNull
     UserPersonLinkResponse findLinkByPersonId(@NonNull UUID personId);
+
+    /**
+     * Compliance check (ADR-0015 §4): returns every ACTIVE user-person link whose
+     * linked person is in an inactive status (SUSPENDED, TERMINATED, DISABLED).
+     * These users should have been disabled when the person was disabled/archived.
+     *
+     * @return offending links; empty when none
+     */
+    @NonNull
+    List<InactivePersonActiveUserResponse> findActiveUsersForInactivePersons();
 }

--- a/pos-people/src/test/java/com/positivity/people/service/UserPersonLinkServiceTest.java
+++ b/pos-people/src/test/java/com/positivity/people/service/UserPersonLinkServiceTest.java
@@ -3,15 +3,20 @@ package com.positivity.people.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.positivity.people.internal.dto.InactivePersonActiveUserResponse;
 import com.positivity.people.internal.dto.LinkUserToPersonRequest;
 import com.positivity.people.internal.dto.PersonResponse;
 import com.positivity.people.internal.dto.UserPersonLinkResponse;
 import com.positivity.people.internal.entity.Person;
 import com.positivity.people.internal.entity.UserPersonLink;
+import com.positivity.people.internal.enums.EmployeeStatus;
+import com.positivity.people.internal.enums.UserLinkStatus;
 import com.positivity.people.internal.exception.PersonNotFoundException;
 import com.positivity.people.internal.exception.UserAlreadyLinkedException;
 import com.positivity.people.internal.exception.UserPersonLinkNotFoundException;
@@ -22,12 +27,14 @@ import com.positivity.security.common.SecurityContextHelper;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -211,5 +218,48 @@ class UserPersonLinkServiceTest {
         List<UUID> userIds = service.findUserIdsByPersonId(testPersonId2);
 
         assertThat(userIds).isEmpty();
+    }
+
+    @Test
+    void findActiveUsersForInactivePersons_mapsViolations() {
+        Person terminated = Person.builder()
+                .id(testPersonId)
+                .firstName("Tina")
+                .lastName("Gone")
+                .status(EmployeeStatus.TERMINATED)
+                .statusEffectiveAt(Instant.parse("2026-01-15T09:30:00Z"))
+                .build();
+        UserPersonLink link = new UserPersonLink();
+        link.setId(UUID.fromString("00000000-0000-0000-0000-0000000000aa"));
+        link.setUserId(testUserId);
+        link.setPerson(terminated);
+        link.setStatus(UserLinkStatus.ACTIVE);
+
+        when(linkRepository.findByStatusAndPerson_StatusIn(eq(UserLinkStatus.ACTIVE), anyCollection()))
+                .thenReturn(List.of(link));
+
+        List<InactivePersonActiveUserResponse> result = service.findActiveUsersForInactivePersons();
+
+        assertThat(result).hasSize(1);
+        InactivePersonActiveUserResponse row = result.get(0);
+        assertThat(row.getUserId()).isEqualTo(testUserId);
+        assertThat(row.getPersonId()).isEqualTo(testPersonId);
+        assertThat(row.getPersonStatus()).isEqualTo(EmployeeStatus.TERMINATED);
+        assertThat(row.getPersonStatusEffectiveAt()).isEqualTo(Instant.parse("2026-01-15T09:30:00Z"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findActiveUsersForInactivePersons_queriesActiveLinksAndInactiveStatuses() {
+        when(linkRepository.findByStatusAndPerson_StatusIn(eq(UserLinkStatus.ACTIVE), anyCollection()))
+                .thenReturn(List.of());
+
+        assertThat(service.findActiveUsersForInactivePersons()).isEmpty();
+
+        ArgumentCaptor<Collection<EmployeeStatus>> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(linkRepository).findByStatusAndPerson_StatusIn(eq(UserLinkStatus.ACTIVE), captor.capture());
+        assertThat(captor.getValue())
+                .containsExactlyInAnyOrder(
+                        EmployeeStatus.SUSPENDED, EmployeeStatus.TERMINATED, EmployeeStatus.DISABLED);
     }
 }


### PR DESCRIPTION
Adds the compliance check requested while investigating the user↔person linkage gap (#714): surface **ACTIVE users whose linked person is inactive**, which ADR-0015 §4 says must not happen ("disabling/archiving a Person MUST disable their active User").

## Change
- **Endpoint**: `GET /v1/people/user-links/inactive-person-active-user` (`people:userLink:view`) → `InactivePersonActiveUserResponse[]` (linkId, userId, personId, personStatus, personStatusEffectiveAt). Empty list when clean.
- **Inactive statuses**: `SUSPENDED`, `TERMINATED`, `DISABLED` (active/on-leave and `null` non-employee persons excluded).
- `UserPersonLinkRepository.findByStatusAndPerson_StatusIn(ACTIVE, inactiveStatuses)`.
- `UserPersonLinkService.findActiveUsersForInactivePersons()`.
- Regenerated `pos-people/openapi.yaml`; SDK regen in durion-positivity-sdk-angular (companion PR).

## Tests
- `UserPersonLinkServiceTest` (+2): maps a TERMINATED-person/active-user violation; asserts the query uses `ACTIVE` + exactly {SUSPENDED, TERMINATED, DISABLED}.
- Full class: **11 tests, 0 failures**.

## Notes
Implements one of the ADR-0039 reconcile checks (companion to the "ACTIVE user without person" reconcile). This is the read/detection side; automated remediation (disabling the user) is a follow-up.

See `docs/adr/0015-identity-entity-relationships.adr.md` §4/§7 and BACKEND_CONTRACT_GUIDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)