### PR TITLE
fix(workorder): real workorder number + standalone parts in detail

### DIFF
--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderDetailServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderDetailServiceImpl.java
@@ -7,9 +7,11 @@ import com.positivity.workorder.internal.dto.WorkorderServiceResponse;
 import com.positivity.workorder.internal.entity.TechnicianAssignment;
 import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.entity.WorkorderLaborEntry;
+import com.positivity.workorder.internal.entity.WorkorderPart;
 import com.positivity.workorder.internal.enums.WorkorderStatus;
 import com.positivity.workorder.internal.repository.TechnicianAssignmentRepository;
 import com.positivity.workorder.internal.repository.WorkorderLaborEntryRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.service.WorkorderDetailService;
 import java.math.BigDecimal;
@@ -17,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -37,6 +40,7 @@ public class WorkorderDetailServiceImpl implements WorkorderDetailService {
     private final WorkorderRepository workorderRepository;
     private final TechnicianAssignmentRepository technicianAssignmentRepository;
     private final WorkorderLaborEntryRepository laborEntryRepository;
+    private final WorkorderPartRepository workorderPartRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -62,7 +66,7 @@ public class WorkorderDetailServiceImpl implements WorkorderDetailService {
 
         // Build part line items
         List<WorkorderPartResponse> partResponses =
-                buildPartResponses(workorder.getServices(), capabilities.isCanViewFinancials());
+                buildPartResponses(workorder, capabilities.isCanViewFinancials());
 
         // Calculate derived status fields
         boolean isStarted = isWorkorderStarted(workorder.getStatus());
@@ -72,9 +76,7 @@ public class WorkorderDetailServiceImpl implements WorkorderDetailService {
         // Build response
         WorkorderDetailResponse.WorkorderDetailResponseBuilder builder = WorkorderDetailResponse.builder()
                 .workorderId(workorder.getId())
-                .workorderNumber(generateWorkorderNumber(workorder.getId())) // Placeholder - implement
-                // sequence lookup
-                // if needed
+                .workorderNumber(workorder.getWorkorderNumber())
                 .status(workorder.getStatus())
                 .customerId(workorder.getCustomerId())
                 .customerName(lookupCustomerName(workorder.getCustomerId()))
@@ -163,41 +165,47 @@ public class WorkorderDetailServiceImpl implements WorkorderDetailService {
                 .toList();
     }
 
-    private List<WorkorderPartResponse> buildPartResponses(
-            List<com.positivity.workorder.internal.entity.WorkorderServiceLine> services, boolean includeFinancials) {
+    private List<WorkorderPartResponse> buildPartResponses(Workorder workorder, boolean includeFinancials) {
+        // Parts attach either under a service line (work_order_service_id) or directly to the
+        // workorder as standalone parts (work_order_id, no service) — the latter is how
+        // estimate-promoted PART items are stored. Collect both so the detail screen shows every
+        // part. The standalone finder filters work_order_service_id IS NULL to avoid duplicating
+        // service-nested parts.
+        Stream<WorkorderPart> serviceNested = workorder.getServices() == null
+                ? Stream.empty()
+                : workorder.getServices().stream()
+                        .flatMap(service -> service.getParts() != null ? service.getParts().stream() : Stream.empty());
 
-        if (services == null || services.isEmpty()) {
-            return List.of();
+        Stream<WorkorderPart> standalone =
+                workorderPartRepository.findByWorkorderIdAndWorkOrderServiceIsNull(workorder.getId()).stream();
+
+        return Stream.concat(serviceNested, standalone)
+                .map(part -> toPartResponse(part, includeFinancials))
+                .toList();
+    }
+
+    private WorkorderPartResponse toPartResponse(WorkorderPart part, boolean includeFinancials) {
+        WorkorderPartResponse.WorkorderPartResponseBuilder builder = WorkorderPartResponse.builder()
+                .id(part.getId())
+                .productEntityId(part.getProductEntityId())
+                .description(part.getDescription())
+                .status(part.getStatus())
+                .quantity(part.getQuantity())
+                .quantityIssued(part.getQuantityIssued())
+                .quantityConsumed(part.getQuantityConsumed())
+                .quantityReturned(part.getQuantityReturned());
+
+        if (includeFinancials) {
+            BigDecimal partCost = (part.getQuantity() != null && part.getUnitPrice() != null)
+                    ? part.getQuantity().multiply(part.getUnitPrice())
+                    : BigDecimal.ZERO;
+
+            builder.unitPrice(part.getUnitPrice())
+                    .partCost(partCost)
+                    .lineTotal(part.getLineTotal());
         }
 
-        // Collect all parts from services
-        return services.stream()
-                .flatMap(service ->
-                        service.getParts() != null ? service.getParts().stream() : java.util.stream.Stream.empty())
-                .map(part -> {
-                    WorkorderPartResponse.WorkorderPartResponseBuilder builder = WorkorderPartResponse.builder()
-                            .id(part.getId())
-                            .productEntityId(part.getProductEntityId())
-                            .description(part.getDescription())
-                            .status(part.getStatus())
-                            .quantity(part.getQuantity())
-                            .quantityIssued(part.getQuantityIssued())
-                            .quantityConsumed(part.getQuantityConsumed())
-                            .quantityReturned(part.getQuantityReturned());
-
-                    if (includeFinancials) {
-                        BigDecimal partCost = (part.getQuantity() != null && part.getUnitPrice() != null)
-                                ? part.getQuantity().multiply(part.getUnitPrice())
-                                : BigDecimal.ZERO;
-
-                        builder.unitPrice(part.getUnitPrice())
-                                .partCost(partCost)
-                                .lineTotal(part.getLineTotal());
-                    }
-
-                    return builder.build();
-                })
-                .toList();
+        return builder.build();
     }
 
     private boolean isWorkorderStarted(WorkorderStatus status) {
@@ -218,11 +226,6 @@ public class WorkorderDetailServiceImpl implements WorkorderDetailService {
                 .map(WorkorderPartResponse::getPartCost)
                 .filter(Objects::nonNull)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-    }
-
-    private String generateWorkorderNumber(UUID workorderId) {
-        // Placeholder - implement proper sequence lookup if needed
-        return "WO-" + workorderId.toString().substring(0, 8).toUpperCase();
     }
 
     private String lookupCustomerName(UUID customerId) {

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderDetailServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderDetailServiceImplTest.java
@@ -6,8 +6,11 @@ import static org.mockito.Mockito.when;
 import com.positivity.workorder.internal.dto.WorkorderDetailResponse;
 import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.enums.WorkorderItemStatus;
 import com.positivity.workorder.internal.repository.TechnicianAssignmentRepository;
 import com.positivity.workorder.internal.repository.WorkorderLaborEntryRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.internal.service.WorkorderDetailServiceImpl;
 import java.time.Instant;
@@ -33,6 +36,9 @@ class WorkorderDetailServiceImplTest {
 
     @Mock
     private WorkorderLaborEntryRepository laborEntryRepository;
+
+    @Mock
+    private WorkorderPartRepository workorderPartRepository;
 
     @InjectMocks
     private WorkorderDetailServiceImpl service;
@@ -64,5 +70,40 @@ class WorkorderDetailServiceImplTest {
         assertThat(response.getAssignedTechnicianId()).isNull();
         assertThat(response.getAssignedTechnicianName()).isNull();
         assertThat(response.getCapabilities().isCanViewFinancials()).isFalse();
+    }
+
+    @Test
+    @DisplayName("getWorkorderDetail: returns stored workorder number and includes standalone parts")
+    void getWorkorderDetail_returnsWorkorderNumberAndStandaloneParts() {
+        UUID workorderId = UUID.fromString("55555555-5555-5555-5555-555555555555");
+        Workorder workorder = Workorder.builder()
+                .id(workorderId)
+                .workorderNumber("WO-2026-1042")
+                .customerId(UUID.fromString("22222222-2222-2222-2222-222222222222"))
+                .vehicleId(UUID.fromString("33333333-3333-3333-3333-333333333333"))
+                .shopId(UUID.fromString("44444444-4444-4444-4444-444444444444"))
+                .status(WorkorderStatus.APPROVED)
+                .updatedAt(Instant.parse("2026-04-18T12:00:00Z"))
+                .services(java.util.List.of())
+                .build();
+
+        WorkorderPart standalonePart = WorkorderPart.builder()
+                .id(UUID.fromString("66666666-6666-6666-6666-666666666666"))
+                .description("Brake pad set")
+                .quantity(java.math.BigDecimal.valueOf(2))
+                .status(WorkorderItemStatus.OPEN)
+                .build();
+
+        when(workorderRepository.findById(workorderId)).thenReturn(Optional.of(workorder));
+        when(technicianAssignmentRepository.findByWorkorder_IdAndCurrentTrue(workorderId))
+                .thenReturn(Optional.empty());
+        when(workorderPartRepository.findByWorkorderIdAndWorkOrderServiceIsNull(workorderId))
+                .thenReturn(java.util.List.of(standalonePart));
+
+        WorkorderDetailResponse response = service.getWorkorderDetail(workorderId, Set.of("workorder:workorder:view"));
+
+        assertThat(response.getWorkorderNumber()).isEqualTo("WO-2026-1042");
+        assertThat(response.getParts()).hasSize(1);
+        assertThat(response.getParts().get(0).getDescription()).isEqualTo("Brake pad set");
     }
 }


### PR DESCRIPTION
## Problem
On the workorder detail screen: the heading showed the raw UUID instead of the human number, and parts were missing.

Two backend root causes (both fields already on the contract — populated wrong):
1. **Number** — `WorkorderDetailServiceImpl` set `workorderNumber` to a placeholder `"WO-" + uuid[0:8]` ("Placeholder - implement sequence lookup") instead of the stored `workorder.getWorkorderNumber()` (the V3 `WO-YYYY-NNNN` value).
2. **Parts** — `buildPartResponses` collected parts only from service lines. Estimate-promoted PART items are stored **standalone** (`workorder` set, `workOrderService = null`, see `WorkorderServiceImpl:344`), so they were never included.

## Fix
- Emit `workorder.getWorkorderNumber()`; delete the placeholder generator.
- `buildPartResponses` unions service-nested parts with standalone parts via the existing `WorkorderPartRepository.findByWorkorderIdAndWorkOrderServiceIsNull` (dedup-safe), through one shared `toPartResponse` mapper.
- Inject `WorkorderPartRepository`.
- New test: stored-number passthrough + standalone-part inclusion.

No OpenAPI/SDK change — `workorderNumber` and `parts` already exist on `WorkorderDetailResponse`.

## Verification
- Compile: SUCCESS
- Unit: **306** tests, 0 failures
- Detail Visibility contract IT: **8** tests, 0 failures

## Related
- Frontend half (consume `workorderNumber`, render it): durion-positivity-frontend (linked PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)