### PR TITLE
[CAP:007] Invoice finder search endpoint (GET /v1/invoices/search)

### DIFF
--- a/pos-invoice/openapi.json
+++ b/pos-invoice/openapi.json
@@ -1207,6 +1207,26 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid pagination parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageInvoiceSearchResult"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks the invoice:manage authority.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageInvoiceSearchResult"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/pos-invoice/openapi.json
+++ b/pos-invoice/openapi.json
@@ -1,23 +1,40 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Positivity Invoice API",
-    "description": "REST API for invoice and billing rules management for commercial accounts",
-    "version": "v1",
+    "title": "POS Invoice API",
+    "description": "API documentation for invoice and billing rules management",
     "contact": {
-      "name": "Durion Platform Team"
-    }
+      "name": "Durion Support Services",
+      "email": "platform@durionpos.org"
+    },
+    "version": "v1"
   },
   "servers": [
     {
-      "url": "http://api-gateway.local/invoice",
-      "description": "API Gateway"
+      "url": "http://localhost:8086",
+      "description": "Generated server url"
     }
   ],
   "tags": [
     {
+      "name": "Payment",
+      "description": "Card payment initiation and capture endpoints"
+    },
+    {
+      "name": "Invoice",
+      "description": "Invoice generation and lifecycle management"
+    },
+    {
+      "name": "Invoice Search",
+      "description": "Invoice finder search and retrieval"
+    },
+    {
       "name": "Billing Rules",
       "description": "Manage billing rules for commercial accounts"
+    },
+    {
+      "name": "Receipt",
+      "description": "Invoice receipt generation and reprint endpoints"
     }
   ],
   "paths": {
@@ -33,7 +50,6 @@
           {
             "name": "partyId",
             "in": "path",
-            "description": "Party/Customer ID",
             "required": true,
             "schema": {
               "type": "string"
@@ -52,13 +68,25 @@
             }
           },
           "404": {
-            "description": "No billing rules configured for this party"
+            "description": "No billing rules configured for this party",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingRulesDTO"
+                }
+              }
+            }
           }
         },
         "security": [
           {
-            "bearerAuth": []
+            "bearerAuth": [
+              "invoice:billing-rules"
+            ]
           }
+        ],
+        "x-required-permissions": [
+          "invoice:billing-rules"
         ]
       },
       "put": {
@@ -72,32 +100,21 @@
           {
             "name": "partyId",
             "in": "path",
-            "description": "Party/Customer ID",
             "required": true,
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "X-User-Id",
-            "in": "header",
-            "description": "User ID performing the operation",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "api-user"
-            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/BillingRulesDTO"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -121,13 +138,1086 @@
             }
           },
           "400": {
-            "description": "Invalid billing rules data"
+            "description": "Invalid billing rules data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingRulesDTO"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "invoice:billing-rules"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "invoice:billing-rules"
+        ]
+      }
+    },
+    "/v1/invoices": {
+      "post": {
+        "tags": [
+          "Invoice"
+        ],
+        "summary": "Create invoice",
+        "description": "Create invoice draft from completed workorder data",
+        "operationId": "createInvoice",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvoiceCreationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Invoice created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceGenerationResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "invoice:manage"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "invoice:manage"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/revert": {
+      "post": {
+        "tags": [
+          "Invoice"
+        ],
+        "summary": "Revert finalized invoice",
+        "description": "Revert a FINALIZED invoice back to DRAFT within 24h of finalization and before GL posting (Story #13, AC6)",
+        "operationId": "revertInvoice",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RevertRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Invoice reverted to DRAFT",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDetailsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "invoice:finalize"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "invoice:manage",
+          "invoice:finalize"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/receipts": {
+      "post": {
+        "tags": [
+          "Receipt"
+        ],
+        "summary": "Generate invoice receipt",
+        "description": "Generate a receipt for an invoice payment using the requested terminal and template",
+        "operationId": "generateReceipt",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateReceiptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Receipt generated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Invoice not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponse"
+                }
+              }
+            }
           }
         },
         "security": [
           {
             "bearerAuth": []
           }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/receipts/{receiptId}/reprint": {
+      "post": {
+        "tags": [
+          "Receipt"
+        ],
+        "summary": "Reprint invoice receipt",
+        "description": "Create a reprint of an existing receipt and record the reason for the reprint",
+        "operationId": "reprintReceipt",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "receiptId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReprintReceiptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Receipt reprinted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Receipt not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Reprint limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/receipts/{receiptId}/print": {
+      "post": {
+        "tags": [
+          "Receipt"
+        ],
+        "summary": "Record printed receipt delivery",
+        "description": "Record the delivery status for a printed receipt associated with an invoice",
+        "operationId": "recordPrintDelivery",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "receiptId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrintDeliveryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Print delivery recorded"
+          },
+          "404": {
+            "description": "Receipt not found"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/receipts/{receiptId}/email": {
+      "post": {
+        "tags": [
+          "Receipt"
+        ],
+        "summary": "Email invoice receipt",
+        "description": "Send an invoice receipt by email and record the delivery status for the attempt",
+        "operationId": "sendEmailReceipt",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "receiptId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmailDeliveryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Email delivery recorded"
+          },
+          "404": {
+            "description": "Receipt not found"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/payments": {
+      "post": {
+        "tags": [
+          "Payment"
+        ],
+        "summary": "Initiate card payment",
+        "description": "Initiate a SALE_CAPTURE or AUTH_ONLY card payment against an invoice",
+        "operationId": "initiatePayment",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InitiatePaymentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Payment intent created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitiatePaymentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or missing required fields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitiatePaymentResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitiatePaymentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Payment method declined",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitiatePaymentResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Payment gateway unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitiatePaymentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/payments/{paymentId}/void": {
+      "post": {
+        "tags": [
+          "PaymentReversal"
+        ],
+        "summary": "Void authorized payment",
+        "description": "Void a previously authorized invoice payment before it is captured",
+        "operationId": "voidPayment",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "paymentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VoidPaymentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Payment voided"
+          },
+          "404": {
+            "description": "Payment intent not found"
+          },
+          "409": {
+            "description": "Invalid payment state"
+          },
+          "422": {
+            "description": "Void window expired"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/payments/{paymentId}/refunds": {
+      "post": {
+        "tags": [
+          "PaymentReversal"
+        ],
+        "summary": "Refund captured payment",
+        "description": "Create a refund for a captured invoice payment and record the refund details",
+        "operationId": "refundPayment",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "paymentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefundPaymentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Refund created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefundPaymentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Payment intent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefundPaymentResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Invalid payment state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefundPaymentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Refund window expired or insufficient refundable amount",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefundPaymentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/payments/{paymentId}/capture": {
+      "post": {
+        "tags": [
+          "Payment"
+        ],
+        "summary": "Capture authorized payment hold",
+        "description": "Capture all or part of a previously authorized invoice payment hold",
+        "operationId": "capturePayment",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "paymentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CaptureAmountRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Payment captured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitiatePaymentResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitiatePaymentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Payment intent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitiatePaymentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/finalize": {
+      "post": {
+        "tags": [
+          "Invoice"
+        ],
+        "summary": "Finalize invoice",
+        "description": "Transition invoice from DRAFT to FINALIZED; enforces permission matrix and emits InvoiceFinalized event for async GL posting (Story #13)",
+        "operationId": "finalizeInvoice",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FinalizationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Invoice finalized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDetailsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "invoice:finalize"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "invoice:manage",
+          "invoice:finalize"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/artifacts/{artifactRefId}/download-token": {
+      "post": {
+        "tags": [
+          "invoice-artifact-controller"
+        ],
+        "summary": "Create a short-lived download token for an invoice artifact",
+        "description": "Issues a short-lived signed token bound to the invoice and artifact. The token is presented to the public download endpoint so a browser can fetch the file via a direct link.",
+        "operationId": "createDownloadToken",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "artifactRefId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactDownloadToken"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Invoice or artifact not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactDownloadToken"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/adjustments": {
+      "post": {
+        "tags": [
+          "Invoice"
+        ],
+        "summary": "Apply invoice adjustment",
+        "description": "Apply discount, fee, or correction to a draft invoice",
+        "operationId": "applyAdjustment",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdjustmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Adjustment applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDetailsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "invoice:manage"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "invoice:manage"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}": {
+      "get": {
+        "tags": [
+          "Invoice"
+        ],
+        "summary": "Get invoice",
+        "description": "Get invoice details",
+        "operationId": "getInvoice",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Invoice found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDetailsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "invoice:manage"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "invoice:manage"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/artifacts": {
+      "get": {
+        "tags": [
+          "invoice-artifact-controller"
+        ],
+        "summary": "List the downloadable artifacts (documents) for an invoice",
+        "description": "Returns the documents available for the invoice (the invoice itself and any receipts) as opaque, URL-safe artifact references with suggested file names and MIME types.",
+        "operationId": "listArtifacts",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Artifacts listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InvoiceArtifact"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Invoice not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InvoiceArtifact"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/invoices/{invoiceId}/artifacts/{artifactRefId}/download": {
+      "get": {
+        "tags": [
+          "invoice-artifact-download-controller"
+        ],
+        "summary": "Download an invoice artifact as PDF using a signed download token",
+        "description": "Streams the artifact as application/pdf. Public endpoint authorized solely by the signed download token (query parameter); intended for browser direct-download links.",
+        "operationId": "download",
+        "parameters": [
+          {
+            "name": "invoiceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "artifactRefId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PDF returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing, invalid, or expired token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Invoice or artifact not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/invoices/search": {
+      "get": {
+        "tags": [
+          "Invoice Search"
+        ],
+        "summary": "Search invoices",
+        "description": "Paginated free-text search for invoices matching the invoice number, customer name, or workorder number.",
+        "operationId": "searchInvoices",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Free-text query matching invoice number, customer name, or workorder number (optional)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageable",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Pageable"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of invoice search results returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageInvoiceSearchResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "invoice:manage"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "invoice:manage"
         ]
       }
     }
@@ -136,72 +1226,1093 @@
     "schemas": {
       "BillingRulesDTO": {
         "type": "object",
-        "description": "Billing rules configuration for a commercial account (CAP:092)",
-        "required": [
-          "partyId",
-          "paymentTermsCode",
-          "invoiceDeliveryMethod",
-          "invoiceGroupingStrategy"
-        ],
+        "description": "Billing rules and invoicing preferences for a billing party",
         "properties": {
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Unique identifier for the billing rules",
-            "nullable": true
+            "description": "Unique identifier of the billing rules record",
+            "example": "01960003-0000-7000-8000-000000000001"
           },
           "partyId": {
             "type": "string",
-            "description": "Party/Customer ID these rules apply to"
+            "description": "Identifier of the party these billing rules apply to",
+            "example": "01960003-0000-7000-8000-000000000002"
           },
           "purchaseOrderRequired": {
             "type": "boolean",
-            "description": "Whether a purchase order is required for invoicing",
-            "default": false
+            "default": false,
+            "description": "Whether a purchase order is required before invoicing",
+            "example": true
           },
           "paymentTermsCode": {
             "type": "string",
-            "description": "Payment terms code (e.g., NET30, NET60, DUE_ON_RECEIPT)"
+            "description": "Payment terms code governing due dates",
+            "example": "NET30"
           },
           "invoiceDeliveryMethod": {
             "type": "string",
-            "description": "How invoices should be delivered to the customer",
+            "description": "Preferred method for delivering invoices",
             "enum": [
               "EMAIL",
               "PORTAL",
               "MAIL"
-            ]
+            ],
+            "example": "EMAIL"
           },
           "invoiceGroupingStrategy": {
             "type": "string",
-            "description": "How to group charges into invoices",
+            "description": "Strategy for grouping line items into invoices",
             "enum": [
               "PER_WORKORDER",
               "PER_VEHICLE",
               "SINGLE_INVOICE"
-            ]
+            ],
+            "example": "PER_WORKORDER"
           },
           "version": {
             "type": "integer",
-            "description": "Optimistic locking version number",
-            "readOnly": true
+            "format": "int32",
+            "description": "Optimistic-locking version of the record",
+            "example": 3
           },
           "createdAt": {
             "type": "string",
             "format": "date-time",
-            "description": "Timestamp when the rules were created",
-            "readOnly": true
+            "description": "Timestamp when the record was created",
+            "example": "2026-01-15 09:30:00+00:00"
           },
           "updatedAt": {
             "type": "string",
             "format": "date-time",
-            "description": "Timestamp when the rules were last updated",
-            "readOnly": true
+            "description": "Timestamp when the record was last updated",
+            "example": "2026-01-16 11:45:00+00:00"
           },
           "updatedBy": {
             "type": "string",
-            "description": "User ID who last updated the rules",
-            "readOnly": true
+            "description": "Identifier of the actor who last updated the record",
+            "example": "jdoe"
+          }
+        },
+        "required": [
+          "createdAt",
+          "invoiceDeliveryMethod",
+          "invoiceGroupingStrategy",
+          "partyId",
+          "paymentTermsCode",
+          "purchaseOrderRequired",
+          "updatedAt",
+          "updatedBy",
+          "version"
+        ]
+      },
+      "InvoiceCreationRequest": {
+        "type": "object",
+        "description": "Internal service payload for creating invoice drafts.",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier backing the invoice draft.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "estimateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Source estimate identifier, when generated from estimate.",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "approvalId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Approval identifier used for billing authorization.",
+            "example": "550e8400-e29b-41d4-a716-446655440002"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Shop location where the sale is made; used to resolve the tax jurisdiction address.",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Idempotency key to prevent duplicate invoice creation.",
+            "example": "inv-create-wo-1234"
+          },
+          "lineItems": {
+            "type": "array",
+            "description": "Line items to include on the invoice.",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceLineItem"
+            }
+          }
+        }
+      },
+      "InvoiceLineItem": {
+        "type": "object",
+        "description": "Invoice line item details.",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Line item description.",
+            "example": "Brake pad replacement"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Quantity billed.",
+            "example": 2.0
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Unit price amount.",
+            "example": 45.0
+          },
+          "amount": {
+            "type": "number",
+            "description": "Line amount (quantity x unit price).",
+            "example": 90.0
+          }
+        },
+        "required": [
+          "amount",
+          "description",
+          "quantity",
+          "unitPrice"
+        ]
+      },
+      "InvoiceGenerationResponse": {
+        "type": "object",
+        "description": "Response payload returned after invoice generation.",
+        "properties": {
+          "invoiceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Generated invoice identifier.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "status": {
+            "type": "string",
+            "description": "Invoice status.",
+            "example": "DRAFT"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Source workorder identifier.",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "estimateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Source estimate identifier.",
+            "example": "550e8400-e29b-41d4-a716-446655440002"
+          },
+          "approvalId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Approval identifier used for generation.",
+            "example": "550e8400-e29b-41d4-a716-446655440003"
+          },
+          "subtotal": {
+            "type": "number",
+            "description": "Subtotal amount before tax.",
+            "example": 120.0
+          },
+          "taxAmount": {
+            "type": "number",
+            "description": "Tax amount.",
+            "example": 9.6
+          },
+          "totalAmount": {
+            "type": "number",
+            "description": "Total amount after tax.",
+            "example": 129.6
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp (UTC).",
+            "example": "2026-02-27 12:00:00+00:00"
+          }
+        },
+        "required": [
+          "createdAt",
+          "invoiceId",
+          "status",
+          "subtotal",
+          "taxAmount",
+          "totalAmount",
+          "workorderId"
+        ]
+      },
+      "RevertRequest": {
+        "type": "object",
+        "description": "Request payload for reverting a finalized invoice back to DRAFT",
+        "properties": {
+          "managerApprovalCode": {
+            "type": "string",
+            "description": "Manager approval code authorizing the reversion",
+            "example": "MGR-7788",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason the invoice is being reverted",
+            "example": "Incorrect line item billed",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "managerApprovalCode",
+          "reason"
+        ]
+      },
+      "InvoiceAdjustmentResponse": {
+        "type": "object",
+        "description": "A monetary adjustment applied to an invoice",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the adjustment entry",
+            "example": "01960003-0000-7000-8000-000000000030"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of adjustment applied",
+            "enum": [
+              "DISCOUNT",
+              "FEE",
+              "CORRECTION"
+            ],
+            "example": "DISCOUNT"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Adjustment amount",
+            "example": 25.0
+          },
+          "reason": {
+            "type": "string",
+            "description": "Business reason justifying the adjustment",
+            "example": "Goodwill discount for delayed service"
+          },
+          "authorizedBy": {
+            "type": "string",
+            "description": "Identifier of the actor who authorized the adjustment",
+            "example": "jdoe"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the adjustment was created",
+            "example": "2026-01-15 09:30:00+00:00"
+          }
+        }
+      },
+      "InvoiceDetailsResponse": {
+        "type": "object",
+        "description": "Full details of an invoice including line items and adjustments",
+        "properties": {
+          "invoiceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the invoice",
+            "example": "01960003-0000-7000-8000-000000000040"
+          },
+          "invoiceNumber": {
+            "type": "string",
+            "description": "Human-readable invoice number",
+            "example": "INV-2026-000123"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the associated workorder",
+            "example": "01960003-0000-7000-8000-000000000041"
+          },
+          "estimateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the source estimate",
+            "example": "01960003-0000-7000-8000-000000000042"
+          },
+          "approvalId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the approval record",
+            "example": "01960003-0000-7000-8000-000000000043"
+          },
+          "partyId": {
+            "type": "string",
+            "description": "Identifier of the billed party",
+            "example": "01960003-0000-7000-8000-000000000044"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current lifecycle status of the invoice",
+            "enum": [
+              "DRAFT",
+              "FINALIZED",
+              "POSTED",
+              "ERROR"
+            ],
+            "example": "FINALIZED"
+          },
+          "subtotal": {
+            "type": "number",
+            "description": "Sum of line items before tax and adjustments",
+            "example": 200.0
+          },
+          "tax": {
+            "type": "number",
+            "description": "Total tax applied to the invoice",
+            "example": 16.0
+          },
+          "total": {
+            "type": "number",
+            "description": "Grand total payable on the invoice",
+            "example": 191.0
+          },
+          "adjustments": {
+            "type": "number",
+            "description": "Net total of all monetary adjustments",
+            "example": -25.0
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the invoice was created",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the invoice was last updated",
+            "example": "2026-01-16 11:45:00+00:00"
+          },
+          "finalizedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the invoice was finalized",
+            "example": "2026-01-16 12:00:00+00:00"
+          },
+          "finalizedBy": {
+            "type": "string",
+            "description": "Identifier of the actor who finalized the invoice",
+            "example": "jdoe"
+          },
+          "revertedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the invoice was reverted to draft",
+            "example": "2026-01-16 13:00:00+00:00"
+          },
+          "reversionReason": {
+            "type": "string",
+            "description": "Reason the invoice was reverted",
+            "example": "Incorrect line item billed"
+          },
+          "revertedBy": {
+            "type": "string",
+            "description": "Identifier of the actor who reverted the invoice",
+            "example": "msmith"
+          },
+          "items": {
+            "type": "array",
+            "description": "Line items belonging to the invoice",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceItemResponse"
+            }
+          },
+          "adjustmentEntries": {
+            "type": "array",
+            "description": "Monetary adjustment entries applied to the invoice",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceAdjustmentResponse"
+            }
+          }
+        },
+        "required": [
+          "adjustmentEntries",
+          "items"
+        ]
+      },
+      "InvoiceItemResponse": {
+        "type": "object",
+        "description": "A single line item on an invoice",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the invoice line item",
+            "example": "01960003-0000-7000-8000-000000000050"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the line item",
+            "example": "Synthetic oil change"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Quantity billed",
+            "example": 1
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Price per unit",
+            "example": 49.99
+          },
+          "amount": {
+            "type": "number",
+            "description": "Extended amount (quantity x unit price)",
+            "example": 49.99
+          },
+          "workorderItemId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the source workorder item",
+            "example": "01960003-0000-7000-8000-000000000051"
+          }
+        }
+      },
+      "GenerateReceiptRequest": {
+        "type": "object",
+        "description": "Request to generate a receipt for an invoice payment",
+        "properties": {
+          "paymentIntentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Payment intent the receipt is generated for",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "terminalId": {
+            "type": "string",
+            "description": "Identifier of the terminal producing the receipt",
+            "example": "TERM-001",
+            "minLength": 1
+          },
+          "templateId": {
+            "type": "string",
+            "description": "Receipt template identifier",
+            "example": "RECEIPT_DEFAULT",
+            "minLength": 1
+          },
+          "templateVersion": {
+            "type": "string",
+            "description": "Receipt template version",
+            "example": "1",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "paymentIntentId",
+          "templateId",
+          "templateVersion",
+          "terminalId"
+        ]
+      },
+      "ReceiptResponse": {
+        "type": "object",
+        "description": "Result of generating a payment receipt",
+        "properties": {
+          "receiptId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the generated receipt",
+            "example": "01960003-0000-7000-8000-000000000060"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Human-readable receipt reference",
+            "example": "RCPT-2026-000789"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the receipt",
+            "enum": [
+              "GENERATED"
+            ],
+            "example": "GENERATED"
+          }
+        },
+        "required": [
+          "receiptId",
+          "status"
+        ]
+      },
+      "ReprintReceiptRequest": {
+        "type": "object",
+        "description": "Request to reprint an existing receipt",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Reason the receipt is being reprinted",
+            "example": "Customer requested a duplicate copy",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "reason"
+        ]
+      },
+      "PrintDeliveryRequest": {
+        "type": "object",
+        "description": "Request to record the delivery status of a printed receipt",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Print delivery outcome status",
+            "enum": [
+              "SUCCESS",
+              "FAILED"
+            ],
+            "example": "SUCCESS"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "EmailDeliveryRequest": {
+        "type": "object",
+        "description": "Request to email a receipt and record the delivery status",
+        "properties": {
+          "emailAddress": {
+            "type": "string",
+            "description": "Recipient email address for the receipt",
+            "example": "customer@example.com",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "description": "Email delivery outcome status",
+            "enum": [
+              "SUCCESS",
+              "FAILED"
+            ],
+            "example": "SUCCESS"
+          }
+        },
+        "required": [
+          "emailAddress",
+          "status"
+        ]
+      },
+      "InitiatePaymentRequest": {
+        "type": "object",
+        "description": "Request to initiate a card payment",
+        "properties": {
+          "paymentFlow": {
+            "type": "string",
+            "description": "Payment flow: SALE_CAPTURE (default one-step) or AUTH_ONLY (two-step)",
+            "enum": [
+              "SALE_CAPTURE",
+              "AUTH_ONLY"
+            ],
+            "example": "SALE_CAPTURE"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Payment amount (must be positive)",
+            "example": 149.99
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Client-provided idempotency key for safe retry",
+            "example": "idem-01960003-0000-7000-8000-000000000010",
+            "minLength": 1
+          },
+          "paymentToken": {
+            "type": "string",
+            "description": "Tokenised card reference (no PAN)",
+            "example": "tok_1NXyZ2eZvKYlo2Cabc12345",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "amount",
+          "idempotencyKey",
+          "paymentFlow",
+          "paymentToken"
+        ]
+      },
+      "InitiatePaymentResponse": {
+        "type": "object",
+        "description": "Payment intent result",
+        "properties": {
+          "paymentIntentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Payment intent identifier",
+            "example": "01960003-0000-7000-8000-000000000020"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current lifecycle status of the payment intent",
+            "enum": [
+              "PENDING",
+              "AUTHORIZED",
+              "CAPTURED",
+              "CAPTURE_FAILED",
+              "VOIDED",
+              "EXPIRED"
+            ],
+            "example": "AUTHORIZED"
+          },
+          "authorizedAmount": {
+            "type": "number",
+            "description": "Amount authorized on the card",
+            "example": 149.99
+          },
+          "capturedAmount": {
+            "type": "number",
+            "description": "Amount captured (funds moved)",
+            "example": 149.99
+          },
+          "voidedRemainderAmount": {
+            "type": "number",
+            "description": "Remainder voided after partial capture",
+            "example": 0.0
+          },
+          "gatewayProvider": {
+            "type": "string",
+            "description": "Gateway provider identifier (e.g., stripe)",
+            "example": "stripe"
+          },
+          "gatewayResponse": {
+            "type": "string",
+            "description": "Raw gateway response JSON for audit",
+            "example": {
+              "id": "pi_3NXyZ2eZvKYlo2Ca",
+              "status": "requires_capture"
+            }
+          }
+        },
+        "required": [
+          "paymentIntentId",
+          "status"
+        ]
+      },
+      "VoidPaymentRequest": {
+        "type": "object",
+        "description": "Request to void an authorized payment before capture",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Reason the payment is being voided",
+            "enum": [
+              "CUSTOMER_REQUEST",
+              "DUPLICATE_AUTHORIZATION",
+              "ENTRY_ERROR",
+              "FRAUD_PREVENTION",
+              "MANAGER_DISCRETION",
+              "OTHER"
+            ],
+            "example": "CUSTOMER_REQUEST"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional free-text notes explaining the void",
+            "example": "Customer cancelled before pickup"
+          }
+        },
+        "required": [
+          "reason"
+        ]
+      },
+      "RefundPaymentRequest": {
+        "type": "object",
+        "description": "Request to refund a captured payment",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "description": "Amount to refund from the captured payment",
+            "example": 25.0
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason the payment is being refunded",
+            "enum": [
+              "CUSTOMER_RETURN",
+              "SERVICE_ERROR",
+              "OVERCHARGE",
+              "DAMAGED_GOODS",
+              "GOODWILL",
+              "CHARGEBACK_AVOIDANCE",
+              "FRAUD_PREVENTION",
+              "MANAGER_DISCRETION",
+              "OTHER"
+            ],
+            "example": "CUSTOMER_RETURN"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional free-text notes explaining the refund",
+            "example": "Returned damaged part"
+          }
+        },
+        "required": [
+          "amount",
+          "reason"
+        ]
+      },
+      "RefundPaymentResponse": {
+        "type": "object",
+        "description": "Result of processing a refund against an invoice payment",
+        "properties": {
+          "refundId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the refund",
+            "example": "01960003-0000-7000-8000-000000000070"
+          },
+          "invoiceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the invoice being refunded",
+            "example": "01960003-0000-7000-8000-000000000040"
+          },
+          "paymentIntentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the originating payment intent",
+            "example": "01960003-0000-7000-8000-000000000020"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Refunded amount",
+            "example": 50.0
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason for the refund",
+            "enum": [
+              "CUSTOMER_RETURN",
+              "SERVICE_ERROR",
+              "OVERCHARGE",
+              "DAMAGED_GOODS",
+              "GOODWILL",
+              "CHARGEBACK_AVOIDANCE",
+              "FRAUD_PREVENTION",
+              "MANAGER_DISCRETION",
+              "OTHER"
+            ],
+            "example": "CUSTOMER_REQUEST"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Free-text notes accompanying the refund",
+            "example": "Partial refund for unused service"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the refund",
+            "enum": [
+              "PENDING",
+              "COMPLETED",
+              "FAILED"
+            ],
+            "example": "COMPLETED"
+          },
+          "gatewayReference": {
+            "type": "string",
+            "description": "Gateway reference identifier for the refund",
+            "example": "re_3NXyZ2eZvKYlo2Ca"
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the refund completed",
+            "example": "2026-01-17 10:15:00+00:00"
+          }
+        },
+        "required": [
+          "invoiceId",
+          "refundId",
+          "status"
+        ]
+      },
+      "CaptureAmountRequest": {
+        "type": "object",
+        "description": "Request to capture all or part of an authorized payment hold",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "description": "Amount to capture from the authorized hold",
+            "example": 89.99
+          },
+          "captureIdempotencyKey": {
+            "type": "string",
+            "description": "Idempotency key ensuring the capture is processed at most once",
+            "example": "capture-550e8400-1",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "amount",
+          "captureIdempotencyKey"
+        ]
+      },
+      "FinalizationRequest": {
+        "type": "object",
+        "description": "Request payload for finalizing an invoice",
+        "properties": {
+          "managerApprovalCode": {
+            "type": "string",
+            "description": "Manager approval code, required when approval threshold is exceeded",
+            "example": "MGR-7788"
+          },
+          "overrideReason": {
+            "type": "string",
+            "description": "Free-text reason for overriding the amount limit",
+            "example": "Customer pre-approved by branch manager"
+          }
+        }
+      },
+      "ArtifactDownloadToken": {
+        "type": "object",
+        "description": "Short-lived signed token for downloading an invoice artifact",
+        "properties": {
+          "downloadToken": {
+            "type": "string",
+            "description": "Opaque signed download token"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the token expires"
+          }
+        }
+      },
+      "AdjustmentRequest": {
+        "type": "object",
+        "description": "Request to apply a monetary adjustment to an invoice",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of adjustment applied to the invoice",
+            "enum": [
+              "DISCOUNT",
+              "FEE",
+              "CORRECTION"
+            ],
+            "example": "DISCOUNT"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Adjustment amount (must be greater than zero)",
+            "example": 25.0,
+            "minimum": 0.0001
+          },
+          "reason": {
+            "type": "string",
+            "description": "Business reason justifying the adjustment",
+            "example": "Goodwill discount for delayed service",
+            "minLength": 1
+          },
+          "authorizedBy": {
+            "type": "string",
+            "description": "Identifier of the actor who authorized the adjustment",
+            "example": "jdoe",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "amount",
+          "authorizedBy",
+          "reason",
+          "type"
+        ]
+      },
+      "InvoiceArtifact": {
+        "type": "object",
+        "description": "A downloadable document associated with an invoice",
+        "properties": {
+          "artifactRefId": {
+            "type": "string",
+            "description": "Opaque, URL-safe artifact reference",
+            "example": "aW52b2ljZTo..."
+          },
+          "fileName": {
+            "type": "string",
+            "description": "Suggested download file name",
+            "example": "Invoice-INV-1001.pdf"
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "MIME type of the rendered artifact",
+            "example": "application/pdf"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the underlying document was created"
+          }
+        }
+      },
+      "Pageable": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "InvoiceSearchResult": {
+        "type": "object",
+        "description": "Lightweight invoice search result enriched with customer name and workorder number",
+        "properties": {
+          "invoiceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Invoice identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "invoiceNumber": {
+            "type": "string",
+            "description": "Human invoice number",
+            "example": "INV-2026-1001"
+          },
+          "customerName": {
+            "type": "string",
+            "description": "Resolved customer display name",
+            "example": "Acme Towing LLC"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Linked workorder identifier"
+          },
+          "workorderNumber": {
+            "type": "string",
+            "description": "Resolved human workorder number",
+            "example": "WO-2026-1001"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current invoice status",
+            "enum": [
+              "DRAFT",
+              "FINALIZED",
+              "POSTED",
+              "ERROR"
+            ],
+            "example": "DRAFT"
+          },
+          "total": {
+            "type": "number",
+            "description": "Invoice grand total",
+            "example": 249.95
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp",
+            "example": "2026-01-15 09:30:00+00:00"
+          }
+        },
+        "required": [
+          "invoiceId",
+          "status"
+        ]
+      },
+      "PageInvoiceSearchResult": {
+        "type": "object",
+        "properties": {
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceSearchResult"
+            }
+          },
+          "number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "numberOfElements": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PageableObject": {
+        "type": "object",
+        "properties": {
+          "offset": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "paged": {
+            "type": "boolean"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "unpaged": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SortObject": {
+        "type": "object",
+        "properties": {
+          "empty": {
+            "type": "boolean"
+          },
+          "sorted": {
+            "type": "boolean"
+          },
+          "unsorted": {
+            "type": "boolean"
           }
         }
       }
@@ -210,8 +2321,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "bearerFormat": "JWT",
-        "description": "JWT Bearer token authentication"
+        "bearerFormat": "JWT"
       }
     }
   }

--- a/pos-invoice/openapi.yaml
+++ b/pos-invoice/openapi.yaml
@@ -740,6 +740,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PageInvoiceSearchResult'
+        '400':
+          description: Invalid pagination parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageInvoiceSearchResult'
+        '403':
+          description: Caller lacks the invoice:manage authority.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageInvoiceSearchResult'
       security:
       - bearerAuth:
         - invoice:manage

--- a/pos-invoice/openapi.yaml
+++ b/pos-invoice/openapi.yaml
@@ -14,6 +14,8 @@ tags:
   description: Card payment initiation and capture endpoints
 - name: Invoice
   description: Invoice generation and lifecycle management
+- name: Invoice Search
+  description: Invoice finder search and retrieval
 - name: Billing Rules
   description: Manage billing rules for commercial accounts
 - name: Receipt
@@ -712,6 +714,37 @@ paths:
               schema:
                 type: string
                 format: byte
+  /v1/invoices/search:
+    get:
+      tags:
+      - Invoice Search
+      summary: Search invoices
+      description: Paginated free-text search for invoices matching the invoice number, customer name, or workorder number.
+      operationId: searchInvoices
+      parameters:
+      - name: q
+        in: query
+        description: Free-text query matching invoice number, customer name, or workorder number (optional)
+        required: false
+        schema:
+          type: string
+      - name: pageable
+        in: query
+        required: true
+        schema:
+          $ref: '#/components/schemas/Pageable'
+      responses:
+        '200':
+          description: Page of invoice search results returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageInvoiceSearchResult'
+      security:
+      - bearerAuth:
+        - invoice:manage
+      x-required-permissions:
+      - invoice:manage
 components:
   schemas:
     BillingRulesDTO:
@@ -1447,6 +1480,126 @@ components:
           type: string
           format: date-time
           description: When the underlying document was created
