### PR TITLE
style: apply Spotless to CAP-007 finder files

### DIFF
--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/client/WorkorderReferenceClient.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/client/WorkorderReferenceClient.java
@@ -91,7 +91,8 @@ public class WorkorderReferenceClient {
      * @return workorder id to human number map
      */
     public @NonNull Map<UUID, String> resolveNumbers(@NonNull Collection<UUID> workorderIds) {
-        List<UUID> ids = workorderIds.stream().filter(Objects::nonNull).distinct().toList();
+        List<UUID> ids =
+                workorderIds.stream().filter(Objects::nonNull).distinct().toList();
         if (ids.isEmpty()) {
             return Map.of();
         }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactExceptionHandler.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactExceptionHandler.java
@@ -26,19 +26,31 @@ public class InvoiceArtifactExceptionHandler {
 
     @ExceptionHandler({InvoiceNotFoundException.class, ArtifactNotFoundException.class})
     public ResponseEntity<ApiError> handleNotFound(RuntimeException ex, HttpServletRequest request) {
-        log.warn("Artifact request returned 404 for {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
+        log.warn(
+                "Artifact request returned 404 for {} {}: {}",
+                request.getMethod(),
+                request.getRequestURI(),
+                ex.getMessage());
         return error(HttpStatus.NOT_FOUND, "NOT_FOUND", ex.getMessage(), request);
     }
 
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ApiError> handleInvalidToken(InvalidTokenException ex, HttpServletRequest request) {
-        log.warn("Artifact request returned 403 for {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
+        log.warn(
+                "Artifact request returned 403 for {} {}: {}",
+                request.getMethod(),
+                request.getRequestURI(),
+                ex.getMessage());
         return error(HttpStatus.FORBIDDEN, "FORBIDDEN", ex.getMessage(), request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiError> handleBadRequest(IllegalArgumentException ex, HttpServletRequest request) {
-        log.warn("Artifact request returned 400 for {} {}: {}", request.getMethod(), request.getRequestURI(), ex.getMessage());
+        log.warn(
+                "Artifact request returned 400 for {} {}: {}",
+                request.getMethod(),
+                request.getRequestURI(),
+                ex.getMessage());
         return error(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), request);
     }
 

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
@@ -44,9 +44,8 @@ public class InvoiceSearchController {
 
     @Operation(
             summary = "Search invoices",
-            description =
-                    "Paginated free-text search for invoices matching the invoice number, "
-                            + "customer name, or workorder number.")
+            description = "Paginated free-text search for invoices matching the invoice number, "
+                    + "customer name, or workorder number.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Page of invoice search results returned."),
         @ApiResponse(

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/controller/InvoiceSearchControllerTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/controller/InvoiceSearchControllerTest.java
@@ -83,7 +83,8 @@ class InvoiceSearchControllerTest {
 
     @Test
     void search_trimsQueryBeforeDelegating() throws Exception {
-        when(invoiceSearchService.search(eq("Acme"), any())).thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 25), 0));
+        when(invoiceSearchService.search(eq("Acme"), any()))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 25), 0));
 
         mockMvc.perform(get("/v1/invoices/search").param("q", "  Acme  ")).andExpect(status().isOk());
 
@@ -92,7 +93,8 @@ class InvoiceSearchControllerTest {
 
     @Test
     void search_missingQuery_delegatesEmptyString() throws Exception {
-        when(invoiceSearchService.search(eq(""), any())).thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 25), 0));
+        when(invoiceSearchService.search(eq(""), any()))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 25), 0));
 
         mockMvc.perform(get("/v1/invoices/search")).andExpect(status().isOk());
 

