### PR TITLE
fix(people): people search 500 — drop stale username predicate

### DIFF
--- a/pos-people/src/main/java/com/positivity/people/internal/repository/PersonSpecifications.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/PersonSpecifications.java
@@ -49,7 +49,8 @@ public final class PersonSpecifications {
             if (q != null && !q.isBlank()) {
                 String pattern = "%" + q.trim().toLowerCase() + "%";
                 // Email now lives in person_contact_point; match it via a correlated subquery
-                // on EMAIL contact-point values.
+                // on EMAIL contact-point values. Username is owned by pos-security (resolved
+                // via user_person_link) and is not a Person column, so it is not searchable here.
                 Subquery<UUID> emailMatch = query.subquery(UUID.class);
                 Root<PersonContactPoint> cp = emailMatch.from(PersonContactPoint.class);
                 emailMatch
@@ -60,7 +61,6 @@ public final class PersonSpecifications {
                 predicates.add(cb.or(
                         cb.like(cb.lower(root.get("firstName")), pattern),
                         cb.like(cb.lower(root.get("lastName")), pattern),
-                        cb.like(cb.lower(root.get("username")), pattern),
                         root.get("id").in(emailMatch)));
             }
 

--- a/pos-people/src/test/java/com/positivity/people/internal/repository/PersonSpecificationsQueryIT.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/repository/PersonSpecificationsQueryIT.java
@@ -1,0 +1,87 @@
+package com.positivity.people.internal.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.people.internal.entity.Person;
+import com.positivity.people.internal.entity.PersonContactPoint;
+import com.positivity.people.internal.enums.ContactPointType;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Executes {@link PersonSpecifications#directoryFilter} against a real JPA metamodel so
+ * the query's attribute references are resolved (the mock-based unit test cannot catch a
+ * predicate that references a non-existent attribute). Guards the people directory/search
+ * paths against regressions like a filter referencing a dropped Person column.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:specquery;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "spring.flyway.enabled=false",
+            "eureka.client.enabled=false"
+        })
+@ActiveProfiles("test")
+class PersonSpecificationsQueryIT {
+
+    @Autowired
+    private PersonRepository personRepository;
+
+    @Autowired
+    private PersonContactPointRepository contactPointRepository;
+
+    @MockitoBean
+    private com.positivity.people.internal.client.SecurityServiceClient securityServiceClient;
+
+    private UUID alice;
+    private UUID bob;
+
+    @BeforeEach
+    void seed() {
+        contactPointRepository.deleteAll();
+        personRepository.deleteAll();
+
+        Person a = personRepository.saveAndFlush(
+                Person.builder().firstName("Alice").lastName("Anderson").build());
+        Person b = personRepository.saveAndFlush(
+                Person.builder().firstName("Bob").lastName("Brown").build());
+        alice = a.getId();
+        bob = b.getId();
+
+        contactPointRepository.saveAndFlush(PersonContactPoint.builder()
+                .personId(bob)
+                .contactType(ContactPointType.EMAIL)
+                .value("bob@example.com")
+                .isPrimary(true)
+                .build());
+    }
+
+    @Test
+    void search_matchesByName() {
+        List<Person> result = personRepository.findAll(PersonSpecifications.directoryFilter(null, "ali"));
+        assertThat(result).extracting(Person::getId).containsExactly(alice);
+    }
+
+    @Test
+    void search_matchesByEmailContactPoint() {
+        List<Person> result = personRepository.findAll(PersonSpecifications.directoryFilter(null, "bob@example"));
+        assertThat(result).extracting(Person::getId).containsExactly(bob);
+    }
+
+    @Test
+    void search_blankReturnsAll() {
+        List<Person> result = personRepository.findAll(PersonSpecifications.directoryFilter(null, "  "));
+        assertThat(result).extracting(Person::getId).containsExactlyInAnyOrder(alice, bob);
+    }
+}


### PR DESCRIPTION
## Problem
All people searches (`/app/people`, `/app/people/directory`) returned 500.

## Cause
#744 removed `Person.username`, but `PersonSpecifications.directoryFilter` still referenced `root.get("username")` in the `q`-search OR clause. JPA cannot resolve the missing metamodel attribute at query time → every search with a query term threw.

## Fix
- Remove the username predicate. Search matches `firstName`, `lastName`, and EMAIL contact-point values. Username is owned by pos-security (resolved via `user_person_link`), not a searchable Person column.
- Add `PersonSpecificationsQueryIT` — executes `directoryFilter` against real JPA so attribute references resolve. The existing mock-based `PersonSpecificationsTest` mocks `Root`/`CriteriaBuilder` and never resolves attributes, which is why the break slipped through.

No API contract change (BACKEND_CONTRACT_GUIDE.md unaffected).

## Tests
`mvn -pl pos-people verify` green — units 103, ITs 103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)