### PR TITLE
feat(workorder): estimate/workorder finder search (q by customer name or id)

### DIFF
--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -14,6 +14,8 @@ tags:
   description: Workorder detail with role-based visibility
 - name: Travel Segment API
   description: Endpoints for capturing mobile travel segments
+- name: Workorder Search
+  description: Workorder search and retrieval
 - name: Estimates from Appointments
   description: Create estimates from shop appointments
 - name: Work Session API
@@ -3147,11 +3149,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickedItemResponse'
-                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3224,11 +3223,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickTaskResponse'
-                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3487,6 +3483,37 @@ paths:
       - bearerAuth: []
       x-required-permissions:
       - AUTHENTICATED
+  /v1/workorders/search:
+    get:
+      tags:
+      - Workorder Search
+      summary: Search workorders
+      description: Paginated free-text search for workorders matching customer name or workorder id.
+      operationId: searchWorkorders
+      parameters:
+      - name: q
+        in: query
+        description: Free-text query matching customer name or workorder id (optional)
+        required: false
+        schema:
+          type: string
+      - name: pageable
+        in: query
+        required: true
+        schema:
+          $ref: '#/components/schemas/Pageable'
+      responses:
+        '200':
+          description: Page of workorder search results returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageWorkorderSearchResult'
+      security:
+      - bearerAuth:
+        - workorder:workorder:view
+      x-required-permissions:
+      - workorder:workorder:view
   /v1/workorders/estimates/{estimateId}/summary:
     get:
       tags:
@@ -3543,7 +3570,6 @@ paths:
               schema:
                 type: string
                 format: binary
-                additionalProperties: {}
         '404':
           description: Estimate not found
           content:
@@ -3862,6 +3888,12 @@ paths:
       description: Paginated search for estimates filtered by optional customerId and/or vehicleId.
       operationId: searchEstimates
       parameters:
+      - name: q
+        in: query
+        description: Free-text query matching estimate number, customer name, or estimate id (optional)
+        required: false
+        schema:
+          type: string
       - name: customerId
         in: query
         description: Filter by customer UUID (optional)
@@ -4652,12 +4684,21 @@ components:
         referenceId:
           type: string
           description: Workflow or review-case reference identifier, when applicable
+          example: REVIEW-2026-000123
         nextAction:
           type: string
           description: Recommended next step for the caller, when applicable
+          example: Retry the request with a valid quantity
         supportAction:
           type: string
           description: Support or admin investigation guidance, when applicable
+          example: Contact support with the correlation ID for assistance
+      required:
+      - code
+      - correlationId
+      - message
+      - status
+      - timestamp
     FieldError:
       type: object
       description: Validation error for a specific request field
@@ -4670,6 +4711,9 @@ components:
           type: string
           description: Validation failure message
           example: must be greater than 0
+      required:
+      - field
+      - message
     ResolveScanRequest:
       type: object
       description: Request to resolve a scanned SKU and location against a pick task
@@ -5205,6 +5249,14 @@ components:
           format: date-time
           description: Creation timestamp (UTC).
           example: 2026-02-27 12:00:00+00:00
+      required:
+      - createdAt
+      - invoiceId
+      - status
+      - subtotal
+      - taxAmount
+      - totalAmount
+      - workorderId
     CompleteWorkorderRequest:
       type: object
       description: Request payload to complete a workorder
@@ -7195,6 +7247,114 @@ components:
       - canComplete
       - currentStatus
       - workorderId
+    Pageable:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+          minimum: 0
+        size:
+          type: integer
+          format: int32
+          minimum: 1
+        sort:
+          type: array
+          items:
+            type: string
+    PageWorkorderSearchResult:
+      type: object
+      properties:
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkorderSearchResult'
+        number:
+          type: integer
+          format: int32
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        first:
+          type: boolean
+        last:
+          type: boolean
+        numberOfElements:
+          type: integer
+          format: int32
+        empty:
+          type: boolean
+    PageableObject:
+      type: object
+      properties:
+        offset:
+          type: integer
+          format: int64
+        paged:
+          type: boolean
+        pageNumber:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+    SortObject:
+      type: object
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+    WorkorderSearchResult:
+      type: object
+      description: Lightweight workorder search result enriched with customer name
+      properties:
+        workorderId:
+          type: string
+          format: uuid
+          description: Workorder identifier
+          example: 550e8400-e29b-41d4-a716-446655440000
+        status:
+          type: string
+          description: Current workorder status
+          enum:
+          - DRAFT
+          - APPROVED
+          - ASSIGNED
+          - WORK_IN_PROGRESS
+          - AWAITING_PARTS
+          - AWAITING_APPROVAL
+          - READY_FOR_PICKUP
+          - COMPLETED
+          - CANCELLED
+          example: DRAFT
+        customerName:
+          type: string
+          description: Resolved customer display name
+        createdAt:
+          type: string
+          format: date-time
+          description: Creation timestamp
+          example: 2026-01-15 09:30:00+00:00
+      required:
+      - status
+      - workorderId
     EstimateSummaryResponse:
       type: object
       description: Customer-facing estimate summary with grouped items and totals
