### PR TITLE
feat(workorder): stored workorder number + vehicle/VIN finder enrichment

### DIFF
--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -7330,6 +7330,14 @@ components:
           format: uuid
           description: Workorder identifier
           example: 550e8400-e29b-41d4-a716-446655440000
+        workorderNumber:
+          type: string
+          description: Human workorder number
+          example: WO-2026-1001
+        estimateNumber:
+          type: string
+          description: Linked estimate number, if created from an estimate
+          example: EST-2026-1001
         status:
           type: string
           description: Current workorder status
@@ -7344,9 +7352,25 @@ components:
           - COMPLETED
           - CANCELLED
           example: DRAFT
+        customerId:
+          type: string
+          format: uuid
+          description: Customer identifier
         customerName:
           type: string
           description: Resolved customer display name
+        vehicleId:
+          type: string
+          format: uuid
+          description: Vehicle identifier
+        vehicleLabel:
+          type: string
+          description: Resolved vehicle label
+          example: 2019 Ford F-150
+        vin:
+          type: string
+          description: Vehicle VIN (full; truncate for display)
+          example: 1FTFW1E50KFA12345
         createdAt:
           type: string
           format: date-time
@@ -7386,6 +7410,14 @@ components:
         customerName:
           type: string
           description: Resolved customer display name
