### PR TITLE
refactor(customer): remove redundant CommercialParty.partyNumber

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/entity/CommercialParty.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/entity/CommercialParty.java
@@ -48,11 +48,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
                 "Organization or company doing business with the service provider. Supports hierarchy and requires at least one contact.")
 public class CommercialParty extends AbstractParty {
 
-    @Column(unique = true, nullable = false)
-    @NotBlank
-    @Schema(description = "Unique party number", example = "PARTY-1001")
-    private String partyNumber;
-
     @Column(nullable = false)
     @NotBlank
     @Schema(description = "Legal name of the organization", example = "Acme Corporation")

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/CommercialPartyRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/CommercialPartyRepository.java
@@ -2,7 +2,6 @@ package com.positivity.customer.internal.repository;
 
 import com.positivity.customer.internal.entity.CommercialParty;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,8 +13,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface CommercialPartyRepository extends JpaRepository<CommercialParty, UUID> {
-    Optional<CommercialParty> findByPartyNumber(String partyNumber);
-
     CommercialParty findByPartyId(UUID partyId);
 
     @Query(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CrmVehicleServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CrmVehicleServiceImpl.java
@@ -333,7 +333,7 @@ public class CrmVehicleServiceImpl implements CrmVehicleService {
         com.positivity.customer.internal.dto.snapshot.AccountSummary acct =
                 new com.positivity.customer.internal.dto.snapshot.AccountSummary(
                         party.getPartyId().toString(),
-                        party.getPartyNumber() != null ? party.getPartyNumber() : "N/A",
+                        party.getCustomerNumber() != null ? party.getCustomerNumber() : "N/A",
                         party.getDisplayName() != null ? party.getDisplayName() : party.getLegalName(),
                         party.getPartyType().name());
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -102,22 +102,22 @@ public class PartyServiceImpl implements PartyService {
                         ? PartyType.valueOf(request.getPartyType())
                         : PartyType.COMMERCIAL);
         party.setStatus(AccountStatus.ACTIVE);
-        party.setPartyNumber(generatePartyNumber());
+        party.setCustomerNumber(generateCustomerNumber());
         if (request.getExternalIdentifiers() != null) {
             party.getExternalIdentifiers().putAll(request.getExternalIdentifiers());
         }
 
         CommercialParty saved = partyRepository.save(party);
         log.info(
-                "Created commercial account with partyId: {}, partyNumber: {}",
+                "Created commercial account with partyId: {}, customerNumber: {}",
                 saved.getPartyId(),
-                saved.getPartyNumber());
+                saved.getCustomerNumber());
 
         return CreateCommercialAccountResponse.builder()
                 .partyId(String.valueOf(saved.getPartyId()))
                 .legalName(saved.getLegalName())
                 .status(saved.getStatus().toString())
-                .customerNumber(saved.getPartyNumber())
+                .customerNumber(saved.getCustomerNumber())
                 .displayName(saved.getDisplayName())
                 .partyType(saved.getPartyType() != null ? saved.getPartyType().toString() : null)
                 .taxId(saved.getTaxId())
@@ -155,8 +155,8 @@ public class PartyServiceImpl implements PartyService {
         return party;
     }
 
-    private String generatePartyNumber() {
-        return "PARTY-" + UUIDv7Generator.generate().toString().substring(0, 8).toUpperCase(Locale.US);
+    private String generateCustomerNumber() {
+        return "CUST-" + UUIDv7Generator.generate().toString().substring(0, 8).toUpperCase(Locale.US);
     }
 
     @Override
@@ -769,14 +769,14 @@ public class PartyServiceImpl implements PartyService {
     }
 
     private AccountSummary buildAccountSummary(CommercialParty party) {
-        String partyNumber = requireText(party.getPartyNumber(), "partyNumber");
+        String customerNumber = requireText(party.getCustomerNumber(), "customerNumber");
         String legalName = requireText(party.getLegalName(), "legalName");
         PartyType partyType = requireNonNullField(party.getPartyType(), "partyType");
         String id = party.getPartyId().toString();
         String name = StringUtils.hasText(party.getDisplayName()) ? party.getDisplayName() : legalName;
         String type = partyType.name();
 
-        return new AccountSummary(id, partyNumber, name, type);
+        return new AccountSummary(id, customerNumber, name, type);
     }
 
     private String requireText(String value, String fieldName) {

--- a/pos-customer/src/main/resources/db/migration/R__seed_customer_operational_data.sql
+++ b/pos-customer/src/main/resources/db/migration/R__seed_customer_operational_data.sql
@@ -249,7 +249,7 @@ ON CONFLICT (customer_id) DO NOTHING;
 --   PartyType: COMMERCIAL = 1
 -- =========================================================================
 
-INSERT INTO commercial_party (customer_id, customer_number, party_number,
+INSERT INTO commercial_party (customer_id, customer_number,
                                legal_name, display_name, tax_id, billing_terms_id,
                                party_type, status, tier, tier_manual_override, parent_party_id,
                                primary_address,
@@ -257,56 +257,56 @@ INSERT INTO commercial_party (customer_id, customer_number, party_number,
 VALUES
     -- STANDARD tier (rows 1–8)
     ('01960021-0000-7000-8000-000000000001'::uuid,
-     'CUST-CP-001', 'PARTY-CP-001',
+     'CUST-CP-001',
      'Piedmont Freight Carriers LLC', 'Piedmont Freight',
      '27-4481203', 'NET-30', 1, 0, 0, false, NULL,
      '3501 Trailer Park Dr, Charlotte, NC 28269',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-000000000002'::uuid,
-     'CUST-CP-002', 'PARTY-CP-002',
+     'CUST-CP-002',
      'Carolina Concrete Supply Co.', 'Carolina Concrete',
      '46-3215872', 'NET-30', 1, 0, 0, false, NULL,
      '8200 Old Concord Rd, Concord, NC 28027',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-000000000003'::uuid,
-     'CUST-CP-003', 'PARTY-CP-003',
+     'CUST-CP-003',
      'Queen City Waste Management Inc.', 'QC Waste',
      '35-2198043', 'NET-45', 1, 0, 0, false, NULL,
      '4801 Wilkinson Blvd, Charlotte, NC 28208',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-000000000004'::uuid,
-     'CUST-CP-004', 'PARTY-CP-004',
+     'CUST-CP-004',
      'Blue Ridge Landscaping Services LLC', 'Blue Ridge Landscaping',
      '82-1563489', 'NET-30', 1, 0, 0, false, NULL,
      '201 Brawley School Rd, Mooresville, NC 28117',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-000000000005'::uuid,
-     'CUST-CP-005', 'PARTY-CP-005',
+     'CUST-CP-005',
      'Tarheel Logistics Group LLC', 'Tarheel Logistics',
      '61-7832941', 'NET-45', 1, 0, 0, false, NULL,
      '1120 Armstrong Rd, Gastonia, NC 28052',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-000000000006'::uuid,
-     'CUST-CP-006', 'PARTY-CP-006',
+     'CUST-CP-006',
      'Mecklenburg Plumbing & Mechanical LLC', 'Meck Plumbing',
      '47-9210583', 'NET-30', 1, 0, 0, false, NULL,
      '6120 Old Pineville Rd, Charlotte, NC 28217',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-000000000007'::uuid,
-     'CUST-CP-007', 'PARTY-CP-007',
+     'CUST-CP-007',
      'Piedmont Ready Mix Corp.', 'Piedmont Ready Mix',
      '56-3841027', 'NET-60', 1, 0, 0, false, NULL,
      '2505 Dale Earnhardt Blvd, Kannapolis, NC 28083',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-000000000008'::uuid,
-     'CUST-CP-008', 'PARTY-CP-008',
+     'CUST-CP-008',
      'Carolina Power & Electrical Services Inc.', 'Carolina Power',
      '29-6713854', 'NET-30', 1, 0, 0, false, NULL,
      '16345 Old Statesville Rd, Huntersville, NC 28078',
@@ -314,35 +314,35 @@ VALUES
 
     -- BRONZE tier (rows 9–13)
     ('01960021-0000-7000-8000-000000000009'::uuid,
-     'CUST-CP-009', 'PARTY-CP-009',
+     'CUST-CP-009',
      'Blue Stone Aggregate & Gravel LLC', 'Blue Stone Aggregate',
      '74-5291836', 'NET-45', 1, 0, 1, false, NULL,
      '808 E Broad St, Statesville, NC 28677',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-00000000000a'::uuid,
-     'CUST-CP-010', 'PARTY-CP-010',
+     'CUST-CP-010',
      'Cabarrus Industrial Cleaning Corp.', 'Cabarrus Cleaning',
      '31-4827653', 'NET-30', 1, 0, 1, false, NULL,
      '4540 Poplar Tent Rd, Concord, NC 28027',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-00000000000b'::uuid,
-     'CUST-CP-011', 'PARTY-CP-011',
+     'CUST-CP-011',
      'Southeast Delivery Solutions LLC', 'SE Delivery',
      '68-9201374', 'NET-30', 1, 0, 1, false, NULL,
      '7302 Albemarle Rd, Charlotte, NC 28212',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-00000000000c'::uuid,
-     'CUST-CP-012', 'PARTY-CP-012',
+     'CUST-CP-012',
      'Carolinas Crane & Rigging Co.', 'Carolinas Crane',
      '45-7832016', 'NET-45', 1, 0, 1, false, NULL,
      '2120 Southend Dr, Charlotte, NC 28203',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-00000000000d'::uuid,
-     'CUST-CP-013', 'PARTY-CP-013',
+     'CUST-CP-013',
      'Lake Norman Propane & Fuels LLC', 'LKN Propane',
      '52-1938476', 'COD', 1, 0, 1, false, NULL,
      '1003 Harbor Rd, Mooresville, NC 28117',
@@ -350,28 +350,28 @@ VALUES
 
     -- SILVER tier (rows 14–17)
     ('01960021-0000-7000-8000-00000000000e'::uuid,
-     'CUST-CP-014', 'PARTY-CP-014',
+     'CUST-CP-014',
      'Rowan County Road Services LLC', 'Rowan Road Services',
      '73-4826015', 'NET-45', 1, 0, 2, false, NULL,
      '505 N Main St, Salisbury, NC 28144',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-00000000000f'::uuid,
-     'CUST-CP-015', 'PARTY-CP-015',
+     'CUST-CP-015',
      'Carolina Fresh Produce Distribution Inc.', 'Carolina Fresh',
      '28-5943016', 'NET-30', 1, 0, 2, false, NULL,
      '3900 Morningside Industrial Dr, Charlotte, NC 28215',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-000000000010'::uuid,
-     'CUST-CP-016', 'PARTY-CP-016',
+     'CUST-CP-016',
      'Piedmont Steel & Metal Recycling LLC', 'Piedmont Metals',
      '34-8710253', 'NET-60', 1, 0, 2, false, NULL,
      '1205 Industrial Ave, Gastonia, NC 28052',
      NOW(), NOW()),
 
     ('01960021-0000-7000-8000-000000000011'::uuid,
-     'CUST-CP-017', 'PARTY-CP-017',
+     'CUST-CP-017',
      'Union County Grading & Excavation Inc.', 'Union Grading',
      '67-2194830', 'NET-45', 1, 0, 2, false, NULL,
      '2301 N Rocky River Rd, Monroe, NC 28112',
@@ -379,7 +379,7 @@ VALUES
 
     -- GOLD tier (rows 18–19)
     ('01960021-0000-7000-8000-000000000012'::uuid,
-     'CUST-CP-018', 'PARTY-CP-018',
+     'CUST-CP-018',
      'Carolina Septic & Environmental LLC', 'Carolina Septic',
      '49-8023174', 'NET-30', 1, 0, 3, false, NULL,
      '5820 Poplar Tent Rd, Concord, NC 28027',
@@ -387,7 +387,7 @@ VALUES
 
     -- INACTIVE (status=1), GOLD tier
     ('01960021-0000-7000-8000-000000000013'::uuid,
-     'CUST-CP-019', 'PARTY-CP-019',
+     'CUST-CP-019',
      'Mecklenburg Tree Service & Timber Inc.', 'Meck Tree',
      '83-5012967', 'NET-30', 1, 1, 3, false, NULL,
      '6401 Beatties Ford Rd, Charlotte, NC 28216',
@@ -395,7 +395,7 @@ VALUES
 
     -- ON_HOLD (status=2), PLATINUM tier
     ('01960021-0000-7000-8000-000000000014'::uuid,
-     'CUST-CP-020', 'PARTY-CP-020',
+     'CUST-CP-020',
      'Highland Moving & Storage LLC', 'Highland Moving',
      '55-1874392', 'NET-60', 1, 2, 4, false, NULL,
      '1801 Cross Beam Dr, Charlotte, NC 28217',

--- a/pos-customer/src/main/resources/db/migration/V1__baseline_customer_schema.sql
+++ b/pos-customer/src/main/resources/db/migration/V1__baseline_customer_schema.sql
@@ -10,7 +10,7 @@ SET TIME ZONE 'UTC';
 
 
 
-CREATE TABLE commercial_party ( party_type smallint NOT NULL, status smallint NOT NULL, tier smallint NOT NULL, tier_manual_override boolean NOT NULL, created_at timestamp(6) with time zone NOT NULL, tier_assigned_at timestamp(6) with time zone, updated_at timestamp(6) with time zone NOT NULL, customer_id uuid NOT NULL, parent_party_id uuid, billing_terms_id character varying(255), customer_number character varying(255) NOT NULL, display_name character varying(255), email character varying(255), legal_name character varying(255) NOT NULL, party_number character varying(255) NOT NULL, phone_number character varying(255), primary_address character varying(255), tax_id character varying(255), tier_assigned_by character varying(255), CONSTRAINT commercial_party_party_type_check CHECK (((party_type >= 0) AND (party_type <= 2))), CONSTRAINT commercial_party_status_check CHECK (((status >= 0) AND (status <= 3))), CONSTRAINT commercial_party_tier_check CHECK (((tier >= 0) AND (tier <= 5))) );
+CREATE TABLE commercial_party ( party_type smallint NOT NULL, status smallint NOT NULL, tier smallint NOT NULL, tier_manual_override boolean NOT NULL, created_at timestamp(6) with time zone NOT NULL, tier_assigned_at timestamp(6) with time zone, updated_at timestamp(6) with time zone NOT NULL, customer_id uuid NOT NULL, parent_party_id uuid, billing_terms_id character varying(255), customer_number character varying(255) NOT NULL, display_name character varying(255), email character varying(255), legal_name character varying(255) NOT NULL, phone_number character varying(255), primary_address character varying(255), tax_id character varying(255), tier_assigned_by character varying(255), CONSTRAINT commercial_party_party_type_check CHECK (((party_type >= 0) AND (party_type <= 2))), CONSTRAINT commercial_party_status_check CHECK (((status >= 0) AND (status <= 3))), CONSTRAINT commercial_party_tier_check CHECK (((tier >= 0) AND (tier <= 5))) );
 
 CREATE TABLE communication_preference ( created_at timestamp(6) with time zone NOT NULL, updated_at timestamp(6) with time zone NOT NULL, version bigint NOT NULL, party_id uuid NOT NULL, preference_id uuid NOT NULL, email_preference character varying(20), marketing_preference character varying(20), phone_preference character varying(20), sms_preference character varying(20), update_source character varying(20), preferences_note character varying(1000) );
 
@@ -48,7 +48,6 @@ CREATE TABLE vehicle_projection ( vehicle_year integer, last_event_at timestamp(
 
 ALTER TABLE commercial_party ADD CONSTRAINT commercial_party_customer_number_key UNIQUE (customer_number);
 
-ALTER TABLE commercial_party ADD CONSTRAINT commercial_party_party_number_key UNIQUE (party_number);
 
 ALTER TABLE commercial_party ADD CONSTRAINT commercial_party_pkey PRIMARY KEY (customer_id);
 

--- a/pos-customer/src/test/java/com/positivity/customer/PartyRelationshipServiceContractBehaviorIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/PartyRelationshipServiceContractBehaviorIT.java
@@ -84,10 +84,6 @@ class PartyRelationshipServiceContractBehaviorIT extends BaseContractIntegration
 
         // Create test party (commercial account)
         testParty = new CommercialParty();
-        testParty.setPartyNumber("TEST-"
-                + UUID.fromString("00000000-0000-0000-0000-000000000001")
-                        .toString()
-                        .substring(0, 8));
         testParty.setLegalName("Test Commercial Account");
         testParty.setDisplayName("Test Commercial Account");
         testParty.setCustomerNumber("CUST-TEST-"

--- a/pos-customer/src/test/java/com/positivity/customer/PersonServiceContractBehaviorIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/PersonServiceContractBehaviorIT.java
@@ -334,7 +334,6 @@ class PersonServiceContractBehaviorIT extends BaseContractIntegrationTest {
 
         CommercialParty party = new CommercialParty();
         party.setCustomerNumber("CUST-2001");
-        party.setPartyNumber("PARTY-2001");
         party.setLegalName("Acme Logistics");
         party.setDisplayName("Acme Logistics");
         commercialPartyRepository.save(party);

--- a/pos-customer/src/test/java/com/positivity/customer/contract/BillingRulesContractBehaviorIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/contract/BillingRulesContractBehaviorIT.java
@@ -76,7 +76,6 @@ class BillingRulesContractBehaviorIT extends BaseContractIntegrationTest {
         party.setPartyType(PartyType.COMMERCIAL);
         party.setLegalName("Billing Rules Test Corp");
         party.setDisplayName("Billing Corp");
-        party.setPartyNumber("BR-" + UUID.fromString("00000000-0000-0000-0000-000000000001"));
         party.setCustomerNumber("CUST-BR-"
                 + UUID.fromString("00000000-0000-0000-0000-000000000001")
                         .toString()

--- a/pos-customer/src/test/java/com/positivity/customer/contract/CrmSnapshotContractBehaviorIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/contract/CrmSnapshotContractBehaviorIT.java
@@ -58,7 +58,6 @@ class CrmSnapshotContractBehaviorIT extends BaseContractIntegrationTest {
         party.setPartyType(PartyType.COMMERCIAL);
         party.setLegalName("Snapshot Test Corp");
         party.setDisplayName("Snapshot Corp");
-        party.setPartyNumber("SNAP-" + UUID.fromString("00000000-0000-0000-0000-000000000001"));
         party.setCustomerNumber("CUST-SNAP-"
                 + UUID.fromString("00000000-0000-0000-0000-000000000001")
                         .toString()

--- a/pos-customer/src/test/java/com/positivity/customer/contract/CustomerRequirementsContractBehaviorIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/contract/CustomerRequirementsContractBehaviorIT.java
@@ -32,7 +32,6 @@ class CustomerRequirementsContractBehaviorIT extends BaseContractIntegrationTest
         party.setPartyType(PartyType.COMMERCIAL);
         party.setLegalName("Requirements Test Corp");
         party.setDisplayName("Requirements Corp");
-        party.setPartyNumber("REQ-" + UUID.randomUUID());
         party.setCustomerNumber("CUST-REQ-" + UUID.randomUUID().toString().substring(0, 8));
         party.setStatus(status);
 

--- a/pos-customer/src/test/java/com/positivity/customer/service/CommercialPartyServiceImplSearchTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/CommercialPartyServiceImplSearchTest.java
@@ -31,7 +31,6 @@ class CommercialPartyServiceImplSearchTest {
     private CommercialParty party(UUID id, String legalName) {
         CommercialParty p = new CommercialParty();
         p.setPartyId(id);
-        p.setPartyNumber("PARTY-" + id.toString().substring(0, 8));
         p.setCustomerNumber("CUST-" + id.toString().substring(0, 8));
         p.setLegalName(legalName);
         p.setDisplayName("Acme");

--- a/pos-customer/src/test/java/com/positivity/customer/service/CommunicationPreferenceServiceContractBehaviorIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/CommunicationPreferenceServiceContractBehaviorIT.java
@@ -61,7 +61,6 @@ class CommunicationPreferenceServiceContractBehaviorIT extends BaseContractInteg
         testParty = new CommercialParty();
         testParty.setLegalName("Test Party");
         testParty.setDisplayName("Test Party");
-        testParty.setPartyNumber("PARTY-TEST-" + sequence);
         testParty.setCustomerNumber("CUST-TEST-" + sequence);
         testParty.setStatus(AccountStatus.ACTIVE);
 

--- a/pos-customer/src/test/java/com/positivity/customer/service/ContactRoleServiceContractBehaviorIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/ContactRoleServiceContractBehaviorIT.java
@@ -79,7 +79,6 @@ class ContactRoleServiceContractBehaviorIT extends BaseContractIntegrationTest {
         testParty.setPartyType(PartyType.COMMERCIAL);
         testParty.setLegalName("Test Party");
         testParty.setDisplayName("Test Party");
-        testParty.setPartyNumber("PARTY-TEST-" + System.currentTimeMillis());
         testParty.setCustomerNumber("CUST-TEST-" + System.currentTimeMillis());
         testParty.setStatus(AccountStatus.ACTIVE);
 

--- a/pos-customer/src/test/java/com/positivity/customer/service/CrmVehicleServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/CrmVehicleServiceImplTest.java
@@ -58,7 +58,7 @@ class CrmVehicleServiceImplTest {
     private CommercialParty commercialParty(UUID id) {
         CommercialParty party = new CommercialParty();
         party.setPartyId(id);
-        party.setPartyNumber("PARTY-" + id.toString().substring(0, 8));
+        party.setCustomerNumber("CUST-" + id.toString().substring(0, 8));
         party.setLegalName("Acme Fleet");
         party.setDisplayName("Acme");
         party.setPartyType(PartyType.COMMERCIAL);

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -101,7 +101,7 @@ class PartyServiceImplTest {
     private CommercialParty party(UUID id) {
         CommercialParty p = new CommercialParty();
         p.setPartyId(id);
-        p.setPartyNumber("PARTY-001");
+        p.setCustomerNumber("CUST-001");
         p.setLegalName("Acme Corp");
         p.setDisplayName("Acme");
         p.setPartyType(PartyType.COMMERCIAL);
@@ -247,10 +247,10 @@ class PartyServiceImplTest {
     }
 
     @Test
-    void buildSnapshotForParty_throwsIllegalState_whenPartyNumberMissing() {
+    void buildSnapshotForParty_throwsIllegalState_whenCustomerNumberMissing() {
         UUID partyId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         CommercialParty p = party(partyId);
-        p.setPartyNumber(" ");
+        p.setCustomerNumber(" ");
 
         when(cacheManager.getCache(CacheConfig.SNAPSHOT_CACHE)).thenReturn(cache);
         when(cache.get(partyId)).thenReturn(null);
@@ -258,7 +258,7 @@ class PartyServiceImplTest {
 
         assertThatThrownBy(() -> service.buildSnapshotForParty(partyId))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("partyNumber");
+                .hasMessageContaining("customerNumber");
     }
 
     @Test
@@ -371,7 +371,7 @@ class PartyServiceImplTest {
         ArgumentCaptor<CommercialParty> partyCaptor = ArgumentCaptor.forClass(CommercialParty.class);
         verify(partyRepository).save(partyCaptor.capture());
         assertThat(partyCaptor.getValue().getPartyType()).isEqualTo(PartyType.COMMERCIAL);
-        assertThat(partyCaptor.getValue().getPartyNumber()).startsWith("PARTY-");
+        assertThat(partyCaptor.getValue().getCustomerNumber()).startsWith("CUST-");
         assertThat(partyCaptor.getValue().getExternalIdentifiers()).containsEntry("erp", "A-100");
     }
 


### PR DESCRIPTION
## Summary
`CommercialParty` inherited `customerNumber` from `AbstractParty` but also declared a duplicate `partyNumber` identity field. `customerNumber` is canonical (Person path, search, DTOs, bulk-loader all use it), so `partyNumber` is removed and every reference points at `customerNumber`.

## Latent bug fixed
`createCommercialAccount` set only `partyNumber` and never `customerNumber`, despite `commercial_party.customer_number` being `NOT NULL UNIQUE`. The create path now generates `customerNumber`.

## Changes
- Drop `partyNumber` field; drop `findByPartyNumber` repository method (zero callers)
- `generatePartyNumber` → `generateCustomerNumber` (`PARTY-` → `CUST-` prefix)
- Snapshot `AccountSummary` built from `customerNumber` (PartyServiceImpl + CrmVehicleServiceImpl)
- Baseline schema `V1`: drop `party_number` column + unique constraint (customer_number unique already present)
- Seed `R__`: drop `party_number` column and 20 row values
- Tests: drop redundant `setPartyNumber`; rename missing-field test + assertion message

## Contract
No API change — create response field already named `customerNumber`; only its source value changed. No OpenAPI/SDK regen needed. Archive migration left untouched.

## Verification
`./mvnw -pl pos-customer test` → **146 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)