### PR TITLE
fix(people): re-run operational seed to populate person_location_assignment

### DIFF
--- a/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
@@ -1,4 +1,9 @@
 -- Repeatable seed migration for pos-people operational data.
+-- Re-run marker 2026-06-24: bump checksum so Flyway re-applies this repeatable.
+-- person_location_assignment rows are guarded by `WHERE EXISTS (location id=...)`; on the
+-- first run the location rows did not yet exist (cross-module seed ordering), so every
+-- assignment was skipped and the repeatable did not retry. Re-applying now that locations
+-- are present populates them (idempotent via ON CONFLICT DO NOTHING).
 -- 39 employees across 7 roles for Durion Positivity (medium truck mechanical repair corporation).
 -- Service centers carry the full shop-operational role set and are staffed with
 -- at least one technician per bay (±2); corporate roles remain at CORP-HQ-001.


### PR DESCRIPTION
## Problem
`person_location_assignment` is empty on alpha → the people-availability query returns no staff for any location → employees don't show where assigned.

## Root cause
The repeatable seed `R__seed_people_operational_data.sql` inserts 17 assignment rows, each guarded by `WHERE EXISTS (SELECT 1 FROM location WHERE id = '<loc>')`. When pos-people seeded **before** pos-location populated `location`, all guards were false → 0 inserted. Being a *repeatable* migration with an unchanged checksum, it never retried after locations appeared → table stays empty.

## Fix
Bump the file's checksum (header comment) so Flyway re-applies the repeatable on the next pos-people deploy. Locations now exist, so the guards pass and the rows insert; idempotent via `ON CONFLICT (id) DO NOTHING`.

## Note / follow-up
Real cause is cross-module seed ordering. Durable hardening (separate change): make assignment seeding resilient to ordering (e.g., re-evaluated post-location, or a verified deferred seed) so fresh environments don't hit this. This PR unblocks current envs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)