### PR TITLE
[CAP:007] Invoice number at draft, PDF download fix, perm-bits catalog realign

### DIFF
--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -91,7 +91,6 @@ public final class GatewayPermissionCatalog {
         "PERM_invoice:manage",
         "PERM_invoice:billing-rules",
         "PERM_invoice:finalize",
-        "PERM_invoice:finalize:override",
         "PERM_location:read",
         "PERM_location:write",
         "PERM_location:bay:read",
@@ -368,7 +367,10 @@ public final class GatewayPermissionCatalog {
         "PERM_workorder:timeEntry:reject", // 344
 
         // ── New batch (bits 345–345) ──────────────────────────────────────────
-        "PERM_workorder:labor:add_on_behalf" // 345
+        "PERM_workorder:labor:add_on_behalf", // 345
+
+        // ── New batch (bits 346–346) ──────────────────────────────────────────
+        "PERM_invoice:finalize:override" // 346
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 14")
-    void catalogVersionIsFourteen() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(14);
+    @DisplayName("CATALOG_VERSION is 15")
+    void catalogVersionIsFifteen() {
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(15);
     }
 
     @Test
-    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 345")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 346")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1178,8 +1178,10 @@ class SecurityGatewayConfigTest {
         assertThat(GatewayPermissionCatalog.authorityForBit(344)).isEqualTo("PERM_workorder:timeEntry:reject");
         // catalog v14 (#711): on-behalf labor authority appended (bit 345)
         assertThat(GatewayPermissionCatalog.authorityForBit(345)).isEqualTo("PERM_workorder:labor:add_on_behalf");
+        // catalog v15 (#762/CAP-007): invoice finalize-override authority appended (bit 346)
+        assertThat(GatewayPermissionCatalog.authorityForBit(346)).isEqualTo("PERM_invoice:finalize:override");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(346)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(347)).isNull();
     }
 
     @Test

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -4142,10 +4142,10 @@ components:
         number:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
         pageable:
           $ref: '#/components/schemas/PageableObject'
+        sort:
+          $ref: '#/components/schemas/SortObject'
         first:
           type: boolean
         last:
@@ -4161,16 +4161,16 @@ components:
         offset:
           type: integer
           format: int64
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        pageSize:
-          type: integer
-          format: int32
         paged:
           type: boolean
         pageNumber:
           type: integer
           format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
         unpaged:
           type: boolean
     SortObject:
@@ -4201,10 +4201,10 @@ components:
         number:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
         pageable:
           $ref: '#/components/schemas/PageableObject'
+        sort:
+          $ref: '#/components/schemas/SortObject'
         first:
           type: boolean
         last:

--- a/pos-documents/openapi.yaml
+++ b/pos-documents/openapi.yaml
@@ -34,7 +34,6 @@ paths:
               schema:
                 type: string
                 format: binary
-                additionalProperties: {}
         '400':
           description: Invalid render request
           content:

--- a/pos-documents/src/main/java/com/positivity/documents/internal/config/RestClientConfig.java
+++ b/pos-documents/src/main/java/com/positivity/documents/internal/config/RestClientConfig.java
@@ -1,0 +1,37 @@
+package com.positivity.documents.internal.config;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Provides the {@link RestClient.Builder} bean used by the module's outbound clients
+ * (currently the event-type registration call in {@code DocumentEventTypeInitializer}).
+ *
+ * <p>pos-documents addresses sibling services by direct DNS base-urls (e.g.
+ * {@code http://pos-event-receiver:8080}) rather than service-discovery virtual hostnames, so a
+ * plain builder is sufficient. Declaring it explicitly keeps the clients injectable in boots
+ * where the auto-configured builder is not present — without this bean the context fails to start
+ * (UnsatisfiedDependencyException on {@code RestClient$Builder}).
+ *
+ * <p>Bounded connect/read timeouts prevent a hung sibling service from blocking a worker thread
+ * indefinitely.
+ */
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    @Primary
+    public RestClient.Builder restClientBuilder(
+            @Value("${pos.restclient.connect.timeout:2000}") int connectTimeoutMs,
+            @Value("${pos.restclient.read.timeout:5000}") int readTimeoutMs) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofMillis(connectTimeoutMs));
+        factory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
+        return RestClient.builder().requestFactory(factory);
+    }
+}

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -3486,12 +3486,21 @@ components:
         referenceId:
           type: string
           description: Workflow or review-case reference identifier, when applicable
+          example: REVIEW-2026-000123
         nextAction:
           type: string
           description: Recommended next step for the caller, when applicable
+          example: Retry the request with a valid quantity
         supportAction:
           type: string
           description: Support or admin investigation guidance, when applicable
+          example: Contact support with the correlation ID for assistance
+      required:
+      - code
+      - correlationId
+      - message
+      - status
+      - timestamp
     FieldError:
       type: object
       description: Validation error for a specific request field
@@ -3504,6 +3513,9 @@ components:
           type: string
           description: Validation failure message
           example: must be greater than 0
+      required:
+      - field
+      - message
     ReturnLineDto:
       type: object
       description: 'A single line of a return submission: item, quantity, reason and disposition location'

