### PR TITLE
fix(workorder): make line items reachable to COMPLETED (#736)

### DIFF
--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -522,6 +522,50 @@ paths:
         - workorder:start
       x-required-permissions:
       - workorder:start
+  /v1/workorders/{workorderId}/services/{serviceLineId}/complete:
+    post:
+      tags:
+      - Work Order API
+      summary: Complete a workorder service line
+      description: Mark a single service line as COMPLETED. Allowed from OPEN/READY_TO_EXECUTE/IN_PROGRESS; rejected for CANCELLED or PENDING_APPROVAL items.
+      operationId: completeServiceItem
+      parameters:
+      - name: workorderId
+        in: path
+        description: Workorder ID
+        required: true
+        schema:
+          type: string
+      - name: serviceLineId
+        in: path
+        description: Service line ID
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Service line completed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkorderItemCompletionResponse'
+        '400':
+          description: Item not completable in its current status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkorderItemCompletionResponse'
+        '404':
+          description: Workorder or service line not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkorderItemCompletionResponse'
+      security:
+      - bearerAuth:
+        - workorder:workorder:complete
+      x-required-permissions:
+      - workorder:workorder:complete
   /v1/workorders/{workorderId}/services/{serviceId}/labor/start:
     post:
       tags:
@@ -883,6 +927,50 @@ paths:
         - inventory:pick_list:execute
       x-required-permissions:
       - inventory:pick_list:execute
+  /v1/workorders/{workorderId}/parts/{partId}/complete:
+    post:
+      tags:
+      - Work Order API
+      summary: Complete a workorder part
+      description: Mark a single part as COMPLETED. Allowed from OPEN/READY_TO_EXECUTE/IN_PROGRESS; rejected for CANCELLED or PENDING_APPROVAL items.
+      operationId: completePartItem
+      parameters:
+      - name: workorderId
+        in: path
+        description: Workorder ID
+        required: true
+        schema:
+          type: string
+      - name: partId
+        in: path
+        description: Part ID
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Part completed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkorderItemCompletionResponse'
+        '400':
+          description: Item not completable in its current status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkorderItemCompletionResponse'
+        '404':
+          description: Workorder or part not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkorderItemCompletionResponse'
+      security:
+      - bearerAuth:
+        - workorder:workorder:complete
+      x-required-permissions:
+      - workorder:workorder:complete
   /v1/workorders/{workorderId}/parts/substitute:
     post:
       tags:
@@ -4508,6 +4596,41 @@ components:
           example: Work started on workorder
       required:
       - currentStatus
+      - workorderId
+    WorkorderItemCompletionResponse:
+      type: object
+      description: Result of completing a workorder line item
+      properties:
+        workorderId:
+          type: string
+          format: uuid
+          description: Workorder identifier
+        itemId:
+          type: string
+          format: uuid
+          description: Line item identifier
+        itemType:
+          type: string
+          description: Item kind
+          enum:
+          - SERVICE
+          - PART
+          example: SERVICE
+        status:
+          type: string
+          description: Resulting item status
+          enum:
+          - PENDING_APPROVAL
+          - OPEN
+          - READY_TO_EXECUTE
+          - IN_PROGRESS
+          - COMPLETED
+          - CANCELLED
+          example: COMPLETED
+      required:
+      - itemId
+      - itemType
+      - status
       - workorderId
     StartLaborRequest:
       type: object

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
@@ -65,6 +65,18 @@ public final class EventTypes {
             .apiVersion("1")
             .build();
 
+    /** Complete a single workorder service line */
+    public static final EventTypeRegistration WORKORDER_SERVICE_ITEM_COMPLETE = EventTypeRegistration.write(
+                    "WORKORDER_SERVICE_ITEM_COMPLETE", "Mark a workorder service line as COMPLETED")
+            .apiVersion("1")
+            .build();
+
+    /** Complete a single workorder part */
+    public static final EventTypeRegistration WORKORDER_PART_ITEM_COMPLETE = EventTypeRegistration.write(
+                    "WORKORDER_PART_ITEM_COMPLETE", "Mark a workorder part as COMPLETED")
+            .apiVersion("1")
+            .build();
+
     /** Generate invoice draft from completed workorder */
     public static final EventTypeRegistration WORKORDER_INVOICE_GENERATE = EventTypeRegistration.write(
                     "WORKORDER_INVOICE_GENERATE", "Generate invoice draft from completed workorder")
@@ -496,6 +508,8 @@ public final class EventTypes {
             WORKORDER_OPERATIONAL_CONTEXT_OVERRIDE,
             WORKORDER_APPROVE,
             WORKORDER_COMPLETE,
+            WORKORDER_SERVICE_ITEM_COMPLETE,
+            WORKORDER_PART_ITEM_COMPLETE,
             WORKORDER_INVOICE_GENERATE,
             WORKORDER_REOPEN,
             // Technician assignment events (CAP:005 Story #161)

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
@@ -10,6 +10,7 @@ import com.positivity.workorder.internal.dto.CompletionPreconditionsResponse;
 import com.positivity.workorder.internal.dto.CreateWorkorderRequest;
 import com.positivity.workorder.internal.dto.ReopenWorkorderRequest;
 import com.positivity.workorder.internal.dto.ReopenWorkorderResponse;
+import com.positivity.workorder.internal.dto.WorkorderItemCompletionResponse;
 import com.positivity.workorder.internal.dto.WorkorderResponse;
 import com.positivity.workorder.internal.dto.WorkorderSnapshotResponse;
 import com.positivity.workorder.internal.dto.WorkorderStateTransitionResponse;
@@ -387,6 +388,58 @@ public class WorkorderController {
                             .workorderId(workorderId)
                             .message(e.getMessage())
                             .build());
+        }
+    }
+
+    @Operation(
+            summary = "Complete a workorder service line",
+            description = "Mark a single service line as COMPLETED. Allowed from OPEN/READY_TO_EXECUTE/IN_PROGRESS; "
+                    + "rejected for CANCELLED or PENDING_APPROVAL items.")
+    @ApiResponse(responseCode = "200", description = "Service line completed.")
+    @ApiResponse(responseCode = "400", description = "Item not completable in its current status.")
+    @ApiResponse(responseCode = "404", description = "Workorder or service line not found.")
+    @PostMapping("/{workorderId}/services/{serviceLineId}/complete")
+    @EmitEvent(id = "WORKORDER_SERVICE_ITEM_COMPLETE", apiVersion = "1")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:workorder:complete"})
+    @PreAuthorize("hasAuthority('workorder:workorder:complete')")
+    public ResponseEntity<WorkorderItemCompletionResponse> completeServiceItem(
+            @Parameter(description = "Workorder ID") @PathVariable UUID workorderId,
+            @Parameter(description = "Service line ID") @PathVariable UUID serviceLineId) {
+        try {
+            return ResponseEntity.ok(
+                    workorderService.completeServiceItem(workorderId, serviceLineId, resolveCurrentActorUserId()));
+        } catch (IllegalArgumentException _) {
+            return ResponseEntity.notFound().build();
+        } catch (IllegalStateException _) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @Operation(
+            summary = "Complete a workorder part",
+            description = "Mark a single part as COMPLETED. Allowed from OPEN/READY_TO_EXECUTE/IN_PROGRESS; "
+                    + "rejected for CANCELLED or PENDING_APPROVAL items.")
+    @ApiResponse(responseCode = "200", description = "Part completed.")
+    @ApiResponse(responseCode = "400", description = "Item not completable in its current status.")
+    @ApiResponse(responseCode = "404", description = "Workorder or part not found.")
+    @PostMapping("/{workorderId}/parts/{partId}/complete")
+    @EmitEvent(id = "WORKORDER_PART_ITEM_COMPLETE", apiVersion = "1")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:workorder:complete"})
+    @PreAuthorize("hasAuthority('workorder:workorder:complete')")
+    public ResponseEntity<WorkorderItemCompletionResponse> completePartItem(
+            @Parameter(description = "Workorder ID") @PathVariable UUID workorderId,
+            @Parameter(description = "Part ID") @PathVariable UUID partId) {
+        try {
+            return ResponseEntity.ok(
+                    workorderService.completePartItem(workorderId, partId, resolveCurrentActorUserId()));
+        } catch (IllegalArgumentException _) {
+            return ResponseEntity.notFound().build();
+        } catch (IllegalStateException _) {
+            return ResponseEntity.badRequest().build();
         }
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderItemCompletionResponse.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderItemCompletionResponse.java
@@ -1,0 +1,42 @@
+package com.positivity.workorder.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.workorder.internal.enums.WorkorderItemStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Result of completing an individual workorder line item (service or part). */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Result of completing a workorder line item")
+public class WorkorderItemCompletionResponse {
+
+    @Schema(description = "Workorder identifier", requiredMode = REQUIRED)
+    @NotNull
+    private UUID workorderId;
+
+    @Schema(description = "Line item identifier", requiredMode = REQUIRED)
+    @NotNull
+    private UUID itemId;
+
+    @Schema(description = "Item kind", example = "SERVICE", requiredMode = REQUIRED)
+    @NotNull
+    private ItemType itemType;
+
+    @Schema(description = "Resulting item status", example = "COMPLETED", requiredMode = REQUIRED)
+    @NotNull
+    private WorkorderItemStatus status;
+
+    public enum ItemType {
+        SERVICE,
+        PART
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
@@ -8,6 +8,7 @@ import com.positivity.workorder.internal.dto.AssignmentUpdatePayload;
 import com.positivity.workorder.internal.dto.AssignmentUpdatedEvent;
 import com.positivity.workorder.internal.dto.OperationalContextOverrideRequest;
 import com.positivity.workorder.internal.dto.OperationalContextResponse;
+import com.positivity.workorder.internal.dto.WorkorderItemCompletionResponse;
 import com.positivity.workorder.internal.dto.WorkorderStartResponse;
 import com.positivity.workorder.internal.entity.AuditEvent;
 import com.positivity.workorder.internal.entity.Estimate;
@@ -15,6 +16,7 @@ import com.positivity.workorder.internal.entity.EstimateItem;
 import com.positivity.workorder.internal.entity.EstimateItemType;
 import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
 import com.positivity.workorder.internal.entity.WorkorderStateTransition;
 import com.positivity.workorder.internal.enums.ApprovalStatus;
 import com.positivity.workorder.internal.enums.WorkorderItemStatus;
@@ -468,6 +470,78 @@ public class WorkorderServiceImpl implements WorkorderService {
                 .findById(workorderId)
                 .map(Workorder::getCompletedAt)
                 .orElse(null);
+    }
+
+    @Override
+    @Transactional
+    public WorkorderItemCompletionResponse completeServiceItem(UUID workorderId, UUID serviceLineId, String actorId) {
+        WorkorderServiceLine line = workorderServiceRepository
+                .findById(serviceLineId)
+                .orElseThrow(() -> new IllegalArgumentException("Service line not found: " + serviceLineId));
+        if (line.getWorkOrder() == null
+                || !workorderId.equals(line.getWorkOrder().getId())) {
+            throw new IllegalArgumentException(
+                    "Service line " + serviceLineId + " does not belong to workorder " + workorderId);
+        }
+        WorkorderItemStatus status = completeItemStatus(line.getStatus(), "service line", serviceLineId);
+        if (status != line.getStatus()) {
+            line.setStatus(status);
+            workorderServiceRepository.save(line);
+            log.info("Service line {} on workorder {} marked COMPLETED by {}", serviceLineId, workorderId, actorId);
+        }
+        return WorkorderItemCompletionResponse.builder()
+                .workorderId(workorderId)
+                .itemId(serviceLineId)
+                .itemType(WorkorderItemCompletionResponse.ItemType.SERVICE)
+                .status(status)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public WorkorderItemCompletionResponse completePartItem(UUID workorderId, UUID partId, String actorId) {
+        WorkorderPart part = workorderPartRepository
+                .findById(partId)
+                .orElseThrow(() -> new IllegalArgumentException("Part not found: " + partId));
+        if (!partBelongsToWorkorder(part, workorderId)) {
+            throw new IllegalArgumentException("Part " + partId + " does not belong to workorder " + workorderId);
+        }
+        WorkorderItemStatus status = completeItemStatus(part.getStatus(), "part", partId);
+        if (status != part.getStatus()) {
+            part.setStatus(status);
+            workorderPartRepository.save(part);
+            log.info("Part {} on workorder {} marked COMPLETED by {}", partId, workorderId, actorId);
+        }
+        return WorkorderItemCompletionResponse.builder()
+                .workorderId(workorderId)
+                .itemId(partId)
+                .itemType(WorkorderItemCompletionResponse.ItemType.PART)
+                .status(status)
+                .build();
+    }
+
+    /**
+     * Validate an item is completable and return COMPLETED. Idempotent when already
+     * COMPLETED; rejects CANCELLED and PENDING_APPROVAL (unapproved) items.
+     */
+    private WorkorderItemStatus completeItemStatus(@Nullable WorkorderItemStatus current, String label, UUID itemId) {
+        if (current == WorkorderItemStatus.COMPLETED) {
+            return WorkorderItemStatus.COMPLETED;
+        }
+        if (current == WorkorderItemStatus.CANCELLED || current == WorkorderItemStatus.PENDING_APPROVAL) {
+            throw new IllegalStateException("Cannot complete " + label + " " + itemId + " in status " + current);
+        }
+        return WorkorderItemStatus.COMPLETED;
+    }
+
+    private boolean partBelongsToWorkorder(WorkorderPart part, UUID workorderId) {
+        if (part.getWorkorder() != null
+                && workorderId.equals(part.getWorkorder().getId())) {
+            return true;
+        }
+        return part.getWorkOrderService() != null
+                && part.getWorkOrderService().getWorkOrder() != null
+                && workorderId.equals(part.getWorkOrderService().getWorkOrder().getId());
     }
 
     @Override

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderStateMachine.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderStateMachine.java
@@ -57,6 +57,11 @@ public class WorkorderStateMachine {
     private static final Set<WorkorderItemStatus> TERMINAL_ITEM_STATUSES =
             Set.of(WorkorderItemStatus.COMPLETED, WorkorderItemStatus.CANCELLED);
 
+    // Active item states that are auto-completed when the workorder is completed (issue #736).
+    // PENDING_APPROVAL is intentionally excluded so unapproved change-request items still block.
+    private static final Set<WorkorderItemStatus> AUTO_COMPLETABLE_ITEM_STATUSES =
+            Set.of(WorkorderItemStatus.OPEN, WorkorderItemStatus.READY_TO_EXECUTE, WorkorderItemStatus.IN_PROGRESS);
+
     private static final Set<WorkorderItemStatus> EXCLUDED_BILLABLE_TOTAL_STATUSES =
             Set.of(WorkorderItemStatus.CANCELLED);
 
@@ -98,6 +103,32 @@ public class WorkorderStateMachine {
         recordTransition(workorderId, fromStatus, toStatus, actorId, reason);
 
         log.info("Workorder {} transitioned from {} to {} by user {}", workorderId, fromStatus, toStatus, actorId);
+    }
+
+    private void autoCompleteOutstandingItems(UUID workorderId, String actorId) {
+        int updated = 0;
+        for (com.positivity.workorder.internal.entity.WorkorderServiceLine service :
+                workorderServiceRepository.findByWorkOrder_Id(workorderId)) {
+            if (AUTO_COMPLETABLE_ITEM_STATUSES.contains(service.getStatus())) {
+                service.setStatus(WorkorderItemStatus.COMPLETED);
+                workorderServiceRepository.save(service);
+                updated++;
+            }
+        }
+        for (WorkorderPart part : loadDeduplicatedWorkorderParts(workorderId)) {
+            if (AUTO_COMPLETABLE_ITEM_STATUSES.contains(part.getStatus())) {
+                part.setStatus(WorkorderItemStatus.COMPLETED);
+                workorderPartRepository.save(part);
+                updated++;
+            }
+        }
+        if (updated > 0) {
+            log.info(
+                    "Auto-completed {} outstanding item(s) on workorder {} during completion by {}",
+                    updated,
+                    workorderId,
+                    actorId);
+        }
     }
 
     private void validateCompletionRequirements(UUID workorderId) {
@@ -241,6 +272,10 @@ public class WorkorderStateMachine {
                     "Workorder %s cannot be completed from status %s. Must be one of: %s",
                     workorderId, currentStatus, COMPLETION_ELIGIBLE_STATUSES));
         }
+
+        // Auto-complete any outstanding work items so completion is not deadlocked (issue #736).
+        // Items that were explicitly completed/cancelled, or are PENDING_APPROVAL, are left as-is.
+        autoCompleteOutstandingItems(workorderId, actorId);
 
         // Finalize immutable billable scope snapshot before completion transition
         captureBillableScopeSnapshot(workorder, actorId, completionNotes);

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/WorkorderService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/WorkorderService.java
@@ -3,6 +3,7 @@ package com.positivity.workorder.service;
 import com.positivity.workorder.internal.dto.AssignmentUpdatedEvent;
 import com.positivity.workorder.internal.dto.OperationalContextOverrideRequest;
 import com.positivity.workorder.internal.dto.OperationalContextResponse;
+import com.positivity.workorder.internal.dto.WorkorderItemCompletionResponse;
 import com.positivity.workorder.internal.dto.WorkorderStartResponse;
 import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.enums.WorkorderStatus;
@@ -24,6 +25,33 @@ public interface WorkorderService {
     Optional<Workorder> getWorkorderById(UUID id);
 
     Workorder createWorkorder(UUID estimateId, UUID customerId);
+
+    /**
+     * Mark a single workorder service line as COMPLETED. Allowed from active item states
+     * (OPEN / READY_TO_EXECUTE / IN_PROGRESS); rejected for CANCELLED or PENDING_APPROVAL.
+     * Completing an already-COMPLETED item is idempotent.
+     *
+     * @param workorderId   owning workorder
+     * @param serviceLineId service line to complete
+     * @param actorId       acting user
+     * @return completion result with the resulting item status
+     */
+    @NonNull
+    WorkorderItemCompletionResponse completeServiceItem(
+            @NonNull UUID workorderId, @NonNull UUID serviceLineId, @NonNull String actorId);
+
+    /**
+     * Mark a single workorder part as COMPLETED. Same transition rules as
+     * {@link #completeServiceItem}.
+     *
+     * @param workorderId owning workorder
+     * @param partId      part to complete
+     * @param actorId     acting user
+     * @return completion result with the resulting item status
+     */
+    @NonNull
+    WorkorderItemCompletionResponse completePartItem(
+            @NonNull UUID workorderId, @NonNull UUID partId, @NonNull String actorId);
 
     /**
      * Create a workorder with idempotency key support.

--- a/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkorderCompletionContractBehaviorIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkorderCompletionContractBehaviorIT.java
@@ -169,13 +169,40 @@ class WorkorderCompletionContractBehaviorIT extends BaseContractIntegrationTest 
     }
 
     @Test
-    @DisplayName("CWC-003: complete workorder is blocked when service/part items are not terminal")
-    void completeWorkorder_ShouldBlockWhenItemsNotTerminal() {
+    @DisplayName("CWC-003: complete workorder auto-completes outstanding OPEN items (issue #736)")
+    void completeWorkorder_ShouldAutoCompleteOutstandingItems() {
         UUID workorderId = seedWorkorder(WorkorderStatus.WORK_IN_PROGRESS, false);
-        seedServiceItem(workorderId, WorkorderItemStatus.OPEN, new BigDecimal("95.00"));
+        UUID serviceId = seedServiceItem(workorderId, WorkorderItemStatus.OPEN, new BigDecimal("95.00"));
+        UUID partId = seedPartItem(workorderId, WorkorderItemStatus.OPEN, new BigDecimal("40.00"));
 
         Map<String, Object> request =
-                Map.of("userId", SYSTEM_USER_ID, "completionNotes", "Attempt completion with open items");
+                Map.of("userId", SYSTEM_USER_ID, "completionNotes", "Complete with outstanding open items");
+
+        givenWithGatewayAuth()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/v1/workorders/{workorderId}/complete", workorderId)
+                .then()
+                .statusCode(200)
+                .body("currentStatus", equalTo("COMPLETED"));
+
+        assertThat(workorderRepository.findById(workorderId).orElseThrow().getStatus())
+                .isEqualTo(WorkorderStatus.COMPLETED);
+        assertThat(workorderServiceRepository.findById(serviceId).orElseThrow().getStatus())
+                .isEqualTo(WorkorderItemStatus.COMPLETED);
+        assertThat(workorderPartRepository.findById(partId).orElseThrow().getStatus())
+                .isEqualTo(WorkorderItemStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("CWC-003B: complete workorder is still blocked by PENDING_APPROVAL items")
+    void completeWorkorder_ShouldBlockWhenItemsPendingApproval() {
+        UUID workorderId = seedWorkorder(WorkorderStatus.WORK_IN_PROGRESS, false);
+        seedServiceItem(workorderId, WorkorderItemStatus.PENDING_APPROVAL, new BigDecimal("95.00"));
+
+        Map<String, Object> request =
+                Map.of("userId", SYSTEM_USER_ID, "completionNotes", "Attempt completion with unapproved item");
 
         givenWithGatewayAuth()
                 .contentType(ContentType.JSON)
@@ -186,8 +213,45 @@ class WorkorderCompletionContractBehaviorIT extends BaseContractIntegrationTest 
                 .statusCode(400)
                 .body("message", notNullValue());
 
-        Workorder workorder = workorderRepository.findById(workorderId).orElseThrow();
-        assertThat(workorder.getStatus()).isEqualTo(WorkorderStatus.WORK_IN_PROGRESS);
+        assertThat(workorderRepository.findById(workorderId).orElseThrow().getStatus())
+                .isEqualTo(WorkorderStatus.WORK_IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("CWC-007: per-item complete endpoints transition service/part items to COMPLETED")
+    void completeItemEndpoints_ShouldMarkItemsCompleted() {
+        UUID workorderId = seedWorkorder(WorkorderStatus.WORK_IN_PROGRESS, false);
+        UUID serviceId = seedServiceItem(workorderId, WorkorderItemStatus.OPEN, new BigDecimal("95.00"));
+        UUID partId = seedPartItem(workorderId, WorkorderItemStatus.OPEN, new BigDecimal("40.00"));
+
+        givenWithGatewayAuth()
+                .when()
+                .post("/v1/workorders/{workorderId}/services/{serviceLineId}/complete", workorderId, serviceId)
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("COMPLETED"));
+
+        givenWithGatewayAuth()
+                .when()
+                .post("/v1/workorders/{workorderId}/parts/{partId}/complete", workorderId, partId)
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("COMPLETED"));
+
+        assertThat(workorderServiceRepository.findById(serviceId).orElseThrow().getStatus())
+                .isEqualTo(WorkorderItemStatus.COMPLETED);
+        assertThat(workorderPartRepository.findById(partId).orElseThrow().getStatus())
+                .isEqualTo(WorkorderItemStatus.COMPLETED);
+
+        // With items terminal, completion succeeds.
+        givenWithGatewayAuth()
+                .contentType(ContentType.JSON)
+                .body(Map.of("userId", SYSTEM_USER_ID, "completionNotes", "Done"))
+                .when()
+                .post("/v1/workorders/{workorderId}/complete", workorderId)
+                .then()
+                .statusCode(200)
+                .body("currentStatus", equalTo("COMPLETED"));
     }
 
     @Test
@@ -288,7 +352,7 @@ class WorkorderCompletionContractBehaviorIT extends BaseContractIntegrationTest 
         return saved.getId();
     }
 
-    private void seedServiceItem(UUID workorderId, WorkorderItemStatus status, BigDecimal lineTotal) {
+    private UUID seedServiceItem(UUID workorderId, WorkorderItemStatus status, BigDecimal lineTotal) {
         Workorder workorder = workorderRepository.findById(workorderId).orElseThrow();
 
         WorkorderServiceLine service = WorkorderServiceLine.builder()
@@ -304,10 +368,10 @@ class WorkorderCompletionContractBehaviorIT extends BaseContractIntegrationTest 
                 .isEmergencySafety(false)
                 .build();
 
-        workorderServiceRepository.save(service);
+        return workorderServiceRepository.save(service).getId();
     }
 
-    private void seedPartItem(UUID workorderId, WorkorderItemStatus status, BigDecimal lineTotal) {
+    private UUID seedPartItem(UUID workorderId, WorkorderItemStatus status, BigDecimal lineTotal) {
         Workorder workorder = workorderRepository.findById(workorderId).orElseThrow();
 
         WorkorderPart part = WorkorderPart.builder()
@@ -325,7 +389,7 @@ class WorkorderCompletionContractBehaviorIT extends BaseContractIntegrationTest 
                 .quantityReturned(BigDecimal.ZERO)
                 .build();
 
-        workorderPartRepository.save(part);
+        return workorderPartRepository.save(part).getId();
     }
 
     private void seedPendingApprovalGatedChangeRequest(UUID workorderId) {

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderItemCompletionTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderItemCompletionTest.java
@@ -1,0 +1,126 @@
+package com.positivity.workorder.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.dto.WorkorderItemCompletionResponse;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.enums.WorkorderItemStatus;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import com.positivity.workorder.internal.service.WorkorderServiceImpl;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class WorkorderItemCompletionTest {
+
+    private static final UUID WORKORDER = UUID.fromString("11111111-0000-0000-0000-000000000001");
+    private static final UUID ITEM = UUID.fromString("22222222-0000-0000-0000-000000000001");
+
+    @Mock
+    private WorkorderServiceRepository workorderServiceRepository;
+
+    @Mock
+    private WorkorderPartRepository workorderPartRepository;
+
+    @InjectMocks
+    private WorkorderServiceImpl service;
+
+    private WorkorderServiceLine line(WorkorderItemStatus status, UUID workorderId) {
+        return WorkorderServiceLine.builder()
+                .id(ITEM)
+                .workOrder(
+                        workorderId == null
+                                ? null
+                                : Workorder.builder().id(workorderId).build())
+                .status(status)
+                .build();
+    }
+
+    private WorkorderPart part(WorkorderItemStatus status, UUID workorderId) {
+        return WorkorderPart.builder()
+                .id(ITEM)
+                .workorder(
+                        workorderId == null
+                                ? null
+                                : Workorder.builder().id(workorderId).build())
+                .status(status)
+                .build();
+    }
+
+    @Test
+    void completeServiceItem_marksOpenLineCompleted() {
+        when(workorderServiceRepository.findById(ITEM))
+                .thenReturn(Optional.of(line(WorkorderItemStatus.OPEN, WORKORDER)));
+
+        WorkorderItemCompletionResponse res = service.completeServiceItem(WORKORDER, ITEM, "tech");
+
+        assertThat(res.getStatus()).isEqualTo(WorkorderItemStatus.COMPLETED);
+        assertThat(res.getItemType()).isEqualTo(WorkorderItemCompletionResponse.ItemType.SERVICE);
+        verify(workorderServiceRepository).save(any());
+    }
+
+    @Test
+    void completeServiceItem_isIdempotentWhenAlreadyCompleted() {
+        when(workorderServiceRepository.findById(ITEM))
+                .thenReturn(Optional.of(line(WorkorderItemStatus.COMPLETED, WORKORDER)));
+
+        WorkorderItemCompletionResponse res = service.completeServiceItem(WORKORDER, ITEM, "tech");
+
+        assertThat(res.getStatus()).isEqualTo(WorkorderItemStatus.COMPLETED);
+        verify(workorderServiceRepository, never()).save(any());
+    }
+
+    @Test
+    void completeServiceItem_rejectsCancelled() {
+        when(workorderServiceRepository.findById(ITEM))
+                .thenReturn(Optional.of(line(WorkorderItemStatus.CANCELLED, WORKORDER)));
+
+        assertThatThrownBy(() -> service.completeServiceItem(WORKORDER, ITEM, "tech"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void completeServiceItem_rejectsForeignWorkorder() {
+        UUID other = UUID.fromString("99999999-0000-0000-0000-000000000009");
+        when(workorderServiceRepository.findById(ITEM)).thenReturn(Optional.of(line(WorkorderItemStatus.OPEN, other)));
+
+        assertThatThrownBy(() -> service.completeServiceItem(WORKORDER, ITEM, "tech"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void completePartItem_marksOpenPartCompleted() {
+        when(workorderPartRepository.findById(ITEM)).thenReturn(Optional.of(part(WorkorderItemStatus.OPEN, WORKORDER)));
+
+        WorkorderItemCompletionResponse res = service.completePartItem(WORKORDER, ITEM, "tech");
+
+        assertThat(res.getStatus()).isEqualTo(WorkorderItemStatus.COMPLETED);
+        assertThat(res.getItemType()).isEqualTo(WorkorderItemCompletionResponse.ItemType.PART);
+        verify(workorderPartRepository).save(any());
+    }
+
+    @Test
+    void completePartItem_rejectsPendingApproval() {
+        when(workorderPartRepository.findById(ITEM))
+                .thenReturn(Optional.of(part(WorkorderItemStatus.PENDING_APPROVAL, WORKORDER)));
+
+        assertThatThrownBy(() -> service.completePartItem(WORKORDER, ITEM, "tech"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
Closes #736.

## Root cause (confirmed)
Workorder service/part items are created **OPEN** at estimate→workorder promotion, but **no API path ever set them to COMPLETED** (labor start/stop, pick complete/consume, return/correct, and change-request flows never touch item status except CR → READY_TO_EXECUTE / CANCELLED / PENDING_APPROVAL). `completeWorkorder` requires every item in `{COMPLETED, CANCELLED}`, so a real workorder could never be completed. The IT masked it by DB-seeding `COMPLETED`.

## Fixes (both, per decision)
**Option 2 — per-item completion endpoints**
- `POST /v1/workorders/{id}/services/{serviceLineId}/complete`
- `POST /v1/workorders/{id}/parts/{partId}/complete`
- Perm `workorder:workorder:complete`. Allowed from OPEN/READY_TO_EXECUTE/IN_PROGRESS; idempotent on COMPLETED; 400 for CANCELLED/PENDING_APPROVAL; 404 on unknown/foreign item. New `WorkorderItemCompletionResponse`.

**Option 3 — auto-terminalize on completion**
- `completeWorkorder` flips remaining active items (OPEN/READY_TO_EXECUTE/IN_PROGRESS) to COMPLETED before validation, so completion never deadlocks. `PENDING_APPROVAL` is excluded and still blocks (unapproved change-request work).

## Tests
- `WorkorderCompletionContractBehaviorIT` rewritten to drive the **real API** (no COMPLETED seeding): CWC-003 auto-completion, CWC-003B PENDING_APPROVAL still blocks, CWC-007 per-item endpoints.
- `WorkorderItemCompletionTest` unit coverage.
- Full pos-workorder suite green: **302 unit + 8 completion IT**.

## Contract
`openapi.yaml` regenerated (2 new endpoints + `WorkorderItemCompletionResponse`). SDK/frontend follow-ups can expose the per-item endpoints if a UI is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)