### PR TITLE
fix(people): V10 crash-loop — drop username only, remove cross-DB users writes

### DIFF
--- a/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_people_operational_data.sql
@@ -408,6 +408,9 @@ UPDATE person
 DO $$
 BEGIN
     IF to_regclass('public.person') IS NOT NULL THEN
+        -- ON CONFLICT (user_id): user_person_links has a UNIQUE(user_id) constraint, so
+        -- guard on user_id (not just the PK id) — a link for any of these users under a
+        -- different id from an earlier seed must not raise a unique violation here.
         INSERT INTO user_person_links (id, user_id, person_id, link_type, status, created_at, created_by)
         VALUES
             ('01960012-0000-7000-8000-000000000001'::uuid, '01960010-0000-7000-8000-000000000001'::uuid, '01960011-0000-7000-8000-000000000001'::uuid, 'PRIMARY', 'ACTIVE', NOW(), 'seed-generator'),
@@ -426,7 +429,7 @@ BEGIN
             ('01960012-0000-7000-8000-00000000000e'::uuid, '01960010-0000-7000-8000-00000000000e'::uuid, '01960011-0000-7000-8000-00000000000e'::uuid, 'PRIMARY', 'ACTIVE', NOW(), 'seed-generator'),
             ('01960012-0000-7000-8000-00000000000f'::uuid, '01960010-0000-7000-8000-00000000000f'::uuid, '01960011-0000-7000-8000-00000000000f'::uuid, 'PRIMARY', 'ACTIVE', NOW(), 'seed-generator'),
             ('01960012-0000-7000-8000-000000000010'::uuid, '01960010-0000-7000-8000-000000000010'::uuid, '01960011-0000-7000-8000-000000000010'::uuid, 'PRIMARY', 'ACTIVE', NOW(), 'seed-generator')
-        ON CONFLICT (id) DO NOTHING;
+        ON CONFLICT (user_id) DO NOTHING;
     END IF;
 END $$;
 