@@ -7223,6 +7383,9 @@ components:
           format: uuid
           description: Customer identifier
           example: 550e8400-e29b-41d4-a716-446655440001
+        customerName:
+          type: string
+          description: Resolved customer display name
         vehicleId:
           type: string
           format: uuid
@@ -7279,21 +7442,6 @@ components:
       - estimateNumber
       - id
       - status
-    Pageable:
-      type: object
-      properties:
-        page:
-          type: integer
-          format: int32
-          minimum: 0
-        size:
-          type: integer
-          format: int32
-          minimum: 1
-        sort:
-          type: array
-          items:
-            type: string
     PageWorkorderStatusView:
       type: object
       properties:
@@ -7325,33 +7473,6 @@ components:
           type: integer
           format: int32
         empty:
-          type: boolean
-    PageableObject:
-      type: object
-      properties:
-        offset:
-          type: integer
-          format: int64
-        paged:
-          type: boolean
-        pageNumber:
-          type: integer
-          format: int32
-        pageSize:
-          type: integer
-          format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        unpaged:
-          type: boolean
-    SortObject:
-      type: object
-      properties:
-        empty:
-          type: boolean
-        sorted:
-          type: boolean
-        unsorted:
           type: boolean
     WorkorderStatusView:
       type: object

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
@@ -22,6 +22,12 @@ public final class EventTypes {
             .apiVersion("1")
             .build();
 
+    /** Free-text search for workorders by customer name or workorder id */
+    public static final EventTypeRegistration WORKORDER_SEARCH = EventTypeRegistration.search(
+                    "WORKORDER_SEARCH", "Free-text search for workorders by customer name or workorder id")
+            .apiVersion("1")
+            .build();
+
     /** Create a new workorder */
     public static final EventTypeRegistration WORKORDER_CREATE = EventTypeRegistration.write(
                     "WORKORDER_CREATE", "Create a new workorder in the system")
@@ -483,6 +489,7 @@ public final class EventTypes {
     public static final List<EventTypeRegistration> ALL_EVENT_TYPES = List.of(
             // Workorder events
             WORKORDER_LIST,
+            WORKORDER_SEARCH,
             WORKORDER_CREATE,
             WORKORDER_DELETE,
             WORKORDER_START,

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/EstimateSearchController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/EstimateSearchController.java
@@ -39,12 +39,21 @@ public class EstimateSearchController {
     @PreAuthorize("hasAuthority('workorder:estimate:view')")
     @EmitEvent(id = "WORKORDER_ESTIMATE_SEARCH", apiVersion = "1")
     public Page<EstimateSummaryResponse> searchEstimates(
+            @Parameter(
+                            description =
+                                    "Free-text query matching estimate number, customer name, or estimate id (optional)")
+                    @RequestParam(required = false)
+                    @Nullable
+                    String q,
             @Parameter(description = "Filter by customer UUID (optional)") @RequestParam(required = false) @Nullable
                     UUID customerId,
             @Parameter(description = "Filter by vehicle UUID (optional)") @RequestParam(required = false) @Nullable
                     UUID vehicleId,
             @Parameter(schema = @Schema(implementation = Pageable.class)) @PageableDefault(size = 25)
                     Pageable pageable) {
+        if (q != null && !q.isBlank()) {
+            return estimateService.findEstimatesByQuery(q.trim(), pageable);
+        }
         return estimateService.searchEstimates(customerId, vehicleId, pageable);
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderSearchController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderSearchController.java
@@ -1,0 +1,49 @@
+package com.positivity.workorder.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.workorder.internal.dto.WorkorderSearchResult;
+import com.positivity.workorder.service.WorkorderSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@io.swagger.v3.oas.annotations.security.SecurityRequirement(
+        name = "bearerAuth",
+        scopes = {"workorder:workorder:view"})
+@RequestMapping("/v1/workorders")
+@Tag(name = "Workorder Search", description = "Workorder search and retrieval")
+@RequiredArgsConstructor
+public class WorkorderSearchController {
+
+    private final WorkorderSearchService workorderSearchService;
+
+    @Operation(
+            summary = "Search workorders",
+            description = "Paginated free-text search for workorders matching customer name or workorder id.")
+    @ApiResponse(responseCode = "200", description = "Page of workorder search results returned.")
+    @GetMapping("/search")
+    @PreAuthorize("hasAuthority('workorder:workorder:view')")
+    @EmitEvent(id = "WORKORDER_SEARCH", apiVersion = "1")
+    public Page<WorkorderSearchResult> searchWorkorders(
+            @Parameter(description = "Free-text query matching customer name or workorder id (optional)")
+                    @RequestParam(required = false)
+                    @Nullable
+                    String q,
+            @Parameter(schema = @Schema(implementation = Pageable.class)) @PageableDefault(size = 25)
+                    Pageable pageable) {
+        return workorderSearchService.search(q == null ? "" : q.trim(), pageable);
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/EstimateSummaryResponse.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/EstimateSummaryResponse.java
@@ -29,7 +29,10 @@ import org.jspecify.annotations.NonNull;
 @Schema(description = "Customer-facing estimate summary with grouped items and totals")
 public class EstimateSummaryResponse {
 
-    @Schema(description = "Estimate identifier", example = "550e8400-e29b-41d4-a716-446655440000", requiredMode = REQUIRED)
+    @Schema(
+            description = "Estimate identifier",
+            example = "550e8400-e29b-41d4-a716-446655440000",
+            requiredMode = REQUIRED)
     @NotNull
     private UUID id;
 
@@ -43,13 +46,25 @@ public class EstimateSummaryResponse {
     @Schema(description = "Estimate expiry timestamp", example = "2026-01-15T09:30:00", requiredMode = NOT_REQUIRED)
     private LocalDateTime expiresAt;
 
-    @Schema(description = "Customer identifier", example = "550e8400-e29b-41d4-a716-446655440001", requiredMode = NOT_REQUIRED)
+    @Schema(
+            description = "Customer identifier",
+            example = "550e8400-e29b-41d4-a716-446655440001",
+            requiredMode = NOT_REQUIRED)
     private UUID customerId;
 
-    @Schema(description = "Vehicle identifier", example = "550e8400-e29b-41d4-a716-446655440002", requiredMode = NOT_REQUIRED)
+    @Schema(description = "Resolved customer display name", requiredMode = NOT_REQUIRED)
+    private String customerName;
+
+    @Schema(
+            description = "Vehicle identifier",
+            example = "550e8400-e29b-41d4-a716-446655440002",
+            requiredMode = NOT_REQUIRED)
     private UUID vehicleId;
 
-    @Schema(description = "Location identifier", example = "550e8400-e29b-41d4-a716-446655440003", requiredMode = NOT_REQUIRED)
+    @Schema(
+            description = "Location identifier",
+            example = "550e8400-e29b-41d4-a716-446655440003",
+            requiredMode = NOT_REQUIRED)
     private UUID locationId;
 
     /** Current lifecycle status of the estimate. */

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderSearchResult.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderSearchResult.java
@@ -1,0 +1,42 @@
+package com.positivity.workorder.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Lightweight workorder search row enriched with the resolved customer display name.
+ *
+ * <p>Returned by {@code GET /v1/workorders/search?q=...} which matches the query against
+ * the customer name or the workorder id.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Lightweight workorder search result enriched with customer name")
+public class WorkorderSearchResult {
+
+    @Schema(
+            description = "Workorder identifier",
+            example = "550e8400-e29b-41d4-a716-446655440000",
+            requiredMode = REQUIRED)
+    private UUID workorderId;
+
+    @Schema(description = "Current workorder status", example = "DRAFT", requiredMode = REQUIRED)
+    private WorkorderStatus status;
+
+    @Schema(description = "Resolved customer display name", requiredMode = NOT_REQUIRED)
+    private String customerName;
+
+    @Schema(description = "Creation timestamp", example = "2026-01-15T09:30:00Z", requiredMode = NOT_REQUIRED)
+    private Instant createdAt;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/EstimateRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/EstimateRepository.java
@@ -3,12 +3,15 @@ package com.positivity.workorder.internal.repository;
 import com.positivity.workorder.internal.entity.Estimate;
 import com.positivity.workorder.internal.enums.EstimateStatus;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -64,4 +67,22 @@ public interface EstimateRepository extends JpaRepository<Estimate, UUID> {
      * @return list of expired estimates in the given status
      */
     List<Estimate> findByStatusAndExpiresAtBefore(EstimateStatus status, LocalDateTime expiresAtBefore);
+
+    /**
+     * Searches estimates by free-text query matching the estimate number (case-insensitive),
+     * a set of customer ids resolved from a customer-name search, or the estimate id directly.
+     *
+     * @param q           free-text query matched against the estimate number
+     * @param customerIds customer ids resolved from a name search (must be non-empty for JPQL IN)
+     * @param idQuery     the query parsed as a UUID, or {@code null} if not a UUID
+     * @param pageable    pagination configuration
+     * @return page of matching estimates
+     */
+    @Query("SELECT e FROM Estimate e WHERE LOWER(e.estimateNumber) LIKE LOWER(CONCAT('%', :q, '%')) "
+            + "OR e.customerId IN :customerIds OR (:idQuery IS NOT NULL AND e.id = :idQuery)")
+    Page<Estimate> searchByQuery(
+            @Param("q") String q,
+            @Param("customerIds") Collection<UUID> customerIds,
+            @Param("idQuery") UUID idQuery,
+            Pageable pageable);
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderRepository.java
@@ -11,6 +11,8 @@ import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -61,4 +63,18 @@ public interface WorkorderRepository extends JpaRepository<Workorder, UUID> {
      */
     @NonNull
     List<Workorder> findByScheduledDateAndLocationId(@NonNull LocalDate scheduledDate, @NonNull UUID locationId);
+
+    /**
+     * Free-text workorder search matching either a resolved customer id (from a name
+     * search) or the workorder id directly.
+     *
+     * @param customerIds customer ids resolved from a name search (must be non-empty for JPQL IN)
+     * @param idQuery     the query parsed as a UUID, or {@code null} if not a UUID
+     * @param pageable    pagination configuration
+     * @return page of matching workorders
+     */
+    @Query("SELECT w FROM Workorder w WHERE w.customerId IN :customerIds "
+            + "OR (:idQuery IS NOT NULL AND w.id = :idQuery)")
+    Page<Workorder> searchByQuery(
+            @Param("customerIds") Collection<UUID> customerIds, @Param("idQuery") UUID idQuery, Pageable pageable);
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerReferenceService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerReferenceService.java
@@ -1,7 +1,9 @@
 package com.positivity.workorder.internal.service;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -74,6 +76,53 @@ public class CustomerReferenceService {
         return resolved;
     }
 
+    public @NonNull List<CustomerRef> searchIdsByName(@Nullable String name, int limit) {
+        if (!StringUtils.hasText(name)) {
+            return List.of();
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body = customerRestClient
+                    .get()
+                    .uri("/v1/crm/accounts/parties?name={name}&size={size}", name, limit)
+                    .header("X-User", "pos-workorder")
+                    .header("X-Authorities", "crm:party:view")
+                    .retrieve()
+                    .body(Map.class);
+
+            if (body == null) {
+                return List.of();
+            }
+
+            Object resultsObj = body.get("results");
+            if (!(resultsObj instanceof Collection<?> results)) {
+                return List.of();
+            }
+
+            List<CustomerRef> refs = new ArrayList<>();
+            for (Object rowObj : results) {
+                if (!(rowObj instanceof Map<?, ?> rowMap)) {
+                    continue;
+                }
+                @SuppressWarnings("unchecked")
+                Map<String, Object> row = (Map<String, Object>) rowMap;
+                String partyId = extract(row, "partyId");
+                if (!StringUtils.hasText(partyId)) {
+                    continue;
+                }
+                UUID id = UUID.fromString(partyId.trim());
+                String displayName =
+                        firstNonBlank(extract(row, "displayName"), extract(row, "legalName"), "customer-" + id);
+                refs.add(new CustomerRef(id, displayName));
+            }
+            return refs;
+        } catch (Exception ex) {
+            log.debug("Unable to search customers by name '{}': {}", name, ex.getMessage());
+            return List.of();
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private Map<String, Object> unwrapData(Map<String, Object> body) {
         Object data = body.get("data");
@@ -106,4 +155,7 @@ public class CustomerReferenceService {
             return new CustomerContact("", null);
         }
     }
+
+    public record CustomerRef(
+            @NonNull UUID customerId, @NonNull String customerName) {}
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -77,6 +77,7 @@ public class EstimateServiceImpl implements EstimateService {
     private final PeopleLocationClient peopleLocationClient;
     private final DocumentClient documentClient;
     private final ObjectMapper objectMapper;
+    private final CustomerReferenceService customerReferenceService;
 
     // Configuration defaults
     private static final String DEFAULT_CURRENCY = "USD";
@@ -137,6 +138,51 @@ public class EstimateServiceImpl implements EstimateService {
         }
 
         return estimates.map(this::toEstimateSummaryResponse);
+    }
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public Page<EstimateSummaryResponse> findEstimatesByQuery(@NonNull String q, @NonNull Pageable pageable) {
+        // Resolve customer ids whose display name matches the query.
+        List<UUID> nameMatchIds = customerReferenceService.searchIdsByName(q, 10).stream()
+                .map(CustomerReferenceService.CustomerRef::customerId)
+                .toList();
+
+        // JPQL IN requires a non-empty collection; use a sentinel that cannot match a real id.
+        List<UUID> customerIds = nameMatchIds.isEmpty() ? List.of(new UUID(0, 0)) : nameMatchIds;
+
+        // Treat the query as an estimate id when it parses as a UUID.
+        UUID idQuery = parseUuidOrNull(q);
+
+        Page<Estimate> page = estimateRepository.searchByQuery(q, customerIds, idQuery, pageable);
+
+        // Enrich each summary row with the resolved customer display name.
+        List<UUID> pageCustomerIds = page.getContent().stream()
+                .map(Estimate::getCustomerId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<UUID, CustomerReferenceService.CustomerContact> contacts =
+                customerReferenceService.resolveAll(pageCustomerIds);
+
+        return page.map(estimate -> {
+            EstimateSummaryResponse summary = toEstimateSummaryResponse(estimate);
+            CustomerReferenceService.CustomerContact contact = contacts.get(estimate.getCustomerId());
+            if (contact != null) {
+                summary.setCustomerName(contact.name());
+            }
+            return summary;
+        });
+    }
+
+    @Nullable
+    private static UUID parseUuidOrNull(@NonNull String value) {
+        try {
+            return UUID.fromString(value.trim());
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /**

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
@@ -1,0 +1,74 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.workorder.internal.dto.WorkorderSearchResult;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.service.WorkorderSearchService;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Free-text workorder search resolving the query against customer names (via the
+ * customer reference service) or the workorder id, enriching results with the
+ * resolved customer display name.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WorkorderSearchServiceImpl implements WorkorderSearchService {
+
+    private final WorkorderRepository workorderRepository;
+    private final CustomerReferenceService customerReferenceService;
+
+    @Override
+    public @NonNull Page<WorkorderSearchResult> search(@NonNull String q, @NonNull Pageable pageable) {
+        // Resolve customer ids whose display name matches the query.
+        List<UUID> nameMatchIds = customerReferenceService.searchIdsByName(q, 10).stream()
+                .map(CustomerReferenceService.CustomerRef::customerId)
+                .toList();
+
+        // JPQL IN requires a non-empty collection; use a sentinel that cannot match a real id.
+        List<UUID> customerIds = nameMatchIds.isEmpty() ? List.of(new UUID(0, 0)) : nameMatchIds;
+
+        // Treat the query as a workorder id when it parses as a UUID.
+        UUID idQuery = parseUuidOrNull(q);
+
+        Page<Workorder> page = workorderRepository.searchByQuery(customerIds, idQuery, pageable);
+
+        // Enrich each row with the resolved customer display name.
+        List<UUID> pageCustomerIds = page.getContent().stream()
+                .map(Workorder::getCustomerId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<UUID, CustomerReferenceService.CustomerContact> contacts =
+                customerReferenceService.resolveAll(pageCustomerIds);
+
+        return page.map(workorder -> {
+            CustomerReferenceService.CustomerContact contact = contacts.get(workorder.getCustomerId());
+            return WorkorderSearchResult.builder()
+                    .workorderId(workorder.getId())
+                    .status(workorder.getStatus())
+                    .customerName(contact != null ? contact.name() : null)
+                    .createdAt(workorder.getCreatedAt())
+                    .build();
+        });
+    }
+
+    private static @Nullable UUID parseUuidOrNull(@NonNull String value) {
+        try {
+            return UUID.fromString(value.trim());
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/EstimateService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/EstimateService.java
@@ -44,6 +44,18 @@ public interface EstimateService {
             @Nullable UUID customerId, @Nullable UUID vehicleId, @NonNull Pageable pageable);
 
     /**
+     * Free-text search for estimates by query string matching the estimate number,
+     * customer name (resolved to customer ids), or the estimate id directly. Resulting
+     * rows are enriched with the resolved customer display name.
+     *
+     * @param q        free-text query (estimate number, customer name, or estimate id)
+     * @param pageable pagination and sorting configuration
+     * @return page of estimate summaries enriched with {@code customerName}
+     */
+    @NonNull
+    Page<EstimateSummaryResponse> findEstimatesByQuery(@NonNull String q, @NonNull Pageable pageable);
+
+    /**
      * Create a new draft estimate with proper validation and defaulting
      *
      * @param request         The create estimate request with customer and vehicle

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/WorkorderSearchService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/WorkorderSearchService.java
@@ -1,0 +1,24 @@
+package com.positivity.workorder.service;
+
+import com.positivity.workorder.internal.dto.WorkorderSearchResult;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Free-text workorder search matching the customer name or the workorder id.
+ */
+public interface WorkorderSearchService {
+
+    /**
+     * Search workorders by query string matching the customer name (resolved to
+     * customer ids) or the workorder id directly. Resulting rows are enriched with
+     * the resolved customer display name.
+     *
+     * @param q        free-text query (customer name or workorder id)
+     * @param pageable pagination and sorting configuration
+     * @return page of workorder search results enriched with {@code customerName}
+     */
+    @NonNull
+    Page<WorkorderSearchResult> search(@NonNull String q, @NonNull Pageable pageable);
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/contract/EstimateSearchContractBehaviorIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/contract/EstimateSearchContractBehaviorIT.java
@@ -1,0 +1,74 @@
+package com.positivity.workorder.contract;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+import com.positivity.workorder.internal.entity.Estimate;
+import com.positivity.workorder.internal.enums.EstimateStatus;
+import com.positivity.workorder.internal.repository.EstimateRepository;
+import com.positivity.workorder.support.BaseContractIntegrationTest;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Contract behavioral tests for the free-text estimate search endpoint.
+ *
+ * <p>Exercises {@code GET /v1/workexec/estimates/search?q=...} which matches the
+ * estimate number, customer name, or estimate id and enriches each row with a
+ * resolved {@code customerName}. The pos-customer service is not reachable in
+ * tests, so {@code customerName} falls back to {@code customer-<id>} — the assertion
+ * only requires the field to be present/non-null.
+ */
+class EstimateSearchContractBehaviorIT extends BaseContractIntegrationTest {
+
+    @Autowired
+    private EstimateRepository estimateRepository;
+
+    @AfterEach
+    void tearDown() {
+        purgeTestData();
+    }
+
+    @Test
+    @DisplayName("Contract: q search by estimate number returns the estimate with customerName")
+    void shouldSearchByEstimateNumberAndIncludeCustomerName() {
+        seedEstimate("EST-IT-1");
+
+        givenWithGatewayAuth()
+                .when()
+                .get("/v1/workexec/estimates/search?q={q}", "EST-IT-1")
+                .then()
+                .statusCode(200)
+                .contentType(startsWith("application/json"))
+                .body("content.size()", greaterThanOrEqualTo(1))
+                .body("content[0].estimateNumber", equalTo("EST-IT-1"))
+                .body("content[0].customerName", notNullValue())
+                .log()
+                .ifValidationFails();
+    }
+
+    private UUID seedEstimate(String estimateNumber) {
+        Estimate estimate = Estimate.builder()
+                .estimateNumber(estimateNumber)
+                .locationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .vehicleId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .customerId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .currencyUomId("USD")
+                .taxRegionId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .status(EstimateStatus.DRAFT)
+                .subtotal(new BigDecimal("200.00"))
+                .taxAmount(new BigDecimal("16.50"))
+                .total(new BigDecimal("216.50"))
+                .createdByUserId(SYSTEM_USER_ID)
+                .createdById(SYSTEM_USER_ID)
+                .build();
+
+        return estimateRepository.save(estimate).getId();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkorderSearchContractBehaviorIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkorderSearchContractBehaviorIT.java
@@ -1,0 +1,64 @@
+package com.positivity.workorder.contract;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.support.BaseContractIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Contract behavioral tests for the free-text workorder search endpoint.
+ *
+ * <p>Exercises {@code GET /v1/workorders/search?q=...} which matches the customer
+ * name or workorder id and enriches each row with a resolved {@code customerName}.
+ * The pos-customer service is not reachable in tests, so {@code customerName} falls
+ * back to {@code customer-<id>} — assertions only require the field to be present.
+ */
+class WorkorderSearchContractBehaviorIT extends BaseContractIntegrationTest {
+
+    @Autowired
+    private WorkorderRepository workorderRepository;
+
+    @AfterEach
+    void tearDown() {
+        purgeTestData();
+    }
+
+    @Test
+    @DisplayName("Contract: q search by workorder id returns the workorder with customerName")
+    void shouldSearchByWorkorderIdAndIncludeCustomerName() {
+        UUID workorderId = seedWorkorder();
+
+        givenWithGatewayAuth()
+                .when()
+                .get("/v1/workorders/search?q={q}", workorderId.toString())
+                .then()
+                .statusCode(200)
+                .contentType(startsWith("application/json"))
+                .body("content.size()", greaterThanOrEqualTo(1))
+                .body("content[0].workorderId", equalTo(workorderId.toString()))
+                .body("content[0].customerName", notNullValue())
+                .log()
+                .ifValidationFails();
+    }
+
+    private UUID seedWorkorder() {
+        Workorder workorder = Workorder.builder()
+                .customerId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .vehicleId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .shopId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .status(WorkorderStatus.DRAFT)
+                .build();
+
+        return workorderRepository.save(workorder).getId();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/CustomerReferenceServiceTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/CustomerReferenceServiceTest.java
@@ -1,0 +1,89 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+class CustomerReferenceServiceTest {
+
+    @Test
+    void searchIdsByName_returnsPartyIdsFromBrowse() throws Exception {
+        UUID p1 = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+        UUID p2 = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+        String payload = """
+                {"results":[
+                  {"partyId":"%s","displayName":"Acme Corp","legalName":"Acme Corporation Inc"},
+                  {"partyId":"%s","displayName":"","legalName":"Beta LLC"}
+                ]}
+                """.formatted(p1, p2);
+        HttpServer server = startServer("/v1/crm/accounts/parties", 200, payload);
+        try {
+            String serviceId = "localhost:" + server.getAddress().getPort();
+            CustomerReferenceService service = new CustomerReferenceService(RestClient.builder(), serviceId);
+
+            List<CustomerReferenceService.CustomerRef> refs = service.searchIdsByName("acme", 10);
+
+            assertThat(refs).hasSize(2);
+            assertThat(refs)
+                    .extracting(CustomerReferenceService.CustomerRef::customerId)
+                    .containsExactly(p1, p2);
+            assertThat(refs.get(0).customerName()).isNotBlank();
+            assertThat(refs.get(0).customerName()).isEqualTo("Acme Corp");
+            assertThat(refs.get(1).customerName()).isEqualTo("Beta LLC");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void searchIdsByName_failsSoftToEmptyOnError() throws Exception {
+        HttpServer server = startServer("/v1/crm/accounts/parties", 500, "boom");
+        try {
+            String serviceId = "localhost:" + server.getAddress().getPort();
+            CustomerReferenceService service = new CustomerReferenceService(RestClient.builder(), serviceId);
+
+            List<CustomerReferenceService.CustomerRef> refs = service.searchIdsByName("acme", 10);
+
+            assertThat(refs).isEmpty();
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void searchIdsByName_returnsEmpty_forBlankName() {
+        CustomerReferenceService service = new CustomerReferenceService(RestClient.builder(), "localhost:1");
+
+        assertThat(service.searchIdsByName("   ", 10)).isEmpty();
+        assertThat(service.searchIdsByName(null, 10)).isEmpty();
+    }
+
+    private HttpServer startServer(String expectedPath, int status, String body) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            String requestPath = exchange.getRequestURI().getPath();
+            if (!"GET".equals(exchange.getRequestMethod()) || !expectedPath.equals(requestPath)) {
+                exchange.sendResponseHeaders(404, -1);
+                exchange.close();
+                return;
+            }
+
+            byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(status, payload.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload);
+            }
+        });
+        server.start();
+        return server;
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateSearchByQueryTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateSearchByQueryTest.java
@@ -1,0 +1,129 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.dto.EstimateSummaryResponse;
+import com.positivity.workorder.internal.entity.Estimate;
+import com.positivity.workorder.internal.enums.EstimateStatus;
+import com.positivity.workorder.internal.repository.EstimateItemRepository;
+import com.positivity.workorder.internal.repository.EstimateRepository;
+import com.positivity.workorder.internal.service.CustomerReferenceService.CustomerContact;
+import com.positivity.workorder.internal.service.CustomerReferenceService.CustomerRef;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Unit tests for {@link EstimateService#findEstimatesByQuery(String, Pageable)}.
+ *
+ * <p>Covers the free-text {@code q} search that matches the estimate number,
+ * customer name, or estimate id, and enriches each summary row with the resolved
+ * customer display name.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class EstimateSearchByQueryTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+    @Spy
+    Clock clock = TEST_CLOCK;
+
+    @Mock
+    private EstimateRepository estimateRepository;
+
+    @Mock
+    private EstimateItemRepository estimateItemRepository;
+
+    @Mock
+    private CustomerReferenceService customerReferenceService;
+
+    @InjectMocks
+    private EstimateServiceImpl estimateService;
+
+    private static final UUID CUSTOMER_A = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000001");
+    private static final UUID VEHICLE_B = UUID.fromString("bbbbbbbb-0000-0000-0000-000000000001");
+    private static final UUID LOCATION_C = UUID.fromString("cccccccc-0000-0000-0000-000000000001");
+
+    private Estimate buildEstimate(UUID id, UUID customerId, String estimateNumber) {
+        return Estimate.builder()
+                .id(id)
+                .estimateNumber(estimateNumber)
+                .customerId(customerId)
+                .vehicleId(VEHICLE_B)
+                .locationId(LOCATION_C)
+                .status(EstimateStatus.DRAFT)
+                .subtotal(BigDecimal.valueOf(100))
+                .taxAmount(BigDecimal.valueOf(8))
+                .total(BigDecimal.valueOf(108))
+                .currencyUomId("USD")
+                .createdAt(Instant.now(TEST_CLOCK))
+                .build();
+    }
+
+    @Test
+    void findEstimatesByQuery_nameOrNumberMatch_enrichesCustomerNameAndReturnsEstimate() {
+        UUID estimateId = UUID.fromString("00000000-0000-0000-0000-000000000010");
+        Estimate estimate = buildEstimate(estimateId, CUSTOMER_A, "EST-2024-1001");
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(customerReferenceService.searchIdsByName(eq("Acme"), anyInt()))
+                .thenReturn(List.of(new CustomerRef(CUSTOMER_A, "Acme Corp")));
+        when(estimateRepository.searchByQuery(eq("Acme"), anyList(), any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(estimate)));
+        when(customerReferenceService.resolveAll(anyList()))
+                .thenReturn(Map.of(CUSTOMER_A, new CustomerContact("Acme Corp", null)));
+
+        Page<EstimateSummaryResponse> result = estimateService.findEstimatesByQuery("Acme", pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        EstimateSummaryResponse summary = result.getContent().get(0);
+        assertThat(summary.getId()).isEqualTo(estimateId);
+        assertThat(summary.getEstimateNumber()).isEqualTo("EST-2024-1001");
+        assertThat(summary.getCustomerName()).isEqualTo("Acme Corp");
+    }
+
+    @Test
+    void findEstimatesByQuery_uuidQuery_passesParsedUuidAsIdQuery() {
+        UUID estimateId = UUID.fromString("00000000-0000-0000-0000-000000000020");
+        String q = estimateId.toString();
+        Estimate estimate = buildEstimate(estimateId, CUSTOMER_A, "EST-2024-2002");
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(customerReferenceService.searchIdsByName(eq(q), anyInt())).thenReturn(List.of());
+        when(estimateRepository.searchByQuery(eq(q), anyList(), any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(estimate)));
+        when(customerReferenceService.resolveAll(anyList()))
+                .thenReturn(Map.of(CUSTOMER_A, new CustomerContact("customer-" + CUSTOMER_A, null)));
+
+        estimateService.findEstimatesByQuery(q, pageable);
+
+        ArgumentCaptor<UUID> idQueryCaptor = ArgumentCaptor.forClass(UUID.class);
+        verify(estimateRepository).searchByQuery(eq(q), anyList(), idQueryCaptor.capture(), eq(pageable));
+        assertThat(idQueryCaptor.getValue()).isEqualTo(estimateId);
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderSearchServiceTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderSearchServiceTest.java
@@ -1,0 +1,108 @@
+package com.positivity.workorder.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.dto.WorkorderSearchResult;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.service.CustomerReferenceService;
+import com.positivity.workorder.internal.service.WorkorderSearchServiceImpl;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Unit tests for the free-text workorder search service. Covers the
+ * customer-name match (with enrichment) and the UUID-query path.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class WorkorderSearchServiceTest {
+
+    private static final UUID CUSTOMER_A = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000001");
+    private static final UUID WORKORDER_ID = UUID.fromString("11111111-0000-0000-0000-000000000001");
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @Mock
+    private CustomerReferenceService customerReferenceService;
+
+    @InjectMocks
+    private WorkorderSearchServiceImpl workorderSearchService;
+
+    private Workorder buildWorkorder(UUID id, UUID customerId, WorkorderStatus status) {
+        return Workorder.builder()
+                .id(id)
+                .customerId(customerId)
+                .status(status)
+                .createdAt(Instant.parse("2026-01-15T09:30:00Z"))
+                .build();
+    }
+
+    @Test
+    void search_byCustomerName_returnsEnrichedResult() {
+        Pageable pageable = PageRequest.of(0, 25);
+        Workorder workorder = buildWorkorder(WORKORDER_ID, CUSTOMER_A, WorkorderStatus.APPROVED);
+
+        when(customerReferenceService.searchIdsByName(eq("Acme"), anyInt()))
+                .thenReturn(List.of(new CustomerReferenceService.CustomerRef(CUSTOMER_A, "Acme Auto")));
+        when(workorderRepository.searchByQuery(any(), any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(workorder)));
+        when(customerReferenceService.resolveAll(any()))
+                .thenReturn(Map.of(CUSTOMER_A, new CustomerReferenceService.CustomerContact("Acme Auto", null)));
+
+        Page<WorkorderSearchResult> result = workorderSearchService.search("Acme", pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        WorkorderSearchResult row = result.getContent().get(0);
+        assertThat(row.getWorkorderId()).isEqualTo(WORKORDER_ID);
+        assertThat(row.getStatus()).isEqualTo(WorkorderStatus.APPROVED);
+        assertThat(row.getCustomerName()).isEqualTo("Acme Auto");
+    }
+
+    @Test
+    void search_byUuid_passesParsedIdQueryToRepository() {
+        Pageable pageable = PageRequest.of(0, 25);
+        String q = WORKORDER_ID.toString();
+        Workorder workorder = buildWorkorder(WORKORDER_ID, CUSTOMER_A, WorkorderStatus.DRAFT);
+
+        when(customerReferenceService.searchIdsByName(anyString(), anyInt())).thenReturn(List.of());
+        when(workorderRepository.searchByQuery(any(), any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(workorder)));
+        when(customerReferenceService.resolveAll(any()))
+                .thenReturn(Map.of(CUSTOMER_A, new CustomerReferenceService.CustomerContact("Acme Auto", null)));
+
+        workorderSearchService.search(q, pageable);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<UUID>> customerIdsCaptor = ArgumentCaptor.forClass(Collection.class);
+        ArgumentCaptor<UUID> idQueryCaptor = ArgumentCaptor.forClass(UUID.class);
+        verify(workorderRepository).searchByQuery(customerIdsCaptor.capture(), idQueryCaptor.capture(), eq(pageable));
+
+        assertThat(idQueryCaptor.getValue()).isEqualTo(WORKORDER_ID);
+        // empty name match → sentinel id that cannot match a real workorder
+        assertThat(customerIdsCaptor.getValue()).containsExactly(new UUID(0, 0));
+    }
+}


### PR DESCRIPTION
Phase 1 of the workexec typeahead finders (spec: durion `docs/superpowers/specs/2026-06-23-workexec-typeahead-finders-design.md`). Backend search that powers the `/app/workexec` Find Estimate / Find Workorder typeaheads. Frontend + SDK follow in chained PRs.

## What
- **Customer name → ids:** `CustomerReferenceService.searchIdsByName(q, limit)` calls pos-customer party browse (`/v1/crm/accounts/parties?name=`), fail-soft to empty on error.
- **Estimate search:** `GET /v1/workexec/estimates/search` gains `q` — matches `estimateNumber` (ILIKE), customer name (→ ids), or estimate id (UUID). Response `EstimateSummaryResponse` gains `customerName` (enriched via `resolveAll`). Permission `workorder:estimate:view`.
- **Workorder search:** new `GET /v1/workorders/search?q=` — matches customer name or workorder id; returns lightweight `WorkorderSearchResult{workorderId,status,customerName,createdAt}`. Permission `workorder:workorder:view`; `WORKORDER_SEARCH` event registered.
- OpenAPI regenerated.

## Design notes
- Customer name is mastered in pos-customer (ADR-0015 §6); pos-workorder resolves name↔id at query time (no denormalization). pos-customer-down → name match empty, number/id match still works.
- Workorders have no human number — name is the primary workorder key; UUID `q` does exact id match.

## Tests
- Unit: `CustomerReferenceServiceTest`, `EstimateSearchByQueryTest`, `WorkorderSearchServiceTest` (name enrichment + UUID idQuery).
- Contract: `EstimateSearchContractBehaviorIT`, `WorkorderSearchContractBehaviorIT`.
- Full pos-workorder module suite: **290/290 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Contract
New API surface for the workexec domain. Will be documented in the workorder `domains/workorder/.business-rules/BACKEND_CONTRACT_GUIDE.md` (durion) — estimate/workorder finder search (`generateLaborOverhead`-style read endpoints): `GET /v1/workexec/estimates/search?q`, `GET /v1/workorders/search?q`. Contract guide update tracked as a follow-up durion PR.
