### PR TITLE
[CAP:007] Batch CRM customer-name resolve for finders (#768)

### DIFF
--- a/pos-customer/README.md
+++ b/pos-customer/README.md
@@ -30,6 +30,7 @@ CRM service for the Durion Positivity ETSMS platform. Manages the customer party
 - `GET /v1/customers/{accountId}/tier` — get account tier
 - `GET /v1/parties/{partyId}` — retrieve a party
 - `GET /v1/crm/accounts/parties/duplicate-check?legalName=...` — check potential duplicate commercial parties
+- `POST /v1/crm/accounts/parties:resolve` — batch-resolve party ids to display names (auth: `crm:party:view`); for sibling-service finder enrichment
 - `GET /v1/parties/{partyId}/contacts` — list contact roles
 - `GET /v1/parties/{partyId}/communicationPreferences` — communication preferences
 - `PUT /v1/crm/accounts/parties/{partyId}/billing-rules` — upsert billing rules for a commercial party

--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -990,6 +990,37 @@ paths:
         - crm:party:create
       x-required-permissions:
       - crm:party:create
+  /v1/crm/accounts/parties:resolve:
+    post:
+      tags:
+      - CRM Accounts
+      summary: Resolve party display names
+      description: Batch-resolve party ids to display names. Consumed server-side by sibling services (e.g. pos-invoice) that store only the party id and need the display name to enrich finder/search rows. Unknown or unresolvable ids are omitted from the response.
+      operationId: resolvePartyNames
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartyNameResolveRequest'
+        required: true
+      responses:
+        '200':
+          description: Resolved party id-to-name pairs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PartyNameRef'
+        '400':
+          description: Invalid resolve request
+        '403':
+          description: Forbidden - insufficient permissions
+      security:
+      - bearerAuth:
+        - crm:party:view
+      x-required-permissions:
+      - crm:party:view
   /v1/crm/accounts/parties/{partyId}/vehicles:
     post:
       tags:
@@ -1826,6 +1857,17 @@ components:
           format: int64
           description: Optimistic lock version.
           example: 1
+      required:
+      - accountId
+      - createdAt
+      - description
+      - isActive
+      - unitNumber
+      - updatedAt
+      - vehicleId
+      - version
+      - vin
+      - vinNormalized
     VehicleTransferRequest:
       type: object
       description: Transfer request with target customer
@@ -2818,6 +2860,35 @@ components:
       required:
       - legalName
       - matchReason
+      - partyId
+    PartyNameResolveRequest:
+      type: object
+      description: Batch request to resolve party ids to display names
+      properties:
+        partyIds:
+          type: array
+          description: Party identifiers to resolve
+          items:
+            type: string
+            format: uuid
+          maxItems: 200
+          minItems: 0
+      required:
+      - partyIds
+    PartyNameRef:
+      type: object
+      description: Party id resolved to its display name
+      properties:
+        partyId:
+          type: string
+          format: uuid
+          description: Party identifier
+          example: 550e8400-e29b-41d4-a716-446655440000
+        displayName:
+          type: string
+          description: Resolved display name (commercial display/legal name or person full name)
+          example: Acme Towing LLC
+      required:
       - partyId
     CreateVehicleForPartyResponse:
       type: object

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/EventTypes.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/EventTypes.java
@@ -42,6 +42,8 @@ public final class EventTypes {
                         .build(),
                 EventTypeRegistration.search("CUSTOMER_PARTY_SEARCH", "Search for parties based on various criteria")
                         .build(),
+                EventTypeRegistration.search("CUSTOMER_PARTY_RESOLVE", "Batch-resolve party ids to display names")
+                        .build(),
                 EventTypeRegistration.approval(
                                 "CUSTOMER_PARTY_MERGE", "Merge multiple parties into a single party record")
                         .build(),

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
@@ -10,6 +10,8 @@ import com.positivity.customer.internal.dto.GetCommunicationPreferencesResponse;
 import com.positivity.customer.internal.dto.GetPartyResponse;
 import com.positivity.customer.internal.dto.MergePartiesRequest;
 import com.positivity.customer.internal.dto.MergePartiesResponse;
+import com.positivity.customer.internal.dto.PartyNameRef;
+import com.positivity.customer.internal.dto.PartyNameResolveRequest;
 import com.positivity.customer.internal.dto.ResolveAccountTierRequest;
 import com.positivity.customer.internal.dto.ResolveAccountTierResponse;
 import com.positivity.customer.internal.dto.SearchPartiesRequest;
@@ -24,11 +26,14 @@ import com.positivity.customer.service.PartyService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -274,6 +279,35 @@ public class CrmAccountsController {
         log.info("searchParties");
         SearchPartiesResponse response = partyService.searchParties(body);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "Resolve party display names",
+            description = "Batch-resolve party ids to display names. Consumed server-side by sibling services "
+                    + "(e.g. pos-invoice) that store only the party id and need the display name to enrich "
+                    + "finder/search rows. Unknown or unresolvable ids are omitted from the response.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Resolved party id-to-name pairs",
+                        content =
+                                @Content(array = @ArraySchema(schema = @Schema(implementation = PartyNameRef.class)))),
+                @ApiResponse(responseCode = "400", description = "Invalid resolve request", content = @Content),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "Forbidden - insufficient permissions",
+                        content = @Content)
+            })
+    @PostMapping("/parties:resolve")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {CrmPermissionRegistry.PARTY_VIEW})
+    @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
+    @EmitEvent(id = "CUSTOMER_PARTY_RESOLVE", apiVersion = "1")
+    public ResponseEntity<List<PartyNameRef>> resolvePartyNames(@Valid @RequestBody PartyNameResolveRequest body) {
+        log.info("resolvePartyNames count={}", body.partyIds().size());
+        return ResponseEntity.ok(partyService.resolveNames(body.partyIds()));
     }
 
     @Operation(summary = "Merge parties", description = "Merge multiple parties into a single party record")

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/PartyNameRef.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/PartyNameRef.java
@@ -1,0 +1,21 @@
+package com.positivity.customer.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+/**
+ * Resolved party id to display name pairing.
+ */
+@Schema(description = "Party id resolved to its display name")
+public record PartyNameRef(
+        @Schema(
+                description = "Party identifier",
+                example = "550e8400-e29b-41d4-a716-446655440000",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID partyId,
+
+        @Schema(
+                description = "Resolved display name (commercial display/legal name or person full name)",
+                example = "Acme Towing LLC",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String displayName) {}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/PartyNameResolveRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/PartyNameResolveRequest.java
@@ -1,0 +1,25 @@
+package com.positivity.customer.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Batch request resolving a set of party ids to their display names.
+ *
+ * <p>Consumed server-side by sibling services (e.g. pos-invoice) that store only the
+ * party id and need the display name to enrich finder/search rows.
+ */
+@Schema(description = "Batch request to resolve party ids to display names")
+public record PartyNameResolveRequest(
+        @Schema(description = "Party identifiers to resolve", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotEmpty
+        @Size(max = 200)
+        List<UUID> partyIds) {
+
+    public PartyNameResolveRequest {
+        partyIds = partyIds == null ? List.of() : List.copyOf(partyIds);
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/PartyNameResolveRequest.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/PartyNameResolveRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -20,6 +21,8 @@ public record PartyNameResolveRequest(
         List<UUID> partyIds) {
 
     public PartyNameResolveRequest {
-        partyIds = partyIds == null ? List.of() : List.copyOf(partyIds);
+        partyIds = partyIds == null
+                ? List.of()
+                : partyIds.stream().filter(Objects::nonNull).distinct().toList();
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -12,6 +12,7 @@ import com.positivity.customer.internal.dto.GetCommunicationPreferencesResponse;
 import com.positivity.customer.internal.dto.GetPartyResponse;
 import com.positivity.customer.internal.dto.MergePartiesRequest;
 import com.positivity.customer.internal.dto.MergePartiesResponse;
+import com.positivity.customer.internal.dto.PartyNameRef;
 import com.positivity.customer.internal.dto.SearchPartiesRequest;
 import com.positivity.customer.internal.dto.SearchPartiesResponse;
 import com.positivity.customer.internal.dto.UpsertBillingRulesRequest;
@@ -354,6 +355,52 @@ public class PartyServiceImpl implements PartyService {
                 .pageNumber(0)
                 .pageSize(summaries.size())
                 .build();
+    }
+
+    /**
+     * Batch-resolve party ids to display names. Intentionally NOT {@code @Transactional}: each
+     * repository {@code findAllById} runs in its own short transaction and the entities are read as
+     * scalars afterwards, so the pos-people HTTP call below never holds a database connection.
+     */
+    @Override
+    @NonNull
+    public List<PartyNameRef> resolveNames(@NonNull List<UUID> partyIds) {
+        List<UUID> ids = partyIds.stream().filter(Objects::nonNull).distinct().toList();
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+
+        Map<UUID, String> namesByPartyId = new java.util.LinkedHashMap<>();
+
+        // Commercial parties: prefer the display/trading name, fall back to the legal name.
+        for (CommercialParty party : partyRepository.findAllById(ids)) {
+            String name = StringUtils.hasText(party.getDisplayName()) ? party.getDisplayName() : party.getLegalName();
+            if (StringUtils.hasText(name)) {
+                namesByPartyId.put(party.getPartyId(), name.trim());
+            }
+        }
+
+        // Person parties: the human name lives in pos-people; resolve it in a single batch call.
+        Map<UUID, UUID> personIdByPartyId = new java.util.LinkedHashMap<>();
+        for (PersonParty person : personPartyRepository.findAllById(ids)) {
+            if (person.getPersonId() != null) {
+                personIdByPartyId.put(person.getPartyId(), person.getPersonId());
+            }
+        }
+        if (!personIdByPartyId.isEmpty()) {
+            Map<UUID, PeopleClient.PersonIdentity> identities =
+                    peopleClient.fetchPersonIdentitiesQuietly(Set.copyOf(personIdByPartyId.values()));
+            personIdByPartyId.forEach((partyId, personId) -> {
+                PeopleClient.PersonIdentity identity = identities.get(personId);
+                if (identity != null && StringUtils.hasText(identity.displayName())) {
+                    namesByPartyId.put(partyId, identity.displayName());
+                }
+            });
+        }
+
+        return namesByPartyId.entrySet().stream()
+                .map(entry -> new PartyNameRef(entry.getKey(), entry.getValue()))
+                .toList();
     }
 
     @Override
@@ -816,8 +863,8 @@ public class PartyServiceImpl implements PartyService {
             PartyRelationship rel, Map<UUID, PeopleClient.PersonIdentity> identities) {
         PersonParty person = rel.getToPerson();
         ContactSummary summary = new ContactSummary();
-        summary.setContactId(
-                Objects.requireNonNull(rel.getPartyRelationshipId(), "partyRelationshipId").toString());
+        summary.setContactId(Objects.requireNonNull(rel.getPartyRelationshipId(), "partyRelationshipId")
+                .toString());
         summary.setPrimary(rel.isPrimaryBillingContact());
         summary.setName(Objects.requireNonNullElse(resolveDisplayName(person, identities), "Unknown"));
         summary.setRoles(Collections.emptyList());

--- a/pos-customer/src/main/java/com/positivity/customer/service/PartyService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/service/PartyService.java
@@ -9,6 +9,7 @@ import com.positivity.customer.internal.dto.GetCommunicationPreferencesResponse;
 import com.positivity.customer.internal.dto.GetPartyResponse;
 import com.positivity.customer.internal.dto.MergePartiesRequest;
 import com.positivity.customer.internal.dto.MergePartiesResponse;
+import com.positivity.customer.internal.dto.PartyNameRef;
 import com.positivity.customer.internal.dto.SearchPartiesRequest;
 import com.positivity.customer.internal.dto.SearchPartiesResponse;
 import com.positivity.customer.internal.dto.UpsertBillingRulesRequest;
@@ -16,6 +17,7 @@ import com.positivity.customer.internal.dto.UpsertCommunicationPreferencesReques
 import com.positivity.customer.internal.dto.UpsertCommunicationPreferencesResponse;
 import com.positivity.customer.internal.dto.snapshot.BillingRuleRef;
 import com.positivity.customer.internal.entity.CommercialParty;
+import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -46,6 +48,14 @@ public interface PartyService {
             String sortOrder);
 
     SearchPartiesResponse searchParties(SearchPartiesRequest request);
+
+    /**
+     * Batch-resolve party ids to display names for sibling-service finder enrichment.
+     * Commercial parties resolve to {@code displayName ?? legalName}; person parties resolve to the
+     * canonical person full name via pos-people. Unknown or unresolvable ids are omitted.
+     */
+    @NonNull
+    List<PartyNameRef> resolveNames(@NonNull List<UUID> partyIds);
 
     MergePartiesResponse mergeParties(UUID survivorPartyId, MergePartiesRequest request);
 

--- a/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/controller/CrmAccountsControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -313,6 +314,37 @@ class CrmAccountsControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                         .header("X-Authorities", "crm:billing_rules:edit"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ─── POST /v1/crm/accounts/parties:resolve ──────────────────────────────
+
+    @Test
+    @DisplayName("resolve parties returns id-to-displayName pairs")
+    void resolvePartyNames_returnsPairs() throws Exception {
+        UUID p1 = UUID.fromString("11111111-0000-0000-0000-000000000001");
+        when(partyService.resolveNames(eq(List.of(p1))))
+                .thenReturn(List.of(new com.positivity.customer.internal.dto.PartyNameRef(p1, "Acme Towing LLC")));
+
+        mockMvc.perform(post("/v1/crm/accounts/parties:resolve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new com.positivity.customer.internal.dto.PartyNameResolveRequest(List.of(p1))))
+                        .header("X-Authorities", "crm:party:view"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].partyId").value(p1.toString()))
+                .andExpect(jsonPath("$[0].displayName").value("Acme Towing LLC"));
+
+        verify(partyService).resolveNames(eq(List.of(p1)));
+    }
+
+    @Test
+    @DisplayName("resolve parties rejects an empty id list")
+    void resolvePartyNames_emptyList_isBadRequest() throws Exception {
+        mockMvc.perform(post("/v1/crm/accounts/parties:resolve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"partyIds\":[]}")
+                        .header("X-Authorities", "crm:party:view"))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyServiceImplResolveNamesTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyServiceImplResolveNamesTest.java
@@ -1,0 +1,138 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.client.PeopleClient;
+import com.positivity.customer.internal.dto.PartyNameRef;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.entity.PersonParty;
+import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link PartyServiceImpl#resolveNames}: commercial display/legal fallback, person
+ * names resolved in a single batched pos-people call, dedupe, and omission of unresolvable ids.
+ */
+@ExtendWith(MockitoExtension.class)
+class PartyServiceImplResolveNamesTest {
+
+    @Mock
+    private java.time.Clock clock;
+
+    @Mock
+    private CommercialPartyRepository partyRepository;
+
+    @Mock
+    private PersonPartyRepository personPartyRepository;
+
+    @Mock
+    private com.positivity.customer.internal.repository.PartyRelationshipRepository partyRelationshipRepository;
+
+    @Mock
+    private org.springframework.cache.CacheManager cacheManager;
+
+    @Mock
+    private PeopleClient peopleClient;
+
+    @Mock
+    private com.positivity.customer.internal.client.VehicleInventoryClient vehicleInventoryClient;
+
+    @InjectMocks
+    private PartyServiceImpl service;
+
+    private static CommercialParty commercial(UUID partyId, String displayName, String legalName) {
+        CommercialParty p = new CommercialParty();
+        p.setPartyId(partyId);
+        p.setDisplayName(displayName);
+        p.setLegalName(legalName);
+        return p;
+    }
+
+    private static PersonParty person(UUID partyId, UUID personId) {
+        PersonParty p = new PersonParty();
+        p.setPartyId(partyId);
+        p.setPersonId(personId);
+        return p;
+    }
+
+    private static PeopleClient.PersonIdentity identity(UUID personId, String first, String last) {
+        return new PeopleClient.PersonIdentity(personId, first, last, null, List.of());
+    }
+
+    @Test
+    void emptyInput_returnsEmpty_withoutTouchingRepositories() {
+        assertThat(service.resolveNames(List.of())).isEmpty();
+        verify(partyRepository, never()).findAllById(anyCollection());
+        verify(personPartyRepository, never()).findAllById(anyCollection());
+    }
+
+    @Test
+    void commercial_prefersDisplayName_fallsBackToLegalName() {
+        UUID withDisplay = UUID.fromString("11111111-0000-0000-0000-000000000001");
+        UUID legalOnly = UUID.fromString("11111111-0000-0000-0000-000000000002");
+        when(partyRepository.findAllById(List.of(withDisplay, legalOnly)))
+                .thenReturn(List.of(
+                        commercial(withDisplay, "Acme Supply", "Acme Industrial Supply LLC"),
+                        commercial(legalOnly, "  ", "Legal Only Inc")));
+        when(personPartyRepository.findAllById(List.of(withDisplay, legalOnly))).thenReturn(List.of());
+
+        List<PartyNameRef> result = service.resolveNames(List.of(withDisplay, legalOnly));
+
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        new PartyNameRef(withDisplay, "Acme Supply"), new PartyNameRef(legalOnly, "Legal Only Inc"));
+        verify(peopleClient, never()).fetchPersonIdentitiesQuietly(anyCollection());
+    }
+
+    @Test
+    void person_resolvedViaSingleBatchedPeopleCall() {
+        UUID partyA = UUID.fromString("22222222-0000-0000-0000-000000000001");
+        UUID partyB = UUID.fromString("22222222-0000-0000-0000-000000000002");
+        UUID personA = UUID.fromString("33333333-0000-0000-0000-000000000001");
+        UUID personB = UUID.fromString("33333333-0000-0000-0000-000000000002");
+        when(partyRepository.findAllById(List.of(partyA, partyB))).thenReturn(List.of());
+        when(personPartyRepository.findAllById(List.of(partyA, partyB)))
+                .thenReturn(List.of(person(partyA, personA), person(partyB, personB)));
+        when(peopleClient.fetchPersonIdentitiesQuietly(anyCollection()))
+                .thenReturn(
+                        Map.of(personA, identity(personA, "John", "Smith"), personB, identity(personB, "Jane", "Doe")));
+
+        List<PartyNameRef> result = service.resolveNames(List.of(partyA, partyB));
+
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        new PartyNameRef(partyA, "John Smith"), new PartyNameRef(partyB, "Jane Doe"));
+        // single batch call, not one per person
+        verify(peopleClient).fetchPersonIdentitiesQuietly(anyCollection());
+    }
+
+    @Test
+    void dedupesIds_andOmitsUnresolvable() {
+        UUID known = UUID.fromString("44444444-0000-0000-0000-000000000001");
+        UUID unknown = UUID.fromString("44444444-0000-0000-0000-000000000002");
+        UUID personNoIdentity = UUID.fromString("44444444-0000-0000-0000-000000000003");
+        UUID personId = UUID.fromString("55555555-0000-0000-0000-000000000003");
+        // duplicate `known` in the input collapses to one
+        when(partyRepository.findAllById(List.of(known, unknown, personNoIdentity)))
+                .thenReturn(List.of(commercial(known, "Known Co", "Known Co LLC")));
+        when(personPartyRepository.findAllById(List.of(known, unknown, personNoIdentity)))
+                .thenReturn(List.of(person(personNoIdentity, personId)));
+        when(peopleClient.fetchPersonIdentitiesQuietly(anyCollection())).thenReturn(Map.of());
+
+        List<PartyNameRef> result = service.resolveNames(List.of(known, known, unknown, personNoIdentity));
+
+        assertThat(result).containsExactly(new PartyNameRef(known, "Known Co"));
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/client/CustomerReferenceClient.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/client/CustomerReferenceClient.java
@@ -89,91 +89,45 @@ public class CustomerReferenceClient {
      * @return party id to display name map
      */
     public @NonNull Map<String, String> resolveNames(@NonNull Collection<String> partyIds) {
-        Map<String, String> resolved = new LinkedHashMap<>();
-        for (String partyId : partyIds) {
-            if (!StringUtils.hasText(partyId) || resolved.containsKey(partyId)) {
-                continue;
-            }
-            String name = resolveName(partyId);
-            if (name != null) {
-                resolved.put(partyId, name);
-            }
+        List<String> ids = partyIds.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .distinct()
+                .toList();
+        if (ids.isEmpty()) {
+            return Map.of();
         }
-        return resolved;
-    }
-
-    private @Nullable String resolveName(@NonNull String partyId) {
         try {
             @SuppressWarnings("unchecked")
-            Map<String, Object> body = crmRestClient
-                    .get()
-                    .uri("/{partyId}", partyId)
+            List<Map<String, Object>> rows = crmRestClient
+                    .post()
+                    .uri("/accounts/parties:resolve")
                     .header("X-User", "pos-invoice")
                     .header("X-Authorities", "crm:party:view")
+                    .body(Map.of("partyIds", ids))
                     .retrieve()
-                    .body(Map.class);
-            if (body == null || body.isEmpty()) {
-                return null;
-            }
-            Map<String, Object> payload = unwrapData(body);
-            return firstNonBlank(
-                    extract(payload, "customerName"),
-                    extract(payload, "displayName"),
-                    extract(payload, "legalName"),
-                    extract(payload, "name"),
-                    composeName(extract(payload, "firstName"), extract(payload, "lastName")));
-        } catch (Exception ex) {
-            log.debug("Unable to resolve customer reference for {}: {}", partyId, ex.getMessage());
-            return null;
-        }
-    }
+                    .body(List.class);
 
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> unwrapData(Map<String, Object> body) {
-        Object data = body.get("data");
-        if (data instanceof Map<?, ?> dataMap) {
-            return (Map<String, Object>) dataMap;
+            if (rows == null) {
+                return Map.of();
+            }
+            Map<String, String> resolved = new LinkedHashMap<>();
+            for (Map<String, Object> row : rows) {
+                String partyId = extract(row, "partyId");
+                String displayName = extract(row, "displayName");
+                if (StringUtils.hasText(partyId) && StringUtils.hasText(displayName)) {
+                    resolved.put(partyId.trim(), displayName.trim());
+                }
+            }
+            return resolved;
+        } catch (Exception ex) {
+            log.debug("Unable to resolve {} customer name(s): {}", ids.size(), ex.getMessage());
+            return Map.of();
         }
-        return body;
     }
 
     private @Nullable String extract(Map<String, Object> payload, String key) {
         Object value = payload.get(key);
         return value != null ? value.toString() : null;
-    }
-
-    private @Nullable String composeName(@Nullable String firstName, @Nullable String lastName) {
-        boolean hasFirst = StringUtils.hasText(firstName);
-        boolean hasLast = StringUtils.hasText(lastName);
-        if (!hasFirst && !hasLast) {
-            return null;
-        }
-        if (!hasFirst) {
-            return lastName.trim();
-        }
-        if (!hasLast) {
-            return firstName.trim();
-        }
-        String f = firstName.trim();
-        String l = lastName.trim();
-        if (l.contains(f)) {
-            return l;
-        }
-        if (f.contains(l)) {
-            return f;
-        }
-        return f + " " + l;
-    }
-
-    private @Nullable String firstNonBlank(String... values) {
-        if (values == null) {
-            return null;
-        }
-        for (String value : values) {
-            if (StringUtils.hasText(value)) {
-                return value.trim();
-            }
-        }
-        return null;
     }
 }

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/client/CustomerReferenceClientTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/client/CustomerReferenceClientTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-import java.util.List;
 import java.util.Map;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,9 +17,8 @@ import org.springframework.web.client.RestClient;
 
 /**
  * Unit tests for {@link CustomerReferenceClient}. Binds {@link MockRestServiceServer} to the
- * {@link RestClient.Builder} the client builds from, so the data-envelope unwrap, name-field
- * fallback precedence, name composition, and silent-failure behaviour are exercised without a
- * live CRM service.
+ * {@link RestClient.Builder} so the by-name search and the batch {@code parties:resolve} mapping
+ * (and silent-failure behaviour) are exercised without a live CRM service.
  */
 class CustomerReferenceClientTest {
 
@@ -56,74 +54,57 @@ class CustomerReferenceClientTest {
     }
 
     @Test
-    void resolveNames_unwrapsDataEnvelope_andAppliesFieldPrecedence() {
-        // customerName wins over displayName/legalName/name
-        server.expect(requestTo(BASE_URL + "/p-1"))
+    void resolveNames_emptyInput_returnsEmptyWithoutCall() {
+        assertThat(client.resolveNames(java.util.List.of())).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    void resolveNames_batchPost_mapsRows() {
+        server.expect(requestTo(BASE_URL + "/accounts/parties:resolve"))
+                .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess(
-                        "{\"data\":{\"customerName\":\"Acme Towing LLC\",\"displayName\":\"ignored\"}}",
+                        "[{\"partyId\":\"p-1\",\"displayName\":\" Acme Towing LLC \"},"
+                                + "{\"partyId\":\"p-2\",\"displayName\":\"Beta Co\"}]",
                         MediaType.APPLICATION_JSON));
 
-        assertThat(client.resolveNames(List.of("p-1"))).containsEntry("p-1", "Acme Towing LLC");
+        assertThat(client.resolveNames(java.util.List.of("p-1", "p-2")))
+                .containsExactly(Map.entry("p-1", "Acme Towing LLC"), Map.entry("p-2", "Beta Co"));
         server.verify();
     }
 
     @Test
-    void resolveNames_fallsBackThroughNameFields() {
-        // no customerName -> displayName used
-        server.expect(requestTo(BASE_URL + "/p-1"))
+    void resolveNames_skipsRowsWithBlankNameOrId() {
+        server.expect(requestTo(BASE_URL + "/accounts/parties:resolve"))
+                .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess(
-                        "{\"displayName\":\"Display Co\",\"legalName\":\"Legal Co\"}", MediaType.APPLICATION_JSON));
+                        "[{\"partyId\":\"p-1\",\"displayName\":\"\"},{\"displayName\":\"orphan\"},"
+                                + "{\"partyId\":\"p-2\",\"displayName\":\"Kept\"}]",
+                        MediaType.APPLICATION_JSON));
 
-        assertThat(client.resolveNames(List.of("p-1"))).containsEntry("p-1", "Display Co");
+        assertThat(client.resolveNames(java.util.List.of("p-1", "p-2"))).containsExactly(Map.entry("p-2", "Kept"));
         server.verify();
     }
 
     @Test
-    void resolveNames_composesFirstLast_whenOnlyPersonFieldsPresent() {
-        server.expect(requestTo(BASE_URL + "/p-1"))
+    void resolveNames_dedupesAndSkipsBlankIds() {
+        // one POST expected; the request body carries the single distinct, non-blank id
+        server.expect(requestTo(BASE_URL + "/accounts/parties:resolve"))
+                .andExpect(method(HttpMethod.POST))
                 .andRespond(
-                        withSuccess("{\"firstName\":\"John\",\"lastName\":\"Smith\"}", MediaType.APPLICATION_JSON));
-
-        assertThat(client.resolveNames(List.of("p-1"))).containsEntry("p-1", "John Smith");
-        server.verify();
-    }
-
-    @Test
-    void resolveNames_dedupesContainedName() {
-        // lastName already contains firstName -> return lastName, not "John John Smith"
-        server.expect(requestTo(BASE_URL + "/p-1"))
-                .andRespond(withSuccess(
-                        "{\"firstName\":\"John\",\"lastName\":\"John Smith\"}", MediaType.APPLICATION_JSON));
-
-        assertThat(client.resolveNames(List.of("p-1"))).containsEntry("p-1", "John Smith");
-        server.verify();
-    }
-
-    @Test
-    void resolveNames_omitsIdWhenBodyEmptyOrUnresolved() {
-        server.expect(requestTo(BASE_URL + "/p-1")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
-
-        assertThat(client.resolveNames(List.of("p-1"))).doesNotContainKey("p-1");
-        server.verify();
-    }
-
-    @Test
-    void resolveNames_remoteError_isSwallowed_returningNoEntry() {
-        server.expect(requestTo(BASE_URL + "/p-1")).andRespond(withServerError());
-
-        assertThat(client.resolveNames(List.of("p-1"))).isEmpty();
-        server.verify();
-    }
-
-    @Test
-    void resolveNames_skipsBlankAndDuplicateIds() {
-        // only one HTTP call expected for the single distinct, non-blank id
-        server.expect(requestTo(BASE_URL + "/p-1"))
-                .andRespond(withSuccess("{\"name\":\"Once\"}", MediaType.APPLICATION_JSON));
+                        withSuccess("[{\"partyId\":\"p-1\",\"displayName\":\"Once\"}]", MediaType.APPLICATION_JSON));
 
         Map<String, String> resolved = client.resolveNames(java.util.Arrays.asList("p-1", "p-1", "  ", null));
 
         assertThat(resolved).containsExactly(Map.entry("p-1", "Once"));
+        server.verify();
+    }
+
+    @Test
+    void resolveNames_remoteError_isSwallowed_returningEmptyMap() {
+        server.expect(requestTo(BASE_URL + "/accounts/parties:resolve")).andRespond(withServerError());
+
+        assertThat(client.resolveNames(java.util.List.of("p-1"))).isEmpty();
         server.verify();
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerReferenceService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerReferenceService.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -69,13 +70,47 @@ public class CustomerReferenceService {
         }
     }
 
+    /**
+     * Resolve display names for a batch of customer ids in a single CRM call (used by finder/search
+     * row enrichment, which needs only the name). Every requested id is present in the result; ids
+     * the CRM cannot resolve fall back to {@code customer-<id>}. Phone is not enriched here — callers
+     * needing it use {@link #resolve(UUID)}.
+     */
     public @NonNull Map<UUID, CustomerContact> resolveAll(@NonNull Collection<UUID> customerIds) {
+        List<UUID> ids =
+                customerIds.stream().filter(Objects::nonNull).distinct().toList();
         Map<UUID, CustomerContact> resolved = new LinkedHashMap<>();
-        for (UUID customerId : customerIds) {
-            if (customerId == null || resolved.containsKey(customerId)) {
-                continue;
+        if (ids.isEmpty()) {
+            return resolved;
+        }
+
+        Map<UUID, String> names = new LinkedHashMap<>();
+        try {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> rows = customerRestClient
+                    .post()
+                    .uri("/v1/crm/accounts/parties:resolve")
+                    .header("X-User", "pos-workorder")
+                    .header("X-Authorities", "crm:party:view")
+                    .body(Map.of("partyIds", ids))
+                    .retrieve()
+                    .body(List.class);
+            if (rows != null) {
+                for (Map<String, Object> row : rows) {
+                    UUID id = parseUuidOrNull(extract(row, "partyId"));
+                    String displayName = extract(row, "displayName");
+                    if (id != null && StringUtils.hasText(displayName)) {
+                        names.put(id, displayName.trim());
+                    }
+                }
             }
-            resolved.put(customerId, resolve(customerId));
+        } catch (Exception ex) {
+            log.debug("Unable to resolve {} customer name(s): {}", ids.size(), ex.getMessage());
+        }
+
+        for (UUID id : ids) {
+            String name = names.get(id);
+            resolved.put(id, new CustomerContact(StringUtils.hasText(name) ? name : "customer-" + id, null));
         }
         return resolved;
     }
@@ -139,6 +174,17 @@ public class CustomerReferenceService {
     private @Nullable String extract(Map<String, Object> payload, String key) {
         Object value = payload.get(key);
         return value != null ? value.toString() : null;
+    }
+
+    private static @Nullable UUID parseUuidOrNull(@Nullable String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value.trim());
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /**

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/CustomerReferenceServiceHttpTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/CustomerReferenceServiceHttpTest.java
@@ -97,13 +97,13 @@ class CustomerReferenceServiceHttpTest {
     }
 
     @Test
-    void resolveAll_deDuplicatesRequests_forRepeatedIds() throws Exception {
+    void resolveAll_usesSingleBatchCall_andDeDuplicatesRepeatedIds() throws Exception {
         UUID customerId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         AtomicInteger callCount = new AtomicInteger();
-        HttpServer server = startServer(
-                "/v1/crm/" + customerId,
+        HttpServer server = startBatchServer(
+                "/v1/crm/accounts/parties:resolve",
                 200,
-                "{\"customerName\":\"Repeated Customer\",\"phone\":\"+1-555-2222\"}",
+                "[{\"partyId\":\"" + customerId + "\",\"displayName\":\"Repeated Customer\"}]",
                 callCount);
         try {
             String serviceId = "localhost:" + server.getAddress().getPort();
@@ -113,10 +113,50 @@ class CustomerReferenceServiceHttpTest {
 
             assertThat(resolved).hasSize(1);
             assertThat(resolved.get(customerId).name()).isEqualTo("Repeated Customer");
+            // one batch POST regardless of repeated input ids
             assertThat(callCount.get()).isEqualTo(1);
         } finally {
             server.stop(0);
         }
+    }
+
+    @Test
+    void resolveAll_fallsBackToCustomerId_whenBatchOmitsId() throws Exception {
+        UUID customerId = UUID.fromString("00000000-0000-0000-0000-000000000009");
+        AtomicInteger callCount = new AtomicInteger();
+        HttpServer server = startBatchServer("/v1/crm/accounts/parties:resolve", 200, "[]", callCount);
+        try {
+            String serviceId = "localhost:" + server.getAddress().getPort();
+            CustomerReferenceService service = new CustomerReferenceService(RestClient.builder(), serviceId);
+
+            var resolved = service.resolveAll(List.of(customerId));
+
+            assertThat(resolved.get(customerId).name()).isEqualTo("customer-" + customerId);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private HttpServer startBatchServer(String expectedPath, int status, String body, AtomicInteger callCount)
+            throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            callCount.incrementAndGet();
+            String requestPath = exchange.getRequestURI().getPath();
+            if (!"POST".equals(exchange.getRequestMethod()) || !expectedPath.equals(requestPath)) {
+                exchange.sendResponseHeaders(404, -1);
+                exchange.close();
+                return;
+            }
+            byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(status, payload.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload);
+            }
+        });
+        server.start();
+        return server;
     }
 
     @Test


### PR DESCRIPTION
## Summary

Replace the invoice/workorder finders' N+1 per-id CRM customer-name lookups with a single batched CRM endpoint (#768).

**pos-customer (producer)**
- `POST /v1/crm/accounts/parties:resolve` — batch-resolve party ids to display names. `PartyNameResolveRequest` (`@NotEmpty @Size(max=200)`) → `List<PartyNameRef>`.
- `PartyService.resolveNames`: commercial → `displayName ?? legalName`; person → single batched `PeopleClient.fetchPersonIdentitiesQuietly`. **Not** `@Transactional` (no DB connection held across the pos-people HTTP call).
- Guarded by `crm:party:view` (no new perm-bit), emits `CUSTOMER_PARTY_RESOLVE`; `openapi.yaml` regenerated.

**pos-invoice (consumer)**
- `CustomerReferenceClient.resolveNames` → one batch POST; dead helpers removed. Also fixes a latent wrong path (`/v1/crm/{id}` did not map).

**pos-workorder (consumer)**
- `CustomerReferenceService.resolveAll` → one batch POST for finder enrichment (search/estimate use name only). `resolve(single)` + phone retained for the WIP detail path (single-id, not an N+1 hotspot).

## Testing
- 3-module `mvn test` green (pos-customer, pos-invoice, pos-workorder).
- New: `PartyServiceImplResolveNamesTest`, `CrmAccountsControllerTest` resolve cases; updated `CustomerReferenceClientTest`, `CustomerReferenceServiceHttpTest`.

## Follow-ups
- #769 — add phone to the batch resolve and route WIP phone through it (then delete the per-id path).
- SDK regen: durion-positivity-sdk-angular branch `cap/CAP007-crm-batch-resolve`.

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)
