### PR TITLE
build: deterministic jar names (finalName) + exact Dockerfile copies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,11 @@
 	</properties>
 
 	<build>
+		<!-- Stable, version-independent artifact name so each module emits e.g. pos-tax.jar.
+		     Keeps target/ deterministic and lets Dockerfiles COPY an exact filename, immune to
+		     leftover versioned jars from prior builds. finalName affects only the target/ file
+		     name, not the installed artifact coordinates, so inter-module resolution is unchanged. -->
+		<finalName>${project.artifactId}</finalName>
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/pos-accounting/Dockerfile
+++ b/pos-accounting/Dockerfile
@@ -16,7 +16,7 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-accounting-*.jar pos-accounting.jar
+COPY target/pos-accounting.jar pos-accounting.jar
 EXPOSE 9001
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-accounting.jar"]
 

--- a/pos-api-gateway/Dockerfile
+++ b/pos-api-gateway/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-api-gateway-*.jar pos-api-gateway.jar
+COPY target/pos-api-gateway.jar pos-api-gateway.jar
 EXPOSE 8080
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-api-gateway.jar"]

--- a/pos-bulk-loader/Dockerfile
+++ b/pos-bulk-loader/Dockerfile
@@ -14,6 +14,6 @@ ARG OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 ENV OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
 ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
-COPY target/pos-bulk-loader-*.jar pos-bulk-loader.jar
+COPY target/pos-bulk-loader.jar pos-bulk-loader.jar
 EXPOSE 8080
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-bulk-loader.jar"]

--- a/pos-catalog/Dockerfile
+++ b/pos-catalog/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-catalog-*.jar pos-catalog.jar
+COPY target/pos-catalog.jar pos-catalog.jar
 EXPOSE 8081
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-catalog.jar"]

--- a/pos-customer/Dockerfile
+++ b/pos-customer/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-customer-*.jar pos-customer.jar
+COPY target/pos-customer.jar pos-customer.jar
 EXPOSE 8082
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-customer.jar"]

--- a/pos-event-receiver/Dockerfile
+++ b/pos-event-receiver/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-event-receiver-*.jar pos-event-receiver.jar
+COPY target/pos-event-receiver.jar pos-event-receiver.jar
 EXPOSE 9002
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-event-receiver.jar"]

--- a/pos-events/Dockerfile
+++ b/pos-events/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-events-*.jar pos-events.jar
+COPY target/pos-events.jar pos-events.jar
 EXPOSE 9003
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-events.jar"]

--- a/pos-image/Dockerfile
+++ b/pos-image/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-image-*.jar pos-image.jar
+COPY target/pos-image.jar pos-image.jar
 EXPOSE 8083
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-image.jar"]

--- a/pos-inquiry/Dockerfile
+++ b/pos-inquiry/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-inquiry-*.jar pos-inquiry.jar
+COPY target/pos-inquiry.jar pos-inquiry.jar
 EXPOSE 9004
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-inquiry.jar"]

--- a/pos-inventory/Dockerfile
+++ b/pos-inventory/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-inventory-*.jar pos-inventory.jar
+COPY target/pos-inventory.jar pos-inventory.jar
 EXPOSE 9005
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-inventory.jar"]

--- a/pos-invoice/Dockerfile
+++ b/pos-invoice/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-invoice-*.jar pos-invoice.jar
+COPY target/pos-invoice.jar pos-invoice.jar
 EXPOSE 9006
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-invoice.jar"]

--- a/pos-location/Dockerfile
+++ b/pos-location/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-location-*.jar pos-location.jar
+COPY target/pos-location.jar pos-location.jar
 EXPOSE 8084
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-location.jar"]

--- a/pos-mcp-server/Dockerfile
+++ b/pos-mcp-server/Dockerfile
@@ -14,6 +14,6 @@ ARG OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 ENV OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
 ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
-COPY target/pos-mcp-server-*.jar pos-mcp-server.jar
+COPY target/pos-mcp-server.jar pos-mcp-server.jar
 EXPOSE 8086
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-mcp-server.jar"]

--- a/pos-order/Dockerfile
+++ b/pos-order/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-order-*.jar pos-order.jar
+COPY target/pos-order.jar pos-order.jar
 EXPOSE 9007
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-order.jar"]

--- a/pos-people/Dockerfile
+++ b/pos-people/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-people-*.jar pos-people.jar
+COPY target/pos-people.jar pos-people.jar
 EXPOSE 8085
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-people.jar"]

--- a/pos-price/Dockerfile
+++ b/pos-price/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-price-*.jar pos-price.jar
+COPY target/pos-price.jar pos-price.jar
 EXPOSE 9008
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-price.jar"]

--- a/pos-security-service/Dockerfile
+++ b/pos-security-service/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-security-service-*.jar pos-security-service.jar
+COPY target/pos-security-service.jar pos-security-service.jar
 EXPOSE 8086
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-security-service.jar"]

--- a/pos-service-discovery/Dockerfile
+++ b/pos-service-discovery/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-service-discovery-*.jar pos-service-discovery.jar
+COPY target/pos-service-discovery.jar pos-service-discovery.jar
 EXPOSE 8761
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-service-discovery.jar"]

