### PR TITLE
refactor(people): move primary/secondary email to person_contact_point (EMAIL)

### DIFF
--- a/pos-people/src/main/java/com/positivity/people/internal/entity/Person.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/Person.java
@@ -82,11 +82,8 @@ public class Person {
     @Column(name = "updated_at")
     private Instant updatedAt;
 
-    private String primaryEmail;
-
-    private String secondaryEmail;
-
-    // Phone numbers consolidated into person_contact_point (PHONE_WORK); see PersonWorkPhoneService.
+    // Email + phone numbers consolidated into person_contact_point (EMAIL / PHONE_WORK);
+    // see PersonEmailService / PersonWorkPhoneService.
 
     /** Optional, validated externally - stick with username not userName */
     private String username;

--- a/pos-people/src/main/java/com/positivity/people/internal/repository/PersonContactPointRepository.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/PersonContactPointRepository.java
@@ -27,6 +27,12 @@ public interface PersonContactPointRepository extends JpaRepository<PersonContac
 
     List<PersonContactPoint> findByContactTypeAndValue(@NonNull ContactPointType contactType, @NonNull String value);
 
+    List<PersonContactPoint> findByContactTypeAndValueIgnoreCase(
+            @NonNull ContactPointType contactType, @NonNull String value);
+
+    List<PersonContactPoint> findByContactTypeAndIsPrimaryAndValueIgnoreCase(
+            @NonNull ContactPointType contactType, boolean isPrimary, @NonNull String value);
+
     void deleteByPersonId(@NonNull UUID personId);
 
     @Modifying

--- a/pos-people/src/main/java/com/positivity/people/internal/repository/PersonRepository.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/PersonRepository.java
@@ -2,26 +2,17 @@ package com.positivity.people.internal.repository;
 
 import com.positivity.people.internal.entity.Person;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface PersonRepository extends JpaRepository<Person, UUID>, JpaSpecificationExecutor<Person> {
 
-    Optional<Person> findByPrimaryEmailIgnoreCase(String primaryEmail);
-
-    Optional<Person> findBySecondaryEmailIgnoreCase(String secondaryEmail);
-
     boolean existsByUsername(String username);
 
     boolean existsByEmployeeNumberIgnoreCase(String employeeNumber);
 
     boolean existsByEmployeeNumberIgnoreCaseAndIdNot(String employeeNumber, UUID id);
-
-    boolean existsByPrimaryEmailIgnoreCase(String primaryEmail);
-
-    boolean existsByPrimaryEmailIgnoreCaseAndIdNot(String primaryEmail, UUID id);
 
     List<Person> findByLegalNameIgnoreCase(String legalName);
 

--- a/pos-people/src/main/java/com/positivity/people/internal/repository/PersonSpecifications.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/PersonSpecifications.java
@@ -1,10 +1,15 @@
 package com.positivity.people.internal.repository;
 
 import com.positivity.people.internal.entity.Person;
+import com.positivity.people.internal.entity.PersonContactPoint;
+import com.positivity.people.internal.enums.ContactPointType;
 import com.positivity.people.internal.enums.EmployeeStatus;
 import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.domain.Specification;
 
 public final class PersonSpecifications {
@@ -28,28 +33,38 @@ public final class PersonSpecifications {
                     }
                     case "INACTIVE" -> {
                         predicates.add(cb.isNotNull(root.get("employeeNumber")));
-                        predicates.add(root.get("status").in(
-                                EmployeeStatus.ON_LEAVE,
-                                EmployeeStatus.SUSPENDED,
-                                EmployeeStatus.TERMINATED,
-                                EmployeeStatus.DISABLED));
+                        predicates.add(root.get("status")
+                                .in(
+                                        EmployeeStatus.ON_LEAVE,
+                                        EmployeeStatus.SUSPENDED,
+                                        EmployeeStatus.TERMINATED,
+                                        EmployeeStatus.DISABLED));
                     }
-                    default -> { /* ALL or unrecognised — no predicate */ }
+                    default -> {
+                        /* ALL or unrecognised — no predicate */
+                    }
                 }
             }
 
             if (q != null && !q.isBlank()) {
                 String pattern = "%" + q.trim().toLowerCase() + "%";
+                // Email now lives in person_contact_point; match it via a correlated subquery
+                // on EMAIL contact-point values.
+                Subquery<UUID> emailMatch = query.subquery(UUID.class);
+                Root<PersonContactPoint> cp = emailMatch.from(PersonContactPoint.class);
+                emailMatch
+                        .select(cp.get("personId"))
+                        .where(cb.and(
+                                cb.equal(cp.get("contactType"), ContactPointType.EMAIL),
+                                cb.like(cb.lower(cp.get("value")), pattern)));
                 predicates.add(cb.or(
                         cb.like(cb.lower(root.get("firstName")), pattern),
                         cb.like(cb.lower(root.get("lastName")), pattern),
-                        cb.like(cb.lower(root.get("primaryEmail")), pattern),
-                        cb.like(cb.lower(root.get("username")), pattern)));
+                        cb.like(cb.lower(root.get("username")), pattern),
+                        root.get("id").in(emailMatch)));
             }
 
