### PR TITLE
fix(workorder): timer stop/list resolves tracked technician or initiator (#729)

### DIFF
--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/WorkorderLaborEntry.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/WorkorderLaborEntry.java
@@ -119,8 +119,13 @@ public class WorkorderLaborEntry {
     private String onBehalfReason;
 
     /**
-     * Stable user id (UUID) of the actor who initiated an on-behalf timer start; null for
-     * self/assignment-default starts. The actor's username is captured separately in {@code createdBy}.
+     * Stable user id (UUID) of the actor who initiated this entry when the tracked {@code technicianId}
+     * differs from the actor — i.e. both the default-attribution path (timer started for the workorder's
+     * assigned technician) and the on-behalf path. Null for self starts, where {@code technicianId} already
+     * identifies the actor. Recording the initiator here is what lets that initiator stop/list the timer
+     * they started (see {@code findActiveByTechnicianOrActor}). The on-behalf path is distinguished by a
+     * non-null {@code onBehalfReason}, not by the presence of this field. The actor's username is captured
+     * separately in {@code createdBy}.
      */
     @Nullable
     @Column(updatable = false, columnDefinition = "UUID")

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderLaborEntryRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderLaborEntryRepository.java
@@ -53,6 +53,21 @@ public interface WorkorderLaborEntryRepository extends JpaRepository<WorkorderLa
     @NonNull
     List<WorkorderLaborEntry> findByTechnicianIdAndEndTimeIsNullOrderByStartTimeDesc(@NonNull UUID technicianId);
 
+    /**
+     * Find active (not stopped) labor entries the actor is responsible for: those tracking the actor as
+     * the technician (self path) or those the actor initiated (default-attribution / on-behalf paths,
+     * where the tracked technician differs from the actor and the actor is recorded in
+     * {@code actedByUserId}). Ordered by start time descending.
+     *
+     * @param actor the authenticated actor id (user id)
+     * @return active labor entries the actor tracks or initiated
+     */
+    @NonNull
+    @Query("SELECT e FROM WorkorderLaborEntry e WHERE e.endTime IS NULL "
+            + "AND (e.technicianId = :actor OR e.actedByUserId = :actor) "
+            + "ORDER BY e.startTime DESC")
+    List<WorkorderLaborEntry> findActiveByTechnicianOrActor(@Param("actor") @NonNull UUID actor);
+
     @NonNull
     List<WorkorderLaborEntry> findByEndTimeIsNotNullAndEndTimeBetween(
             @NonNull LocalDateTime startInclusive, @NonNull LocalDateTime endExclusive);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkexecTimeTrackingServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkexecTimeTrackingServiceImpl.java
@@ -195,7 +195,9 @@ public class WorkexecTimeTrackingServiceImpl implements WorkexecTimeTrackingServ
     @Transactional(readOnly = true)
     @NonNull
     public List<WorkexecTimeTrackingService.TimerEntry> getActiveTimers(@NonNull UUID mechanicId) {
-        return laborEntryRepository.findByTechnicianIdAndEndTimeIsNullOrderByStartTimeDesc(mechanicId).stream()
+        // Mirror stopTimers: surface timers the actor tracks or initiated, so the active list and the
+        // stop operation agree for default-attribution / on-behalf entries.
+        return laborEntryRepository.findActiveByTechnicianOrActor(mechanicId).stream()
                 .map(this::toTimerResponse)
                 .toList();
     }
@@ -258,7 +260,10 @@ public class WorkexecTimeTrackingServiceImpl implements WorkexecTimeTrackingServ
                 .notes(request.laborCode())
                 .createdBy(SecurityContextHelper.getCurrentUsername().orElse(SYSTEM_USER_ID))
                 .onBehalfReason(onBehalf ? request.reason() : null)
-                .actedByUserId(onBehalf ? actorPersonId : null)
+                // Record the initiating actor whenever the tracked technician differs from the actor
+                // (default-attribution and on-behalf paths). This is what lets the initiator stop the
+                // timer they started: stop/active resolve by tracked technician OR initiating actor.
+                .actedByUserId(trackedTechnicianId.equals(actorPersonId) ? null : actorPersonId)
                 .createdAt(Instant.now(clock))
                 .build();
 
@@ -318,8 +323,9 @@ public class WorkexecTimeTrackingServiceImpl implements WorkexecTimeTrackingServ
     @Transactional
     @NonNull
     public List<WorkexecTimeTrackingService.TimerEntry> stopTimers(@NonNull UUID mechanicId) {
-        List<WorkorderLaborEntry> active =
-                laborEntryRepository.findByTechnicianIdAndEndTimeIsNullOrderByStartTimeDesc(mechanicId);
+        // Resolve by tracked technician OR initiating actor so a timer started via the
+        // default-attribution path (tracked technician != actor) can be stopped by its initiator.
+        List<WorkorderLaborEntry> active = laborEntryRepository.findActiveByTechnicianOrActor(mechanicId);
         if (active.isEmpty()) {
             throw new WorkexecTimeTrackingService.WorkexecConflictException(
                     "NO_ACTIVE_TIMER", "No active timer exists for mechanic");

--- a/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkexecTimerContractBehaviorIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkexecTimerContractBehaviorIT.java
@@ -99,6 +99,41 @@ class WorkexecTimerContractBehaviorIT extends AbstractWorkexecContractBehaviorIT
     }
 
     @Test
+    @DisplayName("#729: a default-attribution timer can be stopped by its initiator")
+    void defaultAttributionTimerCanBeStoppedByInitiator() throws Exception {
+        Workorder workorder = seedWorkorderInProgress();
+        UUID assignedTech = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
+        UUID actor = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
+        seedCurrentAssignment(workorder, assignedTech);
+
+        // Actor (not the assigned tech) starts a timer; labor is tracked under the assigned technician.
+        mockMvc.perform(post("/v1/workexec/time-entries/timer/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-User-Id", actor.toString())
+                        .content(objectMapper.writeValueAsString(
+                                WorkexecContractPayloads.timerStartPayload(workorder.getId()))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.mechanicId").value(assignedTech.toString()));
+
+        // The initiator's active list surfaces the timer they started for the assigned technician.
+        mockMvc.perform(get("/v1/workexec/time-entries/timer/active").header("X-User-Id", actor.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].status").value("ACTIVE"))
+                .andExpect(jsonPath("$[0].mechanicId").value(assignedTech.toString()));
+
+        // Regression: the initiator can stop it (previously 409 NO_ACTIVE_TIMER, leaving it open forever).
+        mockMvc.perform(post("/v1/workexec/time-entries/timer/stop").header("X-User-Id", actor.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stopped[0].status").value("COMPLETED"))
+                .andExpect(jsonPath("$.stopped[0].mechanicId").value(assignedTech.toString()));
+
+        // The assigned technician's labor entry is now closed.
+        List<WorkorderLaborEntry> openForTech =
+                laborEntryRepository.findByTechnicianIdAndEndTimeIsNullOrderByStartTimeDesc(assignedTech);
+        assertThat(openForTech).isEmpty();
+    }
+
+    @Test
     @DisplayName("AC5: on-behalf start for a third technician without authority returns 403")
     void onBehalfWithoutAuthorityForbidden() throws Exception {
         Workorder workorder = seedWorkorderInProgress();


### PR DESCRIPTION
Fixes #729 — `POST /v1/workexec/time-entries/timer/stop` could never stop a timer started via the **default-attribution** path.

## Root cause
A timer's `WorkorderLaborEntry` is written under the **tracked technician** (the workorder's current assignee), which can differ from the **initiating actor**. `startTimer` handles that divergence, but `stopTimers` / `getActiveTimers` queried only by the authenticated actor's id (`technicianId = actor`), so they never matched default-attribution entries → stop returned `409 NO_ACTIVE_TIMER` and the entry stayed open forever (cascading `TIMER_ALREADY_ACTIVE` on every later start for that technician).

## Fix
- `startTimer` records the initiating actor in `actedByUserId` for **every** entry whose tracked technician differs from the actor (default-attribution **and** on-behalf), not just on-behalf. On-behalf remains distinguished by a non-null `onBehalfReason` (no consumer keys on-behalf off `actedByUserId`).
- `stopTimers` / `getActiveTimers` resolve active entries by **tracked technician OR initiating actor** via a new `findActiveByTechnicianOrActor` query — so the initiator can stop/list the timers they started, and the tracked technician can still stop their own.
- Self-path and on-behalf behavior unchanged; uniqueness check (`TIMER_ALREADY_ACTIVE`) still keyed on the tracked technician.

## Scope / safety
- **No controller or contract change** — OpenAPI/SDK untouched.
- **No schema change** — reuses the existing `acted_by_user_id` column; field doc updated.

## Tests
- New regression contract test: a default-attribution timer is stoppable by its initiator, and the assigned technician's labor entry is closed.
- Timer contract IT (9) + time-tracking IT (5) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