--- a/pos-shop-manager/Dockerfile
+++ b/pos-shop-manager/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-shop-manager-*.jar pos-shop-manager.jar
+COPY target/pos-shop-manager.jar pos-shop-manager.jar
 EXPOSE 8087
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-shop-manager.jar"]

--- a/pos-tax/Dockerfile
+++ b/pos-tax/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-tax-*.jar pos-tax.jar
+COPY target/pos-tax.jar pos-tax.jar
 EXPOSE 8091
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-tax.jar"]

--- a/pos-tax/pom.xml
+++ b/pos-tax/pom.xml
@@ -13,6 +13,7 @@
     <artifactId>pos-tax</artifactId>
     <name>POS Tax Service</name>
     <description>Tax calculation service with external API passthrough and test mode support</description>
+    <packaging>jar</packaging>
 
     <dependencies>
         <!-- Spring Boot Starters -->
@@ -149,6 +150,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
+                    <skip>false</skip>
                     <excludes>
                         <exclude>
                             <groupId>org.projectlombok</groupId>
@@ -158,7 +160,6 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>repackage</id>
                         <goals>
                             <goal>repackage</goal>
                         </goals>

--- a/pos-vehicle-fitment/Dockerfile
+++ b/pos-vehicle-fitment/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-vehicle-fitment-*.jar pos-vehicle-fitment.jar
+COPY target/pos-vehicle-fitment.jar pos-vehicle-fitment.jar
 EXPOSE 8088
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-vehicle-fitment.jar"]

--- a/pos-vehicle-inventory/Dockerfile
+++ b/pos-vehicle-inventory/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-vehicle-inventory-*.jar pos-vehicle-inventory.jar
+COPY target/pos-vehicle-inventory.jar pos-vehicle-inventory.jar
 EXPOSE 8089
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-vehicle-inventory.jar"]

--- a/pos-vehicle-reference-carapi/Dockerfile
+++ b/pos-vehicle-reference-carapi/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-vehicle-reference-carapi-*.jar pos-vehicle-reference-carapi.jar
+COPY target/pos-vehicle-reference-carapi.jar pos-vehicle-reference-carapi.jar
 EXPOSE 8091
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-vehicle-reference-carapi.jar"]

--- a/pos-vehicle-reference-nhtsa/Dockerfile
+++ b/pos-vehicle-reference-nhtsa/Dockerfile
@@ -16,6 +16,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
 # Default endpoint (otel-collector:4318) does not require authentication
 
-COPY target/pos-vehicle-reference-nhtsa-*.jar pos-vehicle-reference-nhtsa.jar
+COPY target/pos-vehicle-reference-nhtsa.jar pos-vehicle-reference-nhtsa.jar
 EXPOSE 8092
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-vehicle-reference-nhtsa.jar"]

--- a/pos-workorder/Dockerfile
+++ b/pos-workorder/Dockerfile
@@ -17,6 +17,6 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Default endpoint (otel-collector:4318) does not require authentication
 
 WORKDIR /app
-COPY target/pos-workorder-*.jar pos-workorder.jar
+COPY target/pos-workorder.jar pos-workorder.jar
 EXPOSE 8090
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-workorder.jar"]


### PR DESCRIPTION
## Summary

Follow-up to the pos-tax stale-jar investigation. Every module versions via `${revision}`; CI stamps `0.1.<run_number>` into the jar filename. With `mvn package` (no `clean`) and the Dockerfile glob `COPY target/<mod>-*.jar`, any reused `target/` that accumulates two differently-versioned jars fails the image build with *"destination must be a directory"* — so the old image stays deployed (the observed "last deployed 25h ago").

This makes the build deterministic and leftover-proof, repo-wide.

## Changes

- **Parent `pom.xml`** — `<finalName>${project.artifactId}</finalName>` in `<build>`. Every module now emits a version-independent jar (e.g. `pos-tax.jar`). `finalName` changes only the `target/` filename, **not** installed artifact coordinates — verified `~/.m2/.../pos-tax-common-0.1.0-SNAPSHOT.jar` is unchanged, so inter-module resolution is unaffected.
- **All 25 service Dockerfiles** — `COPY target/<mod>.jar` (exact) instead of the `<mod>-*.jar` glob. Leftover versioned jars in `target/` can no longer break the image build.
- **`pos-tax/pom.xml`** — aligned with the other modules: declare `<packaging>jar</packaging>`, add `<skip>false</skip>` to `spring-boot-maven-plugin`, drop the non-standard `repackage` execution id.

## Why this is the right fix

The fragility was **platform-wide**, not pos-tax-specific — all modules share the same `${revision}` scheme and the same glob. Exact-name copy + stable `finalName` removes the failure mode for every service at once.

## Verification

- `./mvnw -pl pos-tax -am clean package` → `pos-tax/target/pos-tax.jar` and `pos-tax-common/target/pos-tax-common.jar` (exact names).
- `.m2` artifact coordinates unchanged → dependency resolution intact.
- CI `cp target/*.jar` staging still copies exactly one jar (spring-boot's `*.jar.original` backup is excluded by the `*.jar` match).

## Note

Local rebuilds should still use `mvn clean`; this change makes the **image** build immune to stale jars regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)