+        vehicleLabel:
+          type: string
+          description: Resolved vehicle label
+          example: 2019 Ford F-150
+        vin:
+          type: string
+          description: Vehicle VIN (full; truncate for display)
+          example: 1FTFW1E50KFA12345
         vehicleId:
           type: string
           format: uuid

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/EstimateSummaryResponse.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/EstimateSummaryResponse.java
@@ -55,6 +55,15 @@ public class EstimateSummaryResponse {
     @Schema(description = "Resolved customer display name", requiredMode = NOT_REQUIRED)
     private String customerName;
 
+    @Schema(description = "Resolved vehicle label", example = "2019 Ford F-150", requiredMode = NOT_REQUIRED)
+    private String vehicleLabel;
+
+    @Schema(
+            description = "Vehicle VIN (full; truncate for display)",
+            example = "1FTFW1E50KFA12345",
+            requiredMode = NOT_REQUIRED)
+    private String vin;
+
     @Schema(
             description = "Vehicle identifier",
             example = "550e8400-e29b-41d4-a716-446655440002",

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderSearchResult.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderSearchResult.java
@@ -31,11 +31,35 @@ public class WorkorderSearchResult {
             requiredMode = REQUIRED)
     private UUID workorderId;
 
+    @Schema(description = "Human workorder number", example = "WO-2026-1001", requiredMode = NOT_REQUIRED)
+    private String workorderNumber;
+
+    @Schema(
+            description = "Linked estimate number, if created from an estimate",
+            example = "EST-2026-1001",
+            requiredMode = NOT_REQUIRED)
+    private String estimateNumber;
+
     @Schema(description = "Current workorder status", example = "DRAFT", requiredMode = REQUIRED)
     private WorkorderStatus status;
 
+    @Schema(description = "Customer identifier", requiredMode = NOT_REQUIRED)
+    private UUID customerId;
+
     @Schema(description = "Resolved customer display name", requiredMode = NOT_REQUIRED)
     private String customerName;
+
+    @Schema(description = "Vehicle identifier", requiredMode = NOT_REQUIRED)
+    private UUID vehicleId;
+
+    @Schema(description = "Resolved vehicle label", example = "2019 Ford F-150", requiredMode = NOT_REQUIRED)
+    private String vehicleLabel;
+
+    @Schema(
+            description = "Vehicle VIN (full; truncate for display)",
+            example = "1FTFW1E50KFA12345",
+            requiredMode = NOT_REQUIRED)
+    private String vin;
 
     @Schema(description = "Creation timestamp", example = "2026-01-15T09:30:00Z", requiredMode = NOT_REQUIRED)
     private Instant createdAt;

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/Workorder.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/Workorder.java
@@ -15,7 +15,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -31,6 +33,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@Table(name = "workorder", uniqueConstraints = @UniqueConstraint(columnNames = {"workorderNumber"}))
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -42,6 +45,9 @@ public class Workorder {
     @UUIDv7Id
     @Column(columnDefinition = "UUID")
     private UUID id;
+
+    @Column(unique = false) // Uniqueness enforced at DB level via unique index on workorderNumber
+    private String workorderNumber; // Human-readable identifier (e.g., WO-2026-1001)
 
     @LastModifiedDate
     @Column(nullable = false)

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderRepository.java
@@ -65,16 +65,30 @@ public interface WorkorderRepository extends JpaRepository<Workorder, UUID> {
     List<Workorder> findByScheduledDateAndLocationId(@NonNull LocalDate scheduledDate, @NonNull UUID locationId);
 
     /**
-     * Free-text workorder search matching either a resolved customer id (from a name
-     * search) or the workorder id directly.
+     * Free-text workorder search matching the workorder number (contains), a resolved
+     * customer id (from a name search), or the workorder id directly.
      *
+     * @param q           free-text term matched against workorderNumber (case-insensitive contains)
      * @param customerIds customer ids resolved from a name search (must be non-empty for JPQL IN)
      * @param idQuery     the query parsed as a UUID, or {@code null} if not a UUID
      * @param pageable    pagination configuration
      * @return page of matching workorders
      */
-    @Query("SELECT w FROM Workorder w WHERE w.customerId IN :customerIds "
+    @Query("SELECT w FROM Workorder w WHERE LOWER(w.workorderNumber) LIKE LOWER(CONCAT('%', :q, '%')) "
+            + "OR w.customerId IN :customerIds "
             + "OR (:idQuery IS NOT NULL AND w.id = :idQuery)")
     Page<Workorder> searchByQuery(
-            @Param("customerIds") Collection<UUID> customerIds, @Param("idQuery") UUID idQuery, Pageable pageable);
+            @Param("q") String q,
+            @Param("customerIds") Collection<UUID> customerIds,
+            @Param("idQuery") UUID idQuery,
+            Pageable pageable);
+
+    /**
+     * Whether a workorder already carries the given human number. Used by number
+     * generation to guarantee global uniqueness.
+     *
+     * @param workorderNumber candidate human number
+     * @return true if any workorder already uses it
+     */
+    boolean existsByWorkorderNumber(@NonNull String workorderNumber);
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -78,6 +78,7 @@ public class EstimateServiceImpl implements EstimateService {
     private final DocumentClient documentClient;
     private final ObjectMapper objectMapper;
     private final CustomerReferenceService customerReferenceService;
+    private final VehicleReferenceService vehicleReferenceService;
 
     // Configuration defaults
     private static final String DEFAULT_CURRENCY = "USD";
@@ -166,11 +167,26 @@ public class EstimateServiceImpl implements EstimateService {
         Map<UUID, CustomerReferenceService.CustomerContact> contacts =
                 customerReferenceService.resolveAll(pageCustomerIds);
 
+        // Enrich with vehicle label + VIN for the finder dropdown.
+        List<UUID> pageVehicleIds = page.getContent().stream()
+                .map(Estimate::getVehicleId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<UUID, VehicleReferenceService.VehicleReference> vehicles =
+                vehicleReferenceService.resolveAll(pageVehicleIds);
+
         return page.map(estimate -> {
             EstimateSummaryResponse summary = toEstimateSummaryResponse(estimate);
             CustomerReferenceService.CustomerContact contact = contacts.get(estimate.getCustomerId());
             if (contact != null) {
                 summary.setCustomerName(contact.name());
+            }
+            VehicleReferenceService.VehicleReference vehicle =
+                    estimate.getVehicleId() != null ? vehicles.get(estimate.getVehicleId()) : null;
+            if (vehicle != null) {
+                summary.setVehicleLabel(vehicle.vehicleInfo());
+                summary.setVin(vehicle.vin());
             }
             return summary;
         });

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
@@ -1,6 +1,7 @@
 package com.positivity.workorder.internal.service;
 
 import com.positivity.workorder.internal.dto.WorkorderSearchResult;
+import com.positivity.workorder.internal.entity.Estimate;
 import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.service.WorkorderSearchService;
@@ -28,6 +29,7 @@ public class WorkorderSearchServiceImpl implements WorkorderSearchService {
 
     private final WorkorderRepository workorderRepository;
     private final CustomerReferenceService customerReferenceService;
+    private final VehicleReferenceService vehicleReferenceService;
 
     @Override
     public @NonNull Page<WorkorderSearchResult> search(@NonNull String q, @NonNull Pageable pageable) {
@@ -42,9 +44,9 @@ public class WorkorderSearchServiceImpl implements WorkorderSearchService {
         // Treat the query as a workorder id when it parses as a UUID.
         UUID idQuery = parseUuidOrNull(q);
 
-        Page<Workorder> page = workorderRepository.searchByQuery(customerIds, idQuery, pageable);
+        Page<Workorder> page = workorderRepository.searchByQuery(q, customerIds, idQuery, pageable);
 
-        // Enrich each row with the resolved customer display name.
+        // Enrich each row with the resolved customer display name and vehicle label/VIN.
         List<UUID> pageCustomerIds = page.getContent().stream()
                 .map(Workorder::getCustomerId)
                 .filter(Objects::nonNull)
@@ -52,13 +54,30 @@ public class WorkorderSearchServiceImpl implements WorkorderSearchService {
                 .toList();
         Map<UUID, CustomerReferenceService.CustomerContact> contacts =
                 customerReferenceService.resolveAll(pageCustomerIds);
+        List<UUID> pageVehicleIds = page.getContent().stream()
+                .map(Workorder::getVehicleId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<UUID, VehicleReferenceService.VehicleReference> vehicles =
+                vehicleReferenceService.resolveAll(pageVehicleIds);
 
         return page.map(workorder -> {
-            CustomerReferenceService.CustomerContact contact = contacts.get(workorder.getCustomerId());
+            CustomerReferenceService.CustomerContact contact =
+                    workorder.getCustomerId() != null ? contacts.get(workorder.getCustomerId()) : null;
+            VehicleReferenceService.VehicleReference vehicle =
+                    workorder.getVehicleId() != null ? vehicles.get(workorder.getVehicleId()) : null;
+            Estimate estimate = workorder.getEstimate();
             return WorkorderSearchResult.builder()
                     .workorderId(workorder.getId())
+                    .workorderNumber(workorder.getWorkorderNumber())
+                    .estimateNumber(estimate != null ? estimate.getEstimateNumber() : null)
                     .status(workorder.getStatus())
+                    .customerId(workorder.getCustomerId())
                     .customerName(contact != null ? contact.name() : null)
+                    .vehicleId(workorder.getVehicleId())
+                    .vehicleLabel(vehicle != null ? vehicle.vehicleInfo() : null)
+                    .vin(vehicle != null ? vehicle.vin() : null)
                     .createdAt(workorder.getCreatedAt())
                     .build();
         });

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
@@ -33,6 +33,7 @@ import com.positivity.workorder.service.PromotionValidationService;
 import com.positivity.workorder.service.WorkorderService;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.Year;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,6 +44,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.context.event.EventListener;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -56,6 +58,9 @@ public class WorkorderServiceImpl implements WorkorderService {
 
     private static final String SYSTEM_ACTOR = "system";
     private static final String IDEMPOTENCY_OPERATION_WORKORDER_CREATE = "workorder.create";
+    private static final String ESTIMATE_PREFIX = "EST-";
+    private static final String WORKORDER_PREFIX = "WO-";
+    private static final int WORKORDER_NUMBER_SEQUENCE_START = 1000;
 
     private final Clock clock;
     private final WorkorderRepository workorderRepository;
@@ -100,6 +105,7 @@ public class WorkorderServiceImpl implements WorkorderService {
 
         Workorder workorder = Workorder.builder()
                 .estimate(estimate)
+                .workorderNumber(generateWorkorderNumber(estimate))
                 .customerId(customerId)
                 .status(WorkorderStatus.DRAFT)
                 .crmPartyId(estimate != null ? estimate.getCrmPartyId() : null)
@@ -110,6 +116,39 @@ public class WorkorderServiceImpl implements WorkorderService {
                                 : new ArrayList<>())
                 .build();
         return createWorkorderInternal(workorder);
+    }
+
+    /**
+     * Generate the human workorder number. When created from an estimate, swap the
+     * estimate's prefix (EST-... -> WO-...) if that value is globally free; otherwise
+     * fall back to an independent WO-YYYY-NNNN sequence. This keeps the workorder number
+     * "matching the estimate number except the prefix" for the common 1:1 case while
+     * guaranteeing global uniqueness for estimate-less or revision cases.
+     */
+    @NonNull
+    private String generateWorkorderNumber(@Nullable Estimate estimate) {
+        if (estimate != null
+                && estimate.getEstimateNumber() != null
+                && estimate.getEstimateNumber().startsWith(ESTIMATE_PREFIX)) {
+            String swapped = WORKORDER_PREFIX + estimate.getEstimateNumber().substring(ESTIMATE_PREFIX.length());
+            if (!workorderRepository.existsByWorkorderNumber(swapped)) {
+                return swapped;
+            }
+            log.debug("Workorder number {} already taken; falling back to sequence", swapped);
+        }
+        return generateSequentialWorkorderNumber();
+    }
+
+    @NonNull
+    private String generateSequentialWorkorderNumber() {
+        String prefix = WORKORDER_PREFIX + Year.now(clock).getValue() + "-";
+        int sequence = WORKORDER_NUMBER_SEQUENCE_START;
+        String candidate;
+        do {
+            candidate = prefix + sequence;
+            sequence++;
+        } while (workorderRepository.existsByWorkorderNumber(candidate));
+        return candidate;
     }
 
     /**

--- a/pos-workorder/src/main/resources/db/migration/V3__add_workorder_number.sql
+++ b/pos-workorder/src/main/resources/db/migration/V3__add_workorder_number.sql
@@ -1,0 +1,27 @@
+-- Add a human-readable workorder number (WO-YYYY-NNNN), analogous to estimate_number.
+-- Going forward, new workorders take the linked estimate's number with the prefix swapped
+-- (EST-2026-1001 -> WO-2026-1001) when that value is globally free, otherwise an independent
+-- WO-YYYY-NNNN sequence. Backfill here assigns existing rows deterministically and uniquely
+-- per year (sequential), so the value is non-null on every row and the unique index holds.
+
+ALTER TABLE workorder ADD COLUMN workorder_number varchar(64);
+
+-- Deterministic sequential backfill, per creation-year, starting at 1000 (mirrors
+-- generateEstimateNumber's starting sequence). row_number() guarantees uniqueness.
+WITH numbered AS (
+    SELECT id,
+           to_char(created_at, 'YYYY') AS yr,
+           row_number() OVER (
+               PARTITION BY to_char(created_at, 'YYYY')
+               ORDER BY created_at, id
+           ) + 999 AS seq
+    FROM workorder
+)
+UPDATE workorder w
+SET workorder_number = 'WO-' || n.yr || '-' || n.seq
+FROM numbered n
+WHERE w.id = n.id;
+
+ALTER TABLE workorder ALTER COLUMN workorder_number SET NOT NULL;
+
+CREATE UNIQUE INDEX ux_workorder_workorder_number ON workorder (workorder_number);

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateSearchByQueryTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateSearchByQueryTest.java
@@ -61,6 +61,9 @@ class EstimateSearchByQueryTest {
     @Mock
     private CustomerReferenceService customerReferenceService;
 
+    @Mock
+    private VehicleReferenceService vehicleReferenceService;
+
     @InjectMocks
     private EstimateServiceImpl estimateService;
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderNumberGenerationTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderNumberGenerationTest.java
@@ -1,0 +1,141 @@
+package com.positivity.workorder.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.client.CustomerValidationClient;
+import com.positivity.workorder.internal.client.ShopmgrOperationalContextClient;
+import com.positivity.workorder.internal.entity.Estimate;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.repository.AuditEventRepository;
+import com.positivity.workorder.internal.repository.EstimateItemRepository;
+import com.positivity.workorder.internal.repository.EstimateRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import com.positivity.workorder.internal.service.WorkorderStateMachine;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Unit tests for workorder human-number generation at creation: prefix-swap from
+ * the linked estimate when free, sequence fallback on collision, and own sequence
+ * for estimate-less workorders.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class WorkorderNumberGenerationTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-06-24T00:00:00Z"), ZoneOffset.UTC);
+    private static final UUID CUSTOMER = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000001");
+
+    @Spy
+    Clock clock = TEST_CLOCK;
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @Mock
+    private EstimateRepository estimateRepository;
+
+    @Mock
+    private EstimateItemRepository estimateItemRepository;
+
+    @Mock
+    private WorkorderServiceRepository workorderServiceRepository;
+
+    @Mock
+    private WorkorderPartRepository workorderPartRepository;
+
+    @Mock
+    private CustomerValidationClient customerValidationClient;
+
+    @Mock
+    private WorkorderStateMachine stateMachine;
+
+    @Mock
+    private AuditEventRepository auditEventRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private PromotionValidationService promotionValidationService;
+
+    @Mock
+    private ShopmgrOperationalContextClient shopmgrClient;
+
+    @InjectMocks
+    private com.positivity.workorder.internal.service.WorkorderServiceImpl service;
+
+    @Test
+    void fromEstimate_swapsPrefixWhenFree() {
+        Estimate estimate = Estimate.builder()
+                .id(UUID.randomUUID())
+                .estimateNumber("EST-2026-1001")
+                .customerId(CUSTOMER)
+                .build();
+        when(estimateRepository.findById(any())).thenReturn(Optional.of(estimate));
+        when(customerValidationClient.checkRequirementsMet(any())).thenReturn(true);
+        when(estimateItemRepository.findByEstimate_IdAndApprovalStatusAndDeletedFalse(any(), any()))
+                .thenReturn(List.of());
+        when(workorderRepository.existsByWorkorderNumber(any())).thenReturn(false);
+        when(workorderRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.createWorkorder(estimate.getId(), CUSTOMER);
+
+        assertThat(captureSaved().getWorkorderNumber()).isEqualTo("WO-2026-1001");
+    }
+
+    @Test
+    void fromEstimate_fallsBackToSequenceWhenSwapTaken() {
+        Estimate estimate = Estimate.builder()
+                .id(UUID.randomUUID())
+                .estimateNumber("EST-2026-1001")
+                .customerId(CUSTOMER)
+                .build();
+        when(estimateRepository.findById(any())).thenReturn(Optional.of(estimate));
+        when(customerValidationClient.checkRequirementsMet(any())).thenReturn(true);
+        when(estimateItemRepository.findByEstimate_IdAndApprovalStatusAndDeletedFalse(any(), any()))
+                .thenReturn(List.of());
+        when(workorderRepository.existsByWorkorderNumber("WO-2026-1001")).thenReturn(true);
+        when(workorderRepository.existsByWorkorderNumber("WO-2026-1000")).thenReturn(false);
+        when(workorderRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.createWorkorder(estimate.getId(), CUSTOMER);
+
+        assertThat(captureSaved().getWorkorderNumber()).isEqualTo("WO-2026-1000");
+    }
+
+    @Test
+    void withoutEstimate_usesSequence() {
+        when(customerValidationClient.checkRequirementsMet(any())).thenReturn(true);
+        when(workorderRepository.existsByWorkorderNumber(any())).thenReturn(false);
+        when(workorderRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.createWorkorder(null, CUSTOMER);
+
+        assertThat(captureSaved().getWorkorderNumber()).isEqualTo("WO-2026-1000");
+    }
+
+    private Workorder captureSaved() {
+        ArgumentCaptor<Workorder> captor = ArgumentCaptor.forClass(Workorder.class);
+        verify(workorderRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderSearchServiceTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderSearchServiceTest.java
@@ -13,6 +13,7 @@ import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.enums.WorkorderStatus;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.internal.service.CustomerReferenceService;
+import com.positivity.workorder.internal.service.VehicleReferenceService;
 import com.positivity.workorder.internal.service.WorkorderSearchServiceImpl;
 import java.time.Instant;
 import java.util.Collection;
@@ -49,6 +50,9 @@ class WorkorderSearchServiceTest {
     @Mock
     private CustomerReferenceService customerReferenceService;
 
+    @Mock
+    private VehicleReferenceService vehicleReferenceService;
+
     @InjectMocks
     private WorkorderSearchServiceImpl workorderSearchService;
 
@@ -68,10 +72,11 @@ class WorkorderSearchServiceTest {
 
         when(customerReferenceService.searchIdsByName(eq("Acme"), anyInt()))
                 .thenReturn(List.of(new CustomerReferenceService.CustomerRef(CUSTOMER_A, "Acme Auto")));
-        when(workorderRepository.searchByQuery(any(), any(), eq(pageable)))
+        when(workorderRepository.searchByQuery(any(), any(), any(), eq(pageable)))
                 .thenReturn(new PageImpl<>(List.of(workorder)));
         when(customerReferenceService.resolveAll(any()))
                 .thenReturn(Map.of(CUSTOMER_A, new CustomerReferenceService.CustomerContact("Acme Auto", null)));
+        when(vehicleReferenceService.resolveAll(any())).thenReturn(Map.of());
 
         Page<WorkorderSearchResult> result = workorderSearchService.search("Acme", pageable);
 
@@ -89,17 +94,19 @@ class WorkorderSearchServiceTest {
         Workorder workorder = buildWorkorder(WORKORDER_ID, CUSTOMER_A, WorkorderStatus.DRAFT);
 
         when(customerReferenceService.searchIdsByName(anyString(), anyInt())).thenReturn(List.of());
-        when(workorderRepository.searchByQuery(any(), any(), eq(pageable)))
+        when(workorderRepository.searchByQuery(any(), any(), any(), eq(pageable)))
                 .thenReturn(new PageImpl<>(List.of(workorder)));
         when(customerReferenceService.resolveAll(any()))
                 .thenReturn(Map.of(CUSTOMER_A, new CustomerReferenceService.CustomerContact("Acme Auto", null)));
+        when(vehicleReferenceService.resolveAll(any())).thenReturn(Map.of());
 
         workorderSearchService.search(q, pageable);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Collection<UUID>> customerIdsCaptor = ArgumentCaptor.forClass(Collection.class);
         ArgumentCaptor<UUID> idQueryCaptor = ArgumentCaptor.forClass(UUID.class);
-        verify(workorderRepository).searchByQuery(customerIdsCaptor.capture(), idQueryCaptor.capture(), eq(pageable));
+        verify(workorderRepository)
+                .searchByQuery(anyString(), customerIdsCaptor.capture(), idQueryCaptor.capture(), eq(pageable));
 
         assertThat(idQueryCaptor.getValue()).isEqualTo(WORKORDER_ID);
         // empty name match → sentinel id that cannot match a real workorder


### PR DESCRIPTION
## Summary
Additive features layered on top of the finder search merged in #734. Rebased onto main (clean delta).

### Workorder number (new)
- Stored human `workorderNumber` (`WO-YYYY-NNNN`), globally unique.
- Set at creation: prefix-swap the linked estimate number (`EST-2026-1001` → `WO-2026-1001`) when free; else an independent `WO-YYYY-NNNN` sequence (estimate-less workorders, or revision collisions).
- Flyway `V3`: add column, deterministic per-year backfill, unique index.

### Finder enrichment (extends #734)
- Workorder finder (`GET /v1/workorders/search`) now also matches `workorderNumber`; results carry `workorderNumber`, `estimateNumber`, and vehicle label/VIN.
- Estimate finder results carry vehicle label/VIN (`EstimateSummaryResponse` + `vehicleLabel`/`vin`).
- Vehicle enrichment reuses existing `VehicleReferenceService.resolveAll`.

### Contract
- `pos-workorder/openapi.yaml` regenerated. SDK + frontend follow in the chain.

### Tests
Full pos-workorder unit suite green (293). New `WorkorderNumberGenerationTest` (swap / fallback / estimate-less); `WorkorderSearchServiceTest` + `EstimateSearchByQueryTest` extended for the new fields/signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
