### PR TITLE
feat(invoice): invoice artifacts API (list / download-token / download)

### DIFF
--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/SecurityGatewayConfig.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/SecurityGatewayConfig.java
@@ -453,10 +453,16 @@ public class SecurityGatewayConfig {
                 || path.startsWith("/v3/api-docs")
                 || path.startsWith("/swagger-resources")
                 || path.startsWith("/eureka")
+                || ARTIFACT_DOWNLOAD_PATH.matcher(path).matches()
                 || isPathMatch(path, authProperties.getAuthPathRoot(), authProperties.getAuthPathPrefix())
                 || isPathMatch(
                         path, authProperties.getStrippedAuthPathRoot(), authProperties.getStrippedAuthPathPrefix());
     }
+
+    // Public, token-authorized invoice artifact download (browser direct-download link cannot carry
+    // a JWT). Authorization is enforced by the signed token in pos-invoice, not at the gateway.
+    private static final java.util.regex.Pattern ARTIFACT_DOWNLOAD_PATH =
+            java.util.regex.Pattern.compile("^/invoice/v1/invoices/[^/]+/artifacts/[^/]+/download$");
 
     private static boolean isPathMatch(String path, String root, String prefix) {
         return (StringUtils.hasText(root) && path.equals(root))

--- a/pos-invoice/openapi.yaml
+++ b/pos-invoice/openapi.yaml
@@ -537,6 +537,42 @@ paths:
       x-required-permissions:
       - invoice:manage
       - invoice:finalize
+  /v1/invoices/{invoiceId}/artifacts/{artifactRefId}/download-token:
+    post:
+      tags:
+      - invoice-artifact-controller
+      summary: Create a short-lived download token for an invoice artifact
+      description: Issues a short-lived signed token bound to the invoice and artifact. The token is presented to the public download endpoint so a browser can fetch the file via a direct link.
+      operationId: createDownloadToken
+      parameters:
+      - name: invoiceId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: artifactRefId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Token issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtifactDownloadToken'
+        '404':
+          description: Invoice or artifact not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtifactDownloadToken'
+      security:
+      - bearerAuth: []
+      x-required-permissions:
+      - AUTHENTICATED
   /v1/invoices/{invoiceId}/adjustments:
     post:
       tags:
@@ -595,6 +631,87 @@ paths:
         - invoice:manage
       x-required-permissions:
       - invoice:manage
+  /v1/invoices/{invoiceId}/artifacts:
+    get:
+      tags:
+      - invoice-artifact-controller
+      summary: List the downloadable artifacts (documents) for an invoice
+      description: Returns the documents available for the invoice (the invoice itself and any receipts) as opaque, URL-safe artifact references with suggested file names and MIME types.
+      operationId: listArtifacts
+      parameters:
+      - name: invoiceId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Artifacts listed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InvoiceArtifact'
+        '404':
+          description: Invoice not found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InvoiceArtifact'
+      security:
+      - bearerAuth: []
+      x-required-permissions:
+      - AUTHENTICATED
+  /v1/invoices/{invoiceId}/artifacts/{artifactRefId}/download:
+    get:
+      tags:
+      - invoice-artifact-download-controller
+      summary: Download an invoice artifact as PDF using a signed download token
+      description: Streams the artifact as application/pdf. Public endpoint authorized solely by the signed download token (query parameter); intended for browser direct-download links.
+      operationId: download
+      parameters:
+      - name: invoiceId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: artifactRefId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: token
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: PDF returned
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
+        '403':
+          description: Missing, invalid, or expired token
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
+        '404':
+          description: Invoice or artifact not found
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
 components:
   schemas:
     BillingRulesDTO:
@@ -1267,6 +1384,17 @@ components:
           type: string
           description: Free-text reason for overriding the amount limit
           example: Customer pre-approved by branch manager
+    ArtifactDownloadToken:
+      type: object
+      description: Short-lived signed token for downloading an invoice artifact
+      properties:
+        downloadToken:
+          type: string
+          description: Opaque signed download token
+        expiresAt:
+          type: string
+          format: date-time
+          description: When the token expires
     AdjustmentRequest:
       type: object
       description: Request to apply a monetary adjustment to an invoice
@@ -1299,6 +1427,26 @@ components:
       - authorizedBy
       - reason
       - type
+    InvoiceArtifact:
+      type: object
+      description: A downloadable document associated with an invoice
+      properties:
+        artifactRefId:
+          type: string
+          description: Opaque, URL-safe artifact reference
+          example: aW52b2ljZTo...
+        fileName:
+          type: string
+          description: Suggested download file name
+          example: Invoice-INV-1001.pdf
+        mimeType:
+          type: string
+          description: MIME type of the rendered artifact
+          example: application/pdf
+        createdAt:
+          type: string
+          format: date-time
+          description: When the underlying document was created
   securitySchemes:
     bearerAuth:
       type: http

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/client/DocumentRenderClient.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/client/DocumentRenderClient.java
@@ -1,0 +1,60 @@
+package com.positivity.invoice.internal.client;
+
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Renders invoice artifacts to PDF via the internal pos-documents service.
+ *
+ * <p>pos-documents is internal-only (no gateway route); reached directly over the service network.
+ * The render endpoint is guarded by {@code documents:render}, propagated via the gateway
+ * authorities header for this service-to-service call (see the tax/location client pattern).
+ */
+@Component
+public class DocumentRenderClient {
+
+    private static final Logger log = LoggerFactory.getLogger(DocumentRenderClient.class);
+
+    private final RestClient restClient;
+
+    public DocumentRenderClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${invoice.documents.base-url:http://pos-documents:8092/v1/documents}") String documentsBaseUrl) {
+        this.restClient = restClientBuilder.baseUrl(documentsBaseUrl).build();
+    }
+
+    /**
+     * Render a document to PDF.
+     *
+     * @param templateId the pos-documents template to apply
+     * @param contentJson the document data as a JSON string
+     * @return the rendered PDF bytes
+     */
+    @NonNull
+    public byte[] renderPdf(@NonNull String templateId, @NonNull String contentJson) {
+        if (log.isDebugEnabled()) {
+            log.debug("Rendering PDF via pos-documents using template {}", templateId);
+        }
+        byte[] pdf = restClient
+                .post()
+                .uri("/render")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_PDF)
+                .header("X-User", "pos-invoice")
+                .header("X-Authorities", "documents:render")
+                .body(Map.of("format", "JSON", "templateId", templateId, "content", contentJson))
+                .retrieve()
+                .body(byte[].class);
+
+        if (pdf == null || pdf.length == 0) {
+            throw new IllegalStateException("pos-documents returned an empty PDF for template " + templateId);
+        }
+        return pdf;
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/config/ArtifactDownloadSecurityConfig.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/config/ArtifactDownloadSecurityConfig.java
@@ -1,0 +1,32 @@
+package com.positivity.invoice.internal.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Permits the public, token-authorized artifact download endpoint.
+ *
+ * <p>The byte download cannot carry a gateway JWT (browsers can't add an Authorization header to a
+ * direct download link), so this higher-precedence filter chain matches only that path and permits
+ * it. Authorization is enforced inside the controller by the signed download token. All other
+ * requests fall through to the shared {@code GatewaySecurityConfig} chain (which requires auth).
+ */
+@Configuration
+public class ArtifactDownloadSecurityConfig {
+
+    static final String DOWNLOAD_PATTERN = "/v1/invoices/*/artifacts/*/download";
+
+    @Bean
+    @Order(0)
+    public SecurityFilterChain artifactDownloadFilterChain(HttpSecurity http) throws Exception {
+        http.securityMatcher(DOWNLOAD_PATTERN)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactController.java
@@ -1,0 +1,60 @@
+package com.positivity.invoice.internal.controller;
+
+import com.positivity.invoice.internal.dto.ArtifactDownloadTokenResponse;
+import com.positivity.invoice.internal.dto.InvoiceArtifactResponse;
+import com.positivity.invoice.internal.service.InvoiceArtifactService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Lists invoice artifacts and mints short-lived download tokens. Both endpoints are
+ * authenticated; the actual byte download is a separate, token-authorized public endpoint
+ * (see {@code InvoiceArtifactDownloadController}).
+ */
+@RestController
+@RequestMapping("/v1/invoices")
+@PreAuthorize("isAuthenticated()")
+public class InvoiceArtifactController {
+
+    private final InvoiceArtifactService artifactService;
+
+    public InvoiceArtifactController(InvoiceArtifactService artifactService) {
+        this.artifactService = artifactService;
+    }
+
+    @Operation(
+            summary = "List the downloadable artifacts (documents) for an invoice",
+            description =
+                    "Returns the documents available for the invoice (the invoice itself and any receipts) as opaque, URL-safe artifact references with suggested file names and MIME types.")
+    @ApiResponse(responseCode = "200", description = "Artifacts listed")
+    @ApiResponse(responseCode = "404", description = "Invoice not found")
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{invoiceId}/artifacts")
+    public ResponseEntity<List<InvoiceArtifactResponse>> listArtifacts(@PathVariable @NonNull UUID invoiceId) {
+        return ResponseEntity.ok(artifactService.listArtifacts(invoiceId));
+    }
+
+    @Operation(
+            summary = "Create a short-lived download token for an invoice artifact",
+            description =
+                    "Issues a short-lived signed token bound to the invoice and artifact. The token is presented to the public download endpoint so a browser can fetch the file via a direct link.")
+    @ApiResponse(responseCode = "200", description = "Token issued")
+    @ApiResponse(responseCode = "404", description = "Invoice or artifact not found")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/{invoiceId}/artifacts/{artifactRefId}/download-token")
+    public ResponseEntity<ArtifactDownloadTokenResponse> createDownloadToken(
+            @PathVariable @NonNull UUID invoiceId, @PathVariable @NonNull String artifactRefId) {
+        return ResponseEntity.ok(artifactService.createDownloadToken(invoiceId, artifactRefId));
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactDownloadController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactDownloadController.java
@@ -1,0 +1,59 @@
+package com.positivity.invoice.internal.controller;
+
+import com.positivity.invoice.internal.service.InvoiceArtifactService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Public, token-authorized download of an invoice artifact as PDF.
+ *
+ * <p>This endpoint is intentionally not behind the gateway JWT (a browser cannot attach an
+ * Authorization header to a direct download link). Authorization is enforced solely by the
+ * short-lived signed token issued by {@code InvoiceArtifactController}; the path is permitted in
+ * {@code ArtifactDownloadSecurityConfig} (downstream) and the gateway public-path list.
+ */
+@RestController
+@RequestMapping("/v1/invoices")
+public class InvoiceArtifactDownloadController {
+
+    private final InvoiceArtifactService artifactService;
+
+    public InvoiceArtifactDownloadController(InvoiceArtifactService artifactService) {
+        this.artifactService = artifactService;
+    }
+
+    @Operation(
+            summary = "Download an invoice artifact as PDF using a signed download token",
+            description =
+                    "Streams the artifact as application/pdf. Public endpoint authorized solely by the signed download token (query parameter); intended for browser direct-download links.")
+    @ApiResponse(responseCode = "200", description = "PDF returned")
+    @ApiResponse(responseCode = "403", description = "Missing, invalid, or expired token")
+    @ApiResponse(responseCode = "404", description = "Invoice or artifact not found")
+    // Authorization is the signed download token (verified in the service), not a role/JWT — a
+    // browser direct-download link cannot carry an Authorization header. permitAll keeps the
+    // endpoint open at the method-security layer; the token is the actual guard.
+    @PreAuthorize("permitAll()")
+    @GetMapping("/{invoiceId}/artifacts/{artifactRefId}/download")
+    public ResponseEntity<byte[]> download(
+            @PathVariable @NonNull UUID invoiceId,
+            @PathVariable @NonNull String artifactRefId,
+            @RequestParam("token") @NonNull String token) {
+        byte[] pdf = artifactService.downloadArtifact(invoiceId, artifactRefId, token);
+        String fileName = artifactService.fileNameFor(invoiceId, artifactRefId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdf);
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactExceptionHandler.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactExceptionHandler.java
@@ -1,0 +1,53 @@
+package com.positivity.invoice.internal.controller;
+
+import com.positivity.invoice.internal.exception.InvoiceNotFoundException;
+import com.positivity.invoice.internal.service.ArtifactTokenService.InvalidTokenException;
+import com.positivity.invoice.internal.service.InvoiceArtifactService.ArtifactNotFoundException;
+import com.positivity.shared.error.ApiError;
+import com.positivity.shared.id.UUIDv7Generator;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/** Maps invoice-artifact errors to HTTP statuses for the artifact controllers. */
+@RestControllerAdvice(
+        assignableTypes = {InvoiceArtifactController.class, InvoiceArtifactDownloadController.class})
+@RequiredArgsConstructor
+public class InvoiceArtifactExceptionHandler {
+    private final Clock clock;
+
+    private static final String X_CORRELATION_ID = "X-Correlation-Id";
+
+    @ExceptionHandler({InvoiceNotFoundException.class, ArtifactNotFoundException.class})
+    public ResponseEntity<ApiError> handleNotFound(RuntimeException ex, HttpServletRequest request) {
+        return error(HttpStatus.NOT_FOUND, "NOT_FOUND", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ApiError> handleInvalidToken(InvalidTokenException ex, HttpServletRequest request) {
+        return error(HttpStatus.FORBIDDEN, "FORBIDDEN", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiError> handleBadRequest(IllegalArgumentException ex, HttpServletRequest request) {
+        return error(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), request);
+    }
+
+    private ResponseEntity<ApiError> error(HttpStatus status, String code, String message, HttpServletRequest request) {
+        String correlationId = correlationId(request);
+        return ResponseEntity.status(status)
+                .header(X_CORRELATION_ID, correlationId)
+                .body(ApiError.of(
+                        code, message, status.value(), Instant.now(clock).toString(), correlationId));
+    }
+
+    private static String correlationId(HttpServletRequest request) {
+        String header = request.getHeader(X_CORRELATION_ID);
+        return (header != null && !header.isBlank()) ? header : UUIDv7Generator.generate().toString();
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/ArtifactDownloadTokenResponse.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/ArtifactDownloadTokenResponse.java
@@ -1,0 +1,15 @@
+package com.positivity.invoice.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+
+/**
+ * Short-lived, signed token authorizing a single artifact download.
+ *
+ * <p>The token is presented as a query parameter to the (public) download endpoint, so a
+ * browser can fetch the file via a direct link without an Authorization header.
+ */
+@Schema(name = "ArtifactDownloadToken", description = "Short-lived signed token for downloading an invoice artifact")
+public record ArtifactDownloadTokenResponse(
+        @Schema(description = "Opaque signed download token") String downloadToken,
+        @Schema(description = "When the token expires") Instant expiresAt) {}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/InvoiceArtifactResponse.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/InvoiceArtifactResponse.java
@@ -1,0 +1,18 @@
+package com.positivity.invoice.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+
+/**
+ * A downloadable document associated with an invoice (the invoice itself or a receipt).
+ *
+ * <p>{@code artifactRefId} is an opaque, URL-safe identifier; pass it back to the
+ * download-token and download endpoints. The bytes are rendered on demand by pos-documents.
+ */
+@Schema(name = "InvoiceArtifact", description = "A downloadable document associated with an invoice")
+public record InvoiceArtifactResponse(
+        @Schema(description = "Opaque, URL-safe artifact reference", example = "aW52b2ljZTo...")
+                String artifactRefId,
+        @Schema(description = "Suggested download file name", example = "Invoice-INV-1001.pdf") String fileName,
+        @Schema(description = "MIME type of the rendered artifact", example = "application/pdf") String mimeType,
+        @Schema(description = "When the underlying document was created") Instant createdAt) {}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/ReceiptRepository.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/ReceiptRepository.java
@@ -1,6 +1,7 @@
 package com.positivity.invoice.internal.repository;
 
 import com.positivity.invoice.internal.entity.Receipt;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -11,4 +12,6 @@ public interface ReceiptRepository extends JpaRepository<Receipt, UUID> {
     Optional<Receipt> findByReference(@NonNull String reference);
 
     long countByInvoice_Id(@NonNull UUID invoiceId);
+
+    List<Receipt> findByInvoice_IdOrderByCreatedAtAsc(@NonNull UUID invoiceId);
 }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/ArtifactRef.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/ArtifactRef.java
@@ -1,0 +1,53 @@
+package com.positivity.invoice.internal.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Identifies a single invoice artifact by type and underlying entity id.
+ *
+ * <p>Serialised to an opaque, URL-safe {@code artifactRefId} (base64url of {@code TYPE:uuid}) so
+ * the frontend can carry it in paths without escaping concerns.
+ */
+public record ArtifactRef(@NonNull Type type, @NonNull UUID id) {
+
+    public enum Type {
+        INVOICE,
+        RECEIPT
+    }
+
+    @NonNull
+    public String encode() {
+        String raw = type.name() + ":" + id;
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @NonNull
+    public static ArtifactRef decode(@NonNull String artifactRefId) {
+        String raw;
+        try {
+            raw = new String(Base64.getUrlDecoder().decode(artifactRefId), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Malformed artifactRefId", ex);
+        }
+        int sep = raw.indexOf(':');
+        if (sep <= 0) {
+            throw new IllegalArgumentException("Malformed artifactRefId");
+        }
+        Type type;
+        try {
+            type = Type.valueOf(raw.substring(0, sep));
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Unknown artifact type in artifactRefId", ex);
+        }
+        UUID id;
+        try {
+            id = UUID.fromString(raw.substring(sep + 1));
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Malformed artifact id in artifactRefId", ex);
+        }
+        return new ArtifactRef(type, id);
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/ArtifactTokenService.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/ArtifactTokenService.java
@@ -1,0 +1,132 @@
+package com.positivity.invoice.internal.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.UUID;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Mints and verifies short-lived, stateless HMAC tokens authorizing a single artifact download.
+ *
+ * <p>Token format: {@code base64url(payload).base64url(hmacSha256(payload))} where payload is
+ * {@code invoiceId|artifactRefId|expiryEpochSeconds}. The token is bound to a specific invoice +
+ * artifact and expires, so it can be handed to a browser for a direct download link.
+ */
+@Service
+public class ArtifactTokenService {
+
+    private static final Logger log = LoggerFactory.getLogger(ArtifactTokenService.class);
+
+    private static final String HMAC_ALGO = "HmacSHA256";
+    private static final Base64.Encoder B64 = Base64.getUrlEncoder().withoutPadding();
+    private static final Base64.Decoder B64D = Base64.getUrlDecoder();
+
+    private final Clock clock;
+    private final byte[] signingKey;
+    private final Duration ttl;
+
+    public ArtifactTokenService(
+            Clock clock,
+            @Value("${invoice.artifacts.signing-secret:}") String signingSecret,
+            @Value("${invoice.artifacts.token-ttl-seconds:300}") long ttlSeconds) {
+        this.clock = clock;
+        if (signingSecret == null || signingSecret.isBlank()) {
+            // Fall back to a per-instance random key so the service still starts. Tokens are
+            // short-lived, so the cost is only that outstanding tokens don't survive a restart and
+            // aren't shared across instances. Set invoice.artifacts.signing-secret in production.
+            byte[] random = new byte[32];
+            new SecureRandom().nextBytes(random);
+            this.signingKey = random;
+            log.warn("invoice.artifacts.signing-secret is not configured; using a per-instance random key. "
+                    + "Set it for stable, multi-instance artifact download tokens.");
+        } else {
+            this.signingKey = signingSecret.getBytes(StandardCharsets.UTF_8);
+        }
+        this.ttl = Duration.ofSeconds(ttlSeconds);
+    }
+
+    /** Issue a token for the given invoice + artifact. */
+    @NonNull
+    public IssuedToken issue(@NonNull UUID invoiceId, @NonNull String artifactRefId) {
+        Instant expiresAt = clock.instant().plus(ttl);
+        String payload = payload(invoiceId, artifactRefId, expiresAt.getEpochSecond());
+        String token = B64.encodeToString(payload.getBytes(StandardCharsets.UTF_8)) + "." + sign(payload);
+        return new IssuedToken(token, expiresAt);
+    }
+
+    /**
+     * Verify a token against the expected invoice + artifact. Throws {@link InvalidTokenException}
+     * if the signature is wrong, the binding mismatches, or it has expired.
+     */
+    public void verify(@NonNull String token, @NonNull UUID invoiceId, @NonNull String artifactRefId) {
+        int dot = token.indexOf('.');
+        if (dot <= 0 || dot == token.length() - 1) {
+            throw new InvalidTokenException("Malformed download token");
+        }
+        String payload;
+        try {
+            payload = new String(B64D.decode(token.substring(0, dot)), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            throw new InvalidTokenException("Malformed download token");
+        }
+        String providedSig = token.substring(dot + 1);
+        if (!constantTimeEquals(providedSig, sign(payload))) {
+            throw new InvalidTokenException("Invalid download token signature");
+        }
+        String[] parts = payload.split("\\|", -1);
+        if (parts.length != 3) {
+            throw new InvalidTokenException("Malformed download token payload");
+        }
+        if (!parts[0].equals(invoiceId.toString()) || !parts[1].equals(artifactRefId)) {
+            throw new InvalidTokenException("Download token does not match the requested artifact");
+        }
+        long exp;
+        try {
+            exp = Long.parseLong(parts[2]);
+        } catch (NumberFormatException ex) {
+            throw new InvalidTokenException("Malformed download token expiry");
+        }
+        if (clock.instant().getEpochSecond() > exp) {
+            throw new InvalidTokenException("Download token has expired");
+        }
+    }
+
+    private String payload(UUID invoiceId, String artifactRefId, long expEpoch) {
+        return invoiceId + "|" + artifactRefId + "|" + expEpoch;
+    }
+
+    private String sign(String payload) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGO);
+            mac.init(new SecretKeySpec(signingKey, HMAC_ALGO));
+            return B64.encodeToString(mac.doFinal(payload.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to sign artifact download token", ex);
+        }
+    }
+
+    private static boolean constantTimeEquals(String a, String b) {
+        return MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** A freshly issued token and its expiry. */
+    public record IssuedToken(@NonNull String token, @NonNull Instant expiresAt) {}
+
+    /** Raised when a presented download token is invalid, mismatched, or expired. */
+    public static class InvalidTokenException extends RuntimeException {
+        public InvalidTokenException(String message) {
+            super(message);
+        }
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceArtifactService.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceArtifactService.java
@@ -1,0 +1,179 @@
+package com.positivity.invoice.internal.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.positivity.invoice.internal.client.DocumentRenderClient;
+import com.positivity.invoice.internal.dto.ArtifactDownloadTokenResponse;
+import com.positivity.invoice.internal.dto.InvoiceArtifactResponse;
+import com.positivity.invoice.internal.entity.Invoice;
+import com.positivity.invoice.internal.entity.Receipt;
+import com.positivity.invoice.internal.exception.InvoiceNotFoundException;
+import com.positivity.invoice.internal.repository.InvoiceRepository;
+import com.positivity.invoice.internal.repository.ReceiptRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Lists, authorizes, and renders the downloadable documents (artifacts) for an invoice.
+ *
+ * <p>Artifacts are not stored: the listing is derived from the invoice and its receipts, and the
+ * PDF bytes are rendered on demand by pos-documents. Downloads are authorized by a short-lived
+ * signed token (see {@link ArtifactTokenService}).
+ */
+@Service
+@Transactional(readOnly = true)
+public class InvoiceArtifactService {
+
+    private static final String INVOICE_TEMPLATE_ID = "invoice-default";
+    private static final String RECEIPT_TEMPLATE_ID = "receipt-default";
+
+    private final InvoiceRepository invoiceRepository;
+    private final ReceiptRepository receiptRepository;
+    private final DocumentRenderClient documentRenderClient;
+    private final ArtifactTokenService tokenService;
+    private final ObjectMapper objectMapper;
+
+    public InvoiceArtifactService(
+            InvoiceRepository invoiceRepository,
+            ReceiptRepository receiptRepository,
+            DocumentRenderClient documentRenderClient,
+            ArtifactTokenService tokenService,
+            ObjectMapper objectMapper) {
+        this.invoiceRepository = invoiceRepository;
+        this.receiptRepository = receiptRepository;
+        this.documentRenderClient = documentRenderClient;
+        this.tokenService = tokenService;
+        this.objectMapper = objectMapper;
+    }
+
+    /** List the artifacts available for an invoice: the invoice document plus each receipt. */
+    @NonNull
+    public List<InvoiceArtifactResponse> listArtifacts(@NonNull UUID invoiceId) {
+        Invoice invoice = requireInvoice(invoiceId);
+
+        List<InvoiceArtifactResponse> artifacts = new ArrayList<>();
+        artifacts.add(new InvoiceArtifactResponse(
+                new ArtifactRef(ArtifactRef.Type.INVOICE, invoiceId).encode(),
+                invoiceFileName(invoice),
+                "application/pdf",
+                invoice.getCreatedAt()));
+
+        for (Receipt receipt : receiptRepository.findByInvoice_IdOrderByCreatedAtAsc(invoiceId)) {
+            artifacts.add(new InvoiceArtifactResponse(
+                    new ArtifactRef(ArtifactRef.Type.RECEIPT, receipt.getId()).encode(),
+                    "Receipt-" + receipt.getReference() + ".pdf",
+                    "application/pdf",
+                    receipt.getCreatedAt()));
+        }
+        return artifacts;
+    }
+
+    /** Issue a short-lived download token for an artifact, after validating it belongs to the invoice. */
+    @NonNull
+    public ArtifactDownloadTokenResponse createDownloadToken(@NonNull UUID invoiceId, @NonNull String artifactRefId) {
+        resolveAndValidate(invoiceId, artifactRefId);
+        ArtifactTokenService.IssuedToken issued = tokenService.issue(invoiceId, artifactRefId);
+        return new ArtifactDownloadTokenResponse(issued.token(), issued.expiresAt());
+    }
+
+    /** Verify the download token and render the artifact to PDF bytes. */
+    @NonNull
+    public byte[] downloadArtifact(@NonNull UUID invoiceId, @NonNull String artifactRefId, @NonNull String token) {
+        tokenService.verify(token, invoiceId, artifactRefId);
+        ArtifactRef ref = resolveAndValidate(invoiceId, artifactRefId);
+        return switch (ref.type()) {
+            case INVOICE -> documentRenderClient.renderPdf(INVOICE_TEMPLATE_ID, invoiceContent(requireInvoice(invoiceId)));
+            case RECEIPT -> documentRenderClient.renderPdf(RECEIPT_TEMPLATE_ID, receiptContent(requireReceipt(ref.id())));
+        };
+    }
+
+    /** Suggested file name for a downloaded artifact. */
+    @NonNull
+    public String fileNameFor(@NonNull UUID invoiceId, @NonNull String artifactRefId) {
+        ArtifactRef ref = resolveAndValidate(invoiceId, artifactRefId);
+        return switch (ref.type()) {
+            case INVOICE -> invoiceFileName(requireInvoice(invoiceId));
+            case RECEIPT -> "Receipt-" + requireReceipt(ref.id()).getReference() + ".pdf";
+        };
+    }
+
+    private ArtifactRef resolveAndValidate(UUID invoiceId, String artifactRefId) {
+        ArtifactRef ref = ArtifactRef.decode(artifactRefId);
+        switch (ref.type()) {
+            case INVOICE -> {
+                if (!ref.id().equals(invoiceId)) {
+                    throw new ArtifactNotFoundException("Artifact does not belong to invoice " + invoiceId);
+                }
+                requireInvoice(invoiceId);
+            }
+            case RECEIPT -> {
+                Receipt receipt = requireReceipt(ref.id());
+                UUID receiptInvoiceId = receipt.getInvoice() == null ? null : receipt.getInvoice().getId();
+                if (!invoiceId.equals(receiptInvoiceId)) {
+                    throw new ArtifactNotFoundException("Receipt does not belong to invoice " + invoiceId);
+                }
+            }
+        }
+        return ref;
+    }
+
+    private Invoice requireInvoice(UUID invoiceId) {
+        return invoiceRepository.findById(invoiceId).orElseThrow(() -> new InvoiceNotFoundException(invoiceId));
+    }
+
+    private Receipt requireReceipt(UUID receiptId) {
+        return receiptRepository
+                .findById(receiptId)
+                .orElseThrow(() -> new ArtifactNotFoundException("Receipt not found: " + receiptId));
+    }
+
+    private String invoiceFileName(Invoice invoice) {
+        String number = invoice.getInvoiceNumber() == null ? invoice.getId().toString() : invoice.getInvoiceNumber();
+        return "Invoice-" + number + ".pdf";
+    }
+
+    private String invoiceContent(Invoice invoice) {
+        Map<String, Object> content = new LinkedHashMap<>();
+        content.put("documentType", "INVOICE");
+        content.put("invoiceId", invoice.getId());
+        content.put("invoiceNumber", invoice.getInvoiceNumber());
+        content.put("status", invoice.getStatus());
+        content.put("subtotal", invoice.getSubtotal());
+        content.put("tax", invoice.getTax());
+        content.put("adjustments", invoice.getAdjustmentsAmount());
+        content.put("total", invoice.getTotal());
+        content.put("createdAt", invoice.getCreatedAt());
+        return toJson(content);
+    }
+
+    private String receiptContent(Receipt receipt) {
+        Map<String, Object> content = new LinkedHashMap<>();
+        content.put("documentType", "RECEIPT");
+        content.put("receiptId", receipt.getId());
+        content.put("reference", receipt.getReference());
+        content.put("status", receipt.getStatus());
+        content.put("createdAt", receipt.getCreatedAt());
+        return toJson(content);
+    }
+
+    private String toJson(Map<String, Object> content) {
+        try {
+            return objectMapper.writeValueAsString(content);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Failed to serialise artifact render content", ex);
+        }
+    }
+
+    /** Raised when a requested artifact does not exist or does not belong to the invoice. */
+    public static class ArtifactNotFoundException extends RuntimeException {
+        public ArtifactNotFoundException(String message) {
+            super(message);
+        }
+    }
+}

--- a/pos-invoice/src/main/resources/application.yml
+++ b/pos-invoice/src/main/resources/application.yml
@@ -18,6 +18,15 @@ server:
   servlet:
     context-path: /
 
+invoice:
+  documents:
+    base-url: ${INVOICE_DOCUMENTS_BASE_URL:http://pos-documents:8092/v1/documents}
+  artifacts:
+    # Set a stable secret in production for multi-instance/restart-safe download tokens.
+    # When blank, a per-instance random key is generated at startup.
+    signing-secret: ${INVOICE_ARTIFACTS_SIGNING_SECRET:}
+    token-ttl-seconds: ${INVOICE_ARTIFACTS_TOKEN_TTL_SECONDS:300}
+
 management:
   server:
     port: 0

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ArtifactTokenServiceTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ArtifactTokenServiceTest.java
@@ -1,0 +1,110 @@
+package com.positivity.invoice.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.positivity.invoice.internal.service.ArtifactTokenService.InvalidTokenException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ArtifactTokenServiceTest {
+
+    private static final UUID INVOICE = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final String REF = new ArtifactRef(ArtifactRef.Type.INVOICE, INVOICE).encode();
+    private static final String SECRET = "test-signing-secret";
+
+    private ArtifactTokenService service(Clock clock) {
+        return new ArtifactTokenService(clock, SECRET, 300);
+    }
+
+    @Test
+    void issueThenVerify_roundTrips() {
+        ArtifactTokenService svc = service(fixed("2026-01-01T00:00:00Z"));
+        ArtifactTokenService.IssuedToken issued = svc.issue(INVOICE, REF);
+
+        svc.verify(issued.token(), INVOICE, REF); // no exception
+        assertThat(issued.expiresAt()).isEqualTo(Instant.parse("2026-01-01T00:05:00Z"));
+    }
+
+    @Test
+    void verify_rejectsTamperedSignature() {
+        ArtifactTokenService svc = service(fixed("2026-01-01T00:00:00Z"));
+        String token = svc.issue(INVOICE, REF).token();
+        String tampered = token.substring(0, token.length() - 2) + (token.endsWith("AA") ? "BB" : "AA");
+
+        assertThatThrownBy(() -> svc.verify(tampered, INVOICE, REF)).isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    void verify_rejectsWrongInvoice() {
+        ArtifactTokenService svc = service(fixed("2026-01-01T00:00:00Z"));
+        String token = svc.issue(INVOICE, REF).token();
+
+        assertThatThrownBy(() -> svc.verify(token, UUID.randomUUID(), REF)).isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    void verify_rejectsWrongArtifact() {
+        ArtifactTokenService svc = service(fixed("2026-01-01T00:00:00Z"));
+        String token = svc.issue(INVOICE, REF).token();
+        String otherRef = new ArtifactRef(ArtifactRef.Type.RECEIPT, UUID.randomUUID()).encode();
+
+        assertThatThrownBy(() -> svc.verify(token, INVOICE, otherRef)).isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    void verify_rejectsExpiredToken() {
+        String token = service(fixed("2026-01-01T00:00:00Z")).issue(INVOICE, REF).token();
+        ArtifactTokenService later = service(fixed("2026-01-01T00:05:01Z"));
+
+        assertThatThrownBy(() -> later.verify(token, INVOICE, REF)).isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    void verify_rejectsTokenSignedWithDifferentSecret() {
+        String token =
+                new ArtifactTokenService(fixed("2026-01-01T00:00:00Z"), "other-secret", 300).issue(INVOICE, REF).token();
+
+        assertThatThrownBy(() -> service(fixed("2026-01-01T00:00:00Z")).verify(token, INVOICE, REF))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    void verify_rejectsMalformedToken() {
+        assertThatThrownBy(() -> service(fixed("2026-01-01T00:00:00Z")).verify("not-a-token", INVOICE, REF))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    void randomKeyFallback_whenSecretBlank_stillIssuesAndVerifies() {
+        ArtifactTokenService svc = new ArtifactTokenService(fixed("2026-01-01T00:00:00Z"), "", 300);
+        String token = svc.issue(INVOICE, REF).token();
+        svc.verify(token, INVOICE, REF); // no exception
+    }
+
+    private static Clock fixed(String instant) {
+        return Clock.fixed(Instant.parse(instant), ZoneOffset.UTC);
+    }
+
+    @Test
+    void artifactRef_encodeDecode_roundTrips() {
+        UUID id = UUID.randomUUID();
+        ArtifactRef ref = new ArtifactRef(ArtifactRef.Type.RECEIPT, id);
+        ArtifactRef decoded = ArtifactRef.decode(ref.encode());
+
+        assertThat(decoded.type()).isEqualTo(ArtifactRef.Type.RECEIPT);
+        assertThat(decoded.id()).isEqualTo(id);
+    }
+
+    @Test
+    void artifactRef_decode_rejectsGarbage() {
+        assertThatThrownBy(() -> ArtifactRef.decode("!!!not-base64!!!"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ArtifactRef.decode(Duration.ZERO.toString()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Summary

Second PR of the invoice-artifacts work. Implements the backend the billing UI's invoice-detail page calls — previously a **404** (no backend endpoint; the frontend used a placeholder `/billing/...` path with no gateway route). Endpoints live under `/v1/invoices` to match the existing gateway `/invoice/**` route.

| Method | Path | Auth |
|---|---|---|
| GET | `/v1/invoices/{id}/artifacts` | JWT |
| POST | `/v1/invoices/{id}/artifacts/{refId}/download-token` | JWT |
| GET | `/v1/invoices/{id}/artifacts/{refId}/download?token=` | **public, token** |

## Design

- **Derived, not stored** — artifacts = the invoice document + each receipt. `artifactRefId` is an opaque base64url `type:id`. No new table.
- **On-demand render** — PDFs rendered via the new `DocumentRenderClient` → pos-documents (`documents:render`).
- **Token-only public download** — browsers can't attach a JWT to a direct download link, so the download is authorized by a short-lived **HMAC-signed** token (`ArtifactTokenService`, bound to invoice+artifact+expiry). The path is permitted by a scoped `@Order(0)` security chain in pos-invoice and added to the gateway public-path list. `ArtifactDownloadSecurityConfig` matches only that path; everything else still hits the shared authenticated chain.

## Changes

- DTOs: `InvoiceArtifactResponse`, `ArtifactDownloadTokenResponse`.
- `ArtifactRef` (encode/decode), `ArtifactTokenService` (HMAC-SHA256; per-instance random-key fallback when no secret configured), `InvoiceArtifactService`.
- Two controllers (list/token; public download) + scoped exception handler.
- `ReceiptRepository.findByInvoice_IdOrderByCreatedAtAsc`.
- Gateway `SecurityGatewayConfig`: public path regex for the artifact download.
- `application.yml`: `invoice.documents.base-url`, `invoice.artifacts.signing-secret`/`token-ttl-seconds`.
- Regenerated `pos-invoice/openapi.yaml`.

## Testing

- `pos-invoice` 143/143 (incl. ArchitectureTest, OpenAPI contract test).
- New `ArtifactTokenServiceTest` (10): round-trip, tamper, wrong-invoice/artifact, expiry, wrong-secret, malformed, random-key fallback, ref encode/decode.

## Dependencies / notes

- Downloads need **pos-documents deployed (#761)** to render; the **list endpoint works immediately and clears the reported 404**.
- `documents:render` must be in the perm-bits catalog for the pos-invoice identity (flagged in #761).
- **Next (PR3):** regenerate the Angular SDK and switch the frontend off the `/billing/...` direct calls (drop the ADR-0041 exceptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Contract impact

Billing domain — see `domains/billing/.business-rules/BACKEND_CONTRACT_GUIDE.md`. Adds three pos-invoice endpoints under `/v1/invoices` (artifacts list, download-token, public token-checked download). The list/token endpoints are JWT-gated; the download is public-but-token-authorized. `pos-invoice/openapi.yaml` regenerated; no existing operation changes shape.