-            return predicates.isEmpty()
-                    ? cb.conjunction()
-                    : cb.and(predicates.toArray(new Predicate[0]));
+            return predicates.isEmpty() ? cb.conjunction() : cb.and(predicates.toArray(new Predicate[0]));
         };
     }
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/service/EmployeeServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/EmployeeServiceImpl.java
@@ -42,6 +42,8 @@ public class EmployeeServiceImpl implements EmployeeService {
 
     private final PersonWorkPhoneService workPhoneService;
 
+    private final PersonEmailService emailService;
+
     private final EmployeeOffboardingRetryRepository offboardingRetryRepository;
 
     private final ObjectMapper objectMapper;
@@ -71,6 +73,14 @@ public class EmployeeServiceImpl implements EmployeeService {
 
         Person saved = personRepository.save(entity);
         workPhoneService.replaceWorkPhones(saved.getId(), extractPhones(request.getContactInfo()));
+        emailService.replaceEmails(
+                saved.getId(),
+                request.getContactInfo() == null
+                        ? null
+                        : normalize(request.getContactInfo().getPrimaryEmail()),
+                request.getContactInfo() == null
+                        ? null
+                        : normalize(request.getContactInfo().getSecondaryEmail()));
         return toEmployeeProfile(saved, warnings);
     }
 
@@ -116,6 +126,14 @@ public class EmployeeServiceImpl implements EmployeeService {
 
         Person saved = personRepository.save(entity);
         workPhoneService.replaceWorkPhones(saved.getId(), extractPhones(request.getContactInfo()));
+        emailService.replaceEmails(
+                saved.getId(),
+                request.getContactInfo() == null
+                        ? null
+                        : normalize(request.getContactInfo().getPrimaryEmail()),
+                request.getContactInfo() == null
+                        ? null
+                        : normalize(request.getContactInfo().getSecondaryEmail()));
         return toEmployeeProfile(saved, warnings);
     }
 
@@ -198,9 +216,8 @@ public class EmployeeServiceImpl implements EmployeeService {
                 : personRepository.existsByEmployeeNumberIgnoreCaseAndIdNot(employeeNumber, employeeId);
 
         boolean duplicatePrimaryEmail = primaryEmail != null
-                && (employeeId == null
-                        ? personRepository.existsByPrimaryEmailIgnoreCase(primaryEmail)
-                        : personRepository.existsByPrimaryEmailIgnoreCaseAndIdNot(primaryEmail, employeeId));
+                && emailService.findPersonIdsByPrimaryEmail(primaryEmail).stream()
+                        .anyMatch(id -> employeeId == null || !id.equals(employeeId));
 
         boolean duplicatePhone = hasDuplicatePhone(employeeId, primaryPhone, secondaryPhone);
         return new DuplicateSignals(duplicateEmployeeNumber, duplicatePrimaryEmail, duplicatePhone);
@@ -258,14 +275,12 @@ public class EmployeeServiceImpl implements EmployeeService {
         }
 
         if (contactInfo != null) {
-            entity.setPrimaryEmail(normalize(contactInfo.getPrimaryEmail()));
-            entity.setSecondaryEmail(normalize(contactInfo.getSecondaryEmail()));
             entity.setContactInfoJson(writeContactInfo(contactInfo));
         } else {
             entity.setContactInfoJson(null);
         }
-        // Phone numbers are persisted separately as PHONE_WORK contact points after save
-        // (see createEmployee/updateEmployee); not stored on the Person entity.
+        // Email + phone numbers are persisted separately as EMAIL / PHONE_WORK contact points
+        // after save (see createEmployee/updateEmployee); not stored on the Person entity.
     }
 
     /** Primary + secondary phone from contact info, normalized and blank-filtered. */
@@ -342,8 +357,9 @@ public class EmployeeServiceImpl implements EmployeeService {
     }
 
     private EmployeeContactInfoDto contactInfoFromColumns(Person person) {
-        String primaryEmail = normalize(person.getPrimaryEmail());
-        String secondaryEmail = normalize(person.getSecondaryEmail());
+        PersonEmailService.EmailPair emails = emailService.getEmails(person.getId());
+        String primaryEmail = normalize(emails.primary());
+        String secondaryEmail = normalize(emails.secondary());
         List<String> phones = workPhoneService.getWorkPhones(person.getId());
         String primaryPhone = phones.size() > 0 ? normalize(phones.get(0)) : null;
         String secondaryPhone = phones.size() > 1 ? normalize(phones.get(1)) : null;

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PersonEmailService.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PersonEmailService.java
@@ -1,0 +1,90 @@
+package com.positivity.people.internal.service;
+
+import com.positivity.people.internal.entity.PersonContactPoint;
+import com.positivity.people.internal.enums.ContactPointType;
+import com.positivity.people.internal.repository.PersonContactPointRepository;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Reads and writes a person's primary/secondary email through {@link PersonContactPoint}
+ * rows of type {@link ContactPointType#EMAIL} (primary = {@code isPrimary} true),
+ * replacing the former primary_email / secondary_email columns on Person.
+ */
+@Service
+@RequiredArgsConstructor
+public class PersonEmailService {
+
+    private final PersonContactPointRepository contactPointRepository;
+
+    /** Primary + secondary email for a person. */
+    public record EmailPair(
+            @Nullable String primary, @Nullable String secondary) {}
+
+    public @NonNull EmailPair getEmails(@NonNull UUID personId) {
+        List<PersonContactPoint> points =
+                contactPointRepository.findByPersonIdAndContactType(personId, ContactPointType.EMAIL);
+        String primary = points.stream()
+                .filter(PersonContactPoint::isPrimary)
+                .map(PersonContactPoint::getValue)
+                .findFirst()
+                .orElseGet(() -> points.stream()
+                        .map(PersonContactPoint::getValue)
+                        .findFirst()
+                        .orElse(null));
+        String secondary = points.stream()
+                .filter(p -> !p.isPrimary())
+                .map(PersonContactPoint::getValue)
+                .filter(value -> !Objects.equals(value, primary))
+                .findFirst()
+                .orElse(null);
+        return new EmailPair(primary, secondary);
+    }
+
+    /** Replace a person's email contact points with the given primary/secondary (blanks skipped). */
+    @Transactional
+    public void replaceEmails(@NonNull UUID personId, @Nullable String primary, @Nullable String secondary) {
+        contactPointRepository.deleteByPersonIdAndContactType(personId, ContactPointType.EMAIL);
+        if (primary != null && !primary.isBlank()) {
+            contactPointRepository.save(build(personId, primary.trim(), true));
+        }
+        if (secondary != null && !secondary.isBlank()) {
+            contactPointRepository.save(build(personId, secondary.trim(), false));
+        }
+    }
+
+    /** Person ids that hold the given value as any EMAIL contact point (case-insensitive). */
+    public @NonNull List<UUID> findPersonIdsByEmail(@NonNull String email) {
+        return contactPointRepository.findByContactTypeAndValueIgnoreCase(ContactPointType.EMAIL, email).stream()
+                .map(PersonContactPoint::getPersonId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    /** Person ids that hold the given value as a PRIMARY email (case-insensitive); duplicate detection. */
+    public @NonNull List<UUID> findPersonIdsByPrimaryEmail(@NonNull String email) {
+        return contactPointRepository
+                .findByContactTypeAndIsPrimaryAndValueIgnoreCase(ContactPointType.EMAIL, true, email)
+                .stream()
+                .map(PersonContactPoint::getPersonId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private PersonContactPoint build(UUID personId, String value, boolean primary) {
+        return PersonContactPoint.builder()
+                .personId(personId)
+                .contactType(ContactPointType.EMAIL)
+                .value(value)
+                .isPrimary(primary)
+                .build();
+    }
+}

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PersonServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PersonServiceImpl.java
@@ -47,6 +47,8 @@ public class PersonServiceImpl implements PersonService {
 
     private final PersonWorkPhoneService workPhoneService;
 
+    private final PersonEmailService emailService;
+
     private final SecurityServiceClient securityServiceClient;
 
     @Value("${pos.people.matching.threshold:30}")
@@ -120,6 +122,7 @@ public class PersonServiceImpl implements PersonService {
         com.positivity.people.internal.entity.Person saved = personRepository.save(toEntity(person));
         workPhoneService.replaceWorkPhones(
                 saved.getId(), person.getPhoneNumbers() == null ? List.of() : person.getPhoneNumbers());
+        emailService.replaceEmails(saved.getId(), person.getPrimaryEmail(), person.getSecondaryEmail());
         return toDto(saved);
     }
 
@@ -140,12 +143,12 @@ public class PersonServiceImpl implements PersonService {
         Map<UUID, ScoredCandidate> candidates = new HashMap<>();
 
         if (email != null) {
-            personRepository
-                    .findByPrimaryEmailIgnoreCase(email)
-                    .ifPresent(person -> addScore(candidates, person, EMAIL_WEIGHT, "EMAIL"));
-            personRepository
-                    .findBySecondaryEmailIgnoreCase(email)
-                    .ifPresent(person -> addScore(candidates, person, EMAIL_WEIGHT, "EMAIL"));
+            List<UUID> emailMatchIds = emailService.findPersonIdsByEmail(email);
+            if (!emailMatchIds.isEmpty()) {
+                personRepository
+                        .findAllById(emailMatchIds)
+                        .forEach(person -> addScore(candidates, person, EMAIL_WEIGHT, "EMAIL"));
+            }
         }
 
         if (phone != null) {
@@ -186,7 +189,8 @@ public class PersonServiceImpl implements PersonService {
                     .matchedBy(new ArrayList<>(matched.getMatchedBy()))
                     .firstName(matched.getPerson().getFirstName())
                     .lastName(matched.getPerson().getLastName())
-                    .primaryEmail(matched.getPerson().getPrimaryEmail())
+                    .primaryEmail(
+                            emailService.getEmails(matched.getPerson().getId()).primary())
                     .phoneNumbers(
                             workPhoneService.getWorkPhones(matched.getPerson().getId()))
                     .build();
@@ -195,11 +199,11 @@ public class PersonServiceImpl implements PersonService {
         com.positivity.people.internal.entity.Person entity = new com.positivity.people.internal.entity.Person();
         entity.setFirstName(firstName);
         entity.setLastName(lastName);
-        entity.setPrimaryEmail(email);
 
         com.positivity.people.internal.entity.Person created = personRepository.save(entity);
         List<String> createdPhones = phone != null ? List.of(phone) : List.of();
         workPhoneService.replaceWorkPhones(created.getId(), createdPhones);
+        emailService.replaceEmails(created.getId(), email, null);
         return ResolvePersonResponse.builder()
                 .personId(created.getId())
                 .matchedExisting(false)
@@ -208,7 +212,7 @@ public class PersonServiceImpl implements PersonService {
                 .matchedBy(List.of("CREATED"))
                 .firstName(created.getFirstName())
                 .lastName(created.getLastName())
-                .primaryEmail(created.getPrimaryEmail())
+                .primaryEmail(email)
                 .phoneNumbers(createdPhones)
                 .build();
     }
@@ -270,8 +274,9 @@ public class PersonServiceImpl implements PersonService {
         dto.setId(entity.getId());
         dto.setFirstName(entity.getFirstName());
         dto.setLastName(entity.getLastName());
-        dto.setPrimaryEmail(entity.getPrimaryEmail());
-        dto.setSecondaryEmail(entity.getSecondaryEmail());
+        PersonEmailService.EmailPair emails = emailService.getEmails(entity.getId());
+        dto.setPrimaryEmail(emails.primary());
+        dto.setSecondaryEmail(emails.secondary());
         dto.setPhoneNumbers(workPhoneService.getWorkPhones(entity.getId()));
         dto.setUsername(entity.getUsername());
         dto.setEmployeeStatus(entity.getStatus());
@@ -283,9 +288,7 @@ public class PersonServiceImpl implements PersonService {
         entity.setId(dto.getId());
         entity.setFirstName(dto.getFirstName());
         entity.setLastName(dto.getLastName());
-        entity.setPrimaryEmail(dto.getPrimaryEmail());
-        entity.setSecondaryEmail(dto.getSecondaryEmail());
-        // phoneNumbers persisted separately as PHONE_WORK contact points (see savePerson).
+        // email + phoneNumbers persisted separately as EMAIL / PHONE_WORK contact points (see savePerson).
         entity.setUsername(dto.getUsername());
         return entity;
     }

--- a/pos-people/src/main/java/com/positivity/people/internal/service/UserPersonLinkServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/UserPersonLinkServiceImpl.java
@@ -40,13 +40,17 @@ public class UserPersonLinkServiceImpl implements UserPersonLinkService {
 
     private final PersonWorkPhoneService workPhoneService;
 
+    private final PersonEmailService emailService;
+
     public UserPersonLinkServiceImpl(
             @NonNull UserPersonLinkRepository linkRepository,
             @NonNull PersonRepository personRepository,
-            @NonNull PersonWorkPhoneService workPhoneService) {
+            @NonNull PersonWorkPhoneService workPhoneService,
+            @NonNull PersonEmailService emailService) {
         this.linkRepository = linkRepository;
         this.personRepository = personRepository;
         this.workPhoneService = workPhoneService;
+        this.emailService = emailService;
     }
 
     @Override
@@ -201,12 +205,13 @@ public class UserPersonLinkServiceImpl implements UserPersonLinkService {
     }
 
     private PersonResponse toPersonResponse(Person person) {
+        PersonEmailService.EmailPair emails = emailService.getEmails(person.getId());
         return PersonResponse.builder()
                 .id(person.getId())
                 .firstName(person.getFirstName())
                 .lastName(person.getLastName())
-                .primaryEmail(person.getPrimaryEmail())
-                .secondaryEmail(person.getSecondaryEmail())
+                .primaryEmail(emails.primary())
+                .secondaryEmail(emails.secondary())
                 .phoneNumbers(workPhoneService.getWorkPhones(person.getId()))
                 .username(person.getUsername())
                 .build();

--- a/pos-people/src/main/resources/db/migration/V9__consolidate_email_into_contact_point.sql
+++ b/pos-people/src/main/resources/db/migration/V9__consolidate_email_into_contact_point.sql
@@ -1,0 +1,30 @@
+-- Consolidate person primary/secondary email into person_contact_point (EMAIL) and drop
+-- the primary_email / secondary_email columns from person. Email now lives only in
+-- person_contact_point (see PersonEmailService).
+
+-- Backfill primary emails (is_primary = true).
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), p.id, 'EMAIL', p.primary_email, TRUE, NOW(), NOW()
+FROM person p
+WHERE p.primary_email IS NOT NULL
+  AND btrim(p.primary_email) <> ''
+  AND NOT EXISTS (
+        SELECT 1 FROM person_contact_point cp
+        WHERE cp.person_id = p.id
+          AND cp.contact_type = 'EMAIL'
+          AND lower(cp.value) = lower(p.primary_email));
+
+-- Backfill secondary emails (is_primary = false).
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), p.id, 'EMAIL', p.secondary_email, FALSE, NOW(), NOW()
+FROM person p
+WHERE p.secondary_email IS NOT NULL
+  AND btrim(p.secondary_email) <> ''
+  AND NOT EXISTS (
+        SELECT 1 FROM person_contact_point cp
+        WHERE cp.person_id = p.id
+          AND cp.contact_type = 'EMAIL'
+          AND lower(cp.value) = lower(p.secondary_email));
+
+ALTER TABLE person DROP COLUMN primary_email;
+ALTER TABLE person DROP COLUMN secondary_email;

--- a/pos-people/src/test/java/com/positivity/people/ContractBehaviorIT.java
+++ b/pos-people/src/test/java/com/positivity/people/ContractBehaviorIT.java
@@ -503,7 +503,6 @@ class ContractBehaviorIT extends BaseContractIntegrationTest {
                 .id(technicianId)
                 .firstName(firstName)
                 .lastName(lastName)
-                .primaryEmail(firstName.toLowerCase() + "@example.com")
                 .build();
         personRepository.save(person);
     }

--- a/pos-people/src/test/java/com/positivity/people/contract/TimeEntryAdjustmentContractIT.java
+++ b/pos-people/src/test/java/com/positivity/people/contract/TimeEntryAdjustmentContractIT.java
@@ -86,7 +86,6 @@ class TimeEntryAdjustmentContractIT extends BaseContractIntegrationTest {
                         .id(personId)
                         .firstName("Contract")
                         .lastName("User")
-                        .primaryEmail("contract-user@example.com")
                         .build()));
 
         TimeEntry timeEntry = new TimeEntry();

--- a/pos-people/src/test/java/com/positivity/people/contract/TimeEntryApprovalContractIT.java
+++ b/pos-people/src/test/java/com/positivity/people/contract/TimeEntryApprovalContractIT.java
@@ -105,7 +105,6 @@ class TimeEntryApprovalContractIT extends BaseContractIntegrationTest {
                         .id(personId)
                         .firstName("Contract")
                         .lastName("Approver")
-                        .primaryEmail("contract-approver@example.com")
                         .build()));
 
         TimeEntry timeEntry = new TimeEntry();

--- a/pos-people/src/test/java/com/positivity/people/contract/TimekeepingApprovalContractIT.java
+++ b/pos-people/src/test/java/com/positivity/people/contract/TimekeepingApprovalContractIT.java
@@ -32,18 +32,20 @@ class TimekeepingApprovalContractIT extends BaseIntegrationTest {
 
     @Autowired
     private PersonRepository personRepository;
+
     @Autowired
     private TimePeriodRepository timePeriodRepository;
+
     @Autowired
     private TimekeepingEntryRepository timekeepingEntryRepository;
 
     private Person seedPerson() {
-        return personRepository.findById(PERSON_ID).orElseGet(() ->
-                personRepository.save(Person.builder()
+        return personRepository
+                .findById(PERSON_ID)
+                .orElseGet(() -> personRepository.save(Person.builder()
                         .id(PERSON_ID)
                         .firstName("Jane")
                         .lastName("Approver")
-                        .primaryEmail("jane.approver@example.com")
                         .build()));
     }
 
@@ -74,9 +76,7 @@ class TimekeepingApprovalContractIT extends BaseIntegrationTest {
     @DisplayName("CP-664-001: GET /approvals/people returns employees with timekeeping entries")
     void listApprovalPeople_returnsEmployees() throws Exception {
         seedPerson();
-        seedEntry(PERSON_ID,
-                Instant.parse("2026-06-05T09:00:00Z"),
-                Instant.parse("2026-06-05T17:00:00Z"));
+        seedEntry(PERSON_ID, Instant.parse("2026-06-05T09:00:00Z"), Instant.parse("2026-06-05T17:00:00Z"));
 
         mockMvc.perform(withAuth(get("/v1/people/timekeeping/approvals/people"), TIMEKEEPING_AUTHORITIES))
                 .andExpect(status().isOk())
@@ -104,9 +104,7 @@ class TimekeepingApprovalContractIT extends BaseIntegrationTest {
     void listTimekeepingEntries_returnsEntries() throws Exception {
         seedPerson();
         TimePeriod period = seedTimePeriod();
-        seedEntry(PERSON_ID,
-                Instant.parse("2026-06-10T08:00:00Z"),
-                Instant.parse("2026-06-10T16:00:00Z"));
+        seedEntry(PERSON_ID, Instant.parse("2026-06-10T08:00:00Z"), Instant.parse("2026-06-10T16:00:00Z"));
 
         mockMvc.perform(withAuth(
                         get("/v1/people/timekeeping/timekeeping-entries")
@@ -124,9 +122,7 @@ class TimekeepingApprovalContractIT extends BaseIntegrationTest {
     void getTimePeriodApproval_returnsSummary() throws Exception {
         seedPerson();
         TimePeriod period = seedTimePeriod();
-        seedEntry(PERSON_ID,
-                Instant.parse("2026-06-15T08:00:00Z"),
-                Instant.parse("2026-06-15T16:00:00Z"));
+        seedEntry(PERSON_ID, Instant.parse("2026-06-15T08:00:00Z"), Instant.parse("2026-06-15T16:00:00Z"));
 
         mockMvc.perform(withAuth(
                         get("/v1/people/timekeeping/time-period-approvals")
@@ -144,13 +140,13 @@ class TimekeepingApprovalContractIT extends BaseIntegrationTest {
     void approvePeriod_approvesEntries() throws Exception {
         seedPerson();
         TimePeriod period = seedTimePeriod();
-        seedEntry(PERSON_ID,
-                Instant.parse("2026-06-20T08:00:00Z"),
-                Instant.parse("2026-06-20T16:00:00Z"));
+        seedEntry(PERSON_ID, Instant.parse("2026-06-20T08:00:00Z"), Instant.parse("2026-06-20T16:00:00Z"));
 
         mockMvc.perform(withAuth(
-                        post("/v1/people/timekeeping/time-periods/{timePeriodId}/people/{personId}/approve",
-                                period.getTimePeriodId(), PERSON_ID),
+                        post(
+                                "/v1/people/timekeeping/time-periods/{timePeriodId}/people/{personId}/approve",
+                                period.getTimePeriodId(),
+                                PERSON_ID),
                         TIMEKEEPING_AUTHORITIES))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.processedCount", greaterThanOrEqualTo(1)))
@@ -162,17 +158,17 @@ class TimekeepingApprovalContractIT extends BaseIntegrationTest {
     void rejectPeriod_rejectsEntries() throws Exception {
         seedPerson();
         TimePeriod period = seedTimePeriod();
-        seedEntry(PERSON_ID,
-                Instant.parse("2026-06-25T08:00:00Z"),
-                Instant.parse("2026-06-25T16:00:00Z"));
+        seedEntry(PERSON_ID, Instant.parse("2026-06-25T08:00:00Z"), Instant.parse("2026-06-25T16:00:00Z"));
 
         String body = """
                 { "reason": "Discrepancy with shop records" }
                 """;
 
         mockMvc.perform(withAuth(
-                        post("/v1/people/timekeeping/time-periods/{timePeriodId}/people/{personId}/reject",
-                                period.getTimePeriodId(), PERSON_ID)
+                        post(
+                                        "/v1/people/timekeeping/time-periods/{timePeriodId}/people/{personId}/reject",
+                                        period.getTimePeriodId(),
+                                        PERSON_ID)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(body),
                         TIMEKEEPING_AUTHORITIES))
@@ -188,8 +184,10 @@ class TimekeepingApprovalContractIT extends BaseIntegrationTest {
         TimePeriod period = seedTimePeriod();
 
         mockMvc.perform(withAuth(
-                        post("/v1/people/timekeeping/time-periods/{timePeriodId}/people/{personId}/reject",
-                                period.getTimePeriodId(), PERSON_ID)
+                        post(
+                                        "/v1/people/timekeeping/time-periods/{timePeriodId}/people/{personId}/reject",
+                                        period.getTimePeriodId(),
+                                        PERSON_ID)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("{}"),
                         TIMEKEEPING_AUTHORITIES))
@@ -210,7 +208,6 @@ class TimekeepingApprovalContractIT extends BaseIntegrationTest {
     @Test
     @DisplayName("VE-664-003: endpoints require authentication (no auth header → 401)")
     void endpoints_withoutAuth_return401() throws Exception {
-        mockMvc.perform(get("/v1/people/timekeeping/approvals/people"))
-                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/v1/people/timekeeping/approvals/people")).andExpect(status().isUnauthorized());
     }
 }

--- a/pos-people/src/test/java/com/positivity/people/contract/WorkSessionContractIT.java
+++ b/pos-people/src/test/java/com/positivity/people/contract/WorkSessionContractIT.java
@@ -164,8 +164,7 @@ class WorkSessionContractIT extends BaseContractIntegrationTest {
 
         String sessionId = objectMapper.readTree(stopResponse).get("sessionId").asText();
 
-        String submitPayload =
-                """
+        String submitPayload = """
 				{
 				  "billableMinutes": 450,
 				  "breakMinutes": 30,
@@ -185,8 +184,7 @@ class WorkSessionContractIT extends BaseContractIntegrationTest {
     @Test
     @DisplayName("VE-120-003: submitting a non-existent session returns 404")
     void VE_120_003_submitWorkSession_nonExistentSession_returns404() throws Exception {
-        String submitPayload =
-                """
+        String submitPayload = """
 				{
 				  "billableMinutes": 60,
 				  "breakMinutes": 0,
@@ -215,8 +213,7 @@ class WorkSessionContractIT extends BaseContractIntegrationTest {
 
         String sessionId = objectMapper.readTree(startResponse).get("sessionId").asText();
 
-        String submitPayload =
-                """
+        String submitPayload = """
 				{
 				  "billableMinutes": 60,
 				  "breakMinutes": 0,
@@ -243,8 +240,7 @@ class WorkSessionContractIT extends BaseContractIntegrationTest {
 
         String sessionId = objectMapper.readTree(response).get("sessionId").asText();
 
-        String invalidPayload =
-                """
+        String invalidPayload = """
 				{
 				  "billableMinutes": -1,
 				  "breakMinutes": 0,
@@ -266,7 +262,6 @@ class WorkSessionContractIT extends BaseContractIntegrationTest {
                 .id(personId)
                 .firstName(firstName)
                 .lastName(lastName)
-                .primaryEmail(firstName.toLowerCase() + "." + lastName.toLowerCase() + "@example.com")
                 .employeeNumber("EMP-" + personId.toString().substring(0, 8))
                 .status(EmployeeStatus.ACTIVE)
                 .build());

--- a/pos-people/src/test/java/com/positivity/people/internal/repository/PersonSpecificationsTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/repository/PersonSpecificationsTest.java
@@ -42,8 +42,7 @@ class PersonSpecificationsTest {
         Root<Person> root = mockRoot();
         CriteriaBuilder cb = mockCb();
 
-        PersonSpecifications.directoryFilter("EMPLOYEE", null)
-                .toPredicate(root, mock(CriteriaQuery.class), cb);
+        PersonSpecifications.directoryFilter("EMPLOYEE", null).toPredicate(root, mock(CriteriaQuery.class), cb);
 
         verify(root).get("employeeNumber");
         verify(cb).isNotNull(any());
@@ -55,8 +54,7 @@ class PersonSpecificationsTest {
         Root<Person> root = mockRoot();
         CriteriaBuilder cb = mockCb();
 
-        PersonSpecifications.directoryFilter("ACTIVE", null)
-                .toPredicate(root, mock(CriteriaQuery.class), cb);
+        PersonSpecifications.directoryFilter("ACTIVE", null).toPredicate(root, mock(CriteriaQuery.class), cb);
 
         verify(root).get("employeeNumber");
         verify(root).get("status");
@@ -67,8 +65,7 @@ class PersonSpecificationsTest {
         Root<Person> root = mockRoot();
         CriteriaBuilder cb = mockCb();
 
-        PersonSpecifications.directoryFilter("ALL", null)
-                .toPredicate(root, mock(CriteriaQuery.class), cb);
+        PersonSpecifications.directoryFilter("ALL", null).toPredicate(root, mock(CriteriaQuery.class), cb);
 
         verify(root, never()).get("employeeNumber");
         verify(root, never()).get("status");

--- a/pos-people/src/test/java/com/positivity/people/internal/service/EmployeeProfileFallbackTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/EmployeeProfileFallbackTest.java
@@ -48,9 +48,24 @@ class EmployeeProfileFallbackTest {
     @Mock
     private PersonWorkPhoneService workPhoneService;
 
+    @Mock
+    private PersonEmailService emailService;
+
+    @org.junit.jupiter.api.BeforeEach
+    void defaultEmailStub() {
+        org.mockito.Mockito.lenient()
+                .when(emailService.getEmails(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(new PersonEmailService.EmailPair(null, null));
+    }
+
     private EmployeeServiceImpl service() {
         return new EmployeeServiceImpl(
-                TEST_CLOCK, personRepository, workPhoneService, offboardingRetryRepository, new ObjectMapper());
+                TEST_CLOCK,
+                personRepository,
+                workPhoneService,
+                emailService,
+                offboardingRetryRepository,
+                new ObjectMapper());
     }
 
     private Person columnSourcedPerson() {
@@ -58,7 +73,6 @@ class EmployeeProfileFallbackTest {
         person.setId(PERSON_ID);
         person.setFirstName("Marcus");
         person.setLastName("Webb");
-        person.setPrimaryEmail("marcus.webb@durion.internal");
         person.setEmployeeNumber("EMP-0001");
         person.setStatus(EmployeeStatus.ACTIVE);
         person.setHireDate(LocalDate.parse("2024-01-01"));
@@ -91,6 +105,8 @@ class EmployeeProfileFallbackTest {
     void getEmployee_fallsBackToContactColumnsWhenJsonMissing() {
         when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(columnSourcedPerson()));
         when(workPhoneService.getWorkPhones(PERSON_ID)).thenReturn(List.of("555-0100", "555-0101"));
+        when(emailService.getEmails(PERSON_ID))
+                .thenReturn(new PersonEmailService.EmailPair("marcus.webb@durion.internal", null));
 
         EmployeeProfileDto profile = service().getEmployee(PERSON_ID);
 

--- a/pos-people/src/test/java/com/positivity/people/internal/service/PersonEmailServiceTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/PersonEmailServiceTest.java
@@ -1,0 +1,69 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.internal.entity.PersonContactPoint;
+import com.positivity.people.internal.enums.ContactPointType;
+import com.positivity.people.internal.repository.PersonContactPointRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PersonEmailServiceTest {
+
+    private static final UUID PERSON = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    @Mock
+    private PersonContactPointRepository repository;
+
+    @InjectMocks
+    private PersonEmailService service;
+
+    private PersonContactPoint cp(String value, boolean primary) {
+        return PersonContactPoint.builder()
+                .personId(PERSON)
+                .contactType(ContactPointType.EMAIL)
+                .value(value)
+                .isPrimary(primary)
+                .build();
+    }
+
+    @Test
+    void getEmails_returnsPrimaryAndSecondary() {
+        when(repository.findByPersonIdAndContactType(PERSON, ContactPointType.EMAIL))
+                .thenReturn(List.of(cp("second@x.com", false), cp("primary@x.com", true)));
+
+        PersonEmailService.EmailPair pair = service.getEmails(PERSON);
+
+        assertThat(pair.primary()).isEqualTo("primary@x.com");
+        assertThat(pair.secondary()).isEqualTo("second@x.com");
+    }
+
+    @Test
+    void replaceEmails_deletesThenSavesPrimaryAndSecondary_skippingBlanks() {
+        service.replaceEmails(PERSON, "primary@x.com", "  ");
+
+        verify(repository).deleteByPersonIdAndContactType(PERSON, ContactPointType.EMAIL);
+        ArgumentCaptor<PersonContactPoint> captor = ArgumentCaptor.forClass(PersonContactPoint.class);
+        verify(repository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getValue()).isEqualTo("primary@x.com");
+        assertThat(captor.getValue().isPrimary()).isTrue();
+    }
+
+    @Test
+    void findPersonIdsByPrimaryEmail_mapsIds() {
+        when(repository.findByContactTypeAndIsPrimaryAndValueIgnoreCase(ContactPointType.EMAIL, true, "primary@x.com"))
+                .thenReturn(List.of(cp("primary@x.com", true)));
+
+        assertThat(service.findPersonIdsByPrimaryEmail("primary@x.com")).containsExactly(PERSON);
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/service/UserPersonLinkServiceTest.java
+++ b/pos-people/src/test/java/com/positivity/people/service/UserPersonLinkServiceTest.java
@@ -54,6 +54,9 @@ class UserPersonLinkServiceTest {
     @Mock
     private com.positivity.people.internal.service.PersonWorkPhoneService workPhoneService;
 
+    @Mock
+    private com.positivity.people.internal.service.PersonEmailService emailService;
+
     private UserPersonLinkServiceImpl service;
 
     // Fixed UUIDs for deterministic tests
@@ -67,7 +70,7 @@ class UserPersonLinkServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new UserPersonLinkServiceImpl(linkRepository, personRepository, workPhoneService);
+        service = new UserPersonLinkServiceImpl(linkRepository, personRepository, workPhoneService, emailService);
 
         // Initialize fixed test UUIDs
         testPersonId = UUID.fromString("00000000-0000-0000-0000-000000000001");
@@ -169,11 +172,14 @@ class UserPersonLinkServiceTest {
                 .id(testPersonId)
                 .firstName("Jordan")
                 .lastName("Case")
-                .primaryEmail("jordan@example.com")
                 .build();
 
         when(linkRepository.findByUserId(testUserId)).thenReturn(Optional.of(link));
         when(personRepository.findById(testPersonId)).thenReturn(Optional.of(person));
+        when(workPhoneService.getWorkPhones(testPersonId)).thenReturn(java.util.List.of());
+        when(emailService.getEmails(testPersonId))
+                .thenReturn(new com.positivity.people.internal.service.PersonEmailService.EmailPair(
+                        "jordan@example.com", null));
 
         PersonResponse response = service.findPersonByUserId(testUserId);
 


### PR DESCRIPTION
## Summary
Moves `primary_email` / `secondary_email` off the `Person` entity into `person_contact_point` (`contact_type=EMAIL`; primary email = `is_primary` true), mirroring the phone consolidation in #742.

## Changes
- **`PersonEmailService`** (new): `getEmails` (primary/secondary `EmailPair`), `replaceEmails` (delete+insert), `findPersonIdsByEmail` / `findPersonIdsByPrimaryEmail`.
- **`Person` entity**: removed `primaryEmail`/`secondaryEmail` columns.
- **Services** route email through contact points: `PersonServiceImpl` (resolve email-match, toDto, savePerson, resolve-create), `EmployeeServiceImpl` (duplicate primary-email check, contact-column read, persist on create/update), `UserPersonLinkServiceImpl` (response). External DTOs unchanged.
- **Directory search**: `PersonSpecifications.directoryFilter` now matches email via an **EXISTS subquery** on `EMAIL` contact points (the `root.get("primaryEmail")` column is gone).
- **Repository**: add `findByContactTypeAndValueIgnoreCase` / `findByContactTypeAndIsPrimaryAndValueIgnoreCase`; removed the four `PersonRepository` email finders.
- **Flyway V9**: backfill `person_contact_point(EMAIL)` from `primary_email` (primary) + `secondary_email` (secondary), dup-guarded, then `DROP` both columns.

## Decisions (confirmed)
- **Uniqueness**: primary-email uniqueness kept via case-insensitive query check (no DB constraint).
- **Directory search**: email stays searchable (subquery).

## Tests
Full pos-people suite green: **97 unit + ITs**. New `PersonEmailServiceTest`. ITs run on H2 with Flyway disabled, so V9's `DROP`/`gen_random_uuid()` only execute on real Postgres.

## ⚠️ Stacked on #742
Base is the phone-consolidation branch (`refactor/people-consolidate-phone-contactpoint`), not main. **Merge #742 first**; this retargets to main after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)