### PR TITLE
fix(workorder): require a real location for estimates, drop sentinel fallback

### DIFF
--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -83,11 +83,8 @@ public class EstimateServiceImpl implements EstimateService {
     // Configuration defaults
     private static final String DEFAULT_CURRENCY = "USD";
     private static final String DEFAULT_TAX_REGION_ID_PROPERTY = "workorder.estimate.default-tax-region-id";
-    private static final String FALLBACK_LOCATION_ID_PROPERTY = "workorder.estimate.fallback-location-id";
     private static final UUID DEFAULT_TAX_REGION_ID =
             UUID.fromString(System.getProperty(DEFAULT_TAX_REGION_ID_PROPERTY, "00000000-0000-0000-0000-000000000001"));
-    private static final UUID FALLBACK_LOCATION_ID =
-            UUID.fromString(System.getProperty(FALLBACK_LOCATION_ID_PROPERTY, "00000000-0000-0000-0000-000000000001"));
 
     // Tax category constants
     private static final String TAX_CATEGORY_GOODS = "GOODS";
@@ -246,10 +243,18 @@ public class EstimateServiceImpl implements EstimateService {
 
         validateCreateEstimateRequest(request);
 
-        // Apply defaults
+        // Apply defaults. An estimate must belong to a real location — staffing, approval
+        // configuration and downstream workorder technician rosters are all keyed on it.
+        // Prefer the request's location, else the creator's primary location. Never fabricate
+        // a placeholder location: a non-existent location silently breaks every downstream
+        // consumer (e.g. the assign page finds no technicians staffed there).
         UUID locationId = request.getLocationId() != null
                 ? request.getLocationId()
-                : peopleLocationClient.resolveCurrentUserPrimaryLocation().orElse(FALLBACK_LOCATION_ID);
+                : peopleLocationClient
+                        .resolveCurrentUserPrimaryLocation()
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                "locationId is required: none was provided and the current user has no primary "
+                                        + "location assignment to derive one from"));
         String currencyUomId = request.getCurrencyUomId() != null ? request.getCurrencyUomId() : DEFAULT_CURRENCY;
         UUID taxRegionId = request.getTaxRegionId() != null ? request.getTaxRegionId() : DEFAULT_TAX_REGION_ID;
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceImplTest.java
@@ -169,6 +169,7 @@ class EstimateServiceImplTest {
         CreateEstimateRequest request = CreateEstimateRequest.builder()
                 .customerId(LOCAL_CUSTOMER_ID)
                 .vehicleId(LOCAL_VEHICLE_ID)
+                .locationId(UUID.fromString("01960003-0000-7000-8000-000000000001"))
                 .build();
         ApprovalConfiguration config =
                 ApprovalConfiguration.builder().id(CONFIG_ID).build();
@@ -181,6 +182,21 @@ class EstimateServiceImplTest {
         assertEquals(LOCAL_CUSTOMER_ID, result.getCustomerId());
         assertEquals(LOCAL_VEHICLE_ID, result.getVehicleId());
         assertEquals(EstimateStatus.DRAFT.toString(), result.getStatus());
+    }
+
+    @Test
+    void createEstimate_noLocationAndNoPrimaryLocation_throwsException() {
+        // No request location and the creator has no primary location to derive one from:
+        // reject rather than fabricating a placeholder location that has no staffing.
+        CreateEstimateRequest request = CreateEstimateRequest.builder()
+                .customerId(LOCAL_CUSTOMER_ID)
+                .vehicleId(LOCAL_VEHICLE_ID)
+                .build();
+        when(peopleLocationClient.resolveCurrentUserPrimaryLocation()).thenReturn(java.util.Optional.empty());
+
+        IllegalArgumentException exception = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class, () -> estimateService.createEstimate(request, "testuser"));
+        org.junit.jupiter.api.Assertions.assertTrue(exception.getMessage().contains("locationId is required"));
     }
 
     @Test

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceTest.java
@@ -93,6 +93,10 @@ class EstimateServiceTest {
 
         when(estimateRepository.existsByLocationIdAndEstimateNumber(any(UUID.class), anyString()))
                 .thenReturn(false);
+
+        // Requests without an explicit location resolve the creator's primary location.
+        when(peopleLocationClient.resolveCurrentUserPrimaryLocation())
+                .thenReturn(java.util.Optional.of(UUID.fromString("01960003-0000-7000-8000-000000000001")));
     }
 
     @Test


### PR DESCRIPTION
## Problem
On the assign page, `GET /v1/people/availability?locationId=00000000-0000-0000-0000-000000000001` returned no technicians.

Root cause is **not** the availability endpoint (it correctly returns staff for a location). The workorder's `shop_id` was the placeholder `00000000-0000-0000-0000-000000000001` — `EstimateServiceImpl`'s `FALLBACK_LOCATION_ID`, assigned when an estimate is created with no request location **and** the creator has no resolvable primary location. That UUID is not a real location and has no staffing (seed staffs technicians only at `01960003-…0001/0002/0003`), so the roster is empty.

## Fix
`createEstimate` now resolves: request location → creator primary location → **fail fast** (`IllegalArgumentException`). It never fabricates a placeholder location. `FALLBACK_LOCATION_ID` and its system property are removed.

A non-existent location silently breaks staffing, approval config, and the workorder technician roster — rejecting is correct (pre-production: clean/correct over a broken default).

## Tests
- New: no-location + no-primary-location → rejection.
- Existing happy paths given a real location or a stubbed primary location.

## Verification
- Compile: SUCCESS
- Unit: **307** / 0
- IT: **191** / 0

## Follow-up (data)
Existing rows already on the placeholder need a one-off repoint to a real staffed location (separate, applied on the environment DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)