### PR TITLE
[CAP:316] Accounting: read-only Location Labor & Overhead Cost Report

### DIFF
--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -6431,12 +6431,17 @@ components:
           type: boolean
           description: True for computed roll-up rows; false for GL-mapped leaf lines
           example: false
+        usdOnly:
+          type: boolean
+          description: True for line 2.11.4, which is reported in USD even on local-currency plants
+          example: false
       required:
       - code
       - isSubtotal
       - label
       - level
       - monthly
+      - usdOnly
       - ytd
     IncomeStatementReport:
       type: object

--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -32,6 +32,8 @@ tags:
   description: Manage journal entries including posting and reversal.
 - name: GL Accounts
   description: Manage chart of accounts including lifecycle actions.
+- name: Location Cost Reporting
+  description: Read-only location Labor & Overhead Cost Report (CAP-316)
 - name: AP Payments
   description: Accounts Payable vendor payment operations
 - name: Financial Reporting
@@ -2418,6 +2420,68 @@ paths:
         - accounting:ap:view
       x-required-permissions:
       - accounting:ap:view
+  /v1/accounting/reports/location/labor-overhead:
+    get:
+      tags:
+      - Location Cost Reporting
+      summary: Generate Labor & Overhead Cost Report
+      description: Return the canonical Labor & Overhead cost-line matrix (12 monthly amounts + YTD, with section subtotals) for a location and fiscal year, derived from posted GL data.
+      operationId: generateLaborOverheadReport
+      parameters:
+      - name: locationId
+        in: query
+        description: Location/dealer identifier (accounting locationId dimension)
+        required: true
+        schema:
+          type: string
+          minLength: 1
+        example: LOC-107
+      - name: fiscalYear
+        in: query
+        description: Fiscal year
+        required: true
+        schema:
+          type: integer
+          format: int32
+        example: 2026
+      - name: asOfMonth
+        in: query
+        description: Highest elapsed month bounding YTD (1-12); defaults to 12
+        required: false
+        schema:
+          type: integer
+          format: int32
+        example: 6
+      responses:
+        '200':
+          description: Report generated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LaborOverheadCostReport'
+        '400':
+          description: Invalid locationId, fiscalYear, or asOfMonth
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LaborOverheadCostReport'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LaborOverheadCostReport'
+        '403':
+          description: Forbidden - missing reporting:view:financial-statements
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LaborOverheadCostReport'
+      security:
+      - bearerAuth:
+        - reporting:view:financial-statements
+      x-required-permissions:
+      - reporting:view:financial-statements
   /v1/accounting/reports/financial/income-statement:
     get:
       tags:
@@ -5263,6 +5327,14 @@ components:
           format: date-time
           description: Creation timestamp (UTC).
           example: 2026-02-27 12:00:00+00:00
+      required:
+      - createdAt
+      - invoiceId
+      - status
+      - subtotal
+      - taxAmount
+      - totalAmount
+      - workorderId
     GLAccountCreateRequest:
       type: object
       description: Request to create a new GL account
@@ -6253,6 +6325,119 @@ components:
       - candidateId
       - invoiceEventId
       - vendorBillId
+    LaborOverheadCostReport:
+      type: object
+      description: Read-only Labor & Overhead Cost Report (CAP-316) for a location and fiscal year
+      properties:
+        locationId:
+          type: string
+          description: Location/dealer identifier (accounting locationId dimension)
+          example: LOC-107
+        locationLabel:
+          type: string
+          description: Human-readable location label
+          example: Smetzer's Wooster
+        fiscalYear:
+          type: integer
+          format: int32
+          description: Fiscal year
+          example: 2026
+        asOfMonth:
+          type: integer
+          format: int32
+          description: Highest elapsed month bounding YTD (1-12)
+          example: 12
+        currency:
+          type: string
+          description: Currency of the amounts (line 2.11.4 is always USD)
+          example: USD
+        localCurrencyPerUsd:
+          type: number
+          description: Local currency units per USD (1.00 for US plants)
+          example: 1.0
+        averageRate:
+          type: number
+          description: Average conversion rate used for the year (1.00 for US plants)
+          example: 1.0
+        lines:
+          type: array
+          description: Cost lines in canonical order (Labor §1, Overhead §2, totals)
+          items:
+            $ref: '#/components/schemas/LaborOverheadReportLine'
+      required:
+      - asOfMonth
+      - averageRate
+      - currency
+      - fiscalYear
+      - lines
+      - localCurrencyPerUsd
+      - locationId
+    LaborOverheadReportLine:
+      type: object
+      description: A single Labor & Overhead cost line with monthly amounts and YTD
+      properties:
+        code:
+          type: string
+          description: Canonical line code
+          example: 1.1.1
+        label:
+          type: string
+          description: Display label
+          example: Hourly wages and bonuses
+        parentCode:
+          type: string
+          description: Parent line code, if any
+          example: '1.1'
+        level:
+          type: integer
+          format: int32
+          description: Hierarchy depth (totals = 1, N.M = 2, N.M.K = 3)
+          example: 3
+        costType:
+          type: string
+          description: Fixed/Variable classification; absent when the source shows none
+          enum:
+          - FIXED
+          - VARIABLE
+          - FIXED_IF_LOW_VOLUME
+        definition:
+          type: string
+          description: Include/exclude guidance from the Definitions tab
+        monthly:
+          type: array
+          description: 12 monthly amounts in canonical order (index 0 = January)
+          example:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 62645
+          - 0
+          - 0
+          items:
+            type: number
+        ytd:
+          type: number
+          description: Year-to-date total over elapsed months
+          example: 62645
+        subtotal:
+          type: boolean
+        isSubtotal:
+          type: boolean
+          description: True for computed roll-up rows; false for GL-mapped leaf lines
+          example: false
+      required:
+      - code
+      - isSubtotal
+      - label
+      - level
+      - monthly
+      - ytd
     IncomeStatementReport:
       type: object
       description: Income statement (Profit & Loss) report built from POSTED journal entries

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
@@ -121,6 +121,12 @@ public final class EventTypes {
                                 "Drill down from GL account to source journal entries")
                         .build(),
 