--- a/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceSearchServiceImplTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceSearchServiceImplTest.java
@@ -111,8 +111,7 @@ class InvoiceSearchServiceImplTest {
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Collection<UUID>> workorderIdsCaptor = ArgumentCaptor.forClass(Collection.class);
         verify(invoiceRepository)
-                .searchByQuery(
-                        eq("INV-2026"), customerIdsCaptor.capture(), workorderIdsCaptor.capture(), eq(pageable));
+                .searchByQuery(eq("INV-2026"), customerIdsCaptor.capture(), workorderIdsCaptor.capture(), eq(pageable));
 
         // Empty reference matches → non-matching sentinels keep the JPQL IN clauses non-empty.
         assertThat(customerIdsCaptor.getValue()).containsExactly("__none__");
@@ -143,7 +142,8 @@ class InvoiceSearchServiceImplTest {
         when(customerReferenceClient.resolveNames(any())).thenReturn(Map.of());
         when(workorderReferenceClient.resolveNumbers(any())).thenReturn(Map.of());
 
-        InvoiceSearchResult row = invoiceSearchService.search("INV", pageable).getContent().get(0);
+        InvoiceSearchResult row =
+                invoiceSearchService.search("INV", pageable).getContent().get(0);
 
         assertThat(row.getCustomerName()).isNull();
         assertThat(row.getWorkorderNumber()).isNull();

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderSearchController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderSearchController.java
@@ -55,10 +55,9 @@ public class WorkorderSearchController {
 
     @Operation(
             summary = "Resolve workorder numbers",
-            description =
-                    "Batch-resolves a set of workorder ids to their human workorder numbers. "
-                            + "Consumed server-side by sibling services that store only the workorder id "
-                            + "and need the human number for finder/search enrichment.")
+            description = "Batch-resolves a set of workorder ids to their human workorder numbers. "
+                    + "Consumed server-side by sibling services that store only the workorder id "
+                    + "and need the human number for finder/search enrichment.")
     @ApiResponse(responseCode = "200", description = "Resolved workorder id-to-number pairings returned.")
     @PostMapping("/numbers:resolve")
     @PreAuthorize("hasAuthority('workorder:workorder:view')")

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberRef.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberRef.java
@@ -9,9 +9,13 @@ import java.util.UUID;
 @Schema(description = "Workorder id resolved to its human workorder number")
 public record WorkorderNumberRef(
         @Schema(
-                        description = "Workorder identifier",
-                        example = "550e8400-e29b-41d4-a716-446655440000",
-                        requiredMode = Schema.RequiredMode.REQUIRED)
-                UUID workorderId,
-        @Schema(description = "Human workorder number", example = "WO-2026-1001", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-                String workorderNumber) {}
+                description = "Workorder identifier",
+                example = "550e8400-e29b-41d4-a716-446655440000",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID workorderId,
+
+        @Schema(
+                description = "Human workorder number",
+                example = "WO-2026-1001",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String workorderNumber) {}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberResolveRequest.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/WorkorderNumberResolveRequest.java
@@ -15,9 +15,9 @@ import java.util.UUID;
 @Schema(description = "Batch request to resolve workorder ids to human workorder numbers")
 public record WorkorderNumberResolveRequest(
         @Schema(description = "Workorder identifiers to resolve", requiredMode = Schema.RequiredMode.REQUIRED)
-                @NotEmpty
-                @Size(max = 200)
-                List<UUID> workorderIds) {
+        @NotEmpty
+        @Size(max = 200)
+        List<UUID> workorderIds) {
 
     public WorkorderNumberResolveRequest {
         workorderIds = workorderIds == null ? List.of() : List.copyOf(workorderIds);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderSearchServiceImpl.java
@@ -85,7 +85,8 @@ public class WorkorderSearchServiceImpl implements WorkorderSearchService {
 
     @Override
     public @NonNull List<WorkorderNumberRef> resolveNumbers(@NonNull Collection<UUID> workorderIds) {
-        List<UUID> ids = workorderIds.stream().filter(Objects::nonNull).distinct().toList();
+        List<UUID> ids =
+                workorderIds.stream().filter(Objects::nonNull).distinct().toList();
         if (ids.isEmpty()) {
             return List.of();
         }

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderNumberResolveTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderNumberResolveTest.java
@@ -41,7 +41,11 @@ class WorkorderNumberResolveTest {
     private WorkorderSearchServiceImpl workorderSearchService;
 
     private Workorder workorder(UUID id, String number) {
-        return Workorder.builder().id(id).workorderNumber(number).status(WorkorderStatus.DRAFT).build();
+        return Workorder.builder()
+                .id(id)
+                .workorderNumber(number)
+                .status(WorkorderStatus.DRAFT)
+                .build();
     }
 
     @Test


### PR DESCRIPTION
## Summary

The invoice/workorder finder files merged via #766/#767 were committed without Spotless formatting (`spotless:check` fails on them on `main`). This applies `spotless:apply` to bring them into compliance.

- **Formatting only** — annotation wrapping + log-line length; no behavior change.
- 10 files across pos-invoice and pos-workorder.

`pos-invoice/.../client/CustomerReferenceClientTest.java` is intentionally **not** included — it is rewritten (and already Spotless-clean) in #770 (batch CRM resolve), so leaving it here avoids a merge collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
