### PR TITLE
fix(deploy): decouple pos-invoice from pos-tax health + pos-tax warmup window

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -460,8 +460,6 @@ services:
         condition: service_healthy
       pos-security-service:
         condition: service_healthy
-      pos-tax:
-        condition: service_healthy
     logging: *logging
     networks:
       - pos-network
@@ -495,9 +493,10 @@ services:
       - pos-network
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://localhost:8091/actuator/health || exit 1" ]
-      interval: 5s
-      timeout: 3s
-      retries: 20
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 90s
 
   pos-location:
     build:


### PR DESCRIPTION
## Problem

After #753 merged, the alpha deploy failed:
```
dependency failed to start: container backend-pos-tax-1 is unhealthy
```

## Root cause (compose wiring, two issues)

1. **`pos-invoice depends_on pos-tax: service_healthy`** — incorrect. pos-invoice calls pos-tax over HTTP at request time, not at boot. The analogous `pos-accounting → pos-invoice` client has no such compose dependency. This coupling let a slow/unhealthy pos-tax abort the entire backend bring-up. **Removed.**
2. **pos-tax healthcheck had no `start_period`** — cold-boot under alpha load (many JVMs + OTEL agents) exhausted the retry window before startup completed. Switched to the lenient pattern already used by `pos-vehicle-inventory`: `start_period 90s, interval 10s, timeout 5s, retries 12`.

## Why this is timing, not an app defect

pos-tax boots healthy in isolation locally (`/actuator/health` → `200 UP`) with no datasource and Flyway disabled, and `EventTypeInitializer` swallows startup errors (non-fatal). So the fix is to orchestration/timing, not the service.

## Verification
- `docker compose config` valid for base and merged alpha-prod.
- Container-log confirmation that pos-tax reaches `Started PosTax...` on alpha to be attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)