+                // LaborOverheadReportController - 1 event (CAP-316)
+                EventTypeRegistration.search(
+                                "REPORT_LABOR_OVERHEAD_GENERATE",
+                                "Generate Labor & Overhead cost report for a location and fiscal year")
+                        .build(),
+
                 // GLMappingController - 2 events (GL Mapping)
                 EventTypeRegistration.write(
                                 "ACCOUNTING_GL_MAPPING_CREATE", "Create GL mapping from external code to GL account")

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/LaborOverheadReportController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/LaborOverheadReportController.java
@@ -1,0 +1,97 @@
+package com.positivity.accounting.internal.controller;
+
+import com.positivity.accounting.internal.dto.LaborOverheadCostReport;
+import com.positivity.accounting.service.LaborOverheadReportService;
+import com.positivity.events.EmitEvent;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST API for the CAP-316 read-only Location Labor &amp; Overhead Cost Report.
+ *
+ * <p>Returns the canonical cost-line matrix (12 monthly amounts + YTD, with section subtotals) for a
+ * location and fiscal year, derived entirely from posted GL data. Lives alongside the financial
+ * reporting endpoints and inherits the financial-reporting permission family (CAP-054).
+ */
+@RestController
+@RequestMapping("/v1/accounting/reports/location")
+@Tag(name = "Location Cost Reporting", description = "Read-only location Labor & Overhead Cost Report (CAP-316)")
+@SecurityRequirement(
+        name = "bearerAuth",
+        scopes = {"reporting:view:financial-statements"})
+@Validated
+public class LaborOverheadReportController {
+
+    private static final int MIN_MONTH = 1;
+    private static final int MAX_MONTH = 12;
+    private static final int MIN_FISCAL_YEAR = 1900;
+    private static final int MAX_FISCAL_YEAR = 9999;
+
+    private final LaborOverheadReportService laborOverheadReportService;
+
+    public LaborOverheadReportController(LaborOverheadReportService laborOverheadReportService) {
+        this.laborOverheadReportService = laborOverheadReportService;
+    }
+
+    /**
+     * Generate the Labor &amp; Overhead Cost Report for a location and fiscal year.
+     */
+    @GetMapping(value = "/labor-overhead", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
+    @EmitEvent(id = "REPORT_LABOR_OVERHEAD_GENERATE", apiVersion = "1")
+    @Operation(
+            summary = "Generate Labor & Overhead Cost Report",
+            description = "Return the canonical Labor & Overhead cost-line matrix (12 monthly amounts + YTD, with"
+                    + " section subtotals) for a location and fiscal year, derived from posted GL data.",
+            tags = {"Location Cost Reporting"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Report generated successfully",
+            content = @Content(schema = @Schema(implementation = LaborOverheadCostReport.class)))
+    @ApiResponse(responseCode = "400", description = "Invalid locationId, fiscalYear, or asOfMonth")
+    @ApiResponse(responseCode = "401", description = "Unauthorized")
+    @ApiResponse(responseCode = "403", description = "Forbidden - missing reporting:view:financial-statements")
+    public ResponseEntity<LaborOverheadCostReport> generateLaborOverheadReport(
+            @Parameter(
+                            description = "Location/dealer identifier (accounting locationId dimension)",
+                            required = true,
+                            example = "LOC-107")
+                    @RequestParam
+                    @NotBlank
+                    @NonNull
+                    String locationId,
+            @Parameter(description = "Fiscal year", required = true, example = "2026") @RequestParam int fiscalYear,
+            @Parameter(description = "Highest elapsed month bounding YTD (1-12); defaults to 12", example = "6")
+                    @RequestParam(required = false)
+                    @Nullable
+                    Integer asOfMonth) {
+
+        // Validation errors use IllegalArgumentException to leverage the module's @RestControllerAdvice,
+        // which maps them to 400 Bad Request with the accounting domain's standard ApiError contract.
+        if (fiscalYear < MIN_FISCAL_YEAR || fiscalYear > MAX_FISCAL_YEAR) {
+            throw new IllegalArgumentException("fiscalYear must be a four-digit year");
+        }
+        if (asOfMonth != null && (asOfMonth < MIN_MONTH || asOfMonth > MAX_MONTH)) {
+            throw new IllegalArgumentException("asOfMonth must be between 1 and 12");
+        }
+
+        LaborOverheadCostReport report = laborOverheadReportService.generate(locationId, fiscalYear, asOfMonth);
+        return ResponseEntity.ok(report);
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/LaborOverheadCostReport.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/LaborOverheadCostReport.java
@@ -1,0 +1,65 @@
+package com.positivity.accounting.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * CAP-316 read-only Labor &amp; Overhead Cost Report for one location and fiscal year: the full
+ * canonical cost-line hierarchy with monthly + YTD amounts, plus the currency context.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Read-only Labor & Overhead Cost Report (CAP-316) for a location and fiscal year")
+public class LaborOverheadCostReport {
+
+    @Schema(
+            description = "Location/dealer identifier (accounting locationId dimension)",
+            example = "LOC-107",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String locationId;
+
+    @Schema(
+            description = "Human-readable location label",
+            example = "Smetzer's Wooster",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String locationLabel;
+
+    @Schema(description = "Fiscal year", example = "2026", requiredMode = Schema.RequiredMode.REQUIRED)
+    private int fiscalYear;
+
+    @Schema(
+            description = "Highest elapsed month bounding YTD (1-12)",
+            example = "12",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private int asOfMonth;
+
+    @Schema(
+            description = "Currency of the amounts (line 2.11.4 is always USD)",
+            example = "USD",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String currency;
+
+    @Schema(
+            description = "Local currency units per USD (1.00 for US plants)",
+            example = "1.00",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private BigDecimal localCurrencyPerUsd;
+
+    @Schema(
+            description = "Average conversion rate used for the year (1.00 for US plants)",
+            example = "1.00",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private BigDecimal averageRate;
+
+    @Schema(
+            description = "Cost lines in canonical order (Labor §1, Overhead §2, totals)",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<LaborOverheadReportLine> lines;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/LaborOverheadReportLine.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/LaborOverheadReportLine.java
@@ -1,0 +1,70 @@
+package com.positivity.accounting.internal.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.positivity.accounting.internal.enums.CostType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * One cost line of the CAP-316 Labor &amp; Overhead report: canonical metadata plus 12 monthly amounts
+ * and the year-to-date total.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "A single Labor & Overhead cost line with monthly amounts and YTD")
+public class LaborOverheadReportLine {
+
+    @Schema(description = "Canonical line code", example = "1.1.1", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String code;
+
+    @Schema(
+            description = "Display label",
+            example = "Hourly wages and bonuses",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String label;
+
+    @Schema(description = "Parent line code, if any", example = "1.1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String parentCode;
+
+    @Schema(
+            description = "Hierarchy depth (totals = 1, N.M = 2, N.M.K = 3)",
+            example = "3",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private int level;
+
+    @Schema(
+            description = "Fixed/Variable classification; absent when the source shows none",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private CostType costType;
+
+    @JsonProperty("isSubtotal")
+    @Schema(
+            description = "True for computed roll-up rows; false for GL-mapped leaf lines",
+            example = "false",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private boolean isSubtotal;
+
+    @Schema(
+            description = "Include/exclude guidance from the Definitions tab",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String definition;
+
+    @Schema(
+            description = "12 monthly amounts in canonical order (index 0 = January)",
+            example = "[0,0,0,0,0,0,0,0,0,62645,0,0]",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<BigDecimal> monthly;
+
+    @Schema(
+            description = "Year-to-date total over elapsed months",
+            example = "62645",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private BigDecimal ytd;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/LaborOverheadReportLine.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/LaborOverheadReportLine.java
@@ -51,6 +51,13 @@ public class LaborOverheadReportLine {
             requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean isSubtotal;
 
+    @JsonProperty("usdOnly")
+    @Schema(
+            description = "True for line 2.11.4, which is reported in USD even on local-currency plants",
+            example = "false",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private boolean usdOnly;
+
     @Schema(
             description = "Include/exclude guidance from the Definitions tab",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/enums/CostType.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/enums/CostType.java
@@ -1,0 +1,13 @@
+package com.positivity.accounting.internal.enums;
+
+/**
+ * Fixed/Variable classification of a Labor &amp; Overhead cost line (CAP-316).
+ *
+ * <p>{@code FIXED_IF_LOW_VOLUME} corresponds to the source form's {@code *} annotation
+ * ("Fixed if volume change is minimal").
+ */
+public enum CostType {
+    FIXED,
+    VARIABLE,
+    FIXED_IF_LOW_VOLUME
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/enums/StatementType.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/enums/StatementType.java
@@ -8,5 +8,8 @@ public enum StatementType {
     INCOME_STATEMENT,
 
     /** Balance Sheet (Statement of Financial Position) */
-    BALANCE_SHEET
+    BALANCE_SHEET,
+
+    /** CAP-316 Labor & Overhead Cost Report line-to-account mapping. */
+    LABOR_OVERHEAD
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/report/LaborOverheadTaxonomy.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/report/LaborOverheadTaxonomy.java
@@ -1,0 +1,470 @@
+package com.positivity.accounting.internal.report;
+
+import com.positivity.accounting.internal.enums.CostType;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Canonical CAP-316 "Labor &amp; Overhead Costs" cost-line taxonomy.
+ *
+ * <p>Codes, labels, hierarchy, Fixed/Variable type, and definitions are taken verbatim from the
+ * CAP-316 spec §3 (source workbook "Master Form" + "Definitions" tabs). The order and numbering are
+ * <b>contractual</b> — the report renders lines in exactly this sequence.
+ *
+ * <p>Leaf lines ({@link LineDef#isSubtotal()} {@code == false}) are resolved to GL accounts via the
+ * persisted {@code StatementLineMapping} ({@code StatementType.LABOR_OVERHEAD}). Subtotal lines are
+ * computed column-wise from their {@link LineDef#childCodes()} and are never mapped directly.
+ *
+ * <p>The {@code *} annotation on a source type ("Fixed if volume change is minimal") maps to
+ * {@link CostType#FIXED_IF_LOW_VOLUME}; otherwise the base classification is used. Lines with no
+ * source classification carry a {@code null} cost type.
+ */
+public final class LaborOverheadTaxonomy {
+
+    /** Synthetic codes for the section/grand total rows (the source form has no numeric code for these). */
+    public static final String TOTAL_LABOR = "TOTAL_LABOR";
+
+    public static final String TOTAL_OVERHEAD = "TOTAL_OVERHEAD";
+
+    public static final String TOTAL_LABOR_OVERHEAD = "TOTAL_LABOR_OVERHEAD";
+
+    /**
+     * A single cost line in the canonical taxonomy.
+     *
+     * @param code unique line code (e.g. {@code "1.1.1"} or a synthetic total code)
+     * @param label display label
+     * @param parentCode parent line code, or {@code null} for top-level / total rows
+     * @param level hierarchy depth (totals = 1; {@code N.M} = 2; {@code N.M.K} = 3)
+     * @param costType Fixed/Variable classification, or {@code null} when the source shows none
+     * @param isSubtotal {@code true} for computed roll-up rows; {@code false} for GL-mapped leaves
+     * @param usdOnly {@code true} for line 2.11.4 (reported in USD even on local-currency plants)
+     * @param definition include/exclude guidance from the Definitions tab
+     * @param childCodes ordered child codes for subtotal rows; empty for leaves
+     */
+    public record LineDef(
+            String code,
+            String label,
+            String parentCode,
+            int level,
+            CostType costType,
+            boolean isSubtotal,
+            boolean usdOnly,
+            String definition,
+            List<String> childCodes) {}
+
+    private static final List<LineDef> LINES = buildLines();
+
+    private static final Map<String, LineDef> BY_CODE = indexByCode(LINES);
+
+    private LaborOverheadTaxonomy() {}
+
+    /** The full ordered taxonomy in canonical (contractual) order. */
+    public static List<LineDef> lines() {
+        return LINES;
+    }
+
+    /** Leaf (GL-mapped) line codes, in canonical order. */
+    public static List<String> leafCodes() {
+        List<String> leaves = new ArrayList<>();
+        for (LineDef line : LINES) {
+            if (!line.isSubtotal()) {
+                leaves.add(line.code());
+            }
+        }
+        return leaves;
+    }
+
+    public static LineDef byCode(String code) {
+        return BY_CODE.get(code);
+    }
+
+    private static Map<String, LineDef> indexByCode(List<LineDef> lines) {
+        Map<String, LineDef> map = new LinkedHashMap<>();
+        for (LineDef line : lines) {
+            map.put(line.code(), line);
+        }
+        return map;
+    }
+
+    private static List<LineDef> buildLines() {
+        List<LineDef> lines = new ArrayList<>();
+
+        // ----------------------------------------------------------------- §1 Labor
+        lines.add(subtotal(
+                "1.1",
+                "Wages and Bonuses (including shop manager)",
+                null,
+                2,
+                "Sum of 1.1.1–1.1.2.",
+                List.of("1.1.1", "1.1.2")));
+        lines.add(leaf(
+                "1.1.1",
+                "Hourly wages and bonuses",
+                "1.1",
+                3,
+                CostType.VARIABLE,
+                false,
+                "Incl: wages/bonuses for hourly retread-plant workers (production, maintenance, janitor, plant clerk),"
+                        + " matching MRT Weekly Production Report hours. Excl: warehousing/distribution/sales/corporate"
+                        + " office wages; production outside the MRT process."));
+        lines.add(leaf(
+                "1.1.2",
+                "Management salaries",
+                "1.1",
+                3,
+                CostType.FIXED_IF_LOW_VOLUME,
+                false,
+                "Incl: salaries/bonuses for salaried retread-plant personnel matching MRT Weekly Production Report"
+                        + " hours."));
+        lines.add(leaf(
+                "1.2",
+                "Misc Labor (contract and temp production employees)",
+                null,
+                2,
+                CostType.VARIABLE,
+                false,
+                "Incl: wages for temporary/contract workers matching MRT Weekly Production Report hours."));
+        lines.add(subtotal(
+                "1.3",
+                "Taxes and Benefits",
+                null,
+                2,
+                "Relating to the wages in §1.1.",
+                List.of("1.3.1", "1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6")));
+        lines.add(leaf("1.3.1", "FICA", "1.3", 3, CostType.VARIABLE, false, "Payroll tax on §1.1 wages."));
+        lines.add(leaf(
+                "1.3.2",
+                "Fed Unemployment",
+                "1.3",
+                3,
+                CostType.VARIABLE,
+                false,
+                "Federal unemployment tax on §1.1 wages."));
+        lines.add(leaf(
+                "1.3.3",
+                "State Unemployment",
+                "1.3",
+                3,
+                CostType.VARIABLE,
+                false,
+                "State unemployment tax on §1.1 wages."));
+        lines.add(leaf(
+                "1.3.4",
+                "Medical/dental insurance, life, health, disability",
+                "1.3",
+                3,
+                CostType.VARIABLE,
+                false,
+                "Employee benefit costs related to §1.1."));
+        lines.add(leaf(
+                "1.3.5",
+                "Retirement plan contributions",
+                "1.3",
+                3,
+                CostType.VARIABLE,
+                false,
+                "Employer retirement contributions related to §1.1."));
+        lines.add(leaf(
+                "1.3.6",
+                "Employee Insurance – workers' comp",
+                "1.3",
+                3,
+                CostType.VARIABLE,
+                false,
+                "Workers' compensation insurance for plant employees."));
+        lines.add(leaf(
+                "1.5",
+                "Uniforms rental / laundry",
+                null,
+                2,
+                CostType.FIXED_IF_LOW_VOLUME,
+                false,
+                "Incl: uniforms or shirt/trouser program, if provided."));
+        lines.add(total(
+                TOTAL_LABOR,
+                "Total Labor",
+                "Section subtotal: sum of 1.1, 1.2, 1.3, 1.5.",
+                List.of("1.1", "1.2", "1.3", "1.5")));
+
+        // -------------------------------------------------------------- §2 Overhead
+        lines.add(subtotal("2.1", "Building", null, 2, "Sum of 2.1.1–2.1.3.", List.of("2.1.1", "2.1.2", "2.1.3")));
+        lines.add(leaf(
+                "2.1.1",
+                "Depreciation",
+                "2.1",
+                3,
+                CostType.FIXED,
+                false,
+                "Incl: \"bricks & mortar\", only if owned, 20-yr straight line. Excl: if renting (use 2.1.3);"
+                        + " building-financing interest; land depreciation."));
+        lines.add(leaf(
+                "2.1.2",
+                "Maintenance",
+                "2.1",
+                3,
+                CostType.FIXED,
+                false,
+                "Incl: building maintenance, garbage removal fees."));
+        lines.add(leaf(
+                "2.1.3",
+                "Rent",
+                "2.1",
+                3,
+                CostType.FIXED,
+                false,
+                "Incl: building rental (only the retread-plant % of footage); leasehold improvements if owned."
+                        + " Excl: mortgage payments."));
+        lines.add(leaf(
+                "2.2",
+                "Training Costs",
+                null,
+                2,
+                CostType.FIXED_IF_LOW_VOLUME,
+                false,
+                "Incl: outside-trainer expense. Excl: trainer/trainee labor (use 1.1.1)."));
+        lines.add(leaf(
+                "2.3",
+                "Employment advertising / recruiting costs",
+                null,
+                2,
+                CostType.FIXED,
+                false,
+                "Recruiting/advertising for plant staff."));
+        lines.add(subtotal(
+                "2.4",
+                "Vehicle expenses (rubber dust trailer, shop truck)",
+                null,
+                2,
+                "Incl: vehicles for retread-plant use only; rubber-dust trailer fees. Excl: sales/distribution/"
+                        + "warehousing vehicles; vehicle insurance (use 2.7.3); forklifts (use 2.11.5).",
+                List.of("2.4.1", "2.4.2", "2.4.3", "2.4.4", "2.4.5")));
+        lines.add(leaf("2.4.1", "Gas & Oil", "2.4", 3, null, false, "Fuel/oil for plant vehicles."));
+        lines.add(leaf("2.4.2", "Maintenance", "2.4", 3, null, false, "Maintenance for plant vehicles."));
+        lines.add(leaf("2.4.3", "Taxes", "2.4", 3, null, false, "Taxes on plant vehicles."));
+        lines.add(leaf(
+                "2.4.4", "Depreciation", "2.4", 3, null, false, "Depreciation of plant vehicles (standard methods)."));
+        lines.add(leaf("2.4.5", "Rent", "2.4", 3, null, false, "Rental of plant vehicles."));
+        lines.add(leaf(
+                "2.5",
+                "Telephone",
+                null,
+                2,
+                CostType.FIXED,
+                false,
+                "Incl: voice/modem/data lines for plant; cell phones for plant personnel."));
+        lines.add(leaf(
+                "2.6",
+                "Travel and Entertainment",
+                null,
+                2,
+                CostType.FIXED,
+                false,
+                "Incl: travel for plant manager/employees (e.g. PMPC). Excl: owner/corporate travel;"
+                        + " promotional/entertainment (sales cost)."));
+        lines.add(subtotal(
+                "2.7",
+                "Insurance",
+                null,
+                2,
+                "Incl: fire/theft/liability for the retread plant; plant-vehicle insurance (2.7.3)."
+                        + " Excl: warehouse/sales insurance.",
+                List.of("2.7.1", "2.7.2", "2.7.3")));
+        lines.add(leaf("2.7.1", "Fire", "2.7", 3, null, false, "Fire insurance for the plant."));
+        lines.add(leaf("2.7.2", "Theft", "2.7", 3, null, false, "Theft insurance for the plant."));
+        lines.add(leaf(
+                "2.7.3",
+                "Liability",
+                "2.7",
+                3,
+                null,
+                false,
+                "Liability insurance for the plant (incl. plant vehicles)."));
+        lines.add(leaf(
+                "2.8",
+                "Property Taxes",
+                null,
+                2,
+                CostType.FIXED,
+                false,
+                "Incl: property taxes for dealer-owned plant. Excl: if building rented; sales/income taxes."));
+        lines.add(subtotal(
+                "2.9", "Supplies", null, 2, "Sum of 2.9.1–2.9.4.", List.of("2.9.1", "2.9.2", "2.9.3", "2.9.4")));
+        lines.add(leaf(
+                "2.9.1",
+                "Shop Consumables (rasps, grinding wheels, brushes)",
+                "2.9",
+                3,
+                CostType.VARIABLE,
+                false,
+                "Incl: buffing blades/brushes, grinding wheels. Excl: materials assembled to the tire (tread rubber,"
+                        + " cushion gum, rope rubber, patches, cement, paint)."));
+        lines.add(leaf(
+                "2.9.2",
+                "Curing Consumables (envelopes, lube, wicks, poly)",
+                "2.9",
+                3,
+                CostType.VARIABLE,
+                false,
+                "Incl: curing envelopes, wicks, envelope lube, poly."));
+        lines.add(leaf(
+                "2.9.3",
+                "Miscellaneous",
+                "2.9",
+                3,
+                CostType.FIXED,
+                false,
+                "Incl: janitorial supplies, treatment chemicals, etc."));
+        lines.add(leaf(
+                "2.9.4",
+                "Office",
+                "2.9",
+                3,
+                CostType.FIXED_IF_LOW_VOLUME,
+                false,
+                "Incl: paper, pens, labels, office supplies."));
+        lines.add(leaf(
+                "2.10",
+                "Utilities – gas, electric, water",
+                null,
+                2,
+                CostType.VARIABLE,
+                false,
+                "Incl: gas/electric/water for the plant (may be an allocated % if shared). Excl: utilities for"
+                        + " other operations in the building."));
+        lines.add(subtotal(
+                "2.11",
+                "Equipment expense",
+                null,
+                2,
+                "Sum of 2.11.1–2.11.6.",
+                List.of("2.11.1", "2.11.2", "2.11.3", "2.11.4", "2.11.5", "2.11.6")));
+        lines.add(leaf(
+                "2.11.1",
+                "Maintenance",
+                "2.11",
+                3,
+                CostType.FIXED_IF_LOW_VOLUME,
+                false,
+                "Incl: equipment repairs/spare parts, computer maintenance, custom-mold cleaning. Excl: items under"
+                        + " MRT warranty."));
+        lines.add(leaf(
+                "2.11.2", "Rental", "2.11", 3, CostType.FIXED, false, "Incl: rental fees for air compressors, etc."));
+        lines.add(leaf(
+                "2.11.3",
+                "Small tools and equipment",
+                "2.11",
+                3,
+                CostType.FIXED,
+                false,
+                "Small tools/equipment purchases."));
+        lines.add(leaf(
+                "2.11.4",
+                "Depreciation – MRT process equipment ($US only)",
+                "2.11",
+                3,
+                CostType.FIXED,
+                true,
+                "Incl: MRT process equipment & installation at start-up/expansion (regardless of ownership); MRT mods"
+                        + " > $5,000; 10-yr straight line (MRT provides value). Excl: non-MRT-process equipment."
+                        + " Reported in USD even on local-currency plants."));
+        lines.add(leaf(
+                "2.11.5",
+                "Depreciation – Other shop equipment (boiler, cyclone, air compressors, capital cost of conversion)",
+                "2.11",
+                3,
+                CostType.FIXED,
+                false,
+                "Incl: dealer-installed process support equipment, forklifts, capital conversion costs; 10-yr straight"
+                        + " line (forklifts/computers use std methods). Excl: MRT-provided gas hot-water unit (in"
+                        + " 2.11.4); equipment sales taxes; equipment financing interest."));
+        lines.add(leaf(
+                "2.11.6",
+                "MRTI equipment leases or rent",
+                "2.11",
+                3,
+                CostType.FIXED,
+                false,
+                "Incl: MRT software license fees (CIA, BIB TREAD); custom-mold rental. Excl: MRT process equipment"
+                        + " rented from MRT/3rd party (in 2.11.4)."));
+        lines.add(leaf(
+                "2.12",
+                "Administration fees",
+                null,
+                2,
+                CostType.FIXED,
+                false,
+                "Incl: allocation for corporate accounting/payroll/personnel support (consistent monthly, not"
+                        + " %-of-sales). Excl: corporate costs that would persist if plant closed (senior mgmt"
+                        + " salaries, sales commissions)."));
+        lines.add(leaf(
+                "2.13",
+                "Inventory charge",
+                null,
+                2,
+                CostType.VARIABLE,
+                false,
+                "Interest charge/credit for money funding inventory of materials & consumables. Expense = positive;"
+                        + " interest income = negative. Excl: casing/stock-casing inventory charges; equipment"
+                        + " financing interest."));
+        lines.add(leaf(
+                "2.14",
+                "Income from rubber dust sales",
+                null,
+                2,
+                CostType.VARIABLE,
+                false,
+                "Income from rubber-dust sales (enter as negative); or removal cost if not sold (positive). Excl:"
+                        + " rubber-dust trailer rentals/fees (use 2.4)."));
+        lines.add(
+                subtotal("2.15", "Production Quality", null, 2, "Sum of 2.15.1–2.15.2.", List.of("2.15.1", "2.15.2")));
+        lines.add(leaf(
+                "2.15.1",
+                "Casings scrapped in production (e.g. torn belts by buffer)",
+                "2.15",
+                3,
+                CostType.VARIABLE,
+                false,
+                "Incl: cost of casings damaged by the plant during production (casing cost + disposal). Excl: RAR"
+                        + " scrap disposal fees."));
+        lines.add(leaf(
+                "2.15.2",
+                "Adjustments (customer returns, user price plus transportation both ways)",
+                "2.15",
+                3,
+                CostType.VARIABLE,
+                false,
+                "Incl: materials/workmanship adjustment costs (fees, transport), shown in the month paid (not"
+                        + " accrual), matching adjustments reported to MRT Quality. Excl: commercial concession"
+                        + " adjustments; RAR disposal fees."));
+        lines.add(total(
+                TOTAL_OVERHEAD,
+                "Total Overhead",
+                "Section subtotal: sum of 2.1–2.15.",
+                List.of(
+                        "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11", "2.12", "2.13",
+                        "2.14", "2.15")));
+        lines.add(total(
+                TOTAL_LABOR_OVERHEAD,
+                "Total Labor & Overhead",
+                "Grand total: Total Labor + Total Overhead.",
+                List.of(TOTAL_LABOR, TOTAL_OVERHEAD)));
+
+        return List.copyOf(lines);
+    }
+
+    private static LineDef leaf(
+            String code, String label, String parent, int level, CostType type, boolean usdOnly, String definition) {
+        return new LineDef(code, label, parent, level, type, false, usdOnly, definition, List.of());
+    }
+
+    private static LineDef subtotal(
+            String code, String label, String parent, int level, String definition, List<String> children) {
+        return new LineDef(code, label, parent, level, null, true, false, definition, children);
+    }
+
+    private static LineDef total(String code, String label, String definition, List<String> children) {
+        return new LineDef(code, label, null, 1, null, true, false, definition, children);
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/JournalEntryLineRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/JournalEntryLineRepository.java
@@ -2,10 +2,13 @@ package com.positivity.accounting.internal.repository;
 
 import com.positivity.accounting.internal.entity.JournalEntryLine;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -49,4 +52,29 @@ public interface JournalEntryLineRepository extends JpaRepository<JournalEntryLi
             + "JOIN jel.journalEntry je "
             + "WHERE jel.glAccount.glAccountId = :glAccountId AND je.status = 'POSTED'")
     BigDecimal getAccountBalance(UUID glAccountId);
+
+    /**
+     * Find posted journal entry lines for a set of GL accounts whose entry transaction date falls
+     * within the given range. The parent entry is fetched so callers can read its transaction date and
+     * each line's dimensions without triggering lazy loads.
+     *
+     * <p>Used by the CAP-316 Labor &amp; Overhead report to gather contributing postings; callers
+     * bucket by month and filter by the {@code locationId} dimension in Java (the JSON dimensions map
+     * is not portably queryable across H2/PostgreSQL).
+     *
+     * @param accountIds GL account ids to include (caller skips the query when empty)
+     * @param start inclusive lower bound on the entry transaction date
+     * @param end inclusive upper bound on the entry transaction date
+     * @return posted lines for those accounts in the date range
+     */
+    @Query("SELECT jel FROM JournalEntryLine jel "
+            + "JOIN FETCH jel.journalEntry je "
+            + "WHERE je.status = 'POSTED' "
+            + "AND jel.glAccount.glAccountId IN :accountIds "
+            + "AND je.transactionDate >= :start "
+            + "AND je.transactionDate <= :end")
+    List<JournalEntryLine> findPostedLinesByAccountsAndDateRange(
+            @Param("accountIds") Collection<UUID> accountIds,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
@@ -1,0 +1,218 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.dto.LaborOverheadCostReport;
+import com.positivity.accounting.internal.dto.LaborOverheadReportLine;
+import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.enums.StatementType;
+import com.positivity.accounting.internal.report.LaborOverheadTaxonomy;
+import com.positivity.accounting.internal.report.LaborOverheadTaxonomy.LineDef;
+import com.positivity.accounting.internal.repository.JournalEntryLineRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
+import com.positivity.accounting.service.LaborOverheadReportService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Read-only implementation of the CAP-316 Labor &amp; Overhead Cost Report.
+ *
+ * <p>Resolves each leaf line to its mapped GL accounts (persisted {@code StatementLineMapping},
+ * {@link StatementType#LABOR_OVERHEAD}), aggregates posted journal-entry-line net amounts
+ * (debit − credit) by month for the requested {@code locationId} dimension, computes subtotal rows
+ * column-wise from the taxonomy, and derives YTD over the elapsed months. Mirrors the posted-state
+ * semantic ({@code je.status = 'POSTED'}) used by the existing financial reporting.
+ */
+@Service
+@Transactional(readOnly = true)
+public class LaborOverheadReportServiceImpl implements LaborOverheadReportService {
+
+    private static final Logger log = LoggerFactory.getLogger(LaborOverheadReportServiceImpl.class);
+
+    private static final int MONTHS = 12;
+    private static final String LOCATION_DIMENSION = "locationId";
+    private static final String CURRENCY_USD = "USD";
+    private static final BigDecimal RATE_US_PLANT = new BigDecimal("1.00");
+
+    private final StatementLineMappingRepository statementLineMappingRepository;
+    private final JournalEntryLineRepository journalEntryLineRepository;
+
+    public LaborOverheadReportServiceImpl(
+            StatementLineMappingRepository statementLineMappingRepository,
+            JournalEntryLineRepository journalEntryLineRepository) {
+        this.statementLineMappingRepository = statementLineMappingRepository;
+        this.journalEntryLineRepository = journalEntryLineRepository;
+    }
+
+    @Override
+    public @NonNull LaborOverheadCostReport generate(
+            @NonNull String locationId, int fiscalYear, @Nullable Integer asOfMonth) {
+
+        int resolvedAsOfMonth = asOfMonth == null ? MONTHS : asOfMonth;
+        log.info(
+                "Generating Labor & Overhead report for location={}, fiscalYear={}, asOfMonth={}",
+                locationId,
+                fiscalYear,
+                resolvedAsOfMonth);
+
+        Map<String, Set<UUID>> leafToAccounts = resolveLeafToAccounts();
+        Map<String, BigDecimal[]> leafMonthly = aggregateLeafMonthly(leafToAccounts, locationId, fiscalYear);
+
+        Map<String, BigDecimal[]> monthlyByCode = new HashMap<>();
+        List<LaborOverheadReportLine> reportLines = new ArrayList<>();
+        for (LineDef def : LaborOverheadTaxonomy.lines()) {
+            BigDecimal[] monthly = computeMonthly(def, leafMonthly, monthlyByCode);
+            reportLines.add(toReportLine(def, monthly, resolvedAsOfMonth));
+        }
+
+        return LaborOverheadCostReport.builder()
+                .locationId(locationId)
+                .locationLabel(locationId)
+                .fiscalYear(fiscalYear)
+                .asOfMonth(resolvedAsOfMonth)
+                .currency(CURRENCY_USD)
+                .localCurrencyPerUsd(RATE_US_PLANT)
+                .averageRate(RATE_US_PLANT)
+                .lines(reportLines)
+                .build();
+    }
+
+    /** Group LABOR_OVERHEAD mappings by line code into the set of contributing GL account ids. */
+    private Map<String, Set<UUID>> resolveLeafToAccounts() {
+        Map<String, Set<UUID>> leafToAccounts = new HashMap<>();
+        statementLineMappingRepository
+                .findByStatementTypeOrderByDisplayOrder(StatementType.LABOR_OVERHEAD)
+                .forEach(mapping -> {
+                    UUID accountId = mapping.getGlAccountId();
+                    if (accountId != null && mapping.getStatementLineCode() != null) {
+                        leafToAccounts
+                                .computeIfAbsent(mapping.getStatementLineCode(), key -> new LinkedHashSet<>())
+                                .add(accountId);
+                    }
+                });
+        return leafToAccounts;
+    }
+
+    /**
+     * Aggregate posted net amounts (debit − credit) per leaf line into a 12-element monthly array,
+     * filtered to the requested location dimension.
+     */
+    private Map<String, BigDecimal[]> aggregateLeafMonthly(
+            Map<String, Set<UUID>> leafToAccounts, String locationId, int fiscalYear) {
+
+        Set<UUID> accountIds = new HashSet<>();
+        leafToAccounts.values().forEach(accountIds::addAll);
+
+        Map<UUID, BigDecimal[]> accountMonthly = new HashMap<>();
+        if (!accountIds.isEmpty()) {
+            LocalDateTime start = LocalDate.of(fiscalYear, 1, 1).atStartOfDay();
+            LocalDateTime end = LocalDate.of(fiscalYear, 12, 31).atTime(LocalTime.MAX);
+            List<JournalEntryLine> lines =
+                    journalEntryLineRepository.findPostedLinesByAccountsAndDateRange(accountIds, start, end);
+            for (JournalEntryLine line : lines) {
+                if (!matchesLocation(line, locationId)) {
+                    continue;
+                }
+                UUID accountId = line.getGlAccountId();
+                LocalDateTime transactionDate = line.getJournalEntry().getTransactionDate();
+                if (accountId == null || transactionDate == null) {
+                    continue;
+                }
+                int monthIndex = transactionDate.getMonthValue() - 1;
+                BigDecimal net = nullToZero(line.getDebitAmount()).subtract(nullToZero(line.getCreditAmount()));
+                BigDecimal[] perAccount = accountMonthly.computeIfAbsent(accountId, key -> zeroMonths());
+                perAccount[monthIndex] = perAccount[monthIndex].add(net);
+            }
+        }
+
+        Map<String, BigDecimal[]> leafMonthly = new HashMap<>();
+        leafToAccounts.forEach((code, accounts) -> {
+            BigDecimal[] monthly = zeroMonths();
+            for (UUID accountId : accounts) {
+                BigDecimal[] perAccount = accountMonthly.get(accountId);
+                if (perAccount != null) {
+                    for (int m = 0; m < MONTHS; m++) {
+                        monthly[m] = monthly[m].add(perAccount[m]);
+                    }
+                }
+            }
+            leafMonthly.put(code, monthly);
+        });
+        return leafMonthly;
+    }
+
+    /** Recursively compute a line's monthly array: leaves from aggregation, subtotals from children. */
+    private BigDecimal[] computeMonthly(
+            LineDef def, Map<String, BigDecimal[]> leafMonthly, Map<String, BigDecimal[]> memo) {
+        BigDecimal[] cached = memo.get(def.code());
+        if (cached != null) {
+            return cached;
+        }
+
+        BigDecimal[] monthly;
+        if (def.isSubtotal()) {
+            monthly = zeroMonths();
+            for (String childCode : def.childCodes()) {
+                LineDef child = LaborOverheadTaxonomy.byCode(childCode);
+                BigDecimal[] childMonthly = computeMonthly(child, leafMonthly, memo);
+                for (int m = 0; m < MONTHS; m++) {
+                    monthly[m] = monthly[m].add(childMonthly[m]);
+                }
+            }
+        } else {
+            monthly = leafMonthly.getOrDefault(def.code(), zeroMonths());
+        }
+
+        memo.put(def.code(), monthly);
+        return monthly;
+    }
+
+    private LaborOverheadReportLine toReportLine(LineDef def, BigDecimal[] monthly, int asOfMonth) {
+        BigDecimal ytd = BigDecimal.ZERO;
+        for (int m = 0; m < asOfMonth && m < MONTHS; m++) {
+            ytd = ytd.add(monthly[m]);
+        }
+        return LaborOverheadReportLine.builder()
+                .code(def.code())
+                .label(def.label())
+                .parentCode(def.parentCode())
+                .level(def.level())
+                .costType(def.costType())
+                .isSubtotal(def.isSubtotal())
+                .definition(def.definition())
+                .monthly(List.of(monthly))
+                .ytd(ytd)
+                .build();
+    }
+
+    private boolean matchesLocation(JournalEntryLine line, String locationId) {
+        Map<String, String> dimensions = line.getDimensions();
+        return dimensions != null && locationId.equals(dimensions.get(LOCATION_DIMENSION));
+    }
+
+    private static BigDecimal[] zeroMonths() {
+        BigDecimal[] months = new BigDecimal[MONTHS];
+        for (int m = 0; m < MONTHS; m++) {
+            months[m] = BigDecimal.ZERO;
+        }
+        return months;
+    }
+
+    private static BigDecimal nullToZero(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
@@ -193,6 +193,7 @@ public class LaborOverheadReportServiceImpl implements LaborOverheadReportServic
                 .level(def.level())
                 .costType(def.costType())
                 .isSubtotal(def.isSubtotal())
+                .usdOnly(def.usdOnly())
                 .definition(def.definition())
                 .monthly(List.of(monthly))
                 .ytd(ytd)

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/LaborOverheadReportService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/LaborOverheadReportService.java
@@ -1,0 +1,25 @@
+package com.positivity.accounting.service;
+
+import com.positivity.accounting.internal.dto.LaborOverheadCostReport;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Read-only CAP-316 Labor &amp; Overhead Cost Report generation.
+ *
+ * <p>Derives the canonical cost-line matrix (monthly + YTD) for a location and fiscal year from posted
+ * GL data. Performs no posting, mutation, or inference.
+ */
+public interface LaborOverheadReportService {
+
+    /**
+     * Generate the Labor &amp; Overhead report for one location and fiscal year.
+     *
+     * @param locationId accounting {@code locationId} dimension value (required)
+     * @param fiscalYear fiscal year
+     * @param asOfMonth highest elapsed month bounding YTD (1-12); {@code null} defaults to December
+     * @return the full canonical report, with {@code 0} amounts for unmapped/zero-activity lines
+     */
+    @NonNull
+    LaborOverheadCostReport generate(@NonNull String locationId, int fiscalYear, @Nullable Integer asOfMonth);
+}

--- a/pos-accounting/src/main/resources/db/migration/V3__seed_labor_overhead_mapping.sql
+++ b/pos-accounting/src/main/resources/db/migration/V3__seed_labor_overhead_mapping.sql
@@ -1,0 +1,44 @@
+-- CAP-316: representative Labor & Overhead report-line -> GL-account mapping.
+--
+-- The full line->account set is authored by the Accounting domain (per the CAP-316 spec); this seeds a
+-- representative subset so the report endpoint is demonstrably wired and testable. Unmapped lines return
+-- 0 (acceptance criteria allow this). The mapping reuses the persisted statement_line_mappings table
+-- under a new statement_type, LABOR_OVERHEAD.
+
+-- Allow the new statement type on the existing check constraint.
+ALTER TABLE statement_line_mappings
+    DROP CONSTRAINT IF EXISTS statement_line_mappings_statement_type_check;
+ALTER TABLE statement_line_mappings
+    ADD CONSTRAINT statement_line_mappings_statement_type_check
+        CHECK (statement_type IN ('INCOME_STATEMENT', 'BALANCE_SHEET', 'LABOR_OVERHEAD'));
+
+-- Representative GL accounts for retread-plant labor & overhead lines.
+INSERT INTO gl_account (gl_account_id, account_code, account_name, account_type, created_at, created_by, modified_at, modified_by)
+VALUES
+    ('a1000000-0000-7000-8000-000000000001'::uuid, '6010', 'Retread Plant Hourly Wages', 'EXPENSE', NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000002'::uuid, '6110', 'Retread Plant FICA Expense', 'EXPENSE', NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000003'::uuid, '6400', 'Retread Plant Utilities', 'EXPENSE', NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000004'::uuid, '6450', 'Retread MRT Equipment Depreciation (USD)', 'EXPENSE', NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000005'::uuid, '6900', 'Rubber Dust Sales Income', 'REVENUE', NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (account_code) DO UPDATE SET
+    account_name = EXCLUDED.account_name,
+    account_type = EXCLUDED.account_type,
+    modified_at = NOW(),
+    modified_by = 'seed-generator';
+
+-- Map representative leaf line codes to those accounts (operation SUM; sign comes from debit-credit net).
+INSERT INTO statement_line_mappings (mapping_id, gl_account_id, account_name, statement_type, statement_line_code, line_description, display_order, operation)
+VALUES
+    ('b1000000-0000-7000-8000-000000000001'::uuid, 'a1000000-0000-7000-8000-000000000001'::uuid, '6010', 'LABOR_OVERHEAD', '1.1.1', 'Hourly wages and bonuses', 1, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000002'::uuid, 'a1000000-0000-7000-8000-000000000002'::uuid, '6110', 'LABOR_OVERHEAD', '1.3.1', 'FICA', 2, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000003'::uuid, 'a1000000-0000-7000-8000-000000000003'::uuid, '6400', 'LABOR_OVERHEAD', '2.10', 'Utilities - gas, electric, water', 3, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000004'::uuid, 'a1000000-0000-7000-8000-000000000004'::uuid, '6450', 'LABOR_OVERHEAD', '2.11.4', 'Depreciation - MRT process equipment ($US only)', 4, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000005'::uuid, 'a1000000-0000-7000-8000-000000000005'::uuid, '6900', 'LABOR_OVERHEAD', '2.14', 'Income from rubber dust sales', 5, 'SUM')
+ON CONFLICT (mapping_id) DO UPDATE SET
+    gl_account_id = EXCLUDED.gl_account_id,
+    account_name = EXCLUDED.account_name,
+    statement_type = EXCLUDED.statement_type,
+    statement_line_code = EXCLUDED.statement_line_code,
+    line_description = EXCLUDED.line_description,
+    display_order = EXCLUDED.display_order,
+    operation = EXCLUDED.operation;

--- a/pos-accounting/src/main/resources/db/migration/V3__seed_labor_overhead_mapping.sql
+++ b/pos-accounting/src/main/resources/db/migration/V3__seed_labor_overhead_mapping.sql
@@ -13,13 +13,13 @@ ALTER TABLE statement_line_mappings
         CHECK (statement_type IN ('INCOME_STATEMENT', 'BALANCE_SHEET', 'LABOR_OVERHEAD'));
 
 -- Representative GL accounts for retread-plant labor & overhead lines.
-INSERT INTO gl_account (gl_account_id, account_code, account_name, account_type, created_at, created_by, modified_at, modified_by)
+INSERT INTO gl_account (gl_account_id, account_code, account_name, account_type, version, created_at, created_by, modified_at, modified_by)
 VALUES
-    ('a1000000-0000-7000-8000-000000000001'::uuid, '6010', 'Retread Plant Hourly Wages', 'EXPENSE', NOW(), 'seed-generator', NOW(), 'seed-generator'),
-    ('a1000000-0000-7000-8000-000000000002'::uuid, '6110', 'Retread Plant FICA Expense', 'EXPENSE', NOW(), 'seed-generator', NOW(), 'seed-generator'),
-    ('a1000000-0000-7000-8000-000000000003'::uuid, '6400', 'Retread Plant Utilities', 'EXPENSE', NOW(), 'seed-generator', NOW(), 'seed-generator'),
-    ('a1000000-0000-7000-8000-000000000004'::uuid, '6450', 'Retread MRT Equipment Depreciation (USD)', 'EXPENSE', NOW(), 'seed-generator', NOW(), 'seed-generator'),
-    ('a1000000-0000-7000-8000-000000000005'::uuid, '6900', 'Rubber Dust Sales Income', 'REVENUE', NOW(), 'seed-generator', NOW(), 'seed-generator')
+    ('a1000000-0000-7000-8000-000000000001'::uuid, '6010', 'Retread Plant Hourly Wages', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000002'::uuid, '6110', 'Retread Plant FICA Expense', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000003'::uuid, '6400', 'Retread Plant Utilities', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000004'::uuid, '6450', 'Retread MRT Equipment Depreciation (USD)', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000005'::uuid, '6900', 'Rubber Dust Sales Income', 'REVENUE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator')
 ON CONFLICT (account_code) DO UPDATE SET
     account_name = EXCLUDED.account_name,
     account_type = EXCLUDED.account_type,

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/LaborOverheadReportContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/LaborOverheadReportContractBehaviorIT.java
@@ -83,6 +83,32 @@ class LaborOverheadReportContractBehaviorIT extends BaseContractIntegrationTest 
         assertThat(line(report, "2.5").getYtd()).isEqualByComparingTo("0");
     }
 
+    @Test
+    @DisplayName("Only POSTED entries contribute: DRAFT and REVERSED on the same account/period are excluded")
+    void excludesNonPostedEntries() throws Exception {
+        // Distinct location: the contract IT shares one H2 instance across tests with no per-test
+        // reset, and line-code mappings are global, so each test scopes its postings by location.
+        String location = "LOC-IT-316-NONPOSTED";
+        GLAccount account = seedAccount("6010-IT2", "Retread Plant Hourly Wages (IT2)");
+        seedMapping("1.1.1", account);
+        seedPostedExpense(account, 3, location, new BigDecimal("1000.00"));
+        seedExpense(account, 3, location, new BigDecimal("500.00"), JournalEntryStatus.DRAFT);
+        seedExpense(account, 3, location, new BigDecimal("700.00"), JournalEntryStatus.REVERSED);
+
+        String json = mockMvc.perform(withAuth(get(PATH)
+                        .param("locationId", location)
+                        .param("fiscalYear", String.valueOf(FISCAL_YEAR))
+                        .param("asOfMonth", "12")))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        LaborOverheadReportLine wages = line(objectMapper.readValue(json, LaborOverheadCostReport.class), "1.1.1");
+        assertThat(wages.getMonthly().get(2)).isEqualByComparingTo("1000.00"); // draft + reversed not counted
+        assertThat(wages.getYtd()).isEqualByComparingTo("1000.00");
+    }
+
     private GLAccount seedAccount(String code, String name) {
         GLAccount account = new GLAccount();
         account.setAccountCode(code);
@@ -105,8 +131,13 @@ class LaborOverheadReportContractBehaviorIT extends BaseContractIntegrationTest 
     }
 
     private void seedPostedExpense(GLAccount account, int month, String location, BigDecimal amount) {
+        seedExpense(account, month, location, amount, JournalEntryStatus.POSTED);
+    }
+
+    private void seedExpense(
+            GLAccount account, int month, String location, BigDecimal amount, JournalEntryStatus status) {
         JournalEntry entry = new JournalEntry();
-        entry.setStatus(JournalEntryStatus.POSTED);
+        entry.setStatus(status);
         entry.setTransactionDate(LocalDateTime.of(FISCAL_YEAR, month, 15, 0, 0));
         entry.setTotalDebits(amount);
         entry.setTotalCredits(amount);

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/LaborOverheadReportContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/LaborOverheadReportContractBehaviorIT.java
@@ -1,0 +1,132 @@
+package com.positivity.accounting.contract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.accounting.BaseContractIntegrationTest;
+import com.positivity.accounting.internal.dto.LaborOverheadCostReport;
+import com.positivity.accounting.internal.dto.LaborOverheadReportLine;
+import com.positivity.accounting.internal.entity.GLAccount;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.entity.StatementLineMapping;
+import com.positivity.accounting.internal.enums.AccountType;
+import com.positivity.accounting.internal.enums.JournalEntryStatus;
+import com.positivity.accounting.internal.enums.OperationType;
+import com.positivity.accounting.internal.enums.StatementType;
+import com.positivity.accounting.internal.report.LaborOverheadTaxonomy;
+import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Provider behavioral contract test (CAP-316): proves the Labor &amp; Overhead report amounts trace to
+ * posted GL data for a seeded location/period, and that subtotals roll up from the contributing leaf.
+ */
+@DisplayName("Labor & Overhead Report ContractBehaviorIT")
+class LaborOverheadReportContractBehaviorIT extends BaseContractIntegrationTest {
+
+    private static final String PATH = "/v1/accounting/reports/location/labor-overhead";
+    private static final String LOCATION = "LOC-IT-316";
+    private static final int FISCAL_YEAR = 2026;
+
+    @Autowired
+    private GLAccountRepository glAccountRepository;
+
+    @Autowired
+    private StatementLineMappingRepository statementLineMappingRepository;
+
+    @Autowired
+    private JournalEntryRepository journalEntryRepository;
+
+    @Test
+    @DisplayName("Report leaf + subtotal amounts trace to a posted journal entry for the location")
+    void reportAmountsTraceToPostedGl() throws Exception {
+        GLAccount account = seedAccount("6010-IT", "Retread Plant Hourly Wages (IT)");
+        seedMapping("1.1.1", account);
+        // Posted expense in March for the target location.
+        seedPostedExpense(account, 3, LOCATION, new BigDecimal("1234.56"));
+        // A different location must not leak into this report.
+        seedPostedExpense(account, 3, "LOC-OTHER", new BigDecimal("9999.00"));
+
+        String json = mockMvc.perform(withAuth(get(PATH)
+                        .param("locationId", LOCATION)
+                        .param("fiscalYear", String.valueOf(FISCAL_YEAR))
+                        .param("asOfMonth", "12")))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        LaborOverheadCostReport report = objectMapper.readValue(json, LaborOverheadCostReport.class);
+        assertThat(report.getLocationId()).isEqualTo(LOCATION);
+        assertThat(report.getLines()).hasSameSizeAs(LaborOverheadTaxonomy.lines());
+
+        LaborOverheadReportLine wages = line(report, "1.1.1");
+        assertThat(wages.getMonthly().get(2)).isEqualByComparingTo("1234.56"); // March
+        assertThat(wages.getMonthly().get(0)).isEqualByComparingTo("0");
+        assertThat(wages.getYtd()).isEqualByComparingTo("1234.56");
+
+        // Subtotal 1.1 and Total Labor roll up from the single contributing leaf.
+        assertThat(line(report, "1.1").getYtd()).isEqualByComparingTo("1234.56");
+        assertThat(line(report, LaborOverheadTaxonomy.TOTAL_LABOR).getYtd()).isEqualByComparingTo("1234.56");
+        assertThat(line(report, LaborOverheadTaxonomy.TOTAL_LABOR_OVERHEAD).getYtd())
+                .isEqualByComparingTo("1234.56");
+        // An unmapped line stays present at zero.
+        assertThat(line(report, "2.5").getYtd()).isEqualByComparingTo("0");
+    }
+
+    private GLAccount seedAccount(String code, String name) {
+        GLAccount account = new GLAccount();
+        account.setAccountCode(code);
+        account.setAccountName(name);
+        account.setAccountType(AccountType.EXPENSE);
+        account.setCreatedBy("contract-test");
+        account.setModifiedBy("contract-test");
+        return glAccountRepository.save(account);
+    }
+
+    private void seedMapping(String lineCode, GLAccount account) {
+        StatementLineMapping mapping = new StatementLineMapping();
+        mapping.setStatementType(StatementType.LABOR_OVERHEAD);
+        mapping.setStatementLineCode(lineCode);
+        mapping.setGlAccount(account);
+        mapping.setAccountName(account.getAccountCode());
+        mapping.setOperation(OperationType.SUM);
+        mapping.setDisplayOrder(1);
+        statementLineMappingRepository.save(mapping);
+    }
+
+    private void seedPostedExpense(GLAccount account, int month, String location, BigDecimal amount) {
+        JournalEntry entry = new JournalEntry();
+        entry.setStatus(JournalEntryStatus.POSTED);
+        entry.setTransactionDate(LocalDateTime.of(FISCAL_YEAR, month, 15, 0, 0));
+        entry.setTotalDebits(amount);
+        entry.setTotalCredits(amount);
+        entry.setIsBalanced(true);
+
+        JournalEntryLine line = new JournalEntryLine();
+        line.setGlAccount(account);
+        line.setAccountCode(account.getAccountCode());
+        line.setDebitAmount(amount);
+        line.setCreditAmount(BigDecimal.ZERO);
+        line.setDimensions(Map.of("locationId", location));
+        entry.addLine(line);
+
+        journalEntryRepository.save(entry);
+    }
+
+    private static LaborOverheadReportLine line(LaborOverheadCostReport report, String code) {
+        return report.getLines().stream()
+                .filter(reportLine -> reportLine.getCode().equals(code))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("missing line " + code));
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/controller/LaborOverheadReportControllerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/controller/LaborOverheadReportControllerTest.java
@@ -1,0 +1,82 @@
+package com.positivity.accounting.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.accounting.BaseIntegrationTest;
+import com.positivity.accounting.internal.dto.LaborOverheadCostReport;
+import com.positivity.accounting.service.LaborOverheadReportService;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Controller tests for {@link LaborOverheadReportController}: happy path, input validation (400),
+ * and authorization (403).
+ */
+@DisplayName("LaborOverheadReportController Tests")
+class LaborOverheadReportControllerTest extends BaseIntegrationTest {
+
+    private static final String PATH = "/v1/accounting/reports/location/labor-overhead";
+
+    @MockitoBean
+    private LaborOverheadReportService laborOverheadReportService;
+
+    private LaborOverheadCostReport stubReport() {
+        return LaborOverheadCostReport.builder()
+                .locationId("LOC-107")
+                .locationLabel("LOC-107")
+                .fiscalYear(2026)
+                .asOfMonth(12)
+                .currency("USD")
+                .localCurrencyPerUsd(new BigDecimal("1.00"))
+                .averageRate(new BigDecimal("1.00"))
+                .lines(List.of())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Returns 200 with the report for an authorized request")
+    void returns200() throws Exception {
+        when(laborOverheadReportService.generate(eq("LOC-107"), eq(2026), any()))
+                .thenReturn(stubReport());
+
+        mockMvc.perform(withAuth(get(PATH).param("locationId", "LOC-107").param("fiscalYear", "2026")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.locationId").value("LOC-107"))
+                .andExpect(jsonPath("$.currency").value("USD"));
+    }
+
+    @Test
+    @DisplayName("Rejects asOfMonth outside 1-12 with 400 VALIDATION_ERROR")
+    void rejectsInvalidAsOfMonth() throws Exception {
+        mockMvc.perform(withAuth(get(PATH)
+                        .param("locationId", "LOC-107")
+                        .param("fiscalYear", "2026")
+                        .param("asOfMonth", "13")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @DisplayName("Rejects a non-four-digit fiscalYear with 400 VALIDATION_ERROR")
+    void rejectsInvalidFiscalYear() throws Exception {
+        mockMvc.perform(withAuth(get(PATH).param("locationId", "LOC-107").param("fiscalYear", "12")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @DisplayName("Returns 403 when the caller lacks the financial-reporting permission")
+    void returns403WithoutPermission() throws Exception {
+        mockMvc.perform(withAuth(
+                        get(PATH).param("locationId", "LOC-107").param("fiscalYear", "2026"), "accounting:je:view"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
@@ -1,0 +1,211 @@
+package com.positivity.accounting.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.positivity.accounting.internal.dto.LaborOverheadCostReport;
+import com.positivity.accounting.internal.dto.LaborOverheadReportLine;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.entity.StatementLineMapping;
+import com.positivity.accounting.internal.enums.StatementType;
+import com.positivity.accounting.internal.report.LaborOverheadTaxonomy;
+import com.positivity.accounting.internal.repository.JournalEntryLineRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link LaborOverheadReportServiceImpl}: taxonomy completeness, monthly bucketing,
+ * subtotal roll-ups, YTD with mid-year asOfMonth, sign preservation, and location-dimension filtering.
+ */
+@ExtendWith(MockitoExtension.class)
+class LaborOverheadReportServiceImplTest {
+
+    private static final String LOCATION = "LOC-1";
+    private static final String OTHER_LOCATION = "LOC-2";
+    private static final int FISCAL_YEAR = 2026;
+
+    private static final UUID ACCT_WAGES = UUID.fromString("a1000000-0000-7000-8000-000000000001");
+    private static final UUID ACCT_FICA = UUID.fromString("a1000000-0000-7000-8000-000000000002");
+    private static final UUID ACCT_DUST = UUID.fromString("a1000000-0000-7000-8000-000000000005");
+
+    @Mock
+    private StatementLineMappingRepository statementLineMappingRepository;
+
+    @Mock
+    private JournalEntryLineRepository journalEntryLineRepository;
+
+    private LaborOverheadReportServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LaborOverheadReportServiceImpl(statementLineMappingRepository, journalEntryLineRepository);
+    }
+
+    private void mappings(StatementLineMapping... mappings) {
+        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(eq(StatementType.LABOR_OVERHEAD)))
+                .thenReturn(List.of(mappings));
+    }
+
+    private void postedLines(JournalEntryLine... lines) {
+        when(journalEntryLineRepository.findPostedLinesByAccountsAndDateRange(any(), any(), any()))
+                .thenReturn(new ArrayList<>(List.of(lines)));
+    }
+
+    private static StatementLineMapping mapping(String lineCode, UUID accountId) {
+        StatementLineMapping mapping = new StatementLineMapping();
+        mapping.setStatementType(StatementType.LABOR_OVERHEAD);
+        mapping.setStatementLineCode(lineCode);
+        mapping.setGlAccountId(accountId);
+        return mapping;
+    }
+
+    private static JournalEntryLine line(
+            UUID accountId, int month, String location, BigDecimal debit, BigDecimal credit) {
+        JournalEntry entry = new JournalEntry();
+        entry.setTransactionDate(LocalDateTime.of(FISCAL_YEAR, month, 15, 0, 0));
+
+        JournalEntryLine line = new JournalEntryLine();
+        line.setJournalEntry(entry);
+        line.setGlAccountId(accountId);
+        line.setDebitAmount(debit);
+        line.setCreditAmount(credit);
+        line.setDimensions(Map.of("locationId", location));
+        return line;
+    }
+
+    private static LaborOverheadReportLine find(LaborOverheadCostReport report, String code) {
+        return report.getLines().stream()
+                .filter(line -> line.getCode().equals(code))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("missing line " + code));
+    }
+
+    private static BigDecimal money(String value) {
+        return new BigDecimal(value);
+    }
+
+    @Test
+    void generate_returnsFullCanonicalTaxonomyInOrder() {
+        mappings(mapping("1.1.1", ACCT_WAGES));
+        postedLines(line(ACCT_WAGES, 1, LOCATION, money("1000"), BigDecimal.ZERO));
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        assertThat(report.getLines()).hasSameSizeAs(LaborOverheadTaxonomy.lines());
+        assertThat(report.getLines().get(0).getCode()).isEqualTo("1.1");
+        assertThat(report.getLines().get(report.getLines().size() - 1).getCode())
+                .isEqualTo(LaborOverheadTaxonomy.TOTAL_LABOR_OVERHEAD);
+        assertThat(find(report, "1.1.1").getMonthly()).hasSize(12);
+    }
+
+    @Test
+    void generate_bucketsLeafAmountsByMonth() {
+        mappings(mapping("1.1.1", ACCT_WAGES));
+        postedLines(
+                line(ACCT_WAGES, 1, LOCATION, money("1000"), BigDecimal.ZERO),
+                line(ACCT_WAGES, 1, LOCATION, money("500"), BigDecimal.ZERO),
+                line(ACCT_WAGES, 10, LOCATION, money("700"), BigDecimal.ZERO));
+
+        LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, 12), "1.1.1");
+
+        assertThat(wages.getMonthly().get(0)).isEqualByComparingTo("1500"); // January
+        assertThat(wages.getMonthly().get(9)).isEqualByComparingTo("700"); // October
+        assertThat(wages.getYtd()).isEqualByComparingTo("2200");
+    }
+
+    @Test
+    void generate_filtersByLocationDimension() {
+        mappings(mapping("1.1.1", ACCT_WAGES));
+        postedLines(
+                line(ACCT_WAGES, 1, LOCATION, money("1000"), BigDecimal.ZERO),
+                line(ACCT_WAGES, 1, OTHER_LOCATION, money("9999"), BigDecimal.ZERO));
+
+        LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, 12), "1.1.1");
+
+        assertThat(wages.getMonthly().get(0)).isEqualByComparingTo("1000");
+    }
+
+    @Test
+    void generate_rollsUpSubtotalsAndTotals() {
+        mappings(mapping("1.1.1", ACCT_WAGES), mapping("1.3.1", ACCT_FICA));
+        postedLines(
+                line(ACCT_WAGES, 1, LOCATION, money("1000"), BigDecimal.ZERO),
+                line(ACCT_FICA, 1, LOCATION, money("76"), BigDecimal.ZERO));
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        assertThat(find(report, "1.1").getMonthly().get(0)).isEqualByComparingTo("1000"); // 1.1.1 + 1.1.2
+        assertThat(find(report, "1.3").getMonthly().get(0)).isEqualByComparingTo("76"); // 1.3.1
+        assertThat(find(report, LaborOverheadTaxonomy.TOTAL_LABOR).getMonthly().get(0))
+                .isEqualByComparingTo("1076"); // 1.1 + 1.2 + 1.3 + 1.5
+        assertThat(find(report, LaborOverheadTaxonomy.TOTAL_LABOR_OVERHEAD)
+                        .getMonthly()
+                        .get(0))
+                .isEqualByComparingTo("1076"); // labor only (no overhead postings)
+        assertThat(find(report, LaborOverheadTaxonomy.TOTAL_LABOR).getYtd()).isEqualByComparingTo("1076");
+    }
+
+    @Test
+    void generate_ytdBoundedByAsOfMonth() {
+        mappings(mapping("1.1.1", ACCT_WAGES));
+        postedLines(
+                line(ACCT_WAGES, 3, LOCATION, money("300"), BigDecimal.ZERO),
+                line(ACCT_WAGES, 9, LOCATION, money("900"), BigDecimal.ZERO));
+
+        LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, 6), "1.1.1");
+
+        assertThat(wages.getMonthly().get(8)).isEqualByComparingTo("900"); // September still populated
+        assertThat(wages.getYtd()).isEqualByComparingTo("300"); // only through June
+    }
+
+    @Test
+    void generate_preservesNegativeSignForIncomeLines() {
+        mappings(mapping("2.14", ACCT_DUST));
+        postedLines(line(ACCT_DUST, 4, LOCATION, BigDecimal.ZERO, money("250"))); // credit -> income
+
+        LaborOverheadReportLine dust = find(service.generate(LOCATION, FISCAL_YEAR, 12), "2.14");
+
+        assertThat(dust.getMonthly().get(3)).isEqualByComparingTo("-250"); // April
+        assertThat(dust.getYtd()).isEqualByComparingTo("-250");
+    }
+
+    @Test
+    void generate_withNoMappings_returnsFullLayoutAllZero() {
+        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(any()))
+                .thenReturn(List.of());
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        assertThat(report.getLines()).hasSameSizeAs(LaborOverheadTaxonomy.lines());
+        assertThat(report.getLines())
+                .allSatisfy(line -> assertThat(line.getYtd()).isEqualByComparingTo("0"));
+        assertThat(find(report, "2.11.4")).isNotNull(); // USD line still present
+    }
+
+    @Test
+    void generate_populatesUsPlantCurrencyContext() {
+        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(any()))
+                .thenReturn(List.of());
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, null);
+
+        assertThat(report.getCurrency()).isEqualTo("USD");
+        assertThat(report.getLocalCurrencyPerUsd()).isEqualByComparingTo("1.00");
+        assertThat(report.getAverageRate()).isEqualByComparingTo("1.00");
+        assertThat(report.getAsOfMonth()).isEqualTo(12); // null defaults to December
+        assertThat(report.getLocationId()).isEqualTo(LOCATION);
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
@@ -38,7 +38,10 @@ class LaborOverheadReportServiceImplTest {
     private static final int FISCAL_YEAR = 2026;
 
     private static final UUID ACCT_WAGES = UUID.fromString("a1000000-0000-7000-8000-000000000001");
+    private static final UUID ACCT_WAGES_2 = UUID.fromString("a1000000-0000-7000-8000-00000000000a");
     private static final UUID ACCT_FICA = UUID.fromString("a1000000-0000-7000-8000-000000000002");
+    private static final UUID ACCT_UTIL = UUID.fromString("a1000000-0000-7000-8000-000000000003");
+    private static final UUID ACCT_INV = UUID.fromString("a1000000-0000-7000-8000-000000000004");
     private static final UUID ACCT_DUST = UUID.fromString("a1000000-0000-7000-8000-000000000005");
 
     @Mock
@@ -207,5 +210,106 @@ class LaborOverheadReportServiceImplTest {
         assertThat(report.getAverageRate()).isEqualByComparingTo("1.00");
         assertThat(report.getAsOfMonth()).isEqualTo(12); // null defaults to December
         assertThat(report.getLocationId()).isEqualTo(LOCATION);
+    }
+
+    @Test
+    void generate_rollsUpOverheadAndGrandTotalFromDistinctSections() {
+        mappings(mapping("1.1.1", ACCT_WAGES), mapping("2.10", ACCT_UTIL));
+        postedLines(
+                line(ACCT_WAGES, 1, LOCATION, money("1000"), BigDecimal.ZERO),
+                line(ACCT_UTIL, 1, LOCATION, money("250"), BigDecimal.ZERO));
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        assertThat(find(report, LaborOverheadTaxonomy.TOTAL_LABOR).getMonthly().get(0))
+                .isEqualByComparingTo("1000");
+        assertThat(find(report, LaborOverheadTaxonomy.TOTAL_OVERHEAD)
+                        .getMonthly()
+                        .get(0))
+                .isEqualByComparingTo("250");
+        assertThat(find(report, LaborOverheadTaxonomy.TOTAL_LABOR_OVERHEAD)
+                        .getMonthly()
+                        .get(0))
+                .isEqualByComparingTo("1250"); // labor + overhead, distinct sections
+    }
+
+    @Test
+    void generate_negativeIncomeLineReducesOverheadTotal() {
+        mappings(mapping("2.10", ACCT_UTIL), mapping("2.13", ACCT_INV));
+        postedLines(
+                line(ACCT_UTIL, 2, LOCATION, money("300"), BigDecimal.ZERO),
+                line(ACCT_INV, 2, LOCATION, BigDecimal.ZERO, money("50"))); // credit -> interest income
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        assertThat(find(report, "2.13").getMonthly().get(1)).isEqualByComparingTo("-50");
+        assertThat(find(report, LaborOverheadTaxonomy.TOTAL_OVERHEAD)
+                        .getMonthly()
+                        .get(1))
+                .isEqualByComparingTo("250"); // 300 - 50, sign survives roll-up
+    }
+
+    @Test
+    void generate_sumsMultipleAccountsMappedToOneLine() {
+        mappings(mapping("1.1.1", ACCT_WAGES), mapping("1.1.1", ACCT_WAGES_2));
+        postedLines(
+                line(ACCT_WAGES, 1, LOCATION, money("1000"), BigDecimal.ZERO),
+                line(ACCT_WAGES_2, 1, LOCATION, money("400"), BigDecimal.ZERO));
+
+        LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, 12), "1.1.1");
+
+        assertThat(wages.getMonthly().get(0)).isEqualByComparingTo("1400"); // both accounts summed
+    }
+
+    @Test
+    void generate_ytdLowerBoundAsOfMonthOne() {
+        mappings(mapping("1.1.1", ACCT_WAGES));
+        postedLines(
+                line(ACCT_WAGES, 1, LOCATION, money("100"), BigDecimal.ZERO),
+                line(ACCT_WAGES, 2, LOCATION, money("200"), BigDecimal.ZERO));
+
+        LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, 1), "1.1.1");
+
+        assertThat(wages.getMonthly().get(1)).isEqualByComparingTo("200"); // February still populated
+        assertThat(wages.getYtd()).isEqualByComparingTo("100"); // YTD only January
+    }
+
+    @Test
+    void generate_ytdDefaultSumsFullYear() {
+        mappings(mapping("1.1.1", ACCT_WAGES));
+        postedLines(
+                line(ACCT_WAGES, 1, LOCATION, money("100"), BigDecimal.ZERO),
+                line(ACCT_WAGES, 6, LOCATION, money("60"), BigDecimal.ZERO),
+                line(ACCT_WAGES, 12, LOCATION, money("12"), BigDecimal.ZERO));
+
+        LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, null), "1.1.1");
+
+        assertThat(wages.getYtd()).isEqualByComparingTo("172"); // null asOfMonth -> all 12 months
+    }
+
+    @Test
+    void generate_excludesLinesWithoutMatchingLocationDimension() {
+        mappings(mapping("1.1.1", ACCT_WAGES));
+        JournalEntryLine nullDimensions = line(ACCT_WAGES, 1, LOCATION, money("100"), BigDecimal.ZERO);
+        nullDimensions.setDimensions(null);
+        JournalEntryLine missingLocationKey = line(ACCT_WAGES, 1, LOCATION, money("200"), BigDecimal.ZERO);
+        missingLocationKey.setDimensions(Map.of("costCenterId", "CC-1"));
+        postedLines(nullDimensions, missingLocationKey, line(ACCT_WAGES, 1, LOCATION, money("5"), BigDecimal.ZERO));
+
+        LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, 12), "1.1.1");
+
+        assertThat(wages.getMonthly().get(0)).isEqualByComparingTo("5"); // only the matching-location line counts
+    }
+
+    @Test
+    void generate_flagsUsdOnlyOnLine2_11_4() {
+        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(any()))
+                .thenReturn(List.of());
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        assertThat(find(report, "2.11.4").isUsdOnly()).isTrue();
+        assertThat(find(report, "2.11.5").isUsdOnly()).isFalse();
+        assertThat(find(report, "1.1.1").isUsdOnly()).isFalse();
     }
 }


### PR DESCRIPTION
## Summary

Implements the CAP-316 backend story (#724): a **read-only** accounting reporting endpoint that returns the canonical "Labor & Overhead Costs" matrix for a **location** and **fiscal year**, derived entirely from **posted GL data**. No posting path, no mutation.

`GET /v1/accounting/reports/location/labor-overhead?locationId={id}&fiscalYear={yyyy}[&asOfMonth={1-12}]`

## What it does

- **Canonical taxonomy** (`LaborOverheadTaxonomy`) — every cost line (Labor §1, Overhead §2, section subtotals, Total Labor & Overhead) in contractual order with `code`, `label`, `parentCode`, `level`, `costType` (`FIXED|VARIABLE|FIXED_IF_LOW_VOLUME`), `isSubtotal`, and `definition`, taken verbatim from the CAP-316 spec §3.
- **Aggregation** — leaf lines resolve to GL accounts via the persisted `StatementLineMapping` (new `StatementType.LABOR_OVERHEAD`); posted journal-line net (debit − credit) is bucketed by month for the requested `locationId` dimension, `monthly[12]` (index 0 = January) + `ytd` over elapsed months. Subtotals are computed column-wise from children, never mapped directly. Sign preserved for income lines (2.13, 2.14). Mirrors the existing `je.status = 'POSTED'` reporting semantic.
- **Authorization** — reuses the financial-reporting permission `reporting:view:financial-statements`; unauthorized → `403` (no new perm-bit).
- **Contract chain** — OpenAPI annotations + regenerated `pos-accounting/openapi.yaml`. The CAP-316 section of `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` (durion) is updated in a separate contract PR (contract-sync gate).

## Tests (636 module tests green)

- `LaborOverheadReportServiceImplTest` — bucketing, subtotal roll-ups, YTD with mid-year `asOfMonth`, negative-sign income lines, location-dimension filtering, empty-layout-all-zero.
- `LaborOverheadReportControllerTest` — 200 / 400 validation / 403.
- `LaborOverheadReportContractBehaviorIT` — amounts trace to a seeded posted journal entry for the location/period.

## Decisions / scope notes

- **Path:** `/location/labor-overhead` per issue #724 (supersedes the spec markdown's `/retread/`).
- **Mapping (v1):** persisted `StatementLineMapping` rows under `LABOR_OVERHEAD`; migration `V3` seeds a **representative** subset so the endpoint is wired + testable. Unmapped lines return `0` (AC allows). The **full domain-authored** line→GL-account set is a follow-up.
- **Currency (v1):** assumes a US plant — `currency=USD`, `localCurrencyPerUsd=averageRate=1.00`, `locationLabel` echoes `locationId`. FX conversion + location-label/currency enrichment are documented follow-ups.

## Follow-ups (out of scope here)
- Full report-line → GL-account mapping (Accounting domain).
- Real FX conversion + location metadata enrichment.
- Angular SDK regen (`durion-positivity-sdk-angular` accounting module) — standard post-merge chain step.
- Frontend screen (durion-positivity-frontend, issue #77).

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)
