### PR TITLE
feat(catalog): service catalog substring search endpoint

### DIFF
--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -1034,11 +1034,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/UomConversionDto'
-                unevaluatedItems: {}
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -1665,6 +1662,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_VIEW
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_VIEW
+  /v1/products/services/search:
+    get:
+      tags:
+      - Products API
+      summary: Search catalog services
+      description: Free-text substring search over service names for typeahead selection.
+      operationId: searchServices
+      parameters:
+      - name: q
+        in: query
+        description: Free-text query matching service name (case-insensitive substring)
+        required: false
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Maximum number of results (1–100)
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Matching services
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServiceDto'
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -4109,10 +4142,10 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
         first:
           type: boolean
         last:
@@ -4128,16 +4161,16 @@ components:
         offset:
           type: integer
           format: int64
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        pageSize:
+          type: integer
+          format: int32
         paged:
           type: boolean
         pageNumber:
           type: integer
           format: int32
-        pageSize:
-          type: integer
-          format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
         unpaged:
           type: boolean
     SortObject:
@@ -4168,10 +4201,10 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
         first:
           type: boolean
         last:

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
@@ -24,6 +24,7 @@ import com.positivity.catalog.service.ProductSearchService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -328,6 +329,30 @@ public class ProductController {
 
         log.debug("Product detail view generated with confidence={}", productDetail.getConfidence());
         return ResponseEntity.ok(productDetail);
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
+    @GetMapping("/services/search")
+    @Operation(
+            summary = "Search catalog services",
+            description = "Free-text substring search over service names for typeahead selection.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Matching services",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = ServiceDto.class))))
+    public ResponseEntity<List<ServiceDto>> searchServices(
+            @Parameter(description = "Free-text query matching service name (case-insensitive substring)")
+                    @RequestParam(required = false)
+                    String q,
+            @Parameter(description = "Maximum number of results (1–100)") @RequestParam(defaultValue = "20")
+                    int limit) {
+        return ResponseEntity.ok(catalogService.searchServices(q, limit));
     }
 
     @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ServiceRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ServiceRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ServiceRepository extends JpaRepository<ServiceEntity, UUID> {
     List<ServiceEntity> findByName(String name);
+
+    List<ServiceEntity> findByNameContainingIgnoreCase(String name);
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ServiceRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ServiceRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ServiceRepository extends JpaRepository<ServiceEntity, UUID> {
     List<ServiceEntity> findByName(String name);
 
-    List<ServiceEntity> findByNameContainingIgnoreCase(String name);
+    List<ServiceEntity> findByNameContainingIgnoreCaseOrderByNameAsc(String name);
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
@@ -76,7 +76,7 @@ public class CatalogServiceImpl implements CatalogService {
             return Collections.emptyList();
         }
         int capped = Math.max(1, Math.min(limit, 100));
-        return serviceRepository.findByNameContainingIgnoreCase(q.trim()).stream()
+        return serviceRepository.findByNameContainingIgnoreCaseOrderByNameAsc(q.trim()).stream()
                 .map(this::toServiceDto)
                 .limit(capped)
                 .toList();

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
@@ -71,6 +71,17 @@ public class CatalogServiceImpl implements CatalogService {
                 .toList();
     }
 
+    public List<ServiceDto> searchServices(String q, int limit) {
+        if (q == null || q.isBlank()) {
+            return Collections.emptyList();
+        }
+        int capped = Math.max(1, Math.min(limit, 100));
+        return serviceRepository.findByNameContainingIgnoreCase(q.trim()).stream()
+                .map(this::toServiceDto)
+                .limit(capped)
+                .toList();
+    }
+
     public Optional<NonInventoryProductDto> getNonInventoryProductById(UUID productId) {
         return nonInventoryProductRepository.findById(productId).map(this::toNonInventoryProductDto);
     }

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/CatalogService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/CatalogService.java
@@ -20,6 +20,8 @@ public interface CatalogService {
 
     List<ServiceDto> getServicesByName(String name);
 
+    List<ServiceDto> searchServices(String q, int limit);
+
     Optional<NonInventoryProductDto> getNonInventoryProductById(UUID productId);
 
     List<NonInventoryProductDto> getNonInventoryProductsByName(String name);

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/CatalogServiceImplTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/CatalogServiceImplTest.java
@@ -1,0 +1,82 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.dto.ServiceDto;
+import com.positivity.catalog.internal.entity.ServiceEntity;
+import com.positivity.catalog.internal.repository.CatalogRepository;
+import com.positivity.catalog.internal.repository.NonInventoryProductRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.catalog.internal.repository.ServiceRepository;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CatalogServiceImplTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private ServiceRepository serviceRepository;
+
+    @Mock
+    private NonInventoryProductRepository nonInventoryProductRepository;
+
+    @Mock
+    private CatalogRepository catalogRepository;
+
+    @InjectMocks
+    private CatalogServiceImpl catalogService;
+
+    private static ServiceEntity service(String name) {
+        ServiceEntity e = new ServiceEntity();
+        e.setId(UUID.randomUUID());
+        e.setName(name);
+        e.setShortDescription("short");
+        e.setLongDescription("long");
+        return e;
+    }
+
+    @Test
+    void searchServices_blankQuery_returnsEmptyAndSkipsRepository() {
+        assertThat(catalogService.searchServices("   ", 20)).isEmpty();
+        assertThat(catalogService.searchServices(null, 20)).isEmpty();
+        verifyNoInteractions(serviceRepository);
+    }
+
+    @Test
+    void searchServices_mapsMatchesToDtos() {
+        when(serviceRepository.findByNameContainingIgnoreCase("brake"))
+                .thenReturn(List.of(service("Brake pad replacement"), service("Brake fluid flush")));
+
+        List<ServiceDto> result = catalogService.searchServices("brake", 20);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(ServiceDto::getName).containsExactly("Brake pad replacement", "Brake fluid flush");
+    }
+
+    @Test
+    void searchServices_trimsQuery() {
+        when(serviceRepository.findByNameContainingIgnoreCase("oil")).thenReturn(List.of(service("Oil change")));
+
+        assertThat(catalogService.searchServices("  oil  ", 20)).hasSize(1);
+    }
+
+    @Test
+    void searchServices_capsResultsToLimit() {
+        List<ServiceEntity> many =
+                IntStream.range(0, 50).mapToObj(i -> service("Service " + i)).toList();
+        when(serviceRepository.findByNameContainingIgnoreCase("service")).thenReturn(many);
+
+        assertThat(catalogService.searchServices("service", 5)).hasSize(5);
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/CatalogServiceImplTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/CatalogServiceImplTest.java
@@ -55,7 +55,7 @@ class CatalogServiceImplTest {
 
     @Test
     void searchServices_mapsMatchesToDtos() {
-        when(serviceRepository.findByNameContainingIgnoreCase("brake"))
+        when(serviceRepository.findByNameContainingIgnoreCaseOrderByNameAsc("brake"))
                 .thenReturn(List.of(service("Brake pad replacement"), service("Brake fluid flush")));
 
         List<ServiceDto> result = catalogService.searchServices("brake", 20);
@@ -66,7 +66,7 @@ class CatalogServiceImplTest {
 
     @Test
     void searchServices_trimsQuery() {
-        when(serviceRepository.findByNameContainingIgnoreCase("oil")).thenReturn(List.of(service("Oil change")));
+        when(serviceRepository.findByNameContainingIgnoreCaseOrderByNameAsc("oil")).thenReturn(List.of(service("Oil change")));
 
         assertThat(catalogService.searchServices("  oil  ", 20)).hasSize(1);
     }
@@ -75,7 +75,7 @@ class CatalogServiceImplTest {
     void searchServices_capsResultsToLimit() {
         List<ServiceEntity> many =
                 IntStream.range(0, 50).mapToObj(i -> service("Service " + i)).toList();
-        when(serviceRepository.findByNameContainingIgnoreCase("service")).thenReturn(many);
+        when(serviceRepository.findByNameContainingIgnoreCaseOrderByNameAsc("service")).thenReturn(many);
 
         assertThat(catalogService.searchServices("service", 5)).hasSize(5);
     }


### PR DESCRIPTION
## Summary
Adds `GET /v1/products/services/search?q=&limit=` — a case-insensitive substring search over catalog service names, to power a typeahead for selecting services (e.g. on the estimate labor screen). Services previously exposed only exact-name (`/services/name/{name}`) and by-id lookups, so no typeahead source existed.

## Changes
- `ServiceRepository.findByNameContainingIgnoreCase`
- `CatalogService.searchServices(q, limit)`: blank query → empty; trims query; caps results to 1–100 (default 20)
- `ProductController.searchServices` with OpenAPI annotations + `ROLE_ADMIN`/`ROLE_CATALOG_VIEW` security
- Regenerated `pos-catalog/openapi.yaml` (aggregate left untouched — full-repo regen is separate)
- Unit tests: blank, substring delegation, trim, limit cap (4 tests, green)

## Contract
Aligns with `BACKEND_CONTRACT_GUIDE.md` catalog service lookups (read-only search; same security as product search).

## Test
`mvn -pl pos-catalog test -Dtest=CatalogServiceImplTest` → 4 passed.

## Downstream
SDK + frontend PRs follow (catalog SDK `searchServices`, estimate-labor typeahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)