+    Pageable:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+          minimum: 0
+        size:
+          type: integer
+          format: int32
+          minimum: 1
+        sort:
+          type: array
+          items:
+            type: string
+    InvoiceSearchResult:
+      type: object
+      description: Lightweight invoice search result enriched with customer name and workorder number
+      properties:
+        invoiceId:
+          type: string
+          format: uuid
+          description: Invoice identifier
+          example: 550e8400-e29b-41d4-a716-446655440000
+        invoiceNumber:
+          type: string
+          description: Human invoice number
+          example: INV-2026-1001
+        customerName:
+          type: string
+          description: Resolved customer display name
+          example: Acme Towing LLC
+        workorderId:
+          type: string
+          format: uuid
+          description: Linked workorder identifier
+        workorderNumber:
+          type: string
+          description: Resolved human workorder number
+          example: WO-2026-1001
+        status:
+          type: string
+          description: Current invoice status
+          enum:
+          - DRAFT
+          - FINALIZED
+          - POSTED
+          - ERROR
+          example: DRAFT
+        total:
+          type: number
+          description: Invoice grand total
+          example: 249.95
+        createdAt:
+          type: string
+          format: date-time
+          description: Creation timestamp
+          example: 2026-01-15 09:30:00+00:00
+      required:
+      - invoiceId
+      - status
+    PageInvoiceSearchResult:
+      type: object
+      properties:
+        totalPages:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        size:
+          type: integer
+          format: int32
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceSearchResult'
+        number:
+          type: integer
+          format: int32
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        first:
+          type: boolean
+        last:
+          type: boolean
+        numberOfElements:
+          type: integer
+          format: int32
+        empty:
+          type: boolean
+    PageableObject:
+      type: object
+      properties:
+        offset:
+          type: integer
+          format: int64
+        paged:
+          type: boolean
+        pageNumber:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+    SortObject:
+      type: object
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
   securitySchemes:
     bearerAuth:
       type: http

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/client/CustomerReferenceClient.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/client/CustomerReferenceClient.java
@@ -1,0 +1,179 @@
+package com.positivity.invoice.internal.client;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Outbound client resolving customer (party) identifiers and display names from the CRM
+ * service (pos-customer). Used by invoice search to (a) translate a free-text customer
+ * name into matching party ids and (b) enrich result rows with the resolved display name.
+ *
+ * <p>Mirrors the proven pos-workorder {@code CustomerReferenceService} finder pattern, with
+ * party ids kept as strings to match the invoice {@code partyId} column.
+ */
+@Component
+public class CustomerReferenceClient {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomerReferenceClient.class);
+
+    private final RestClient crmRestClient;
+
+    public CustomerReferenceClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${invoice.crm.base-url:http://pos-customer:8080/v1/crm}") String crmBaseUrl) {
+        this.crmRestClient = restClientBuilder.baseUrl(crmBaseUrl).build();
+    }
+
+    /**
+     * Resolve party ids whose CRM display name matches the query.
+     *
+     * @param name  free-text customer name query
+     * @param limit maximum number of matches to request
+     * @return matching party ids (empty when blank query or no match)
+     */
+    public @NonNull List<String> searchIdsByName(@Nullable String name, int limit) {
+        if (!StringUtils.hasText(name)) {
+            return List.of();
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body = crmRestClient
+                    .get()
+                    .uri("/accounts/parties?name={name}&size={size}", name, limit)
+                    .header("X-User", "pos-invoice")
+                    .header("X-Authorities", "crm:party:view")
+                    .retrieve()
+                    .body(Map.class);
+
+            if (body == null) {
+                return List.of();
+            }
+            Object resultsObj = body.get("results");
+            if (!(resultsObj instanceof Collection<?> results)) {
+                return List.of();
+            }
+            List<String> ids = new ArrayList<>();
+            for (Object rowObj : results) {
+                if (!(rowObj instanceof Map<?, ?> rowMap)) {
+                    continue;
+                }
+                @SuppressWarnings("unchecked")
+                Map<String, Object> row = (Map<String, Object>) rowMap;
+                String partyId = extract(row, "partyId");
+                if (StringUtils.hasText(partyId)) {
+                    ids.add(partyId.trim());
+                }
+            }
+            return ids;
+        } catch (Exception ex) {
+            log.debug("Unable to search customers by name '{}': {}", name, ex.getMessage());
+            return List.of();
+        }
+    }
+
+    /**
+     * Resolve display names for a batch of party ids. Unknown ids are omitted.
+     *
+     * @param partyIds party ids to resolve
+     * @return party id to display name map
+     */
+    public @NonNull Map<String, String> resolveNames(@NonNull Collection<String> partyIds) {
+        Map<String, String> resolved = new LinkedHashMap<>();
+        for (String partyId : partyIds) {
+            if (!StringUtils.hasText(partyId) || resolved.containsKey(partyId)) {
+                continue;
+            }
+            String name = resolveName(partyId);
+            if (name != null) {
+                resolved.put(partyId, name);
+            }
+        }
+        return resolved;
+    }
+
+    private @Nullable String resolveName(@NonNull String partyId) {
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body = crmRestClient
+                    .get()
+                    .uri("/{partyId}", partyId)
+                    .header("X-User", "pos-invoice")
+                    .header("X-Authorities", "crm:party:view")
+                    .retrieve()
+                    .body(Map.class);
+            if (body == null || body.isEmpty()) {
+                return null;
+            }
+            Map<String, Object> payload = unwrapData(body);
+            return firstNonBlank(
+                    extract(payload, "customerName"),
+                    extract(payload, "displayName"),
+                    extract(payload, "legalName"),
+                    extract(payload, "name"),
+                    composeName(extract(payload, "firstName"), extract(payload, "lastName")));
+        } catch (Exception ex) {
+            log.debug("Unable to resolve customer reference for {}: {}", partyId, ex.getMessage());
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> unwrapData(Map<String, Object> body) {
+        Object data = body.get("data");
+        if (data instanceof Map<?, ?> dataMap) {
+            return (Map<String, Object>) dataMap;
+        }
+        return body;
+    }
+
+    private @Nullable String extract(Map<String, Object> payload, String key) {
+        Object value = payload.get(key);
+        return value != null ? value.toString() : null;
+    }
+
+    private @Nullable String composeName(@Nullable String firstName, @Nullable String lastName) {
+        boolean hasFirst = StringUtils.hasText(firstName);
+        boolean hasLast = StringUtils.hasText(lastName);
+        if (!hasFirst && !hasLast) {
+            return null;
+        }
+        if (!hasFirst) {
+            return lastName.trim();
+        }
+        if (!hasLast) {
+            return firstName.trim();
+        }
+        String f = firstName.trim();
+        String l = lastName.trim();
+        if (l.contains(f)) {
+            return l;
+        }
+        if (f.contains(l)) {
+            return f;
+        }
+        return f + " " + l;
+    }
+
+    private @Nullable String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/client/WorkorderReferenceClient.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/client/WorkorderReferenceClient.java
@@ -1,0 +1,142 @@
+package com.positivity.invoice.internal.client;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Outbound client resolving workorder identifiers and human workorder numbers from the
+ * workorder service (pos-workorder). Used by invoice search to (a) translate a free-text
+ * workorder number into matching workorder ids and (b) enrich result rows with the human
+ * workorder number, since the invoice row stores only the workorder id.
+ */
+@Component
+public class WorkorderReferenceClient {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkorderReferenceClient.class);
+
+    private final RestClient workorderRestClient;
+
+    public WorkorderReferenceClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${invoice.workorder.base-url:http://pos-workorder:8080/v1/workorders}") String workorderBaseUrl) {
+        this.workorderRestClient = restClientBuilder.baseUrl(workorderBaseUrl).build();
+    }
+
+    /**
+     * Resolve workorder ids whose human number (or customer) matches the query, reusing the
+     * workorder free-text search endpoint.
+     *
+     * @param q     free-text workorder number query
+     * @param limit maximum number of matches to request
+     * @return matching workorder ids (empty when blank query or no match)
+     */
+    public @NonNull List<UUID> searchIdsByNumber(@Nullable String q, int limit) {
+        if (!StringUtils.hasText(q)) {
+            return List.of();
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body = workorderRestClient
+                    .get()
+                    .uri("/search?q={q}&size={size}", q, limit)
+                    .header("X-User", "pos-invoice")
+                    .header("X-Authorities", "workorder:workorder:view")
+                    .retrieve()
+                    .body(Map.class);
+
+            if (body == null) {
+                return List.of();
+            }
+            Object contentObj = body.get("content");
+            if (!(contentObj instanceof Collection<?> content)) {
+                return List.of();
+            }
+            List<UUID> ids = new ArrayList<>();
+            for (Object rowObj : content) {
+                if (!(rowObj instanceof Map<?, ?> rowMap)) {
+                    continue;
+                }
+                String workorderId = stringValue(rowMap.get("workorderId"));
+                if (StringUtils.hasText(workorderId)) {
+                    UUID parsed = parseUuidOrNull(workorderId);
+                    if (parsed != null) {
+                        ids.add(parsed);
+                    }
+                }
+            }
+            return ids;
+        } catch (Exception ex) {
+            log.debug("Unable to search workorders by number '{}': {}", q, ex.getMessage());
+            return List.of();
+        }
+    }
+
+    /**
+     * Resolve human workorder numbers for a batch of workorder ids. Unknown ids are omitted.
+     *
+     * @param workorderIds workorder ids to resolve
+     * @return workorder id to human number map
+     */
+    public @NonNull Map<UUID, String> resolveNumbers(@NonNull Collection<UUID> workorderIds) {
+        List<UUID> ids = workorderIds.stream().filter(Objects::nonNull).distinct().toList();
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> rows = workorderRestClient
+                    .post()
+                    .uri("/numbers:resolve")
+                    .header("X-User", "pos-invoice")
+                    .header("X-Authorities", "workorder:workorder:view")
+                    .body(Map.of("workorderIds", ids))
+                    .retrieve()
+                    .body(List.class);
+
+            if (rows == null) {
+                return Map.of();
+            }
+            Map<UUID, String> resolved = new LinkedHashMap<>();
+            for (Map<String, Object> row : rows) {
+                String workorderId = stringValue(row.get("workorderId"));
+                String workorderNumber = stringValue(row.get("workorderNumber"));
+                UUID parsed = parseUuidOrNull(workorderId);
+                if (parsed != null && StringUtils.hasText(workorderNumber)) {
+                    resolved.put(parsed, workorderNumber.trim());
+                }
+            }
+            return resolved;
+        } catch (Exception ex) {
+            log.debug("Unable to resolve workorder numbers for {} id(s): {}", ids.size(), ex.getMessage());
+            return Map.of();
+        }
+    }
+
+    private static @Nullable String stringValue(@Nullable Object value) {
+        return value != null ? value.toString() : null;
+    }
+
+    private static @Nullable UUID parseUuidOrNull(@Nullable String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value.trim());
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/config/EventTypes.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/config/EventTypes.java
@@ -41,6 +41,11 @@ public final class EventTypes {
             .apiVersion("1")
             .build();
 
+    public static final EventTypeRegistration INVOICE_SEARCH = EventTypeRegistration.fastRead(
+                    "INVOICE_SEARCH", "Free-text invoice search by invoice number, customer name, or workorder number")
+            .apiVersion("1")
+            .build();
+
     public static final EventTypeRegistration INVOICE_ADJUSTMENT_APPLY = EventTypeRegistration.write(
                     "INVOICE_ADJUSTMENT_APPLY", "Apply adjustment to draft invoice")
             .apiVersion("1")
@@ -133,6 +138,7 @@ public final class EventTypes {
                 BILLING_RULES_UPSERT,
                 INVOICE_CREATE,
                 INVOICE_GET,
+                INVOICE_SEARCH,
                 INVOICE_ADJUSTMENT_APPLY,
                 INVOICE_FINALIZATION_REQUESTED,
                 INVOICE_FINALIZED,

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/config/RestClientConfig.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/config/RestClientConfig.java
@@ -1,0 +1,26 @@
+package com.positivity.invoice.internal.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Provides the {@link RestClient.Builder} bean used by the module's outbound clients
+ * (tax, location, document-render, CRM and workorder references).
+ *
+ * <p>pos-invoice addresses sibling services by direct DNS base-urls (e.g.
+ * {@code http://pos-customer:8080}) rather than service-discovery virtual hostnames, so a
+ * plain builder is sufficient. Declaring it explicitly keeps the clients injectable in boots
+ * where the auto-configured builder is not present (e.g. the {@code openapi}/{@code dev}
+ * profile with service discovery disabled).
+ */
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    @Primary
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/config/RestClientConfig.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/config/RestClientConfig.java
@@ -1,8 +1,11 @@
 package com.positivity.invoice.internal.config;
 
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -14,13 +17,21 @@ import org.springframework.web.client.RestClient;
  * plain builder is sufficient. Declaring it explicitly keeps the clients injectable in boots
  * where the auto-configured builder is not present (e.g. the {@code openapi}/{@code dev}
  * profile with service discovery disabled).
+ *
+ * <p>Bounded connect/read timeouts prevent a hung sibling service from blocking a worker
+ * thread (and any pooled DB connection) indefinitely.
  */
 @Configuration
 public class RestClientConfig {
 
     @Bean
     @Primary
-    public RestClient.Builder restClientBuilder() {
-        return RestClient.builder();
+    public RestClient.Builder restClientBuilder(
+            @Value("${pos.restclient.connect.timeout:2000}") int connectTimeoutMs,
+            @Value("${pos.restclient.read.timeout:5000}") int readTimeoutMs) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofMillis(connectTimeoutMs));
+        factory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
+        return RestClient.builder().requestFactory(factory);
     }
 }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
@@ -7,11 +7,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,12 +37,19 @@ public class InvoiceSearchController {
 
     private final InvoiceSearchService invoiceSearchService;
 
+    /** Hard cap on page size so a caller cannot request an unbounded enrichment fan-out. */
+    private static final int MAX_PAGE_SIZE = 50;
+
     @Operation(
             summary = "Search invoices",
             description =
                     "Paginated free-text search for invoices matching the invoice number, "
                             + "customer name, or workorder number.")
-    @ApiResponse(responseCode = "200", description = "Page of invoice search results returned.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Page of invoice search results returned."),
+        @ApiResponse(responseCode = "400", description = "Invalid pagination parameters."),
+        @ApiResponse(responseCode = "403", description = "Caller lacks the invoice:manage authority.")
+    })
     @GetMapping("/search")
     @PreAuthorize("hasAuthority('invoice:manage')")
     @EmitEvent(id = "INVOICE_SEARCH", apiVersion = "1")
@@ -50,8 +60,17 @@ public class InvoiceSearchController {
                     @RequestParam(required = false)
                     @Nullable
                     String q,
-            @Parameter(schema = @Schema(implementation = Pageable.class)) @PageableDefault(size = 25)
+            @Parameter(schema = @Schema(implementation = Pageable.class))
+                    @PageableDefault(size = 25, sort = "createdAt", direction = Sort.Direction.DESC)
                     Pageable pageable) {
-        return invoiceSearchService.search(q == null ? "" : q.trim(), pageable);
+        return invoiceSearchService.search(q == null ? "" : q.trim(), capPageSize(pageable));
+    }
+
+    /** Clamp the requested page size to {@link #MAX_PAGE_SIZE}, preserving page index and sort. */
+    private static Pageable capPageSize(Pageable pageable) {
+        if (pageable.isPaged() && pageable.getPageSize() > MAX_PAGE_SIZE) {
+            return PageRequest.of(pageable.getPageNumber(), MAX_PAGE_SIZE, pageable.getSort());
+        }
+        return pageable;
     }
 }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
@@ -1,0 +1,57 @@
+package com.positivity.invoice.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.invoice.internal.dto.InvoiceSearchResult;
+import com.positivity.invoice.service.InvoiceSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Free-text invoice search backing the billing invoice finder. Matches the query against the
+ * invoice number, the customer name, or the workorder number.
+ */
+@RestController
+@io.swagger.v3.oas.annotations.security.SecurityRequirement(
+        name = "bearerAuth",
+        scopes = {"invoice:manage"})
+@RequestMapping("/v1/invoices")
+@Tag(name = "Invoice Search", description = "Invoice finder search and retrieval")
+@RequiredArgsConstructor
+public class InvoiceSearchController {
+
+    private final InvoiceSearchService invoiceSearchService;
+
+    @Operation(
+            summary = "Search invoices",
+            description =
+                    "Paginated free-text search for invoices matching the invoice number, "
+                            + "customer name, or workorder number.")
+    @ApiResponse(responseCode = "200", description = "Page of invoice search results returned.")
+    @GetMapping("/search")
+    @PreAuthorize("hasAuthority('invoice:manage')")
+    @EmitEvent(id = "INVOICE_SEARCH", apiVersion = "1")
+    public Page<InvoiceSearchResult> searchInvoices(
+            @Parameter(
+                            description =
+                                    "Free-text query matching invoice number, customer name, or workorder number (optional)")
+                    @RequestParam(required = false)
+                    @Nullable
+                    String q,
+            @Parameter(schema = @Schema(implementation = Pageable.class)) @PageableDefault(size = 25)
+                    Pageable pageable) {
+        return invoiceSearchService.search(q == null ? "" : q.trim(), pageable);
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/InvoiceSearchResult.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/InvoiceSearchResult.java
@@ -1,0 +1,57 @@
+package com.positivity.invoice.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.invoice.internal.enums.InvoiceStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Lightweight invoice search row for the billing invoice finder.
+ *
+ * <p>Returned by {@code GET /v1/invoices/search?q=...} which matches the query against the
+ * invoice number, the customer name, or the workorder number. Customer name and workorder
+ * number are resolved from sibling services (CRM, workorder) since the invoice row stores
+ * only the party id and the workorder id.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Lightweight invoice search result enriched with customer name and workorder number")
+public class InvoiceSearchResult {
+
+    @Schema(
+            description = "Invoice identifier",
+            example = "550e8400-e29b-41d4-a716-446655440000",
+            requiredMode = REQUIRED)
+    private UUID invoiceId;
+
+    @Schema(description = "Human invoice number", example = "INV-2026-1001", requiredMode = NOT_REQUIRED)
+    private String invoiceNumber;
+
+    @Schema(description = "Resolved customer display name", example = "Acme Towing LLC", requiredMode = NOT_REQUIRED)
+    private String customerName;
+
+    @Schema(description = "Linked workorder identifier", requiredMode = NOT_REQUIRED)
+    private UUID workorderId;
+
+    @Schema(description = "Resolved human workorder number", example = "WO-2026-1001", requiredMode = NOT_REQUIRED)
+    private String workorderNumber;
+
+    @Schema(description = "Current invoice status", example = "DRAFT", requiredMode = REQUIRED)
+    private InvoiceStatus status;
+
+    @Schema(description = "Invoice grand total", example = "249.95", requiredMode = NOT_REQUIRED)
+    private BigDecimal total;
+
+    @Schema(description = "Creation timestamp", example = "2026-01-15T09:30:00Z", requiredMode = NOT_REQUIRED)
+    private Instant createdAt;
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/InvoiceRepository.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/InvoiceRepository.java
@@ -38,7 +38,7 @@ public interface InvoiceRepository extends JpaRepository<Invoice, UUID> {
      * @param pageable     pagination and sorting configuration
      * @return page of matching invoices
      */
-    @Query("SELECT i FROM Invoice i WHERE LOWER(i.invoiceNumber) LIKE LOWER(CONCAT('%', :q, '%')) "
+    @Query("SELECT i FROM Invoice i WHERE LOWER(i.invoiceNumber) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '\\' "
             + "OR i.partyId IN :customerIds "
             + "OR i.workorderId IN :workorderIds")
     @NonNull

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/InvoiceRepository.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/InvoiceRepository.java
@@ -2,11 +2,16 @@ package com.positivity.invoice.internal.repository;
 
 import com.positivity.invoice.internal.entity.Invoice;
 import com.positivity.invoice.internal.enums.InvoiceStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InvoiceRepository extends JpaRepository<Invoice, UUID> {
 
@@ -18,4 +23,28 @@ public interface InvoiceRepository extends JpaRepository<Invoice, UUID> {
 
     @NonNull
     Optional<Invoice> findByInvoiceNumber(@NonNull String invoiceNumber);
+
+    /**
+     * Free-text invoice search matching the invoice number (substring, case-insensitive),
+     * the customer (party) ids resolved from a name query, or the workorder ids resolved
+     * from a workorder-number query.
+     *
+     * <p>JPQL {@code IN} requires non-empty collections; callers pass a non-matching
+     * sentinel when a leg yields no ids.
+     *
+     * @param q            free-text query matched against the invoice number
+     * @param customerIds  party ids resolved from the customer-name leg
+     * @param workorderIds workorder ids resolved from the workorder-number leg
+     * @param pageable     pagination and sorting configuration
+     * @return page of matching invoices
+     */
+    @Query("SELECT i FROM Invoice i WHERE LOWER(i.invoiceNumber) LIKE LOWER(CONCAT('%', :q, '%')) "
+            + "OR i.partyId IN :customerIds "
+            + "OR i.workorderId IN :workorderIds")
+    @NonNull
+    Page<Invoice> searchByQuery(
+            @Param("q") @NonNull String q,
+            @Param("customerIds") @NonNull Collection<String> customerIds,
+            @Param("workorderIds") @NonNull Collection<UUID> workorderIds,
+            @NonNull Pageable pageable);
 }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceSearchServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceSearchServiceImpl.java
@@ -15,7 +15,7 @@ import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 /**
  * Free-text invoice search resolving the query against invoice numbers, customer names (via
@@ -23,10 +23,14 @@ import org.springframework.transaction.annotation.Transactional;
  * enriching each row with the resolved customer display name and human workorder number.
  *
  * <p>Mirrors the pos-workorder {@code WorkorderSearchServiceImpl} finder pattern.
+ *
+ * <p>No method-level transaction is declared: the search is a single repository read whose
+ * mapping touches only scalar columns (no lazy associations), and the post-query CRM/workorder
+ * enrichment performs remote HTTP calls — running those inside an open transaction would hold a
+ * pooled DB connection for the duration of the remote calls.
  */
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class InvoiceSearchServiceImpl implements InvoiceSearchService {
 
     /** Sentinel that cannot match a real party id, keeping the JPQL IN clause non-empty. */
@@ -41,6 +45,12 @@ public class InvoiceSearchServiceImpl implements InvoiceSearchService {
 
     @Override
     public @NonNull Page<InvoiceSearchResult> search(@NonNull String q, @NonNull Pageable pageable) {
+        // A blank query would degenerate to LIKE '%%' (full-table scan in undefined order); a
+        // finder requires an actual term, so short-circuit to an empty page.
+        if (!StringUtils.hasText(q)) {
+            return Page.empty(pageable);
+        }
+
         // Resolve the query against customer names and workorder numbers in sibling services.
         List<String> nameMatchPartyIds = customerReferenceClient.searchIdsByName(q, 10);
         List<UUID> numberMatchWorkorderIds = workorderReferenceClient.searchIdsByNumber(q, 10);
@@ -49,7 +59,8 @@ public class InvoiceSearchServiceImpl implements InvoiceSearchService {
         List<UUID> workorderIds =
                 numberMatchWorkorderIds.isEmpty() ? List.of(NO_WORKORDER_SENTINEL) : numberMatchWorkorderIds;
 
-        Page<Invoice> page = invoiceRepository.searchByQuery(q, customerIds, workorderIds, pageable);
+        // Escape LIKE wildcards so a query containing % or _ matches literally.
+        Page<Invoice> page = invoiceRepository.searchByQuery(escapeLike(q), customerIds, workorderIds, pageable);
 
         // Enrich each row with the resolved customer display name and human workorder number.
         List<String> pagePartyIds = page.getContent().stream()
@@ -77,5 +88,14 @@ public class InvoiceSearchServiceImpl implements InvoiceSearchService {
                 .total(invoice.getTotal())
                 .createdAt(invoice.getCreatedAt())
                 .build());
+    }
+
+    /**
+     * Escape SQL LIKE metacharacters ({@code \}, {@code %}, {@code _}) so a user query is
+     * matched as a literal substring. Pairs with the {@code ESCAPE '\'} clause in the repository
+     * query.
+     */
+    private static @NonNull String escapeLike(@NonNull String q) {
+        return q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceSearchServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceSearchServiceImpl.java
@@ -1,0 +1,81 @@
+package com.positivity.invoice.internal.service;
+
+import com.positivity.invoice.internal.client.CustomerReferenceClient;
+import com.positivity.invoice.internal.client.WorkorderReferenceClient;
+import com.positivity.invoice.internal.dto.InvoiceSearchResult;
+import com.positivity.invoice.internal.entity.Invoice;
+import com.positivity.invoice.internal.repository.InvoiceRepository;
+import com.positivity.invoice.service.InvoiceSearchService;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Free-text invoice search resolving the query against invoice numbers, customer names (via
+ * the CRM reference client) and workorder numbers (via the workorder reference client),
+ * enriching each row with the resolved customer display name and human workorder number.
+ *
+ * <p>Mirrors the pos-workorder {@code WorkorderSearchServiceImpl} finder pattern.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InvoiceSearchServiceImpl implements InvoiceSearchService {
+
+    /** Sentinel that cannot match a real party id, keeping the JPQL IN clause non-empty. */
+    private static final String NO_PARTY_SENTINEL = "__none__";
+
+    /** Sentinel that cannot match a real workorder id, keeping the JPQL IN clause non-empty. */
+    private static final UUID NO_WORKORDER_SENTINEL = new UUID(0L, 0L);
+
+    private final InvoiceRepository invoiceRepository;
+    private final CustomerReferenceClient customerReferenceClient;
+    private final WorkorderReferenceClient workorderReferenceClient;
+
+    @Override
+    public @NonNull Page<InvoiceSearchResult> search(@NonNull String q, @NonNull Pageable pageable) {
+        // Resolve the query against customer names and workorder numbers in sibling services.
+        List<String> nameMatchPartyIds = customerReferenceClient.searchIdsByName(q, 10);
+        List<UUID> numberMatchWorkorderIds = workorderReferenceClient.searchIdsByNumber(q, 10);
+
+        List<String> customerIds = nameMatchPartyIds.isEmpty() ? List.of(NO_PARTY_SENTINEL) : nameMatchPartyIds;
+        List<UUID> workorderIds =
+                numberMatchWorkorderIds.isEmpty() ? List.of(NO_WORKORDER_SENTINEL) : numberMatchWorkorderIds;
+
+        Page<Invoice> page = invoiceRepository.searchByQuery(q, customerIds, workorderIds, pageable);
+
+        // Enrich each row with the resolved customer display name and human workorder number.
+        List<String> pagePartyIds = page.getContent().stream()
+                .map(Invoice::getPartyId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        List<UUID> pageWorkorderIds = page.getContent().stream()
+                .map(Invoice::getWorkorderId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        Map<String, String> customerNames = customerReferenceClient.resolveNames(pagePartyIds);
+        Map<UUID, String> workorderNumbers = workorderReferenceClient.resolveNumbers(pageWorkorderIds);
+
+        return page.map(invoice -> InvoiceSearchResult.builder()
+                .invoiceId(invoice.getId())
+                .invoiceNumber(invoice.getInvoiceNumber())
+                .customerName(invoice.getPartyId() != null ? customerNames.get(invoice.getPartyId()) : null)
+                .workorderId(invoice.getWorkorderId())
+                .workorderNumber(
+                        invoice.getWorkorderId() != null ? workorderNumbers.get(invoice.getWorkorderId()) : null)
+                .status(invoice.getStatus())
+                .total(invoice.getTotal())
+                .createdAt(invoice.getCreatedAt())
+                .build());
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/service/InvoiceSearchService.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/service/InvoiceSearchService.java
@@ -1,0 +1,26 @@
+package com.positivity.invoice.service;
+
+import com.positivity.invoice.internal.dto.InvoiceSearchResult;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Free-text invoice search matching the invoice number, the customer name, or the
+ * workorder number.
+ */
+public interface InvoiceSearchService {
+
+    /**
+     * Search invoices by query string matching the invoice number directly, the customer
+     * name (resolved to party ids via CRM), or the workorder number (resolved to workorder
+     * ids via the workorder service). Result rows are enriched with the resolved customer
+     * display name and human workorder number.
+     *
+     * @param q        free-text query (invoice number, customer name, or workorder number)
+     * @param pageable pagination and sorting configuration
+     * @return page of invoice search results
+     */
+    @NonNull
+    Page<InvoiceSearchResult> search(@NonNull String q, @NonNull Pageable pageable);
+}

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/controller/InvoiceSearchControllerTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/controller/InvoiceSearchControllerTest.java
@@ -1,0 +1,97 @@
+package com.positivity.invoice.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.invoice.internal.dto.InvoiceSearchResult;
+import com.positivity.invoice.internal.enums.InvoiceStatus;
+import com.positivity.invoice.service.InvoiceSearchService;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Controller-layer unit tests for {@link InvoiceSearchController}. Uses standalone MockMvc
+ * (no Spring context); authority enforcement is validated at the security layer. Asserts the
+ * query is trimmed and delegated, and the paginated body is serialized.
+ */
+@ExtendWith(MockitoExtension.class)
+class InvoiceSearchControllerTest {
+
+    private static final UUID INVOICE_ID = UUID.fromString("11111111-0000-0000-0000-000000000001");
+
+    @Mock
+    private InvoiceSearchService invoiceSearchService;
+
+    @InjectMocks
+    private InvoiceSearchController invoiceSearchController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(invoiceSearchController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .build();
+    }
+
+    private InvoiceSearchResult row() {
+        return InvoiceSearchResult.builder()
+                .invoiceId(INVOICE_ID)
+                .invoiceNumber("INV-2026-1001")
+                .customerName("Acme Towing LLC")
+                .workorderNumber("WO-2026-1001")
+                .status(InvoiceStatus.DRAFT)
+                .total(new BigDecimal("249.95"))
+                .createdAt(Instant.parse("2026-01-15T09:30:00Z"))
+                .build();
+    }
+
+    @Test
+    void search_returnsPagedResults() throws Exception {
+        when(invoiceSearchService.search(eq("Acme"), any()))
+                .thenReturn(new PageImpl<>(List.of(row()), PageRequest.of(0, 25), 1));
+
+        mockMvc.perform(get("/v1/invoices/search").param("q", "Acme"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].invoiceId").value(INVOICE_ID.toString()))
+                .andExpect(jsonPath("$.content[0].invoiceNumber").value("INV-2026-1001"))
+                .andExpect(jsonPath("$.content[0].customerName").value("Acme Towing LLC"))
+                .andExpect(jsonPath("$.content[0].workorderNumber").value("WO-2026-1001"));
+    }
+
+    @Test
+    void search_trimsQueryBeforeDelegating() throws Exception {
+        when(invoiceSearchService.search(eq("Acme"), any())).thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 25), 0));
+
+        mockMvc.perform(get("/v1/invoices/search").param("q", "  Acme  ")).andExpect(status().isOk());
+
+        verify(invoiceSearchService).search(eq("Acme"), any());
+    }
+
+    @Test
+    void search_missingQuery_delegatesEmptyString() throws Exception {
+        when(invoiceSearchService.search(eq(""), any())).thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 25), 0));
+
+        mockMvc.perform(get("/v1/invoices/search")).andExpect(status().isOk());
+
+        verify(invoiceSearchService).search(eq(""), any());
+    }
+}

--- a/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceSearchServiceImplTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceSearchServiceImplTest.java
@@ -1,0 +1,142 @@
+package com.positivity.invoice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.invoice.internal.client.CustomerReferenceClient;
+import com.positivity.invoice.internal.client.WorkorderReferenceClient;
+import com.positivity.invoice.internal.dto.InvoiceSearchResult;
+import com.positivity.invoice.internal.entity.Invoice;
+import com.positivity.invoice.internal.enums.InvoiceStatus;
+import com.positivity.invoice.internal.repository.InvoiceRepository;
+import com.positivity.invoice.internal.service.InvoiceSearchServiceImpl;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Unit tests for the free-text invoice search service. Covers the customer-name and
+ * workorder-number resolution legs (with row enrichment) and the empty-match sentinel path.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class InvoiceSearchServiceImplTest {
+
+    private static final UUID INVOICE_ID = UUID.fromString("11111111-0000-0000-0000-000000000001");
+    private static final UUID WORKORDER_ID = UUID.fromString("22222222-0000-0000-0000-000000000001");
+    private static final String PARTY_ID = "party-001";
+
+    @Mock
+    private InvoiceRepository invoiceRepository;
+
+    @Mock
+    private CustomerReferenceClient customerReferenceClient;
+
+    @Mock
+    private WorkorderReferenceClient workorderReferenceClient;
+
+    @InjectMocks
+    private InvoiceSearchServiceImpl invoiceSearchService;
+
+    private Invoice buildInvoice() {
+        Invoice invoice = new Invoice();
+        invoice.setId(INVOICE_ID);
+        invoice.setInvoiceNumber("INV-2026-1001");
+        invoice.setWorkorderId(WORKORDER_ID);
+        invoice.setPartyId(PARTY_ID);
+        invoice.setStatus(InvoiceStatus.DRAFT);
+        invoice.setTotal(new BigDecimal("249.95"));
+        invoice.setCreatedAt(Instant.parse("2026-01-15T09:30:00Z"));
+        return invoice;
+    }
+
+    @Test
+    void search_byCustomerName_returnsEnrichedResult() {
+        Pageable pageable = PageRequest.of(0, 25);
+        Invoice invoice = buildInvoice();
+
+        when(customerReferenceClient.searchIdsByName(eq("Acme"), anyInt())).thenReturn(List.of(PARTY_ID));
+        when(workorderReferenceClient.searchIdsByNumber(anyString(), anyInt())).thenReturn(List.of());
+        when(invoiceRepository.searchByQuery(any(), any(), any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(invoice)));
+        when(customerReferenceClient.resolveNames(any())).thenReturn(Map.of(PARTY_ID, "Acme Towing LLC"));
+        when(workorderReferenceClient.resolveNumbers(any())).thenReturn(Map.of(WORKORDER_ID, "WO-2026-1001"));
+
+        Page<InvoiceSearchResult> result = invoiceSearchService.search("Acme", pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        InvoiceSearchResult row = result.getContent().get(0);
+        assertThat(row.getInvoiceId()).isEqualTo(INVOICE_ID);
+        assertThat(row.getInvoiceNumber()).isEqualTo("INV-2026-1001");
+        assertThat(row.getCustomerName()).isEqualTo("Acme Towing LLC");
+        assertThat(row.getWorkorderNumber()).isEqualTo("WO-2026-1001");
+        assertThat(row.getStatus()).isEqualTo(InvoiceStatus.DRAFT);
+        assertThat(row.getTotal()).isEqualByComparingTo("249.95");
+    }
+
+    @Test
+    void search_noReferenceMatches_passesSentinelsToRepository() {
+        Pageable pageable = PageRequest.of(0, 25);
+
+        when(customerReferenceClient.searchIdsByName(anyString(), anyInt())).thenReturn(List.of());
+        when(workorderReferenceClient.searchIdsByNumber(anyString(), anyInt())).thenReturn(List.of());
+        when(invoiceRepository.searchByQuery(any(), any(), any(), eq(pageable))).thenReturn(new PageImpl<>(List.of()));
+        when(customerReferenceClient.resolveNames(any())).thenReturn(Map.of());
+        when(workorderReferenceClient.resolveNumbers(any())).thenReturn(Map.of());
+
+        invoiceSearchService.search("INV-2026", pageable);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<String>> customerIdsCaptor = ArgumentCaptor.forClass(Collection.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<UUID>> workorderIdsCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(invoiceRepository)
+                .searchByQuery(
+                        eq("INV-2026"), customerIdsCaptor.capture(), workorderIdsCaptor.capture(), eq(pageable));
+
+        // Empty reference matches → non-matching sentinels keep the JPQL IN clauses non-empty.
+        assertThat(customerIdsCaptor.getValue()).containsExactly("__none__");
+        assertThat(workorderIdsCaptor.getValue()).containsExactly(new UUID(0L, 0L));
+    }
+
+    @Test
+    void search_byWorkorderNumber_resolvesWorkorderIds() {
+        Pageable pageable = PageRequest.of(0, 25);
+        Invoice invoice = buildInvoice();
+
+        when(customerReferenceClient.searchIdsByName(anyString(), anyInt())).thenReturn(List.of());
+        when(workorderReferenceClient.searchIdsByNumber(eq("WO-2026-1001"), anyInt()))
+                .thenReturn(List.of(WORKORDER_ID));
+        when(invoiceRepository.searchByQuery(any(), any(), any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(invoice)));
+        when(customerReferenceClient.resolveNames(any())).thenReturn(Map.of(PARTY_ID, "Acme Towing LLC"));
+        when(workorderReferenceClient.resolveNumbers(any())).thenReturn(Map.of(WORKORDER_ID, "WO-2026-1001"));
+
+        invoiceSearchService.search("WO-2026-1001", pageable);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<UUID>> workorderIdsCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(invoiceRepository).searchByQuery(anyString(), any(), workorderIdsCaptor.capture(), eq(pageable));
+        assertThat(workorderIdsCaptor.getValue()).containsExactly(WORKORDER_ID);
+    }
+}

--- a/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceSearchServiceImplTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceSearchServiceImplTest.java
@@ -120,6 +120,50 @@ class InvoiceSearchServiceImplTest {
     }
 
     @Test
+    void search_blankQuery_shortCircuitsWithoutTouchingClientsOrRepository() {
+        Page<InvoiceSearchResult> result = invoiceSearchService.search("  ", PageRequest.of(0, 25));
+
+        assertThat(result.getContent()).isEmpty();
+        verify(customerReferenceClient, org.mockito.Mockito.never()).searchIdsByName(anyString(), anyInt());
+        verify(workorderReferenceClient, org.mockito.Mockito.never()).searchIdsByNumber(anyString(), anyInt());
+        verify(invoiceRepository, org.mockito.Mockito.never()).searchByQuery(any(), any(), any(), any());
+    }
+
+    @Test
+    void search_rowWithNullReferences_doesNotThrowAndOmitsEnrichment() {
+        Pageable pageable = PageRequest.of(0, 25);
+        Invoice invoice = buildInvoice();
+        invoice.setPartyId(null);
+        invoice.setWorkorderId(null);
+
+        when(customerReferenceClient.searchIdsByName(anyString(), anyInt())).thenReturn(List.of());
+        when(workorderReferenceClient.searchIdsByNumber(anyString(), anyInt())).thenReturn(List.of());
+        when(invoiceRepository.searchByQuery(any(), any(), any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(invoice)));
+        when(customerReferenceClient.resolveNames(any())).thenReturn(Map.of());
+        when(workorderReferenceClient.resolveNumbers(any())).thenReturn(Map.of());
+
+        InvoiceSearchResult row = invoiceSearchService.search("INV", pageable).getContent().get(0);
+
+        assertThat(row.getCustomerName()).isNull();
+        assertThat(row.getWorkorderNumber()).isNull();
+    }
+
+    @Test
+    void search_escapesLikeWildcardsInQuery() {
+        Pageable pageable = PageRequest.of(0, 25);
+        when(customerReferenceClient.searchIdsByName(anyString(), anyInt())).thenReturn(List.of());
+        when(workorderReferenceClient.searchIdsByNumber(anyString(), anyInt())).thenReturn(List.of());
+        when(invoiceRepository.searchByQuery(any(), any(), any(), eq(pageable))).thenReturn(new PageImpl<>(List.of()));
+        when(customerReferenceClient.resolveNames(any())).thenReturn(Map.of());
+        when(workorderReferenceClient.resolveNumbers(any())).thenReturn(Map.of());
+
+        invoiceSearchService.search("50%_x", pageable);
+
+        verify(invoiceRepository).searchByQuery(eq("50\\%\\_x"), any(), any(), eq(pageable));
+    }
+
+    @Test
     void search_byWorkorderNumber_resolvesWorkorderIds() {
         Pageable pageable = PageRequest.of(0, 25);
         Invoice invoice = buildInvoice();

--- a/pos-workorder/openapi.json
+++ b/pos-workorder/openapi.json
@@ -1,6073 +1,11707 @@
 {
-    "openapi": "3.1.0",
-    "info": {
-        "title": "POS Workorder Service API",
-        "description": "Workorder service for managing workorders and tasks",
-        "contact": {
-            "name": "Durion Team",
-            "email": "louis.burroughs@gmail.com"
-        },
-        "version": "v1"
+  "openapi": "3.1.0",
+  "info": {
+    "title": "POS Workorder Service API",
+    "description": "Workorder service for managing workorders and tasks",
+    "contact": {
+      "name": "Durion Support Services",
+      "email": "louis.burroughs@gmail.com"
     },
-    "servers": [
-        {
-            "url": "http://localhost:8096",
-            "description": "Generated server url"
-        }
-    ],
-    "tags": [
-        {
-            "name": "Work Order API",
-            "description": "Endpoints for work order management"
-        },
-        {
-            "name": "Workorder Detail",
-            "description": "Workorder detail with role-based visibility"
-        },
-        {
-            "name": "Approval Configuration API",
-            "description": "Endpoints for managing approval configurations by location and customer"
-        },
-        {
-            "name": "Workorder Part Adjustments",
-            "description": "Part substitutions, returns, and corrections"
-        },
-        {
-            "name": "Technician Assignment API",
-            "description": "Endpoints for assigning technicians to workorders"
-        },
-        {
-            "name": "Change Request API",
-            "description": "Endpoints for managing additional work requests and approvals"
-        },
-        {
-            "name": "Workorder Labor API",
-            "description": "Endpoints for tracking labor performed on workorders"
-        },
-        {
-            "name": "Workorder Parts Usage",
-            "description": "Track parts issue, consumption, and returns"
-        },
-        {
-            "name": "Estimate API",
-            "description": "Endpoints for estimate management and approval workflow"
-        }
-    ],
-    "paths": {
-        "/v1/workorders/{workorderId}/technician": {
-            "get": {
-                "tags": [
-                    "Technician Assignment API"
-                ],
-                "summary": "Get technician assignment",
-                "description": "Retrieve the current technician assignment and full assignment history for a workorder.",
-                "operationId": "getTechnicianAssignment",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the workorder",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Assignment retrieved successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder not found or no assignment exists",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "Technician Assignment API"
-                ],
-                "summary": "Reassign workorder to different technician",
-                "description": "Reassign a workorder to a different technician. Records reassignment reason and maintains history.",
-                "operationId": "reassignTechnician",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the workorder",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "description": "Optional idempotency key to prevent duplicate reassignments",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "tech-reassign-550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "description": "User ID from gateway authentication",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440100"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Reassign technician request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ReassignTechnicianRequest"
-                            },
-                            "examples": {
-                                "reassignTechnician": {
-                                    "description": "reassignTechnician",
-                                    "value": {
-                                        "newTechnicianId": "550e8400-e29b-41d4-a716-446655440121",
-                                        "reassignedByUserId": "550e8400-e29b-41d4-a716-446655440100",
-                                        "reason": "Scheduling conflict",
-                                        "notes": "Reassigned due to availability"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Technician reassigned successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid state transition or no current assignment",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Permission denied",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Technician Assignment API"
-                ],
-                "summary": "Assign technician to workorder",
-                "description": "Assign a technician to a work order. Transitions workorder to ASSIGNED status if currently APPROVED.",
-                "operationId": "assignTechnician",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the workorder",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "description": "Optional idempotency key to prevent duplicate assignments",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "tech-assign-550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "description": "User ID from gateway authentication",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440100"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Assign technician request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AssignTechnicianRequest"
-                            },
-                            "examples": {
-                                "assignTechnician": {
-                                    "description": "assignTechnician",
-                                    "value": {
-                                        "technicianId": "550e8400-e29b-41d4-a716-446655440120",
-                                        "assignedByUserId": "550e8400-e29b-41d4-a716-446655440100",
-                                        "notes": "Primary technician assigned"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Technician assigned successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid state transition",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Permission denied",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder or technician not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TechnicianAssignmentResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/labor/{entryId}/adjust": {
-            "put": {
-                "tags": [
-                    "Workorder Labor API"
-                ],
-                "summary": "Adjust labor hours",
-                "description": "Manually adjust hours worked on a labor entry with a reason for audit trail.",
-                "operationId": "adjustLaborHours",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the workorder",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    {
-                        "name": "entryId",
-                        "in": "path",
-                        "description": "ID of the labor entry to adjust",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440100"
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "description": "Optional idempotency key to prevent duplicate adjustments",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "labor-adjust-550e8400-e29b-41d4-a716-446655440100"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Adjust labor request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AdjustLaborRequest"
-                            },
-                            "examples": {
-                                "adjustLabor": {
-                                    "description": "adjustLabor",
-                                    "value": {
-                                        "hoursWorked": 2.5,
-                                        "adjustmentReason": "Corrected after timesheet review"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Labor hours adjusted successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid hours value",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Permission denied",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Labor entry not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workexec/approvalConfigurations/{approvalId}": {
-            "get": {
-                "tags": [
-                    "Approval Configuration API"
-                ],
-                "summary": "Get configuration by ID",
-                "description": "Retrieve an approval configuration by its unique ID.",
-                "operationId": "getConfigurationById",
-                "parameters": [
-                    {
-                        "name": "approvalId",
-                        "in": "path",
-                        "description": "ID of the configuration to retrieve",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Configuration found and returned.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApprovalConfigurationResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Configuration not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApprovalConfigurationResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "Approval Configuration API"
-                ],
-                "summary": "Update an approval configuration",
-                "description": "Update an existing approval configuration.",
-                "operationId": "updateConfiguration",
-                "parameters": [
-                    {
-                        "name": "approvalId",
-                        "in": "path",
-                        "description": "ID of the configuration to update",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Updated configuration object",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ApprovalConfigurationRequest"
-                            },
-                            "examples": {
-                                "updateApprovalConfig": {
-                                    "description": "updateApprovalConfig",
-                                    "value": {
-                                        "approvalThreshold": 750.0,
-                                        "requiresManagerApproval": true
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "404": {
-                        "description": "Configuration not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApprovalConfigurationResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Configuration updated successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApprovalConfigurationResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Approval Configuration API"
-                ],
-                "summary": "Delete an approval configuration",
-                "description": "Delete a configuration by its unique ID.",
-                "operationId": "deleteConfiguration",
-                "parameters": [
-                    {
-                        "name": "approvalId",
-                        "in": "path",
-                        "description": "ID of the configuration to delete",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Configuration deleted successfully."
-                    },
-                    "404": {
-                        "description": "Configuration not found."
-                    }
-                }
-            }
-        },
-        "/v1/workorders": {
-            "get": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Get all work orders",
-                "description": "Retrieve a list of all work orders.",
-                "operationId": "getAllWorkorders",
-                "responses": {
-                    "200": {
-                        "description": "List of work orders returned successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/WorkorderResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Create a new work order",
-                "description": "Add a new work order to the system. Supports idempotent creation via Idempotency-Key header to prevent duplicate workorders.",
-                "operationId": "createWorkorder",
-                "parameters": [
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "description": "Optional idempotency key to prevent duplicate creation (recommended for retries)",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "workorder-create-550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Work order creation request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateWorkorderRequest"
-                            },
-                            "examples": {
-                                "createWorkorder": {
-                                    "description": "createWorkorder",
-                                    "value": {
-                                        "estimateId": "550e8400-e29b-41d4-a716-446655440001",
-                                        "customerId": "550e8400-e29b-41d4-a716-446655440010"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Work order created successfully, or existing work order returned if idempotency key was previously processed.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/start": {
-            "post": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Start a work order",
-                "description": "Start work on a work order, transitioning it to WORK_IN_PROGRESS status.",
-                "operationId": "startWorkorder",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order to start",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Start workorder request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/StartWorkorderRequest"
-                            },
-                            "examples": {
-                                "startWorkorder": {
-                                    "description": "startWorkorder",
-                                    "value": {
-                                        "userId": "550e8400-e29b-41d4-a716-446655440100",
-                                        "reason": "Technician started work"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Work order started successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/StartWorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid state transition or pending change requests.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/StartWorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Work order not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/StartWorkorderResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/services/{serviceId}/labor/start": {
-            "post": {
-                "tags": [
-                    "Workorder Labor API"
-                ],
-                "summary": "Start labor session",
-                "description": "Start tracking labor on a specific service item. Only one active session allowed per service.",
-                "operationId": "startLaborSession",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the workorder",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    {
-                        "name": "serviceId",
-                        "in": "path",
-                        "description": "ID of the service item",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440010"
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "description": "Optional idempotency key to prevent duplicate starts",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "labor-start-550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "description": "User ID from gateway authentication",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440100"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Start labor request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/StartLaborRequest"
-                            },
-                            "examples": {
-                                "startLabor": {
-                                    "description": "startLabor",
-                                    "value": {
-                                        "technicianId": "550e8400-e29b-41d4-a716-446655440120",
-                                        "notes": "Starting diagnostic work"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "Labor session started successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Idempotent request - existing session returned",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid state - active session exists or invalid status",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Permission denied",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder or service not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/reopen": {
-            "post": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Reopen completed workorder",
-                "description": "Controlled reopen for completed workorders. Requires elevated permission and mandatory reason.",
-                "operationId": "reopenWorkorder",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the completed workorder to reopen",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Reopen workorder request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ReopenWorkorderRequest"
-                            },
-                            "examples": {
-                                "reopenWorkorder": {
-                                    "description": "reopenWorkorder",
-                                    "value": {
-                                        "userId": "550e8400-e29b-41d4-a716-446655440100",
-                                        "reopenReason": "Customer requested additional work"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Workorder reopened successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ReopenWorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Workorder cannot be reopened or reason missing.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ReopenWorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Work order not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ReopenWorkorderResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/parts/substitute": {
-            "post": {
-                "tags": [
-                    "Workorder Part Adjustments"
-                ],
-                "summary": "Substitute part",
-                "description": "Replace one part with another. Original part preserved for history.",
-                "operationId": "substitutePart",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Substitute part request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SubstitutePartRequest"
-                            },
-                            "examples": {
-                                "substitutePart": {
-                                    "description": "substitutePart",
-                                    "value": {
-                                        "originalPartId": "550e8400-e29b-41d4-a716-446655440050",
-                                        "substitutePartId": "550e8400-e29b-41d4-a716-446655440051",
-                                        "reason": "Supplier substitution",
-                                        "notes": "Equivalent OEM part"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "Part substituted successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Idempotency conflict",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder or part not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request (part already consumed, etc.)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/parts/return": {
-            "post": {
-                "tags": [
-                    "Workorder Parts Usage"
-                ],
-                "summary": "Return unused parts to inventory",
-                "description": "Return unused parts after partial consumption or service completion",
-                "operationId": "returnParts",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Return part request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ReturnPartRequest"
-                            },
-                            "examples": {
-                                "returnParts": {
-                                    "description": "returnParts",
-                                    "value": {
-                                        "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
-                                        "quantity": 1
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "400": {
-                        "description": "Invalid request (exceeds available quantity, etc.)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder or part not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "201": {
-                        "description": "Parts returned successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/parts/returnUnused": {
-            "post": {
-                "tags": [
-                    "Workorder Part Adjustments"
-                ],
-                "summary": "Return unused quantity",
-                "description": "Return unused part quantity beyond normal return flow",
-                "operationId": "returnUnusedQuantity",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Return unused quantity request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ReturnPartQuantityRequest"
-                            },
-                            "examples": {
-                                "returnUnused": {
-                                    "description": "returnUnused",
-                                    "value": {
-                                        "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
-                                        "quantity": 1,
-                                        "reason": "Unused after repair",
-                                        "notes": "Returned to stock"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "400": {
-                        "description": "Invalid request (exceeds available quantity, etc.)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder or part not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "201": {
-                        "description": "Unused quantity returned successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/parts/issue": {
-            "post": {
-                "tags": [
-                    "Workorder Parts Usage"
-                ],
-                "summary": "Issue parts to workorder",
-                "description": "Issue parts from inventory, reserving them for consumption on the workorder",
-                "operationId": "issueParts",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Issue part request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/IssuePartRequest"
-                            },
-                            "examples": {
-                                "issueParts": {
-                                    "description": "issueParts",
-                                    "value": {
-                                        "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
-                                        "quantity": 2
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "Parts issued successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Idempotency conflict (duplicate key)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder or part not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request (negative quantity, etc.)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/parts/correct": {
-            "post": {
-                "tags": [
-                    "Workorder Part Adjustments"
-                ],
-                "summary": "Correct part quantity",
-                "description": "Administrative correction for data entry errors",
-                "operationId": "correctPartQuantity",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Correct part quantity request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CorrectPartQuantityRequest"
-                            },
-                            "examples": {
-                                "correctPartQuantity": {
-                                    "description": "correctPartQuantity",
-                                    "value": {
-                                        "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
-                                        "newQuantity": 3,
-                                        "reason": "Data correction",
-                                        "notes": "Corrected after inventory count"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "Part quantity corrected successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder or part not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/parts/consume": {
-            "post": {
-                "tags": [
-                    "Workorder Parts Usage"
-                ],
-                "summary": "Consume parts on workorder",
-                "description": "Record actual consumption of parts. Quantity consumed cannot exceed quantity issued.",
-                "operationId": "consumeParts",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Consume part request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ConsumePartRequest"
-                            },
-                            "examples": {
-                                "consumeParts": {
-                                    "description": "consumeParts",
-                                    "value": {
-                                        "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
-                                        "quantity": 1
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "400": {
-                        "description": "Invalid request (exceeds issued quantity, etc.)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder or part not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "201": {
-                        "description": "Parts consumption recorded successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/labor/{entryId}/stop": {
-            "post": {
-                "tags": [
-                    "Workorder Labor API"
-                ],
-                "summary": "Stop labor session",
-                "description": "Stop an active labor session and calculate hours worked.",
-                "operationId": "stopLaborSession",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the workorder",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    {
-                        "name": "entryId",
-                        "in": "path",
-                        "description": "ID of the labor entry to stop",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440100"
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "description": "Optional idempotency key to prevent duplicate stops",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "labor-stop-550e8400-e29b-41d4-a716-446655440100"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Labor session stopped successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Session already stopped",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Permission denied",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Labor entry not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/generate-invoice": {
-            "post": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Generate invoice draft from completed workorder",
-                "description": "Generate an invoice draft from a completed workorder with optional idempotency key.",
-                "operationId": "generateInvoice",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the completed work order",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "description": "Optional idempotency key to prevent duplicate invoice generation (recommended for retries)",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "invoice-generate-550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Invoice generated successfully or existing invoice returned for idempotent replay.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InvoiceGenerationResponse"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Work order is not in COMPLETED state.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InvoiceGenerationResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Work order not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InvoiceGenerationResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/complete": {
-            "post": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Complete a work order",
-                "description": "Complete a work order, transitioning it to COMPLETED status and emitting a WorkCompleted event.",
-                "operationId": "completeWorkorder",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order to complete",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Complete workorder request",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CompleteWorkorderRequest"
-                            },
-                            "examples": {
-                                "completeWorkorder": {
-                                    "description": "completeWorkorder",
-                                    "value": {
-                                        "userId": "550e8400-e29b-41d4-a716-446655440100",
-                                        "completionNotes": "Completed and verified"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Work order completed successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CompleteWorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Work order not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CompleteWorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid state transition or work order already completed.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CompleteWorkorderResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/changeRequests": {
-            "get": {
-                "tags": [
-                    "Change Request API"
-                ],
-                "summary": "Get all change requests for a work order",
-                "description": "Retrieve all change requests associated with a specific work order",
-                "operationId": "getChangeRequestsByWorkorder",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "List of change requests returned",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ChangeRequestResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Change Request API"
-                ],
-                "summary": "Create a change request",
-                "description": "Technician creates a request for additional work beyond authorized scope. Items are marked as PENDING_APPROVAL until advisor approves. Requires description and at least one service or part item. Supports idempotent creation via Idempotency-Key header to prevent duplicate change requests.",
-                "operationId": "createChangeRequest",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "description": "Optional idempotency key to prevent duplicate creation (recommended for retries)",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "change-request-create-550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Change request details including items",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateChangeRequestDTO"
-                            },
-                            "examples": {
-                                "createChangeRequest": {
-                                    "description": "createChangeRequest",
-                                    "value": {
-                                        "description": "Customer requested additional diagnostics",
-                                        "approvalGated": true
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Change request created successfully, or existing change request returned if idempotency key was previously processed",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request - missing description, no items, or validation failed",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Work order not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/approval": {
-            "post": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Approve a work order with customer signature",
-                "description": "Transition work order to APPROVED status with customer signature capture. Work order can be approved from DRAFT status. Requires customer ID validation and signature data (base64-encoded image).",
-                "operationId": "approveWorkorder",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order to approve",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Approval request with customer ID and signature capture",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ApproveWorkorderRequest"
-                            },
-                            "examples": {
-                                "approveWorkorder": {
-                                    "description": "approveWorkorder",
-                                    "value": {
-                                        "customerId": "550e8400-e29b-41d4-a716-446655440010",
-                                        "signatureData": "base64-signature",
-                                        "signatureMimeType": "image/png",
-                                        "signerName": "Jane Customer",
-                                        "notes": "Approved by customer"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "400": {
-                        "description": "Work order cannot be approved in current state or customer ID mismatch.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Work order approved successfully with signature captured.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Work order not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates": {
-            "get": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Get all estimates",
-                "description": "Retrieve a list of all estimates.",
-                "operationId": "getAllEstimates",
-                "responses": {
-                    "200": {
-                        "description": "List of estimates returned successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/EstimateResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Create a new draft estimate",
-                "description": "Create a new estimate in DRAFT status for a customer and vehicle. Requires ESTIMATE_CREATE permission. System will generate a unique estimate number and apply default values for location, currency, and tax region if not provided.",
-                "operationId": "createEstimate",
-                "requestBody": {
-                    "description": "Estimate creation request with customer and vehicle IDs",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateEstimateRequest"
-                            },
-                            "examples": {
-                                "createEstimate": {
-                                    "description": "createEstimate",
-                                    "value": {
-                                        "customerId": "550e8400-e29b-41d4-a716-446655440010",
-                                        "vehicleId": "550e8400-e29b-41d4-a716-446655440011",
-                                        "locationId": "550e8400-e29b-41d4-a716-446655440020"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "400": {
-                        "description": "Invalid request - missing required fields.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict - estimate could not be created due to state or integrity constraints.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden - user does not have ESTIMATE_CREATE permission.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "201": {
-                        "description": "Estimate created successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error - unexpected estimate creation failure.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/submit-for-approval": {
-            "post": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Submit estimate for customer approval",
-                "description": "Submit a DRAFT estimate for customer approval. Creates immutable snapshot and transitions to PENDING_APPROVAL state. Validates completeness (has customer, vehicle, line items, calculated totals). CAP:003 Issue #168 - Submit Estimate for Customer Approval",
-                "operationId": "submitForApproval",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "ID of the estimate to submit",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "400": {
-                        "description": "Estimate is incomplete or not in DRAFT state",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Estimate not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Estimate submitted for approval successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/snapshots": {
-            "post": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Create historical snapshot",
-                "description": "Capture an immutable snapshot of the estimate's complete state (estimate + all line items) for audit trail and version history purposes.",
-                "operationId": "createEstimateSnapshot",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "Estimate ID",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    {
-                        "name": "notes",
-                        "in": "query",
-                        "description": "Optional notes about why snapshot was created",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "Snapshot captured before approval"
-                    }
-                ],
-                "responses": {
-                    "404": {
-                        "description": "Estimate not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateSnapshotResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Snapshot created successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateSnapshotResponse"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Snapshot creation failed",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateSnapshotResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/reopen": {
-            "post": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Reopen a declined estimate",
-                "description": "Transition a declined estimate back to DRAFT state. Can only be done within the configured expiry period.",
-                "operationId": "reopenEstimate",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "ID of the estimate to reopen",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "400": {
-                        "description": "Estimate cannot be reopened (not declined or expired).",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Estimate not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Estimate reopened successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/promote": {
-            "post": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Promote approved estimate to workorder",
-                "description": "Promote an approved estimate to a workorder. Validates preconditions: estimate must be APPROVED, not expired, have approved items, and not already promoted. Returns 409 ALREADY_PROMOTED with existingWorkorderId if estimate was previously promoted (idempotency). CAP:004 Story #26 - Create Workorder from Approved Estimate.",
-                "operationId": "promoteEstimateToWorkorder",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "ID of the estimate to promote",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "description": "Idempotency-Key header for safe retries",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "estimate-promote-550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "409": {
-                        "description": "Estimate already promoted (ALREADY_PROMOTED) or approval invalid/expired",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Estimate not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Validation error - estimate not in correct state",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Workorder created successfully from estimate",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/items": {
-            "post": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Add line item to estimate",
-                "description": "Add a part or labor line item to a draft estimate. Estimate must be in DRAFT status. For PART items, provide productId or description. For LABOR items, provide serviceId or description.",
-                "operationId": "addEstimateItem",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "Estimate ID",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Line item details",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/AddEstimateItemRequest"
-                            },
-                            "examples": {
-                                "addEstimateItem": {
-                                    "description": "addEstimateItem",
-                                    "value": {
-                                        "itemType": "LABOR",
-                                        "description": "Brake inspection",
-                                        "quantity": 1,
-                                        "unitPrice": 129.99,
-                                        "taxCode": "LABOR_STANDARD"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Line item added successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateItemResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Estimate not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateItemResponse"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Estimate not in DRAFT status (INVALID_STATE)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateItemResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Validation error or invalid request",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateItemResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/decline": {
-            "post": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Decline an estimate",
-                "description": "Transition estimate to declined state. Estimate can be declined from DRAFT or APPROVED status.",
-                "operationId": "declineEstimate",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "ID of the estimate to decline",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    {
-                        "name": "reason",
-                        "in": "query",
-                        "description": "Reason for decline",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "Customer declined additional work"
-                    }
-                ],
-                "responses": {
-                    "400": {
-                        "description": "Estimate cannot be declined in current state.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Estimate not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Estimate declined successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/calculate": {
-            "post": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Calculate taxes and totals",
-                "description": "Calculate subtotal, tax amount, and total for an estimate based on its line items. Estimate must be in DRAFT status. Uses stub tax calculation (8.25% flat rate) pending pos-accounting integration.",
-                "operationId": "calculateEstimateTotals",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "Estimate ID",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "404": {
-                        "description": "Estimate not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {}
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Totals calculated successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {}
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Estimate not in DRAFT status (INVALID_STATE)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {}
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/approval": {
-            "post": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Approve an estimate with customer signature",
-                "description": "Transition estimate to approved state with customer signature capture. Estimate can be approved from DRAFT status. Requires customer ID validation and signature data (base64-encoded image). For commercial accounts with PO enforcement enabled, a purchase order number must be provided (CAP:092 Story #98).",
-                "operationId": "approveEstimate",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "ID of the estimate to approve",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Approval request with customer ID, signature capture, and optional selective line item approvals",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ApproveEstimateRequest"
-                            },
-                            "examples": {
-                                "approveEstimate": {
-                                    "description": "approveEstimate",
-                                    "value": {
-                                        "customerId": "550e8400-e29b-41d4-a716-446655440010",
-                                        "signatureData": "base64-signature",
-                                        "signatureMimeType": "image/png",
-                                        "signerName": "Jane Customer",
-                                        "notes": "Approved estimate",
-                                        "purchaseOrderNumber": "PO-12345"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "400": {
-                        "description": "Estimate cannot be approved in current state, customer ID mismatch, or PO required but not provided.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Estimate not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Estimate approved successfully with signature captured.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/changeRequests/{changeId}/emergency-override": {
-            "post": {
-                "tags": [
-                    "Change Request API"
-                ],
-                "summary": "Apply emergency override",
-                "description": "Manager applies emergency override to approve a change request with exception. Requires Manager role and a valid exception reason. Items move from PENDING_APPROVAL to READY_TO_EXECUTE status.",
-                "operationId": "applyEmergencyOverride",
-                "parameters": [
-                    {
-                        "name": "changeId",
-                        "in": "path",
-                        "description": "ID of the change request",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Emergency override details including manager ID and reason",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/EmergencyOverrideDTO"
-                            },
-                            "examples": {
-                                "emergencyOverride": {
-                                    "description": "emergencyOverride",
-                                    "value": {
-                                        "managerId": "550e8400-e29b-41d4-a716-446655440110",
-                                        "exceptionReason": "Safety-critical repair authorized"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Emergency override applied successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Cannot apply override - invalid state or missing reason",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Change request not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Insufficient permissions - Manager role required",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/changeRequests/{changeId}/decline": {
-            "post": {
-                "tags": [
-                    "Change Request API"
-                ],
-                "summary": "Decline a change request",
-                "description": "Service Advisor declines the change request. Items move from PENDING_APPROVAL to CANCELLED status (not billable). Approval note is required to record the decline decision.",
-                "operationId": "declineChangeRequest",
-                "parameters": [
-                    {
-                        "name": "changeId",
-                        "in": "path",
-                        "description": "ID of the change request",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Decline details including note",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/DeclineChangeRequestDTO"
-                            },
-                            "examples": {
-                                "declineChangeRequest": {
-                                    "description": "declineChangeRequest",
-                                    "value": {
-                                        "approvalNote": "Declined by customer"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "404": {
-                        "description": "Change request not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Cannot decline - invalid state or missing note",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Change request declined successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/changeRequests/{changeId}/approve": {
-            "post": {
-                "tags": [
-                    "Change Request API"
-                ],
-                "summary": "Approve a change request",
-                "description": "Service Advisor approves the change request. Items move from PENDING_APPROVAL to READY_TO_EXECUTE status. Approval note is required as the approval artifact.",
-                "operationId": "approveChangeRequest",
-                "parameters": [
-                    {
-                        "name": "changeId",
-                        "in": "path",
-                        "description": "ID of the change request",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Approval details including user ID and note",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ApproveChangeRequestDTO"
-                            },
-                            "examples": {
-                                "approveChangeRequest": {
-                                    "description": "approveChangeRequest",
-                                    "value": {
-                                        "approvedBy": "550e8400-e29b-41d4-a716-446655440100",
-                                        "approvalNote": "Approved after customer confirmation"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Change request approved successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Change request not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Cannot approve - invalid state or missing approval note",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/changeRequests/{changeId}/acknowledgeDenial": {
-            "post": {
-                "tags": [
-                    "Change Request API"
-                ],
-                "summary": "Record customer denial acknowledgment",
-                "description": "For declined emergency/safety items, record that customer acknowledged the denial. Required before closing the work order and returning the vehicle.",
-                "operationId": "recordCustomerDenialAcknowledgment",
-                "parameters": [
-                    {
-                        "name": "changeId",
-                        "in": "path",
-                        "description": "ID of the change request",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "400": {
-                        "description": "Not an emergency request or invalid state"
-                    },
-                    "404": {
-                        "description": "Change request not found"
-                    },
-                    "204": {
-                        "description": "Acknowledgment recorded successfully"
-                    }
-                }
-            }
-        },
-        "/v1/workexec/time-entries/timer/stop": {
-            "post": {
-                "tags": [
-                    "workexec-time-tracking-controller"
-                ],
-                "operationId": "stopTimers",
-                "parameters": [
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {}
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workexec/time-entries/timer/start": {
-            "post": {
-                "tags": [
-                    "workexec-time-tracking-controller"
-                ],
-                "operationId": "startTimer",
-                "parameters": [
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/WorkexecTimerStartRequest"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {}
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workexec/labor-performed": {
-            "post": {
-                "tags": [
-                    "workexec-time-tracking-controller"
-                ],
-                "operationId": "createLaborPerformed",
-                "parameters": [
-                    {
-                        "name": "Idempotency-Key",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "X-Correlation-Id",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/WorkexecLaborPerformedRequest"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {}
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workexec/approvalConfigurations": {
-            "post": {
-                "tags": [
-                    "Approval Configuration API"
-                ],
-                "summary": "Create a new approval configuration",
-                "description": "Add a new approval configuration.",
-                "operationId": "createConfiguration",
-                "requestBody": {
-                    "description": "Configuration object to be created",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ApprovalConfigurationRequest"
-                            },
-                            "examples": {
-                                "createApprovalConfig": {
-                                    "description": "createApprovalConfig",
-                                    "value": {
-                                        "locationId": "550e8400-e29b-41d4-a716-446655440020",
-                                        "customerId": "550e8400-e29b-41d4-a716-446655440010",
-                                        "approvalThreshold": 500.0,
-                                        "requiresManagerApproval": true
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Configuration created successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApprovalConfigurationResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/items/{itemId}": {
-            "delete": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Remove line item",
-                "description": "Remove a line item from a draft estimate (soft delete). Estimate must be in DRAFT status.",
-                "operationId": "deleteEstimateItem",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "Estimate ID",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    {
-                        "name": "itemId",
-                        "in": "path",
-                        "description": "Item ID",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Line item removed successfully"
-                    },
-                    "409": {
-                        "description": "Estimate not in DRAFT status (INVALID_STATE)"
-                    },
-                    "404": {
-                        "description": "Estimate or item not found"
-                    }
-                }
-            },
-            "patch": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Update line item",
-                "description": "Update an existing line item on a draft estimate. Estimate must be in DRAFT status. Only provided fields will be updated.",
-                "operationId": "updateEstimateItem",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "Estimate ID",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    {
-                        "name": "itemId",
-                        "in": "path",
-                        "description": "Item ID",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    }
-                ],
-                "requestBody": {
-                    "description": "Updated item fields",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateEstimateItemRequest"
-                            },
-                            "examples": {
-                                "updateEstimateItem": {
-                                    "description": "updateEstimateItem",
-                                    "value": {
-                                        "description": "Brake inspection and adjustment",
-                                        "quantity": 1,
-                                        "unitPrice": 149.99,
-                                        "taxCode": "LABOR_STANDARD"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Line item updated successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateItemResponse"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Estimate not in DRAFT status (INVALID_STATE)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateItemResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Validation error or invalid request",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateItemResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Estimate or item not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateItemResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}": {
-            "get": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Get work order by ID",
-                "description": "Retrieve a work order by its unique ID.",
-                "operationId": "getWorkorderById",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order to retrieve",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Work order found and returned.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Work order not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Delete a work order",
-                "description": "Delete a work order by its unique ID.",
-                "operationId": "deleteWorkorder",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order to delete",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Work order deleted successfully."
-                    },
-                    "404": {
-                        "description": "Work order not found."
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/transitions": {
-            "get": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Get transition history",
-                "description": "Retrieve the state transition history for a work order.",
-                "operationId": "getTransitionHistory",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Transition history returned successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/WorkorderStateTransitionResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/snapshots": {
-            "get": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Get snapshot history",
-                "description": "Retrieve the snapshot history for a work order.",
-                "operationId": "getSnapshotHistory",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Snapshot history returned successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/WorkorderSnapshotResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/parts/usageHistory": {
-            "get": {
-                "tags": [
-                    "Workorder Parts Usage"
-                ],
-                "summary": "Get parts usage history",
-                "description": "Retrieve usage history (issue, consume, return events) for parts on the workorder",
-                "operationId": "getUsageHistory",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    },
-                    {
-                        "name": "partLineId",
-                        "in": "query",
-                        "description": "Optional part line ID to filter history for a specific part",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440050"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Usage history retrieved successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder or part not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/parts/adjustments": {
-            "get": {
-                "tags": [
-                    "Workorder Part Adjustments"
-                ],
-                "summary": "Get part adjustment history",
-                "description": "Retrieve adjustment history (substitutions, returns, corrections) for parts on the workorder",
-                "operationId": "getAdjustmentHistory",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    },
-                    {
-                        "name": "partId",
-                        "in": "query",
-                        "description": "Optional part ID to filter history for a specific part",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440050"
-                    }
-                ],
-                "responses": {
-                    "404": {
-                        "description": "Workorder or part not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Adjustment history retrieved successfully (newest first)",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/labor": {
-            "get": {
-                "tags": [
-                    "Workorder Labor API"
-                ],
-                "summary": "Get labor history",
-                "description": "Retrieve all labor entries for a workorder, ordered newest first.",
-                "operationId": "getLaborHistory",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the workorder",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Labor history retrieved successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Permission denied",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/detail": {
-            "get": {
-                "tags": [
-                    "Workorder Detail"
-                ],
-                "summary": "Get workorder detail with role-based visibility",
-                "description": "Returns comprehensive workorder detail. Financial fields are conditionally included based on user authorities. Capability flags indicate which actions the user can perform.",
-                "operationId": "getWorkorderDetail",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "Workorder ID",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    {
-                        "name": "X-Authorities",
-                        "in": "header",
-                        "description": "User authorities (comma-separated)",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "workorder:workorder:view,workorder:financials:view"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Workorder detail retrieved successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderDetailResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Workorder not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkorderDetailResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/completion-preconditions": {
-            "get": {
-                "tags": [
-                    "Work Order API"
-                ],
-                "summary": "Validate completion preconditions",
-                "description": "Evaluate completion preconditions for a workorder and return checklist + blocking reasons.",
-                "operationId": "getCompletionPreconditions",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the workorder to validate",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Completion preconditions evaluated successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CompletionPreconditionsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Work order not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CompletionPreconditionsResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/{workorderId}/canClose": {
-            "get": {
-                "tags": [
-                    "Change Request API"
-                ],
-                "summary": "Check if work order can be closed",
-                "description": "Verify all declined emergency/safety items have customer denial acknowledgment",
-                "operationId": "canCloseWorkorder",
-                "parameters": [
-                    {
-                        "name": "workorderId",
-                        "in": "path",
-                        "description": "ID of the work order",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns true if work order can be closed, false otherwise",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "boolean"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}": {
-            "get": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Get estimate by ID",
-                "description": "Retrieve an estimate by its unique ID.",
-                "operationId": "getEstimateById",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "ID of the estimate to retrieve",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "404": {
-                        "description": "Estimate not found.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Estimate found and returned.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Delete an estimate",
-                "description": "Delete an estimate by its unique ID.",
-                "operationId": "deleteEstimate",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "ID of the estimate to delete",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Estimate deleted successfully."
-                    },
-                    "404": {
-                        "description": "Estimate not found."
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/{estimateId}/summary": {
-            "get": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Get estimate summary (customer-facing)",
-                "description": "Retrieve a customer-facing summary of an estimate with grouped line items (parts and labor) and financial breakdown. PDF generation not implemented (requires document service integration).",
-                "operationId": "getEstimateSummary",
-                "parameters": [
-                    {
-                        "name": "estimateId",
-                        "in": "path",
-                        "description": "Estimate ID",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "404": {
-                        "description": "Estimate not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateSummaryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Summary retrieved successfully",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/EstimateSummaryResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/shop/{locationId}": {
-            "get": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Get estimates by shop",
-                "description": "Retrieve all estimates for a specific shop.",
-                "operationId": "getEstimatesByShop",
-                "parameters": [
-                    {
-                        "name": "locationId",
-                        "in": "path",
-                        "description": "ID of the shop",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440020"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "List of estimates returned successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/EstimateResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/location/{locationId}": {
-            "get": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Get estimates by location",
-                "description": "Retrieve all estimates for a specific location.",
-                "operationId": "getEstimatesByLocation",
-                "parameters": [
-                    {
-                        "name": "locationId",
-                        "in": "path",
-                        "description": "ID of the location",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440020"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "List of estimates returned successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/EstimateResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/estimates/customer/{customerId}": {
-            "get": {
-                "tags": [
-                    "Estimate API"
-                ],
-                "summary": "Get estimates by customer",
-                "description": "Retrieve all estimates for a specific customer.",
-                "operationId": "getEstimatesByCustomer",
-                "parameters": [
-                    {
-                        "name": "customerId",
-                        "in": "path",
-                        "description": "ID of the customer",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440010"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "List of estimates returned successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/EstimateResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workorders/changeRequests/{changeId}": {
-            "get": {
-                "tags": [
-                    "Change Request API"
-                ],
-                "summary": "Get change request by ID",
-                "description": "Retrieve details of a specific change request",
-                "operationId": "getChangeRequestById",
-                "parameters": [
-                    {
-                        "name": "changeId",
-                        "in": "path",
-                        "description": "ID of the change request",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Change request found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Change request not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeRequestResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workexec": {
-            "get": {
-                "tags": [
-                    "Approval Configuration API"
-                ],
-                "summary": "Get all approval configurations",
-                "description": "Retrieve a list of all approval configurations.",
-                "operationId": "getAllConfigurations",
-                "responses": {
-                    "200": {
-                        "description": "List of configurations returned successfully.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ApprovalConfigurationResponse"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workexec/time-entries/timer/active": {
-            "get": {
-                "tags": [
-                    "workexec-time-tracking-controller"
-                ],
-                "operationId": "getActiveTimerEntries",
-                "parameters": [
-                    {
-                        "name": "X-User-Id",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {}
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workexec/job-time-totals": {
-            "get": {
-                "tags": [
-                    "workexec-time-tracking-controller"
-                ],
-                "operationId": "getJobTimeTotals",
-                "parameters": [
-                    {
-                        "name": "startDate",
-                        "in": "query",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "date"
-                        }
-                    },
-                    {
-                        "name": "endDate",
-                        "in": "query",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "date"
-                        }
-                    },
-                    {
-                        "name": "timezone",
-                        "in": "query",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "locationId",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        }
-                    },
-                    {
-                        "name": "technicianIds",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "format": "uuid"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {}
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/workexec/approvalConfigurations/applicable": {
-            "get": {
-                "tags": [
-                    "Approval Configuration API"
-                ],
-                "summary": "Get applicable configuration",
-                "description": "Get the most specific configuration for a location and customer.",
-                "operationId": "getApplicableConfiguration",
-                "parameters": [
-                    {
-                        "name": "locationId",
-                        "in": "query",
-                        "description": "Location ID",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440020"
-                    },
-                    {
-                        "name": "customerId",
-                        "in": "query",
-                        "description": "Customer ID",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "550e8400-e29b-41d4-a716-446655440010"
-                    }
-                ],
-                "responses": {
-                    "404": {
-                        "description": "No configuration found (default will be used).",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApprovalConfigurationResponse"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Configuration found and returned.",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApprovalConfigurationResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "AssignmentHistoryEntry": {
-                "type": "object",
-                "description": "Assignment history entry",
-                "properties": {
-                    "technicianId": {
-                        "type": "string",
-                        "description": "Technician ID for this assignment period",
-                        "example": "550e8400-e29b-41d4-a716-446655440050"
-                    },
-                    "technicianName": {
-                        "type": "string",
-                        "description": "Technician display name",
-                        "example": "John Smith"
-                    },
-                    "assignedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "When the technician was assigned",
-                        "example": "2024-01-27T14:30:00"
-                    },
-                    "assignedBy": {
-                        "type": "string",
-                        "description": "ID of user who assigned the technician",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "unassignedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "When the technician was unassigned (null for current assignment)",
-                        "example": "2024-01-27T16:00:00"
-                    },
-                    "reason": {
-                        "type": "string",
-                        "description": "Reason for reassignment/unassignment",
-                        "example": "Technician called out sick"
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Assignment notes"
-                    }
-                }
-            },
-            "TechnicianAssignmentResponse": {
-                "type": "object",
-                "description": "Technician assignment response",
-                "properties": {
-                    "workorderId": {
-                        "type": "string",
-                        "description": "Work order ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    "technicianId": {
-                        "type": "string",
-                        "description": "Assigned technician ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440050"
-                    },
-                    "technicianName": {
-                        "type": "string",
-                        "description": "Technician display name",
-                        "example": "John Smith"
-                    },
-                    "assignedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "When the technician was assigned",
-                        "example": "2024-01-27T14:30:00"
-                    },
-                    "assignedBy": {
-                        "type": "string",
-                        "description": "ID of user who assigned the technician",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "previousTechnicianId": {
-                        "type": "string",
-                        "description": "Previous technician ID if this was a reassignment",
-                        "example": "550e8400-e29b-41d4-a716-446655440049"
-                    },
-                    "previousTechnicianName": {
-                        "type": "string",
-                        "description": "Previous technician name if this was a reassignment",
-                        "example": "Jane Doe"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Status of the workorder after assignment",
-                        "example": "ASSIGNED"
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "Operation result message",
-                        "example": "Technician assigned successfully"
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Assignment notes"
-                    },
-                    "reassignmentReason": {
-                        "type": "string",
-                        "description": "Reason for reassignment if applicable"
-                    },
-                    "reassignedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "When technician was reassigned",
-                        "example": "2024-01-27T15:30:00"
-                    },
-                    "reassignedBy": {
-                        "type": "string",
-                        "description": "ID of user who performed reassignment",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "technicianCertifications": {
-                        "type": "array",
-                        "description": "Technician certifications",
-                        "example": [
-                            "ASE Master Technician",
-                            "Brake Specialist"
-                        ],
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "currentStatus": {
-                        "type": "string",
-                        "description": "Current workorder status",
-                        "example": "WORK_IN_PROGRESS"
-                    },
-                    "assignmentHistory": {
-                        "type": "array",
-                        "description": "Full assignment history for the workorder",
-                        "items": {
-                            "$ref": "#/components/schemas/AssignmentHistoryEntry"
-                        }
-                    }
-                }
-            },
-            "ReassignTechnicianRequest": {
-                "type": "object",
-                "description": "Request to reassign a workorder to a different technician",
-                "properties": {
-                    "newTechnicianId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "ID of the new technician",
-                        "example": "550e8400-e29b-41d4-a716-446655440051"
-                    },
-                    "reassignedByUserId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "ID of the user performing the reassignment (defaults from X-User-Id header if not provided)",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "reason": {
-                        "type": "string",
-                        "description": "Reason for reassignment",
-                        "example": "Original technician unavailable, reassigning to available tech"
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Additional notes for the reassignment"
-                    },
-                    "notifyPreviousTechnician": {
-                        "type": "boolean",
-                        "default": "false",
-                        "description": "Whether to send notification to previous technician"
-                    }
-                },
-                "required": [
-                    "newTechnicianId"
-                ]
-            },
-            "WorkorderLaborEntryResponse": {
-                "type": "object",
-                "description": "Labor entry response",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Unique ID of the labor entry",
-                        "example": "550e8400-e29b-41d4-a716-446655440100"
-                    },
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Workorder ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    "workorderServiceId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Service line item ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440010"
-                    },
-                    "technicianId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Technician ID who performed the work",
-                        "example": "550e8400-e29b-41d4-a716-446655440050"
-                    },
-                    "startTime": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Labor session start time",
-                        "example": "2024-01-27T14:30:00"
-                    },
-                    "endTime": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Labor session end time (null if still active)",
-                        "example": "2024-01-27T16:30:00"
-                    },
-                    "hoursWorked": {
-                        "type": "number",
-                        "description": "Hours worked",
-                        "example": 2.0
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Session notes",
-                        "example": "Brake pads replaced successfully"
-                    },
-                    "adjustmentReason": {
-                        "type": "string",
-                        "description": "Adjustment reason (if hours were manually adjusted)",
-                        "example": "Corrected for break time"
-                    },
-                    "active": {
-                        "type": "boolean",
-                        "description": "Whether this session is still active (not stopped)",
-                        "example": false
-                    },
-                    "createdBy": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "User who created this entry",
-                        "example": "550e8400-e29b-41d4-a716-446655440002"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Creation timestamp",
-                        "example": "2024-01-27T14:30:00Z"
-                    }
-                }
-            },
-            "AdjustLaborRequest": {
-                "type": "object",
-                "description": "Request to manually adjust labor hours",
-                "properties": {
-                    "hoursWorked": {
-                        "type": "number",
-                        "description": "Adjusted hours worked",
-                        "example": 2.5
-                    },
-                    "adjustmentReason": {
-                        "type": "string",
-                        "description": "Reason for the adjustment",
-                        "example": "Manual correction for break time"
-                    }
-                },
-                "required": [
-                    "adjustmentReason",
-                    "hoursWorked"
-                ]
-            },
-            "ApprovalConfigurationRequest": {
-                "type": "object",
-                "description": "Request DTO for approval configuration creation and updates",
-                "properties": {
-                    "locationId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Location ID for this configuration (null = applies to all locations)",
-                        "example": 1
-                    },
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Customer ID for this configuration (null = applies to all customers)",
-                        "example": 2
-                    },
-                    "approvalMethod": {
-                        "type": "string",
-                        "description": "Approval method",
-                        "example": "CLICK_CONFIRM"
-                    },
-                    "declineExpiryDays": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Number of days a declined estimate can be reopened",
-                        "example": 30,
-                        "minimum": 0
-                    },
-                    "requireSignature": {
-                        "type": "boolean",
-                        "description": "Whether signature is required",
-                        "example": false
-                    },
-                    "priority": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Priority for configuration matching (0=default, 1=location-specific, 2=customer-specific)",
-                        "example": 0,
-                        "minimum": 0
-                    }
-                },
-                "required": [
-                    "approvalMethod"
-                ]
-            },
-            "ApprovalConfigurationResponse": {
-                "type": "object",
-                "description": "Response DTO for approval configurations",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Unique identifier for the configuration",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "locationId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Location ID for this configuration (null = applies to all locations)",
-                        "example": 1
-                    },
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Customer ID for this configuration (null = applies to all customers)",
-                        "example": 2
-                    },
-                    "approvalMethod": {
-                        "type": "string",
-                        "description": "Approval method",
-                        "example": "CLICK_CONFIRM"
-                    },
-                    "declineExpiryDays": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Number of days a declined estimate can be reopened",
-                        "example": 30
-                    },
-                    "requireSignature": {
-                        "type": "boolean",
-                        "description": "Whether signature is required",
-                        "example": false
-                    },
-                    "priority": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Priority for configuration matching (0=default, 1=location-specific, 2=customer-specific)",
-                        "example": 0
-                    }
-                }
-            },
-            "CreateWorkorderRequest": {
-                "type": "object",
-                "description": "Request DTO for workorder creation",
-                "properties": {
-                    "estimateId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Estimate ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Customer ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440002"
-                    }
-                },
-                "required": [
-                    "customerId",
-                    "estimateId"
-                ]
-            },
-            "WorkorderResponse": {
-                "type": "object",
-                "description": "Response DTO for workorders",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Unique identifier for the workorder",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "estimateId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Estimate ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Customer ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440002"
-                    },
-                    "shopId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Shop ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440003"
-                    },
-                    "vehicleId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Vehicle ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440004"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Workorder status",
-                        "example": "DRAFT"
-                    },
-                    "approvedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the workorder was approved"
-                    },
-                    "completedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the workorder was completed"
-                    },
-                    "isReopened": {
-                        "type": "boolean",
-                        "description": "Whether the completed workorder is currently reopened for controlled edits"
-                    },
-                    "reopenedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the workorder was reopened"
-                    }
-                }
-            },
-            "AssignTechnicianRequest": {
-                "type": "object",
-                "description": "Request to assign a technician to a workorder",
-                "properties": {
-                    "technicianId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "ID of the technician to assign",
-                        "example": "550e8400-e29b-41d4-a716-446655440050"
-                    },
-                    "assignedByUserId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "ID of the user performing the assignment (defaults from X-User-Id header if not provided)",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Assignment notes or reason",
-                        "example": "Assigned to senior tech for brake system work"
-                    }
-                },
-                "required": [
-                    "technicianId"
-                ]
-            },
-            "StartWorkorderRequest": {
-                "type": "object",
-                "properties": {
-                    "userId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "reason": {
-                        "type": "string"
-                    }
-                }
-            },
-            "StartWorkorderResponse": {
-                "type": "object",
-                "properties": {
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "previousStatus": {
-                        "type": "string"
-                    },
-                    "currentStatus": {
-                        "type": "string"
-                    },
-                    "transitionedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "message": {
-                        "type": "string"
-                    }
-                }
-            },
-            "StartLaborRequest": {
-                "type": "object",
-                "description": "Request to start a labor session on a workorder service",
-                "properties": {
-                    "technicianId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "ID of the technician performing the work",
-                        "example": "550e8400-e29b-41d4-a716-446655440050"
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Optional notes about the labor session",
-                        "example": "Beginning brake pad replacement"
-                    }
-                },
-                "required": [
-                    "technicianId"
-                ]
-            },
-            "ReopenWorkorderRequest": {
-                "type": "object",
-                "description": "Request payload for controlled workorder reopen",
-                "properties": {
-                    "userId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "User initiating reopen action",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "reopenReason": {
-                        "type": "string",
-                        "description": "Mandatory reason for reopening completed workorder",
-                        "example": "Corrected labor hours"
-                    }
-                }
-            },
-            "ReopenWorkorderResponse": {
-                "type": "object",
-                "description": "Response payload for controlled workorder reopen",
-                "properties": {
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Workorder identifier"
-                    },
-                    "currentStatus": {
-                        "type": "string",
-                        "description": "Current lifecycle status"
-                    },
-                    "isReopened": {
-                        "type": "boolean",
-                        "description": "Whether the workorder is reopened for controlled edits"
-                    },
-                    "reopenedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Reopen timestamp"
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "Operation message"
-                    }
-                }
-            },
-            "SubstitutePartRequest": {
-                "type": "object",
-                "properties": {
-                    "originalPartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "substitutePartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "reason": {
-                        "type": "string"
-                    },
-                    "notes": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "originalPartId",
-                    "reason",
-                    "substitutePartId"
-                ]
-            },
-            "WorkorderPartAdjustmentEventResponse": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "originalPartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "originalPartDescription": {
-                        "type": "string"
-                    },
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "adjustmentType": {
-                        "type": "string"
-                    },
-                    "substitutedWithPartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "substitutedWithPartDescription": {
-                        "type": "string"
-                    },
-                    "quantityAdjustment": {
-                        "type": "number"
-                    },
-                    "reason": {
-                        "type": "string"
-                    },
-                    "performedBy": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "performedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "notes": {
-                        "type": "string"
-                    }
-                }
-            },
-            "ReturnPartRequest": {
-                "type": "object",
-                "properties": {
-                    "workorderPartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "quantity": {
-                        "type": "number",
-                        "minimum": 0.0001
-                    },
-                    "notes": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "quantity",
-                    "workorderPartId"
-                ]
-            },
-            "WorkorderPartUsageEventResponse": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "workorderPartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "eventType": {
-                        "type": "string"
-                    },
-                    "quantity": {
-                        "type": "number"
-                    },
-                    "performedBy": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "performedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "notes": {
-                        "type": "string"
-                    },
-                    "partDescription": {
-                        "type": "string"
-                    }
-                }
-            },
-            "ReturnPartQuantityRequest": {
-                "type": "object",
-                "properties": {
-                    "workorderPartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "quantity": {
-                        "type": "number"
-                    },
-                    "reason": {
-                        "type": "string"
-                    },
-                    "notes": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "quantity",
-                    "reason",
-                    "workorderPartId"
-                ]
-            },
-            "IssuePartRequest": {
-                "type": "object",
-                "properties": {
-                    "workorderPartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "quantity": {
-                        "type": "number",
-                        "minimum": 0.0001
-                    },
-                    "notes": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "quantity",
-                    "workorderPartId"
-                ]
-            },
-            "CorrectPartQuantityRequest": {
-                "type": "object",
-                "properties": {
-                    "workorderPartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "newQuantity": {
-                        "type": "number"
-                    },
-                    "reason": {
-                        "type": "string"
-                    },
-                    "notes": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "newQuantity",
-                    "reason",
-                    "workorderPartId"
-                ]
-            },
-            "ConsumePartRequest": {
-                "type": "object",
-                "properties": {
-                    "workorderPartId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "quantity": {
-                        "type": "number",
-                        "minimum": 0.0001
-                    },
-                    "notes": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "quantity",
-                    "workorderPartId"
-                ]
-            },
-            "InvoiceGenerationResponse": {
-                "type": "object",
-                "properties": {
-                    "invoiceId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "estimateId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "approvalId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "subtotal": {
-                        "type": "number"
-                    },
-                    "taxAmount": {
-                        "type": "number"
-                    },
-                    "totalAmount": {
-                        "type": "number"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                }
-            },
-            "CompleteWorkorderRequest": {
-                "type": "object",
-                "properties": {
-                    "userId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "completionNotes": {
-                        "type": "string"
-                    }
-                }
-            },
-            "CompleteWorkorderResponse": {
-                "type": "object",
-                "properties": {
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "previousStatus": {
-                        "type": "string"
-                    },
-                    "currentStatus": {
-                        "type": "string"
-                    },
-                    "completedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "message": {
-                        "type": "string"
-                    }
-                }
-            },
-            "CreateChangeRequestDTO": {
-                "type": "object",
-                "properties": {
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "requestedByUserId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "isEmergencyException": {
-                        "type": "boolean"
-                    },
-                    "exceptionReason": {
-                        "type": "string"
-                    },
-                    "services": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/WorkorderItemDTO"
-                        }
-                    },
-                    "parts": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/WorkorderItemDTO"
-                        }
-                    }
-                }
-            },
-            "WorkorderItemDTO": {
-                "type": "object",
-                "properties": {
-                    "serviceEntityId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "productEntityId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "nonInventoryProductEntityId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "quantity": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    "isEmergencySafety": {
-                        "type": "boolean"
-                    },
-                    "photoEvidenceUrl": {
-                        "type": "string"
-                    },
-                    "emergencyNotes": {
-                        "type": "string"
-                    },
-                    "photoNotPossible": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            "ChangeRequestResponse": {
-                "type": "object",
-                "description": "Response DTO for change requests",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Unique identifier for the change request",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Workorder ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    "requestedByUserId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "User ID who requested the change",
-                        "example": "550e8400-e29b-41d4-a716-446655440002"
-                    },
-                    "requestedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the change was requested"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Change request status",
-                        "example": "AWAITING_ADVISOR_REVIEW"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Description of the change request"
-                    },
-                    "isEmergencyException": {
-                        "type": "boolean",
-                        "description": "Whether this is an emergency exception"
-                    },
-                    "exceptionReason": {
-                        "type": "string",
-                        "description": "Reason for the exception if applicable"
-                    },
-                    "approvalNote": {
-                        "type": "string",
-                        "description": "Approval notes"
-                    },
-                    "isApprovalGated": {
-                        "type": "boolean",
-                        "description": "Whether approval is gated"
-                    },
-                    "approvedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the change was approved"
-                    },
-                    "approvedBy": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "User ID who approved the change"
-                    },
-                    "declinedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the change was declined"
-                    }
-                }
-            },
-            "ApproveWorkorderRequest": {
-                "type": "object",
-                "description": "Request to approve a work order with customer signature",
-                "properties": {
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Customer ID who is approving the work order",
-                        "example": 12345
-                    },
-                    "signatureData": {
-                        "type": "string",
-                        "description": "Base64-encoded signature image data (PNG format recommended)",
-                        "example": "data:image/png;base64,iVBORw0KGgoAAAANS..."
-                    },
-                    "signatureMimeType": {
-                        "type": "string",
-                        "description": "MIME type of signature (e.g., image/png, image/jpeg)",
-                        "example": "image/png"
-                    },
-                    "signerName": {
-                        "type": "string",
-                        "description": "Name of person providing signature",
-                        "example": "John Doe"
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Additional notes or comments",
-                        "example": "Approved after reviewing repair details"
-                    },
-                    "lineItemApprovals": {
-                        "type": "array",
-                        "description": "Individual line item approvals/rejections. If omitted, all items are considered approved.",
-                        "items": {
-                            "$ref": "#/components/schemas/LineItemApprovalDto"
-                        }
-                    }
-                },
-                "required": [
-                    "customerId"
-                ]
-            },
-            "LineItemApprovalDto": {
-                "type": "object",
-                "description": "Approval or rejection status for a specific line item",
-                "properties": {
-                    "lineItemId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "ID of the line item (service/product) being approved or rejected",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "approved": {
-                        "type": "boolean",
-                        "description": "Whether this line item is approved (true) or rejected (false)",
-                        "example": true
-                    },
-                    "rejectionReason": {
-                        "type": "string",
-                        "description": "Reason for rejection (required if approved=false)",
-                        "example": "Customer declined optional service"
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Additional notes about this line item decision",
-                        "example": "Customer wants to get second opinion"
-                    }
-                },
-                "required": [
-                    "approved",
-                    "lineItemId"
-                ]
-            },
-            "CreateEstimateRequest": {
-                "type": "object",
-                "properties": {
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "vehicleId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "locationId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "currencyUomId": {
-                        "type": "string"
-                    },
-                    "taxRegionId": {
-                        "type": "string",
-                        "format": "uuid"
-                    }
-                },
-                "required": [
-                    "customerId",
-                    "vehicleId"
-                ]
-            },
-            "EstimateResponse": {
-                "type": "object",
-                "description": "Response DTO for estimates",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Unique identifier for the estimate",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "estimateNumber": {
-                        "type": "string",
-                        "description": "Estimate number",
-                        "example": "EST-2024-1000"
-                    },
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Customer ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    "vehicleId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Vehicle ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440002"
-                    },
-                    "locationId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Location ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440003"
-                    },
-                    "currencyUomId": {
-                        "type": "string",
-                        "description": "Currency UOM ID",
-                        "example": "USD"
-                    },
-                    "taxRegionId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Tax region ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440004"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Estimate status",
-                        "example": "DRAFT"
-                    },
-                    "createdByUserId": {
-                        "type": "string",
-                        "description": "Username who created the estimate",
-                        "example": "john.doe"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the estimate was created"
-                    },
-                    "subtotal": {
-                        "type": "number",
-                        "description": "Subtotal amount before tax",
-                        "example": 150.0
-                    },
-                    "taxAmount": {
-                        "type": "number",
-                        "description": "Tax amount",
-                        "example": 12.38
-                    },
-                    "total": {
-                        "type": "number",
-                        "description": "Total amount including tax",
-                        "example": 162.38
-                    },
-                    "submittedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the estimate was submitted for approval"
-                    },
-                    "submittedBy": {
-                        "type": "string",
-                        "description": "Username who submitted the estimate for approval",
-                        "example": "john.doe"
-                    },
-                    "expiresAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the approval window expires"
-                    },
-                    "approvedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Date and time the estimate was approved"
-                    },
-                    "approvedBy": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Customer UUID who approved the estimate",
-                        "example": "550e8400-e29b-41d4-a716-446655440005"
-                    },
-                    "signatureData": {
-                        "type": "string",
-                        "description": "Base64-encoded signature image"
-                    },
-                    "signatureMimeType": {
-                        "type": "string",
-                        "description": "MIME type of the signature image",
-                        "example": "image/png"
-                    },
-                    "signerName": {
-                        "type": "string",
-                        "description": "Name of person who signed"
-                    },
-                    "approvalNotes": {
-                        "type": "string",
-                        "description": "Additional notes provided at approval time"
-                    },
-                    "purchaseOrderNumber": {
-                        "type": "string",
-                        "description": "Purchase order number for commercial accounts",
-                        "example": "PO-2024-12345"
-                    },
-                    "version": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Optimistic locking version"
-                    }
-                }
-            },
-            "EstimateSnapshotResponse": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "estimateId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "DRAFT",
-                            "PENDING_APPROVAL",
-                            "APPROVED",
-                            "DECLINED",
-                            "EXPIRED"
-                        ]
-                    },
-                    "snapshotData": {
-                        "type": "string"
-                    },
-                    "capturedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "capturedById": {
-                        "type": "string"
-                    },
-                    "notes": {
-                        "type": "string"
-                    }
-                }
-            },
-            "AddEstimateItemRequest": {
-                "type": "object",
-                "properties": {
-                    "itemType": {
-                        "type": "string",
-                        "enum": [
-                            "PART",
-                            "LABOR"
-                        ]
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "quantity": {
-                        "type": "number",
-                        "minimum": 0.0001
-                    },
-                    "unitPrice": {
-                        "type": "number",
-                        "minimum": 0.00
-                    },
-                    "taxCode": {
-                        "type": "string"
-                    },
-                    "productId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "serviceId": {
-                        "type": "string",
-                        "format": "uuid"
-                    }
-                },
-                "required": [
-                    "itemType",
-                    "quantity",
-                    "unitPrice"
-                ]
-            },
-            "EstimateItemResponse": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "estimateId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "itemType": {
-                        "type": "string",
-                        "enum": [
-                            "PART",
-                            "LABOR"
-                        ]
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "quantity": {
-                        "type": "number"
-                    },
-                    "unitPrice": {
-                        "type": "number"
-                    },
-                    "lineTotal": {
-                        "type": "number"
-                    },
-                    "taxCode": {
-                        "type": "string"
-                    },
-                    "productId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "serviceId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                }
-            },
-            "ApproveEstimateRequest": {
-                "type": "object",
-                "description": "Request to approve an estimate with customer signature",
-                "properties": {
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Customer ID who is approving the estimate",
-                        "example": 12345
-                    },
-                    "signatureData": {
-                        "type": "string",
-                        "description": "Base64-encoded signature image data (PNG format recommended)",
-                        "example": "data:image/png;base64,iVBORw0KGgoAAAANS..."
-                    },
-                    "signatureMimeType": {
-                        "type": "string",
-                        "description": "MIME type of signature (e.g., image/png, image/jpeg)",
-                        "example": "image/png"
-                    },
-                    "signerName": {
-                        "type": "string",
-                        "description": "Name of person providing signature",
-                        "example": "John Doe"
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Additional notes or comments",
-                        "example": "Approved with customer present"
-                    },
-                    "lineItemApprovals": {
-                        "type": "array",
-                        "description": "Individual line item approvals/rejections. If omitted, all items are considered approved.",
-                        "items": {
-                            "$ref": "#/components/schemas/LineItemApprovalDto"
-                        }
-                    },
-                    "purchaseOrderNumber": {
-                        "type": "string",
-                        "description": "Purchase order number (required when PO enforcement is enabled for the account)",
-                        "example": "PO-2024-12345"
-                    }
-                },
-                "required": [
-                    "customerId"
-                ]
-            },
-            "EmergencyOverrideDTO": {
-                "type": "object",
-                "properties": {
-                    "managerId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "exceptionReason": {
-                        "type": "string"
-                    }
-                }
-            },
-            "DeclineChangeRequestDTO": {
-                "type": "object",
-                "properties": {
-                    "approvalNote": {
-                        "type": "string"
-                    }
-                }
-            },
-            "ApproveChangeRequestDTO": {
-                "type": "object",
-                "properties": {
-                    "approvedBy": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "approvalNote": {
-                        "type": "string"
-                    }
-                }
-            },
-            "WorkexecTimerStartRequest": {
-                "type": "object",
-                "description": "Start timer request for workexec time entries",
-                "properties": {
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "workorderItemId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "laborCode": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "workorderId"
-                ]
-            },
-            "LaborQuantity": {
-                "type": "object",
-                "properties": {
-                    "quantity": {
-                        "type": "number"
-                    },
-                    "unit": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "quantity",
-                    "unit"
-                ]
-            },
-            "SourceReference": {
-                "type": "object",
-                "properties": {
-                    "system": {
-                        "type": "string"
-                    },
-                    "sourceReferenceId": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "sourceReferenceId",
-                    "system"
-                ]
-            },
-            "WorkexecLaborPerformedRequest": {
-                "type": "object",
-                "description": "Request payload for recording labor performed from external systems",
-                "properties": {
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Workorder identifier"
-                    },
-                    "technicianId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Technician identifier"
-                    },
-                    "performedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Timestamp when labor was performed"
-                    },
-                    "labor": {
-                        "$ref": "#/components/schemas/LaborQuantity",
-                        "description": "Labor quantity and unit"
-                    },
-                    "source": {
-                        "$ref": "#/components/schemas/SourceReference",
-                        "description": "External source metadata"
-                    }
-                },
-                "required": [
-                    "labor",
-                    "performedAt",
-                    "source",
-                    "technicianId",
-                    "workorderId"
-                ]
-            },
-            "UpdateEstimateItemRequest": {
-                "type": "object",
-                "properties": {
-                    "description": {
-                        "type": "string"
-                    },
-                    "quantity": {
-                        "type": "number",
-                        "minimum": 0.0001
-                    },
-                    "unitPrice": {
-                        "type": "number",
-                        "minimum": 0.00
-                    },
-                    "taxCode": {
-                        "type": "string"
-                    }
-                }
-            },
-            "WorkorderStateTransitionResponse": {
-                "type": "object",
-                "description": "Work order state transition history entry",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Unique identifier for this transition record",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "ID of the work order",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "fromStatus": {
-                        "type": "string",
-                        "description": "The status the work order transitioned FROM",
-                        "example": "DRAFT"
-                    },
-                    "toStatus": {
-                        "type": "string",
-                        "description": "The status the work order transitioned TO",
-                        "example": "WORK_IN_PROGRESS"
-                    },
-                    "transitionedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Timestamp when the transition occurred"
-                    },
-                    "transitionedBy": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "User ID who performed the transition",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "reason": {
-                        "type": "string",
-                        "description": "Reason for the transition",
-                        "example": "Customer approved the estimate"
-                    },
-                    "metadata": {
-                        "type": "string",
-                        "description": "Additional metadata about the transition"
-                    }
-                }
-            },
-            "WorkorderSnapshotResponse": {
-                "type": "object",
-                "description": "Work order snapshot history entry",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Unique identifier for this snapshot record",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "ID of the work order",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Status of the work order at the time of this snapshot",
-                        "example": "WORK_IN_PROGRESS"
-                    },
-                    "capturedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Timestamp when the snapshot was captured"
-                    },
-                    "capturedBy": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "User ID who captured the snapshot",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "snapshotType": {
-                        "type": "string",
-                        "description": "Type of snapshot (e.g., MANUAL, AUTOMATIC, SYSTEM)",
-                        "example": "MANUAL"
-                    },
-                    "snapshotData": {
-                        "type": "string",
-                        "description": "Snapshot data (typically JSON)"
-                    },
-                    "reason": {
-                        "type": "string",
-                        "description": "Reason for capturing the snapshot"
-                    }
-                }
-            },
-            "WorkorderCapabilities": {
-                "type": "object",
-                "description": "Capability flags for workorder actions based on user authorities",
-                "properties": {
-                    "canStart": {
-                        "type": "boolean",
-                        "description": "User can start workorder",
-                        "example": true
-                    },
-                    "canApprove": {
-                        "type": "boolean",
-                        "description": "User can approve workorder",
-                        "example": false
-                    },
-                    "canAssignTechnician": {
-                        "type": "boolean",
-                        "description": "User can assign/reassign technicians",
-                        "example": true
-                    },
-                    "canRecordLabor": {
-                        "type": "boolean",
-                        "description": "User can record labor entries",
-                        "example": true
-                    },
-                    "canRecordPartsUsage": {
-                        "type": "boolean",
-                        "description": "User can record parts usage",
-                        "example": true
-                    },
-                    "canViewFinancials": {
-                        "type": "boolean",
-                        "description": "User can view financial data",
-                        "example": false
-                    },
-                    "canEditWorkorder": {
-                        "type": "boolean",
-                        "description": "User can edit workorder",
-                        "example": true
-                    },
-                    "canDeleteWorkorder": {
-                        "type": "boolean",
-                        "description": "User can delete workorder",
-                        "example": false
-                    }
-                }
-            },
-            "WorkorderDetailResponse": {
-                "type": "object",
-                "description": "Comprehensive workorder detail with role-based visibility",
-                "properties": {
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Workorder ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "workorderNumber": {
-                        "type": "string",
-                        "description": "Workorder number (from sequence)",
-                        "example": "WO-2024-5001"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Workorder status",
-                        "enum": [
-                            "DRAFT",
-                            "APPROVED",
-                            "ASSIGNED",
-                            "WORK_IN_PROGRESS",
-                            "AWAITING_PARTS",
-                            "AWAITING_APPROVAL",
-                            "READY_FOR_PICKUP",
-                            "COMPLETED",
-                            "CANCELLED"
-                        ],
-                        "example": "WORK_IN_PROGRESS"
-                    },
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Customer ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    "customerName": {
-                        "type": "string",
-                        "description": "Customer name",
-                        "example": "John Doe"
-                    },
-                    "vehicleId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Vehicle ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440002"
-                    },
-                    "vehicleDescription": {
-                        "type": "string",
-                        "description": "Vehicle description",
-                        "example": 2020
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Creation timestamp",
-                        "example": "2024-01-27T10:00:00Z"
-                    },
-                    "createdBy": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Created by user ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440003"
-                    },
-                    "isStarted": {
-                        "type": "boolean",
-                        "description": "Is workorder started (derived from status)",
-                        "example": true
-                    },
-                    "isInProgress": {
-                        "type": "boolean",
-                        "description": "Is workorder in progress (derived from status)",
-                        "example": true
-                    },
-                    "isCompleted": {
-                        "type": "boolean",
-                        "description": "Is workorder completed (derived from status)",
-                        "example": false
-                    },
-                    "startedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Start timestamp",
-                        "example": "2024-01-27T14:30:00Z"
-                    },
-                    "assignedTechnicianId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Assigned technician ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440004"
-                    },
-                    "assignedTechnicianName": {
-                        "type": "string",
-                        "description": "Assigned technician name",
-                        "example": "Jane Smith"
-                    },
-                    "services": {
-                        "type": "array",
-                        "description": "Service line items with labor totals",
-                        "items": {
-                            "$ref": "#/components/schemas/WorkorderServiceResponse"
-                        }
-                    },
-                    "parts": {
-                        "type": "array",
-                        "description": "Part line items with usage totals",
-                        "items": {
-                            "$ref": "#/components/schemas/WorkorderPartResponse"
-                        }
-                    },
-                    "estimatedTotal": {
-                        "type": "number",
-                        "description": "Estimated total (conditionally included based on canViewFinancials)",
-                        "example": 1245.5
-                    },
-                    "laborTotal": {
-                        "type": "number",
-                        "description": "Total labor cost (conditionally included)",
-                        "example": 425.0
-                    },
-                    "partsTotal": {
-                        "type": "number",
-                        "description": "Total parts cost (conditionally included)",
-                        "example": 720.5
-                    },
-                    "taxTotal": {
-                        "type": "number",
-                        "description": "Total tax (conditionally included)",
-                        "example": 100.0
-                    },
-                    "capabilities": {
-                        "$ref": "#/components/schemas/WorkorderCapabilities",
-                        "description": "Capability flags indicating allowed actions"
-                    }
-                },
-                "required": [
-                    "capabilities",
-                    "createdAt",
-                    "createdBy",
-                    "customerId",
-                    "status",
-                    "vehicleId",
-                    "workorderId"
-                ]
-            },
-            "WorkorderPartResponse": {
-                "type": "object",
-                "description": "Workorder part line item with usage totals",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Part line item ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "productEntityId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Product entity ID from catalog",
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Part description",
-                        "example": "Brake Rotor - Front"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Part line status",
-                        "enum": [
-                            "PENDING_APPROVAL",
-                            "OPEN",
-                            "READY_TO_EXECUTE",
-                            "IN_PROGRESS",
-                            "COMPLETED",
-                            "CANCELLED"
-                        ],
-                        "example": "OPEN"
-                    },
-                    "quantity": {
-                        "type": "number",
-                        "description": "Authorized quantity from estimate",
-                        "example": 2.0
-                    },
-                    "unitPrice": {
-                        "type": "number",
-                        "description": "Unit price per part",
-                        "example": 65.0
-                    },
-                    "quantityIssued": {
-                        "type": "number",
-                        "description": "Quantity issued from inventory",
-                        "example": 2.0
-                    },
-                    "quantityConsumed": {
-                        "type": "number",
-                        "description": "Quantity consumed (cannot be returned)",
-                        "example": 1.5
-                    },
-                    "quantityReturned": {
-                        "type": "number",
-                        "description": "Quantity returned to inventory",
-                        "example": 0.5
-                    },
-                    "partCost": {
-                        "type": "number",
-                        "description": "Total part cost (authorized quantity * unit price)",
-                        "example": 130.0
-                    },
-                    "lineTotal": {
-                        "type": "number",
-                        "description": "Line total from estimate",
-                        "example": 130.0
-                    }
-                }
-            },
-            "WorkorderServiceResponse": {
-                "type": "object",
-                "description": "Workorder service line item with labor totals",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Service line item ID",
-                        "example": "550e8400-e29b-41d4-a716-446655440000"
-                    },
-                    "serviceEntityId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Service entity ID from catalog",
-                        "example": "550e8400-e29b-41d4-a716-446655440001"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Service description",
-                        "example": "Brake Pad Replacement"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Service line status",
-                        "enum": [
-                            "PENDING_APPROVAL",
-                            "OPEN",
-                            "READY_TO_EXECUTE",
-                            "IN_PROGRESS",
-                            "COMPLETED",
-                            "CANCELLED"
-                        ],
-                        "example": "OPEN"
-                    },
-                    "quantity": {
-                        "type": "number",
-                        "description": "Authorized quantity (hours for labor)",
-                        "example": 2.5
-                    },
-                    "unitPrice": {
-                        "type": "number",
-                        "description": "Unit price (hourly rate)",
-                        "example": 85.0
-                    },
-                    "totalLaborHours": {
-                        "type": "number",
-                        "description": "Total labor hours recorded",
-                        "example": 1.5
-                    },
-                    "laborCost": {
-                        "type": "number",
-                        "description": "Total labor cost",
-                        "example": 127.5
-                    },
-                    "lineTotal": {
-                        "type": "number",
-                        "description": "Line total from estimate",
-                        "example": 212.5
-                    }
-                }
-            },
-            "CompletionPreconditionsResponse": {
-                "type": "object",
-                "description": "Completion precondition evaluation response",
-                "properties": {
-                    "workorderId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Workorder identifier"
-                    },
-                    "canComplete": {
-                        "type": "boolean",
-                        "description": "Whether the workorder can be completed"
-                    },
-                    "currentStatus": {
-                        "type": "string",
-                        "description": "Current status"
-                    },
-                    "checklistItems": {
-                        "type": "array",
-                        "description": "Checklist items evaluated before completion",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "blockingReasons": {
-                        "type": "array",
-                        "description": "Blocking reasons that prevent completion",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "unresolvedApprovalGatedChangeRequests": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Number of unresolved approval-gated change requests"
-                    },
-                    "nonTerminalServiceItems": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Number of service items not in COMPLETED/CANCELLED status"
-                    },
-                    "nonTerminalPartItems": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Number of part items not in COMPLETED/CANCELLED status"
-                    },
-                    "emergencyDenialAcknowledged": {
-                        "type": "boolean",
-                        "description": "Whether emergency denial acknowledgment requirements are satisfied"
-                    },
-                    "hasBillableItems": {
-                        "type": "boolean",
-                        "description": "Whether at least one billable item exists for final snapshot"
-                    }
-                }
-            },
-            "EstimateSummaryResponse": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "estimateNumber": {
-                        "type": "string"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "customerId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "vehicleId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "partItems": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/EstimateItemResponse"
-                        }
-                    },
-                    "laborItems": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/EstimateItemResponse"
-                        }
-                    },
-                    "subtotal": {
-                        "type": "number"
-                    },
-                    "taxAmount": {
-                        "type": "number"
-                    },
-                    "total": {
-                        "type": "number"
-                    },
-                    "currencyUomId": {
-                        "type": "string"
-                    }
-                }
-            }
-        }
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8086",
+      "description": "Generated server url"
     }
+  ],
+  "tags": [
+    {
+      "name": "Workorder Detail",
+      "description": "Workorder detail with role-based visibility"
+    },
+    {
+      "name": "Travel Segment API",
+      "description": "Endpoints for capturing mobile travel segments"
+    },
+    {
+      "name": "Workorder Search",
+      "description": "Workorder search and retrieval"
+    },
+    {
+      "name": "Estimates from Appointments",
+      "description": "Create estimates from shop appointments"
+    },
+    {
+      "name": "Work Session API",
+      "description": "Endpoints for managing technician work sessions and break segments"
+    },
+    {
+      "name": "Workorder Labor API",
+      "description": "Endpoints for tracking labor performed on workorders"
+    },
+    {
+      "name": "Workorder Pick Facade",
+      "description": "Browser-facing pick list and pick task endpoints for workorder fulfillment"
+    },
+    {
+      "name": "Estimate Search",
+      "description": "Estimate search and retrieval"
+    },
+    {
+      "name": "Workorder Parts Usage",
+      "description": "Track parts issue, consumption, and returns"
+    },
+    {
+      "name": "Daily Dispatch Board Dashboard",
+      "description": "Dispatch board aggregation and conflict detection"
+    },
+    {
+      "name": "Work Order API",
+      "description": "Endpoints for work order management"
+    },
+    {
+      "name": "Approval Configuration API",
+      "description": "Endpoints for managing approval configurations by location and customer"
+    },
+    {
+      "name": "Workexec Time Tracking API",
+      "description": "Endpoints for timer operations, labor entry creation, and job time totals"
+    },
+    {
+      "name": "Operational Context",
+      "description": "Workorder execution context operations"
+    },
+    {
+      "name": "Workorder Part Adjustments",
+      "description": "Part substitutions, returns, and corrections"
+    },
+    {
+      "name": "Workorder Picked Items",
+      "description": "Browser-facing picked items and consume endpoints for workorder fulfillment"
+    },
+    {
+      "name": "Substitute Link API",
+      "description": "Operations for product substitute links and workorder substitute suggestions"
+    },
+    {
+      "name": "Technician Assignment API",
+      "description": "Endpoints for assigning technicians to workorders"
+    },
+    {
+      "name": "Change Request API",
+      "description": "Endpoints for managing additional work requests and approvals"
+    },
+    {
+      "name": "Estimate API",
+      "description": "Endpoints for estimate management and approval workflow"
+    },
+    {
+      "name": "WIP Dashboard",
+      "description": "Endpoints for Work-In-Progress status visibility"
+    },
+    {
+      "name": "Time Entry API",
+      "description": "Endpoints for approving and rejecting submitted time entries"
+    }
+  ],
+  "paths": {
+    "/v1/workorders/{workorderId}/technician": {
+      "get": {
+        "tags": [
+          "Technician Assignment API"
+        ],
+        "summary": "Get technician assignment",
+        "description": "Retrieve the current technician assignment and full assignment history for a workorder.",
+        "operationId": "getTechnicianAssignment",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the workorder",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Assignment retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder not found or no assignment exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:view"
+        ]
+      },
+      "put": {
+        "tags": [
+          "Technician Assignment API"
+        ],
+        "summary": "Reassign workorder to different technician",
+        "description": "Reassign a workorder to a different technician. Records reassignment reason and maintains history.",
+        "operationId": "reassignTechnician",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the workorder",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key to prevent duplicate reassignments",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "tech-reassign-550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "requestBody": {
+          "description": "Reassign technician request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReassignTechnicianRequest"
+              },
+              "examples": {
+                "reassignTechnician": {
+                  "description": "reassignTechnician",
+                  "value": {
+                    "newTechnicianId": "550e8400-e29b-41d4-a716-446655440121",
+                    "reassignedByUserId": "550e8400-e29b-41d4-a716-446655440100",
+                    "reason": "Scheduling conflict",
+                    "notes": "Reassigned due to availability"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Technician reassigned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid state transition or no current assignment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:assign-technician"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:assign-technician"
+        ]
+      },
+      "post": {
+        "tags": [
+          "Technician Assignment API"
+        ],
+        "summary": "Assign technician to workorder",
+        "description": "Assign a technician to a work order. Transitions workorder to ASSIGNED status if currently APPROVED.",
+        "operationId": "assignTechnician",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the workorder",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key to prevent duplicate assignments",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "tech-assign-550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "requestBody": {
+          "description": "Assign technician request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignTechnicianRequest"
+              },
+              "examples": {
+                "assignTechnician": {
+                  "description": "assignTechnician",
+                  "value": {
+                    "technicianId": "550e8400-e29b-41d4-a716-446655440120",
+                    "assignedByUserId": "550e8400-e29b-41d4-a716-446655440100",
+                    "notes": "Primary technician assigned"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Technician assigned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid state transition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or technician not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TechnicianAssignmentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:assign-technician"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:assign-technician"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/labor/{entryId}/adjust": {
+      "put": {
+        "tags": [
+          "Workorder Labor API"
+        ],
+        "summary": "Adjust labor hours",
+        "description": "Manually adjust hours worked on a labor entry with a reason for audit trail.",
+        "operationId": "adjustLaborHours",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the workorder",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "description": "ID of the labor entry to adjust",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440100"
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key to prevent duplicate adjustments",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "labor-adjust-550e8400-e29b-41d4-a716-446655440100"
+          }
+        ],
+        "requestBody": {
+          "description": "Adjust labor request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdjustLaborRequest"
+              },
+              "examples": {
+                "adjustLabor": {
+                  "description": "adjustLabor",
+                  "value": {
+                    "hoursWorked": 2.5,
+                    "adjustmentReason": "Corrected after timesheet review"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Labor hours adjusted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid hours value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Labor entry not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add"
+        ]
+      }
+    },
+    "/v1/workexec/approvalConfigurations/{approvalId}": {
+      "get": {
+        "tags": [
+          "Approval Configuration API"
+        ],
+        "summary": "Get configuration by ID",
+        "description": "Retrieve an approval configuration by its unique ID.",
+        "operationId": "getConfigurationById",
+        "parameters": [
+          {
+            "name": "approvalId",
+            "in": "path",
+            "description": "ID of the configuration to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Configuration found and returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalConfigurationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Configuration not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalConfigurationResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:approval_config:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:approval_config:view"
+        ]
+      },
+      "put": {
+        "tags": [
+          "Approval Configuration API"
+        ],
+        "summary": "Update an approval configuration",
+        "description": "Update an existing approval configuration.",
+        "operationId": "updateConfiguration",
+        "parameters": [
+          {
+            "name": "approvalId",
+            "in": "path",
+            "description": "ID of the configuration to update",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Updated configuration object",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalConfigurationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Configuration updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalConfigurationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Configuration not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalConfigurationResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:approval_config:edit"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:approval_config:edit"
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Approval Configuration API"
+        ],
+        "summary": "Delete an approval configuration",
+        "description": "Delete a configuration by its unique ID.",
+        "operationId": "deleteConfiguration",
+        "parameters": [
+          {
+            "name": "approvalId",
+            "in": "path",
+            "description": "ID of the configuration to delete",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Configuration deleted successfully."
+          },
+          "404": {
+            "description": "Configuration not found."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:approval_config:delete"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:approval_config:delete"
+        ]
+      }
+    },
+    "/v1/workorders": {
+      "get": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Get all work orders",
+        "description": "Retrieve a list of all work orders.",
+        "operationId": "getAllWorkorders",
+        "responses": {
+          "200": {
+            "description": "List of work orders returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:view"
+        ]
+      },
+      "post": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Create a new work order",
+        "description": "Add a new work order to the system. Supports idempotent creation via Idempotency-Key header to prevent duplicate workorders.",
+        "operationId": "createWorkorder",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key to prevent duplicate creation (recommended for retries)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "workorder-create-550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Work order creation request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkorderRequest"
+              },
+              "examples": {
+                "createWorkorder": {
+                  "description": "createWorkorder",
+                  "value": {
+                    "estimateId": "550e8400-e29b-41d4-a716-446655440001",
+                    "customerId": "550e8400-e29b-41d4-a716-446655440010"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Work order created successfully, or existing work order returned if idempotency key was previously processed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/suggestSubstitutes": {
+      "post": {
+        "tags": [
+          "Substitute Link API"
+        ],
+        "summary": "Suggest workorder substitutes",
+        "description": "Suggest substitute parts for a workorder based on the parts currently required",
+        "operationId": "suggestSubstitutes",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Substitute suggestions returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SubstituteLinkResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/start": {
+      "post": {
+        "tags": [
+          "Operational Context"
+        ],
+        "summary": "Start work on workorder, locking operational context",
+        "description": "Transitions the workorder into active execution and locks operational context to prevent further overrides.",
+        "operationId": "startWork",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartWorkorderRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Work started, context locked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderStartResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Cannot start workorder due to pending change requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderStartResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderStartResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Work already started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderStartResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:start"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:start"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/services/{serviceLineId}/complete": {
+      "post": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Complete a workorder service line",
+        "description": "Mark a single service line as COMPLETED. Allowed from OPEN/READY_TO_EXECUTE/IN_PROGRESS; rejected for CANCELLED or PENDING_APPROVAL items.",
+        "operationId": "completeServiceItem",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "serviceLineId",
+            "in": "path",
+            "description": "Service line ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service line completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderItemCompletionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Item not completable in its current status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderItemCompletionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or service line not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderItemCompletionResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:complete"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:complete"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/services/{serviceId}/labor/start": {
+      "post": {
+        "tags": [
+          "Workorder Labor API"
+        ],
+        "summary": "Start labor session",
+        "description": "Start tracking labor on a specific service item. Only one active session allowed per service.",
+        "operationId": "startLaborSession",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the workorder",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          {
+            "name": "serviceId",
+            "in": "path",
+            "description": "ID of the service item",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440010"
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key to prevent duplicate starts",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "labor-start-550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "requestBody": {
+          "description": "Start labor request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartLaborRequest"
+              },
+              "examples": {
+                "startLabor": {
+                  "description": "startLabor",
+                  "value": {
+                    "technicianId": "550e8400-e29b-41d4-a716-446655440120",
+                    "notes": "Starting diagnostic work"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Labor session started successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Idempotent request - existing session returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid state - active session exists or invalid status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or service not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/reopen": {
+      "post": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Reopen completed workorder",
+        "description": "Controlled reopen for completed workorders. Requires elevated permission and mandatory reason.",
+        "operationId": "reopenWorkorder",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the completed workorder to reopen",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Reopen workorder request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReopenWorkorderRequest"
+              },
+              "examples": {
+                "reopenWorkorder": {
+                  "description": "reopenWorkorder",
+                  "value": {
+                    "reopenReason": "Customer requested additional work"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Workorder reopened successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReopenWorkorderResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Workorder cannot be reopened or reason missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReopenWorkorderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work order not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReopenWorkorderResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:reopen_completed"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:reopen_completed"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/picked-items:consume": {
+      "post": {
+        "tags": [
+          "Workorder Picked Items"
+        ],
+        "summary": "Consume picked items into workorder",
+        "description": "Consume the picked items for a workorder so parts usage is recorded against the job",
+        "operationId": "consumePickedItems",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConsumePickedItemsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Picked items consumed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumePickedItemsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:parts:consume"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:parts:consume"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/pick-tasks/{pickTaskId}:resolve-scan": {
+      "post": {
+        "tags": [
+          "Workorder Pick Facade"
+        ],
+        "summary": "Resolve scan for pick task",
+        "description": "Resolve a scanned item for a workorder pick task before confirming fulfillment",
+        "operationId": "resolveScan",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "pickTaskId",
+            "in": "path",
+            "description": "Pick task ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveScanRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Scan resolved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolveScanResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or pick task not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "inventory:pick_list:execute"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "inventory:pick_list:execute"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/pick-tasks/{pickTaskId}:complete": {
+      "post": {
+        "tags": [
+          "Workorder Pick Facade"
+        ],
+        "summary": "Complete pick task",
+        "description": "Complete a workorder pick task after all of its pick lines are confirmed",
+        "operationId": "completePickTask",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "pickTaskId",
+            "in": "path",
+            "description": "Pick task ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "requestBody": {
+          "description": "Completion details; omit or send {} if no reason is provided",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompletePickTaskRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pick task completed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPickTaskResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or pick task not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "inventory:pick_list:execute"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "inventory:pick_list:execute"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/pick-tasks/{pickTaskId}/lines/{pickLineId}:confirm": {
+      "post": {
+        "tags": [
+          "Workorder Pick Facade"
+        ],
+        "summary": "Confirm pick line quantity",
+        "description": "Confirm the picked quantity for a workorder pick line after scan resolution",
+        "operationId": "confirmPickLine",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "pickTaskId",
+            "in": "path",
+            "description": "Pick task ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          {
+            "name": "pickLineId",
+            "in": "path",
+            "description": "Pick line ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440002"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmPickLineRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Pick line confirmed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPickTaskResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder, pick task, or pick line not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Scan mismatch or domain validation error from pos-inventory",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "inventory:pick_list:execute"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "inventory:pick_list:execute"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/parts/{partId}/complete": {
+      "post": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Complete a workorder part",
+        "description": "Mark a single part as COMPLETED. Allowed from OPEN/READY_TO_EXECUTE/IN_PROGRESS; rejected for CANCELLED or PENDING_APPROVAL items.",
+        "operationId": "completePartItem",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "partId",
+            "in": "path",
+            "description": "Part ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Part completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderItemCompletionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Item not completable in its current status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderItemCompletionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or part not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderItemCompletionResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:complete"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:complete"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/parts/substitute": {
+      "post": {
+        "tags": [
+          "Workorder Part Adjustments"
+        ],
+        "summary": "Substitute part",
+        "description": "Replace one part with another. Original part preserved for history.",
+        "operationId": "substitutePart",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Substitute part request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubstitutePartRequest"
+              },
+              "examples": {
+                "substitutePart": {
+                  "description": "substitutePart",
+                  "value": {
+                    "originalPartId": "550e8400-e29b-41d4-a716-446655440050",
+                    "substitutePartId": "550e8400-e29b-41d4-a716-446655440051",
+                    "reason": "Supplier substitution",
+                    "notes": "Equivalent OEM part"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Part substituted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (part already consumed, etc.)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or part not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:parts:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:parts:add"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/parts/return": {
+      "post": {
+        "tags": [
+          "Workorder Parts Usage"
+        ],
+        "summary": "Return unused parts to inventory",
+        "description": "Return unused parts after partial consumption or service completion",
+        "operationId": "returnParts",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Return part request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReturnPartRequest"
+              },
+              "examples": {
+                "returnParts": {
+                  "description": "returnParts",
+                  "value": {
+                    "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
+                    "quantity": 1
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Parts returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (exceeds available quantity, etc.)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or part not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:parts:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:parts:add"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/parts/returnUnused": {
+      "post": {
+        "tags": [
+          "Workorder Part Adjustments"
+        ],
+        "summary": "Return unused quantity",
+        "description": "Return unused part quantity beyond normal return flow",
+        "operationId": "returnUnusedQuantity",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Return unused quantity request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReturnPartQuantityRequest"
+              },
+              "examples": {
+                "returnUnused": {
+                  "description": "returnUnused",
+                  "value": {
+                    "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
+                    "quantity": 1,
+                    "reason": "Unused after repair",
+                    "notes": "Returned to stock"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Unused quantity returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (exceeds available quantity, etc.)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or part not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:parts:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:parts:add"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/parts/issue": {
+      "post": {
+        "tags": [
+          "Workorder Parts Usage"
+        ],
+        "summary": "Issue parts to workorder",
+        "description": "Issue parts from inventory, reserving them for consumption on the workorder",
+        "operationId": "issueParts",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Issue part request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IssuePartRequest"
+              },
+              "examples": {
+                "issueParts": {
+                  "description": "issueParts",
+                  "value": {
+                    "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
+                    "quantity": 2
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Parts issued successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (negative quantity, etc.)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or part not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict (duplicate key)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:parts:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:parts:add"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/parts/correct": {
+      "post": {
+        "tags": [
+          "Workorder Part Adjustments"
+        ],
+        "summary": "Correct part quantity",
+        "description": "Administrative correction for data entry errors",
+        "operationId": "correctPartQuantity",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Correct part quantity request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CorrectPartQuantityRequest"
+              },
+              "examples": {
+                "correctPartQuantity": {
+                  "description": "correctPartQuantity",
+                  "value": {
+                    "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
+                    "newQuantity": 3,
+                    "reason": "Data correction",
+                    "notes": "Corrected after inventory count"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Part quantity corrected successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or part not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:parts:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:parts:add"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/parts/consume": {
+      "post": {
+        "tags": [
+          "Workorder Parts Usage"
+        ],
+        "summary": "Consume parts on workorder",
+        "description": "Record actual consumption of parts. Quantity consumed cannot exceed quantity issued.",
+        "operationId": "consumeParts",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Consume part request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConsumePartRequest"
+              },
+              "examples": {
+                "consumeParts": {
+                  "description": "consumeParts",
+                  "value": {
+                    "workorderPartId": "550e8400-e29b-41d4-a716-446655440050",
+                    "quantity": 1
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Parts consumption recorded successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request (exceeds issued quantity, etc.)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or part not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:parts:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:parts:add"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/operationalContext/override": {
+      "post": {
+        "tags": [
+          "Operational Context"
+        ],
+        "summary": "Manager override of operational context",
+        "description": "Applies a manager-authorized override to operational context values before work starts; request is rejected once context is locked.",
+        "operationId": "overrideOperationalContext",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OperationalContextOverrideRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Override applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationalContextResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationalContextResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Context locked (work started)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationalContextResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:operationalContext:override"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:operationalContext:override"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/labor/{entryId}/stop": {
+      "post": {
+        "tags": [
+          "Workorder Labor API"
+        ],
+        "summary": "Stop labor session",
+        "description": "Stop an active labor session and calculate hours worked.",
+        "operationId": "stopLaborSession",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the workorder",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "description": "ID of the labor entry to stop",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440100"
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key to prevent duplicate stops",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "labor-stop-550e8400-e29b-41d4-a716-446655440100"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Labor session stopped successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Session already stopped",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Labor entry not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/generate-invoice": {
+      "post": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Generate invoice draft from completed workorder",
+        "description": "Generate an invoice draft from a completed workorder with optional idempotency key.",
+        "operationId": "generateInvoice",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the completed work order",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key to prevent duplicate invoice generation (recommended for retries)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "invoice-generate-550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Invoice generated successfully or existing invoice returned for idempotent replay.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceGenerationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work order not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceGenerationResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Work order is not in COMPLETED state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceGenerationResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:generate_invoice"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:generate_invoice"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/complete": {
+      "post": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Complete a work order",
+        "description": "Complete a work order, transitioning it to COMPLETED status and emitting a WorkCompleted event.",
+        "operationId": "completeWorkorder",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the work order to complete",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Complete workorder request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteWorkorderRequest"
+              },
+              "examples": {
+                "completeWorkorder": {
+                  "description": "completeWorkorder",
+                  "value": {
+                    "completionNotes": "Completed and verified"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Work order completed successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompleteWorkorderResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid state transition or work order already completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompleteWorkorderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work order not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompleteWorkorderResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:complete"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:complete"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/changeRequests": {
+      "get": {
+        "tags": [
+          "Change Request API"
+        ],
+        "summary": "Get all change requests for a work order",
+        "description": "Retrieve all change requests associated with a specific work order",
+        "operationId": "getChangeRequestsByWorkorder",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the work order",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of change requests returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChangeRequestResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:change_request:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:change_request:view"
+        ]
+      },
+      "post": {
+        "tags": [
+          "Change Request API"
+        ],
+        "summary": "Create a change request",
+        "description": "Technician creates a request for additional work beyond authorized scope. Items are marked as PENDING_APPROVAL until advisor approves. Requires description and at least one service or part item. Supports idempotent creation via Idempotency-Key header to prevent duplicate change requests.",
+        "operationId": "createChangeRequest",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the work order",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key to prevent duplicate creation (recommended for retries)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "change-request-create-550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Change request details including items",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateChangeRequestDTO"
+              },
+              "examples": {
+                "createChangeRequest": {
+                  "description": "createChangeRequest",
+                  "value": {
+                    "description": "Customer requested additional diagnostics",
+                    "approvalGated": true
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Change request created successfully, or existing change request returned if idempotency key was previously processed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - missing description, no items, or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work order not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:change_request:create"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:change_request:create"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/approval": {
+      "post": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Approve a work order with customer signature",
+        "description": "Transition work order to APPROVED status with customer signature capture. Work order can be approved from DRAFT status. Requires customer ID validation and signature data (base64-encoded image).",
+        "operationId": "approveWorkorder",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the work order to approve",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Approval request with customer ID and signature capture",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApproveWorkorderRequest"
+              },
+              "examples": {
+                "approveWorkorder": {
+                  "description": "approveWorkorder",
+                  "value": {
+                    "customerId": "550e8400-e29b-41d4-a716-446655440010",
+                    "signatureData": "base64-signature",
+                    "signatureMimeType": "image/png",
+                    "signerName": "Jane Customer",
+                    "notes": "Approved by customer"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Work order approved successfully with signature captured.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Work order cannot be approved in current state or customer ID mismatch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work order not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:approve"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:approve"
+        ]
+      }
+    },
+    "/v1/workorders/workSessions/{workSessionId}/stop": {
+      "post": {
+        "tags": [
+          "Work Session API"
+        ],
+        "summary": "Stop a work session",
+        "description": "Technician stops an active work session. Records end time and transitions the session to COMPLETED status.",
+        "operationId": "stopWorkSession",
+        "parameters": [
+          {
+            "name": "workSessionId",
+            "in": "path",
+            "description": "ID of the work session to stop",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StopWorkSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Work session stopped successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - work session not active or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkSessionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkSessionResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "timekeeping:work_session:stop"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "timekeeping:work_session:stop"
+        ]
+      }
+    },
+    "/v1/workorders/workSessions/{workSessionId}/breaks": {
+      "post": {
+        "tags": [
+          "Work Session API"
+        ],
+        "summary": "Start a break segment",
+        "description": "Technician records the start of a break within an active work session.",
+        "operationId": "addBreakSegment",
+        "parameters": [
+          {
+            "name": "workSessionId",
+            "in": "path",
+            "description": "ID of the work session",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddBreakSegmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Break segment started successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BreakSegmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - work session not active or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BreakSegmentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BreakSegmentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "timekeeping:work_session:break_start"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "timekeeping:work_session:break_start"
+        ]
+      }
+    },
+    "/v1/workorders/workSessions/{workSessionId}/breaks/{breakSegmentId}/stop": {
+      "post": {
+        "tags": [
+          "Work Session API"
+        ],
+        "summary": "Stop a break segment",
+        "description": "Technician records the end of a break segment within an active work session.",
+        "operationId": "stopBreakSegment",
+        "parameters": [
+          {
+            "name": "workSessionId",
+            "in": "path",
+            "description": "ID of the work session",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "breakSegmentId",
+            "in": "path",
+            "description": "ID of the break segment to stop",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Break segment stopped successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BreakSegmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Break segment not active or work session invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BreakSegmentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work session or break segment not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BreakSegmentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "timekeeping:work_session:break_stop"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "timekeeping:work_session:break_stop"
+        ]
+      }
+    },
+    "/v1/workorders/workSessions/start": {
+      "post": {
+        "tags": [
+          "Work Session API"
+        ],
+        "summary": "Start a work session",
+        "description": "Technician starts a work session on a work order. Creates an IN_PROGRESS work session and records the start time.",
+        "operationId": "startWorkSession",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartWorkSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Work session started successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - missing required fields or work order not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkSessionResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "timekeeping:work_session:create"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "timekeeping:work_session:create"
+        ]
+      }
+    },
+    "/v1/workorders/travelSegments/{travelSegmentId}/stop": {
+      "post": {
+        "tags": [
+          "Travel Segment API"
+        ],
+        "summary": "Stop a travel segment",
+        "description": "Stop an active travel segment and record the final travel details",
+        "operationId": "stopTravelSegment",
+        "parameters": [
+          {
+            "name": "travelSegmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StopTravelSegmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TravelSegmentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add"
+        ]
+      }
+    },
+    "/v1/workorders/travelSegments/{travelSegmentId}/adjustments": {
+      "post": {
+        "tags": [
+          "Travel Segment API"
+        ],
+        "summary": "Create a post-approval adjustment for a travel segment",
+        "description": "Create an adjustment for a previously recorded travel segment after approval",
+        "operationId": "createAdjustment",
+        "parameters": [
+          {
+            "name": "travelSegmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTravelSegmentAdjustmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TravelSegmentAdjustmentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add"
+        ]
+      }
+    },
+    "/v1/workorders/travelSegments/submit/{mobileWorkAssignmentId}": {
+      "post": {
+        "tags": [
+          "Travel Segment API"
+        ],
+        "summary": "Submit travel segments for a mobile work assignment",
+        "description": "Submit recorded travel segments for a mobile work assignment for downstream processing",
+        "operationId": "submitTravelSegments",
+        "parameters": [
+          {
+            "name": "mobileWorkAssignmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitTravelSegmentsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TravelSegmentResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add"
+        ]
+      }
+    },
+    "/v1/workorders/travelSegments/start": {
+      "post": {
+        "tags": [
+          "Travel Segment API"
+        ],
+        "summary": "Start a travel segment",
+        "description": "Start a travel segment for a technician beginning travel related to work execution",
+        "operationId": "startTravelSegment",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartTravelSegmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TravelSegmentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add"
+        ]
+      }
+    },
+    "/v1/workorders/timeEntries/{timeEntryId}/reject": {
+      "post": {
+        "tags": [
+          "Time Entry API"
+        ],
+        "summary": "Reject a time entry in SUBMITTED state",
+        "description": "Reject a submitted time entry and record the rejection details for follow-up",
+        "operationId": "rejectTimeEntry",
+        "parameters": [
+          {
+            "name": "timeEntryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RejectTimeEntryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeEntryResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:timeEntry:reject"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:timeEntry:reject"
+        ]
+      }
+    },
+    "/v1/workorders/timeEntries/{timeEntryId}/approve": {
+      "post": {
+        "tags": [
+          "Time Entry API"
+        ],
+        "summary": "Approve a time entry in SUBMITTED state",
+        "description": "Approve a submitted time entry so it can move forward in the workorder timekeeping workflow",
+        "operationId": "approveTimeEntry",
+        "parameters": [
+          {
+            "name": "timeEntryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeEntryResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:timeEntry:approve"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:timeEntry:approve"
+        ]
+      }
+    },
+    "/v1/workorders/numbers:resolve": {
+      "post": {
+        "tags": [
+          "Workorder Search"
+        ],
+        "summary": "Resolve workorder numbers",
+        "description": "Batch-resolves a set of workorder ids to their human workorder numbers. Consumed server-side by sibling services that store only the workorder id and need the human number for finder/search enrichment.",
+        "operationId": "resolveNumbers",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkorderNumberResolveRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Resolved workorder id-to-number pairings returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderNumberRef"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:view"
+        ]
+      }
+    },
+    "/v1/workorders/estimates": {
+      "get": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Get all estimates",
+        "description": "Retrieve a list of all estimates.",
+        "operationId": "getAllEstimates",
+        "responses": {
+          "200": {
+            "description": "List of estimates returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EstimateResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:view"
+        ]
+      },
+      "post": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Create a new draft estimate",
+        "description": "Create a new estimate in DRAFT status for a customer and vehicle. Requires ESTIMATE_CREATE permission. System will generate a unique estimate number and apply default values for location, currency, and tax region if not provided.",
+        "operationId": "createEstimate",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key for safe retries",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "estimate-create-550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Estimate creation request with customer and vehicle IDs",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEstimateRequest"
+              },
+              "examples": {
+                "createEstimate": {
+                  "description": "createEstimate",
+                  "value": {
+                    "customerId": "550e8400-e29b-41d4-a716-446655440010",
+                    "vehicleId": "550e8400-e29b-41d4-a716-446655440011",
+                    "locationId": "550e8400-e29b-41d4-a716-446655440020"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Estimate created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - missing required fields.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - user does not have ESTIMATE_CREATE permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict - estimate could not be created due to state or integrity constraints.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - unexpected estimate creation failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:create"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:create"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/submit-for-approval": {
+      "post": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Submit estimate for customer approval",
+        "description": "Submit a DRAFT estimate for customer approval. Creates immutable snapshot and transitions to PENDING_APPROVAL state. Validates completeness (has customer, vehicle, line items, calculated totals). CAP:003 Issue #168 - Submit Estimate for Customer Approval",
+        "operationId": "submitForApproval",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "ID of the estimate to submit",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Estimate submitted for approval successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Estimate is incomplete or not in DRAFT state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:submit"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:submit"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/snapshots": {
+      "post": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Create historical snapshot",
+        "description": "Capture an immutable snapshot of the estimate's complete state (estimate + all line items) for audit trail and version history purposes.",
+        "operationId": "createEstimateSnapshot",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "Estimate ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "notes",
+            "in": "query",
+            "description": "Optional notes about why snapshot was created",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Snapshot captured before approval"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Snapshot created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateSnapshotResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateSnapshotResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Snapshot creation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateSnapshotResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate_snapshot:create"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate_snapshot:create"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/reopen": {
+      "post": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Reopen a declined estimate",
+        "description": "Transition a declined estimate back to DRAFT state. Can only be done within the configured expiry period.",
+        "operationId": "reopenEstimate",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "ID of the estimate to reopen",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Estimate reopened successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Estimate cannot be reopened (not declined or expired).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:reopen"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:reopen"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/promote": {
+      "post": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Promote approved estimate to workorder",
+        "description": "Promote an approved estimate to a workorder. Validates preconditions: estimate must be APPROVED, not expired, have approved items, and not already promoted. Returns 409 ALREADY_PROMOTED with existingWorkorderId if estimate was previously promoted (idempotency). CAP:004 Story #26 - Create a workorder from approved estimate.",
+        "operationId": "promoteEstimateToWorkorder",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "ID of the estimate to promote",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Idempotency-Key header for safe retries",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "estimate-promote-550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Workorder created successfully from estimate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error - estimate not in correct state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Estimate already promoted (ALREADY_PROMOTED) or approval invalid/expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:promote"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:promote"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/items": {
+      "post": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Add line item to estimate",
+        "description": "Add a part or labor line item to a draft estimate. Estimate must be in DRAFT status. For PART items, provide productId or description. For LABOR items, provide serviceId or description.",
+        "operationId": "addEstimateItem",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "Estimate ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Line item details",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddEstimateItemRequest"
+              },
+              "examples": {
+                "addEstimateItem": {
+                  "description": "addEstimateItem",
+                  "value": {
+                    "itemType": "LABOR",
+                    "description": "Brake inspection",
+                    "quantity": 1,
+                    "unitPrice": 129.99,
+                    "taxCode": "LABOR_STANDARD"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Line item added successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateItemResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error or invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateItemResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateItemResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Estimate not in DRAFT status (INVALID_STATE)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateItemResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate_item:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate_item:add"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/decline": {
+      "post": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Decline an estimate",
+        "description": "Transition estimate to declined state. Estimate can be declined from DRAFT or APPROVED status.",
+        "operationId": "declineEstimate",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "ID of the estimate to decline",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "reason",
+            "in": "query",
+            "description": "Reason for decline",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Customer declined additional work"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Estimate declined successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Estimate cannot be declined in current state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:decline"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:decline"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/calculate": {
+      "post": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Calculate taxes and totals",
+        "description": "Calculate subtotal, tax amount, and total for an estimate based on its line items. Estimate must be in DRAFT status. Uses stub tax calculation (8.25% flat rate) pending pos-accounting integration.",
+        "operationId": "calculateEstimateTotals",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "Estimate ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Totals calculated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Estimate not in DRAFT status (INVALID_STATE)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:calculate"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:calculate"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/approval": {
+      "post": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Approve an estimate with customer signature",
+        "description": "Transition estimate to approved state with customer signature capture. Estimate can be approved from DRAFT status. Requires customer ID validation and signature data (base64-encoded image). For commercial accounts with PO enforcement enabled, a purchase order number must be provided (CAP:092 Story #98).",
+        "operationId": "approveEstimate",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "ID of the estimate to approve",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Approval request with customer ID, signature capture, and optional selective line item approvals",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApproveEstimateRequest"
+              },
+              "examples": {
+                "approveEstimate": {
+                  "description": "approveEstimate",
+                  "value": {
+                    "customerId": "550e8400-e29b-41d4-a716-446655440010",
+                    "signatureData": "base64-signature",
+                    "signatureMimeType": "image/png",
+                    "signerName": "Jane Customer",
+                    "notes": "Approved estimate",
+                    "purchaseOrderNumber": "PO-12345"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Estimate approved successfully with signature captured.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Estimate cannot be approved in current state, customer ID mismatch, or PO required but not provided.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:approve"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:approve"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/from-appointment": {
+      "post": {
+        "tags": [
+          "Estimates from Appointments"
+        ],
+        "summary": "Create draft estimate from appointment",
+        "description": "Creates a new DRAFT estimate from an appointment. Idempotent: returns existing estimate if appointmentId already has one.",
+        "operationId": "createEstimateFromAppointment",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEstimateFromAppointmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Estimate created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEstimateFromAppointmentResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Existing estimate returned (idempotent)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEstimateFromAppointmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid required fields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEstimateFromAppointmentResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEstimateFromAppointmentResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEstimateFromAppointmentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workorders/changeRequests/{changeId}/emergency-override": {
+      "post": {
+        "tags": [
+          "Change Request API"
+        ],
+        "summary": "Apply emergency override",
+        "description": "Manager applies emergency override to approve a change request with exception. Requires Manager role and a valid exception reason. Items move from PENDING_APPROVAL to READY_TO_EXECUTE status.",
+        "operationId": "applyEmergencyOverride",
+        "parameters": [
+          {
+            "name": "changeId",
+            "in": "path",
+            "description": "ID of the change request",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Emergency override details including manager ID and reason",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmergencyOverrideDTO"
+              },
+              "examples": {
+                "emergencyOverride": {
+                  "description": "emergencyOverride",
+                  "value": {
+                    "managerId": "550e8400-e29b-41d4-a716-446655440110",
+                    "exceptionReason": "Safety-critical repair authorized"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Emergency override applied successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Cannot apply override - invalid state or missing reason",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions - Manager role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Change request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:change_request:emergency_override"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:change_request:emergency_override"
+        ]
+      }
+    },
+    "/v1/workorders/changeRequests/{changeId}/decline": {
+      "post": {
+        "tags": [
+          "Change Request API"
+        ],
+        "summary": "Decline a change request",
+        "description": "Service Advisor declines the change request. Items move from PENDING_APPROVAL to CANCELLED status (not billable). Approval note is required to record the decline decision.",
+        "operationId": "declineChangeRequest",
+        "parameters": [
+          {
+            "name": "changeId",
+            "in": "path",
+            "description": "ID of the change request",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Decline details including note",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeclineChangeRequestDTO"
+              },
+              "examples": {
+                "declineChangeRequest": {
+                  "description": "declineChangeRequest",
+                  "value": {
+                    "approvalNote": "Declined by customer"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Change request declined successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Cannot decline - invalid state or missing note",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Change request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:change_request:decline"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:change_request:decline"
+        ]
+      }
+    },
+    "/v1/workorders/changeRequests/{changeId}/approve": {
+      "post": {
+        "tags": [
+          "Change Request API"
+        ],
+        "summary": "Approve a change request",
+        "description": "Service Advisor approves the change request. Items move from PENDING_APPROVAL to READY_TO_EXECUTE status. Approval note is required as the approval artifact.",
+        "operationId": "approveChangeRequest",
+        "parameters": [
+          {
+            "name": "changeId",
+            "in": "path",
+            "description": "ID of the change request",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "requestBody": {
+          "description": "Approval details including user ID and note",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApproveChangeRequestDTO"
+              },
+              "examples": {
+                "approveChangeRequest": {
+                  "description": "approveChangeRequest",
+                  "value": {
+                    "approvedBy": "550e8400-e29b-41d4-a716-446655440100",
+                    "approvalNote": "Approved after customer confirmation"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Change request approved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Cannot approve - invalid state or missing approval note",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Change request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:change_request:approve"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:change_request:approve"
+        ]
+      }
+    },
+    "/v1/workorders/changeRequests/{changeId}/acknowledgeDenial": {
+      "post": {
+        "tags": [
+          "Change Request API"
+        ],
+        "summary": "Record customer denial acknowledgment",
+        "description": "For declined emergency/safety items, record that customer acknowledged the denial. Required before closing the work order and returning the vehicle.",
+        "operationId": "recordCustomerDenialAcknowledgment",
+        "parameters": [
+          {
+            "name": "changeId",
+            "in": "path",
+            "description": "ID of the change request",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Acknowledgment recorded successfully"
+          },
+          "400": {
+            "description": "Not an emergency request or invalid state"
+          },
+          "404": {
+            "description": "Change request not found"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workexec/time-entries/timer/stop": {
+      "post": {
+        "tags": [
+          "Workexec Time Tracking API"
+        ],
+        "summary": "Stop timers",
+        "description": "Stop active timer entries for the authenticated mechanic",
+        "operationId": "stopTimers",
+        "responses": {
+          "200": {
+            "description": "Timers stopped successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkexecTimerStopResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid authenticated user id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict while stopping timers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add"
+        ]
+      }
+    },
+    "/v1/workexec/time-entries/timer/start": {
+      "post": {
+        "tags": [
+          "Workexec Time Tracking API"
+        ],
+        "summary": "Start timer",
+        "description": "Start a workexec timer entry for the authenticated mechanic",
+        "operationId": "startTimer",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional idempotency key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "timer-start-550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "requestBody": {
+          "description": "Timer start payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkexecTimerStartRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Timer started successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkexecTimerEntryResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Idempotent replay returned existing timer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkexecTimerEntryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid authenticated user id, or missing reason",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Attributing labor to another technician without workorder:labor:add_on_behalf",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Referenced resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict while starting timer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add",
+              "workorder:labor:add_on_behalf"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add",
+          "workorder:labor:add_on_behalf"
+        ]
+      }
+    },
+    "/v1/workexec/labor-performed": {
+      "post": {
+        "tags": [
+          "Workexec Time Tracking API"
+        ],
+        "summary": "Create labor performed entry",
+        "description": "Create a labor-performed record with idempotency support",
+        "operationId": "createLaborPerformed",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Idempotency key for safe retries",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "workexec-labor-550e8400-e29b-41d4-a716-446655440001"
+          },
+          {
+            "name": "X-Correlation-Id",
+            "in": "header",
+            "description": "Optional correlation id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "corr-12345"
+          }
+        ],
+        "requestBody": {
+          "description": "Labor-performed payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkexecLaborPerformedRequest"
+              },
+              "example": {
+                "workorderId": "550e8400-e29b-41d4-a716-446655440001"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Labor entry created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkexecLaborPerformedResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Idempotent replay returned existing labor entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkexecLaborPerformedResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Related resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict while recording labor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:add"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:add"
+        ]
+      }
+    },
+    "/v1/workexec/approvalConfigurations": {
+      "post": {
+        "tags": [
+          "Approval Configuration API"
+        ],
+        "summary": "Create a new approval configuration",
+        "description": "Add a new approval configuration.",
+        "operationId": "createConfiguration",
+        "requestBody": {
+          "description": "Configuration object to be created",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalConfigurationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Configuration created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalConfigurationResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:approval_config:create"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:approval_config:create"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}": {
+      "get": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Get estimate by ID",
+        "description": "Retrieve an estimate by its unique ID.",
+        "operationId": "getEstimateById",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "ID of the estimate to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Estimate found and returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:view"
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Delete an estimate",
+        "description": "Delete an estimate by its unique ID.",
+        "operationId": "deleteEstimate",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "ID of the estimate to delete",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Estimate deleted successfully."
+          },
+          "404": {
+            "description": "Estimate not found."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:delete"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:delete"
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Patch estimate status",
+        "description": "Patch the status of an estimate by applying an allowed workflow transition",
+        "operationId": "patchEstimateStatus",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Estimate status updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Estimate patch request is invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Estimate transition is not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:edit"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:edit"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/items/{itemId}": {
+      "delete": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Remove line item",
+        "description": "Remove a line item from a draft estimate (soft delete). Estimate must be in DRAFT status.",
+        "operationId": "deleteEstimateItem",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "Estimate ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "description": "Item ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Line item removed successfully"
+          },
+          "404": {
+            "description": "Estimate or item not found"
+          },
+          "409": {
+            "description": "Estimate not in DRAFT status (INVALID_STATE)"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate_item:delete"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate_item:delete"
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Update line item",
+        "description": "Update an existing line item on a draft estimate. Estimate must be in DRAFT status. Only provided fields will be updated.",
+        "operationId": "updateEstimateItem",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "Estimate ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "description": "Item ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "requestBody": {
+          "description": "Updated item fields",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEstimateItemRequest"
+              },
+              "examples": {
+                "updateEstimateItem": {
+                  "description": "updateEstimateItem",
+                  "value": {
+                    "description": "Brake inspection and adjustment",
+                    "quantity": 1,
+                    "unitPrice": 149.99,
+                    "taxCode": "LABOR_STANDARD"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Line item updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateItemResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error or invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateItemResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate or item not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateItemResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Estimate not in DRAFT status (INVALID_STATE)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateItemResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate_item:edit"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate_item:edit"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}": {
+      "get": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Get work order by ID",
+        "description": "Retrieve a work order by its unique ID.",
+        "operationId": "getWorkorderById",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the work order to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Work order found and returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work order not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:view"
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Delete a work order",
+        "description": "Delete a work order by its unique ID.",
+        "operationId": "deleteWorkorder",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the work order to delete",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Work order deleted successfully."
+          },
+          "404": {
+            "description": "Work order not found."
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/transitions": {
+      "get": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Get transition history",
+        "description": "Retrieve the state transition history for a work order.",
+        "operationId": "getTransitionHistory",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the work order",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transition history returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderStateTransitionResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/snapshots": {
+      "get": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Get snapshot history",
+        "description": "Retrieve the snapshot history for a work order.",
+        "operationId": "getSnapshotHistory",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the work order",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Snapshot history returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderSnapshotResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/picked-items": {
+      "get": {
+        "tags": [
+          "Workorder Picked Items"
+        ],
+        "summary": "Get picked items for workorder",
+        "description": "Retrieve the items already picked for a workorder before they are consumed",
+        "operationId": "getPickedItems",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Picked items retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "additionalProperties": {},
+                  "contains": {},
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderPickedItemResponse"
+                  },
+                  "unevaluatedItems": {}
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "inventory:pick_list:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "inventory:pick_list:view"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/pick-list": {
+      "get": {
+        "tags": [
+          "Workorder Pick Facade"
+        ],
+        "summary": "Get pick list for workorder",
+        "description": "Retrieve the pick list for a workorder so parts can be staged and fulfilled",
+        "operationId": "getPickList",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pick list retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPickListResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "inventory:pick_list:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "inventory:pick_list:view"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/pick-list/tasks": {
+      "get": {
+        "tags": [
+          "Workorder Pick Facade"
+        ],
+        "summary": "Get pick tasks for workorder",
+        "description": "Retrieve the pick tasks for a workorder to guide pick-list execution",
+        "operationId": "getPickTasks",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pick tasks retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "additionalProperties": {},
+                  "contains": {},
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderPickTaskResponse"
+                  },
+                  "unevaluatedItems": {}
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "inventory:pick_list:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "inventory:pick_list:view"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/parts/usageHistory": {
+      "get": {
+        "tags": [
+          "Workorder Parts Usage"
+        ],
+        "summary": "Get parts usage history",
+        "description": "Retrieve usage history (issue, consume, return events) for parts on the workorder",
+        "operationId": "getUsageHistory",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "partLineId",
+            "in": "query",
+            "description": "Optional part line ID to filter history for a specific part",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440050"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage history retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or part not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderPartUsageEventResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:parts:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:parts:view"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/parts/adjustments": {
+      "get": {
+        "tags": [
+          "Workorder Part Adjustments"
+        ],
+        "summary": "Get part adjustment history",
+        "description": "Retrieve adjustment history (substitutions, returns, corrections) for parts on the workorder",
+        "operationId": "getAdjustmentHistory",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "partId",
+            "in": "query",
+            "description": "Optional part ID to filter history for a specific part",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440050"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Adjustment history retrieved successfully (newest first)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder or part not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderPartAdjustmentEventResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:parts:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:parts:view"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/operationalContext": {
+      "get": {
+        "tags": [
+          "Operational Context"
+        ],
+        "summary": "Get operational context for workorder",
+        "description": "Returns the current operational context for a workorder, including flags and source data used to drive execution decisions.",
+        "operationId": "getOperationalContext",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operational context returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationalContextResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationalContextResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/labor": {
+      "get": {
+        "tags": [
+          "Workorder Labor API"
+        ],
+        "summary": "Get labor history",
+        "description": "Retrieve all labor entries for a workorder, ordered newest first.",
+        "operationId": "getLaborHistory",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the workorder",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Labor history retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkorderLaborEntryResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:view"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/detail": {
+      "get": {
+        "tags": [
+          "Workorder Detail"
+        ],
+        "summary": "Get workorder detail with role-based visibility",
+        "description": "Returns comprehensive workorder detail. Financial fields are conditionally included based on user authorities. Capability flags indicate which actions the user can perform.",
+        "operationId": "getWorkorderDetail",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "Workorder ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Workorder detail retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderDetailResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workorder not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderDetailResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/completion-preconditions": {
+      "get": {
+        "tags": [
+          "Work Order API"
+        ],
+        "summary": "Validate completion preconditions",
+        "description": "Evaluate completion preconditions for a workorder and return checklist + blocking reasons.",
+        "operationId": "getCompletionPreconditions",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the workorder to validate",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Completion preconditions evaluated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompletionPreconditionsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work order not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompletionPreconditionsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:complete"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:complete"
+        ]
+      }
+    },
+    "/v1/workorders/{workorderId}/canClose": {
+      "get": {
+        "tags": [
+          "Change Request API"
+        ],
+        "summary": "Check if work order can be closed",
+        "description": "Verify all declined emergency/safety items have customer denial acknowledgment",
+        "operationId": "canCloseWorkorder",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "ID of the work order",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns true if work order can be closed, false otherwise",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-permissions": [
+          "AUTHENTICATED"
+        ]
+      }
+    },
+    "/v1/workorders/search": {
+      "get": {
+        "tags": [
+          "Workorder Search"
+        ],
+        "summary": "Search workorders",
+        "description": "Paginated free-text search for workorders matching customer name or workorder id.",
+        "operationId": "searchWorkorders",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Free-text query matching customer name or workorder id (optional)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageable",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Pageable"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of workorder search results returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageWorkorderSearchResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:workorder:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:workorder:view"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/summary": {
+      "get": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Get estimate summary (customer-facing)",
+        "description": "Retrieve a customer-facing summary of an estimate with grouped line items (parts and labor) and financial breakdown. Use the /{estimateId}/pdf endpoint to generate a PDF document.",
+        "operationId": "getEstimateSummary",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "Estimate ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Summary retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateSummaryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateSummaryResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:view"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/{estimateId}/pdf": {
+      "get": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Generate estimate PDF",
+        "description": "Generate a PDF document for an estimate containing header details, line items grouped by type (parts and labor), and financial totals. Rendered via pos-documents service.",
+        "operationId": "generateEstimatePdf",
+        "parameters": [
+          {
+            "name": "estimateId",
+            "in": "path",
+            "description": "Estimate ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PDF generated successfully",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estimate not found",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Document service unavailable",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:view"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/shop/{locationId}": {
+      "get": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Get estimates by shop",
+        "description": "Retrieve all estimates for a specific shop.",
+        "operationId": "getEstimatesByShop",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "path",
+            "description": "ID of the shop",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440020"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of estimates returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EstimateResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:view"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/location/{locationId}": {
+      "get": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Get estimates by location",
+        "description": "Retrieve all estimates for a specific location.",
+        "operationId": "getEstimatesByLocation",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "path",
+            "description": "ID of the location",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440020"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of estimates returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EstimateResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:view"
+        ]
+      }
+    },
+    "/v1/workorders/estimates/customer/{customerId}": {
+      "get": {
+        "tags": [
+          "Estimate API"
+        ],
+        "summary": "Get estimates by customer",
+        "description": "Retrieve all estimates for a specific customer.",
+        "operationId": "getEstimatesByCustomer",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "ID of the customer",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440010"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of estimates returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EstimateResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:view"
+        ]
+      }
+    },
+    "/v1/workorders/changeRequests/{changeId}": {
+      "get": {
+        "tags": [
+          "Change Request API"
+        ],
+        "summary": "Get change request by ID",
+        "description": "Retrieve details of a specific change request",
+        "operationId": "getChangeRequestById",
+        "parameters": [
+          {
+            "name": "changeId",
+            "in": "path",
+            "description": "ID of the change request",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Change request found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Change request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeRequestResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:change_request:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:change_request:view"
+        ]
+      }
+    },
+    "/v1/workexec": {
+      "get": {
+        "tags": [
+          "Approval Configuration API"
+        ],
+        "summary": "Get all approval configurations",
+        "description": "Retrieve a list of all approval configurations.",
+        "operationId": "getAllConfigurations",
+        "responses": {
+          "200": {
+            "description": "List of configurations returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ApprovalConfigurationResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:approval_config:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:approval_config:view"
+        ]
+      }
+    },
+    "/v1/workexec/wip": {
+      "get": {
+        "tags": [
+          "WIP Dashboard"
+        ],
+        "summary": "List active WIP workorders",
+        "description": "Returns a paginated list of workorders in active WIP statuses. When the caller holds workorder:wip:view_all_locations, results span all locations.",
+        "operationId": "listWip",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "query",
+            "description": "Location ID to filter workorders by",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "multiLocation",
+            "in": "query",
+            "description": "Request cross-location results; requires workorder:wip:view_all_locations",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageable",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Pageable"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageWorkorderStatusView"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:wip:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:wip:view"
+        ]
+      }
+    },
+    "/v1/workexec/wip/{workorderId}": {
+      "get": {
+        "tags": [
+          "WIP Dashboard"
+        ],
+        "summary": "Get WIP detail for a workorder",
+        "description": "Returns full WIP detail for a single workorder including status history.",
+        "operationId": "getWipDetail",
+        "parameters": [
+          {
+            "name": "workorderId",
+            "in": "path",
+            "description": "UUID of the workorder",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderStatusDetail"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:wip:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:wip:view"
+        ]
+      }
+    },
+    "/v1/workexec/time-entries/timer/active": {
+      "get": {
+        "tags": [
+          "Workexec Time Tracking API"
+        ],
+        "summary": "Get active timers",
+        "description": "Retrieve active timer entries for the authenticated mechanic",
+        "operationId": "getActiveTimerEntries",
+        "responses": {
+          "200": {
+            "description": "Active timers returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkexecTimerEntryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid authenticated user id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:view"
+        ]
+      }
+    },
+    "/v1/workexec/job-time-totals": {
+      "get": {
+        "tags": [
+          "Workexec Time Tracking API"
+        ],
+        "summary": "Get job time totals",
+        "description": "Retrieve aggregated tracked hours for a date range, timezone, and optional location/technicians",
+        "operationId": "getJobTimeTotals",
+        "parameters": [
+          {
+            "name": "startDate",
+            "in": "query",
+            "description": "Start date (inclusive)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2026-03-01"
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "description": "End date (inclusive)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2026-03-02"
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "description": "IANA timezone",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "America/New_York"
+          },
+          {
+            "name": "locationId",
+            "in": "query",
+            "description": "Optional location filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440010"
+          },
+          {
+            "name": "technicianIds",
+            "in": "query",
+            "description": "Optional technician filters",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": [
+              "550e8400-e29b-41d4-a716-446655440120"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job time totals returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:labor:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:labor:view"
+        ]
+      }
+    },
+    "/v1/workexec/estimates/search": {
+      "get": {
+        "tags": [
+          "Estimate Search"
+        ],
+        "summary": "Search estimates",
+        "description": "Paginated search for estimates filtered by optional customerId and/or vehicleId.",
+        "operationId": "searchEstimates",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Free-text query matching estimate number, customer name, or estimate id (optional)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "query",
+            "description": "Filter by customer UUID (optional)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vehicleId",
+            "in": "query",
+            "description": "Filter by vehicle UUID (optional)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageable",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Pageable"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of estimate summaries returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageEstimateSummaryResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:estimate:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:estimate:view"
+        ]
+      }
+    },
+    "/v1/workexec/dashboard/today": {
+      "get": {
+        "tags": [
+          "Daily Dispatch Board Dashboard"
+        ],
+        "summary": "Get daily dispatch dashboard",
+        "description": "Returns workorder, mechanic, bay, and conflict data for the given location and date",
+        "operationId": "getDashboard",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:dashboard:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:dashboard:view"
+        ]
+      }
+    },
+    "/v1/workexec/approvalConfigurations/applicable": {
+      "get": {
+        "tags": [
+          "Approval Configuration API"
+        ],
+        "summary": "Get applicable configuration",
+        "description": "Get the most specific configuration for a location and customer.",
+        "operationId": "getApplicableConfiguration",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "query",
+            "description": "Location ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440020"
+          },
+          {
+            "name": "customerId",
+            "in": "query",
+            "description": "Customer ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440010"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Configuration found and returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalConfigurationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No configuration found (default will be used).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalConfigurationResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "workorder:approval_config:view"
+            ]
+          }
+        ],
+        "x-required-permissions": [
+          "workorder:approval_config:view"
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AssignmentHistoryEntry": {
+        "type": "object",
+        "description": "Assignment history entry",
+        "properties": {
+          "technicianId": {
+            "type": "string",
+            "description": "Technician ID for this assignment period",
+            "example": "550e8400-e29b-41d4-a716-446655440050"
+          },
+          "technicianName": {
+            "type": "string",
+            "description": "Technician display name",
+            "example": "John Smith"
+          },
+          "assignedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the technician was assigned",
+            "example": "2024-01-27 14:30:00"
+          },
+          "assignedBy": {
+            "type": "string",
+            "description": "ID of user who assigned the technician",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "unassignedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the technician was unassigned (null for current assignment)",
+            "example": "2024-01-27 16:00:00"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason for reassignment/unassignment",
+            "example": "Technician called out sick"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Assignment notes",
+            "example": "Customer requested morning slot"
+          }
+        }
+      },
+      "TechnicianAssignmentResponse": {
+        "type": "object",
+        "description": "Technician assignment response",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "description": "Work order ID",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "technicianId": {
+            "type": "string",
+            "description": "Assigned technician ID",
+            "example": "550e8400-e29b-41d4-a716-446655440050"
+          },
+          "technicianName": {
+            "type": "string",
+            "description": "Technician display name",
+            "example": "John Smith"
+          },
+          "assignedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the technician was assigned",
+            "example": "2024-01-27 14:30:00"
+          },
+          "assignedBy": {
+            "type": "string",
+            "description": "ID of user who assigned the technician",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "previousTechnicianId": {
+            "type": "string",
+            "description": "Previous technician ID if this was a reassignment",
+            "example": "550e8400-e29b-41d4-a716-446655440049"
+          },
+          "previousTechnicianName": {
+            "type": "string",
+            "description": "Previous technician name if this was a reassignment",
+            "example": "Jane Doe"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the workorder after assignment",
+            "example": "ASSIGNED"
+          },
+          "message": {
+            "type": "string",
+            "description": "Operation result message",
+            "example": "Technician assigned successfully"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Assignment notes",
+            "example": "Customer requested morning slot"
+          },
+          "reassignmentReason": {
+            "type": "string",
+            "description": "Reason for reassignment if applicable",
+            "example": "Original technician called out sick"
+          },
+          "reassignedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When technician was reassigned",
+            "example": "2024-01-27 15:30:00"
+          },
+          "reassignedBy": {
+            "type": "string",
+            "description": "ID of user who performed reassignment",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "technicianCertifications": {
+            "type": "array",
+            "description": "Technician certifications",
+            "example": [
+              "ASE Master Technician",
+              "Brake Specialist"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "currentStatus": {
+            "type": "string",
+            "description": "Current workorder status",
+            "example": "WORK_IN_PROGRESS"
+          },
+          "assignmentHistory": {
+            "type": "array",
+            "description": "Full assignment history for the workorder",
+            "items": {
+              "$ref": "#/components/schemas/AssignmentHistoryEntry"
+            }
+          }
+        }
+      },
+      "ReassignTechnicianRequest": {
+        "type": "object",
+        "description": "Request to reassign a workorder to a different technician",
+        "properties": {
+          "newTechnicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the new technician",
+            "example": "550e8400-e29b-41d4-a716-446655440051"
+          },
+          "reassignedByUserId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the user performing the reassignment (defaults from X-User-Id header if not provided)",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason for reassignment",
+            "example": "Original technician unavailable, reassigning to available tech"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Additional notes for the reassignment",
+            "example": "Customer requested senior technician"
+          },
+          "notifyPreviousTechnician": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to send notification to previous technician",
+            "example": true
+          }
+        },
+        "required": [
+          "newTechnicianId"
+        ]
+      },
+      "WorkorderLaborEntryResponse": {
+        "type": "object",
+        "description": "Labor entry response",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique ID of the labor entry",
+            "example": "550e8400-e29b-41d4-a716-446655440100"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder ID",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "workorderServiceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Service line item ID",
+            "example": "550e8400-e29b-41d4-a716-446655440010"
+          },
+          "technicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Technician ID who performed the work",
+            "example": "550e8400-e29b-41d4-a716-446655440050"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Labor session start time",
+            "example": "2024-01-27 14:30:00"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Labor session end time (null if still active)",
+            "example": "2024-01-27 16:30:00"
+          },
+          "hoursWorked": {
+            "type": "number",
+            "description": "Hours worked",
+            "example": 2.0
+          },
+          "notes": {
+            "type": "string",
+            "description": "Session notes",
+            "example": "Brake pads replaced successfully"
+          },
+          "adjustmentReason": {
+            "type": "string",
+            "description": "Adjustment reason (if hours were manually adjusted)",
+            "example": "Corrected for break time"
+          },
+          "active": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this session is still active (not stopped)",
+            "example": false
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "User who created this entry",
+            "example": "system@syte.com"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp",
+            "example": "2024-01-27 14:30:00+00:00"
+          }
+        },
+        "required": [
+          "active",
+          "id",
+          "workorderId"
+        ]
+      },
+      "AdjustLaborRequest": {
+        "type": "object",
+        "description": "Request to manually adjust labor hours",
+        "properties": {
+          "hoursWorked": {
+            "type": "number",
+            "description": "Adjusted hours worked",
+            "example": 2.5
+          },
+          "adjustmentReason": {
+            "type": "string",
+            "description": "Reason for the adjustment",
+            "example": "Manual correction for break time"
+          }
+        },
+        "required": [
+          "adjustmentReason",
+          "hoursWorked"
+        ]
+      },
+      "ApprovalConfigurationRequest": {
+        "type": "object",
+        "description": "Request DTO for approval configuration creation and updates",
+        "properties": {
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Location ID for this configuration (null = applies to all locations)",
+            "example": "00000000-0000-0000-0000-000000000001"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer ID for this configuration (null = applies to all customers)",
+            "example": "00000000-0000-0000-0000-000000000002"
+          },
+          "approvalMethod": {
+            "type": "string",
+            "description": "Approval method",
+            "example": "CLICK_CONFIRM"
+          },
+          "declineExpiryDays": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of days a declined estimate can be reopened",
+            "example": 30,
+            "minimum": 0
+          },
+          "requireSignature": {
+            "type": "string",
+            "default": "false",
+            "description": "Whether signature is required",
+            "example": "false"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Priority for configuration matching (0=default, 1=location-specific, 2=customer-specific)",
+            "example": 0,
+            "minimum": 0
+          }
+        },
+        "required": [
+          "approvalMethod"
+        ]
+      },
+      "ApprovalConfigurationResponse": {
+        "type": "object",
+        "description": "Response DTO for approval configurations",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the configuration",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Location ID for this configuration (null = applies to all locations)",
+            "example": "00000000-0000-0000-0000-000000000001"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer ID for this configuration (null = applies to all customers)",
+            "example": "00000000-0000-0000-0000-000000000002"
+          },
+          "approvalMethod": {
+            "type": "string",
+            "description": "Approval method",
+            "example": "CLICK_CONFIRM"
+          },
+          "declineExpiryDays": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of days a declined estimate can be reopened",
+            "example": 30
+          },
+          "requireSignature": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether signature is required",
+            "example": false
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Priority for configuration matching (0=default, 1=location-specific, 2=customer-specific)",
+            "example": 0
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "CreateWorkorderRequest": {
+        "type": "object",
+        "description": "Request DTO for workorder creation",
+        "properties": {
+          "estimateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Estimate ID",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer ID",
+            "example": "01960003-0000-7000-8000-000000000002"
+          }
+        },
+        "required": [
+          "customerId",
+          "estimateId"
+        ]
+      },
+      "WorkorderResponse": {
+        "type": "object",
+        "description": "Response DTO for workorders",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the workorder",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "estimateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Estimate ID",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer ID",
+            "example": "550e8400-e29b-41d4-a716-446655440002"
+          },
+          "shopId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Shop ID",
+            "example": "550e8400-e29b-41d4-a716-446655440003"
+          },
+          "vehicleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Vehicle ID",
+            "example": "550e8400-e29b-41d4-a716-446655440004"
+          },
+          "status": {
+            "type": "string",
+            "description": "Workorder status",
+            "example": "DRAFT"
+          },
+          "approvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the workorder was approved"
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the workorder was completed"
+          },
+          "isReopened": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the completed workorder is currently reopened for controlled edits"
+          },
+          "reopenedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the workorder was reopened"
+          },
+          "crmPartyId": {
+            "type": "string",
+            "description": "CRM party identifier",
+            "example": "01952f4e-0000-7000-8000-000000000001"
+          },
+          "crmVehicleId": {
+            "type": "string",
+            "description": "CRM vehicle identifier",
+            "example": "01952f4e-0000-7000-8000-000000000002"
+          },
+          "crmContactIds": {
+            "type": "array",
+            "description": "List of CRM contact identifiers",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AssignTechnicianRequest": {
+        "type": "object",
+        "description": "Request to assign a technician to a workorder",
+        "properties": {
+          "technicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the technician to assign",
+            "example": "550e8400-e29b-41d4-a716-446655440050"
+          },
+          "assignedByUserId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the user performing the assignment (defaults from X-User-Id header if not provided)",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Assignment notes or reason",
+            "example": "Assigned to senior tech for brake system work"
+          }
+        },
+        "required": [
+          "technicianId"
+        ]
+      },
+      "SubstituteLinkResponse": {
+        "type": "object",
+        "description": "A substitute-part link associating a product with an approved substitute",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the substitute link",
+            "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
+          },
+          "productId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the product the substitute applies to",
+            "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
+          },
+          "substitutePartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the substitute part",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "substituteType": {
+            "type": "string",
+            "description": "Type of substitution relationship",
+            "enum": [
+              "EQUIVALENT",
+              "APPROVED_ALTERNATIVE",
+              "UPGRADE",
+              "DOWNGRADE"
+            ],
+            "example": "EQUIVALENT"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Ordering priority of this substitute among alternatives (lower is preferred)",
+            "example": 1
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Version for optimistic locking",
+            "example": 0
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the link",
+            "example": "system"
+          },
+          "updatedBy": {
+            "type": "string",
+            "description": "Identifier of the user who last updated the link",
+            "example": "system"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "autoSuggest": {
+            "type": "boolean"
+          },
+          "isAutoSuggest": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this substitute is automatically suggested during picking",
+            "example": true
+          },
+          "isActive": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this substitute link is currently active",
+            "example": true
+          }
+        },
+        "required": [
+          "id",
+          "isActive",
+          "isAutoSuggest",
+          "priority",
+          "productId",
+          "substitutePartId",
+          "substituteType",
+          "version"
+        ]
+      },
+      "StartWorkorderRequest": {
+        "type": "object",
+        "description": "Optional request payload used when starting a workorder",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "deprecated": true,
+            "description": "Deprecated. Actor identity is resolved from authenticated security context."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Optional reason associated with start transition",
+            "example": "Vehicle pulled into service bay"
+          }
+        }
+      },
+      "WorkorderStartResponse": {
+        "type": "object",
+        "description": "Response returned after starting work on a workorder",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the workorder that was started",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "operationalContextVersion": {
+            "type": "string",
+            "description": "Operational context version for optimistic concurrency",
+            "example": "2"
+          },
+          "workStartedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when work was started on the workorder",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "previousStatus": {
+            "type": "string",
+            "description": "Workorder status prior to the start transition",
+            "example": "ASSIGNED"
+          },
+          "currentStatus": {
+            "type": "string",
+            "description": "Workorder status after the start transition",
+            "example": "WORK_IN_PROGRESS"
+          },
+          "transitionedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the status transition occurred",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable message describing the start outcome",
+            "example": "Work started on workorder"
+          }
+        },
+        "required": [
+          "currentStatus",
+          "workorderId"
+        ]
+      },
+      "WorkorderItemCompletionResponse": {
+        "type": "object",
+        "description": "Result of completing a workorder line item",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier"
+          },
+          "itemId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Line item identifier"
+          },
+          "itemType": {
+            "type": "string",
+            "description": "Item kind",
+            "enum": [
+              "SERVICE",
+              "PART"
+            ],
+            "example": "SERVICE"
+          },
+          "status": {
+            "type": "string",
+            "description": "Resulting item status",
+            "enum": [
+              "PENDING_APPROVAL",
+              "OPEN",
+              "READY_TO_EXECUTE",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "CANCELLED"
+            ],
+            "example": "COMPLETED"
+          }
+        },
+        "required": [
+          "itemId",
+          "itemType",
+          "status",
+          "workorderId"
+        ]
+      },
+      "StartLaborRequest": {
+        "type": "object",
+        "description": "Request to start a labor session on a workorder service",
+        "properties": {
+          "technicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the technician performing the work",
+            "example": "550e8400-e29b-41d4-a716-446655440050"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional notes about the labor session",
+            "example": "Beginning brake pad replacement"
+          }
+        },
+        "required": [
+          "technicianId"
+        ]
+      },
+      "ReopenWorkorderRequest": {
+        "type": "object",
+        "description": "Request payload for controlled workorder reopen",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "deprecated": true,
+            "description": "Deprecated. Actor identity is resolved from authenticated security context.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "reopenReason": {
+            "type": "string",
+            "description": "Mandatory reason for reopening completed workorder",
+            "example": "Corrected labor hours",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "reopenReason"
+        ]
+      },
+      "ReopenWorkorderResponse": {
+        "type": "object",
+        "description": "Response payload for controlled workorder reopen",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "currentStatus": {
+            "type": "string",
+            "description": "Current lifecycle status",
+            "example": "WORK_IN_PROGRESS"
+          },
+          "isReopened": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the workorder is reopened for controlled edits",
+            "example": true
+          },
+          "reopenedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Reopen timestamp",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "message": {
+            "type": "string",
+            "description": "Operation message",
+            "example": "Workorder reopened successfully"
+          }
+        },
+        "required": [
+          "currentStatus",
+          "isReopened",
+          "message",
+          "reopenedAt",
+          "workorderId"
+        ]
+      },
+      "ConsumeItem": {
+        "type": "object",
+        "description": "A single picked item to consume",
+        "properties": {
+          "pickTaskId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the pick task to consume from",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "quantityToConsume": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Quantity to consume",
+            "example": 2
+          }
+        },
+        "required": [
+          "pickTaskId",
+          "quantityToConsume"
+        ]
+      },
+      "ConsumePickedItemsRequest": {
+        "type": "object",
+        "description": "Request to consume previously picked items into a workorder",
+        "properties": {
+          "items": {
+            "type": "array",
+            "description": "Items to consume",
+            "items": {
+              "$ref": "#/components/schemas/ConsumeItem"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ConsumePickedItemsResponse": {
+        "type": "object",
+        "description": "Result of consuming picked items into a workorder",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the workorder the items were consumed into",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "totalItemsConsumed": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total number of items consumed",
+            "example": 2
+          },
+          "results": {
+            "type": "array",
+            "description": "Per-item consumption results",
+            "items": {
+              "$ref": "#/components/schemas/ConsumedItemResult"
+            }
+          }
+        },
+        "required": [
+          "totalItemsConsumed",
+          "workorderId"
+        ]
+      },
+      "ConsumedItemResult": {
+        "type": "object",
+        "description": "Outcome of consuming a single picked item",
+        "properties": {
+          "pickTaskId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the pick task consumed",
+            "example": "01960003-0000-7000-8000-000000000002"
+          },
+          "quantityConsumed": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Quantity actually consumed",
+            "example": 2
+          },
+          "status": {
+            "type": "string",
+            "description": "Outcome status for the item",
+            "enum": [
+              "SUCCESS",
+              "PARTIAL",
+              "FAILED"
+            ],
+            "example": "SUCCESS"
+          }
+        },
+        "required": [
+          "pickTaskId",
+          "quantityConsumed",
+          "status"
+        ]
+      },
+      "ApiError": {
+        "type": "object",
+        "description": "Standard error response envelope returned by all Durion backend APIs",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code",
+            "example": "ORDER_NOT_FOUND"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message",
+            "example": "Order '550e8400-e29b-41d4-a716-446655440000' was not found"
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "description": "HTTP status code",
+            "example": 404
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "ISO 8601 UTC timestamp of the error",
+            "example": "2026-03-17 14:30:00+00:00"
+          },
+          "correlationId": {
+            "type": "string",
+            "description": "Unique correlation ID for distributed request tracing",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "fieldErrors": {
+            "type": "array",
+            "description": "Field-level validation errors; present (non-null) for validation-related errors such as VALIDATION_ERROR or VALIDATION_FAILED; omitted for all other error types",
+            "items": {
+              "$ref": "#/components/schemas/FieldError"
+            }
+          },
+          "referenceId": {
+            "type": "string",
+            "description": "Workflow or review-case reference identifier, when applicable",
+            "example": "REVIEW-2026-000123"
+          },
+          "nextAction": {
+            "type": "string",
+            "description": "Recommended next step for the caller, when applicable",
+            "example": "Retry the request with a valid quantity"
+          },
+          "supportAction": {
+            "type": "string",
+            "description": "Support or admin investigation guidance, when applicable",
+            "example": "Contact support with the correlation ID for assistance"
+          }
+        },
+        "required": [
+          "code",
+          "correlationId",
+          "message",
+          "status",
+          "timestamp"
+        ]
+      },
+      "FieldError": {
+        "type": "object",
+        "description": "Validation error for a specific request field",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "Field name",
+            "example": "quantity"
+          },
+          "message": {
+            "type": "string",
+            "description": "Validation failure message",
+            "example": "must be greater than 0"
+          }
+        },
+        "required": [
+          "field",
+          "message"
+        ]
+      },
+      "ResolveScanRequest": {
+        "type": "object",
+        "description": "Request to resolve a scanned SKU and location against a pick task",
+        "properties": {
+          "scannedSkuId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the SKU that was scanned",
+            "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
+          },
+          "scannedLocationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the location where the scan occurred",
+            "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
+          }
+        },
+        "required": [
+          "scannedLocationId",
+          "scannedSkuId"
+        ]
+      },
+      "ResolveScanResponse": {
+        "type": "object",
+        "description": "Result of resolving a scanned SKU and location against a pick task",
+        "properties": {
+          "pickTaskId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the pick task the scan resolved against",
+            "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
+          },
+          "pickListId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the pick list containing the resolved task",
+            "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
+          },
+          "resolvedSkuId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the SKU resolved for the scan (may differ from scanned SKU after substitution)",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "resolvedLocationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the location resolved for the scan",
+            "example": "01960003-0000-7000-8000-000000000002"
+          },
+          "matched": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the scan matched the expected SKU and location for the pick task",
+            "example": true
+          },
+          "matchStatus": {
+            "type": "string",
+            "description": "Human-readable status describing the match outcome",
+            "example": "MATCHED"
+          }
+        },
+        "required": [
+          "matched",
+          "pickListId",
+          "pickTaskId"
+        ]
+      },
+      "CompletePickTaskRequest": {
+        "type": "object",
+        "description": "Request to complete a pick task",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Optional reason for completing the pick task",
+            "example": "All lines picked"
+          }
+        }
+      },
+      "WorkorderPickTaskResponse": {
+        "type": "object",
+        "description": "Response describing a single pick task within a pick list",
+        "properties": {
+          "pickTaskId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Pick task identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "pickListId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the pick list the task belongs to",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "skuId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the SKU to pick",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the location to pick from",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "requiredQty": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Quantity required to pick",
+            "example": 2
+          },
+          "pickedQty": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Quantity already picked",
+            "example": 2
+          },
+          "remainingQty": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Quantity remaining to pick",
+            "example": 2
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the pick task",
+            "example": "OPEN"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Sort order of the pick task within the list",
+            "example": 2
+          },
+          "version": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Optimistic-locking version of the pick task",
+            "example": 2
+          }
+        },
+        "required": [
+          "locationId",
+          "pickListId",
+          "pickTaskId",
+          "pickedQty",
+          "remainingQty",
+          "requiredQty",
+          "skuId",
+          "sortOrder",
+          "status",
+          "version"
+        ]
+      },
+      "ConfirmPickLineRequest": {
+        "type": "object",
+        "description": "Request to confirm a picked pick-list line",
+        "properties": {
+          "quantityPicked": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Quantity picked for the line",
+            "example": 2
+          }
+        },
+        "required": [
+          "quantityPicked"
+        ]
+      },
+      "SubstitutePartRequest": {
+        "type": "object",
+        "description": "Request payload for substituting an authorized part",
+        "properties": {
+          "originalPartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Original part identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440500"
+          },
+          "substitutePartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Substitute part identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440501"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Audit reason for substitution",
+            "example": "Original part unavailable, equivalent substitute used",
+            "minLength": 1
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional substitution notes",
+            "example": "Customer notified and approved substitute"
+          }
+        },
+        "required": [
+          "originalPartId",
+          "reason",
+          "substitutePartId"
+        ]
+      },
+      "WorkorderPartAdjustmentEventResponse": {
+        "type": "object",
+        "description": "Response payload for workorder part adjustment events",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Adjustment event identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440700"
+          },
+          "originalPartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Original part identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440500"
+          },
+          "originalPartDescription": {
+            "type": "string",
+            "description": "Original part description",
+            "example": "Brake Pad Set - Front"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "adjustmentType": {
+            "type": "string",
+            "description": "Adjustment type",
+            "example": "SUBSTITUTION"
+          },
+          "substitutedWithPartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Substitute part identifier for substitution adjustments",
+            "example": "550e8400-e29b-41d4-a716-446655440501"
+          },
+          "substitutedWithPartDescription": {
+            "type": "string",
+            "description": "Substitute part description",
+            "example": "Brake Pad Set - Ceramic"
+          },
+          "quantityAdjustment": {
+            "type": "number",
+            "description": "Signed quantity adjustment",
+            "example": -1
+          },
+          "reason": {
+            "type": "string",
+            "description": "Adjustment reason",
+            "example": "Equivalent part used due to stock shortage"
+          },
+          "performedBy": {
+            "type": "string",
+            "description": "Actor identifier who performed adjustment",
+            "example": "tech@shop.local"
+          },
+          "performedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Adjustment timestamp",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional additional notes",
+            "example": "Customer notified"
+          }
+        },
+        "required": [
+          "adjustmentType",
+          "id",
+          "originalPartId",
+          "performedAt",
+          "performedBy",
+          "quantityAdjustment",
+          "workorderId"
+        ]
+      },
+      "ReturnPartRequest": {
+        "type": "object",
+        "description": "Request payload to return unused issued parts to inventory",
+        "properties": {
+          "workorderPartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder part identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440500"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Quantity to return",
+            "example": 1,
+            "minimum": 0.0001
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional return notes",
+            "example": "Returned to stock after over-issue"
+          }
+        },
+        "required": [
+          "quantity",
+          "workorderPartId"
+        ]
+      },
+      "WorkorderPartUsageEventResponse": {
+        "type": "object",
+        "description": "Response payload for workorder part usage events",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Usage event identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440710"
+          },
+          "workorderPartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder part identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440500"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "eventType": {
+            "type": "string",
+            "description": "Event type",
+            "example": "ISSUED"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Quantity associated with event",
+            "example": 1
+          },
+          "performedBy": {
+            "type": "string",
+            "description": "Actor identifier who performed event",
+            "example": "tech@shop.local"
+          },
+          "performedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Event timestamp",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional event notes",
+            "example": "Issued from main bay"
+          },
+          "partDescription": {
+            "type": "string",
+            "description": "Part description for display",
+            "example": "Brake Pad Set - Front"
+          }
+        },
+        "required": [
+          "eventType",
+          "id",
+          "performedAt",
+          "performedBy",
+          "quantity",
+          "workorderId",
+          "workorderPartId"
+        ]
+      },
+      "ReturnPartQuantityRequest": {
+        "type": "object",
+        "description": "Request payload for returning unused authorized part quantity",
+        "properties": {
+          "workorderPartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder part identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440500"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Quantity to return",
+            "example": 1
+          },
+          "reason": {
+            "type": "string",
+            "description": "Audit reason for return",
+            "example": "Part not needed after inspection"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional return notes",
+            "example": "Returned unopened package"
+          }
+        },
+        "required": [
+          "quantity",
+          "reason",
+          "workorderPartId"
+        ]
+      },
+      "IssuePartRequest": {
+        "type": "object",
+        "description": "Request payload to issue authorized part quantity to a workorder",
+        "properties": {
+          "workorderPartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder part identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440500"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Quantity to issue",
+            "example": 1,
+            "minimum": 0.0001
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional issue notes",
+            "example": "Issued from bin A-14"
+          }
+        },
+        "required": [
+          "quantity",
+          "workorderPartId"
+        ]
+      },
+      "CorrectPartQuantityRequest": {
+        "type": "object",
+        "description": "Request payload for administratively correcting authorized part quantity",
+        "properties": {
+          "workorderPartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder part identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "newQuantity": {
+            "type": "number",
+            "description": "Corrected authorized quantity",
+            "example": 2
+          },
+          "reason": {
+            "type": "string",
+            "description": "Audit reason for correction",
+            "example": "Inventory recount adjusted authorized quantity",
+            "minLength": 1
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional correction notes",
+            "example": "Adjusted after parts counter verification"
+          }
+        },
+        "required": [
+          "newQuantity",
+          "reason",
+          "workorderPartId"
+        ]
+      },
+      "ConsumePartRequest": {
+        "type": "object",
+        "description": "Request payload to consume authorized part quantity on a workorder",
+        "properties": {
+          "workorderPartId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder part identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Quantity to consume",
+            "example": 2,
+            "minimum": 0.0001
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional usage notes",
+            "example": "Installed on front axle"
+          }
+        },
+        "required": [
+          "quantity",
+          "workorderPartId"
+        ]
+      },
+      "OperationalContextOverrideRequest": {
+        "type": "object",
+        "description": "Manager override payload for workorder operational context",
+        "properties": {
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Location identifier to set on the workorder",
+            "example": "550e8400-e29b-41d4-a716-446655440300"
+          },
+          "bayId": {
+            "type": "string",
+            "description": "Optional bay identifier",
+            "example": "BAY-12"
+          },
+          "assignedMechanics": {
+            "type": "array",
+            "description": "Assigned mechanic identifiers",
+            "example": [
+              "550e8400-e29b-41d4-a716-446655440120"
+            ],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "assignedResources": {
+            "type": "array",
+            "description": "Assigned resource identifiers",
+            "example": [
+              "550e8400-e29b-41d4-a716-446655440301"
+            ],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "constraints": {
+            "type": "array",
+            "description": "Optional execution constraints",
+            "example": [
+              "ALIGNMENT_RACK_REQUIRED"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "locationId"
+        ]
+      },
+      "OperationalContextResponse": {
+        "type": "object",
+        "description": "Operational context details for a workorder",
+        "properties": {
+          "version": {
+            "type": "string",
+            "description": "Operational context version",
+            "example": "3"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Location identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440300"
+          },
+          "bayId": {
+            "type": "string",
+            "description": "Bay identifier",
+            "example": "BAY-12"
+          },
+          "scheduledStartAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Scheduled start time",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "scheduledEndAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Scheduled end time",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "assignedMechanics": {
+            "type": "array",
+            "description": "Assigned mechanic identifiers",
+            "example": [
+              "550e8400-e29b-41d4-a716-446655440120"
+            ],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "assignedResources": {
+            "type": "array",
+            "description": "Assigned resource identifiers",
+            "example": [
+              "550e8400-e29b-41d4-a716-446655440301"
+            ],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "constraints": {
+            "type": "array",
+            "description": "Operational constraints",
+            "example": [
+              "ALIGNMENT_RACK_REQUIRED"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "locked": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether context is locked after work start",
+            "example": false
+          }
+        },
+        "required": [
+          "locked"
+        ]
+      },
+      "InvoiceGenerationResponse": {
+        "type": "object",
+        "description": "Response payload returned after invoice generation.",
+        "properties": {
+          "invoiceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Generated invoice identifier.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "status": {
+            "type": "string",
+            "description": "Invoice status.",
+            "example": "DRAFT"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Source workorder identifier.",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "estimateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Source estimate identifier.",
+            "example": "550e8400-e29b-41d4-a716-446655440002"
+          },
+          "approvalId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Approval identifier used for generation.",
+            "example": "550e8400-e29b-41d4-a716-446655440003"
+          },
+          "subtotal": {
+            "type": "number",
+            "description": "Subtotal amount before tax.",
+            "example": 120.0
+          },
+          "taxAmount": {
+            "type": "number",
+            "description": "Tax amount.",
+            "example": 9.6
+          },
+          "totalAmount": {
+            "type": "number",
+            "description": "Total amount after tax.",
+            "example": 129.6
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp (UTC).",
+            "example": "2026-02-27 12:00:00+00:00"
+          }
+        },
+        "required": [
+          "createdAt",
+          "invoiceId",
+          "status",
+          "subtotal",
+          "taxAmount",
+          "totalAmount",
+          "workorderId"
+        ]
+      },
+      "CompleteWorkorderRequest": {
+        "type": "object",
+        "description": "Request payload to complete a workorder",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "deprecated": true,
+            "description": "Deprecated. Actor identity is resolved from authenticated security context."
+          },
+          "completionNotes": {
+            "type": "string",
+            "description": "Optional completion notes recorded for closeout",
+            "example": "Completed and verified"
+          }
+        }
+      },
+      "CompleteWorkorderResponse": {
+        "type": "object",
+        "description": "Response payload for workorder completion",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "previousStatus": {
+            "type": "string",
+            "description": "Status prior to completion",
+            "example": "WORK_IN_PROGRESS"
+          },
+          "currentStatus": {
+            "type": "string",
+            "description": "Status after completion",
+            "example": "COMPLETED"
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when completion was recorded",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "message": {
+            "type": "string",
+            "description": "Operation outcome message",
+            "example": "Work order completed successfully"
+          }
+        },
+        "required": [
+          "completedAt",
+          "currentStatus",
+          "previousStatus",
+          "workorderId"
+        ]
+      },
+      "CreateChangeRequestDTO": {
+        "type": "object",
+        "description": "Request payload for creating a change request",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of additional requested work",
+            "example": "Customer requested additional diagnostics",
+            "minLength": 1
+          },
+          "isEmergencyException": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this request contains emergency/safety exception items",
+            "example": false
+          },
+          "exceptionReason": {
+            "type": "string",
+            "description": "Exception reason when emergency override context applies",
+            "example": "Safety-critical repair"
+          },
+          "services": {
+            "type": "array",
+            "description": "Service items included in this change request",
+            "example": [],
+            "items": {
+              "$ref": "#/components/schemas/WorkorderItemDTO"
+            }
+          },
+          "parts": {
+            "type": "array",
+            "description": "Part items included in this change request",
+            "example": [],
+            "items": {
+              "$ref": "#/components/schemas/WorkorderItemDTO"
+            }
+          }
+        },
+        "required": [
+          "description"
+        ]
+      },
+      "WorkorderItemDTO": {
+        "type": "object",
+        "description": "Service or part line item included in a change request",
+        "properties": {
+          "serviceEntityId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Service catalog entity identifier for service items",
+            "example": "01960003-0000-7000-8000-000000000010"
+          },
+          "productEntityId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Product entity identifier for inventory part items",
+            "example": "01960003-0000-7000-8000-000000000011"
+          },
+          "nonInventoryProductEntityId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Product entity identifier for non-inventory part items",
+            "example": "01960003-0000-7000-8000-000000000012"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Requested quantity for part line items",
+            "example": 2
+          },
+          "isEmergencySafety": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this item is emergency/safety related",
+            "example": false
+          },
+          "photoEvidenceUrl": {
+            "type": "string",
+            "description": "Photo evidence URL for emergency/safety documentation",
+            "example": "https://cdn.example.com/evidence/photo-123.jpg"
+          },
+          "emergencyNotes": {
+            "type": "string",
+            "description": "Emergency notes used when photo evidence is unavailable",
+            "example": "Brake line rupture visible after wheel removal"
+          },
+          "photoNotPossible": {
+            "type": "boolean",
+            "default": false,
+            "description": "Flag indicating photo capture was not possible",
+            "example": false
+          }
+        }
+      },
+      "ChangeRequestResponse": {
+        "type": "object",
+        "description": "Response DTO for change requests",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the change request",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder ID",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "requestedByUserId": {
+            "type": "string",
+            "description": "User ID who requested the change",
+            "example": "system@positivity.com"
+          },
+          "requestedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the change was requested"
+          },
+          "status": {
+            "type": "string",
+            "description": "Change request status",
+            "example": "AWAITING_ADVISOR_REVIEW"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the change request"
+          },
+          "isEmergencyException": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this is an emergency exception"
+          },
+          "exceptionReason": {
+            "type": "string",
+            "description": "Reason for the exception if applicable"
+          },
+          "approvalNote": {
+            "type": "string",
+            "description": "Approval notes"
+          },
+          "isApprovalGated": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether approval is gated"
+          },
+          "approvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the change was approved"
+          },
+          "approvedBy": {
+            "type": "string",
+            "description": "User ID who approved the change",
+            "example": "system@positivity.com"
+          },
+          "declinedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the change was declined"
+          }
+        }
+      },
+      "ApproveWorkorderRequest": {
+        "type": "object",
+        "description": "Request to approve a work order with customer signature",
+        "properties": {
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer ID who is approving the work order",
+            "example": "00000000-0000-0000-0000-000000000001"
+          },
+          "signatureData": {
+            "type": "string",
+            "description": "Base64-encoded signature image data (PNG format recommended)",
+            "example": "data:image/png;base64,iVBORw0KGgoAAAANS..."
+          },
+          "signatureMimeType": {
+            "type": "string",
+            "description": "MIME type of signature (e.g., image/png, image/jpeg)",
+            "example": "image/png"
+          },
+          "signerName": {
+            "type": "string",
+            "description": "Name of person providing signature",
+            "example": "John Doe"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Additional notes or comments",
+            "example": "Approved after reviewing repair details"
+          },
+          "lineItemApprovals": {
+            "type": "array",
+            "description": "Individual line item approvals/rejections. If omitted, all items are considered approved.",
+            "items": {
+              "$ref": "#/components/schemas/LineItemApprovalDto"
+            }
+          }
+        },
+        "required": [
+          "customerId"
+        ]
+      },
+      "LineItemApprovalDto": {
+        "type": "object",
+        "description": "Approval or rejection status for a specific line item",
+        "properties": {
+          "lineItemId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the line item (service/product) being approved or rejected",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "approved": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this line item is approved (true) or rejected (false)",
+            "example": true
+          },
+          "rejectionReason": {
+            "type": "string",
+            "description": "Reason for rejection (required if approved=false)",
+            "example": "Customer declined optional service"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Additional notes about this line item decision",
+            "example": "Customer wants to get second opinion"
+          }
+        },
+        "required": [
+          "approved",
+          "lineItemId"
+        ]
+      },
+      "StopWorkSessionRequest": {
+        "type": "object",
+        "description": "Request payload for stopping a work session",
+        "properties": {
+          "mechanicId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional mechanic ID for disambiguation when multiple sessions could match",
+            "example": "01960003-0000-7000-8000-000000000001"
+          }
+        }
+      },
+      "WorkSessionResponse": {
+        "type": "object",
+        "description": "Response DTO for a work session",
+        "properties": {
+          "workSessionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the work session"
+          },
+          "mechanicId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the mechanic"
+          },
+          "workOrderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the work order"
+          },
+          "workOrderTaskId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the work order task"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the work location"
+          },
+          "resourceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional resource/bay ID"
+          },
+          "startAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Session start timestamp"
+          },
+          "endAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Session end timestamp"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the work session",
+            "enum": [
+              "IN_PROGRESS",
+              "COMPLETED",
+              "APPROVED",
+              "REJECTED"
+            ]
+          },
+          "locked": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the session is locked"
+          },
+          "totalDurationSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total session duration in seconds"
+          },
+          "approvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the session was approved"
+          },
+          "approvedByUserId": {
+            "type": "string",
+            "description": "User ID of the approver"
+          },
+          "approvalNotes": {
+            "type": "string",
+            "description": "Notes provided at approval"
+          },
+          "lockedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the session was locked"
+          },
+          "overlapOverrideUsed": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether an overlap override was used"
+          },
+          "overrideReason": {
+            "type": "string",
+            "description": "Reason provided for the overlap override"
+          }
+        }
+      },
+      "AddBreakSegmentRequest": {
+        "type": "object",
+        "description": "Request payload for adding a break segment to a work session",
+        "properties": {
+          "breakType": {
+            "type": "string",
+            "description": "Type of break",
+            "enum": [
+              "MEAL",
+              "REST",
+              "OTHER"
+            ],
+            "example": "MEAL"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional break notes",
+            "example": "Lunch break"
+          }
+        }
+      },
+      "BreakSegmentResponse": {
+        "type": "object",
+        "description": "Response DTO for a break segment",
+        "properties": {
+          "breakSegmentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the break segment",
+            "example": "550e8400-e29b-41d4-a716-446655440400"
+          },
+          "workSessionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the parent work session",
+            "example": "550e8400-e29b-41d4-a716-446655440401"
+          },
+          "breakStartAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Break start timestamp",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "breakEndAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Break end timestamp",
+            "example": "2026-01-15 10:00:00+00:00"
+          },
+          "breakType": {
+            "type": "string",
+            "description": "Type of break",
+            "enum": [
+              "MEAL",
+              "REST",
+              "OTHER"
+            ],
+            "example": "MEAL"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional break notes",
+            "example": "Lunch break"
+          }
+        },
+        "required": [
+          "breakSegmentId",
+          "breakStartAt",
+          "workSessionId"
+        ]
+      },
+      "StartWorkSessionRequest": {
+        "type": "object",
+        "description": "Request payload for starting a work session",
+        "properties": {
+          "mechanicId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the mechanic starting the session"
+          },
+          "workOrderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the work order"
+          },
+          "workOrderTaskId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the work order task"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the work location"
+          },
+          "resourceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional resource/bay ID"
+          },
+          "overlapOverrideReason": {
+            "type": "string",
+            "description": "Reason for overriding overlap policy (requires permission)"
+          }
+        },
+        "required": [
+          "locationId",
+          "mechanicId",
+          "workOrderId",
+          "workOrderTaskId"
+        ]
+      },
+      "StopTravelSegmentRequest": {
+        "type": "object",
+        "description": "Request body for stopping an in-progress travel segment",
+        "properties": {
+          "toLocationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the location reached when the travel segment stops",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional notes recorded when stopping the travel segment",
+            "example": "Arrived at customer site, parking on south lot"
+          }
+        }
+      },
+      "TravelSegmentResponse": {
+        "type": "object",
+        "description": "Response representation of a travel segment",
+        "properties": {
+          "travelSegmentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the travel segment",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "mobileWorkAssignmentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the mobile work assignment this segment belongs to",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "technicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the technician who performed the travel",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "segmentType": {
+            "type": "string",
+            "description": "Direction or purpose of the travel leg",
+            "enum": [
+              "DEPART_SHOP",
+              "ARRIVE_CUSTOMER_SITE",
+              "DEPART_CUSTOMER_SITE",
+              "ARRIVE_SHOP",
+              "TRAVEL_BETWEEN_SITES",
+              "DEADHEAD"
+            ],
+            "example": "DEPART_SHOP"
+          },
+          "startAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the travel segment started",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "endAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the travel segment ended",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "fromLocationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the origin location",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "toLocationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the destination location",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "workOrderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the workorder associated with the travel",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "durationMinutes": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Effective travel duration in minutes",
+            "example": 2
+          },
+          "rawMinutes": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Raw recorded travel minutes before buffering",
+            "example": 2
+          },
+          "bufferedMinutes": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Buffered travel minutes applied by policy",
+            "example": 2
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the travel segment",
+            "enum": [
+              "DRAFT",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "SUBMITTED",
+              "APPROVED",
+              "CANCELLED"
+            ],
+            "example": "DRAFT"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the segment",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "lastModifiedBy": {
+            "type": "string",
+            "description": "Identifier of the user who last modified the segment",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "lastModifiedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the segment was last modified",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "actedByUserId": {
+            "type": "string",
+            "description": "Identifier of the user who acted to record the segment",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "actedForPersonId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the person the segment was recorded on behalf of",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "onBehalfReasonCode": {
+            "type": "string",
+            "description": "Reason code when the segment was entered on behalf of another person",
+            "enum": [
+              "TECHNICIAN_UNAVAILABLE",
+              "FORGOT_TO_CLOCK",
+              "DATA_ENTRY_ERROR"
+            ],
+            "example": "TECHNICIAN_UNAVAILABLE"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the segment was created",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the segment was last updated",
+            "example": "2026-01-15 09:30:00+00:00"
+          }
+        },
+        "required": [
+          "createdAt",
+          "mobileWorkAssignmentId",
+          "segmentType",
+          "status",
+          "technicianId",
+          "travelSegmentId",
+          "updatedAt"
+        ]
+      },
+      "CreateTravelSegmentAdjustmentRequest": {
+        "type": "object",
+        "description": "Request payload to adjust a travel segment's recorded times",
+        "properties": {
+          "adjustedStartAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Adjusted travel segment start timestamp",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "adjustedEndAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Adjusted travel segment end timestamp",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "adjustmentReason": {
+            "type": "string",
+            "description": "Reason justifying the travel segment time adjustment",
+            "example": "Corrected start time after GPS sync",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "adjustmentReason"
+        ]
+      },
+      "TravelSegmentAdjustmentResponse": {
+        "type": "object",
+        "description": "Response representation of a travel segment time adjustment",
+        "properties": {
+          "adjustmentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the adjustment",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "travelSegmentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the travel segment that was adjusted",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "adjustedStartAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Adjusted start timestamp of the travel segment",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "adjustedEndAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Adjusted end timestamp of the travel segment",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "adjustmentReason": {
+            "type": "string",
+            "description": "Reason recorded for the adjustment",
+            "example": "Corrected for traffic delay not logged automatically"
+          },
+          "adjustedByUserId": {
+            "type": "string",
+            "description": "Identifier of the user who made the adjustment",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "approvalStatus": {
+            "type": "string",
+            "description": "Approval status of the adjustment",
+            "example": "PENDING"
+          },
+          "approvedByUserId": {
+            "type": "string",
+            "description": "Identifier of the user who approved the adjustment",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "approvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the adjustment was approved",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the adjustment was created",
+            "example": "2026-01-15 09:30:00+00:00"
+          }
+        },
+        "required": [
+          "adjustmentId",
+          "createdAt",
+          "travelSegmentId"
+        ]
+      },
+      "SubmitTravelSegmentsRequest": {
+        "type": "object",
+        "description": "Request payload for submitting travel segments for a work date",
+        "properties": {
+          "workDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Work date whose travel segments are being submitted",
+            "example": "2026-01-15"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional notes accompanying the travel segment submission",
+            "example": "All segments verified against GPS log"
+          }
+        },
+        "required": [
+          "workDate"
+        ]
+      },
+      "StartTravelSegmentRequest": {
+        "type": "object",
+        "description": "Request body for starting a travel segment",
+        "properties": {
+          "mobileWorkAssignmentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the mobile work assignment the travel segment belongs to",
+            "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
+          },
+          "technicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the technician performing the travel",
+            "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
+          },
+          "segmentType": {
+            "type": "string",
+            "description": "Direction or purpose of this travel leg",
+            "enum": [
+              "DEPART_SHOP",
+              "ARRIVE_CUSTOMER_SITE",
+              "DEPART_CUSTOMER_SITE",
+              "ARRIVE_SHOP",
+              "TRAVEL_BETWEEN_SITES",
+              "DEADHEAD"
+            ],
+            "example": "DEPART_SHOP"
+          },
+          "fromLocationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the origin location for the travel leg",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "toLocationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the destination location for the travel leg",
+            "example": "01960003-0000-7000-8000-000000000002"
+          },
+          "workOrderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the workorder associated with the travel",
+            "example": "01960003-0000-7000-8000-000000000003"
+          },
+          "actedForPersonId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the person on whose behalf this segment is entered, if applicable",
+            "example": "01960003-0000-7000-8000-000000000004"
+          },
+          "onBehalfReasonCode": {
+            "type": "string",
+            "description": "Reason code when the segment is entered on behalf of another person",
+            "enum": [
+              "TECHNICIAN_UNAVAILABLE",
+              "FORGOT_TO_CLOCK",
+              "DATA_ENTRY_ERROR"
+            ],
+            "example": "TECHNICIAN_UNAVAILABLE"
+          }
+        },
+        "required": [
+          "mobileWorkAssignmentId",
+          "segmentType",
+          "technicianId"
+        ]
+      },
+      "RejectTimeEntryRequest": {
+        "type": "object",
+        "description": "Request body for rejecting a time entry",
+        "properties": {
+          "rejectionReason": {
+            "type": "string",
+            "description": "Mandatory reason for rejection",
+            "example": "Hours exceed approved estimate",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "rejectionReason"
+        ]
+      },
+      "TimeEntryResponse": {
+        "type": "object",
+        "description": "Response representation of a time entry",
+        "properties": {
+          "timeEntryId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the time entry",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "personId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the person the time entry belongs to",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "workOrderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the workorder associated with the time entry",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "startAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the time entry started",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "endAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the time entry ended",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the time entry",
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "APPROVED",
+              "REJECTED"
+            ],
+            "example": "SUBMITTED"
+          },
+          "submittedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the time entry was submitted",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "decisionByUserId": {
+            "type": "string",
+            "description": "Identifier of the user who approved or rejected the entry",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "decisionAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp when the approval decision was made",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "rejectionReason": {
+            "type": "string",
+            "description": "Reason supplied when the time entry was rejected",
+            "example": "Hours exceed scheduled shift"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the time entry was created",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the time entry was last updated",
+            "example": "2026-01-15 09:30:00+00:00"
+          }
+        },
+        "required": [
+          "createdAt",
+          "personId",
+          "startAt",
+          "status",
+          "timeEntryId",
+          "updatedAt",
+          "workOrderId"
+        ]
+      },
+      "WorkorderNumberResolveRequest": {
+        "type": "object",
+        "description": "Batch request to resolve workorder ids to human workorder numbers",
+        "properties": {
+          "workorderIds": {
+            "type": "array",
+            "description": "Workorder identifiers to resolve",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "maxItems": 200,
+            "minItems": 0
+          }
+        },
+        "required": [
+          "workorderIds"
+        ]
+      },
+      "WorkorderNumberRef": {
+        "type": "object",
+        "description": "Workorder id resolved to its human workorder number",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workorderNumber": {
+            "type": "string",
+            "description": "Human workorder number",
+            "example": "WO-2026-1001"
+          }
+        },
+        "required": [
+          "workorderId"
+        ]
+      },
+      "CreateEstimateRequest": {
+        "type": "object",
+        "description": "Request payload for creating an estimate",
+        "properties": {
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "vehicleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Vehicle identifier",
+            "example": "01960003-0000-7000-8000-000000000002"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional location identifier; defaults from session when omitted",
+            "example": "01960003-0000-7000-8000-000000000003"
+          },
+          "currencyUomId": {
+            "type": "string",
+            "description": "Optional currency code; defaults when omitted",
+            "example": "USD"
+          },
+          "taxRegionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional tax region identifier; defaults when omitted",
+            "example": "01960003-0000-7000-8000-000000000004"
+          },
+          "subtotal": {
+            "type": "number",
+            "description": "Optional subtotal amount before tax",
+            "example": 500.0
+          },
+          "taxAmount": {
+            "type": "number",
+            "description": "Optional tax amount",
+            "example": 50.0
+          },
+          "total": {
+            "type": "number",
+            "description": "Optional total amount including tax",
+            "example": 550.0
+          },
+          "crmPartyId": {
+            "type": "string",
+            "description": "CRM party identifier (UUIDv7 string)",
+            "example": "01952f4e-0000-7000-8000-000000000001",
+            "maxLength": 36,
+            "minLength": 0
+          },
+          "crmVehicleId": {
+            "type": "string",
+            "description": "CRM vehicle identifier (UUIDv7 string)",
+            "example": "01952f4e-0000-7000-8000-000000000002",
+            "maxLength": 36,
+            "minLength": 0
+          },
+          "crmContactIds": {
+            "type": "array",
+            "description": "List of CRM contact identifiers (may be empty)",
+            "example": [
+              "01952f4e-0000-7000-8000-000000000003"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "crmContactIds",
+          "crmPartyId",
+          "crmVehicleId",
+          "customerId",
+          "vehicleId"
+        ]
+      },
+      "EstimateResponse": {
+        "type": "object",
+        "description": "Response DTO for estimates",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the estimate",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "estimateNumber": {
+            "type": "string",
+            "description": "Estimate number",
+            "example": "EST-2024-1000"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer ID",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "vehicleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Vehicle ID",
+            "example": "550e8400-e29b-41d4-a716-446655440002"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Location ID",
+            "example": "550e8400-e29b-41d4-a716-446655440003"
+          },
+          "currencyUomId": {
+            "type": "string",
+            "description": "Currency UOM ID",
+            "example": "USD"
+          },
+          "taxRegionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Tax region ID",
+            "example": "550e8400-e29b-41d4-a716-446655440004"
+          },
+          "status": {
+            "type": "string",
+            "description": "Estimate status",
+            "example": "DRAFT"
+          },
+          "createdByUserId": {
+            "type": "string",
+            "description": "Username who created the estimate",
+            "example": "john.doe"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the estimate was created",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "subtotal": {
+            "type": "number",
+            "description": "Subtotal amount before tax",
+            "example": 150.0
+          },
+          "taxAmount": {
+            "type": "number",
+            "description": "Tax amount",
+            "example": 12.38
+          },
+          "total": {
+            "type": "number",
+            "description": "Total amount including tax",
+            "example": 162.38
+          },
+          "submittedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the estimate was submitted for approval",
+            "example": "2026-01-15 09:30:00"
+          },
+          "submittedBy": {
+            "type": "string",
+            "description": "Username who submitted the estimate for approval",
+            "example": "john.doe"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the approval window expires",
+            "example": "2026-01-15 09:30:00"
+          },
+          "approvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time the estimate was approved",
+            "example": "2026-01-15 09:30:00"
+          },
+          "approvedBy": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer UUID who approved the estimate",
+            "example": "550e8400-e29b-41d4-a716-446655440005"
+          },
+          "signatureData": {
+            "type": "string",
+            "description": "Base64-encoded signature image",
+            "example": "iVBORw0KGgo="
+          },
+          "signatureMimeType": {
+            "type": "string",
+            "description": "MIME type of the signature image",
+            "example": "image/png"
+          },
+          "signerName": {
+            "type": "string",
+            "description": "Name of person who signed",
+            "example": "Jane Customer"
+          },
+          "approvalNotes": {
+            "type": "string",
+            "description": "Additional notes provided at approval time",
+            "example": "Customer approved all items"
+          },
+          "purchaseOrderNumber": {
+            "type": "string",
+            "description": "Purchase order number for commercial accounts",
+            "example": "PO-2024-12345"
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optimistic locking version",
+            "example": 2
+          },
+          "crmPartyId": {
+            "type": "string",
+            "description": "CRM party identifier",
+            "example": "01952f4e-0000-7000-8000-000000000001"
+          },
+          "crmVehicleId": {
+            "type": "string",
+            "description": "CRM vehicle identifier",
+            "example": "01952f4e-0000-7000-8000-000000000002"
+          },
+          "crmContactIds": {
+            "type": "array",
+            "description": "List of CRM contact identifiers",
+            "example": [
+              "01952f4e-0000-7000-8000-000000000003"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "estimateNumber",
+          "id",
+          "status"
+        ]
+      },
+      "EstimateSnapshotResponse": {
+        "type": "object",
+        "description": "Response payload for captured estimate snapshots",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Snapshot identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440030"
+          },
+          "estimateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Estimate identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "status": {
+            "type": "string",
+            "description": "Estimate status at capture time",
+            "enum": [
+              "DRAFT",
+              "PENDING_APPROVAL",
+              "OPEN",
+              "PENDING_CUSTOMER",
+              "APPROVED",
+              "DECLINED",
+              "EXPIRED",
+              "SCHEDULED",
+              "INVOICED",
+              "CANCELLED",
+              "ARCHIVED"
+            ],
+            "example": "PENDING_APPROVAL"
+          },
+          "snapshotData": {
+            "type": "string",
+            "description": "Serialized snapshot content",
+            "example": {
+              "total": 162.38
+            }
+          },
+          "capturedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Snapshot capture timestamp",
+            "example": "2026-01-15 09:30:00"
+          },
+          "capturedById": {
+            "type": "string",
+            "description": "Actor identifier that captured the snapshot",
+            "example": "advisor@shop.local"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional snapshot notes",
+            "example": "Captured at submission"
+          }
+        },
+        "required": [
+          "estimateId",
+          "id",
+          "status"
+        ]
+      },
+      "AddEstimateItemRequest": {
+        "type": "object",
+        "description": "Request payload for adding a line item to an estimate",
+        "properties": {
+          "itemType": {
+            "type": "string",
+            "description": "Type of estimate item",
+            "enum": [
+              "PART",
+              "LABOR"
+            ],
+            "example": "PART"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description when no catalog reference is provided",
+            "example": "Brake pad replacement"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Requested quantity",
+            "example": 2,
+            "minimum": 0.0001
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Unit price for the line item",
+            "example": 49.99,
+            "minimum": 0.0
+          },
+          "taxCode": {
+            "type": "string",
+            "description": "Optional tax code",
+            "example": "TX-GENERAL"
+          },
+          "productId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Referenced product identifier for PART items",
+            "example": "550e8400-e29b-41d4-a716-446655440020"
+          },
+          "serviceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Referenced service identifier for LABOR items",
+            "example": "550e8400-e29b-41d4-a716-446655440021"
+          }
+        },
+        "required": [
+          "itemType",
+          "quantity",
+          "unitPrice"
+        ]
+      },
+      "EstimateItemResponse": {
+        "type": "object",
+        "description": "Response payload for estimate line items",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Estimate item identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440020"
+          },
+          "estimateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Parent estimate identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "itemType": {
+            "type": "string",
+            "description": "Estimate item type",
+            "enum": [
+              "PART",
+              "LABOR"
+            ],
+            "example": "PART"
+          },
+          "description": {
+            "type": "string",
+            "description": "Item description",
+            "example": "Front brake pad replacement"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Item quantity",
+            "example": 2
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Unit price",
+            "example": 59.99
+          },
+          "lineTotal": {
+            "type": "number",
+            "description": "Computed line total",
+            "example": 119.98
+          },
+          "taxCode": {
+            "type": "string",
+            "description": "Tax code",
+            "example": "TX-GENERAL"
+          },
+          "productId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Referenced product identifier when itemType=PART",
+            "example": "550e8400-e29b-41d4-a716-446655440021"
+          },
+          "serviceId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Referenced service identifier when itemType=LABOR",
+            "example": "550e8400-e29b-41d4-a716-446655440022"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Record creation timestamp"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Record last update timestamp"
+          }
+        }
+      },
+      "ApproveEstimateRequest": {
+        "type": "object",
+        "description": "Request to approve an estimate with customer signature",
+        "properties": {
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer ID who is approving the estimate",
+            "example": "00000000-0000-0000-0000-000000000001"
+          },
+          "signatureData": {
+            "type": "string",
+            "description": "Base64-encoded signature image data (PNG format recommended)",
+            "example": "data:image/png;base64,iVBORw0KGgoAAAANS..."
+          },
+          "signatureMimeType": {
+            "type": "string",
+            "description": "MIME type of signature (e.g., image/png, image/jpeg)",
+            "example": "image/png"
+          },
+          "signerName": {
+            "type": "string",
+            "description": "Name of person providing signature",
+            "example": "John Doe"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Additional notes or comments",
+            "example": "Approved with customer present"
+          },
+          "lineItemApprovals": {
+            "type": "array",
+            "description": "Individual line item approvals/rejections. If omitted, all items are considered approved.",
+            "items": {
+              "$ref": "#/components/schemas/LineItemApprovalDto"
+            }
+          },
+          "purchaseOrderNumber": {
+            "type": "string",
+            "description": "Purchase order number (required when PO enforcement is enabled for the account)",
+            "example": "PO-2024-12345"
+          }
+        },
+        "required": [
+          "customerId"
+        ]
+      },
+      "CreateEstimateFromAppointmentRequest": {
+        "type": "object",
+        "description": "Request payload to create an estimate from an appointment",
+        "properties": {
+          "idempotencyKey": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Idempotency key to prevent duplicate estimate creation",
+            "example": "01960003-0000-7000-8000-000000000010"
+          },
+          "appointmentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Appointment identifier",
+            "example": "01960003-0000-7000-8000-000000000011"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer identifier",
+            "example": "01960003-0000-7000-8000-000000000012"
+          },
+          "vehicleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Vehicle identifier",
+            "example": "01960003-0000-7000-8000-000000000013"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Location identifier",
+            "example": "01960003-0000-7000-8000-000000000014"
+          },
+          "requestedServices": {
+            "type": "array",
+            "description": "Requested services captured from appointment context",
+            "example": [
+              "Oil change",
+              "Brake inspection"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "appointmentId",
+          "customerId",
+          "idempotencyKey",
+          "locationId",
+          "vehicleId"
+        ]
+      },
+      "CreateEstimateFromAppointmentResponse": {
+        "type": "object",
+        "description": "Response payload for estimate creation from appointment",
+        "properties": {
+          "estimateId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Created estimate identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "status": {
+            "type": "string",
+            "description": "Created estimate status",
+            "example": "DRAFT"
+          },
+          "created": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether a new estimate was created (false when idempotency returns existing record)",
+            "example": true
+          }
+        },
+        "required": [
+          "created",
+          "estimateId",
+          "status"
+        ]
+      },
+      "EmergencyOverrideDTO": {
+        "type": "object",
+        "description": "Request payload for applying an emergency override",
+        "properties": {
+          "exceptionReason": {
+            "type": "string",
+            "description": "Reason justifying emergency override",
+            "example": "Safety-critical repair authorized",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "exceptionReason"
+        ]
+      },
+      "DeclineChangeRequestDTO": {
+        "type": "object",
+        "description": "Request payload for declining a change request",
+        "properties": {
+          "approvalNote": {
+            "type": "string",
+            "description": "Decline note captured as the decision artifact",
+            "example": "Declined by customer",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "approvalNote"
+        ]
+      },
+      "ApproveChangeRequestDTO": {
+        "type": "object",
+        "description": "Request payload for approving a change request",
+        "properties": {
+          "approvedBy": {
+            "type": "string",
+            "format": "uuid",
+            "deprecated": true,
+            "description": "Deprecated. Actor identity is resolved from authenticated security context.",
+            "example": "550e8400-e29b-41d4-a716-446655440100"
+          },
+          "approvalNote": {
+            "type": "string",
+            "description": "Approval note captured as the decision artifact",
+            "example": "Approved after customer confirmation",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "approvalNote"
+        ]
+      },
+      "WorkexecTimerEntryResponse": {
+        "type": "object",
+        "description": "Timer entry response for workexec timer APIs",
+        "properties": {
+          "timeEntryId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Timer entry identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440600"
+          },
+          "mechanicId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Mechanic identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440120"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workorderItemId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional workorder item identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440010"
+          },
+          "laborCode": {
+            "type": "string",
+            "description": "Labor code",
+            "example": "DIAG"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timer start timestamp"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timer stop timestamp"
+          },
+          "durationInSeconds": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Computed duration in seconds",
+            "example": 3600
+          },
+          "status": {
+            "type": "string",
+            "description": "Timer status",
+            "example": "STOPPED"
+          }
+        }
+      },
+      "WorkexecTimerStopResponse": {
+        "type": "object",
+        "description": "Stop timer response containing all stopped timers",
+        "properties": {
+          "stopped": {
+            "type": "array",
+            "description": "Stopped timer entries",
+            "items": {
+              "$ref": "#/components/schemas/WorkexecTimerEntryResponse"
+            }
+          }
+        }
+      },
+      "WorkexecTimerStartRequest": {
+        "type": "object",
+        "description": "Start timer request for workexec time entries",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workorderItemId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional workorder line item identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440010"
+          },
+          "laborCode": {
+            "type": "string",
+            "description": "Optional labor code associated with timer",
+            "example": "DIAG"
+          },
+          "technicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional technician whose labor this timer tracks. Omit to use the workorder's current assignment, or yourself if the workorder is unassigned. Supplying a technician other than yourself or the current assignee requires the 'workorder:labor:add_on_behalf' authority and a reason.",
+            "example": "550e8400-e29b-41d4-a716-446655440099"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Required when starting a timer on behalf of a technician other than yourself or the current assignee.",
+            "example": "Lead starting timer for helper technician",
+            "maxLength": 500,
+            "minLength": 0
+          }
+        },
+        "required": [
+          "workorderId"
+        ]
+      },
+      "LaborQuantity": {
+        "type": "object",
+        "description": "Labor quantity and unit of measure",
+        "properties": {
+          "quantity": {
+            "type": "number",
+            "description": "Amount of labor performed",
+            "example": 1.5
+          },
+          "unit": {
+            "type": "string",
+            "description": "Unit of measure for the labor quantity",
+            "example": "HOURS",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "quantity",
+          "unit"
+        ]
+      },
+      "SourceReference": {
+        "type": "object",
+        "description": "External source system reference metadata",
+        "properties": {
+          "system": {
+            "type": "string",
+            "description": "Identifier of the originating external system",
+            "example": "workexec",
+            "minLength": 1
+          },
+          "sourceReferenceId": {
+            "type": "string",
+            "description": "Reference identifier of the record in the source system",
+            "example": "EXT-REF-12345",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "sourceReferenceId",
+          "system"
+        ]
+      },
+      "WorkexecLaborPerformedRequest": {
+        "type": "object",
+        "description": "Request payload for recording labor performed from external systems",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "technicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Technician identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440120"
+          },
+          "performedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when labor was performed",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "labor": {
+            "$ref": "#/components/schemas/LaborQuantity"
+          },
+          "source": {
+            "$ref": "#/components/schemas/SourceReference"
+          }
+        },
+        "required": [
+          "labor",
+          "performedAt",
+          "source",
+          "technicianId",
+          "workorderId"
+        ]
+      },
+      "WorkexecLaborPerformedResponse": {
+        "type": "object",
+        "description": "Recorded labor-performed response",
+        "properties": {
+          "laborPerformedId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Labor performed record identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440700"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "technicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Technician identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440120"
+          },
+          "performedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when labor was performed",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Labor quantity",
+            "example": 1.5
+          },
+          "unit": {
+            "type": "string",
+            "description": "Labor quantity unit",
+            "example": "HOURS"
+          },
+          "sourceSystem": {
+            "type": "string",
+            "description": "Source system identifier",
+            "example": "workexec"
+          },
+          "sourceReferenceId": {
+            "type": "string",
+            "description": "Source reference identifier",
+            "example": "EXT-REF-12345"
+          }
+        },
+        "required": [
+          "laborPerformedId",
+          "performedAt",
+          "quantity",
+          "sourceReferenceId",
+          "sourceSystem",
+          "technicianId",
+          "unit",
+          "workorderId"
+        ]
+      },
+      "UpdateEstimateItemRequest": {
+        "type": "object",
+        "description": "Request payload for partial update of an estimate line item",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Updated description",
+            "example": "Front brake pad replacement"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Updated quantity",
+            "example": 2,
+            "minimum": 0.0001
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Updated unit price",
+            "example": 59.99,
+            "minimum": 0.0
+          },
+          "taxCode": {
+            "type": "string",
+            "description": "Updated tax code",
+            "example": "TX-GENERAL"
+          }
+        }
+      },
+      "WorkorderStateTransitionResponse": {
+        "type": "object",
+        "description": "Work order state transition history entry",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for this transition record",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the work order",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "fromStatus": {
+            "type": "string",
+            "description": "The status the work order transitioned FROM",
+            "example": "DRAFT"
+          },
+          "toStatus": {
+            "type": "string",
+            "description": "The status the work order transitioned TO",
+            "example": "WORK_IN_PROGRESS"
+          },
+          "transitionedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the transition occurred"
+          },
+          "transitionedBy": {
+            "type": "string",
+            "description": "Stable actor identifier who performed the transition",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason for the transition",
+            "example": "Customer approved the estimate"
+          },
+          "metadata": {
+            "type": "string",
+            "description": "Additional metadata about the transition"
+          }
+        }
+      },
+      "WorkorderSnapshotResponse": {
+        "type": "object",
+        "description": "Work order snapshot history entry",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for this snapshot record",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the work order",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the work order at the time of this snapshot",
+            "example": "WORK_IN_PROGRESS"
+          },
+          "capturedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the snapshot was captured"
+          },
+          "capturedBy": {
+            "type": "string",
+            "description": "Stable actor identifier who captured the snapshot",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "snapshotType": {
+            "type": "string",
+            "description": "Type of snapshot (e.g., MANUAL, AUTOMATIC, SYSTEM)",
+            "example": "MANUAL"
+          },
+          "snapshotData": {
+            "type": "string",
+            "description": "Snapshot data (typically JSON)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason for capturing the snapshot"
+          }
+        }
+      },
+      "WorkorderPickedItemResponse": {
+        "type": "object",
+        "description": "Response describing a picked item resulting from a pick task",
+        "properties": {
+          "pickTaskId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the pick task that produced this item",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "pickListId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the pick list the task belongs to",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "skuId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the SKU that was picked",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "qtyPicked": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Quantity picked",
+            "example": 2
+          },
+          "qtyConsumed": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Quantity consumed from the picked amount",
+            "example": 2
+          },
+          "qtyRemaining": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Quantity remaining from the picked amount",
+            "example": 2
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the picked item",
+            "example": "PICKED"
+          }
+        },
+        "required": [
+          "pickListId",
+          "pickTaskId",
+          "qtyConsumed",
+          "qtyPicked",
+          "qtyRemaining",
+          "skuId",
+          "status"
+        ]
+      },
+      "WorkorderPickListResponse": {
+        "type": "object",
+        "description": "Response describing a workorder pick list",
+        "properties": {
+          "pickListId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Pick list identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the workorder the pick list belongs to",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the pick list",
+            "example": "OPEN"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Priority ordering of the pick list",
+            "example": 2
+          },
+          "dueAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp the pick list is due",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp the pick list was created",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp the pick list was last updated",
+            "example": "2026-01-15 09:30:00+00:00"
+          }
+        },
+        "required": [
+          "createdAt",
+          "dueAt",
+          "pickListId",
+          "priority",
+          "status",
+          "updatedAt",
+          "workorderId"
+        ]
+      },
+      "WorkorderCapabilities": {
+        "type": "object",
+        "description": "Capability flags for workorder actions based on user authorities",
+        "properties": {
+          "canStart": {
+            "type": "boolean",
+            "default": false,
+            "description": "User can start workorder",
+            "example": true
+          },
+          "canApprove": {
+            "type": "boolean",
+            "default": false,
+            "description": "User can approve workorder",
+            "example": false
+          },
+          "canAssignTechnician": {
+            "type": "boolean",
+            "default": false,
+            "description": "User can assign/reassign technicians",
+            "example": true
+          },
+          "canRecordLabor": {
+            "type": "boolean",
+            "default": false,
+            "description": "User can record labor entries",
+            "example": true
+          },
+          "canRecordPartsUsage": {
+            "type": "boolean",
+            "default": false,
+            "description": "User can record parts usage",
+            "example": true
+          },
+          "canViewFinancials": {
+            "type": "boolean",
+            "default": false,
+            "description": "User can view financial data",
+            "example": false
+          },
+          "canEditWorkorder": {
+            "type": "boolean",
+            "default": false,
+            "description": "User can edit workorder",
+            "example": true
+          },
+          "canDeleteWorkorder": {
+            "type": "boolean",
+            "default": false,
+            "description": "User can delete workorder",
+            "example": false
+          }
+        },
+        "required": [
+          "canApprove",
+          "canAssignTechnician",
+          "canDeleteWorkorder",
+          "canEditWorkorder",
+          "canRecordLabor",
+          "canRecordPartsUsage",
+          "canStart",
+          "canViewFinancials"
+        ]
+      },
+      "WorkorderDetailResponse": {
+        "type": "object",
+        "description": "Comprehensive workorder detail with role-based visibility",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder ID",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workorderNumber": {
+            "type": "string",
+            "description": "Workorder number (from sequence)",
+            "example": "WO-2024-5001"
+          },
+          "status": {
+            "type": "string",
+            "description": "Workorder status",
+            "enum": [
+              "DRAFT",
+              "APPROVED",
+              "ASSIGNED",
+              "WORK_IN_PROGRESS",
+              "AWAITING_PARTS",
+              "AWAITING_APPROVAL",
+              "READY_FOR_PICKUP",
+              "COMPLETED",
+              "CANCELLED"
+            ],
+            "example": "WORK_IN_PROGRESS"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer ID",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "customerName": {
+            "type": "string",
+            "description": "Customer name",
+            "example": "John Doe"
+          },
+          "vehicleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Vehicle ID",
+            "example": "550e8400-e29b-41d4-a716-446655440002"
+          },
+          "vehicleDescription": {
+            "type": "string",
+            "description": "Vehicle description",
+            "example": "\"2020 Toyota Camry (VIN: 1HGBH41JXMN109186)\""
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp",
+            "example": "2024-01-27 10:00:00+00:00"
+          },
+          "createdBy": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Created by user ID",
+            "example": "550e8400-e29b-41d4-a716-446655440003"
+          },
+          "isStarted": {
+            "type": "string",
+            "description": "Is workorder started (derived from status)",
+            "example": "true"
+          },
+          "isInProgress": {
+            "type": "string",
+            "description": "Is workorder in progress (derived from status)",
+            "example": "true"
+          },
+          "isCompleted": {
+            "type": "string",
+            "description": "Is workorder completed (derived from status)",
+            "example": "false"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Start timestamp",
+            "example": "2024-01-27 14:30:00+00:00"
+          },
+          "assignedTechnicianId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Assigned technician ID",
+            "example": "550e8400-e29b-41d4-a716-446655440004"
+          },
+          "services": {
+            "type": "array",
+            "description": "Service line items with labor totals",
+            "items": {
+              "$ref": "#/components/schemas/WorkorderServiceResponse"
+            }
+          },
+          "parts": {
+            "type": "array",
+            "description": "Part line items with usage totals",
+            "items": {
+              "$ref": "#/components/schemas/WorkorderPartResponse"
+            }
+          },
+          "estimatedTotal": {
+            "type": "number",
+            "description": "Estimated total (conditionally included based on canViewFinancials)",
+            "example": 1245.5
+          },
+          "laborTotal": {
+            "type": "number",
+            "description": "Total labor cost (conditionally included)",
+            "example": 425.0
+          },
+          "partsTotal": {
+            "type": "number",
+            "description": "Total parts cost (conditionally included)",
+            "example": 720.5
+          },
+          "taxTotal": {
+            "type": "number",
+            "description": "Total tax (conditionally included)",
+            "example": 100.0
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/WorkorderCapabilities"
+          }
+        },
+        "required": [
+          "capabilities",
+          "createdAt",
+          "createdBy",
+          "customerId",
+          "status",
+          "vehicleId",
+          "workorderId"
+        ]
+      },
+      "WorkorderPartResponse": {
+        "type": "object",
+        "description": "Workorder part line item with usage totals",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Part line item ID",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "productEntityId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Product entity ID from catalog",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "description": {
+            "type": "string",
+            "description": "Part description",
+            "example": "Brake Rotor - Front"
+          },
+          "status": {
+            "type": "string",
+            "description": "Part line status",
+            "enum": [
+              "PENDING_APPROVAL",
+              "OPEN",
+              "READY_TO_EXECUTE",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "CANCELLED"
+            ],
+            "example": "OPEN"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Authorized quantity from estimate",
+            "example": 2.0
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Unit price per part",
+            "example": 65.0
+          },
+          "quantityIssued": {
+            "type": "number",
+            "description": "Quantity issued from inventory",
+            "example": 2.0
+          },
+          "quantityConsumed": {
+            "type": "number",
+            "description": "Quantity consumed (cannot be returned)",
+            "example": 1.5
+          },
+          "quantityReturned": {
+            "type": "number",
+            "description": "Quantity returned to inventory",
+            "example": 0.5
+          },
+          "partCost": {
+            "type": "number",
+            "description": "Total part cost (authorized quantity * unit price)",
+            "example": 130.0
+          },
+          "lineTotal": {
+            "type": "number",
+            "description": "Line total from estimate",
+            "example": 130.0
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "WorkorderServiceResponse": {
+        "type": "object",
+        "description": "Workorder service line item with labor totals",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Service line item ID",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "serviceEntityId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Service entity ID from catalog",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "description": {
+            "type": "string",
+            "description": "Service description",
+            "example": "Brake Pad Replacement"
+          },
+          "status": {
+            "type": "string",
+            "description": "Service line status",
+            "enum": [
+              "PENDING_APPROVAL",
+              "OPEN",
+              "READY_TO_EXECUTE",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "CANCELLED"
+            ],
+            "example": "OPEN"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Authorized quantity (hours for labor)",
+            "example": 2.5
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Unit price (hourly rate)",
+            "example": 85.0
+          },
+          "totalLaborHours": {
+            "type": "number",
+            "description": "Total labor hours recorded",
+            "example": 1.5
+          },
+          "laborCost": {
+            "type": "number",
+            "description": "Total labor cost",
+            "example": 127.5
+          },
+          "lineTotal": {
+            "type": "number",
+            "description": "Line total from estimate",
+            "example": 212.5
+          }
+        }
+      },
+      "CompletionPreconditionsResponse": {
+        "type": "object",
+        "description": "Completion precondition evaluation response",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "canComplete": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the workorder can be completed",
+            "example": true
+          },
+          "currentStatus": {
+            "type": "string",
+            "description": "Current status",
+            "example": "WORK_IN_PROGRESS"
+          },
+          "checklistItems": {
+            "type": "array",
+            "description": "Checklist items evaluated before completion",
+            "example": [
+              "All service items completed"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "blockingReasons": {
+            "type": "array",
+            "description": "Blocking reasons that prevent completion",
+            "example": [
+              "Unresolved approval-gated change request"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "unresolvedApprovalGatedChangeRequests": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of unresolved approval-gated change requests",
+            "example": 2
+          },
+          "nonTerminalServiceItems": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of service items not in COMPLETED/CANCELLED status",
+            "example": 2
+          },
+          "nonTerminalPartItems": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of part items not in COMPLETED/CANCELLED status",
+            "example": 2
+          },
+          "emergencyDenialAcknowledged": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether emergency denial acknowledgment requirements are satisfied",
+            "example": true
+          },
+          "hasBillableItems": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether at least one billable item exists for final snapshot",
+            "example": true
+          }
+        },
+        "required": [
+          "canComplete",
+          "currentStatus",
+          "workorderId"
+        ]
+      },
+      "Pageable": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PageWorkorderSearchResult": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkorderSearchResult"
+            }
+          },
+          "number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "numberOfElements": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PageableObject": {
+        "type": "object",
+        "properties": {
+          "offset": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "paged": {
+            "type": "boolean"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "unpaged": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SortObject": {
+        "type": "object",
+        "properties": {
+          "empty": {
+            "type": "boolean"
+          },
+          "sorted": {
+            "type": "boolean"
+          },
+          "unsorted": {
+            "type": "boolean"
+          }
+        }
+      },
+      "WorkorderSearchResult": {
+        "type": "object",
+        "description": "Lightweight workorder search result enriched with customer name",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "workorderNumber": {
+            "type": "string",
+            "description": "Human workorder number",
+            "example": "WO-2026-1001"
+          },
+          "estimateNumber": {
+            "type": "string",
+            "description": "Linked estimate number, if created from an estimate",
+            "example": "EST-2026-1001"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current workorder status",
+            "enum": [
+              "DRAFT",
+              "APPROVED",
+              "ASSIGNED",
+              "WORK_IN_PROGRESS",
+              "AWAITING_PARTS",
+              "AWAITING_APPROVAL",
+              "READY_FOR_PICKUP",
+              "COMPLETED",
+              "CANCELLED"
+            ],
+            "example": "DRAFT"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer identifier"
+          },
+          "customerName": {
+            "type": "string",
+            "description": "Resolved customer display name"
+          },
+          "vehicleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Vehicle identifier"
+          },
+          "vehicleLabel": {
+            "type": "string",
+            "description": "Resolved vehicle label",
+            "example": "2019 Ford F-150"
+          },
+          "vin": {
+            "type": "string",
+            "description": "Vehicle VIN (full; truncate for display)",
+            "example": "1FTFW1E50KFA12345"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp",
+            "example": "2026-01-15 09:30:00+00:00"
+          }
+        },
+        "required": [
+          "status",
+          "workorderId"
+        ]
+      },
+      "EstimateSummaryResponse": {
+        "type": "object",
+        "description": "Customer-facing estimate summary with grouped items and totals",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Estimate identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "estimateNumber": {
+            "type": "string",
+            "description": "Estimate number",
+            "example": "EST-2026-1001"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Estimate expiry timestamp",
+            "example": "2026-01-15 09:30:00"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Customer identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "customerName": {
+            "type": "string",
+            "description": "Resolved customer display name"
+          },
+          "vehicleLabel": {
+            "type": "string",
+            "description": "Resolved vehicle label",
+            "example": "2019 Ford F-150"
+          },
+          "vin": {
+            "type": "string",
+            "description": "Vehicle VIN (full; truncate for display)",
+            "example": "1FTFW1E50KFA12345"
+          },
+          "vehicleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Vehicle identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440002"
+          },
+          "locationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Location identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440003"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current estimate status",
+            "enum": [
+              "DRAFT",
+              "PENDING_APPROVAL",
+              "OPEN",
+              "PENDING_CUSTOMER",
+              "APPROVED",
+              "DECLINED",
+              "EXPIRED",
+              "SCHEDULED",
+              "INVOICED",
+              "CANCELLED",
+              "ARCHIVED"
+            ],
+            "example": "DRAFT"
+          },
+          "partItems": {
+            "type": "array",
+            "description": "Part line items",
+            "items": {
+              "$ref": "#/components/schemas/EstimateItemResponse"
+            }
+          },
+          "laborItems": {
+            "type": "array",
+            "description": "Labor line items",
+            "items": {
+              "$ref": "#/components/schemas/EstimateItemResponse"
+            }
+          },
+          "subtotal": {
+            "type": "number",
+            "description": "Subtotal amount",
+            "example": 150.0
+          },
+          "taxAmount": {
+            "type": "number",
+            "description": "Tax amount",
+            "example": 12.38
+          },
+          "total": {
+            "type": "number",
+            "description": "Total amount",
+            "example": 162.38
+          },
+          "currencyUomId": {
+            "type": "string",
+            "description": "Currency code",
+            "example": "USD"
+          }
+        },
+        "required": [
+          "estimateNumber",
+          "id",
+          "status"
+        ]
+      },
+      "PageWorkorderStatusView": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkorderStatusView"
+            }
+          },
+          "number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "numberOfElements": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        }
+      },
+      "WorkorderStatusView": {
+        "type": "object",
+        "description": "Summary view of a workorder's work-in-progress status",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder unique identifier"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current workorder status",
+            "enum": [
+              "DRAFT",
+              "APPROVED",
+              "ASSIGNED",
+              "WORK_IN_PROGRESS",
+              "AWAITING_PARTS",
+              "AWAITING_APPROVAL",
+              "READY_FOR_PICKUP",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          },
+          "assignedTechnicianId": {
+            "type": "string",
+            "description": "ID of the technician currently assigned (null if unassigned)"
+          },
+          "locationId": {
+            "type": "string",
+            "description": "Location ID the workorder belongs to"
+          },
+          "estimatedCompletionTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Estimated time of completion (null if not set)"
+          },
+          "customerName": {
+            "type": "string",
+            "description": "Full name of the customer"
+          },
+          "vehicleInfo": {
+            "type": "string",
+            "description": "Human-readable vehicle description (year/make/model/trim)"
+          },
+          "lastUpdatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the last status update"
+          }
+        }
+      },
+      "WorkorderStatusDetail": {
+        "type": "object",
+        "description": "Full WIP detail for a single workorder",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workorder unique identifier"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current workorder status",
+            "enum": [
+              "DRAFT",
+              "APPROVED",
+              "ASSIGNED",
+              "WORK_IN_PROGRESS",
+              "AWAITING_PARTS",
+              "AWAITING_APPROVAL",
+              "READY_FOR_PICKUP",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          },
+          "assignedTechnicianId": {
+            "type": "string",
+            "description": "ID of the technician currently assigned (null if unassigned)"
+          },
+          "locationId": {
+            "type": "string",
+            "description": "Location ID the workorder belongs to"
+          },
+          "estimatedCompletionTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Estimated time of completion (null if not set)"
+          },
+          "customerName": {
+            "type": "string",
+            "description": "Full name of the customer"
+          },
+          "vehicleInfo": {
+            "type": "string",
+            "description": "Human-readable vehicle description (year/make/model/trim)"
+          },
+          "lastUpdatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the last status update"
+          },
+          "statusHistory": {
+            "type": "array",
+            "description": "Ordered history of all status changes for this workorder",
+            "items": {
+              "$ref": "#/components/schemas/WorkorderStatusHistoryEntry"
+            }
+          },
+          "phoneNumber": {
+            "type": "string",
+            "description": "Customer contact phone number (null if not available)"
+          },
+          "vehicleVin": {
+            "type": "string",
+            "description": "Vehicle VIN (null if not recorded)"
+          },
+          "serviceDescription": {
+            "type": "string",
+            "description": "Summary of the service being performed"
+          },
+          "internalNotes": {
+            "type": "string",
+            "description": "Internal shop notes (null if none)"
+          },
+          "partsBlocking": {
+            "type": "array",
+            "description": "Part numbers or descriptions that are blocking progress",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "WorkorderStatusHistoryEntry": {
+        "type": "object",
+        "description": "A single entry in the workorder status history",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Status reached at this point in history",
+            "enum": [
+              "DRAFT",
+              "APPROVED",
+              "ASSIGNED",
+              "WORK_IN_PROGRESS",
+              "AWAITING_PARTS",
+              "AWAITING_APPROVAL",
+              "READY_FOR_PICKUP",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          },
+          "changedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the status change occurred"
+          },
+          "changedBy": {
+            "type": "string",
+            "description": "Identity of the user who changed the status"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Optional reason provided for the status change"
+          }
+        }
+      },
+      "PageEstimateSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EstimateSummaryResponse"
+            }
+          },
+          "number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "numberOfElements": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        }
+      },
+      "BayStatus": {
+        "type": "object",
+        "description": "Current status of a service bay",
+        "properties": {
+          "bayId": {
+            "type": "string",
+            "description": "Identifier of the bay",
+            "example": "BAY-01"
+          },
+          "bayName": {
+            "type": "string",
+            "description": "Human-readable bay name",
+            "example": "Front Bay 1"
+          },
+          "status": {
+            "type": "string",
+            "description": "Operational status of the bay",
+            "example": "OCCUPIED"
+          },
+          "assignedWorkorderId": {
+            "type": "string",
+            "description": "Identifier of the workorder currently assigned to the bay",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "available": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the bay is currently available",
+            "example": false
+          }
+        },
+        "required": [
+          "available",
+          "bayId",
+          "status"
+        ]
+      },
+      "ConflictEntry": {
+        "type": "object",
+        "description": "A detected scheduling or resource conflict on the dispatch board",
+        "properties": {
+          "conflictType": {
+            "type": "string",
+            "description": "Type of conflict detected",
+            "example": "DOUBLE_BOOKING"
+          },
+          "severity": {
+            "type": "string",
+            "description": "Severity of the conflict",
+            "example": "HIGH"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable conflict message",
+            "example": "Mechanic assigned to two workorders in the same slot"
+          },
+          "affectedResourceId": {
+            "type": "string",
+            "description": "Identifier of the affected resource (mechanic or bay)",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "affectedWorkorderId": {
+            "type": "string",
+            "description": "Identifier of the affected workorder",
+            "example": "01960003-0000-7000-8000-000000000002"
+          }
+        },
+        "required": [
+          "conflictType",
+          "message",
+          "severity"
+        ]
+      },
+      "DashboardResponse": {
+        "type": "object",
+        "description": "Daily Dispatch Board dashboard aggregate response",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "The date this dashboard is for",
+            "example": "2026-01-15"
+          },
+          "locationId": {
+            "type": "string",
+            "description": "Location identifier",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "workorders": {
+            "type": "array",
+            "description": "Workorder summaries for the day",
+            "example": [],
+            "items": {
+              "$ref": "#/components/schemas/WorkorderSummary"
+            }
+          },
+          "mechanics": {
+            "type": "array",
+            "description": "Mechanic statuses",
+            "example": [],
+            "items": {
+              "$ref": "#/components/schemas/MechanicStatus"
+            }
+          },
+          "bays": {
+            "type": "array",
+            "description": "Service bay statuses",
+            "example": [],
+            "items": {
+              "$ref": "#/components/schemas/BayStatus"
+            }
+          },
+          "conflicts": {
+            "type": "array",
+            "description": "Detected conflicts",
+            "example": [],
+            "items": {
+              "$ref": "#/components/schemas/ConflictEntry"
+            }
+          },
+          "lastRefreshed": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when data was last refreshed",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "dataQualityWarning": {
+            "type": "boolean",
+            "default": false,
+            "description": "True when one or more upstream data sources were unavailable during aggregation; data may be incomplete",
+            "example": false
+          }
+        },
+        "required": [
+          "date",
+          "lastRefreshed",
+          "locationId",
+          "workorders"
+        ]
+      },
+      "MechanicStatus": {
+        "type": "object",
+        "description": "Current availability and status of a mechanic",
+        "properties": {
+          "personId": {
+            "type": "string",
+            "description": "Identifier of the mechanic person",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "Mechanic first name",
+            "example": "Alex"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "Mechanic last name",
+            "example": "Rivera"
+          },
+          "currentStatus": {
+            "type": "string",
+            "description": "Current work status of the mechanic",
+            "example": "AVAILABLE"
+          },
+          "assignedWorkorderId": {
+            "type": "string",
+            "description": "Identifier of the workorder the mechanic is currently assigned to",
+            "example": "01960003-0000-7000-8000-000000000002"
+          },
+          "onBreak": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the mechanic is currently on break",
+            "example": false
+          },
+          "breakExpectedReturn": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Expected return time when the mechanic is on break",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "ptoEntries": {
+            "type": "array",
+            "description": "Paid time-off entries for the mechanic",
+            "items": {
+              "$ref": "#/components/schemas/PtoEntry"
+            }
+          }
+        },
+        "required": [
+          "personId"
+        ]
+      },
+      "PtoEntry": {
+        "type": "object",
+        "description": "Paid time off entry affecting technician availability",
+        "properties": {
+          "ptoId": {
+            "type": "string",
+            "description": "Identifier of the PTO entry",
+            "example": "PTO-12345"
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Start timestamp of the PTO period",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "end": {
+            "type": "string",
+            "format": "date-time",
+            "description": "End timestamp of the PTO period",
+            "example": "2026-01-15 09:30:00+00:00"
+          },
+          "ptoType": {
+            "type": "string",
+            "description": "Type of paid time off",
+            "example": "VACATION"
+          }
+        },
+        "required": [
+          "end",
+          "ptoId",
+          "ptoType",
+          "start"
+        ]
+      },
+      "WorkorderSummary": {
+        "type": "object",
+        "description": "Summary view of a workorder for list displays",
+        "properties": {
+          "workorderId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the workorder",
+            "example": "01960003-0000-7000-8000-000000000001"
+          },
+          "workorderNumber": {
+            "type": "string",
+            "description": "Human-readable workorder number",
+            "example": "WO-2024-5001"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current workorder status",
+            "example": "WORK_IN_PROGRESS"
+          },
+          "customerName": {
+            "type": "string",
+            "description": "Name of the customer",
+            "example": "John Doe"
+          },
+          "vehicleDescription": {
+            "type": "string",
+            "description": "Human-readable vehicle description",
+            "example": "2020 Toyota Camry"
+          },
+          "scheduledDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the workorder is scheduled for",
+            "example": "2026-01-15"
+          },
+          "assignedMechanicId": {
+            "type": "string",
+            "description": "Identifier of the assigned mechanic",
+            "example": "01960003-0000-7000-8000-000000000002"
+          },
+          "assignedBayId": {
+            "type": "string",
+            "description": "Identifier of the assigned bay",
+            "example": "01960003-0000-7000-8000-000000000003"
+          },
+          "estimatedLaborHours": {
+            "type": "number",
+            "description": "Estimated labor hours for the workorder",
+            "example": 2.5
+          }
+        },
+        "required": [
+          "workorderId"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  }
 }

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -2015,6 +2015,33 @@ paths:
         - workorder:timeEntry:approve
       x-required-permissions:
       - workorder:timeEntry:approve