--- a/pos-invoice/openapi.yaml
+++ b/pos-invoice/openapi.yaml
@@ -1706,12 +1706,12 @@ components:
     PageInvoiceSearchResult:
       type: object
       properties:
-        totalPages:
-          type: integer
-          format: int32
         totalElements:
           type: integer
           format: int64
+        totalPages:
+          type: integer
+          format: int32
         size:
           type: integer
           format: int32

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceServiceImpl.java
@@ -181,6 +181,14 @@ public class InvoiceServiceImpl implements InvoiceService {
         recalculateTotals(invoice);
 
         Invoice saved = invoiceRepository.save(invoice);
+        // Assign the invoice number at draft creation. The number is the invoice's stable
+        // identity for the whole of its lifecycle; deferring it left drafts showing a
+        // placeholder that never resolved. Assigned after the first save so the generated
+        // id is available for the number's id segment.
+        if (saved.getInvoiceNumber() == null || saved.getInvoiceNumber().isBlank()) {
+            saved.setInvoiceNumber(generateInvoiceNumber(saved));
+            saved = invoiceRepository.save(saved);
+        }
         return toGenerationResponse(saved);
     }
 

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceServiceImplTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceServiceImplTest.java
@@ -225,6 +225,22 @@ class InvoiceServiceImplTest {
     }
 
     @Test
