### PR TITLE
[CAP:007] Invoice finder + artifact-list diagnostic logging

### DIFF
--- a/pos-invoice/openapi.json
+++ b/pos-invoice/openapi.json
@@ -1213,7 +1213,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PageInvoiceSearchResult"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -1223,7 +1223,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PageInvoiceSearchResult"
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -2335,6 +2335,67 @@
             "type": "boolean"
           }
         }
+      },
+      "ApiError": {
+        "type": "object",
+        "description": "Standard error response envelope returned by all Durion backend APIs",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code",
+            "example": "ORDER_NOT_FOUND"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message",
+            "example": "Order '550e8400-e29b-41d4-a716-446655440000' was not found"
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "description": "HTTP status code",
+            "example": 404
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "ISO 8601 UTC timestamp of the error",
+            "example": "2026-03-17 14:30:00+00:00"
+          },
+          "correlationId": {
+            "type": "string",
+            "description": "Unique correlation ID for distributed request tracing",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "fieldErrors": {
+            "type": "array",
+            "description": "Field-level validation errors; present (non-null) for validation-related errors such as VALIDATION_ERROR or VALIDATION_FAILED; omitted for all other error types",
+            "items": {
+              "$ref": "#/components/schemas/FieldError"
+            }
+          },
+          "referenceId": {
+            "type": "string",
+            "description": "Workflow or review-case reference identifier, when applicable",
+            "example": "REVIEW-2026-000123"
+          },
+          "nextAction": {
+            "type": "string",
+            "description": "Recommended next step for the caller, when applicable",
+            "example": "Retry the request with a valid quantity"
+          },
+          "supportAction": {
+            "type": "string",
+            "description": "Support or admin investigation guidance, when applicable",
+            "example": "Contact support with the correlation ID for assistance"
+          }
+        },
+        "required": [
+          "code",
+          "correlationId",
+          "message",
+          "status",
+          "timestamp"
+        ]
       }
     },
     "securitySchemes": {

--- a/pos-invoice/openapi.yaml
+++ b/pos-invoice/openapi.yaml
@@ -745,13 +745,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PageInvoiceSearchResult'
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Caller lacks the invoice:manage authority.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PageInvoiceSearchResult'
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - invoice:manage
@@ -1507,6 +1507,69 @@ components:
           type: array
           items:
             type: string
+    ApiError:
+      type: object
+      description: Standard error response envelope returned by all Durion backend APIs
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+          example: ORDER_NOT_FOUND
+        message:
+          type: string
+          description: Human-readable error message
+          example: Order '550e8400-e29b-41d4-a716-446655440000' was not found
+        status:
+          type: integer
+          format: int32
+          description: HTTP status code
+          example: 404
+        timestamp:
+          type: string
+          description: ISO 8601 UTC timestamp of the error
+          example: 2026-03-17 14:30:00+00:00
+        correlationId:
+          type: string
+          description: Unique correlation ID for distributed request tracing
+          example: 550e8400-e29b-41d4-a716-446655440000
+        fieldErrors:
+          type: array
+          description: Field-level validation errors; present (non-null) for validation-related errors such as VALIDATION_ERROR or VALIDATION_FAILED; omitted for all other error types
+          items:
+            $ref: '#/components/schemas/FieldError'
+        referenceId:
+          type: string
+          description: Workflow or review-case reference identifier, when applicable
+          example: REVIEW-2026-000123
+        nextAction:
+          type: string
+          description: Recommended next step for the caller, when applicable
+          example: Retry the request with a valid quantity
+        supportAction:
+          type: string
+          description: Support or admin investigation guidance, when applicable
+          example: Contact support with the correlation ID for assistance
+      required:
+      - code
+      - correlationId
+      - message
+      - status
+      - timestamp
+    FieldError:
+      type: object
+      description: Validation error for a specific request field
+      properties:
+        field:
+          type: string
+          description: Field name
+          example: quantity
+        message:
+          type: string
+          description: Validation failure message
+          example: must be greater than 0
+      required:
+      - field
+      - message
     InvoiceSearchResult:
       type: object
       description: Lightweight invoice search result enriched with customer name and workorder number

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
  * authenticated; the actual byte download is a separate, token-authorized public endpoint
  * (see {@code InvoiceArtifactDownloadController}).
  */
+@Slf4j
 @RestController
 @RequestMapping("/v1/invoices")
 @PreAuthorize("isAuthenticated()")
@@ -42,7 +44,10 @@ public class InvoiceArtifactController {
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/{invoiceId}/artifacts")
     public ResponseEntity<List<InvoiceArtifactResponse>> listArtifacts(@PathVariable @NonNull UUID invoiceId) {
-        return ResponseEntity.ok(artifactService.listArtifacts(invoiceId));
+        log.info("listArtifacts request received for invoice {}", invoiceId);
+        List<InvoiceArtifactResponse> artifacts = artifactService.listArtifacts(invoiceId);
+        log.info("listArtifacts returning {} artifact(s) for invoice {}", artifacts.size(), invoiceId);
+        return ResponseEntity.ok(artifacts);
     }
 
     @Operation(

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactExceptionHandler.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactExceptionHandler.java
@@ -9,12 +9,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /** Maps invoice-artifact errors to HTTP statuses for the artifact controllers. */
+@Slf4j
 @RestControllerAdvice(assignableTypes = {InvoiceArtifactController.class, InvoiceArtifactDownloadController.class})
 @RequiredArgsConstructor
 public class InvoiceArtifactExceptionHandler {
@@ -24,16 +26,19 @@ public class InvoiceArtifactExceptionHandler {
 
     @ExceptionHandler({InvoiceNotFoundException.class, ArtifactNotFoundException.class})
     public ResponseEntity<ApiError> handleNotFound(RuntimeException ex, HttpServletRequest request) {
+        log.warn("Artifact request returned 404 for {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
         return error(HttpStatus.NOT_FOUND, "NOT_FOUND", ex.getMessage(), request);
     }
 
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ApiError> handleInvalidToken(InvalidTokenException ex, HttpServletRequest request) {
+        log.warn("Artifact request returned 403 for {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
         return error(HttpStatus.FORBIDDEN, "FORBIDDEN", ex.getMessage(), request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiError> handleBadRequest(IllegalArgumentException ex, HttpServletRequest request) {
+        log.warn("Artifact request returned 400 for {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
         return error(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), request);
     }
 

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
@@ -3,8 +3,10 @@ package com.positivity.invoice.internal.controller;
 import com.positivity.events.EmitEvent;
 import com.positivity.invoice.internal.dto.InvoiceSearchResult;
 import com.positivity.invoice.service.InvoiceSearchService;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -47,8 +49,14 @@ public class InvoiceSearchController {
                             + "customer name, or workorder number.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Page of invoice search results returned."),
-        @ApiResponse(responseCode = "400", description = "Invalid pagination parameters."),
-        @ApiResponse(responseCode = "403", description = "Caller lacks the invoice:manage authority.")
+        @ApiResponse(
+                responseCode = "400",
+                description = "Invalid pagination parameters.",
+                content = @Content(schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Caller lacks the invoice:manage authority.",
+                content = @Content(schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping("/search")
     @PreAuthorize("hasAuthority('invoice:manage')")

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/client/CustomerReferenceClientTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/client/CustomerReferenceClientTest.java
@@ -1,0 +1,129 @@
+package com.positivity.invoice.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link CustomerReferenceClient}. Binds {@link MockRestServiceServer} to the
+ * {@link RestClient.Builder} the client builds from, so the data-envelope unwrap, name-field
+ * fallback precedence, name composition, and silent-failure behaviour are exercised without a
+ * live CRM service.
+ */
+class CustomerReferenceClientTest {
+
+    private static final String BASE_URL = "http://pos-customer:8080/v1/crm";
+
+    private RestClient.Builder builder;
+    private MockRestServiceServer server;
+    private CustomerReferenceClient client;
+
+    @BeforeEach
+    void setUp() {
+        builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new CustomerReferenceClient(builder, BASE_URL);
+    }
+
+    @Test
+    void searchIdsByName_blankQuery_returnsEmptyWithoutCall() {
+        assertThat(client.searchIdsByName("  ", 50)).isEmpty();
+        server.verify(); // no HTTP expectation registered => no call made
+    }
+
+    @Test
+    void searchIdsByName_extractsPartyIds_skippingNonMapRows() {
+        server.expect(requestTo(Matchers.containsString("/accounts/parties?name=Acme&size=50")))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(
+                        "{\"results\":[{\"partyId\":\"p-1\"},\"junk\",{\"noId\":true},{\"partyId\":\" p-2 \"}]}",
+                        MediaType.APPLICATION_JSON));
+
+        assertThat(client.searchIdsByName("Acme", 50)).containsExactly("p-1", "p-2");
+        server.verify();
+    }
+
+    @Test
+    void resolveNames_unwrapsDataEnvelope_andAppliesFieldPrecedence() {
+        // customerName wins over displayName/legalName/name
+        server.expect(requestTo(BASE_URL + "/p-1"))
+                .andRespond(withSuccess(
+                        "{\"data\":{\"customerName\":\"Acme Towing LLC\",\"displayName\":\"ignored\"}}",
+                        MediaType.APPLICATION_JSON));
+
+        assertThat(client.resolveNames(List.of("p-1"))).containsEntry("p-1", "Acme Towing LLC");
+        server.verify();
+    }
+
+    @Test
+    void resolveNames_fallsBackThroughNameFields() {
+        // no customerName -> displayName used
+        server.expect(requestTo(BASE_URL + "/p-1"))
+                .andRespond(withSuccess(
+                        "{\"displayName\":\"Display Co\",\"legalName\":\"Legal Co\"}", MediaType.APPLICATION_JSON));
+
+        assertThat(client.resolveNames(List.of("p-1"))).containsEntry("p-1", "Display Co");
+        server.verify();
+    }
+
+    @Test
+    void resolveNames_composesFirstLast_whenOnlyPersonFieldsPresent() {
+        server.expect(requestTo(BASE_URL + "/p-1"))
+                .andRespond(
+                        withSuccess("{\"firstName\":\"John\",\"lastName\":\"Smith\"}", MediaType.APPLICATION_JSON));
+
+        assertThat(client.resolveNames(List.of("p-1"))).containsEntry("p-1", "John Smith");
+        server.verify();
+    }
+
+    @Test
+    void resolveNames_dedupesContainedName() {
+        // lastName already contains firstName -> return lastName, not "John John Smith"
+        server.expect(requestTo(BASE_URL + "/p-1"))
+                .andRespond(withSuccess(
+                        "{\"firstName\":\"John\",\"lastName\":\"John Smith\"}", MediaType.APPLICATION_JSON));
+
+        assertThat(client.resolveNames(List.of("p-1"))).containsEntry("p-1", "John Smith");
+        server.verify();
+    }
+
+    @Test
+    void resolveNames_omitsIdWhenBodyEmptyOrUnresolved() {
+        server.expect(requestTo(BASE_URL + "/p-1")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+        assertThat(client.resolveNames(List.of("p-1"))).doesNotContainKey("p-1");
+        server.verify();
+    }
+
+    @Test
+    void resolveNames_remoteError_isSwallowed_returningNoEntry() {
+        server.expect(requestTo(BASE_URL + "/p-1")).andRespond(withServerError());
+
+        assertThat(client.resolveNames(List.of("p-1"))).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    void resolveNames_skipsBlankAndDuplicateIds() {
+        // only one HTTP call expected for the single distinct, non-blank id
+        server.expect(requestTo(BASE_URL + "/p-1"))
+                .andRespond(withSuccess("{\"name\":\"Once\"}", MediaType.APPLICATION_JSON));
+
+        Map<String, String> resolved = client.resolveNames(java.util.Arrays.asList("p-1", "p-1", "  ", null));
+
+        assertThat(resolved).containsExactly(Map.entry("p-1", "Once"));
+        server.verify();
+    }
+}

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/client/WorkorderReferenceClientTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/client/WorkorderReferenceClientTest.java
@@ -1,0 +1,88 @@
+package com.positivity.invoice.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.List;
+import java.util.UUID;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link WorkorderReferenceClient}. Binds {@link MockRestServiceServer} to the
+ * {@link RestClient.Builder} so id parsing, the batch {@code numbers:resolve} mapping, and
+ * silent-failure behaviour are exercised without a live workorder service.
+ */
+class WorkorderReferenceClientTest {
+
+    private static final String BASE_URL = "http://pos-workorder:8080/v1/workorders";
+    private static final UUID WO_1 = UUID.fromString("11111111-0000-0000-0000-000000000001");
+    private static final UUID WO_2 = UUID.fromString("22222222-0000-0000-0000-000000000002");
+
+    private RestClient.Builder builder;
+    private MockRestServiceServer server;
+    private WorkorderReferenceClient client;
+
+    @BeforeEach
+    void setUp() {
+        builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new WorkorderReferenceClient(builder, BASE_URL);
+    }
+
+    @Test
+    void searchIdsByNumber_blankQuery_returnsEmptyWithoutCall() {
+        assertThat(client.searchIdsByNumber(" ", 50)).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    void searchIdsByNumber_parsesContentIds_skippingBadUuids() {
+        server.expect(requestTo(Matchers.containsString("/search?q=WO-2026&size=50")))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(
+                        "{\"content\":[{\"workorderId\":\"" + WO_1 + "\"},{\"workorderId\":\"not-a-uuid\"},"
+                                + "{\"noId\":1},{\"workorderId\":\"" + WO_2 + "\"}]}",
+                        MediaType.APPLICATION_JSON));
+
+        assertThat(client.searchIdsByNumber("WO-2026", 50)).containsExactly(WO_1, WO_2);
+        server.verify();
+    }
+
+    @Test
+    void resolveNumbers_emptyInput_returnsEmptyWithoutCall() {
+        assertThat(client.resolveNumbers(List.of())).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    void resolveNumbers_mapsBatchResponse_skippingBadIdsAndBlankNumbers() {
+        server.expect(requestTo(BASE_URL + "/numbers:resolve"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(
+                        "[{\"workorderId\":\"" + WO_1 + "\",\"workorderNumber\":\" WO-2026-1001 \"},"
+                                + "{\"workorderId\":\"" + WO_2 + "\",\"workorderNumber\":\"\"},"
+                                + "{\"workorderId\":\"bad\",\"workorderNumber\":\"WO-X\"}]",
+                        MediaType.APPLICATION_JSON));
+
+        assertThat(client.resolveNumbers(List.of(WO_1, WO_2)))
+                .containsExactly(java.util.Map.entry(WO_1, "WO-2026-1001"));
+        server.verify();
+    }
+
+    @Test
+    void resolveNumbers_remoteError_isSwallowed_returningEmptyMap() {
+        server.expect(requestTo(BASE_URL + "/numbers:resolve")).andRespond(withServerError());
+
+        assertThat(client.resolveNumbers(List.of(WO_1))).isEmpty();
+        server.verify();
+    }
+}

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/controller/InvoiceSearchControllerTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/controller/InvoiceSearchControllerTest.java
@@ -1,5 +1,6 @@
 package com.positivity.invoice.internal.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -18,11 +19,14 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -93,5 +97,28 @@ class InvoiceSearchControllerTest {
         mockMvc.perform(get("/v1/invoices/search")).andExpect(status().isOk());
 
         verify(invoiceSearchService).search(eq(""), any());
+    }
+
+    @Test
+    void search_clampsPageSizeToMax_preservingPageIndexAndSort() throws Exception {
+        when(invoiceSearchService.search(eq("Acme"), any()))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(2, 50), 0));
+
+        mockMvc.perform(get("/v1/invoices/search")
+                        .param("q", "Acme")
+                        .param("page", "2")
+                        .param("size", "200")
+                        .param("sort", "invoiceNumber,asc"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(invoiceSearchService).search(eq("Acme"), pageableCaptor.capture());
+        Pageable delegated = pageableCaptor.getValue();
+        assertThat(delegated.getPageSize()).isEqualTo(50);
+        assertThat(delegated.getPageNumber()).isEqualTo(2);
+        assertThat(delegated.getSort().getOrderFor("invoiceNumber"))
+                .isNotNull()
+                .extracting(Sort.Order::getDirection)
+                .isEqualTo(Sort.Direction.ASC);
     }
 }


### PR DESCRIPTION
## Summary

CAP-007 invoice finder backend, plus diagnostic logging for the invoice artifacts endpoint.

- **Invoice finder** — `GET /v1/invoices/search` (`InvoiceSearchController` / `InvoiceSearchService`), `InvoiceSearchResult` DTO, repository query.
- **Workorder support** — workorder number resolve + search endpoints, `EventTypes` additions, OpenAPI regen (`pos-workorder` yaml/json).
- **RestClientConfig** — `@Primary` builder so new RestClient clients boot (openapi/dev profile).
- **Artifact-list logging** — `InvoiceArtifactController.listArtifacts` logs entry + result count; `InvoiceArtifactExceptionHandler` now logs every 404/403/400 (was silent). Added to trace an artifacts-endpoint 404 on durionpos.org where no log line appeared — confirms whether the request reaches pos-invoice and which branch fires.

## Testing

- `mvn -pl pos-invoice compile` clean.
- Unit/controller tests for invoice search + workorder number resolve included.

## Notes

- Diagnostic logging only surfaces once pos-invoice is redeployed. A *missing* `listArtifacts request received` line on durionpos.org indicates a gateway-level 404 (route/instance not live), not a service NOT_FOUND.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