+  /v1/workorders/numbers:resolve:
+    post:
+      tags:
+      - Workorder Search
+      summary: Resolve workorder numbers
+      description: Batch-resolves a set of workorder ids to their human workorder numbers. Consumed server-side by sibling services that store only the workorder id and need the human number for finder/search enrichment.
+      operationId: resolveNumbers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkorderNumberResolveRequest'
+        required: true
+      responses:
+        '200':
+          description: Resolved workorder id-to-number pairings returned.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkorderNumberRef'
+      security:
+      - bearerAuth:
+        - workorder:workorder:view
+      x-required-permissions:
+      - workorder:workorder:view
   /v1/workorders/estimates:
     get:
       tags:
@@ -3237,8 +3264,11 @@ paths:
             application/json:
               schema:
                 type: array
+                additionalProperties: {}
+                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickedItemResponse'
+                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3311,8 +3341,11 @@ paths:
             application/json:
               schema:
                 type: array
+                additionalProperties: {}
+                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickTaskResponse'
+                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3658,6 +3691,7 @@ paths:
               schema:
                 type: string
                 format: binary
+                additionalProperties: {}
         '404':
           description: Estimate not found
           content:
@@ -6159,6 +6193,35 @@ components:
       - timeEntryId
       - updatedAt
       - workOrderId
