### PR TITLE
refactor(people): drop person.username, resolve via user_person_link → pos-security

### DIFF
--- a/pos-people/src/main/java/com/positivity/people/internal/client/SecurityServiceClient.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/client/SecurityServiceClient.java
@@ -10,7 +10,11 @@ import com.positivity.people.internal.client.dto.UserRoleAssignmentRequest;
 import com.positivity.people.internal.client.dto.UserRoleDto;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -65,6 +69,66 @@ public class SecurityServiceClient {
         return users.stream()
                 .filter(user -> user.getUsername() != null && username.equalsIgnoreCase(user.getUsername()))
                 .findFirst();
+    }
+
+    /** Fetch a user by id; empty when not found (404). */
+    @NonNull
+    public Optional<User> getUserById(@NonNull UUID userId) {
+        log.debug("Fetching user by id: {}", userId);
+        try {
+            User user = restClient
+                    .get()
+                    .uri("/v1/users/{id}", userId)
+                    .retrieve()
+                    .onStatus(
+                            statusCode -> statusCode.value() == 401 || statusCode.value() == 403,
+                            (request, response) -> {
+                                throw new SecurityServiceException(
+                                        "Not authorized to query users in security service",
+                                        response.getStatusCode().value());
+                            })
+                    .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                        throw new SecurityServiceException(
+                                "Security service failed while fetching user",
+                                response.getStatusCode().value());
+                    })
+                    .body(User.class);
+            return Optional.ofNullable(user);
+        } catch (org.springframework.web.client.HttpClientErrorException.NotFound notFound) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Batch-resolve usernames for the given user ids (single list call, filtered locally).
+     * Ids without a user are absent from the result.
+     */
+    @NonNull
+    public Map<UUID, String> getUsernamesByIds(@NonNull Collection<UUID> userIds) {
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+        Set<UUID> wanted = new HashSet<>(userIds);
+        List<User> users = restClient
+                .get()
+                .uri("/v1/users")
+                .retrieve()
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    throw new SecurityServiceException(
+                            "Security service failed while fetching users",
+                            response.getStatusCode().value());
+                })
+                .body(new ParameterizedTypeReference<List<User>>() {});
+        if (users == null) {
+            return Map.of();
+        }
+        Map<UUID, String> byId = new HashMap<>();
+        for (User user : users) {
+            if (user.getId() != null && user.getUsername() != null && wanted.contains(user.getId())) {
+                byId.put(user.getId(), user.getUsername());
+            }
+        }
+        return byId;
     }
 
     /**

--- a/pos-people/src/main/java/com/positivity/people/internal/client/SecurityServiceClient.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/client/SecurityServiceClient.java
@@ -113,6 +113,11 @@ public class SecurityServiceClient {
                 .get()
                 .uri("/v1/users")
                 .retrieve()
+                .onStatus(statusCode -> statusCode.value() == 401 || statusCode.value() == 403, (request, response) -> {
+                    throw new SecurityServiceException(
+                            "Not authorized to query users in security service",
+                            response.getStatusCode().value());
+                })
                 .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
                     throw new SecurityServiceException(
                             "Security service failed while fetching users",

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/Person.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/Person.java
@@ -84,9 +84,7 @@ public class Person {
 
     // Email + phone numbers consolidated into person_contact_point (EMAIL / PHONE_WORK);
     // see PersonEmailService / PersonWorkPhoneService.
-
-    /** Optional, validated externally - stick with username not userName */
-    private String username;
+    // Username is owned by pos-security and resolved via user_person_link; see PersonUsernameService.
 
     @PreUpdate
     public void ensureStatusEffectiveAt() {

--- a/pos-people/src/main/java/com/positivity/people/internal/repository/PersonRepository.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/PersonRepository.java
@@ -8,8 +8,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface PersonRepository extends JpaRepository<Person, UUID>, JpaSpecificationExecutor<Person> {
 
-    boolean existsByUsername(String username);
-
     boolean existsByEmployeeNumberIgnoreCase(String employeeNumber);
 
     boolean existsByEmployeeNumberIgnoreCaseAndIdNot(String employeeNumber, UUID id);

--- a/pos-people/src/main/java/com/positivity/people/internal/repository/UserPersonLinkRepository.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/UserPersonLinkRepository.java
@@ -36,6 +36,8 @@ public interface UserPersonLinkRepository extends JpaRepository<UserPersonLink, 
 
     List<UserPersonLink> findByPerson_Id(@NonNull UUID personId);
 
+    List<UserPersonLink> findByPerson_IdIn(@NonNull Collection<UUID> personIds);
+
     Optional<UserPersonLink> findByPerson_IdAndStatus(@NonNull UUID personId, @NonNull UserLinkStatus status);
 
     Optional<UserPersonLink> findFirstByPerson_IdAndStatusOrderByCreatedAtDesc(

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PersonServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PersonServiceImpl.java
@@ -1,6 +1,5 @@
 package com.positivity.people.internal.service;
 
-import com.positivity.people.internal.client.SecurityServiceClient;
 import com.positivity.people.internal.dto.Person;
 import com.positivity.people.internal.dto.ResolvePersonRequest;
 import com.positivity.people.internal.dto.ResolvePersonResponse;
@@ -49,7 +48,7 @@ public class PersonServiceImpl implements PersonService {
 
     private final PersonEmailService emailService;
 
-    private final SecurityServiceClient securityServiceClient;
+    private final PersonUsernameService usernameService;
 
     @Value("${pos.people.matching.threshold:30}")
     private int defaultMatchingThreshold;
@@ -57,15 +56,22 @@ public class PersonServiceImpl implements PersonService {
     @Override
     @NonNull
     public List<Person> getAllPeople(@Nullable String type, @Nullable String q) {
-        return personRepository.findAll(PersonSpecifications.directoryFilter(type, q)).stream()
+        List<Person> people = personRepository.findAll(PersonSpecifications.directoryFilter(type, q)).stream()
                 .map(this::toDto)
                 .toList();
+        Map<UUID, String> usernames = usernameService.usernamesByPersonId(
+                people.stream().map(Person::getId).toList());
+        people.forEach(p -> p.setUsername(usernames.get(p.getId())));
+        return people;
     }
 
     @Override
     @NonNull
     public Optional<Person> getPersonById(@NonNull UUID id) {
-        return personRepository.findById(id).map(this::toDto);
+        return personRepository.findById(id).map(this::toDto).map(dto -> {
+            dto.setUsername(usernameService.usernameForPerson(id));
+            return dto;
+        });
     }
 
     @Override
@@ -87,6 +93,9 @@ public class PersonServiceImpl implements PersonService {
                                                 cp.getContactType(), cp.getValue(), cp.isPrimary()),
                                         Collectors.toList())));
         people.forEach(p -> p.setContactPoints(contactsByPerson.getOrDefault(p.getId(), List.of())));
+
+        Map<UUID, String> usernames = usernameService.usernamesByPersonId(ids);
+        people.forEach(p -> p.setUsername(usernames.get(p.getId())));
         return people;
     }
 
@@ -113,17 +122,15 @@ public class PersonServiceImpl implements PersonService {
     @Transactional
     @NonNull
     public Person savePerson(@NonNull Person person) {
-        if (person.getUsername() != null
-                && !person.getUsername().isBlank()
-                && !validateUsernameWithSecurityService(person.getUsername())) {
-            throw new IllegalArgumentException("Username is not valid or does not exist in security service");
-        }
-
+        // Username is owned by pos-security and linked via user_person_link; it is not a
+        // Person attribute and is not persisted here.
         com.positivity.people.internal.entity.Person saved = personRepository.save(toEntity(person));
         workPhoneService.replaceWorkPhones(
                 saved.getId(), person.getPhoneNumbers() == null ? List.of() : person.getPhoneNumbers());
         emailService.replaceEmails(saved.getId(), person.getPrimaryEmail(), person.getSecondaryEmail());
-        return toDto(saved);
+        Person dto = toDto(saved);
+        dto.setUsername(usernameService.usernameForPerson(saved.getId()));
+        return dto;
     }
 
     @Override
@@ -222,11 +229,6 @@ public class PersonServiceImpl implements PersonService {
         personRepository.deleteById(id);
     }
 
-    private boolean validateUsernameWithSecurityService(String username) {
-        return securityServiceClient.getUserByUsername(username).isPresent()
-                && !personRepository.existsByUsername(username);
-    }
-
     private int resolveThreshold(Integer thresholdOverride) {
         int threshold = thresholdOverride != null ? thresholdOverride : defaultMatchingThreshold;
         return Math.max(0, threshold);
@@ -278,7 +280,7 @@ public class PersonServiceImpl implements PersonService {
         dto.setPrimaryEmail(emails.primary());
         dto.setSecondaryEmail(emails.secondary());
         dto.setPhoneNumbers(workPhoneService.getWorkPhones(entity.getId()));
-        dto.setUsername(entity.getUsername());
+        // username resolved from pos-security via user_person_link by the caller (single or batched).
         dto.setEmployeeStatus(entity.getStatus());
         return dto;
     }
@@ -288,8 +290,7 @@ public class PersonServiceImpl implements PersonService {
         entity.setId(dto.getId());
         entity.setFirstName(dto.getFirstName());
         entity.setLastName(dto.getLastName());
-        // email + phoneNumbers persisted separately as EMAIL / PHONE_WORK contact points (see savePerson).
-        entity.setUsername(dto.getUsername());
+        // email + phoneNumbers persisted separately as contact points; username owned by pos-security.
         return entity;
     }
 

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PersonUsernameService.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PersonUsernameService.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -18,9 +19,13 @@ import org.springframework.stereotype.Service;
  * Resolves a person's username from pos-security (the system of record for credentials)
  * via the user_person_link mapping (personId → userId → security user). Username is no
  * longer stored on Person.
+ *
+ * <p>Resolution is fail-soft: a pos-security outage leaves the username absent rather than
+ * failing the person read, since username is non-essential enrichment on directory/detail.
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PersonUsernameService {
 
     private final UserPersonLinkRepository linkRepository;
@@ -28,13 +33,23 @@ public class PersonUsernameService {
 
     /** Username for a single person, or null if unlinked / not resolvable. */
     public @Nullable String usernameForPerson(@NonNull UUID personId) {
-        return linkRepository.findByPerson_Id(personId).stream()
+        UUID userId = linkRepository.findByPerson_Id(personId).stream()
                 .map(UserPersonLink::getUserId)
                 .filter(Objects::nonNull)
                 .findFirst()
-                .flatMap(securityServiceClient::getUserById)
-                .map(com.positivity.people.internal.client.dto.User::getUsername)
                 .orElse(null);
+        if (userId == null) {
+            return null;
+        }
+        try {
+            return securityServiceClient
+                    .getUserById(userId)
+                    .map(com.positivity.people.internal.client.dto.User::getUsername)
+                    .orElse(null);
+        } catch (RuntimeException ex) {
+            log.warn("Username resolution failed for person {} (user {}): {}", personId, userId, ex.getMessage());
+            return null;
+        }
     }
 
     /** Batch personId → username (one security list call), for directory/list paths. */
@@ -46,7 +61,13 @@ public class PersonUsernameService {
                 .filter(link -> link.getUserId() != null && link.getPerson() != null)
                 .collect(Collectors.toMap(
                         link -> link.getPerson().getId(), UserPersonLink::getUserId, (existing, ignored) -> existing));
-        Map<UUID, String> usernameByUserId = securityServiceClient.getUsernamesByIds(userIdByPerson.values());
+        Map<UUID, String> usernameByUserId;
+        try {
+            usernameByUserId = securityServiceClient.getUsernamesByIds(userIdByPerson.values());
+        } catch (RuntimeException ex) {
+            log.warn("Batch username resolution failed for {} person(s): {}", userIdByPerson.size(), ex.getMessage());
+            return Map.of();
+        }
         Map<UUID, String> result = new HashMap<>();
         userIdByPerson.forEach((personId, userId) -> {
             String username = usernameByUserId.get(userId);

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PersonUsernameService.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PersonUsernameService.java
@@ -1,0 +1,59 @@
+package com.positivity.people.internal.service;
+
+import com.positivity.people.internal.client.SecurityServiceClient;
+import com.positivity.people.internal.entity.UserPersonLink;
+import com.positivity.people.internal.repository.UserPersonLinkRepository;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves a person's username from pos-security (the system of record for credentials)
+ * via the user_person_link mapping (personId → userId → security user). Username is no
+ * longer stored on Person.
+ */
+@Service
+@RequiredArgsConstructor
+public class PersonUsernameService {
+
+    private final UserPersonLinkRepository linkRepository;
+    private final SecurityServiceClient securityServiceClient;
+
+    /** Username for a single person, or null if unlinked / not resolvable. */
+    public @Nullable String usernameForPerson(@NonNull UUID personId) {
+        return linkRepository.findByPerson_Id(personId).stream()
+                .map(UserPersonLink::getUserId)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .flatMap(securityServiceClient::getUserById)
+                .map(com.positivity.people.internal.client.dto.User::getUsername)
+                .orElse(null);
+    }
+
+    /** Batch personId → username (one security list call), for directory/list paths. */
+    public @NonNull Map<UUID, String> usernamesByPersonId(@NonNull Collection<UUID> personIds) {
+        if (personIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<UUID, UUID> userIdByPerson = linkRepository.findByPerson_IdIn(personIds).stream()
+                .filter(link -> link.getUserId() != null && link.getPerson() != null)
+                .collect(Collectors.toMap(
+                        link -> link.getPerson().getId(), UserPersonLink::getUserId, (existing, ignored) -> existing));
+        Map<UUID, String> usernameByUserId = securityServiceClient.getUsernamesByIds(userIdByPerson.values());
+        Map<UUID, String> result = new HashMap<>();
+        userIdByPerson.forEach((personId, userId) -> {
+            String username = usernameByUserId.get(userId);
+            if (username != null) {
+                result.put(personId, username);
+            }
+        });
+        return result;
+    }
+}

--- a/pos-people/src/main/java/com/positivity/people/internal/service/UserPersonLinkServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/UserPersonLinkServiceImpl.java
@@ -42,15 +42,19 @@ public class UserPersonLinkServiceImpl implements UserPersonLinkService {
 
     private final PersonEmailService emailService;
 
+    private final PersonUsernameService usernameService;
+
     public UserPersonLinkServiceImpl(
             @NonNull UserPersonLinkRepository linkRepository,
             @NonNull PersonRepository personRepository,
             @NonNull PersonWorkPhoneService workPhoneService,
-            @NonNull PersonEmailService emailService) {
+            @NonNull PersonEmailService emailService,
+            @NonNull PersonUsernameService usernameService) {
         this.linkRepository = linkRepository;
         this.personRepository = personRepository;
         this.workPhoneService = workPhoneService;
         this.emailService = emailService;
+        this.usernameService = usernameService;
     }
 
     @Override
@@ -213,7 +217,7 @@ public class UserPersonLinkServiceImpl implements UserPersonLinkService {
                 .primaryEmail(emails.primary())
                 .secondaryEmail(emails.secondary())
                 .phoneNumbers(workPhoneService.getWorkPhones(person.getId()))
-                .username(person.getUsername())
+                .username(usernameService.usernameForPerson(person.getId()))
                 .build();
     }
 }

--- a/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
@@ -16,111 +16,375 @@
 SET TIME ZONE 'UTC';
 
 -- person rows
-INSERT INTO person (id, first_name, last_name, username, employee_number, primary_email, status, hire_date, created_at, updated_at)
+INSERT INTO person (id, first_name, last_name, employee_number, status, hire_date, created_at, updated_at)
 VALUES
-    ('01960011-0000-7000-8000-000000000001'::uuid, 'Marcus',   'Webb',     'marcus.webb',     'EMP-0001', 'marcus.webb@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000002'::uuid, 'Diana',    'Rowe',     'diana.rowe',      'EMP-0002', 'diana.rowe@durion.internal',      'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000003'::uuid, 'Terrence', 'Blake',    'terrence.blake',  'EMP-0003', 'terrence.blake@durion.internal',  'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000004'::uuid, 'Sandra',   'Cruz',     'sandra.cruz',     'EMP-0004', 'sandra.cruz@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000005'::uuid, 'Kyle',     'Brennan',  'kyle.brennan',    'EMP-0005', 'kyle.brennan@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000006'::uuid, 'DeShawn',  'Morris',   'deshawn.morris',  'EMP-0006', 'deshawn.morris@durion.internal',  'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000007'::uuid, 'Carlos',   'Ruiz',     'carlos.ruiz',     'EMP-0007', 'carlos.ruiz@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000008'::uuid, 'Amber',    'Nguyen',   'amber.nguyen',    'EMP-0008', 'amber.nguyen@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000009'::uuid, 'Eddie',    'Vasquez',  'eddie.vasquez',   'EMP-0009', 'eddie.vasquez@durion.internal',   'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000000a'::uuid, 'Priya',    'Patel',    'priya.patel',     'EMP-0010', 'priya.patel@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000000b'::uuid, 'James',    'Okafor',   'james.okafor',    'EMP-0011', 'james.okafor@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000000c'::uuid, 'Rachel',   'Kim',      'rachel.kim',      'EMP-0012', 'rachel.kim@durion.internal',      'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000000d'::uuid, 'Tyrone',   'Williams', 'tyrone.williams', 'EMP-0013', 'tyrone.williams@durion.internal', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000000e'::uuid, 'Olivia',   'Chen',     'olivia.chen',     'EMP-0014', 'olivia.chen@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000000f'::uuid, 'Harold',   'Sanders',  'harold.sanders',  'EMP-0015', 'harold.sanders@durion.internal',  'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000010'::uuid, 'Irene',    'Torres',   'irene.torres',    'EMP-0016', 'irene.torres@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW())
+    ('01960011-0000-7000-8000-000000000001'::uuid, 'Marcus', 'Webb', 'EMP-0001', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000002'::uuid, 'Diana', 'Rowe', 'EMP-0002', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000003'::uuid, 'Terrence', 'Blake', 'EMP-0003', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000004'::uuid, 'Sandra', 'Cruz', 'EMP-0004', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000005'::uuid, 'Kyle', 'Brennan', 'EMP-0005', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000006'::uuid, 'DeShawn', 'Morris', 'EMP-0006', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000007'::uuid, 'Carlos', 'Ruiz', 'EMP-0007', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000008'::uuid, 'Amber', 'Nguyen', 'EMP-0008', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000009'::uuid, 'Eddie', 'Vasquez', 'EMP-0009', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000000a'::uuid, 'Priya', 'Patel', 'EMP-0010', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000000b'::uuid, 'James', 'Okafor', 'EMP-0011', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000000c'::uuid, 'Rachel', 'Kim', 'EMP-0012', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000000d'::uuid, 'Tyrone', 'Williams', 'EMP-0013', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000000e'::uuid, 'Olivia', 'Chen', 'EMP-0014', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000000f'::uuid, 'Harold', 'Sanders', 'EMP-0015', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000010'::uuid, 'Irene', 'Torres', 'EMP-0016', 'ACTIVE', CURRENT_DATE, NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
+
+-- Re-seed emails as EMAIL contact points (person email columns removed).
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000001'::uuid, 'EMAIL', 'marcus.webb@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000001'::uuid AND contact_type='EMAIL' AND value='marcus.webb@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000002'::uuid, 'EMAIL', 'diana.rowe@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000002'::uuid AND contact_type='EMAIL' AND value='diana.rowe@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000003'::uuid, 'EMAIL', 'terrence.blake@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000003'::uuid AND contact_type='EMAIL' AND value='terrence.blake@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000004'::uuid, 'EMAIL', 'sandra.cruz@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000004'::uuid AND contact_type='EMAIL' AND value='sandra.cruz@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000005'::uuid, 'EMAIL', 'kyle.brennan@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000005'::uuid AND contact_type='EMAIL' AND value='kyle.brennan@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000006'::uuid, 'EMAIL', 'deshawn.morris@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000006'::uuid AND contact_type='EMAIL' AND value='deshawn.morris@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000007'::uuid, 'EMAIL', 'carlos.ruiz@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000007'::uuid AND contact_type='EMAIL' AND value='carlos.ruiz@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000008'::uuid, 'EMAIL', 'amber.nguyen@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000008'::uuid AND contact_type='EMAIL' AND value='amber.nguyen@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000009'::uuid, 'EMAIL', 'eddie.vasquez@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000009'::uuid AND contact_type='EMAIL' AND value='eddie.vasquez@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000000a'::uuid, 'EMAIL', 'priya.patel@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000000a'::uuid AND contact_type='EMAIL' AND value='priya.patel@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000000b'::uuid, 'EMAIL', 'james.okafor@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000000b'::uuid AND contact_type='EMAIL' AND value='james.okafor@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000000c'::uuid, 'EMAIL', 'rachel.kim@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000000c'::uuid AND contact_type='EMAIL' AND value='rachel.kim@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000000d'::uuid, 'EMAIL', 'tyrone.williams@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000000d'::uuid AND contact_type='EMAIL' AND value='tyrone.williams@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000000e'::uuid, 'EMAIL', 'olivia.chen@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000000e'::uuid AND contact_type='EMAIL' AND value='olivia.chen@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000000f'::uuid, 'EMAIL', 'harold.sanders@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000000f'::uuid AND contact_type='EMAIL' AND value='harold.sanders@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000010'::uuid, 'EMAIL', 'irene.torres@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000010'::uuid AND contact_type='EMAIL' AND value='irene.torres@durion.internal');
 
 -- =========================================================================
 -- Group A: 50 customer persons (01960024-*) — person_party.person_id in pos-customer
 -- =========================================================================
 
-INSERT INTO person (id, first_name, last_name, primary_email, status, created_at, updated_at)
+INSERT INTO person (id, first_name, last_name, status, created_at, updated_at)
 VALUES
-    ('01960024-0000-7000-8000-000000000001'::uuid, 'Marcus',   'Patterson', 'marcus.patterson@example.com',   'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000002'::uuid, 'Jennifer', 'Holloway',  'jennifer.holloway@example.com',  'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000003'::uuid, 'Robert',   'Castillo',  'robert.castillo@example.com',    'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000004'::uuid, 'Angela',   'Freeman',   'angela.freeman@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000005'::uuid, 'Derek',    'Washington','derek.washington@example.com',   'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000006'::uuid, 'Patricia', 'Simmons',   'patricia.simmons@example.com',   'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000007'::uuid, 'Kevin',    'Thornton',  'kevin.thornton@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000008'::uuid, 'Linda',    'Guerrero',  'linda.guerrero@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000009'::uuid, 'James',    'Caldwell',  'james.caldwell@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000000a'::uuid, 'Tanya',    'Robinson',  'tanya.robinson@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000000b'::uuid, 'Michael',  'Owens',     'michael.owens@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000000c'::uuid, 'Cheryl',   'Hawkins',   'cheryl.hawkins@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000000d'::uuid, 'Ronald',   'Jenkins',   'ronald.jenkins@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000000e'::uuid, 'Denise',   'Foster',    'denise.foster@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000000f'::uuid, 'Anthony',  'Bryant',    'anthony.bryant@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000010'::uuid, 'Brenda',   'Coleman',   'brenda.coleman@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000011'::uuid, 'Steven',   'Gardner',   'steven.gardner@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000012'::uuid, 'Nicole',   'Harrison',  'nicole.harrison@example.com',    'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000013'::uuid, 'Gary',     'Alexander', 'gary.alexander@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000014'::uuid, 'Carolyn',  'Mitchell',  'carolyn.mitchell@example.com',   'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000015'::uuid, 'Timothy',  'Dixon',     'timothy.dixon@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000016'::uuid, 'Sandra',   'Reeves',    'sandra.reeves@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000017'::uuid, 'Walter',   'Hughes',    'walter.hughes@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000018'::uuid, 'Pamela',   'Lewis',     'pamela.lewis@example.com',       'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000019'::uuid, 'Larry',    'Peterson',  'larry.peterson@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000001a'::uuid, 'Deborah',  'Barnes',    'deborah.barnes@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000001b'::uuid, 'Frank',    'Murphy',    'frank.murphy@example.com',       'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000001c'::uuid, 'Sharon',   'Powell',    'sharon.powell@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000001d'::uuid, 'Raymond',  'Bailey',    'raymond.bailey@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000001e'::uuid, 'Cynthia',  'Ross',      'cynthia.ross@example.com',       'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000001f'::uuid, 'Jose',     'Rivera',    'jose.rivera@example.com',        'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000020'::uuid, 'Gloria',   'Turner',    'gloria.turner@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000021'::uuid, 'Douglas',  'Stewart',   'douglas.stewart@example.com',    'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000022'::uuid, 'Shirley',  'Flores',    'shirley.flores@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000023'::uuid, 'Henry',    'Griffin',   'henry.griffin@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000024'::uuid, 'Marie',    'Evans',     'marie.evans@example.com',        'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000025'::uuid, 'Bruce',    'King',      'bruce.king@example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000026'::uuid, 'Wanda',    'Sanchez',   'wanda.sanchez@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000027'::uuid, 'Keith',    'Ward',      'keith.ward@example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000028'::uuid, 'Phyllis',  'Long',      'phyllis.long@example.com',       'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000029'::uuid, 'Carl',     'Price',     'carl.price@example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000002a'::uuid, 'Martha',   'Scott',     'martha.scott@example.com',       'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000002b'::uuid, 'Albert',   'Rogers',    'albert.rogers@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000002c'::uuid, 'Virginia', 'Henderson', 'virginia.henderson@example.com', 'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000002d'::uuid, 'Harry',    'Hill',      'harry.hill@example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000002e'::uuid, 'Doris',    'Wood',      'doris.wood@example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-00000000002f'::uuid, 'Raymond',  'James',     'raymond.james@example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000030'::uuid, 'Betty',    'Crawford',  'betty.crawford@example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000031'::uuid, 'Samuel',   'Reed',      'samuel.reed@example.com',        'ACTIVE', NOW(), NOW()),
-    ('01960024-0000-7000-8000-000000000032'::uuid, 'Dorothy',  'Bell',      'dorothy.bell@example.com',       'ACTIVE', NOW(), NOW())
+    ('01960024-0000-7000-8000-000000000001'::uuid, 'Marcus', 'Patterson', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000002'::uuid, 'Jennifer', 'Holloway', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000003'::uuid, 'Robert', 'Castillo', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000004'::uuid, 'Angela', 'Freeman', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000005'::uuid, 'Derek', 'Washington', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000006'::uuid, 'Patricia', 'Simmons', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000007'::uuid, 'Kevin', 'Thornton', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000008'::uuid, 'Linda', 'Guerrero', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000009'::uuid, 'James', 'Caldwell', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000000a'::uuid, 'Tanya', 'Robinson', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000000b'::uuid, 'Michael', 'Owens', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000000c'::uuid, 'Cheryl', 'Hawkins', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000000d'::uuid, 'Ronald', 'Jenkins', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000000e'::uuid, 'Denise', 'Foster', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000000f'::uuid, 'Anthony', 'Bryant', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000010'::uuid, 'Brenda', 'Coleman', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000011'::uuid, 'Steven', 'Gardner', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000012'::uuid, 'Nicole', 'Harrison', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000013'::uuid, 'Gary', 'Alexander', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000014'::uuid, 'Carolyn', 'Mitchell', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000015'::uuid, 'Timothy', 'Dixon', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000016'::uuid, 'Sandra', 'Reeves', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000017'::uuid, 'Walter', 'Hughes', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000018'::uuid, 'Pamela', 'Lewis', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000019'::uuid, 'Larry', 'Peterson', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000001a'::uuid, 'Deborah', 'Barnes', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000001b'::uuid, 'Frank', 'Murphy', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000001c'::uuid, 'Sharon', 'Powell', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000001d'::uuid, 'Raymond', 'Bailey', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000001e'::uuid, 'Cynthia', 'Ross', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000001f'::uuid, 'Jose', 'Rivera', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000020'::uuid, 'Gloria', 'Turner', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000021'::uuid, 'Douglas', 'Stewart', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000022'::uuid, 'Shirley', 'Flores', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000023'::uuid, 'Henry', 'Griffin', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000024'::uuid, 'Marie', 'Evans', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000025'::uuid, 'Bruce', 'King', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000026'::uuid, 'Wanda', 'Sanchez', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000027'::uuid, 'Keith', 'Ward', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000028'::uuid, 'Phyllis', 'Long', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000029'::uuid, 'Carl', 'Price', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000002a'::uuid, 'Martha', 'Scott', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000002b'::uuid, 'Albert', 'Rogers', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000002c'::uuid, 'Virginia', 'Henderson', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000002d'::uuid, 'Harry', 'Hill', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000002e'::uuid, 'Doris', 'Wood', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-00000000002f'::uuid, 'Raymond', 'James', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000030'::uuid, 'Betty', 'Crawford', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000031'::uuid, 'Samuel', 'Reed', 'ACTIVE', NOW(), NOW()),
+    ('01960024-0000-7000-8000-000000000032'::uuid, 'Dorothy', 'Bell', 'ACTIVE', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
+
+-- Re-seed emails as EMAIL contact points (person email columns removed).
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000001'::uuid, 'EMAIL', 'marcus.patterson@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000001'::uuid AND contact_type='EMAIL' AND value='marcus.patterson@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000002'::uuid, 'EMAIL', 'jennifer.holloway@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000002'::uuid AND contact_type='EMAIL' AND value='jennifer.holloway@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000003'::uuid, 'EMAIL', 'robert.castillo@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000003'::uuid AND contact_type='EMAIL' AND value='robert.castillo@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000004'::uuid, 'EMAIL', 'angela.freeman@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000004'::uuid AND contact_type='EMAIL' AND value='angela.freeman@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000005'::uuid, 'EMAIL', 'derek.washington@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000005'::uuid AND contact_type='EMAIL' AND value='derek.washington@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000006'::uuid, 'EMAIL', 'patricia.simmons@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000006'::uuid AND contact_type='EMAIL' AND value='patricia.simmons@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000007'::uuid, 'EMAIL', 'kevin.thornton@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000007'::uuid AND contact_type='EMAIL' AND value='kevin.thornton@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000008'::uuid, 'EMAIL', 'linda.guerrero@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000008'::uuid AND contact_type='EMAIL' AND value='linda.guerrero@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000009'::uuid, 'EMAIL', 'james.caldwell@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000009'::uuid AND contact_type='EMAIL' AND value='james.caldwell@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000000a'::uuid, 'EMAIL', 'tanya.robinson@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000000a'::uuid AND contact_type='EMAIL' AND value='tanya.robinson@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000000b'::uuid, 'EMAIL', 'michael.owens@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000000b'::uuid AND contact_type='EMAIL' AND value='michael.owens@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000000c'::uuid, 'EMAIL', 'cheryl.hawkins@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000000c'::uuid AND contact_type='EMAIL' AND value='cheryl.hawkins@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000000d'::uuid, 'EMAIL', 'ronald.jenkins@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000000d'::uuid AND contact_type='EMAIL' AND value='ronald.jenkins@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000000e'::uuid, 'EMAIL', 'denise.foster@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000000e'::uuid AND contact_type='EMAIL' AND value='denise.foster@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000000f'::uuid, 'EMAIL', 'anthony.bryant@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000000f'::uuid AND contact_type='EMAIL' AND value='anthony.bryant@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000010'::uuid, 'EMAIL', 'brenda.coleman@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000010'::uuid AND contact_type='EMAIL' AND value='brenda.coleman@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000011'::uuid, 'EMAIL', 'steven.gardner@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000011'::uuid AND contact_type='EMAIL' AND value='steven.gardner@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000012'::uuid, 'EMAIL', 'nicole.harrison@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000012'::uuid AND contact_type='EMAIL' AND value='nicole.harrison@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000013'::uuid, 'EMAIL', 'gary.alexander@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000013'::uuid AND contact_type='EMAIL' AND value='gary.alexander@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000014'::uuid, 'EMAIL', 'carolyn.mitchell@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000014'::uuid AND contact_type='EMAIL' AND value='carolyn.mitchell@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000015'::uuid, 'EMAIL', 'timothy.dixon@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000015'::uuid AND contact_type='EMAIL' AND value='timothy.dixon@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000016'::uuid, 'EMAIL', 'sandra.reeves@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000016'::uuid AND contact_type='EMAIL' AND value='sandra.reeves@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000017'::uuid, 'EMAIL', 'walter.hughes@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000017'::uuid AND contact_type='EMAIL' AND value='walter.hughes@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000018'::uuid, 'EMAIL', 'pamela.lewis@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000018'::uuid AND contact_type='EMAIL' AND value='pamela.lewis@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000019'::uuid, 'EMAIL', 'larry.peterson@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000019'::uuid AND contact_type='EMAIL' AND value='larry.peterson@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000001a'::uuid, 'EMAIL', 'deborah.barnes@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000001a'::uuid AND contact_type='EMAIL' AND value='deborah.barnes@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000001b'::uuid, 'EMAIL', 'frank.murphy@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000001b'::uuid AND contact_type='EMAIL' AND value='frank.murphy@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000001c'::uuid, 'EMAIL', 'sharon.powell@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000001c'::uuid AND contact_type='EMAIL' AND value='sharon.powell@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000001d'::uuid, 'EMAIL', 'raymond.bailey@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000001d'::uuid AND contact_type='EMAIL' AND value='raymond.bailey@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000001e'::uuid, 'EMAIL', 'cynthia.ross@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000001e'::uuid AND contact_type='EMAIL' AND value='cynthia.ross@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000001f'::uuid, 'EMAIL', 'jose.rivera@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000001f'::uuid AND contact_type='EMAIL' AND value='jose.rivera@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000020'::uuid, 'EMAIL', 'gloria.turner@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000020'::uuid AND contact_type='EMAIL' AND value='gloria.turner@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000021'::uuid, 'EMAIL', 'douglas.stewart@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000021'::uuid AND contact_type='EMAIL' AND value='douglas.stewart@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000022'::uuid, 'EMAIL', 'shirley.flores@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000022'::uuid AND contact_type='EMAIL' AND value='shirley.flores@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000023'::uuid, 'EMAIL', 'henry.griffin@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000023'::uuid AND contact_type='EMAIL' AND value='henry.griffin@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000024'::uuid, 'EMAIL', 'marie.evans@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000024'::uuid AND contact_type='EMAIL' AND value='marie.evans@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000025'::uuid, 'EMAIL', 'bruce.king@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000025'::uuid AND contact_type='EMAIL' AND value='bruce.king@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000026'::uuid, 'EMAIL', 'wanda.sanchez@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000026'::uuid AND contact_type='EMAIL' AND value='wanda.sanchez@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000027'::uuid, 'EMAIL', 'keith.ward@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000027'::uuid AND contact_type='EMAIL' AND value='keith.ward@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000028'::uuid, 'EMAIL', 'phyllis.long@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000028'::uuid AND contact_type='EMAIL' AND value='phyllis.long@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000029'::uuid, 'EMAIL', 'carl.price@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000029'::uuid AND contact_type='EMAIL' AND value='carl.price@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000002a'::uuid, 'EMAIL', 'martha.scott@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000002a'::uuid AND contact_type='EMAIL' AND value='martha.scott@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000002b'::uuid, 'EMAIL', 'albert.rogers@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000002b'::uuid AND contact_type='EMAIL' AND value='albert.rogers@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000002c'::uuid, 'EMAIL', 'virginia.henderson@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000002c'::uuid AND contact_type='EMAIL' AND value='virginia.henderson@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000002d'::uuid, 'EMAIL', 'harry.hill@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000002d'::uuid AND contact_type='EMAIL' AND value='harry.hill@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000002e'::uuid, 'EMAIL', 'doris.wood@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000002e'::uuid AND contact_type='EMAIL' AND value='doris.wood@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-00000000002f'::uuid, 'EMAIL', 'raymond.james@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-00000000002f'::uuid AND contact_type='EMAIL' AND value='raymond.james@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000030'::uuid, 'EMAIL', 'betty.crawford@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000030'::uuid AND contact_type='EMAIL' AND value='betty.crawford@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000031'::uuid, 'EMAIL', 'samuel.reed@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000031'::uuid AND contact_type='EMAIL' AND value='samuel.reed@example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960024-0000-7000-8000-000000000032'::uuid, 'EMAIL', 'dorothy.bell@example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960024-0000-7000-8000-000000000032'::uuid AND contact_type='EMAIL' AND value='dorothy.bell@example.com');
 
 -- =========================================================================
 -- Group B: 20 commercial primary contact persons (01960025-*) — contact.person_id in pos-customer
 -- =========================================================================
 
-INSERT INTO person (id, first_name, last_name, primary_email, status, created_at, updated_at)
+INSERT INTO person (id, first_name, last_name, status, created_at, updated_at)
 VALUES
-    ('01960025-0000-7000-8000-000000000001'::uuid, 'Greg',      'Whitfield',  'g.whitfield@piedmontfreight.example.com',   'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000002'::uuid, 'Teresa',    'Mullen',     't.mullen@carolinaconcrete.example.com',     'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000003'::uuid, 'Darnell',   'Okafor',     'd.okafor@qcwaste.example.com',              'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000004'::uuid, 'Brittany',  'Norris',     'b.norris@blueridgelandscaping.example.com', 'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000005'::uuid, 'Marcus',    'Tillman',    'm.tillman@tarheellogistics.example.com',    'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000006'::uuid, 'Christine', 'Walters',    'c.walters@meckplumbing.example.com',        'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000007'::uuid, 'Donald',    'Frazier',    'd.frazier@piedmontreadymix.example.com',    'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000008'::uuid, 'Alicia',    'Stephens',   'a.stephens@carolinapower.example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000009'::uuid, 'Keith',     'Burnham',    'k.burnham@bluestoneaggregate.example.com',  'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-00000000000a'::uuid, 'Tamara',    'McPherson',  't.mcpherson@cabarruscleaning.example.com',  'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-00000000000b'::uuid, 'Wesley',    'Parrish',    'w.parrish@sedelivery.example.com',          'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-00000000000c'::uuid, 'Renee',     'Holt',       'r.holt@carolinascrane.example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-00000000000d'::uuid, 'Calvin',    'Dunmore',    'c.dunmore@lknpropane.example.com',          'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-00000000000e'::uuid, 'Latasha',   'Gooden',     'l.gooden@rowanroad.example.com',            'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-00000000000f'::uuid, 'Bryan',     'Cantrell',   'b.cantrell@carolinafresh.example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000010'::uuid, 'Monica',    'Byrd',       'm.byrd@piedmontmetals.example.com',         'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000011'::uuid, 'Cedric',    'Blackwell',  'c.blackwell@uniongrading.example.com',      'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000012'::uuid, 'Veronica',  'Pratt',      'v.pratt@carolinaseptic.example.com',        'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000013'::uuid, 'Jonathon',  'Culpepper',  'j.culpepper@mecktree.example.com',          'ACTIVE', NOW(), NOW()),
-    ('01960025-0000-7000-8000-000000000014'::uuid, 'Sheryl',    'Davenport',  's.davenport@highlandmoving.example.com',    'ACTIVE', NOW(), NOW())
+    ('01960025-0000-7000-8000-000000000001'::uuid, 'Greg', 'Whitfield', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000002'::uuid, 'Teresa', 'Mullen', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000003'::uuid, 'Darnell', 'Okafor', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000004'::uuid, 'Brittany', 'Norris', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000005'::uuid, 'Marcus', 'Tillman', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000006'::uuid, 'Christine', 'Walters', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000007'::uuid, 'Donald', 'Frazier', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000008'::uuid, 'Alicia', 'Stephens', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000009'::uuid, 'Keith', 'Burnham', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-00000000000a'::uuid, 'Tamara', 'McPherson', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-00000000000b'::uuid, 'Wesley', 'Parrish', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-00000000000c'::uuid, 'Renee', 'Holt', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-00000000000d'::uuid, 'Calvin', 'Dunmore', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-00000000000e'::uuid, 'Latasha', 'Gooden', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-00000000000f'::uuid, 'Bryan', 'Cantrell', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000010'::uuid, 'Monica', 'Byrd', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000011'::uuid, 'Cedric', 'Blackwell', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000012'::uuid, 'Veronica', 'Pratt', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000013'::uuid, 'Jonathon', 'Culpepper', 'ACTIVE', NOW(), NOW()),
+    ('01960025-0000-7000-8000-000000000014'::uuid, 'Sheryl', 'Davenport', 'ACTIVE', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
+
+-- Re-seed emails as EMAIL contact points (person email columns removed).
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000001'::uuid, 'EMAIL', 'g.whitfield@piedmontfreight.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000001'::uuid AND contact_type='EMAIL' AND value='g.whitfield@piedmontfreight.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000002'::uuid, 'EMAIL', 't.mullen@carolinaconcrete.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000002'::uuid AND contact_type='EMAIL' AND value='t.mullen@carolinaconcrete.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000003'::uuid, 'EMAIL', 'd.okafor@qcwaste.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000003'::uuid AND contact_type='EMAIL' AND value='d.okafor@qcwaste.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000004'::uuid, 'EMAIL', 'b.norris@blueridgelandscaping.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000004'::uuid AND contact_type='EMAIL' AND value='b.norris@blueridgelandscaping.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000005'::uuid, 'EMAIL', 'm.tillman@tarheellogistics.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000005'::uuid AND contact_type='EMAIL' AND value='m.tillman@tarheellogistics.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000006'::uuid, 'EMAIL', 'c.walters@meckplumbing.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000006'::uuid AND contact_type='EMAIL' AND value='c.walters@meckplumbing.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000007'::uuid, 'EMAIL', 'd.frazier@piedmontreadymix.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000007'::uuid AND contact_type='EMAIL' AND value='d.frazier@piedmontreadymix.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000008'::uuid, 'EMAIL', 'a.stephens@carolinapower.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000008'::uuid AND contact_type='EMAIL' AND value='a.stephens@carolinapower.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000009'::uuid, 'EMAIL', 'k.burnham@bluestoneaggregate.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000009'::uuid AND contact_type='EMAIL' AND value='k.burnham@bluestoneaggregate.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-00000000000a'::uuid, 'EMAIL', 't.mcpherson@cabarruscleaning.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-00000000000a'::uuid AND contact_type='EMAIL' AND value='t.mcpherson@cabarruscleaning.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-00000000000b'::uuid, 'EMAIL', 'w.parrish@sedelivery.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-00000000000b'::uuid AND contact_type='EMAIL' AND value='w.parrish@sedelivery.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-00000000000c'::uuid, 'EMAIL', 'r.holt@carolinascrane.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-00000000000c'::uuid AND contact_type='EMAIL' AND value='r.holt@carolinascrane.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-00000000000d'::uuid, 'EMAIL', 'c.dunmore@lknpropane.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-00000000000d'::uuid AND contact_type='EMAIL' AND value='c.dunmore@lknpropane.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-00000000000e'::uuid, 'EMAIL', 'l.gooden@rowanroad.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-00000000000e'::uuid AND contact_type='EMAIL' AND value='l.gooden@rowanroad.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-00000000000f'::uuid, 'EMAIL', 'b.cantrell@carolinafresh.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-00000000000f'::uuid AND contact_type='EMAIL' AND value='b.cantrell@carolinafresh.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000010'::uuid, 'EMAIL', 'm.byrd@piedmontmetals.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000010'::uuid AND contact_type='EMAIL' AND value='m.byrd@piedmontmetals.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000011'::uuid, 'EMAIL', 'c.blackwell@uniongrading.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000011'::uuid AND contact_type='EMAIL' AND value='c.blackwell@uniongrading.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000012'::uuid, 'EMAIL', 'v.pratt@carolinaseptic.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000012'::uuid AND contact_type='EMAIL' AND value='v.pratt@carolinaseptic.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000013'::uuid, 'EMAIL', 'j.culpepper@mecktree.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000013'::uuid AND contact_type='EMAIL' AND value='j.culpepper@mecktree.example.com');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960025-0000-7000-8000-000000000014'::uuid, 'EMAIL', 's.davenport@highlandmoving.example.com', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960025-0000-7000-8000-000000000014'::uuid AND contact_type='EMAIL' AND value='s.davenport@highlandmoving.example.com');
 
 -- =========================================================================
 -- Group C (REMOVED): the 20 commercial billing contacts (01960026-*) were
@@ -258,39 +522,103 @@ ON CONFLICT (id) DO NOTHING;
 -- These are staffing records only; no security users / logins are seeded.
 -- =========================================================================
 
-INSERT INTO person (id, first_name, last_name, username, employee_number, primary_email, status, hire_date, created_at, updated_at)
+INSERT INTO person (id, first_name, last_name, employee_number, status, hire_date, created_at, updated_at)
 VALUES
-    -- CLT-MAIN-001 technicians (+5 → 8 total)
-    ('01960011-0000-7000-8000-000000000011'::uuid, 'Hector',  'Alvarez',    'hector.alvarez',  'EMP-0017', 'hector.alvarez@durion.internal',  'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000012'::uuid, 'Naomi',   'Ford',       'naomi.ford',      'EMP-0018', 'naomi.ford@durion.internal',      'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000013'::uuid, 'Trevor',  'Quinn',      'trevor.quinn',    'EMP-0019', 'trevor.quinn@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000014'::uuid, 'Camille', 'Boyd',       'camille.boyd',    'EMP-0020', 'camille.boyd@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000015'::uuid, 'Andre',   'Foster',     'andre.foster',    'EMP-0021', 'andre.foster@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    -- CLT-SOUTH-001 technicians (+5 → 7 total)
-    ('01960011-0000-7000-8000-000000000016'::uuid, 'Lila',    'Montgomery', 'lila.montgomery', 'EMP-0022', 'lila.montgomery@durion.internal', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000017'::uuid, 'Desmond', 'Pace',       'desmond.pace',    'EMP-0023', 'desmond.pace@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000018'::uuid, 'Brooke',  'Hadley',     'brooke.hadley',   'EMP-0024', 'brooke.hadley@durion.internal',   'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000019'::uuid, 'Felix',   'Romano',     'felix.romano',    'EMP-0025', 'felix.romano@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000001a'::uuid, 'Gina',    'Vaughn',     'gina.vaughn',     'EMP-0026', 'gina.vaughn@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    -- CLT-NORTH-001 technicians (+4 → 6 total)
-    ('01960011-0000-7000-8000-00000000001b'::uuid, 'Omar',    'Haddad',     'omar.haddad',     'EMP-0027', 'omar.haddad@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000001c'::uuid, 'Sierra',  'Lowe',       'sierra.lowe',     'EMP-0028', 'sierra.lowe@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000001d'::uuid, 'Russell', 'Pike',       'russell.pike',    'EMP-0029', 'russell.pike@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-00000000001e'::uuid, 'Maya',    'Devlin',     'maya.devlin',     'EMP-0030', 'maya.devlin@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    -- CLT-MOB-HUB-001 technicians (+2 → 2 total, sized to 2 mobile units)
-    ('01960011-0000-7000-8000-00000000001f'::uuid, 'Caleb',   'Frost',      'caleb.frost',     'EMP-0031', 'caleb.frost@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000020'::uuid, 'Yvonne',  'Marsh',      'yvonne.marsh',    'EMP-0032', 'yvonne.marsh@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    -- Role coverage: LOCATION_MANAGER for SOUTH / NORTH / MOB-HUB
-    ('01960011-0000-7000-8000-000000000021'::uuid, 'Bernard', 'Cole',       'bernard.cole',    'EMP-0033', 'bernard.cole@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000022'::uuid, 'Gloria',  'Mensah',     'gloria.mensah',   'EMP-0034', 'gloria.mensah@durion.internal',   'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000023'::uuid, 'Victor',  'Salazar',    'victor.salazar',  'EMP-0035', 'victor.salazar@durion.internal',  'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    -- Role coverage: DISPATCHER for NORTH / MOB-HUB
-    ('01960011-0000-7000-8000-000000000024'::uuid, 'Renee',   'Albright',   'renee.albright',  'EMP-0036', 'renee.albright@durion.internal',  'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000025'::uuid, 'Curtis',  'Benton',     'curtis.benton',   'EMP-0037', 'curtis.benton@durion.internal',   'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    -- Role coverage: SERVICE_ADVISOR for NORTH / MOB-HUB
-    ('01960011-0000-7000-8000-000000000026'::uuid, 'Paula',   'Knight',     'paula.knight',    'EMP-0038', 'paula.knight@durion.internal',    'ACTIVE', CURRENT_DATE, NOW(), NOW()),
-    ('01960011-0000-7000-8000-000000000027'::uuid, 'Simon',   'Hayes',      'simon.hayes',     'EMP-0039', 'simon.hayes@durion.internal',     'ACTIVE', CURRENT_DATE, NOW(), NOW())
+    ('01960011-0000-7000-8000-000000000011'::uuid, 'Hector', 'Alvarez', 'EMP-0017', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000012'::uuid, 'Naomi', 'Ford', 'EMP-0018', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000013'::uuid, 'Trevor', 'Quinn', 'EMP-0019', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000014'::uuid, 'Camille', 'Boyd', 'EMP-0020', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000015'::uuid, 'Andre', 'Foster', 'EMP-0021', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000016'::uuid, 'Lila', 'Montgomery', 'EMP-0022', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000017'::uuid, 'Desmond', 'Pace', 'EMP-0023', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000018'::uuid, 'Brooke', 'Hadley', 'EMP-0024', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000019'::uuid, 'Felix', 'Romano', 'EMP-0025', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000001a'::uuid, 'Gina', 'Vaughn', 'EMP-0026', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000001b'::uuid, 'Omar', 'Haddad', 'EMP-0027', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000001c'::uuid, 'Sierra', 'Lowe', 'EMP-0028', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000001d'::uuid, 'Russell', 'Pike', 'EMP-0029', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000001e'::uuid, 'Maya', 'Devlin', 'EMP-0030', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-00000000001f'::uuid, 'Caleb', 'Frost', 'EMP-0031', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000020'::uuid, 'Yvonne', 'Marsh', 'EMP-0032', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000021'::uuid, 'Bernard', 'Cole', 'EMP-0033', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000022'::uuid, 'Gloria', 'Mensah', 'EMP-0034', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000023'::uuid, 'Victor', 'Salazar', 'EMP-0035', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000024'::uuid, 'Renee', 'Albright', 'EMP-0036', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000025'::uuid, 'Curtis', 'Benton', 'EMP-0037', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000026'::uuid, 'Paula', 'Knight', 'EMP-0038', 'ACTIVE', CURRENT_DATE, NOW(), NOW()),
+    ('01960011-0000-7000-8000-000000000027'::uuid, 'Simon', 'Hayes', 'EMP-0039', 'ACTIVE', CURRENT_DATE, NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
+
+-- Re-seed emails as EMAIL contact points (person email columns removed).
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000011'::uuid, 'EMAIL', 'hector.alvarez@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000011'::uuid AND contact_type='EMAIL' AND value='hector.alvarez@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000012'::uuid, 'EMAIL', 'naomi.ford@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000012'::uuid AND contact_type='EMAIL' AND value='naomi.ford@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000013'::uuid, 'EMAIL', 'trevor.quinn@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000013'::uuid AND contact_type='EMAIL' AND value='trevor.quinn@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000014'::uuid, 'EMAIL', 'camille.boyd@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000014'::uuid AND contact_type='EMAIL' AND value='camille.boyd@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000015'::uuid, 'EMAIL', 'andre.foster@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000015'::uuid AND contact_type='EMAIL' AND value='andre.foster@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000016'::uuid, 'EMAIL', 'lila.montgomery@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000016'::uuid AND contact_type='EMAIL' AND value='lila.montgomery@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000017'::uuid, 'EMAIL', 'desmond.pace@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000017'::uuid AND contact_type='EMAIL' AND value='desmond.pace@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000018'::uuid, 'EMAIL', 'brooke.hadley@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000018'::uuid AND contact_type='EMAIL' AND value='brooke.hadley@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000019'::uuid, 'EMAIL', 'felix.romano@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000019'::uuid AND contact_type='EMAIL' AND value='felix.romano@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000001a'::uuid, 'EMAIL', 'gina.vaughn@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000001a'::uuid AND contact_type='EMAIL' AND value='gina.vaughn@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000001b'::uuid, 'EMAIL', 'omar.haddad@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000001b'::uuid AND contact_type='EMAIL' AND value='omar.haddad@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000001c'::uuid, 'EMAIL', 'sierra.lowe@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000001c'::uuid AND contact_type='EMAIL' AND value='sierra.lowe@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000001d'::uuid, 'EMAIL', 'russell.pike@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000001d'::uuid AND contact_type='EMAIL' AND value='russell.pike@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000001e'::uuid, 'EMAIL', 'maya.devlin@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000001e'::uuid AND contact_type='EMAIL' AND value='maya.devlin@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-00000000001f'::uuid, 'EMAIL', 'caleb.frost@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-00000000001f'::uuid AND contact_type='EMAIL' AND value='caleb.frost@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000020'::uuid, 'EMAIL', 'yvonne.marsh@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000020'::uuid AND contact_type='EMAIL' AND value='yvonne.marsh@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000021'::uuid, 'EMAIL', 'bernard.cole@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000021'::uuid AND contact_type='EMAIL' AND value='bernard.cole@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000022'::uuid, 'EMAIL', 'gloria.mensah@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000022'::uuid AND contact_type='EMAIL' AND value='gloria.mensah@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000023'::uuid, 'EMAIL', 'victor.salazar@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000023'::uuid AND contact_type='EMAIL' AND value='victor.salazar@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000024'::uuid, 'EMAIL', 'renee.albright@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000024'::uuid AND contact_type='EMAIL' AND value='renee.albright@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000025'::uuid, 'EMAIL', 'curtis.benton@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000025'::uuid AND contact_type='EMAIL' AND value='curtis.benton@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000026'::uuid, 'EMAIL', 'paula.knight@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000026'::uuid AND contact_type='EMAIL' AND value='paula.knight@durion.internal');
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '01960011-0000-7000-8000-000000000027'::uuid, 'EMAIL', 'simon.hayes@durion.internal', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM person_contact_point WHERE person_id='01960011-0000-7000-8000-000000000027'::uuid AND contact_type='EMAIL' AND value='simon.hayes@durion.internal');
 
 -- person_location_assignment for the additional staff (guarded by location existence).
 -- effective_from = CURRENT_DATE keeps each row distinct under the

--- a/pos-people/src/main/resources/db/migration/R__seed_reference_people.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_reference_people.sql
@@ -22,13 +22,23 @@ ON CONFLICT (timekeeping_policy_id) DO NOTHING;
 -- person (System Administrator) — admin.alpha's person record. Required so the
 -- guarded user_person_links insert below fires; without it admin.alpha is a User
 -- with no Person, violating ADR-0015 §3 (durion-positivity-backend#714).
-INSERT INTO person (id, first_name, last_name, legal_name, primary_email, status, status_effective_at, username, created_at, updated_at)
+INSERT INTO person (id, first_name, last_name, legal_name, status, status_effective_at, created_at, updated_at)
 VALUES (
     '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid,
     'System', 'Administrator', 'System Administrator',
-    'admin.alpha@durionpos.org', 'ACTIVE', NOW(), 'admin.alpha', NOW(), NOW()
+    'ACTIVE', NOW(), NOW(), NOW()
 )
 ON CONFLICT (id) DO NOTHING;
+
+-- Email now lives in person_contact_point (EMAIL); username is resolved via
+-- user_person_links → pos-security. Re-seed admin.alpha's email here.
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid, 'EMAIL', 'admin.alpha@durionpos.org', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM person_contact_point
+    WHERE person_id = '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid
+      AND contact_type = 'EMAIL'
+      AND value = 'admin.alpha@durionpos.org');
 
 -- user_person_links (guarded by external person existence)
 DO $$

--- a/pos-people/src/main/resources/db/migration/V10__move_username_to_user_link.sql
+++ b/pos-people/src/main/resources/db/migration/V10__move_username_to_user_link.sql
@@ -1,0 +1,30 @@
+-- Username is owned by pos-security (users) and associated to a person via
+-- user_person_links. Remove person.username; ensure each legacy username exists as a
+-- security user and is linked, so no username is lost.
+
+-- 1. Create security users for person usernames not already present. Password is copied
+--    from an existing non-admin user as a default (admin's credential is never reused);
+--    these accounts should have their password reset before use.
+INSERT INTO users (id, username, password)
+SELECT gen_random_uuid(),
+       p.username,
+       COALESCE(
+           (SELECT u2.password FROM users u2 WHERE lower(u2.username) <> 'admin' ORDER BY u2.username LIMIT 1),
+           (SELECT u3.password FROM users u3 ORDER BY u3.username LIMIT 1))
+FROM person p
+WHERE p.username IS NOT NULL
+  AND btrim(p.username) <> ''
+  AND NOT EXISTS (SELECT 1 FROM users u WHERE lower(u.username) = lower(p.username));
+
+-- 2. Link each person to its security user (user_person_links.user_id is unique → one
+--    link per user; skip if that user is already linked).
+INSERT INTO user_person_links (id, person_id, user_id, status, link_type, created_at, created_by)
+SELECT gen_random_uuid(), p.id, u.id, 'ACTIVE', 'PRIMARY', NOW(), 'migration-v10'
+FROM person p
+JOIN users u ON lower(u.username) = lower(p.username)
+WHERE p.username IS NOT NULL
+  AND btrim(p.username) <> ''
+  AND NOT EXISTS (SELECT 1 FROM user_person_links l WHERE l.user_id = u.id);
+
+-- 3. Drop the column; username is now resolved via user_person_links → pos-security.
+ALTER TABLE person DROP COLUMN username;

--- a/pos-people/src/test/java/com/positivity/people/controller/UserPersonLinkControllerIT.java
+++ b/pos-people/src/test/java/com/positivity/people/controller/UserPersonLinkControllerIT.java
@@ -47,6 +47,11 @@ class UserPersonLinkControllerIT {
     @Autowired
     private UserPersonLinkRepository userPersonLinkRepository;
 
+    // Username is resolved from pos-security; mock the client so the IT does not make a
+    // real cross-service call (getUserById/getUsernamesByIds default to empty).
+    @org.springframework.test.context.bean.override.mockito.MockitoBean
+    private com.positivity.people.internal.client.SecurityServiceClient securityServiceClient;
+
     @BeforeEach
     void resetData() {
         userPersonLinkRepository.deleteAll();

--- a/pos-people/src/test/java/com/positivity/people/internal/service/PersonUsernameServiceTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/PersonUsernameServiceTest.java
@@ -1,0 +1,75 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.internal.client.SecurityServiceClient;
+import com.positivity.people.internal.client.dto.User;
+import com.positivity.people.internal.entity.Person;
+import com.positivity.people.internal.entity.UserPersonLink;
+import com.positivity.people.internal.repository.UserPersonLinkRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PersonUsernameServiceTest {
+
+    private static final UUID PERSON = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID USER = UUID.fromString("00000000-0000-0000-0000-000000000099");
+
+    @Mock
+    private UserPersonLinkRepository linkRepository;
+
+    @Mock
+    private SecurityServiceClient securityServiceClient;
+
+    @InjectMocks
+    private PersonUsernameService service;
+
+    private UserPersonLink link() {
+        UserPersonLink l = new UserPersonLink();
+        l.setUserId(USER);
+        l.setPerson(Person.builder().id(PERSON).build());
+        return l;
+    }
+
+    private User user() {
+        User u = new User();
+        u.setId(USER);
+        u.setUsername("jordan");
+        return u;
+    }
+
+    @Test
+    void usernameForPerson_resolvesViaLinkAndSecurity() {
+        when(linkRepository.findByPerson_Id(PERSON)).thenReturn(List.of(link()));
+        when(securityServiceClient.getUserById(USER)).thenReturn(Optional.of(user()));
+
+        assertThat(service.usernameForPerson(PERSON)).isEqualTo("jordan");
+    }
+
+    @Test
+    void usernameForPerson_nullWhenUnlinked() {
+        when(linkRepository.findByPerson_Id(PERSON)).thenReturn(List.of());
+
+        assertThat(service.usernameForPerson(PERSON)).isNull();
+    }
+
+    @Test
+    void usernamesByPersonId_batchResolves() {
+        when(linkRepository.findByPerson_IdIn(List.of(PERSON))).thenReturn(List.of(link()));
+        when(securityServiceClient.getUsernamesByIds(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Map.of(USER, "jordan"));
+
+        Map<UUID, String> result = service.usernamesByPersonId(List.of(PERSON));
+
+        assertThat(result).containsEntry(PERSON, "jordan");
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/service/UserPersonLinkServiceTest.java
+++ b/pos-people/src/test/java/com/positivity/people/service/UserPersonLinkServiceTest.java
@@ -57,6 +57,9 @@ class UserPersonLinkServiceTest {
     @Mock
     private com.positivity.people.internal.service.PersonEmailService emailService;
 
+    @Mock
+    private com.positivity.people.internal.service.PersonUsernameService usernameService;
+
     private UserPersonLinkServiceImpl service;
 
     // Fixed UUIDs for deterministic tests
@@ -70,7 +73,8 @@ class UserPersonLinkServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new UserPersonLinkServiceImpl(linkRepository, personRepository, workPhoneService, emailService);
+        service = new UserPersonLinkServiceImpl(
+                linkRepository, personRepository, workPhoneService, emailService, usernameService);
 
         // Initialize fixed test UUIDs
         testPersonId = UUID.fromString("00000000-0000-0000-0000-000000000001");


### PR DESCRIPTION
## Summary
`username` is owned by pos-security and linked through `user_person_link`; it is not a `Person` attribute. This drops the column and resolves usernames on read by following the link to pos-security.

## Changes
- **SecurityServiceClient**: `getUserById(UUID)` (fail-soft on 404 → empty) and batch `getUsernamesByIds(Collection<UUID>)`.
- **PersonUsernameService** (new): single + batched username resolution via `user_person_link` → pos-security.
- **PersonServiceImpl / UserPersonLinkServiceImpl**: no longer persist/validate username; populate it from the resolver (batched in list paths).
- Remove `Person.username` field and `PersonRepository.existsByUsername`.
- **V10**: create users for any `person.username` not yet present (copying a non-admin default password), backfill `user_person_links`, then `DROP COLUMN person.username`.

## Also fixes #743 latent fresh-DB break
The repeatable people seeds still inserted `person.primary_email` after V9 dropped that column → fresh-DB deploy would fail. De-columned the person inserts and re-seed email (and username via links) as contact points.

## Tests
`mvn -pl pos-people verify` green — units 100, ITs 103. New `PersonUsernameServiceTest`; `UserPersonLinkControllerIT` mocks `SecurityServiceClient` so the IT makes no real cross-service call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Contract
No API contract change — `username` remains on the Person/PersonResponse DTOs (now resolved at read time instead of stored). No OpenAPI/SDK regen required. Behaviour aligns with the people domain BACKEND_CONTRACT_GUIDE.md.
