### PR TITLE
fix(workorder): surface reason in technician assign/reassign 400

### DIFF
--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/TechnicianAssignmentController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/TechnicianAssignmentController.java
@@ -118,8 +118,18 @@ public class TechnicianAssignmentController {
             return ResponseEntity.notFound().build();
         } catch (IllegalStateException e) {
             log.warn("Assignment failed - invalid state: {}", e.getMessage());
-            return ResponseEntity.badRequest().build();
+            // Surface the reason (e.g. workorder status not assignable) so the client can show
+            // it instead of an empty 400.
+            return ResponseEntity.badRequest().body(errorResponse(workorderId, e.getMessage()));
         }
+    }
+
+    /** Build a minimal response carrying just the failure reason for error status codes. */
+    private TechnicianAssignmentResponse errorResponse(UUID workorderId, String message) {
+        return TechnicianAssignmentResponse.builder()
+                .workorderId(workorderId.toString())
+                .message(message)
+                .build();
     }
 
     /**
@@ -201,7 +211,7 @@ public class TechnicianAssignmentController {
             return ResponseEntity.notFound().build();
         } catch (IllegalStateException e) {
             log.warn("Reassignment failed - invalid state: {}", e.getMessage());
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(errorResponse(workorderId, e.getMessage()));
         }
     }
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/contract/TechnicianAssignmentContractBehaviorIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/contract/TechnicianAssignmentContractBehaviorIT.java
@@ -256,7 +256,9 @@ class TechnicianAssignmentContractBehaviorIT extends BaseContractIntegrationTest
                 .then()
                 .log()
                 .ifValidationFails()
-                .statusCode(400); // Bad request due to invalid state
+                .statusCode(400) // Bad request due to invalid state
+                // The reason is surfaced in the body, not an empty 400.
+                .body("message", org.hamcrest.Matchers.containsString("Cannot assign technician"));
 
         // Then: Verify no assignment was created
         List<TechnicianAssignment> assignments =


### PR DESCRIPTION
## Problem
Assigning a technician on a non-approved workorder returned an **empty 400**. The assign page showed a generic "Failed to save" with no reason.

`assignTechnician`/`reassignTechnician` caught `IllegalStateException` (workorder not in an assignable status) and returned `badRequest().build()`, discarding the message: *"Cannot assign technician: workorder must be in APPROVED, ASSIGNED, or WORK_IN_PROGRESS status. Current status: …"*

## Fix
Return that message in the response body (the existing `TechnicianAssignmentResponse.message` field) while keeping the **400** status. The frontend already reads `err.error.message`, so it now displays the real reason — no frontend change.

Locked with a contract assertion that the 400 body carries the reason.

## Not changed
Status code (still 400) and success schema are untouched → no OpenAPI/SDK change. This is the error-surfacing fix only; the *workflow* rule (assignment requires an APPROVED+ workorder) is unchanged and correct.

## Verification
- Compile: SUCCESS
- Unit: **307** / 0
- Technician Assignment contract IT: **6** / 0 (now asserts the 400 body message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)