+    WorkorderNumberResolveRequest:
+      type: object
+      description: Batch request to resolve workorder ids to human workorder numbers
+      properties:
+        workorderIds:
+          type: array
+          description: Workorder identifiers to resolve
+          items:
+            type: string
+            format: uuid
+          maxItems: 200
+          minItems: 0
+      required:
+      - workorderIds
+    WorkorderNumberRef:
+      type: object
+      description: Workorder id resolved to its human workorder number
+      properties:
+        workorderId:
+          type: string
+          format: uuid
+          description: Workorder identifier
+          example: 550e8400-e29b-41d4-a716-446655440000
+        workorderNumber:
+          type: string
+          description: Human workorder number
+          example: WO-2026-1001
+      required:
+      - workorderId
     CreateEstimateRequest:
       type: object
       description: Request payload for creating an estimate
@@ -7161,10 +7224,6 @@ components:
           format: uuid
           description: Assigned technician ID
           example: 550e8400-e29b-41d4-a716-446655440004
-        assignedTechnicianName:
-          type: string
-          description: Assigned technician name
-          example: Jane Smith
         services:
           type: array
           description: Service line items with labor totals

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
@@ -28,6 +28,12 @@ public final class EventTypes {
             .apiVersion("1")
             .build();
 
+    /** Batch-resolve workorder ids to human workorder numbers */
+    public static final EventTypeRegistration WORKORDER_NUMBER_RESOLVE = EventTypeRegistration.fastRead(
+                    "WORKORDER_NUMBER_RESOLVE", "Batch-resolve workorder ids to human workorder numbers")
+            .apiVersion("1")
+            .build();
+
     /** Create a new workorder */
     public static final EventTypeRegistration WORKORDER_CREATE = EventTypeRegistration.write(
                     "WORKORDER_CREATE", "Create a new workorder in the system")
@@ -502,6 +508,7 @@ public final class EventTypes {
             // Workorder events
             WORKORDER_LIST,
             WORKORDER_SEARCH,
+            WORKORDER_NUMBER_RESOLVE,
             WORKORDER_CREATE,
             WORKORDER_DELETE,
             WORKORDER_START,

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderSearchController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderSearchController.java
@@ -1,6 +1,8 @@
 package com.positivity.workorder.internal.controller;
 
 import com.positivity.events.EmitEvent;
+import com.positivity.workorder.internal.dto.WorkorderNumberRef;
+import com.positivity.workorder.internal.dto.WorkorderNumberResolveRequest;
 import com.positivity.workorder.internal.dto.WorkorderSearchResult;
 import com.positivity.workorder.service.WorkorderSearchService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +10,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
@@ -15,6 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,5 +51,19 @@ public class WorkorderSearchController {
             @Parameter(schema = @Schema(implementation = Pageable.class)) @PageableDefault(size = 25)
                     Pageable pageable) {
         return workorderSearchService.search(q == null ? "" : q.trim(), pageable);
+    }
+
+    @Operation(
+            summary = "Resolve workorder numbers",
+            description =
+                    "Batch-resolves a set of workorder ids to their human workorder numbers. "
+                            + "Consumed server-side by sibling services that store only the workorder id "
+                            + "and need the human number for finder/search enrichment.")
+    @ApiResponse(responseCode = "200", description = "Resolved workorder id-to-number pairings returned.")
+    @PostMapping("/numbers:resolve")
+    @PreAuthorize("hasAuthority('workorder:workorder:view')")
+    @EmitEvent(id = "WORKORDER_NUMBER_RESOLVE", apiVersion = "1")
+    public List<WorkorderNumberRef> resolveNumbers(@Valid @RequestBody WorkorderNumberResolveRequest request) {
+        return workorderSearchService.resolveNumbers(request.workorderIds());
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberRef.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberRef.java
@@ -1,0 +1,17 @@
+package com.positivity.workorder.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+/**
+ * Resolved workorder id to human workorder number pairing.
+ */
+@Schema(description = "Workorder id resolved to its human workorder number")
+public record WorkorderNumberRef(
+        @Schema(
+                        description = "Workorder identifier",
+                        example = "550e8400-e29b-41d4-a716-446655440000",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                UUID workorderId,
+        @Schema(description = "Human workorder number", example = "WO-2026-1001", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                String workorderNumber) {}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberResolveRequest.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberResolveRequest.java
@@ -1,6 +1,8 @@
 package com.positivity.workorder.internal.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.UUID;
 
@@ -13,6 +15,8 @@ import java.util.UUID;
 @Schema(description = "Batch request to resolve workorder ids to human workorder numbers")
 public record WorkorderNumberResolveRequest(
         @Schema(description = "Workorder identifiers to resolve", requiredMode = Schema.RequiredMode.REQUIRED)
+                @NotEmpty
+                @Size(max = 200)
                 List<UUID> workorderIds) {
 
     public WorkorderNumberResolveRequest {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberResolveRequest.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberResolveRequest.java
@@ -1,0 +1,21 @@
+package com.positivity.workorder.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Batch request resolving a set of workorder ids to their human workorder numbers.
+ *
+ * <p>Consumed server-side by sibling services (e.g. pos-invoice) that store only the
+ * workorder id and need the human number to enrich finder/search rows.
+ */
+@Schema(description = "Batch request to resolve workorder ids to human workorder numbers")
+public record WorkorderNumberResolveRequest(
+        @Schema(description = "Workorder identifiers to resolve", requiredMode = Schema.RequiredMode.REQUIRED)
+                List<UUID> workorderIds) {
+
+    public WorkorderNumberResolveRequest {
+        workorderIds = workorderIds == null ? List.of() : List.copyOf(workorderIds);
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
@@ -1,10 +1,12 @@
 package com.positivity.workorder.internal.service;
 
+import com.positivity.workorder.internal.dto.WorkorderNumberRef;
 import com.positivity.workorder.internal.dto.WorkorderSearchResult;
 import com.positivity.workorder.internal.entity.Estimate;
 import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.service.WorkorderSearchService;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -79,6 +81,17 @@ public class WorkorderSearchServiceImpl implements WorkorderSearchService {
                     .createdAt(workorder.getCreatedAt())
                     .build();
         });
+    }
+
+    @Override
+    public @NonNull List<WorkorderNumberRef> resolveNumbers(@NonNull Collection<UUID> workorderIds) {
+        List<UUID> ids = workorderIds.stream().filter(Objects::nonNull).distinct().toList();
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        return workorderRepository.findAllById(ids).stream()
+                .map(w -> new WorkorderNumberRef(w.getId(), w.getWorkorderNumber()))
+                .toList();
     }
 
     private static @Nullable UUID parseUuidOrNull(@NonNull String value) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/WorkorderSearchService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/WorkorderSearchService.java
@@ -1,6 +1,10 @@
 package com.positivity.workorder.service;
 
+import com.positivity.workorder.internal.dto.WorkorderNumberRef;
 import com.positivity.workorder.internal.dto.WorkorderSearchResult;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,4 +25,15 @@ public interface WorkorderSearchService {
      */
     @NonNull
     Page<WorkorderSearchResult> search(@NonNull String q, @NonNull Pageable pageable);
+
+    /**
+     * Resolve a batch of workorder ids to their human workorder numbers. Unknown ids
+     * are omitted from the result. Used by sibling services that store only the
+     * workorder id and need the human number for finder/search enrichment.
+     *
+     * @param workorderIds workorder ids to resolve
+     * @return id-to-number pairings for the ids that exist
+     */
+    @NonNull
+    List<WorkorderNumberRef> resolveNumbers(@NonNull Collection<UUID> workorderIds);
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderNumberResolveTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderNumberResolveTest.java
@@ -1,0 +1,66 @@
+package com.positivity.workorder.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.dto.WorkorderNumberRef;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.service.CustomerReferenceService;
+import com.positivity.workorder.internal.service.VehicleReferenceService;
+import com.positivity.workorder.internal.service.WorkorderSearchServiceImpl;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the batch workorder-number resolution used by sibling services
+ * (e.g. pos-invoice) to enrich finder rows with the human workorder number.
+ */
+@ExtendWith(MockitoExtension.class)
+class WorkorderNumberResolveTest {
+
+    private static final UUID WORKORDER_A = UUID.fromString("11111111-0000-0000-0000-000000000001");
+    private static final UUID WORKORDER_B = UUID.fromString("11111111-0000-0000-0000-000000000002");
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @Mock
+    private CustomerReferenceService customerReferenceService;
+
+    @Mock
+    private VehicleReferenceService vehicleReferenceService;
+
+    @InjectMocks
+    private WorkorderSearchServiceImpl workorderSearchService;
+
+    private Workorder workorder(UUID id, String number) {
+        return Workorder.builder().id(id).workorderNumber(number).status(WorkorderStatus.DRAFT).build();
+    }
+
+    @Test
+    void resolveNumbers_returnsIdToNumberPairings() {
+        when(workorderRepository.findAllById(List.of(WORKORDER_A, WORKORDER_B)))
+                .thenReturn(List.of(workorder(WORKORDER_A, "WO-2026-1001"), workorder(WORKORDER_B, "WO-2026-1002")));
+
+        List<WorkorderNumberRef> refs = workorderSearchService.resolveNumbers(List.of(WORKORDER_A, WORKORDER_B));
+
+        assertThat(refs)
+                .extracting(WorkorderNumberRef::workorderId, WorkorderNumberRef::workorderNumber)
+                .containsExactlyInAnyOrder(
+                        org.assertj.core.groups.Tuple.tuple(WORKORDER_A, "WO-2026-1001"),
+                        org.assertj.core.groups.Tuple.tuple(WORKORDER_B, "WO-2026-1002"));
+    }
+
+    @Test
+    void resolveNumbers_emptyInput_returnsEmptyWithoutRepositoryCall() {
+        List<WorkorderNumberRef> refs = workorderSearchService.resolveNumbers(List.of());
+        assertThat(refs).isEmpty();
+    }
+}


### PR DESCRIPTION
## Capability: CAP:007 — Convert Workorder to Invoice

**Parent capability:** louisburroughs/durion#7
**Parent story:** louisburroughs/durion#337
**Backend child:** Closes #765

### Summary
Adds a free-text **invoice finder** backing the billing landing invoice-detail card.
New endpoint `GET /v1/invoices/search?q=` matches the query against **invoice number**,
**customer name**, and **workorder number**, returning a paginated `InvoiceSearchResult`
enriched with the resolved customer display name and human workorder number.

The invoice row stores only `workorderId` and `partyId`, so resolution/enrichment go
through two new RestClient clients (`CustomerReferenceClient` → pos-customer,
`WorkorderReferenceClient` → pos-workorder), mirroring the pos-workorder finder.

### Key changes
- **pos-invoice:** `InvoiceSearchController` (`invoice:manage`, `INVOICE_SEARCH` event),
  `InvoiceSearchService(+Impl)`, `InvoiceSearchResult`, `InvoiceRepository.searchByQuery`,
  `CustomerReferenceClient`, `WorkorderReferenceClient`, `RestClientConfig`
  (`@Primary RestClient.Builder` so outbound clients resolve under the openapi/dev profile).
- **pos-workorder:** `POST /v1/workorders/numbers:resolve` batch id→number endpoint
  (`WORKORDER_NUMBER_RESOLVE`) consumed server-side by pos-invoice for enrichment.
- Regenerated `pos-invoice/openapi.yaml` + `openapi.json` (also resyncs prior drift).

### Query semantics
`invoiceNumber LIKE %q% OR partyId IN :customerIds OR workorderId IN :workorderIds`
(name leg → customerIds via CRM; number leg → workorderIds via workorder svc; empty legs
use non-matching sentinels).

### Tests
- [x] Unit tests added — `InvoiceSearchServiceImplTest` (3), `WorkorderNumberResolveTest` (2)
- [x] Controller tests — `InvoiceSearchControllerTest` (3)
- How to run: `./mvnw -pl pos-invoice,pos-workorder test -Dtest='InvoiceSearch*,WorkorderNumberResolveTest'`

**Result:** 8/8 passing. OpenAPI regen boots clean.

### Contract / docs
- [x] OpenAPI annotations on the new controller; spec regenerated.
- [x] Angular SDK regenerated (separate PR).
- Contract guide: `durion/domains/billing/.business-rules/BACKEND_CONTRACT_GUIDE.md`.

### Risk & Rollback
- Risk: Low — additive read endpoint; no migrations; no breaking changes.
- Rollback: revert the commit.

### Related
- Closes #765 · part of louisburroughs/durion#7 · contract PR louisburroughs/durion#338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPnKQCAYe7utAWerR4H7gY
