### PR TITLE
fix(workorder): resolve shop-location address for estimate tax (#755)

### DIFF
--- a/pos-workorder/README.md
+++ b/pos-workorder/README.md
@@ -12,7 +12,7 @@ Core workorder service for the Durion Positivity ETSMS platform. Manages the ful
 - Manage part usage, part substitutions, and part pick coordination
 - Apply and validate promotional offers on workorder lines
 - Generate invoices at completion by calling `pos-invoice`
-- Calculate tax on estimate totals via `pos-tax`
+- Calculate tax on estimate totals via `pos-tax`, resolving the estimate's shop-location address from `pos-location` as the tax jurisdiction
 - Emit Kafka events for cross-service consumption (configurable; off by default)
 
 ## Key Classes
@@ -53,6 +53,7 @@ Core workorder service for the Durion Positivity ETSMS platform. Manages the ful
 | `pos.customer.base-url`        | `http://pos-customer:8084` | Customer service URL             |
 | `pos.vehicle.base-url`         | `http://pos-vehicle:8088`  | Vehicle service URL              |
 | `pos.tax.base-url`             | `http://pos-tax:8091`      | Tax service URL                  |
+| `pos.location.base-url`        | `http://pos-location:8080` | Location service URL             |
 | `workorder.kafka.enabled`      | `false`                    | Enable Kafka event emission      |
 | `workorder.kafka.events-topic` | `workorder.events.v1`      | Kafka topic for workorder events |
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/client/LocationAddressResponse.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/client/LocationAddressResponse.java
@@ -1,0 +1,68 @@
+package com.positivity.workorder.internal.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Minimal projection of pos-location's {@code LocationResponseDTO}, limited to the
+ * address fields needed to build a tax jurisdiction address. Unknown properties are
+ * ignored so this stays decoupled from the full location contract.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LocationAddressResponse {
+
+    private @Nullable String addressLine1;
+    private @Nullable String addressLine2;
+    private @Nullable String city;
+    private @Nullable String state;
+    private @Nullable String postalCode;
+    private @Nullable String country;
+
+    public @Nullable String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public void setAddressLine1(@Nullable String addressLine1) {
+        this.addressLine1 = addressLine1;
+    }
+
+    public @Nullable String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public void setAddressLine2(@Nullable String addressLine2) {
+        this.addressLine2 = addressLine2;
+    }
+
+    public @Nullable String getCity() {
+        return city;
+    }
+
+    public void setCity(@Nullable String city) {
+        this.city = city;
+    }
+
+    public @Nullable String getState() {
+        return state;
+    }
+
+    public void setState(@Nullable String state) {
+        this.state = state;
+    }
+
+    public @Nullable String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(@Nullable String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public @Nullable String getCountry() {
+        return country;
+    }
+
+    public void setCountry(@Nullable String country) {
+        this.country = country;
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/client/LocationClient.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/client/LocationClient.java
@@ -3,7 +3,6 @@ package com.positivity.workorder.internal.client;
 import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -17,7 +16,6 @@ import org.springframework.web.client.RestClient;
  */
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class LocationClient {
 
     private final RestClient locationServiceRestClient;

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/client/LocationClient.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/client/LocationClient.java
@@ -1,0 +1,74 @@
+package com.positivity.workorder.internal.client;
+
+import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Resolves the shop-location address used as the tax jurisdiction (the place where
+ * the sale is made) for estimate tax calculation.
+ *
+ * <p>Per the platform rule, other services must not replicate address data: they
+ * store the {@code locationId} and query pos-location for the full address.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LocationClient {
+
+    private final RestClient locationServiceRestClient;
+
+    /**
+     * Fetch the location's address and map it to a tax destination address.
+     *
+     * @param locationId the shop location backing the estimate
+     * @return the destination address for tax calculation
+     * @throws IllegalStateException if the location cannot be resolved or lacks the
+     *     country/postal code required for tax jurisdiction determination
+     */
+    @NonNull
+    public TaxAddress resolveTaxAddress(@NonNull UUID locationId) {
+        // pos-location guards GET /v1/locations/{id} with @PreAuthorize('location:read').
+        // Propagate the required authority via the gateway authorities header for this
+        // service-to-service call (see the people/tax client patterns).
+        LocationAddressResponse location = locationServiceRestClient
+                .get()
+                .uri("/v1/locations/{locationId}", locationId)
+                .header("X-User", "pos-workorder")
+                .header("X-Authorities", "location:read")
+                .retrieve()
+                .body(LocationAddressResponse.class);
+
+        if (location == null) {
+            throw new IllegalStateException("pos-location returned no address for locationId " + locationId);
+        }
+
+        String country = trimToNull(location.getCountry());
+        String postalCode = trimToNull(location.getPostalCode());
+        if (country == null || postalCode == null) {
+            throw new IllegalStateException("Location " + locationId
+                    + " is missing country/postalCode required for tax jurisdiction determination");
+        }
+
+        return TaxAddress.builder()
+                .countryCode(country)
+                .regionCode(trimToNull(location.getState()))
+                .city(trimToNull(location.getCity()))
+                .postalCode(postalCode)
+                .line1(trimToNull(location.getAddressLine1()))
+                .line2(trimToNull(location.getAddressLine2()))
+                .build();
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/LocationClientConfig.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/LocationClientConfig.java
@@ -1,0 +1,21 @@
+package com.positivity.workorder.internal.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Configuration for the pos-location service REST client used to resolve a
+ * shop-location address for tax jurisdiction determination.
+ */
+@Configuration
+public class LocationClientConfig {
+
+    @Bean
+    public RestClient locationServiceRestClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${pos.location.base-url:http://pos-location:8080}") String locationServiceBaseUrl) {
+        return restClientBuilder.baseUrl(locationServiceBaseUrl).build();
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -7,6 +7,7 @@ import com.positivity.tax.common.dto.TaxCalculationResponse;
 import com.positivity.tax.common.dto.TaxLineItem;
 import com.positivity.tax.common.enums.TaxReferenceType;
 import com.positivity.workorder.internal.client.DocumentClient;
+import com.positivity.workorder.internal.client.LocationClient;
 import com.positivity.workorder.internal.client.PeopleLocationClient;
 import com.positivity.workorder.internal.client.TaxClient;
 import com.positivity.workorder.internal.dto.AddEstimateItemRequest;
@@ -74,6 +75,7 @@ public class EstimateServiceImpl implements EstimateService {
     private final ApplicationEventPublisher eventPublisher;
     private final BillingRulesClientService billingRulesClientService;
     private final TaxClient taxClient;
+    private final LocationClient locationClient;
     private final PeopleLocationClient peopleLocationClient;
     private final DocumentClient documentClient;
     private final ObjectMapper objectMapper;
@@ -89,9 +91,6 @@ public class EstimateServiceImpl implements EstimateService {
     // Tax category constants
     private static final String TAX_CATEGORY_GOODS = "GOODS";
     private static final String TAX_CATEGORY_SERVICES = "SERVICES";
-
-    // Default postal code - should be replaced with location service lookup
-    private static final String DEFAULT_POSTAL_CODE = "78701"; // Austin, TX
 
     @Override
     public List<EstimateResponse> getAllEstimates() {
@@ -1041,32 +1040,26 @@ public class EstimateServiceImpl implements EstimateService {
         List<TaxLineItem> taxLineItems =
                 items.stream().map(this::buildTaxLineItemFromEstimateItem).toList();
 
-        // Get postal code from estimate's location
-        // NOTE: Currently using default postal code. Should integrate with pos-location
-        // service
-        // to retrieve actual postal code for estimate.getLocationId()
-        String postalCode = DEFAULT_POSTAL_CODE;
-
-        TaxCalculationRequest taxRequest = TaxCalculationRequest.builder()
-                .lineItems(taxLineItems)
-                .locale("en-US")
-                .currencyCode("USD")
-                .destinationAddress(TaxAddress.builder()
-                        .countryCode("US")
-                        .regionCode("CA")
-                        .postalCode(postalCode)
-                        .build())
-                .customerId(estimate.getCustomerId().toString())
-                .referenceId(estimateId)
-                .referenceType(TaxReferenceType.ESTIMATE)
-                .build();
-
         BigDecimal subtotal;
         BigDecimal taxAmount;
         BigDecimal total;
         boolean testMode = false;
 
         try {
+            // Resolve the estimate's shop-location address from pos-location so tax is
+            // calculated against the real jurisdiction (estimate.getLocationId()).
+            TaxAddress destinationAddress = locationClient.resolveTaxAddress(estimate.getLocationId());
+
+            TaxCalculationRequest taxRequest = TaxCalculationRequest.builder()
+                    .lineItems(taxLineItems)
+                    .locale("en-US")
+                    .currencyCode("USD")
+                    .destinationAddress(destinationAddress)
+                    .customerId(estimate.getCustomerId().toString())
+                    .referenceId(estimateId)
+                    .referenceType(TaxReferenceType.ESTIMATE)
+                    .build();
+
             TaxCalculationResponse taxResponse = taxClient.calculateTax(taxRequest);
             subtotal = taxResponse.getSubtotal();
             taxAmount = taxResponse.getTotalTax();

--- a/pos-workorder/src/main/resources/application.yml
+++ b/pos-workorder/src/main/resources/application.yml
@@ -79,6 +79,8 @@ pos:
     base-url: ${POS_VEHICLE_BASE_URL:http://pos-vehicle:8088}
   tax:
     base-url: ${POS_TAX_BASE_URL:http://pos-tax:8091}
+  location:
+    base-url: ${POS_LOCATION_BASE_URL:http://pos-location:8080}
   invoice:
     service-id: ${POS_INVOICE_SERVICE_ID:invoice}
   inventory:

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceImplTest.java
@@ -2,8 +2,13 @@ package com.positivity.workorder.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.positivity.tax.common.dto.TaxCalculationRequest;
+import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import com.positivity.workorder.internal.client.LocationClient;
 import com.positivity.workorder.internal.client.PeopleLocationClient;
 import com.positivity.workorder.internal.client.TaxClient;
 import com.positivity.workorder.internal.dto.AddEstimateItemRequest;
@@ -33,6 +38,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -70,6 +76,9 @@ class EstimateServiceImplTest {
 
     @Mock
     private TaxClient taxClient;
+
+    @Mock
+    private LocationClient locationClient;
 
     @Mock
     private PeopleLocationClient peopleLocationClient;
@@ -182,6 +191,57 @@ class EstimateServiceImplTest {
         assertEquals(LOCAL_CUSTOMER_ID, result.getCustomerId());
         assertEquals(LOCAL_VEHICLE_ID, result.getVehicleId());
         assertEquals(EstimateStatus.DRAFT.toString(), result.getStatus());
+    }
+
+    @Test
+    void calculateEstimateTaxesAndTotals_sendsResolvedShopLocationAddressToTax() {
+        UUID locationId = UUID.fromString("01960003-0000-7000-8000-000000000001");
+        Estimate draft = Estimate.builder()
+                .id(ESTIMATE_ID)
+                .customerId(CUSTOMER_ID)
+                .vehicleId(VEHICLE_ID)
+                .locationId(locationId)
+                .status(EstimateStatus.DRAFT)
+                .build();
+        EstimateItem item = EstimateItem.builder()
+                .id(ITEM_ID)
+                .estimate(draft)
+                .itemType(EstimateItemType.PART)
+                .description("Brake pad")
+                .quantity(new BigDecimal("2"))
+                .unitPrice(new BigDecimal("25.00"))
+                .build();
+
+        TaxAddress resolved = TaxAddress.builder()
+                .countryCode("US")
+                .regionCode("WA")
+                .city("Seattle")
+                .postalCode("98101")
+                .line1("123 Pike St")
+                .build();
+
+        when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.of(draft));
+        when(estimateItemRepository.findByEstimate_IdAndDeletedFalse(ESTIMATE_ID))
+                .thenReturn(List.of(item));
+        when(locationClient.resolveTaxAddress(locationId)).thenReturn(resolved);
+        when(taxClient.calculateTax(any(TaxCalculationRequest.class)))
+                .thenReturn(TaxCalculationResponse.builder()
+                        .subtotal(new BigDecimal("50.00"))
+                        .totalTax(new BigDecimal("4.50"))
+                        .total(new BigDecimal("54.50"))
+                        .testMode(false)
+                        .build());
+        when(estimateRepository.save(any(Estimate.class))).thenAnswer(i -> i.getArgument(0));
+
+        estimateService.calculateEstimateTaxesAndTotals(ESTIMATE_ID, "testuser");
+
+        ArgumentCaptor<TaxCalculationRequest> captor = ArgumentCaptor.forClass(TaxCalculationRequest.class);
+        verify(taxClient).calculateTax(captor.capture());
+        TaxAddress sent = captor.getValue().getDestinationAddress();
+        assertEquals("US", sent.getCountryCode());
+        assertEquals("WA", sent.getRegionCode());
+        assertEquals("98101", sent.getPostalCode());
+        assertEquals("Seattle", sent.getCity());
     }
 
     @Test


### PR DESCRIPTION
## Summary

`EstimateServiceImpl` built its `TaxCalculationRequest` with a hardcoded placeholder destination address (`US/CA/78701`, Austin TX), so estimate tax was calculated against the wrong jurisdiction for every location. Fixes #755.

## Changes

- **New `LocationClient`** (+ `LocationAddressResponse`, `LocationClientConfig`) — resolves the estimate's shop-location address from pos-location (`GET /v1/locations/{id}`, `location:read` authority) and maps `Location{country,state,city,postalCode,line1/2}` → `TaxAddress`. Mirrors the pos-invoice shop-location fix, adapted to pos-workorder's named-bean RestClient style.
- **`EstimateServiceImpl.calculateEstimateTaxesAndTotals`** — replaced the hardcoded `TaxAddress` with `locationClient.resolveTaxAddress(estimate.getLocationId())`. Removed `DEFAULT_POSTAL_CODE` and the placeholder NOTE. Resolution sits inside the existing try/catch, so a pos-location outage degrades to the same deterministic fallback math as a tax-service outage (no new hard-fail path).
- **Config/docs** — added `pos.location.base-url` (`POS_LOCATION_BASE_URL`, default `http://pos-location:8080`) to `application.yml` and the README.
- **Test** — new `EstimateServiceImplTest` case captures the outbound `TaxCalculationRequest` and asserts the resolved `country`/`state`/`postalCode`/`city` are forwarded to pos-tax.

## Acceptance

- [x] Estimate tax requests carry the real shop-location `country`/`state`/`postalCode`.
- [x] No hardcoded jurisdiction remains in `EstimateServiceImpl`.
- [x] Unit test asserts the resolved address is sent to pos-tax.

## Verification

`./mvnw -pl pos-workorder test -Dtest=EstimateServiceImplTest` → `Tests run: 14, Failures: 0, Errors: 0` — BUILD SUCCESS.

No controller or API contract touched → no OpenAPI/SDK regeneration required, and no `BACKEND_CONTRACT_GUIDE.md` entry changes (internal service-to-service client wiring only).

Follow-up to the invoice→tax shop-location fix (`feat/invoice-tax-shop-location`); this estimate fix is independent and does not depend on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- contract-sync: BACKEND_CONTRACT_GUIDE.md reference retained -->
