### PR TITLE
feat(documents): deploy pos-documents as an internal service

### DIFF
--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          ALL_SERVICES_JSON='["pos-accounting","pos-api-gateway","pos-bulk-loader","pos-catalog","pos-customer","pos-event-receiver","pos-image","pos-inventory","pos-invoice","pos-location","pos-mcp-server","pos-people","pos-price","pos-security-service","pos-service-discovery","pos-shop-manager","pos-tax","pos-vehicle-inventory","pos-workorder"]'
+          ALL_SERVICES_JSON='["pos-accounting","pos-api-gateway","pos-bulk-loader","pos-catalog","pos-customer","pos-documents","pos-event-receiver","pos-image","pos-inventory","pos-invoice","pos-location","pos-mcp-server","pos-people","pos-price","pos-security-service","pos-service-discovery","pos-shop-manager","pos-tax","pos-vehicle-inventory","pos-workorder"]'
           FORCE_FULL_REBUILD=false
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then

--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -71,6 +71,7 @@ BACKEND_SERVICES=(
   pos-bulk-loader
   pos-catalog
   pos-customer
+  pos-documents
   pos-event-receiver
   pos-image
   pos-inventory

--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -130,6 +130,11 @@ services:
     restart: unless-stopped
     logging: *logging
 
+  pos-documents:
+    image: ${ECR_REGISTRY}/durion/pos-documents:${BACKEND_TAG}
+    restart: unless-stopped
+    logging: *logging
+
   pos-vehicle-inventory:
     image: ${ECR_REGISTRY}/durion/pos-vehicle-inventory:${BACKEND_TAG}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -500,6 +500,33 @@ services:
       retries: 12
       start_period: 90s
 
+  # Internal-only PDF rendering service. Never routed through the gateway; reached
+  # directly over pos-network (e.g. by pos-invoice at http://pos-documents:8092/v1/documents).
+  pos-documents:
+    build:
+      context: ./pos-documents
+      dockerfile: Dockerfile
+    environment:
+      EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
+      <<: [ *pos-security-client-env, *pos-events-client-env ]
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      SERVER_PORT: 8092
+      MANAGEMENT_SERVER_PORT: 8092
+    depends_on:
+      eureka-server:
+        condition: service_healthy
+      pos-security-service:
+        condition: service_healthy
+    logging: *logging
+    networks:
+      - pos-network
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:8092/actuator/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 90s
+
   pos-location:
     build:
       context: ./pos-location

--- a/pos-documents/Dockerfile
+++ b/pos-documents/Dockerfile
@@ -1,0 +1,21 @@
+FROM eclipse-temurin:25-jdk-alpine
+VOLUME /tmp
+
+# Download Grafana OpenTelemetry Java Agent
+ARG GRAFANA_OTEL_AGENT_VERSION=v2.9.0
+ADD https://github.com/grafana/grafana-opentelemetry-java/releases/download/${GRAFANA_OTEL_AGENT_VERSION}/grafana-opentelemetry-java.jar /opt/grafana-opentelemetry-java.jar
+
+# OpenTelemetry configuration (override at runtime as needed)
+ARG JAVA_OPTS
+ENV JAVA_OPTS=$JAVA_OPTS
+ENV OTEL_RESOURCE_ATTRIBUTES="service.name=DURION-POSITIVITY-BACKEND,service.namespace=durion-group,deployment.environment=pre-production"
+ENV OTEL_SERVICE_NAME=pos-documents
+ARG OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
+ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
+# Default endpoint (otel-collector:4318) does not require authentication
+
+COPY target/pos-documents.jar pos-documents.jar
+EXPOSE 8092
+ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-documents.jar"]

--- a/pos-documents/src/main/resources/application.yml
+++ b/pos-documents/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: documents
 
 server:
-  port: 0
+  port: ${SERVER_PORT:8092}
   tomcat:
     max-http-header-size: 65536
 


### PR DESCRIPTION
## Summary

First PR of the invoice-artifacts work. The artifacts feature needs on-demand PDF rendering, but **pos-documents was never deployed** — a built module with no Dockerfile, `server.port: 0`, and absent from docker-compose, the alpha deploy list, the prod overlay, and the CI service list. The render capability was dormant.

This stands pos-documents up as an **internal-only** service (same pattern as pos-tax — no gateway route; reached directly over `pos-network`).

## Changes

- **`pos-documents/Dockerfile`** (new) — standard pattern, exact `COPY target/pos-documents.jar`.
- **`application.yml`** — `server.port: ${SERVER_PORT:8092}` (was `0`).
- **`docker-compose.yml`** — pos-documents service on `8092` (eureka + security/events env, healthcheck, `depends_on` eureka+security). Reachable at `http://pos-documents:8092/v1/documents`.
- **`deployment/alpha/docker-compose.prod.yml`** — image overlay block.
- **`deployment/alpha/deploy-backend.sh`** — add `pos-documents` to `BACKEND_SERVICES`.
- **`build-push-ecr.yml`** — add `pos-documents` to `ALL_SERVICES_JSON` (CI builds/pushes it).

Stateless — no datasource/Flyway.

## Verification

- `mvn -pl pos-documents -am clean package` → `pos-documents/target/pos-documents.jar` (matches the Dockerfile exact-copy).
- `docker compose config` valid.

## ⚠️ Manual follow-ups before alpha can run it
1. **Pre-create the ECR repo `durion/pos-documents`** (admin identity; the CI push fails *"repository does not exist"* otherwise — the known new-service gotcha).
2. **Perm-bits**: ensure `documents:render` is in the catalog for the pos-invoice service identity (needed when pos-invoice calls render in the next PR).

## Next PRs
2. pos-invoice `DocumentRenderClient` + artifacts endpoints (list / HMAC download-token / public token-checked download) + OpenAPI.
3. Angular SDK regen + frontend swaps the `/billing/...` direct calls for the SDK (drops the ADR-0041 exceptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)