### PR TITLE
fix(tax): default to built-in test calculator until real tax service exists

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -483,6 +483,8 @@ services:
       SERVER_PORT: 8091
       MANAGEMENT_SERVER_PORT: 8091
       SPRING_FLYWAY_ENABLED: "false"
+      # Use the built-in test tax calculator locally; no real external tax service exists yet.
+      TAX_TEST_MODE: "true"
     depends_on:
       eureka-server:
         condition: service_healthy

--- a/pos-tax/src/main/resources/application.yml
+++ b/pos-tax/src/main/resources/application.yml
@@ -50,7 +50,9 @@ springdoc:
 pos:
   tax:
     test-mode:
-      enabled: ${TAX_TEST_MODE:false}
+      # Default to the built-in test calculator until a real external tax service is wired.
+      # Set TAX_TEST_MODE=false (and configure external-service.base-url) to route externally.
+      enabled: ${TAX_TEST_MODE:true}
       default-rates:
         STATE: 0.0725 # 7.25% state tax
         COUNTY: 0.01 # 1% county tax


### PR DESCRIPTION
## Summary

Follow-up to #756/#757. With the invoice→pos-location→pos-tax path now connected, pos-tax failed `TAX_CALCULATE` with `UnknownHostException: api.taxservice.example.com` (HTTP 500).

pos-tax routes to an external tax service whose `base-url` defaults to the placeholder `https://api.taxservice.example.com`. No real external tax service is wired in any environment yet — pos-tax is meant to **mock** tax via its built-in `TestModeTaxCalculator` until one is integrated.

The `test-mode.enabled` flag defaulted to `false` (`${TAX_TEST_MODE:false}`), so every calculation hit the placeholder host.

## Change

- `pos-tax/application.yml`: `test-mode.enabled` default `false` → `true` (`${TAX_TEST_MODE:true}`). Set `TAX_TEST_MODE=false` (and configure `external-service.base-url`) to route to a real service when one exists.
- `docker-compose.yml`: set `TAX_TEST_MODE: "true"` explicitly for pos-tax (local clarity).

The app already supports both modes (`TaxCalculationServiceImpl` routes on `isTestMode()`); this only changes the default.

## Effect

Invoice tax calculation completes end-to-end using the test calculator (`testMode=true` in the response), unblocking invoice creation locally and in deployed envs until the real tax integration lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)