### PR TITLE
refactor(people): unify person name model on first/last (#726)

### DIFF
--- a/pos-people/docs/PLAN-726-person-name-reconciliation.md
+++ b/pos-people/docs/PLAN-726-person-name-reconciliation.md
@@ -1,0 +1,90 @@
+# PLAN-726 — Reconcile Person name model to a single authoritative representation
+
+**Issue:** [#726](https://github.com/louisburroughs/durion-positivity-backend/issues/726) (tech-debt)
+**ADR:** [ADR-0015](../../docs/adr/0015-identity-entity-relationships.adr.md) — invariant **I2**: Person name & contact attributes owned by `pos-people`.
+**Predecessor:** PR #725 (stop-gap), people-collapse-2026-06 re-baseline (contact half).
+
+---
+
+## Scope correction vs. the issue text
+
+The issue was filed **before** the `people-collapse-2026-06` re-baseline. The **contact** half is already reconciled:
+
+- `contact_info_json` is no longer a stored column — `Person.contactInfoJson` is a read-only Hibernate `@Formula` over `person_contact_point` (EMAIL / PHONE_WORK).
+- Contact writes go through `person_contact_point` via `PersonWorkPhoneService` / `PersonEmailService` — the typed/authoritative model per ADR-0015.
+
+So #726 narrows to two things:
+
+1. **Collapse the name duplication** — `first_name`/`last_name` **and** `legal_name`/`preferred_name` are both stored; the first/last split is a heuristic.
+2. **Remove the now-vestigial stop-gaps** from PR #725 and the contact-collapse interim.
+
+### Canonical decision
+
+**Structured `firstName` / `lastName` + `preferredName` is canonical. `legal_name` is dropped.**
+
+Rationale: the broad read surface already reads/queries structured first/last —
+directory (`PersonServiceImpl`), name-search typeahead
+(`findByFirstNameIgnoreCase` / `findByLastNameIgnoreCase`), reports,
+availability, timekeeping-approval, user-person-link (6+ readers).
+`legal_name`/`preferred_name` is read only by the Employee profile path.
+
+**Accepted trade-off:** free-form full legal name (middle names, suffixes such
+as "Robert James Smith Jr.") is no longer stored distinctly. Flag for HR/payroll
+if legal-document matching is needed later.
+
+---
+
+## Current state (evidence)
+
+| Concern | State now | File |
+| --- | --- | --- |
+| `contactInfoJson` | Derived `@Formula`, not stored | `entity/Person.java:54` |
+| Contact write | Authoritative via `person_contact_point` | `EmployeeServiceImpl.replaceContactPoints` |
+| Name | **Stored twice**: `first_name`/`last_name` + `legal_name`/`preferred_name` | `entity/Person.java:39-47` |
+
+Live stop-gaps to remove (`EmployeeServiceImpl`):
+
+- `applyStructuredName` — heuristic split `legalName` → first/last on write (`:245`)
+- `resolveLegalName` — compose first/last when `legalName` blank (`:337`)
+- `resolveContactInfo` / `readContactInfo` / `contactInfoFromColumns` — vestigial blob-parse duality now that the blob is derived (`:353-391`)
+- `Person.contactInfoJson` `@Formula` field itself (`:54`)
+
+---
+
+## Phase 1 — Backend service + entity
+
+1. **`entity/Person.java`** — drop `legalName` field; drop `contactInfoJson` `@Formula` field. Keep `firstName` / `lastName` / `preferredName`.
+2. **`service/EmployeeServiceImpl.java`**
+   - Delete `applyStructuredName`, `resolveLegalName`, `resolveContactInfo`, `readContactInfo`, `contactInfoFromColumns`, and the `ObjectMapper` dependency.
+   - `applyIdentity` sets `firstName` / `lastName` / `preferredName` directly from the request.
+   - `toEmployeeProfile` reads `firstName` / `lastName` / `preferredName`; contact read becomes the single email/phone-service path.
+   - Duplicate detection: replace `hasAmbiguousLegalNameMatch` + `findByLegalNameIgnoreCase` with first/last matching (`findByFirstNameIgnoreCase` / `findByLastNameIgnoreCase`).
+3. **`repository/PersonRepository.java`** — remove `findByLegalNameIgnoreCase`.
+4. **`service/PeopleReportsServiceImpl.java`, `service/TimekeepingApprovalServiceImpl.java`** — switch any `legalName` read → `firstName`/`lastName` composition.
+
+## Phase 2 — DTOs + contract chain (mandatory: controller → OpenAPI → SDK → frontend)
+
+5. **`dto/CreateEmployeeRequest.java` / `dto/UpdateEmployeeRequest.java`** — `legalName`(`@NotBlank`)/`preferredName` → `firstName`(`@NotBlank`)/`lastName`/`preferredName`.
+6. **`dto/EmployeeProfileDto.java`** — `legalName` → `firstName`/`lastName`.
+7. **`dto/PersonBulkIngestRecord.java` + `controller/PersonBulkIngestController.java`** — `legalName` input → `firstName`/`lastName`.
+8. **OpenAPI annotations** on `EmployeeController` + bulk controller → regenerate `OpenAPI.yaml` → update **Angular SDK** → update frontend employee form + profile components (legalName field → first/last).
+
+## Phase 3 — Migration + seed
+
+9. New `V2__drop_legal_name.sql` — one-time backfill for any row with null `first_name` but present `legal_name` (reuse archived `V7__backfill_person_first_last_from_legal_name.sql` split), then `alter table person drop column legal_name`.
+10. **`R__seed_reference_people.sql`** — drop `legal_name`, populate `first_name`/`last_name`.
+
+## Phase 4 — Tests
+
+11. Update `EmployeeProfileContractBehaviorIT`, `EmployeeOffboardingContractBehaviorIT`, `PersonBulkIngestControllerTest`.
+12. **Delete `EmployeeProfileFallbackTest`** (tests the removed stop-gap); add a single-model assertion if it leaves a coverage gap.
+
+---
+
+## Done criteria
+
+- `legal_name` column gone; `Person` stores name once (`first_name`/`last_name`/`preferred_name`).
+- No `contactInfoJson` field; contact read/write only via `person_contact_point`.
+- No fallback/sync stop-gaps in `EmployeeServiceImpl`.
+- Contract chain in sync: controller annotations ↔ `OpenAPI.yaml` ↔ Angular SDK ↔ frontend.
+- All pos-people tests green.

--- a/pos-people/docs/hr-functions-guide.md
+++ b/pos-people/docs/hr-functions-guide.md
@@ -91,7 +91,8 @@ Person records are the underlying identity layer beneath employee records. They 
 
 For large-scale onboarding (e.g. system migrations or importing from an HRIS), employees can be created in bulk via a single request. Each record in the batch requires:
 
-- `legalName`
+- `firstName`
+- `lastName`
 - `employeeNumber`
 - `hireDate` (format: `YYYY-MM-DD`)
 - `preferredName` (optional)

--- a/pos-people/openapi.yaml
+++ b/pos-people/openapi.yaml
@@ -2334,10 +2334,15 @@ components:
       type: object
       description: Request to update an existing employee record
       properties:
-        legalName:
+        firstName:
           type: string
-          description: Legal name of the employee
-          example: Jane Smith
+          description: First (given) name of the employee
+          example: Jane
+          minLength: 1
+        lastName:
+          type: string
+          description: Last (family) name of the employee
+          example: Smith
           minLength: 1
         preferredName:
           type: string
@@ -2379,8 +2384,9 @@ components:
           example: STRICT
       required:
       - employeeNumber
+      - firstName
       - hireDate
-      - legalName
+      - lastName
       - status
     EmployeeProfileDto:
       type: object
@@ -2391,10 +2397,14 @@ components:
           format: uuid
           description: Employee identifier
           example: 01960011-0000-7000-8000-000000000001
-        legalName:
+        firstName:
           type: string
-          description: Legal name of the employee
-          example: Jane Smith
+          description: First (given) name of the employee
+          example: Jane
+        lastName:
+          type: string
+          description: Last (family) name of the employee
+          example: Smith
         preferredName:
           type: string
           description: Preferred name of the employee
@@ -2449,9 +2459,10 @@ components:
             type: string
       required:
       - employeeNumber
+      - firstName
       - hireDate
       - id
-      - legalName
+      - lastName
       - status
     PersonRoleAssignmentRequest:
       type: object
@@ -3035,10 +3046,15 @@ components:
       type: object
       description: Request to create an employee record
       properties:
-        legalName:
+        firstName:
           type: string
-          description: Legal name of the employee
-          example: Jane Smith
+          description: First (given) name of the employee
+          example: Jane
+          minLength: 1
+        lastName:
+          type: string
+          description: Last (family) name of the employee
+          example: Smith
           minLength: 1
         preferredName:
           type: string
@@ -3080,8 +3096,9 @@ components:
           example: STRICT
       required:
       - employeeNumber
+      - firstName
       - hireDate
-      - legalName
+      - lastName
       - status
     DisableEmployeeRequestDto:
       type: object
@@ -3135,10 +3152,15 @@ components:
       type: object
       description: Single person record within a bulk ingest payload
       properties:
-        legalName:
+        firstName:
           type: string
-          description: Legal name of the person
-          example: Jane Smith
+          description: First (given) name of the person
+          example: Jane
+          minLength: 1
+        lastName:
+          type: string
+          description: Last (family) name of the person
+          example: Smith
           minLength: 1
         preferredName:
           type: string
@@ -3164,8 +3186,9 @@ components:
           example: +1-555-123-4567
       required:
       - employeeNumber
+      - firstName
       - hireDate
-      - legalName
+      - lastName
     BulkIngestResponse:
       type: object
       description: 'Summary outcome of a bulk ingest job: per-record results plus aggregate counts'

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/PersonBulkIngestController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/PersonBulkIngestController.java
@@ -61,7 +61,8 @@ public class PersonBulkIngestController extends AbstractBulkIngestController<Per
                 LocalDate hireDate = parseHireDate(ingestRecord.getHireDate());
 
                 CreateEmployeeRequest createEmployeeRequest = new CreateEmployeeRequest();
-                createEmployeeRequest.setLegalName(ingestRecord.getLegalName());
+                createEmployeeRequest.setFirstName(ingestRecord.getFirstName());
+                createEmployeeRequest.setLastName(ingestRecord.getLastName());
                 createEmployeeRequest.setPreferredName(ingestRecord.getPreferredName());
                 createEmployeeRequest.setEmployeeNumber(ingestRecord.getEmployeeNumber());
                 createEmployeeRequest.setStatus(EmployeeStatus.ACTIVE);

--- a/pos-people/src/main/java/com/positivity/people/internal/dto/CreateEmployeeRequest.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/dto/CreateEmployeeRequest.java
@@ -13,12 +13,19 @@ import lombok.Data;
 @Schema(description = "Request to create an employee record")
 public class CreateEmployeeRequest {
 
-    @NotBlank(message = "legalName is required")
+    @NotBlank(message = "firstName is required")
     @Schema(
-            description = "Legal name of the employee",
-            example = "Jane Smith",
+            description = "First (given) name of the employee",
+            example = "Jane",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private String legalName;
+    private String firstName;
+
+    @NotBlank(message = "lastName is required")
+    @Schema(
+            description = "Last (family) name of the employee",
+            example = "Smith",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String lastName;
 
     @Schema(
             description = "Preferred name of the employee",

--- a/pos-people/src/main/java/com/positivity/people/internal/dto/EmployeeProfileDto.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/dto/EmployeeProfileDto.java
@@ -21,10 +21,16 @@ public class EmployeeProfileDto {
     private UUID id;
 
     @Schema(
-            description = "Legal name of the employee",
-            example = "Jane Smith",
+            description = "First (given) name of the employee",
+            example = "Jane",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private String legalName;
+    private String firstName;
+
+    @Schema(
+            description = "Last (family) name of the employee",
+            example = "Smith",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String lastName;
 
     @Schema(
             description = "Preferred name of the employee",

--- a/pos-people/src/main/java/com/positivity/people/internal/dto/PersonBulkIngestRecord.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/dto/PersonBulkIngestRecord.java
@@ -10,10 +10,17 @@ public class PersonBulkIngestRecord {
 
     @NotBlank
     @Schema(
-            description = "Legal name of the person",
-            example = "Jane Smith",
+            description = "First (given) name of the person",
+            example = "Jane",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private String legalName;
+    private String firstName;
+
+    @NotBlank
+    @Schema(
+            description = "Last (family) name of the person",
+            example = "Smith",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String lastName;
 
     @Schema(
             description = "Preferred name of the person",

--- a/pos-people/src/main/java/com/positivity/people/internal/dto/UpdateEmployeeRequest.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/dto/UpdateEmployeeRequest.java
@@ -13,12 +13,19 @@ import lombok.Data;
 @Schema(description = "Request to update an existing employee record")
 public class UpdateEmployeeRequest {
 
-    @NotBlank(message = "legalName is required")
+    @NotBlank(message = "firstName is required")
     @Schema(
-            description = "Legal name of the employee",
-            example = "Jane Smith",
+            description = "First (given) name of the employee",
+            example = "Jane",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private String legalName;
+    private String firstName;
+
+    @NotBlank(message = "lastName is required")
+    @Schema(
+            description = "Last (family) name of the employee",
+            example = "Smith",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String lastName;
 
     @Schema(
             description = "Preferred name of the employee",

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/Person.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/Person.java
@@ -40,29 +40,8 @@ public class Person {
 
     private String lastName;
 
-    @Column(name = "legal_name")
-    private String legalName;
-
     @Column(name = "preferred_name")
     private String preferredName;
-
-    // Derived, read-only: the legacy contact-info blob is no longer stored. It is computed
-    // from person_contact_point (EMAIL / PHONE_WORK, primary + secondary) so existing readers
-    // keep working without a duplicate column. JSON is assembled with portable string ops
-    // (no DB-specific JSON functions) so it works on both Postgres and the H2 test DB. Values
-    // are emails/phones (no embedded quotes), so manual JSON assembly is safe.
-    @org.hibernate.annotations.Formula(
-            "(select '{\"primaryEmail\":' || coalesce('\"' || max(case when cp.contact_type = 'EMAIL'"
-                    + " and cp.is_primary then cp.\"value\" end) || '\"', 'null')"
-                    + " || ',\"secondaryEmail\":' || coalesce('\"' || max(case when cp.contact_type = 'EMAIL'"
-                    + " and not cp.is_primary then cp.\"value\" end) || '\"', 'null')"
-                    + " || ',\"primaryPhone\":' || coalesce('\"' || max(case when cp.contact_type = 'PHONE_WORK'"
-                    + " and cp.is_primary then cp.\"value\" end) || '\"', 'null')"
-                    + " || ',\"secondaryPhone\":' || coalesce('\"' || max(case when cp.contact_type = 'PHONE_WORK'"
-                    + " and not cp.is_primary then cp.\"value\" end) || '\"', 'null')"
-                    + " || '}'"
-                    + " from person_contact_point cp where cp.person_id = id having count(*) > 0)")
-    private String contactInfoJson;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)

--- a/pos-people/src/main/java/com/positivity/people/internal/repository/PersonRepository.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/repository/PersonRepository.java
@@ -8,8 +8,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface PersonRepository extends JpaRepository<Person, UUID>, JpaSpecificationExecutor<Person> {
 
-    List<Person> findByLegalNameIgnoreCase(String legalName);
-
     List<Person> findByLastNameIgnoreCase(String lastName);
 
     List<Person> findByFirstNameIgnoreCase(String firstName);

--- a/pos-people/src/main/java/com/positivity/people/internal/service/EmployeeServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/EmployeeServiceImpl.java
@@ -1,7 +1,5 @@
 package com.positivity.people.internal.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.positivity.people.internal.dto.CreateEmployeeRequest;
 import com.positivity.people.internal.dto.DisableEmployeeRequestDto;
 import com.positivity.people.internal.dto.EmployeeContactInfoDto;
@@ -50,8 +48,6 @@ public class EmployeeServiceImpl implements EmployeeService {
 
     private final EmployeeOffboardingRetryRepository offboardingRetryRepository;
 
-    private final ObjectMapper objectMapper;
-
     @Override
     @Transactional
     public @NonNull EmployeeProfileDto createEmployee(@NonNull CreateEmployeeRequest request) {
@@ -61,10 +57,11 @@ public class EmployeeServiceImpl implements EmployeeService {
                 request.getDuplicatePolicy(),
                 request.getEmployeeNumber(),
                 request.getContactInfo(),
-                request.getLegalName());
+                request.getFirstName(),
+                request.getLastName());
 
         Person person = new Person();
-        applyIdentity(person, request.getLegalName(), request.getPreferredName(), request.getContactInfo());
+        applyIdentity(person, request.getFirstName(), request.getLastName(), request.getPreferredName());
         Person savedPerson = personRepository.save(person);
 
         Employee employee = Employee.builder().personId(savedPerson.getId()).build();
@@ -103,9 +100,10 @@ public class EmployeeServiceImpl implements EmployeeService {
                 request.getDuplicatePolicy(),
                 request.getEmployeeNumber(),
                 request.getContactInfo(),
-                request.getLegalName());
+                request.getFirstName(),
+                request.getLastName());
 
-        applyIdentity(person, request.getLegalName(), request.getPreferredName(), request.getContactInfo());
+        applyIdentity(person, request.getFirstName(), request.getLastName(), request.getPreferredName());
         Person savedPerson = personRepository.save(person);
 
         Employee employee = employeeRepository
@@ -183,7 +181,8 @@ public class EmployeeServiceImpl implements EmployeeService {
             DuplicatePolicy duplicatePolicy,
             String employeeNumber,
             EmployeeContactInfoDto contactInfo,
-            String legalName) {
+            String firstName,
+            String lastName) {
         DuplicatePolicy policy = duplicatePolicy != null ? duplicatePolicy : DuplicatePolicy.STRICT;
 
         DuplicateSignals duplicateSignals = collectDuplicateSignals(employeeId, employeeNumber, contactInfo);
@@ -200,8 +199,8 @@ public class EmployeeServiceImpl implements EmployeeService {
             warnings.add("Potential duplicate detected; request accepted due to BALANCED duplicatePolicy");
         }
 
-        if (hasAmbiguousLegalNameMatch(employeeId, legalName)) {
-            warnings.add("Ambiguous duplicate match detected by legalName similarity");
+        if (hasAmbiguousNameMatch(employeeId, firstName, lastName)) {
+            warnings.add("Ambiguous duplicate match detected by name similarity");
         }
 
         return warnings;
@@ -227,46 +226,24 @@ public class EmployeeServiceImpl implements EmployeeService {
         return new DuplicateSignals(duplicateEmployeeNumber, duplicatePrimaryEmail, duplicatePhone);
     }
 
-    private boolean hasAmbiguousLegalNameMatch(UUID employeeId, String legalName) {
-        if (legalName == null || legalName.isBlank()) {
+    private boolean hasAmbiguousNameMatch(UUID employeeId, String firstName, String lastName) {
+        if (firstName == null || firstName.isBlank() || lastName == null || lastName.isBlank()) {
             return false;
         }
-        return personRepository.findByLegalNameIgnoreCase(legalName).stream()
+        return personRepository.findByLastNameIgnoreCase(lastName).stream()
+                .filter(person -> firstName.equalsIgnoreCase(person.getFirstName()))
                 .anyMatch(person -> employeeId == null || !person.getId().equals(employeeId));
     }
 
     /**
-     * Keep the typed {@code firstName}/{@code lastName} columns in sync with {@code legalName} so a
-     * person created or edited through the Employee path also surfaces a name in the directory and
-     * the people typeahead (which read first/last). The first whitespace-delimited token becomes the
-     * first name and the remainder the last name — a heuristic split, but it keeps both views
-     * consistent. The structured {@code legalName} remains the authoritative value.
+     * Person identity: authoritative structured name. Email + phone are persisted as
+     * EMAIL / PHONE_WORK contact points after save (see createEmployee/updateEmployee), so no
+     * contact value is written here.
      */
-    private void applyStructuredName(Person entity, String legalName) {
-        if (legalName == null || legalName.isBlank()) {
-            return;
-        }
-        String trimmed = legalName.trim();
-        int firstSpace = trimmed.indexOf(' ');
-        if (firstSpace < 0) {
-            entity.setFirstName(trimmed);
-            entity.setLastName("");
-        } else {
-            entity.setFirstName(trimmed.substring(0, firstSpace));
-            entity.setLastName(trimmed.substring(firstSpace + 1).trim());
-        }
-    }
-
-    /** Person identity: legal/preferred names, derived first/last. */
-    private void applyIdentity(
-            Person entity, String legalName, String preferredName, EmployeeContactInfoDto contactInfo) {
-        entity.setLegalName(legalName);
-        entity.setPreferredName(preferredName);
-        applyStructuredName(entity, legalName);
-        // Email + phone are persisted as EMAIL / PHONE_WORK contact points after save (see
-        // createEmployee/updateEmployee); contactInfoJson is a read-only @Formula derived from
-        // those contact points, so nothing is written here. (contactInfo is consumed by the
-        // contact-point writes in the caller.)
+    private void applyIdentity(Person entity, String firstName, String lastName, String preferredName) {
+        entity.setFirstName(normalize(firstName));
+        entity.setLastName(normalize(lastName));
+        entity.setPreferredName(normalize(preferredName));
     }
 
     /** Employment attributes on the Employee record. */
@@ -315,13 +292,14 @@ public class EmployeeServiceImpl implements EmployeeService {
     private EmployeeProfileDto toEmployeeProfile(Person person, Employee employee, List<String> warnings) {
         return EmployeeProfileDto.builder()
                 .id(person.getId())
-                .legalName(resolveLegalName(person))
+                .firstName(person.getFirstName())
+                .lastName(person.getLastName())
                 .preferredName(person.getPreferredName())
                 .employeeNumber(employee != null ? employee.getEmployeeNumber() : null)
                 .status(employee != null ? employee.getStatus() : null)
                 .hireDate(employee != null ? employee.getHireDate() : null)
                 .terminationDate(employee != null ? employee.getTerminationDate() : null)
-                .contactInfo(resolveContactInfo(person))
+                .contactInfo(buildContactInfo(person))
                 .statusEffectiveAt(employee != null ? employee.getStatusEffectiveAt() : null)
                 .createdAt(person.getCreatedAt())
                 .updatedAt(person.getUpdatedAt())
@@ -329,36 +307,8 @@ public class EmployeeServiceImpl implements EmployeeService {
                 .build();
     }
 
-    /**
-     * The employee profile historically read {@code legalName}, but persons created via the
-     * People path (and seed data) populate only {@code firstName}/{@code lastName}. Fall back to
-     * the composed first/last name so the profile is never blank for those records.
-     */
-    private String resolveLegalName(Person person) {
-        String legalName = person.getLegalName();
-        if (legalName != null && !legalName.isBlank()) {
-            return legalName;
-        }
-        String composed = java.util.stream.Stream.of(person.getFirstName(), person.getLastName())
-                .filter(value -> value != null && !value.isBlank())
-                .collect(java.util.stream.Collectors.joining(" "));
-        return composed.isBlank() ? legalName : composed;
-    }
-
-    /**
-     * Prefer the structured {@code contactInfoJson} blob, but fall back to the typed contact
-     * columns ({@code primaryEmail}/{@code secondaryEmail}/{@code phoneNumbers}) when the blob is
-     * absent — as it is for column-sourced persons (People path and seed data).
-     */
-    private EmployeeContactInfoDto resolveContactInfo(Person person) {
-        EmployeeContactInfoDto fromJson = readContactInfo(person.getContactInfoJson());
-        if (fromJson != null) {
-            return fromJson;
-        }
-        return contactInfoFromColumns(person);
-    }
-
-    private EmployeeContactInfoDto contactInfoFromColumns(Person person) {
+    /** Read contact info from the authoritative person_contact_point rows (EMAIL / PHONE_WORK). */
+    private EmployeeContactInfoDto buildContactInfo(Person person) {
         PersonEmailService.EmailPair emails = emailService.getEmails(person.getId());
         String primaryEmail = normalize(emails.primary());
         String secondaryEmail = normalize(emails.secondary());
@@ -376,18 +326,6 @@ public class EmployeeServiceImpl implements EmployeeService {
         dto.setPrimaryPhone(primaryPhone);
         dto.setSecondaryPhone(secondaryPhone);
         return dto;
-    }
-
-    private EmployeeContactInfoDto readContactInfo(String contactInfoJson) {
-        if (contactInfoJson == null || contactInfoJson.isBlank()) {
-            return null;
-        }
-        try {
-            return objectMapper.readValue(contactInfoJson, EmployeeContactInfoDto.class);
-        } catch (JsonProcessingException exception) {
-            log.warn("Failed to deserialize contact info JSON. Returning null. reason={}", exception.getMessage());
-            return null;
-        }
     }
 
     private void applyAssignmentPolicy(UUID employeeId, DisableEmployeeRequestDto request, String actorId) {

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PeopleReportsServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PeopleReportsServiceImpl.java
@@ -359,11 +359,6 @@ public class PeopleReportsServiceImpl implements PeopleReportsService {
                         + (person.getLastName() == null ? "" : person.getLastName()))
                 .trim();
         if (displayName.isBlank()
-                && person.getLegalName() != null
-                && !person.getLegalName().isBlank()) {
-            displayName = person.getLegalName();
-        }
-        if (displayName.isBlank()
                 && person.getPreferredName() != null
                 && !person.getPreferredName().isBlank()) {
             displayName = person.getPreferredName();

--- a/pos-people/src/main/java/com/positivity/people/internal/service/TimekeepingApprovalServiceImpl.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/TimekeepingApprovalServiceImpl.java
@@ -202,7 +202,7 @@ public class TimekeepingApprovalServiceImpl implements TimekeepingApprovalServic
         if (p.getFirstName() != null) {
             return p.getFirstName() + " " + p.getLastName();
         }
-        return p.getLegalName() != null ? p.getLegalName() : p.getId().toString();
+        return p.getId().toString();
     }
 
     private Instant toInstant(LocalDate date) {

--- a/pos-people/src/main/resources/db/migration/R__seed_reference_people.sql
+++ b/pos-people/src/main/resources/db/migration/R__seed_reference_people.sql
@@ -22,10 +22,10 @@ VALUES ('7b1f81a7-34fa-f0f9-7caf-a55541d36a60'::uuid, 'GLOBAL', NULL, 10, NOW(),
 ON CONFLICT (timekeeping_policy_id) DO NOTHING;
 
 -- person (System Administrator) — admin.alpha's person record (identity only).
-INSERT INTO person (id, first_name, last_name, legal_name, created_at, updated_at)
+INSERT INTO person (id, first_name, last_name, created_at, updated_at)
 VALUES (
     '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid,
-    'System', 'Administrator', 'System Administrator',
+    'System', 'Administrator',
     NOW(), NOW()
 )
 ON CONFLICT (id) DO NOTHING;

--- a/pos-people/src/main/resources/db/migration/V2__drop_legal_name.sql
+++ b/pos-people/src/main/resources/db/migration/V2__drop_legal_name.sql
@@ -1,0 +1,22 @@
+-- Reconcile the person name model to a single authoritative representation (issue #726).
+--
+-- The Employee path historically wrote legal_name while the directory / typeahead and most
+-- readers use first_name/last_name. first_name/last_name is now canonical; legal_name is removed.
+-- This migration backfills any row that still carries legal_name but no first_name (Employee-path
+-- rows created before the unification), then drops the redundant column.
+--
+-- Split heuristic (first whitespace-delimited token -> first_name, remainder -> last_name) is a
+-- one-time data repair for legacy rows only; new writes set first_name/last_name directly.
+UPDATE person
+SET first_name = split_part(trim(legal_name), ' ', 1),
+    last_name = CASE
+        WHEN position(' ' IN trim(legal_name)) > 0
+            THEN trim(substring(trim(legal_name) FROM position(' ' IN trim(legal_name)) + 1))
+        ELSE ''
+    END,
+    updated_at = NOW()
+WHERE (first_name IS NULL OR first_name = '')
+  AND legal_name IS NOT NULL
+  AND trim(legal_name) <> '';
+
+ALTER TABLE person DROP COLUMN legal_name;

--- a/pos-people/src/test/java/com/positivity/people/contract/EmployeeOffboardingContractBehaviorIT.java
+++ b/pos-people/src/test/java/com/positivity/people/contract/EmployeeOffboardingContractBehaviorIT.java
@@ -82,7 +82,8 @@ class EmployeeOffboardingContractBehaviorIT extends BaseContractIntegrationTest 
         }
         String payload = """
 				{
-				  "legalName": "Offboarding Employee",
+				  "firstName": "Offboarding",
+				  "lastName": "Employee",
 				  "preferredName": "Offboarding",
 				  "employeeNumber": "%s",
 				  "status": "ACTIVE",

--- a/pos-people/src/test/java/com/positivity/people/contract/EmployeeProfileContractBehaviorIT.java
+++ b/pos-people/src/test/java/com/positivity/people/contract/EmployeeProfileContractBehaviorIT.java
@@ -28,7 +28,8 @@ class EmployeeProfileContractBehaviorIT extends BaseContractIntegrationTest {
                                 employeeNumber, "alex.117.001+" + employeeNumber + "@example.com", "STRICT"))))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.employeeNumber").value(employeeNumber))
-                .andExpect(jsonPath("$.legalName").value("Alex Carter"));
+                .andExpect(jsonPath("$.firstName").value("Alex"))
+                .andExpect(jsonPath("$.lastName").value("Carter"));
     }
 
     @Test
@@ -36,7 +37,8 @@ class EmployeeProfileContractBehaviorIT extends BaseContractIntegrationTest {
     void ve117001_invalidDates_returns422() throws Exception {
         String payload = """
 				{
-				  "legalName": "Alex Carter",
+				  "firstName": "Alex",
+				  "lastName": "Carter",
 				  "preferredName": "Alex",
 				  "employeeNumber": "EMP-117-002",
 				  "status": "ACTIVE",
@@ -144,7 +146,8 @@ class EmployeeProfileContractBehaviorIT extends BaseContractIntegrationTest {
 
         String updatePayload = """
 				{
-				  "legalName": "Alex Carter",
+				  "firstName": "Alex",
+				  "lastName": "Carter",
 				  "preferredName": "A. Carter",
 				                                                        "employeeNumber": "%s",
 				  "status": "ON_LEAVE",
@@ -172,7 +175,8 @@ class EmployeeProfileContractBehaviorIT extends BaseContractIntegrationTest {
         }
         return """
 				{
-				  "legalName": "Alex Carter",
+				  "firstName": "Alex",
+				  "lastName": "Carter",
 				  "preferredName": "Alex",
 				  "employeeNumber": "%s",
 				  "status": "ACTIVE",

--- a/pos-people/src/test/java/com/positivity/people/internal/controller/PersonBulkIngestControllerTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/controller/PersonBulkIngestControllerTest.java
@@ -50,7 +50,8 @@ class PersonBulkIngestControllerTest {
     @Test
     void bulkIngest_returnsOkWithResults_whenAllRecordsSucceed() throws Exception {
         PersonBulkIngestRecord ingestRecord = new PersonBulkIngestRecord();
-        ingestRecord.setLegalName("Alice Brown");
+        ingestRecord.setFirstName("Alice");
+        ingestRecord.setLastName("Brown");
         ingestRecord.setEmployeeNumber("EMP-001");
         ingestRecord.setHireDate("2025-01-15");
 
@@ -61,7 +62,8 @@ class PersonBulkIngestControllerTest {
 
         EmployeeProfileDto profile = EmployeeProfileDto.builder()
                 .id(EMPLOYEE_ID)
-                .legalName("Alice Brown")
+                .firstName("Alice")
+                .lastName("Brown")
                 .employeeNumber("EMP-001")
                 .build();
 
@@ -79,7 +81,8 @@ class PersonBulkIngestControllerTest {
     @Test
     void bulkIngest_returnsPartialFailure_whenSomeDatesAreInvalid() throws Exception {
         PersonBulkIngestRecord ingestRecord = new PersonBulkIngestRecord();
-        ingestRecord.setLegalName("Bob Jones");
+        ingestRecord.setFirstName("Bob");
+        ingestRecord.setLastName("Jones");
         ingestRecord.setEmployeeNumber("EMP-002");
         ingestRecord.setHireDate("15-Jan-2025"); // invalid ISO format
 

--- a/pos-people/src/test/java/com/positivity/people/internal/service/EmployeeProfileMappingTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/EmployeeProfileMappingTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.positivity.people.internal.dto.CreateEmployeeRequest;
 import com.positivity.people.internal.dto.EmployeeProfileDto;
 import com.positivity.people.internal.entity.Employee;
@@ -28,15 +27,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * Unit tests for {@link EmployeeServiceImpl#getEmployee} name/contact fallback.
- *
- * Persons created via the People path (and seed data) populate the typed
- * {@code firstName}/{@code lastName} and contact columns, but not the
- * employee-specific {@code legalName}/{@code contactInfoJson}. The profile must
- * still surface a name and contact for those records.
+ * Unit tests for {@link EmployeeServiceImpl#getEmployee} / create mapping under the unified name
+ * model: the structured {@code firstName}/{@code lastName} columns are authoritative, and contact
+ * is read from person_contact_point (EMAIL / PHONE_WORK). There is no {@code legalName} or
+ * {@code contactInfoJson} fallback any longer.
  */
 @ExtendWith(MockitoExtension.class)
-class EmployeeProfileFallbackTest {
+class EmployeeProfileMappingTest {
 
     private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
     private static final UUID PERSON_ID = UUID.fromString("01960011-0000-7000-8000-000000000001");
@@ -70,23 +67,21 @@ class EmployeeProfileFallbackTest {
                 employeeRepository,
                 workPhoneService,
                 emailService,
-                offboardingRetryRepository,
-                new ObjectMapper());
+                offboardingRetryRepository);
     }
 
-    private Person columnSourcedPerson() {
+    private Person person() {
         Person person = new Person();
         person.setId(PERSON_ID);
         person.setFirstName("Marcus");
         person.setLastName("Webb");
         person.setCreatedAt(Instant.parse("2024-01-01T09:30:00Z"));
         person.setUpdatedAt(Instant.parse("2024-02-01T14:05:00Z"));
-        // legalName and contactInfoJson intentionally left null (People-path / seed record).
         return person;
     }
 
-    /** Employment record carrying the employee-specific attributes that moved off Person. */
-    private Employee columnSourcedEmployee() {
+    /** Employment record carrying the employee-specific attributes that live on Employee. */
+    private Employee employee() {
         return Employee.builder()
                 .personId(PERSON_ID)
                 .employeeNumber("EMP-0001")
@@ -97,7 +92,7 @@ class EmployeeProfileFallbackTest {
 
     @Test
     void getEmployee_mapsCreatedAndUpdatedTimestamps() {
-        when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(columnSourcedPerson()));
+        when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(person()));
 
         EmployeeProfileDto profile = service().getEmployee(PERSON_ID);
 
@@ -106,17 +101,18 @@ class EmployeeProfileFallbackTest {
     }
 
     @Test
-    void getEmployee_fallsBackToFirstLastNameWhenLegalNameMissing() {
-        when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(columnSourcedPerson()));
+    void getEmployee_mapsFirstAndLastName() {
+        when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(person()));
 
         EmployeeProfileDto profile = service().getEmployee(PERSON_ID);
 
-        assertThat(profile.getLegalName()).isEqualTo("Marcus Webb");
+        assertThat(profile.getFirstName()).isEqualTo("Marcus");
+        assertThat(profile.getLastName()).isEqualTo("Webb");
     }
 
     @Test
-    void getEmployee_fallsBackToContactColumnsWhenJsonMissing() {
-        when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(columnSourcedPerson()));
+    void getEmployee_mapsContactFromContactPoints() {
+        when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(person()));
         when(workPhoneService.getWorkPhones(PERSON_ID)).thenReturn(List.of("555-0100", "555-0101"));
         when(emailService.getEmails(PERSON_ID))
                 .thenReturn(new PersonEmailService.EmailPair("marcus.webb@durion.internal", null));
@@ -129,20 +125,10 @@ class EmployeeProfileFallbackTest {
         assertThat(profile.getContactInfo().getSecondaryPhone()).isEqualTo("555-0101");
     }
 
-    @Test
-    void getEmployee_prefersExplicitLegalNameOverFirstLast() {
-        Person person = columnSourcedPerson();
-        person.setLegalName("Marcus Aurelius Webb");
-        when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(person));
-
-        EmployeeProfileDto profile = service().getEmployee(PERSON_ID);
-
-        assertThat(profile.getLegalName()).isEqualTo("Marcus Aurelius Webb");
-    }
-
-    private CreateEmployeeRequest createRequest(String legalName) {
+    private CreateEmployeeRequest createRequest(String firstName, String lastName) {
         CreateEmployeeRequest request = new CreateEmployeeRequest();
-        request.setLegalName(legalName);
+        request.setFirstName(firstName);
+        request.setLastName(lastName);
         request.setEmployeeNumber("EMP-0001");
         request.setStatus(EmployeeStatus.ACTIVE);
         request.setHireDate(LocalDate.parse("2024-01-01"));
@@ -150,26 +136,14 @@ class EmployeeProfileFallbackTest {
     }
 
     @Test
-    void createEmployee_syncsFirstAndLastNameFromLegalName() {
+    void createEmployee_persistsFirstAndLastNameDirectly() {
         when(personRepository.save(any(Person.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        service().createEmployee(createRequest("Marcus Webb"));
+        service().createEmployee(createRequest("Marcus", "Webb"));
 
         ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
         verify(personRepository).save(captor.capture());
         assertThat(captor.getValue().getFirstName()).isEqualTo("Marcus");
         assertThat(captor.getValue().getLastName()).isEqualTo("Webb");
-    }
-
-    @Test
-    void createEmployee_putsTrailingTokensInLastName() {
-        when(personRepository.save(any(Person.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-        service().createEmployee(createRequest("Marcus Aurelius Webb"));
-
-        ArgumentCaptor<Person> captor = ArgumentCaptor.forClass(Person.class);
-        verify(personRepository).save(captor.capture());
-        assertThat(captor.getValue().getFirstName()).isEqualTo("Marcus");
-        assertThat(captor.getValue().getLastName()).isEqualTo("Aurelius Webb");
     }
 }

--- a/pos-people/src/test/java/com/positivity/people/migration/FlywayMigrationIT.java
+++ b/pos-people/src/test/java/com/positivity/people/migration/FlywayMigrationIT.java
@@ -48,6 +48,8 @@ class FlywayMigrationIT {
         assertThat(droppedColumn(jdbc, "person", "employee_number")).isTrue();
         assertThat(droppedColumn(jdbc, "person", "status")).isTrue();
         assertThat(droppedColumn(jdbc, "person", "contact_info_json")).isTrue();
+        // Name model unified on first_name/last_name (#726); redundant legal_name dropped.
+        assertThat(droppedColumn(jdbc, "person", "legal_name")).isTrue();
 
         // Assignments reference employee; user_person_links is keyed by username.
         assertThat(hasColumn(jdbc, "employee_location_assignment", "employee_id"))


### PR DESCRIPTION
Closes #726.

## Summary
Reconcile the employee ↔ person ↔ contact model to a single authoritative name representation. Structured `firstName`/`lastName` (+ `preferredName`) is now canonical; the redundant `legal_name` and the PR #725 stop-gaps are removed. (Contact half was already reconciled by the people-collapse re-baseline: `contactInfoJson` is a derived `@Formula`.)

## Contract impact
This change touches the API contract (controllers, DTOs, OpenAPI). Per the people-domain `BACKEND_CONTRACT_GUIDE.md`, the employee create/update/profile and bulk-ingest contracts now expose `firstName`/`lastName` in place of `legalName`:
- `CreateEmployeeRequest` / `UpdateEmployeeRequest`: `legalName` → `firstName` (required) + `lastName` (required)
- `EmployeeProfileDto`: `legalName` → `firstName` + `lastName`
- `PersonBulkIngestRecord`: `legalName` → `firstName` + `lastName`
- `pos-people/openapi.yaml` regenerated; HR functions guide updated.

Contract chain propagated: controller annotations → `OpenAPI.yaml` → Angular SDK → frontend (companion PRs below).

## Changes
- **Person**: drop `legalName` field and the derived `contactInfoJson` `@Formula`.
- **EmployeeServiceImpl**: `applyIdentity` sets first/last/preferred directly; duplicate detection matches on first+last; profile reads first/last; contact read from `person_contact_point` only. Removed `resolveLegalName`, `resolveContactInfo`/`readContactInfo` blob path, `applyStructuredName` heuristic, and the `ObjectMapper` dep.
- **DTOs + OpenAPI** (`Create`/`Update`/`Profile`/`BulkIngestRecord`): `legalName` → `firstName`/`lastName`.
- **PersonRepository**: drop `findByLegalNameIgnoreCase`.
- **Migration** `V2__drop_legal_name.sql`: backfill legacy rows (one-time heuristic), then drop the column. Seed updated to first/last.
- **Tests**: rewrote the fallback test as a mapping test; updated contract ITs + bulk-ingest test; `FlywayMigrationIT` asserts `legal_name` dropped.

## Verification
- pos-people compiles; targeted ITs green on Testcontainers Postgres (FlywayMigrationIT, EmployeeProfile/Offboarding contract, bulk-ingest, mapping).

## Companion PRs
- SDK: louisburroughs/durion-positivity-sdk-angular#20
- Frontend: louisburroughs/durion-positivity-frontend#131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