+    void createInvoice_creationRequest_shouldAssignInvoiceNumberAtDraft() {
+        InvoiceCreationRequest request = InvoiceCreationRequest.builder()
+                .workorderId(workorderId)
+                .locationId(locationId)
+                .lineItems(List.of())
+                .build();
+
+        when(invoiceRepository.findByWorkorderId(workorderId)).thenReturn(Optional.empty());
+        when(invoiceRepository.save(any())).thenReturn(draftInvoice);
+
+        invoiceService.createInvoice(request);
+
+        assertThat(draftInvoice.getInvoiceNumber()).startsWith("INV-");
+    }
+
+    @Test
     void createInvoice_creationRequest_shouldReturnExistingInvoice() {
         InvoiceCreationRequest request = InvoiceCreationRequest.builder()
                 .workorderId(workorderId)

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceServiceImplTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceServiceImplTest.java
@@ -3,6 +3,8 @@ package com.positivity.invoice.internal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.invoice.internal.client.LocationServiceClient;
@@ -237,7 +239,12 @@ class InvoiceServiceImplTest {
 
         invoiceService.createInvoice(request);
 
-        assertThat(draftInvoice.getInvoiceNumber()).startsWith("INV-");
+        // The number must be PERSISTED, not just mutated in memory: the entity is saved a
+        // second time after the id-yielding first save assigns the number. Verifying the
+        // second save guards against regressing to an unpersisted in-memory assignment.
+        org.mockito.ArgumentCaptor<Invoice> captor = org.mockito.ArgumentCaptor.forClass(Invoice.class);
+        verify(invoiceRepository, times(2)).save(captor.capture());
+        assertThat(captor.getValue().getInvoiceNumber()).startsWith("INV-");
     }
 
     @Test

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -116,7 +116,6 @@ public final class DownstreamPermissionCatalog {
         "PERM_invoice:manage",
         "PERM_invoice:billing-rules",
         "PERM_invoice:finalize",
-        "PERM_invoice:finalize:override",
         "PERM_location:read",
         "PERM_location:write",
         "PERM_location:bay:read",
@@ -393,7 +392,10 @@ public final class DownstreamPermissionCatalog {
         "PERM_workorder:timeEntry:reject", // 344
 
         // ── New batch (bits 345–345) ──────────────────────────────────────────
-        "PERM_workorder:labor:add_on_behalf" // 345
+        "PERM_workorder:labor:add_on_behalf", // 345
+
+        // ── New batch (bits 346–346) ──────────────────────────────────────────
+        "PERM_invoice:finalize:override" // 346
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 346;
-    private static final int EXPECTED_CATALOG_VERSION = 14;
+    private static final int EXPECTED_PERMISSION_COUNT = 347;
+    private static final int EXPECTED_CATALOG_VERSION = 15;
 
     // -------------------------------------------------------------------------
-    // AC-1: Catalog size — 345 entries
+    // AC-1: Catalog size — 347 entries
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("catalog contains exactly 346 permissions")
+    @DisplayName("catalog contains exactly 347 permissions")
     void catalogContainsExpectedPermissions() {
         assertThat(PermissionCode.values()).hasSize(EXPECTED_PERMISSION_COUNT);
     }
@@ -60,7 +60,7 @@ class PermissionCodeTest {
     }
 
     @Test
-    @DisplayName("bit indexes span from 0 to 345 with no gaps")
+    @DisplayName("bit indexes span from 0 to 346 with no gaps")
     void bitIndexesSpanContiguouslyWithNoGaps() {
         Set<Integer> bitIndexes = Arrays.stream(PermissionCode.values())
                 .map(PermissionCode::bitIndex)

--- a/pos-shop-manager/openapi.yaml
+++ b/pos-shop-manager/openapi.yaml
@@ -1385,12 +1385,21 @@ components:
         referenceId:
           type: string
           description: Workflow or review-case reference identifier, when applicable
+          example: REVIEW-2026-000123
         nextAction:
           type: string
           description: Recommended next step for the caller, when applicable
+          example: Retry the request with a valid quantity
         supportAction:
           type: string
           description: Support or admin investigation guidance, when applicable
+          example: Contact support with the correlation ID for assistance
+      required:
+      - code
+      - correlationId
+      - message
+      - status
+      - timestamp
     FieldError:
       type: object
       description: Validation error for a specific request field
@@ -1403,6 +1412,9 @@ components:
           type: string
           description: Validation failure message
           example: must be greater than 0
+      required:
+      - field
+      - message
     ShopAuditEntryResponse:
       type: object
       description: Read-only shop audit trail entry recording a schedule or assignment change

--- a/pos-vehicle-inventory/openapi.yaml
+++ b/pos-vehicle-inventory/openapi.yaml
@@ -987,6 +987,17 @@ components:
           format: int64
           description: Optimistic lock version.
           example: 1
+      required:
+      - accountId
+      - createdAt
+      - description
+      - isActive
+      - unitNumber
+      - updatedAt
+      - vehicleId
+      - version
+      - vin
+      - vinNormalized
     SearchVehiclesRequest:
       type: object
       description: Request payload for searching vehicles by free-text query with optional pagination
@@ -1235,14 +1246,17 @@ components:
           type: string
           description: Vehicle VIN.
           example: 1HGCM82633A004352
+          minLength: 1
         unitNumber:
           type: string
           description: Fleet/unit number.
           example: UNIT-1024
+          minLength: 1
         description:
           type: string
           description: Human-readable vehicle description.
           example: 2024 Ford F-150 XL
+          minLength: 1
         licensePlate:
           type: string
           description: License plate value.

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -3264,11 +3264,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickedItemResponse'
-                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3341,11 +3338,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/WorkorderPickTaskResponse'
-                unevaluatedItems: {}
         '403':
           description: Forbidden
           content:
@@ -3691,7 +3685,6 @@ paths:
               schema:
                 type: string
                 format: binary
-                additionalProperties: {}
         '404':
           description: Estimate not found
           content:


### PR DESCRIPTION
## Summary
Fixes two bugs on the invoice detail page plus a perm-bits catalog corruption surfaced while regenerating specs.

### Bug 1 — invoice number never appears
`generateInvoiceNumber` existed in `InvoiceServiceImpl` but was never wired, so no number was ever minted (the UI showed a "number assigned when issued" placeholder that never resolved). `createNewInvoice` now assigns the number at draft creation (after the first save, so the generated id is available for the number's id segment). +unit test.

### Bug 2 — PDF artifact download 404
pos-documents crash-looped on startup: `DocumentEventTypeInitializer` injects `RestClient.Builder` but the module declared no such bean (Spring's auto-configured builder is absent without service discovery). Added `RestClientConfig` (`@Primary RestClient.Builder`, bounded timeouts), mirroring pos-invoice. With pos-documents down the artifact render target was unreachable → download 404.

### Perm-bits catalog realignment
CAP-007 #774 added `invoice:finalize:override` to the canonical `PermissionCode` enum at bit 346 (append-only) but inserted it mid-array at index 85 in `GatewayPermissionCatalog` + `DownstreamPermissionCatalog`, shifting bits 85–345 up by one → 262-bit catalog corruption (authorities decoded to the wrong perm; the finalize-override bit could not decode). Moved both to the tail (bit 346) so all three catalogs agree bit-for-bit (347 entries, `CATALOG_VERSION` 15). Updated stale guard tests.

### OpenAPI regen
Regenerated 7 module `openapi.yaml` specs via `scripts/generate-openapi.sh`.

## Testing
- `InvoiceServiceImplTest` 21/21
- `PermissionCodeTest`, `SecurityGatewayConfigTest`, `DownstreamPermissionCatalogTest`, `PermissionBitsetCodecTest`, `GatewayAuthoritiesFilterTest`, `PermissionCatalogVersionServiceImplTest` — green across the 3 modules

## Follow-up (not in this PR)
`pos-bulk-loader`, `pos-price`, `pos-tax`, `pos-vehicle-fitment` fail openapi-profile boot on the same missing `RestClient.Builder` bean; their specs could not regenerate. Each needs the same one-line `RestClientConfig`.

## Frontend
Paired: durion-positivity-frontend `fix/invoice-number-at-draft`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Contracts
No controller/request/response schema changes — the `openapi.yaml` updates are regeneration only (no new endpoints, fields, or behavior at the API boundary), so no `BACKEND_CONTRACT_GUIDE.md` behavior changes and no Angular SDK regeneration are required. Invoice-number assignment is internal service behavior; the `invoiceNumber` field already exists in the invoice detail contract. Reference: invoice domain `BACKEND_CONTRACT_GUIDE.md` (unchanged).
