### PR TITLE
fix(customer): restore V1 baseline, drop party_number via forward migration

### DIFF
--- a/pos-customer/src/main/resources/db/migration/V12__drop_commercial_party_party_number.sql
+++ b/pos-customer/src/main/resources/db/migration/V12__drop_commercial_party_party_number.sql
@@ -1,0 +1,16 @@
+-- =============================================================
+-- V12__drop_commercial_party_party_number.sql
+-- Remove the redundant commercial_party.party_number column.
+--
+-- Supersedes the in-place edit of the V1 baseline made in #720,
+-- which mutated an already-applied migration and broke Flyway
+-- validation on existing databases. The baseline is restored to
+-- its original checksum; this forward migration drops the column
+-- the proper way so existing environments self-heal on deploy and
+-- fresh environments converge to the same schema.
+-- =============================================================
+SET TIME ZONE 'UTC';
+
+ALTER TABLE commercial_party DROP CONSTRAINT IF EXISTS commercial_party_party_number_key;
+
+ALTER TABLE commercial_party DROP COLUMN IF EXISTS party_number;

--- a/pos-customer/src/main/resources/db/migration/V1__baseline_customer_schema.sql
+++ b/pos-customer/src/main/resources/db/migration/V1__baseline_customer_schema.sql
@@ -10,7 +10,7 @@ SET TIME ZONE 'UTC';
 
 
 
-CREATE TABLE commercial_party ( party_type smallint NOT NULL, status smallint NOT NULL, tier smallint NOT NULL, tier_manual_override boolean NOT NULL, created_at timestamp(6) with time zone NOT NULL, tier_assigned_at timestamp(6) with time zone, updated_at timestamp(6) with time zone NOT NULL, customer_id uuid NOT NULL, parent_party_id uuid, billing_terms_id character varying(255), customer_number character varying(255) NOT NULL, display_name character varying(255), email character varying(255), legal_name character varying(255) NOT NULL, phone_number character varying(255), primary_address character varying(255), tax_id character varying(255), tier_assigned_by character varying(255), CONSTRAINT commercial_party_party_type_check CHECK (((party_type >= 0) AND (party_type <= 2))), CONSTRAINT commercial_party_status_check CHECK (((status >= 0) AND (status <= 3))), CONSTRAINT commercial_party_tier_check CHECK (((tier >= 0) AND (tier <= 5))) );
+CREATE TABLE commercial_party ( party_type smallint NOT NULL, status smallint NOT NULL, tier smallint NOT NULL, tier_manual_override boolean NOT NULL, created_at timestamp(6) with time zone NOT NULL, tier_assigned_at timestamp(6) with time zone, updated_at timestamp(6) with time zone NOT NULL, customer_id uuid NOT NULL, parent_party_id uuid, billing_terms_id character varying(255), customer_number character varying(255) NOT NULL, display_name character varying(255), email character varying(255), legal_name character varying(255) NOT NULL, party_number character varying(255) NOT NULL, phone_number character varying(255), primary_address character varying(255), tax_id character varying(255), tier_assigned_by character varying(255), CONSTRAINT commercial_party_party_type_check CHECK (((party_type >= 0) AND (party_type <= 2))), CONSTRAINT commercial_party_status_check CHECK (((status >= 0) AND (status <= 3))), CONSTRAINT commercial_party_tier_check CHECK (((tier >= 0) AND (tier <= 5))) );
 
 CREATE TABLE communication_preference ( created_at timestamp(6) with time zone NOT NULL, updated_at timestamp(6) with time zone NOT NULL, version bigint NOT NULL, party_id uuid NOT NULL, preference_id uuid NOT NULL, email_preference character varying(20), marketing_preference character varying(20), phone_preference character varying(20), sms_preference character varying(20), update_source character varying(20), preferences_note character varying(1000) );
 
@@ -48,6 +48,7 @@ CREATE TABLE vehicle_projection ( vehicle_year integer, last_event_at timestamp(
 
 ALTER TABLE commercial_party ADD CONSTRAINT commercial_party_customer_number_key UNIQUE (customer_number);
 
+ALTER TABLE commercial_party ADD CONSTRAINT commercial_party_party_number_key UNIQUE (party_number);
 
 ALTER TABLE commercial_party ADD CONSTRAINT commercial_party_pkey PRIMARY KEY (customer_id);
 


### PR DESCRIPTION
## Problem
#720 removed `commercial_party.party_number` by **editing the already-applied V1 baseline migration**. Mutating an applied migration changes its Flyway checksum, so validation fails on every DB that recorded the original V1:

```
Migration checksum mismatch for migration version 1
-> Applied to database : -1938018842
-> Resolved locally    : 697420880
```

pos-customer crash-loops on boot → gateway returns **503 on all customer endpoints** (customer search on the New Estimate screen, etc.). Surfaced on alpha when the mesh was redeployed.

## Fix
Flyway hygiene — baselines are immutable; column drops belong in forward migrations:
- **Restore** `V1__baseline_customer_schema.sql` to its original content (checksum matches existing DBs again).
- **Add** `V12__drop_commercial_party_party_number.sql` — drops the column + its unique constraint, idempotent (`IF EXISTS`).

Existing environments self-heal on deploy (V1 validates → V12 drops the column); fresh environments converge to the same schema. The `R__` seed and `CommercialParty` entity already omit `party_number` (from #720), so nothing repopulates it.

## Verification
`FlywayMigrationIT` + `CrmSnapshotContractBehaviorIT` boot the full V1→V12→seed chain on a fresh Postgres testcontainer — 7 tests green.

## Ops note (alpha already mitigated)
Alpha was hot-fixed manually (repair V1 checksum + drop the orphaned column) to stop the crash-loop. On rollout of this PR, alpha's V1 history checksum must be reset to the original `-1938018842` so the restored V1 validates; V12 then runs as a no-op (`IF EXISTS`). No code contract/SDK change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)