### PR TITLE
feat(customer): browse name term also matches customer number

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -212,10 +212,13 @@ public class PartyServiceImpl implements PartyService {
     private boolean matchesBrowseFilter(
             SearchPartiesResponse.PartySummary s, String name, String status, String partyType, String customerNumber) {
         if (StringUtils.hasText(name)) {
+            // Unified typeahead term: match legal name, display name, OR customer number
+            // so a single query box finds customers by name or by account number.
             String needle = name.toLowerCase(java.util.Locale.ROOT);
             String legal = s.getLegalName() != null ? s.getLegalName().toLowerCase(java.util.Locale.ROOT) : "";
             String display = s.getDisplayName() != null ? s.getDisplayName().toLowerCase(java.util.Locale.ROOT) : "";
-            if (!legal.contains(needle) && !display.contains(needle)) {
+            String number = s.getCustomerNumber() != null ? s.getCustomerNumber().toLowerCase(java.util.Locale.ROOT) : "";
+            if (!legal.contains(needle) && !display.contains(needle) && !number.contains(needle)) {
                 return false;
             }
         }

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -514,6 +514,23 @@ class PartyServiceImplTest {
     }
 
     @Test
+    void browseParties_nameTerm_alsoMatchesCustomerNumber() {
+        when(partyRepository.findAll())
+                .thenReturn(List.of(
+                        browseable("01", "Acme Industrial", "CUST-100", AccountStatus.ACTIVE),
+                        browseable("02", "Beta Supplies", "CUST-200", AccountStatus.ACTIVE)));
+        when(personPartyRepository.findIndividualCustomers()).thenReturn(List.of());
+
+        // A single typeahead term routed through `name` finds a customer by account number.
+        SearchPartiesResponse response =
+                service.browseParties(Pageable.unpaged(), "cust-200", null, null, null, null, null);
+
+        assertThat(response.getResults())
+                .extracting(SearchPartiesResponse.PartySummary::getLegalName)
+                .containsExactly("Beta Supplies");
+    }
+
+    @Test
     void browseParties_filtersByStatusAndCustomerNumber() {
         when(partyRepository.findAll())
                 .thenReturn(List.of(


### PR DESCRIPTION
## Summary
The party browse `name` filter matched legal/display name only, so a single customer typeahead box couldn't find accounts by number server-side. This extends the `name` predicate to also match `customerNumber` (case-insensitive contains) — making `name` a unified typeahead term (name **or** account number).

The separate `customerNumber` param is unchanged for callers that filter by it explicitly.

## Why
Frontend customer pickers currently cache one 200-row page and filter client-side (can't find customers beyond the first 200). With unified server-side matching they can query per keystroke instead. `browseParties` already filters the full directory in-memory, so there's no new scaling cost.

## Test
`mvn -pl pos-customer test -Dtest=PartyServiceImplTest` → 44 passed (added `browseParties_nameTerm_alsoMatchesCustomerNumber`).

No API contract change (internal filter logic) — no OpenAPI/SDK regen.

## Downstream
Frontend PR switches `CustomerLookupComponent` (+ estimate-create) to debounced server-side `searchParties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)