### PR TITLE
fix(invoice): pos-location service-to-service port 8080

### DIFF
--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/client/LocationServiceClient.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/client/LocationServiceClient.java
@@ -25,7 +25,7 @@ public class LocationServiceClient {
 
     public LocationServiceClient(
             RestClient.Builder restClientBuilder,
-            @Value("${invoice.location.base-url:http://pos-location:8084/v1/locations}") String locationBaseUrl) {
+            @Value("${invoice.location.base-url:http://pos-location:8080/v1/locations}") String locationBaseUrl) {
         this.restClient = restClientBuilder.baseUrl(locationBaseUrl).build();
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #756. Invoice tax calculation now reaches pos-location, but the call failed with `Connection refused` to `http://pos-location:8084`.

`8084` is the **host → container** port mapping (`8084:8080` in docker-compose). Inside `pos-network` the service listens on `SERVER_PORT: 8080`. Service-to-service calls must use the container port, so `LocationServiceClient` now defaults to `http://pos-location:8080/v1/locations`.

(pos-tax works on `8091` because its `SERVER_PORT` genuinely is `8091`.)

## Change

- `LocationServiceClient` default base URL: `8084` → `8080`.

Overridable via `invoice.location.base-url`.

## Caveat

Once the connection succeeds, the `location:read` authority propagation (gateway / perm-bits catalog) is the next thing to verify at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)