### PR TITLE
fix(workorder): resolve customer name + vehicle label/VIN from pos-customer

### DIFF
--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerReferenceService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerReferenceService.java
@@ -50,11 +50,15 @@ public class CustomerReferenceService {
             }
 
             Map<String, Object> payload = unwrapData(body);
+            // The /v1/crm/{id} representation returns firstName/lastName (lastName carries the
+            // legal/organization name for commercial parties); the browse representation returns
+            // displayName/legalName. Cover both so resolution does not fall back to "customer-<id>".
             String name = firstNonBlank(
                     extract(payload, "customerName"),
                     extract(payload, "displayName"),
-                    extract(payload, "name"),
                     extract(payload, "legalName"),
+                    extract(payload, "name"),
+                    composeName(extract(payload, "firstName"), extract(payload, "lastName")),
                     fallbackName);
             String phone = firstNonBlank(
                     extract(payload, "phoneNumber"), extract(payload, "phone"), extract(payload, "mobilePhone"));
@@ -135,6 +139,34 @@ public class CustomerReferenceService {
     private @Nullable String extract(Map<String, Object> payload, String key) {
         Object value = payload.get(key);
         return value != null ? value.toString() : null;
+    }
+
+    /**
+     * Compose a display name from first/last parts. For commercial parties {@code lastName}
+     * already carries the full legal name (and {@code firstName} is a prefix of it), so the
+     * longer value is returned to avoid duplication; for individuals the two parts are joined.
+     */
+    private @Nullable String composeName(@Nullable String firstName, @Nullable String lastName) {
+        boolean hasFirst = StringUtils.hasText(firstName);
+        boolean hasLast = StringUtils.hasText(lastName);
+        if (!hasFirst && !hasLast) {
+            return null;
+        }
+        if (!hasFirst) {
+            return lastName.trim();
+        }
+        if (!hasLast) {
+            return firstName.trim();
+        }
+        String f = firstName.trim();
+        String l = lastName.trim();
+        if (l.contains(f)) {
+            return l;
+        }
+        if (f.contains(l)) {
+            return f;
+        }
+        return f + " " + l;
     }
 
     private @Nullable String firstNonBlank(String... values) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -167,14 +167,13 @@ public class EstimateServiceImpl implements EstimateService {
         Map<UUID, CustomerReferenceService.CustomerContact> contacts =
                 customerReferenceService.resolveAll(pageCustomerIds);
 
-        // Enrich with vehicle label + VIN for the finder dropdown.
-        List<UUID> pageVehicleIds = page.getContent().stream()
-                .map(Estimate::getVehicleId)
-                .filter(java.util.Objects::nonNull)
-                .distinct()
+        // Enrich with vehicle label + VIN for the finder dropdown. Vehicles are mastered under
+        // the owning CRM account, so resolution is keyed by (customerId, vehicleId).
+        List<VehicleReferenceService.VehicleKey> vehicleKeys = page.getContent().stream()
+                .filter(e -> e.getVehicleId() != null)
+                .map(e -> new VehicleReferenceService.VehicleKey(e.getCustomerId(), e.getVehicleId()))
                 .toList();
-        Map<UUID, VehicleReferenceService.VehicleReference> vehicles =
-                vehicleReferenceService.resolveAll(pageVehicleIds);
+        Map<UUID, VehicleReferenceService.VehicleReference> vehicles = vehicleReferenceService.resolveAll(vehicleKeys);
 
         return page.map(estimate -> {
             EstimateSummaryResponse summary = toEstimateSummaryResponse(estimate);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/VehicleReferenceService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/VehicleReferenceService.java
@@ -1,73 +1,156 @@
 package com.positivity.workorder.internal.service;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 
+/**
+ * Resolves vehicle display data (label + VIN) from pos-customer, where vehicles are
+ * mastered under the owning CRM account: {@code GET /v1/crm/{accountId}/vehicles} and
+ * {@code GET /v1/crm/{accountId}/vehicles/{vehicleId}}. Resolution therefore needs both
+ * the customer (account) id and the vehicle id. Fail-soft: any error yields a
+ * {@code vehicle-<id>} fallback so callers can still render the other fields.
+ */
 @Service
 public class VehicleReferenceService {
 
     private static final Logger log = LoggerFactory.getLogger(VehicleReferenceService.class);
 
-    private final RestClient vehicleRestClient;
+    private final RestClient customerRestClient;
 
     public VehicleReferenceService(
-            RestClient.Builder restClientBuilder,
-            @Value("${pos.vehicle.base-url:http://pos-vehicle:8088}") String vehicleBaseUrl) {
-        this.vehicleRestClient = restClientBuilder.baseUrl(vehicleBaseUrl).build();
+            @Qualifier("loadBalancedRestClientBuilder") RestClient.Builder restClientBuilder,
+            @Value("${pos.customer.service-id:customer}") String serviceId) {
+        this.customerRestClient =
+                restClientBuilder.baseUrl("http://" + serviceId).build();
     }
 
-    public @NonNull VehicleReference resolve(@Nullable UUID vehicleId) {
+    /** A (customer, vehicle) pair to resolve. */
+    public record VehicleKey(
+            @Nullable UUID customerId, @Nullable UUID vehicleId) {}
+
+    public @NonNull VehicleReference resolve(@Nullable UUID customerId, @Nullable UUID vehicleId) {
         if (vehicleId == null) {
             return VehicleReference.empty();
         }
-
+        if (customerId == null) {
+            return fallback(vehicleId);
+        }
         try {
             @SuppressWarnings("unchecked")
-            Map<String, Object> body = vehicleRestClient
+            Map<String, Object> body = customerRestClient
                     .get()
-                    .uri("/v1/vehicles/{vehicleId}", vehicleId)
+                    .uri("/v1/crm/{customerId}/vehicles/{vehicleId}", customerId, vehicleId)
+                    .header("X-User", "pos-workorder")
+                    .header("X-Authorities", "crm:party:view")
                     .retrieve()
                     .body(Map.class);
-
-            String fallbackInfo = "vehicle-" + vehicleId;
             if (body == null || body.isEmpty()) {
-                return new VehicleReference(fallbackInfo, null);
+                return fallback(vehicleId);
             }
-
-            Map<String, Object> payload = unwrapData(body);
-            String info = firstNonBlank(
-                    extract(payload, "vehicleInfo"),
-                    extract(payload, "vehicleDescription"),
-                    extract(payload, "description"),
-                    extract(payload, "displayName"),
-                    fallbackInfo);
-            String vin = firstNonBlank(extract(payload, "vin"), extract(payload, "vehicleVin"));
-            return new VehicleReference(info, vin);
+            return toReference(unwrapData(body), vehicleId);
         } catch (Exception ex) {
-            log.debug("Unable to resolve vehicle reference for {}: {}", vehicleId, ex.getMessage());
-            return new VehicleReference("vehicle-" + vehicleId, null);
+            log.debug("Unable to resolve vehicle {} for customer {}: {}", vehicleId, customerId, ex.getMessage());
+            return fallback(vehicleId);
         }
     }
 
-    public @NonNull Map<UUID, VehicleReference> resolveAll(@NonNull Collection<UUID> vehicleIds) {
-        Map<UUID, VehicleReference> resolved = new LinkedHashMap<>();
-        for (UUID vehicleId : vehicleIds) {
-            if (vehicleId == null || resolved.containsKey(vehicleId)) {
+    /**
+     * Resolve a batch of (customer, vehicle) pairs. The owning account's vehicle list is
+     * fetched once per distinct customer and indexed by vehicle id. Returns a map keyed by
+     * vehicle id (fallback entry when a vehicle is missing from its account's list).
+     */
+    public @NonNull Map<UUID, VehicleReference> resolveAll(@NonNull Collection<VehicleKey> keys) {
+        Map<UUID, List<UUID>> vehiclesByCustomer = new LinkedHashMap<>();
+        for (VehicleKey key : keys) {
+            if (key == null || key.vehicleId() == null || key.customerId() == null) {
                 continue;
             }
-            resolved.put(vehicleId, resolve(vehicleId));
+            vehiclesByCustomer
+                    .computeIfAbsent(key.customerId(), c -> new ArrayList<>())
+                    .add(key.vehicleId());
+        }
+
+        Map<UUID, VehicleReference> resolved = new LinkedHashMap<>();
+        for (Map.Entry<UUID, List<UUID>> entry : vehiclesByCustomer.entrySet()) {
+            Map<UUID, VehicleReference> index = fetchCustomerVehicles(entry.getKey());
+            for (UUID vehicleId : entry.getValue()) {
+                if (!resolved.containsKey(vehicleId)) {
+                    resolved.put(vehicleId, index.getOrDefault(vehicleId, fallback(vehicleId)));
+                }
+            }
         }
         return resolved;
+    }
+
+    private @NonNull Map<UUID, VehicleReference> fetchCustomerVehicles(@NonNull UUID customerId) {
+        try {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> rows = customerRestClient
+                    .get()
+                    .uri("/v1/crm/{customerId}/vehicles", customerId)
+                    .header("X-User", "pos-workorder")
+                    .header("X-Authorities", "crm:party:view")
+                    .retrieve()
+                    .body(List.class);
+            if (rows == null || rows.isEmpty()) {
+                return Map.of();
+            }
+            Map<UUID, VehicleReference> index = new LinkedHashMap<>();
+            for (Map<String, Object> row : rows) {
+                String id = extract(row, "vehicleId");
+                if (!StringUtils.hasText(id)) {
+                    continue;
+                }
+                try {
+                    UUID vehicleId = UUID.fromString(id.trim());
+                    index.put(vehicleId, toReference(row, vehicleId));
+                } catch (IllegalArgumentException ignore) {
+                    // skip non-UUID vehicle ids
+                }
+            }
+            return index;
+        } catch (Exception ex) {
+            log.debug("Unable to list vehicles for customer {}: {}", customerId, ex.getMessage());
+            return Map.of();
+        }
+    }
+
+    private @NonNull VehicleReference toReference(@NonNull Map<String, Object> payload, @NonNull UUID vehicleId) {
+        String label = firstNonBlank(
+                composeLabel(extract(payload, "year"), extract(payload, "make"), extract(payload, "model")),
+                extract(payload, "description"),
+                extract(payload, "vehicleInfo"),
+                extract(payload, "displayName"),
+                "vehicle-" + vehicleId);
+        String vin = firstNonBlank(extract(payload, "vin"), extract(payload, "vinNormalized"));
+        return new VehicleReference(label, vin);
+    }
+
+    private @Nullable String composeLabel(@Nullable String year, @Nullable String make, @Nullable String model) {
+        List<String> parts = new ArrayList<>();
+        for (String p : new String[] {year, make, model}) {
+            if (StringUtils.hasText(p)) {
+                parts.add(p.trim());
+            }
+        }
+        return parts.isEmpty() ? null : String.join(" ", parts);
+    }
+
+    private @NonNull VehicleReference fallback(@NonNull UUID vehicleId) {
+        return new VehicleReference("vehicle-" + vehicleId, null);
     }
 
     @SuppressWarnings("unchecked")
@@ -81,7 +164,14 @@ public class VehicleReferenceService {
 
     private @Nullable String extract(Map<String, Object> payload, String key) {
         Object value = payload.get(key);
-        return value != null ? value.toString() : null;
+        if (value == null) {
+            return null;
+        }
+        // year often arrives as a number; normalise without a trailing ".0"
+        if (value instanceof Number number) {
+            return String.valueOf(number.longValue());
+        }
+        return value.toString();
     }
 
     private @Nullable String firstNonBlank(String... values) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WipServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WipServiceImpl.java
@@ -113,7 +113,8 @@ public class WipServiceImpl implements WipService {
             customerContact = new CustomerReferenceService.CustomerContact(
                     wo.getCustomerId() != null ? "customer-" + wo.getCustomerId() : "", null);
         }
-        VehicleReferenceService.VehicleReference vehicleReference = vehicleReferenceService.resolve(wo.getVehicleId());
+        VehicleReferenceService.VehicleReference vehicleReference =
+                vehicleReferenceService.resolve(wo.getCustomerId(), wo.getVehicleId());
         if (vehicleReference == null) {
             vehicleReference = new VehicleReferenceService.VehicleReference(
                     wo.getVehicleId() != null ? "vehicle-" + wo.getVehicleId() : "", null);
@@ -155,9 +156,9 @@ public class WipServiceImpl implements WipService {
                         .collect(java.util.stream.Collectors.toSet()));
         Map<UUID, VehicleReferenceService.VehicleReference> vehicleById =
                 vehicleReferenceService.resolveAll(content.stream()
-                        .map(Workorder::getVehicleId)
-                        .filter(java.util.Objects::nonNull)
-                        .collect(java.util.stream.Collectors.toSet()));
+                        .filter(w -> w.getVehicleId() != null)
+                        .map(w -> new VehicleReferenceService.VehicleKey(w.getCustomerId(), w.getVehicleId()))
+                        .toList());
         final Map<UUID, CustomerReferenceService.CustomerContact> customerLookup = customerById;
         final Map<UUID, VehicleReferenceService.VehicleReference> vehicleLookup = vehicleById;
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
@@ -54,13 +54,11 @@ public class WorkorderSearchServiceImpl implements WorkorderSearchService {
                 .toList();
         Map<UUID, CustomerReferenceService.CustomerContact> contacts =
                 customerReferenceService.resolveAll(pageCustomerIds);
-        List<UUID> pageVehicleIds = page.getContent().stream()
-                .map(Workorder::getVehicleId)
-                .filter(Objects::nonNull)
-                .distinct()
+        List<VehicleReferenceService.VehicleKey> vehicleKeys = page.getContent().stream()
+                .filter(w -> w.getVehicleId() != null)
+                .map(w -> new VehicleReferenceService.VehicleKey(w.getCustomerId(), w.getVehicleId()))
                 .toList();
-        Map<UUID, VehicleReferenceService.VehicleReference> vehicles =
-                vehicleReferenceService.resolveAll(pageVehicleIds);
+        Map<UUID, VehicleReferenceService.VehicleReference> vehicles = vehicleReferenceService.resolveAll(vehicleKeys);
 
         return page.map(workorder -> {
             CustomerReferenceService.CustomerContact contact =

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/CustomerReferenceServiceHttpTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/CustomerReferenceServiceHttpTest.java
@@ -39,6 +39,45 @@ class CustomerReferenceServiceHttpTest {
     }
 
     @Test
+    void resolve_usesLegalName_forCommercialPartyRepresentation() throws Exception {
+        // The /v1/crm/{id} representation emits firstName/lastName (no customerName/displayName);
+        // for commercial parties lastName carries the full legal name.
+        UUID customerId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        String payload =
+                "{\"firstName\":\"Blue Ridge Landscaping\",\"lastName\":\"Blue Ridge Landscaping Services LLC\"}";
+        AtomicInteger callCount = new AtomicInteger();
+        HttpServer server = startServer("/v1/crm/" + customerId, 200, payload, callCount);
+        try {
+            String serviceId = "localhost:" + server.getAddress().getPort();
+            CustomerReferenceService service = new CustomerReferenceService(RestClient.builder(), serviceId);
+
+            CustomerReferenceService.CustomerContact contact = service.resolve(customerId);
+
+            assertThat(contact.name()).isEqualTo("Blue Ridge Landscaping Services LLC");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void resolve_joinsFirstAndLastName_forIndividualParty() throws Exception {
+        UUID customerId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        String payload = "{\"firstName\":\"Jane\",\"lastName\":\"Smith\"}";
+        AtomicInteger callCount = new AtomicInteger();
+        HttpServer server = startServer("/v1/crm/" + customerId, 200, payload, callCount);
+        try {
+            String serviceId = "localhost:" + server.getAddress().getPort();
+            CustomerReferenceService service = new CustomerReferenceService(RestClient.builder(), serviceId);
+
+            CustomerReferenceService.CustomerContact contact = service.resolve(customerId);
+
+            assertThat(contact.name()).isEqualTo("Jane Smith");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
     void resolve_returnsFallback_whenRemoteReturns404() throws Exception {
         UUID customerId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         AtomicInteger callCount = new AtomicInteger();

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/VehicleReferenceServiceHttpTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/VehicleReferenceServiceHttpTest.java
@@ -3,6 +3,7 @@ package com.positivity.workorder.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.positivity.workorder.internal.service.VehicleReferenceService;
+import com.positivity.workorder.internal.service.VehicleReferenceService.VehicleKey;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -16,21 +17,21 @@ import org.springframework.web.client.RestClient;
 
 class VehicleReferenceServiceHttpTest {
 
+    private static final UUID CUSTOMER = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID VEHICLE = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
     @Test
-    void resolve_parsesVehicleInfoAndVin_fromDataEnvelope() throws Exception {
-        UUID vehicleId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        String payload = """
-                {"data":{"vehicleDescription":"2022 Honda Civic EX","vin":"1HGBH41JXMN109186"}}
-                """;
+    void resolve_buildsLabelFromYearMakeModel_andVin() throws Exception {
+        String payload = "{\"vehicleId\":\"" + VEHICLE
+                + "\",\"make\":\"Honda\",\"model\":\"Civic\",\"year\":2022,\"vin\":\"1HGBH41JXMN109186\"}";
         AtomicInteger callCount = new AtomicInteger();
-        HttpServer server = startServer("/v1/vehicles/" + vehicleId, 200, payload, callCount);
+        HttpServer server = startServer("/v1/crm/" + CUSTOMER + "/vehicles/" + VEHICLE, 200, payload, callCount);
         try {
-            String baseUrl = "http://localhost:" + server.getAddress().getPort();
-            VehicleReferenceService service = new VehicleReferenceService(RestClient.builder(), baseUrl);
+            VehicleReferenceService service = newService(server);
 
-            VehicleReferenceService.VehicleReference ref = service.resolve(vehicleId);
+            VehicleReferenceService.VehicleReference ref = service.resolve(CUSTOMER, VEHICLE);
 
-            assertThat(ref.vehicleInfo()).isEqualTo("2022 Honda Civic EX");
+            assertThat(ref.vehicleInfo()).isEqualTo("2022 Honda Civic");
             assertThat(ref.vin()).isEqualTo("1HGBH41JXMN109186");
             assertThat(callCount.get()).isEqualTo(1);
         } finally {
@@ -40,44 +41,55 @@ class VehicleReferenceServiceHttpTest {
 
     @Test
     void resolve_returnsFallback_whenRemoteReturns404() throws Exception {
-        UUID vehicleId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         AtomicInteger callCount = new AtomicInteger();
-        HttpServer server = startServer("/v1/vehicles/" + vehicleId, 404, "{}", callCount);
+        HttpServer server = startServer("/v1/crm/" + CUSTOMER + "/vehicles/" + VEHICLE, 404, "{}", callCount);
         try {
-            String baseUrl = "http://localhost:" + server.getAddress().getPort();
-            VehicleReferenceService service = new VehicleReferenceService(RestClient.builder(), baseUrl);
+            VehicleReferenceService service = newService(server);
 
-            VehicleReferenceService.VehicleReference ref = service.resolve(vehicleId);
+            VehicleReferenceService.VehicleReference ref = service.resolve(CUSTOMER, VEHICLE);
 
-            assertThat(ref.vehicleInfo()).isEqualTo("vehicle-" + vehicleId);
+            assertThat(ref.vehicleInfo()).isEqualTo("vehicle-" + VEHICLE);
             assertThat(ref.vin()).isNull();
-            assertThat(callCount.get()).isEqualTo(1);
         } finally {
             server.stop(0);
         }
     }
 
     @Test
-    void resolveAll_deDuplicatesRequests_forRepeatedIds() throws Exception {
-        UUID vehicleId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    void resolve_returnsFallback_whenCustomerUnknown() {
+        VehicleReferenceService service = new VehicleReferenceService(RestClient.builder(), "localhost:1");
+        VehicleReferenceService.VehicleReference ref = service.resolve(null, VEHICLE);
+        assertThat(ref.vehicleInfo()).isEqualTo("vehicle-" + VEHICLE);
+    }
+
+    @Test
+    void resolveAll_listsPerCustomerOnce_andIndexesByVehicleId() throws Exception {
+        UUID v2 = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        String listPayload = "[{\"vehicleId\":\"" + VEHICLE
+                + "\",\"make\":\"Toyota\",\"model\":\"Tacoma\",\"year\":2014,\"vin\":\"VIN-A\"},"
+                + "{\"vehicleId\":\"" + v2
+                + "\",\"make\":\"Ford\",\"model\":\"F-150\",\"year\":2019,\"vin\":\"VIN-B\"}]";
         AtomicInteger callCount = new AtomicInteger();
-        HttpServer server = startServer(
-                "/v1/vehicles/" + vehicleId,
-                200,
-                "{\"vehicleInfo\":\"2021 Ford F-150\",\"vehicleVin\":\"VIN-123\"}",
-                callCount);
+        HttpServer server = startServer("/v1/crm/" + CUSTOMER + "/vehicles", 200, listPayload, callCount);
         try {
-            String baseUrl = "http://localhost:" + server.getAddress().getPort();
-            VehicleReferenceService service = new VehicleReferenceService(RestClient.builder(), baseUrl);
+            VehicleReferenceService service = newService(server);
 
-            var resolved = service.resolveAll(List.of(vehicleId, vehicleId));
+            var resolved = service.resolveAll(List.of(new VehicleKey(CUSTOMER, VEHICLE), new VehicleKey(CUSTOMER, v2)));
 
-            assertThat(resolved).hasSize(1);
-            assertThat(resolved.get(vehicleId).vehicleInfo()).isEqualTo("2021 Ford F-150");
+            assertThat(resolved).hasSize(2);
+            assertThat(resolved.get(VEHICLE).vehicleInfo()).isEqualTo("2014 Toyota Tacoma");
+            assertThat(resolved.get(VEHICLE).vin()).isEqualTo("VIN-A");
+            assertThat(resolved.get(v2).vehicleInfo()).isEqualTo("2019 Ford F-150");
+            // One list call for the shared customer.
             assertThat(callCount.get()).isEqualTo(1);
         } finally {
             server.stop(0);
         }
+    }
+
+    private VehicleReferenceService newService(HttpServer server) {
+        String serviceId = "localhost:" + server.getAddress().getPort();
+        return new VehicleReferenceService(RestClient.builder(), serviceId);
     }
 
     private HttpServer startServer(String expectedPath, int status, String body, AtomicInteger callCount)
@@ -91,7 +103,6 @@ class VehicleReferenceServiceHttpTest {
                 exchange.close();
                 return;
             }
-
             byte[] payload = body.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "application/json");
             exchange.sendResponseHeaders(status, payload.length);

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WipServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WipServiceImplTest.java
@@ -155,9 +155,9 @@ class WipServiceImplTest {
                 .thenAnswer(invocation ->
                         new CustomerReferenceService.CustomerContact("customer-" + invocation.getArgument(0), null));
         lenient()
-                .when(vehicleReferenceService.resolve(any(UUID.class)))
+                .when(vehicleReferenceService.resolve(any(), any(UUID.class)))
                 .thenAnswer(invocation ->
-                        new VehicleReferenceService.VehicleReference("vehicle-" + invocation.getArgument(0), null));
+                        new VehicleReferenceService.VehicleReference("vehicle-" + invocation.getArgument(1), null));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
On `/app/workexec`, finder dropdowns showed `customer-<uuid>` and `vehicle-<uuid>` (no VIN). Diagnosed live on alpha via direct API probes.

## Fixes
**1. Customer name** — `GET /v1/crm/{id}` returns `firstName`/`lastName`/`customerNumber` (commercial `lastName` = legal name), not `customerName`/`displayName`/`name`/`legalName`. `CustomerReferenceService.resolve` matched none → `customer-<id>` fallback. Now reads `displayName`/`legalName` and composes `firstName`/`lastName` (de-duped when lastName holds the legal name).

**2. Vehicle label/VIN** — vehicles are mastered in **pos-customer** under the owning account (`GET /v1/crm/{accountId}/vehicles[/{vehicleId}]`), but `VehicleReferenceService` queried **pos-vehicle** → 404. Repointed at pos-customer, keyed by `(customerId, vehicleId)`; label built from year/make/model; `resolveAll` lists each account once and indexes by vehicle id.

Both gaps also affected the WIP dashboard (shared services) — fixed there too.

## Scope
Internal enrichment only — no API/SDK/frontend contract change. Callers updated: estimate finder, workorder finder, WIP.

## Tests
`CustomerReferenceServiceHttpTest` +2; `VehicleReferenceServiceHttpTest` rewritten for the pos-customer endpoints; `WipServiceImplTest` stub updated. Full pos-workorder suite green (296).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
