### PR TITLE
fix(workorder): use crm:vehicle:view for vehicle resolution

### DIFF
--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/VehicleReferenceService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/VehicleReferenceService.java
@@ -54,7 +54,7 @@ public class VehicleReferenceService {
                     .get()
                     .uri("/v1/crm/{customerId}/vehicles/{vehicleId}", customerId, vehicleId)
                     .header("X-User", "pos-workorder")
-                    .header("X-Authorities", "crm:party:view")
+                    .header("X-Authorities", "crm:vehicle:view")
                     .retrieve()
                     .body(Map.class);
             if (body == null || body.isEmpty()) {
@@ -102,7 +102,7 @@ public class VehicleReferenceService {
                     .get()
                     .uri("/v1/crm/{customerId}/vehicles", customerId)
                     .header("X-User", "pos-workorder")
-                    .header("X-Authorities", "crm:party:view")
+                    .header("X-Authorities", "crm:vehicle:view")
                     .retrieve()
                     .body(List.class);
             if (rows == null || rows.isEmpty()) {


### PR DESCRIPTION
## Problem
After #737 deployed to alpha, **customer names resolve but vehicle label/VIN still fall back** to `vehicle-<id>`. Root cause: the pos-customer vehicle endpoints (`GET /v1/crm/{customerId}/vehicles[/{vehicleId}]`, `CrmVehiclesController`) require **`crm:vehicle:view`**, but `VehicleReferenceService` sent **`crm:party:view`** in the service-to-service `X-Authorities` header → 403 → fail-soft fallback. (Live probing with the admin token masked this — it carries all perms.)

## Fix
Send `crm:vehicle:view` on both the single-vehicle and list calls.

## Verification
`VehicleReferenceServiceHttpTest` green. Will re-confirm on alpha after deploy (real label/VIN in the finder dropdowns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)