### PR TITLE
[CAP:714] Seed admin.alpha person + user-person link

### DIFF
--- a/pos-people/src/main/resources/db/migration/R__seed_reference_people.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_reference_people.sql
@@ -19,6 +19,17 @@ INSERT INTO timekeeping_policy (
 VALUES ('7b1f81a7-34fa-f0f9-7caf-a55541d36a60'::uuid, 'GLOBAL', NULL, 10, NOW(), 'seed-generator', NOW(), NOW())
 ON CONFLICT (timekeeping_policy_id) DO NOTHING;
 
+-- person (System Administrator) — admin.alpha's person record. Required so the
+-- guarded user_person_links insert below fires; without it admin.alpha is a User
+-- with no Person, violating ADR-0015 §3 (durion-positivity-backend#714).
+INSERT INTO person (id, first_name, last_name, legal_name, primary_email, status, status_effective_at, username, created_at, updated_at)
+VALUES (
+    '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid,
+    'System', 'Administrator', 'System Administrator',
+    'admin.alpha@durionpos.org', 'ACTIVE', NOW(), 'admin.alpha', NOW(), NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+
 -- user_person_links (guarded by external person existence)
 DO $$
 BEGIN

--- a/pos-security-service/src/main/resources/db/migration/R__seed_reference_security.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_reference_security.sql
@@ -43,9 +43,12 @@ VALUES ('190cbafe-4c1b-7e5f-768f-4b3c0d58a165'::uuid, 'TECHNICIAN', 'Canonical p
 ON CONFLICT (name) DO NOTHING;
 
 -- Users
-INSERT INTO users (id, username, password, enabled)
-VALUES ('d981cd20-55a1-b43c-9332-0ef2cd630e1a'::uuid, 'admin.alpha', '${seed_admin_password_hash}', TRUE) 
-ON CONFLICT (username) DO UPDATE SET password = EXCLUDED.password, enabled = EXCLUDED.enabled;
+-- person_id mirrors the authoritative pos-people user_person_links row (ADR-0043);
+-- required so admin.alpha's JWT carries a personId claim (ADR-0022) and is not a
+-- User without a Person (ADR-0015 §3; durion-positivity-backend#714).
+INSERT INTO users (id, username, password, enabled, person_id)
+VALUES ('d981cd20-55a1-b43c-9332-0ef2cd630e1a'::uuid, 'admin.alpha', '${seed_admin_password_hash}', TRUE, '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid)
+ON CONFLICT (username) DO UPDATE SET password = EXCLUDED.password, enabled = EXCLUDED.enabled, person_id = EXCLUDED.person_id;
 
 -- Permissions (derived from permissions.yaml)
 INSERT INTO permissions (id, name, description, domain, resource, action, registered_at, registered_by_service, version, bit_index)


### PR DESCRIPTION
Closes #714.

`admin.alpha` was seeded as a `User` with no `Person` — violating **ADR-0015 §3** ("a User must be linked to a Person") and leaving the JWT without a `personId` claim (ADR-0022). Root cause: the `user_person_links` insert was guarded on person `583fa3b3-…` which the seed never inserted, and the security `users` row left `person_id` NULL.

## Changes
- **`pos-people` `R__seed_reference_people.sql`** — insert person `583fa3b3-d1bf-a40d-8e21-8cd54424d5d0` (System Administrator) **before** the guarded `user_person_links` block, so the existing guard `EXISTS(person …)` passes and the link (user `d981cd20-…` → person `583fa3b3-…`) now fires. `pos-people.user_person_links` is the authoritative store (ADR-0043).
- **`pos-security-service` `R__seed_reference_security.sql`** — set `users.person_id = 583fa3b3-…` for admin.alpha (mirrors the authoritative link per ADR-0043) so the issued token carries `personId` (ADR-0022). Added to the `ON CONFLICT … DO UPDATE` so existing rows backfill.

## Validation
Both repeatable seeds are exercised by booting Flyway in contract ITs (would crash boot on SQL error):
- `UserPersonLinkContractBehaviorIT` (pos-people): **4/4**
- `RolePermissionContractBehaviorIT` (pos-security-service): **6/6**

On a fresh environment admin.alpha now resolves to a person, `GET /v1/people/users/{adminUserId}/person` returns it, and the token carries a `personId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)