--- a/pos-people/src/main/resources/db/migration/R__seed_reference_people.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_reference_people.sql
@@ -46,6 +46,9 @@ BEGIN
     IF to_regclass('public.person') IS NOT NULL
        AND EXISTS (SELECT 1 FROM person WHERE id = '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid)
     THEN
+        -- ON CONFLICT (user_id): user_person_links has a UNIQUE(user_id) constraint, so
+        -- guard on user_id (not just the PK id) — a link for this user under a different
+        -- id from an earlier seed must not raise a unique violation here.
         INSERT INTO user_person_links (id, user_id, person_id, link_type, status, created_at, created_by)
         VALUES (
             '4790360f-65ab-20e9-88e3-7bf9277bf2b9'::uuid,
@@ -56,7 +59,7 @@ BEGIN
             NOW(),
             'seed-generator'
         )
-        ON CONFLICT (id) DO NOTHING;
+        ON CONFLICT (user_id) DO NOTHING;
     END IF;
 END $$;
 

--- a/pos-people/src/main/resources/db/migration/V10__move_username_to_user_link.sql
+++ b/pos-people/src/main/resources/db/migration/V10__move_username_to_user_link.sql
@@ -1,30 +1,12 @@
--- Username is owned by pos-security (users) and associated to a person via
--- user_person_links. Remove person.username; ensure each legacy username exists as a
--- security user and is linked, so no username is lost.
-
--- 1. Create security users for person usernames not already present. Password is copied
---    from an existing non-admin user as a default (admin's credential is never reused);
---    these accounts should have their password reset before use.
-INSERT INTO users (id, username, password)
-SELECT gen_random_uuid(),
-       p.username,
-       COALESCE(
-           (SELECT u2.password FROM users u2 WHERE lower(u2.username) <> 'admin' ORDER BY u2.username LIMIT 1),
-           (SELECT u3.password FROM users u3 ORDER BY u3.username LIMIT 1))
-FROM person p
-WHERE p.username IS NOT NULL
-  AND btrim(p.username) <> ''
-  AND NOT EXISTS (SELECT 1 FROM users u WHERE lower(u.username) = lower(p.username));
-
--- 2. Link each person to its security user (user_person_links.user_id is unique → one
---    link per user; skip if that user is already linked).
-INSERT INTO user_person_links (id, person_id, user_id, status, link_type, created_at, created_by)
-SELECT gen_random_uuid(), p.id, u.id, 'ACTIVE', 'PRIMARY', NOW(), 'migration-v10'
-FROM person p
-JOIN users u ON lower(u.username) = lower(p.username)
-WHERE p.username IS NOT NULL
-  AND btrim(p.username) <> ''
-  AND NOT EXISTS (SELECT 1 FROM user_person_links l WHERE l.user_id = u.id);
-
--- 3. Drop the column; username is now resolved via user_person_links → pos-security.
-ALTER TABLE person DROP COLUMN username;
+-- Username is owned by pos-security (its own `users` table, a separate database that
+-- pos-people cannot reach) and is associated to a person via user_person_links. It is no
+-- longer a Person attribute: it is resolved on read by following user_person_links.user_id
+-- to pos-security. Drop the redundant local column.
+--
+-- NOTE: creating security users / backfilling user_person_links for any legacy
+-- person.username is intentionally NOT done here — a pos-people migration has no access to
+-- pos-security's `users` table (the earlier version of this script tried to INSERT INTO
+-- users and failed on deploy with "relation \"users\" does not exist"). That one-time
+-- backfill (only for persons that have a username but no link) belongs to pos-security or
+-- an app-level task against its API.
+ALTER TABLE person DROP COLUMN IF EXISTS username;


### PR DESCRIPTION
## Incident
pos-people was crash-looping (503 on all routes incl `/actuator/health`) on alpha. Downstream, CRM `/app/crm/customers` showed blank person names and blank primary contacts.

## Cause
`V10__move_username_to_user_link.sql` tried to `INSERT INTO users` and backfill `user_person_links`. But `users` is owned by **pos-security in a separate database** — pos-people cannot see it. Deploy log:

```
Migrating schema "public" to version "10 - move username to user link"
ERROR: relation "users" does not exist   (SQLSTATE 42P01)   Line 8
Application run failed → context init cancelled
```

Flyway ran V10 in a transaction, rolled back fully (column NOT dropped, no partial data), and marked V10 failed → app refuses to start → 503.

CRM goes blank because pos-customer keeps **no local copy** of person identity (ADR-0015 I2, #684) and sources names/contacts solely from pos-people `/v1/people/by-ids`. With pos-people down, the resilient (quiet) fetch returns empty → names/contacts degrade to null. Re-adding local name/email columns would be the wrong fix (reintroduces the redundancy that was just removed) — restoring pos-people is correct.

## Fix
V10 now only drops the redundant column:

```sql
ALTER TABLE person DROP COLUMN IF EXISTS username;
```

No cross-DB writes. Username is already resolved on read via `user_person_links` → pos-security (#744), so nothing depends on the local column. Creating security users / backfilling links for legacy usernames is a pos-security / app-level task, not a pos-people migration.

## Recovery (envs where old V10 failed)
1. Merge → CI builds the corrected image.
2. On the `positivity` DB, clear the failed history row:
   ```sql
   DELETE FROM flyway_schema_history WHERE version = '10';
   ```
   (or `flyway repair`)
3. Deploy/restart pos-people → corrected V10 runs, column drops, service starts, CRM names return.

## Why CI missed it
ITs run with `spring.flyway.enabled=false` + H2 `ddl-auto=create-drop`, so V9/V10 are never executed against Postgres. Follow-up: add a Testcontainers Postgres job that runs the Flyway migrations in CI. No API contract change (BACKEND_CONTRACT_GUIDE.md unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)