### PR TITLE
fix(deploy): include pos-tax in alpha BACKEND_SERVICES

### DIFF
--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -81,6 +81,7 @@ BACKEND_SERVICES=(
   pos-price
   pos-security-service
   pos-shop-manager
+  pos-tax
   pos-vehicle-inventory
   pos-workorder
 )


### PR DESCRIPTION
## Summary

pos-tax was running `sha-e6c7859` (commit #753) while the rest of the fleet was on the current `sha-c623bab`. Its image builds and pushes fine every release — the gap is in the **deploy** step.

`deployment/alpha/deploy-backend.sh` recreates services with:

```bash
docker compose up -d --force-recreate "${BACKEND_SERVICES[@]}"
```

…and `pos-tax` was **missing from the `BACKEND_SERVICES` array**. So it was never force-recreated. It got deployed once in #753 and then skipped by every deploy since, pinning it to that sha. pos-tax is internal-only (no gateway route), which is why it was easy to leave out.

## Change

- Add `pos-tax` to `BACKEND_SERVICES` in `deploy-backend.sh`.

The script is uploaded to S3 by the ECR workflow (`build-push-ecr.yml`) and pulled by the alpha host at deploy time, so this propagates on the next merge to `main`.

## Effect

Next deploy force-recreates pos-tax with the current image — it will finally pick up #756/#758/#759 (shop-location tax request, test-mode default, deterministic jar). Confirms the end of the invoice→tax chain on alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)