### PR TITLE
feat(mcp-server): per-request telemetry emission — Gate 1 (both paths) + Gate 2C workflow state

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -10,9 +10,12 @@ import com.positivity.mcp.internal.orchestration.memory.SessionSummary;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
 import com.positivity.mcp.internal.service.PermissionCodes;
 import com.positivity.mcp.internal.service.SystemPromptDefaults;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetryFactory;
+import com.positivity.mcp.internal.telemetry.NltiTelemetryEmitter;
 import com.positivity.mcp.service.AgentOrchestrationService;
 import com.positivity.mcp.service.CurrentUserContext;
 import com.positivity.mcp.service.RolePromptResolver;
+import com.positivity.mcp.service.RolePromptResolver.AssembledPrompt;
 import com.positivity.mcp.service.SessionAgentCacheMetrics;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
@@ -23,14 +26,17 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -65,6 +71,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
 
     private final RolePromptResolver rolePromptResolver;
     private final SimpleChatClassifier simpleChatClassifier;
+    private final @Nullable NltiTelemetryEmitter telemetryEmitter;
 
     private final int memoryMaxMessages;
     private final int rateLimitPerSession;
@@ -81,6 +88,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             @Nullable SessionSummary sessionSummary,
             @NonNull RolePromptResolver rolePromptResolver,
             @NonNull SimpleChatClassifier simpleChatClassifier,
+            @Nullable NltiTelemetryEmitter telemetryEmitter,
             @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
             @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
             @Value("${mcp.agent.memory-max-messages:100}") int memoryMaxMessages,
@@ -96,6 +104,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         this.sessionSummary = sessionSummary;
         this.rolePromptResolver = rolePromptResolver;
         this.simpleChatClassifier = simpleChatClassifier;
+        this.telemetryEmitter = telemetryEmitter;
         this.memoryMaxMessages = memoryMaxMessages;
         this.rateLimitPerSession = rateLimitPerSession;
         this.requestCountCache = Caffeine.newBuilder()
@@ -190,6 +199,11 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             if (toolExecutionAuditLogger != null) {
                 toolExecutionAuditLogger.logToolExecution(null, username, true, false, elapsedMs, null);
             }
+            List<String> toolNames = sharedOrchestrationSupport.toolNames(selectedTools);
+            String ragScope = toolRegistry.resolveRagScopeForTools(selectedTools);
+            AssembledPrompt assembled = rolePromptResolver.assemble(role, ragScope);
+            List<String> promptLayers = assembled != null ? assembled.layers() : List.of();
+            emitChatTelemetry(currentUserContext, toolNames, promptLayers, false, null, elapsedMs, "SUCCESS", null);
             return response;
         } catch (RuntimeException exception) {
             int elapsedMs = (int) (System.currentTimeMillis() - startMs);
@@ -202,6 +216,15 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                         elapsedMs,
                         exception.getClass().getSimpleName());
             }
+            emitChatTelemetry(
+                    currentUserContext,
+                    List.of(),
+                    List.of(),
+                    false,
+                    null,
+                    elapsedMs,
+                    "ERROR",
+                    exception.getClass().getSimpleName());
             throw new IllegalStateException(
                     "MCP chat failed role=%s elapsedMs=%d errorName=%s"
                             .formatted(role, elapsedMs, exception.getClass().getSimpleName()),
@@ -346,7 +369,51 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             toolExecutionAuditLogger.logToolExecution(
                     null, currentUserContext.username(), true, false, elapsedMs, null);
         }
+        emitChatTelemetry(currentUserContext, List.of(), List.of(), true, null, elapsedMs, "SUCCESS", null);
         return response;
+    }
+
+    /**
+     * Emits one {@code nlti.request.telemetry} event for a completed chat request (Gate 1). Never
+     * throws into the request path — a telemetry failure is logged and swallowed. No-op when no
+     * emitter is configured. {@code correlationId} is taken from the request MDC when present.
+     */
+    private void emitChatTelemetry(
+            @NonNull CurrentUserContext currentUserContext,
+            @NonNull List<String> selectedToolNames,
+            @NonNull List<String> promptLayers,
+            boolean simpleChat,
+            @Nullable String simpleChatRule,
+            long totalMs,
+            @NonNull String status,
+            @Nullable String errorCode) {
+        if (telemetryEmitter == null) {
+            return;
+        }
+        try {
+            String correlationId = MDC.get("correlationId");
+            if (correlationId == null || correlationId.isBlank()) {
+                correlationId = UUID.randomUUID().toString();
+            }
+            telemetryEmitter.emit(NltiRequestTelemetryFactory.forChatRequest(
+                    correlationId,
+                    Instant.now().toString(),
+                    currentUserContext.primaryRole(),
+                    currentUserContext.permissionCodes().size(),
+                    selectedToolNames,
+                    promptLayers,
+                    simpleChat,
+                    simpleChatRule,
+                    totalMs,
+                    status,
+                    errorCode));
+        } catch (RuntimeException telemetryFailure) {
+            LOGGER.warn(
+                    "MCP telemetry emission failed role={} status={}",
+                    currentUserContext.primaryRole(),
+                    status,
+                    telemetryFailure);
+        }
     }
 
     private static @NonNull String formatUserContext(@NonNull CurrentUserContext currentUserContext) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -203,7 +203,16 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             String ragScope = toolRegistry.resolveRagScopeForTools(selectedTools);
             AssembledPrompt assembled = rolePromptResolver.assemble(role, ragScope);
             List<String> promptLayers = assembled != null ? assembled.layers() : List.of();
-            emitChatTelemetry(currentUserContext, toolNames, promptLayers, false, null, elapsedMs, "SUCCESS", null);
+            emitChatTelemetry(
+                    currentUserContext,
+                    toolNames,
+                    promptLayers,
+                    false,
+                    null,
+                    selection.workflowState().name(),
+                    elapsedMs,
+                    "SUCCESS",
+                    null);
             return response;
         } catch (RuntimeException exception) {
             int elapsedMs = (int) (System.currentTimeMillis() - startMs);
@@ -221,6 +230,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                     List.of(),
                     List.of(),
                     false,
+                    null,
                     null,
                     elapsedMs,
                     "ERROR",
@@ -369,7 +379,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             toolExecutionAuditLogger.logToolExecution(
                     null, currentUserContext.username(), true, false, elapsedMs, null);
         }
-        emitChatTelemetry(currentUserContext, List.of(), List.of(), true, null, elapsedMs, "SUCCESS", null);
+        emitChatTelemetry(currentUserContext, List.of(), List.of(), true, null, null, elapsedMs, "SUCCESS", null);
         return response;
     }
 
@@ -384,6 +394,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             @NonNull List<String> promptLayers,
             boolean simpleChat,
             @Nullable String simpleChatRule,
+            @Nullable String workflowState,
             long totalMs,
             @NonNull String status,
             @Nullable String errorCode) {
@@ -404,6 +415,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                     promptLayers,
                     simpleChat,
                     simpleChatRule,
+                    workflowState,
                     totalMs,
                     status,
                     errorCode));

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -8,8 +8,11 @@ import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
 import com.positivity.mcp.internal.service.PermissionCodes;
 import com.positivity.mcp.internal.service.SystemPromptDefaults;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetryFactory;
+import com.positivity.mcp.internal.telemetry.NltiTelemetryEmitter;
 import com.positivity.mcp.service.CurrentUserContext;
 import com.positivity.mcp.service.RolePromptResolver;
+import com.positivity.mcp.service.RolePromptResolver.AssembledPrompt;
 import com.positivity.mcp.service.StreamingAgentOrchestrationService;
 import com.positivity.mcp.service.StreamingSessionAgentCacheMetrics;
 import dev.langchain4j.memory.ChatMemory;
@@ -18,13 +21,16 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.AiServices;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -56,6 +62,9 @@ public class StreamingSessionAgentManager
     @Nullable
     private final ToolExecutionAuditLogger toolExecutionAuditLogger;
 
+    @Nullable
+    private final NltiTelemetryEmitter telemetryEmitter;
+
     private final int memoryMaxMessages;
     private final int rateLimitPerSession;
 
@@ -67,6 +76,7 @@ public class StreamingSessionAgentManager
             @NonNull ScopedContentRetrieverFactory scopedContentRetrieverFactory,
             @NonNull RolePromptResolver rolePromptResolver,
             @Nullable ToolExecutionAuditLogger toolExecutionAuditLogger,
+            @Nullable NltiTelemetryEmitter telemetryEmitter,
             @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
             @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
             @Value("${mcp.agent.memory-max-messages:100}") int memoryMaxMessages,
@@ -78,6 +88,7 @@ public class StreamingSessionAgentManager
         this.scopedContentRetrieverFactory = scopedContentRetrieverFactory;
         this.rolePromptResolver = rolePromptResolver;
         this.toolExecutionAuditLogger = toolExecutionAuditLogger;
+        this.telemetryEmitter = telemetryEmitter;
         this.memoryMaxMessages = memoryMaxMessages;
         this.rateLimitPerSession = rateLimitPerSession;
         int sanitizedMaxCachedAgents = Math.max(1, maxCachedAgents);
@@ -131,6 +142,14 @@ public class StreamingSessionAgentManager
         StreamingPosAssistant agent =
                 roleAgentCache.get(role + MEMORY_KEY_SEPARATOR + cacheKey, ignored -> buildAgent(role, allTools));
 
+        // Capture on the calling thread: the Reactor completion signals run on a scheduler thread
+        // where the request MDC (correlationId) and prompt layers are no longer available.
+        List<String> toolNames = sharedOrchestrationSupport.toolNames(allTools);
+        String ragScope = toolRegistry.resolveRagScopeForTools(allTools);
+        AssembledPrompt assembled = rolePromptResolver.assemble(role, ragScope);
+        List<String> promptLayers = assembled != null ? assembled.layers() : List.of();
+        String correlationId = resolveCorrelationId();
+
         String userContext = formatUserContext(currentUserContext);
         return Flux.<String>create(emitter -> streamTokens(agent, memoryId, message, userContext, emitter))
                 .doOnComplete(() -> {
@@ -144,8 +163,11 @@ public class StreamingSessionAgentManager
                     if (toolExecutionAuditLogger != null) {
                         toolExecutionAuditLogger.logToolExecution(null, username, true, false, elapsedMs, null);
                     }
+                    emitStreamTelemetry(
+                            correlationId, currentUserContext, toolNames, promptLayers, elapsedMs, "SUCCESS", null);
                 })
                 .doOnError(exception -> {
+                    int elapsedMs = (int) (System.currentTimeMillis() - startMs);
                     LOGGER.warn(
                             "MCP streaming chat failed username={} role={} preview=\"{}\" error={}",
                             username,
@@ -158,9 +180,17 @@ public class StreamingSessionAgentManager
                                 username,
                                 false,
                                 false,
-                                0,
+                                elapsedMs,
                                 exception.getClass().getSimpleName());
                     }
+                    emitStreamTelemetry(
+                            correlationId,
+                            currentUserContext,
+                            List.of(),
+                            List.of(),
+                            elapsedMs,
+                            "ERROR",
+                            exception.getClass().getSimpleName());
                 });
     }
 
@@ -287,6 +317,52 @@ public class StreamingSessionAgentManager
     private static int tokenCount(@NonNull String text) {
         return SimpleChatRuleCatalog.tokenize(SimpleChatRuleCatalog.normalize(text))
                 .size();
+    }
+
+    /**
+     * Emits one {@code nlti.request.telemetry} event for a completed streaming request (Gate 1).
+     * Called from Reactor completion signals; {@code correlationId} is captured on the calling
+     * thread and passed in. Never throws into the stream; no-op when no emitter is configured.
+     */
+    private void emitStreamTelemetry(
+            @NonNull String correlationId,
+            @NonNull CurrentUserContext currentUserContext,
+            @NonNull List<String> selectedToolNames,
+            @NonNull List<String> promptLayers,
+            long totalMs,
+            @NonNull String status,
+            @Nullable String errorCode) {
+        if (telemetryEmitter == null) {
+            return;
+        }
+        try {
+            telemetryEmitter.emit(NltiRequestTelemetryFactory.forChatRequest(
+                    correlationId,
+                    Instant.now().toString(),
+                    currentUserContext.primaryRole(),
+                    currentUserContext.permissionCodes().size(),
+                    selectedToolNames,
+                    promptLayers,
+                    false,
+                    null,
+                    totalMs,
+                    status,
+                    errorCode));
+        } catch (RuntimeException telemetryFailure) {
+            LOGGER.warn(
+                    "MCP streaming telemetry emission failed role={} status={}",
+                    currentUserContext.primaryRole(),
+                    status,
+                    telemetryFailure);
+        }
+    }
+
+    private static @NonNull String resolveCorrelationId() {
+        String correlationId = MDC.get("correlationId");
+        if (correlationId == null || correlationId.isBlank()) {
+            return UUID.randomUUID().toString();
+        }
+        return correlationId;
     }
 
     private static long elapsedMs(long startNanos) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -149,6 +149,7 @@ public class StreamingSessionAgentManager
         AssembledPrompt assembled = rolePromptResolver.assemble(role, ragScope);
         List<String> promptLayers = assembled != null ? assembled.layers() : List.of();
         String correlationId = resolveCorrelationId();
+        String workflowState = selection.workflowState().name();
 
         String userContext = formatUserContext(currentUserContext);
         return Flux.<String>create(emitter -> streamTokens(agent, memoryId, message, userContext, emitter))
@@ -164,7 +165,14 @@ public class StreamingSessionAgentManager
                         toolExecutionAuditLogger.logToolExecution(null, username, true, false, elapsedMs, null);
                     }
                     emitStreamTelemetry(
-                            correlationId, currentUserContext, toolNames, promptLayers, elapsedMs, "SUCCESS", null);
+                            correlationId,
+                            currentUserContext,
+                            toolNames,
+                            promptLayers,
+                            workflowState,
+                            elapsedMs,
+                            "SUCCESS",
+                            null);
                 })
                 .doOnError(exception -> {
                     int elapsedMs = (int) (System.currentTimeMillis() - startMs);
@@ -188,6 +196,7 @@ public class StreamingSessionAgentManager
                             currentUserContext,
                             List.of(),
                             List.of(),
+                            workflowState,
                             elapsedMs,
                             "ERROR",
                             exception.getClass().getSimpleName());
@@ -329,6 +338,7 @@ public class StreamingSessionAgentManager
             @NonNull CurrentUserContext currentUserContext,
             @NonNull List<String> selectedToolNames,
             @NonNull List<String> promptLayers,
+            @Nullable String workflowState,
             long totalMs,
             @NonNull String status,
             @Nullable String errorCode) {
@@ -345,6 +355,7 @@ public class StreamingSessionAgentManager
                     promptLayers,
                     false,
                     null,
+                    workflowState,
                     totalMs,
                     status,
                     errorCode));

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolSelectionEngine.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ToolSelectionEngine.java
@@ -81,7 +81,7 @@ public class ToolSelectionEngine {
                     sharedOrchestrationSupport.toolNames(fallbackTools),
                     sharedOrchestrationSupport.preview(message));
         }
-        return new ToolSelectionResult(roleTools, fallbackTools);
+        return new ToolSelectionResult(roleTools, fallbackTools, workflowState);
     }
 
     public @NonNull List<Object> fullFallbackTools() {
@@ -297,5 +297,13 @@ public class ToolSelectionEngine {
     }
 
     public record ToolSelectionResult(
-            @NonNull List<Object> roleTools, @NonNull List<Object> fallbackTools) {}
+            @NonNull List<Object> roleTools,
+            @NonNull List<Object> fallbackTools,
+            @NonNull WorkflowState workflowState) {
+
+        /** Backward-compatible constructor defaulting to {@link WorkflowState#IDLE}. */
+        public ToolSelectionResult(@NonNull List<Object> roleTools, @NonNull List<Object> fallbackTools) {
+            this(roleTools, fallbackTools, WorkflowState.IDLE);
+        }
+    }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetry.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetry.java
@@ -63,7 +63,8 @@ public record NltiRequestTelemetry(
             @Nullable String domain,
             @Nullable String complexity,
             @Nullable Tier tier,
-            @Nullable String simpleChatRule) {}
+            @Nullable String simpleChatRule,
+            @Nullable String workflowState) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Model(

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactory.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactory.java
@@ -1,0 +1,90 @@
+package com.positivity.mcp.internal.telemetry;
+
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.Actor;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.Latency;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.Outcome;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.PromptLayer;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.Rag;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.Routing;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.Tier;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.Tools;
+import java.util.List;
+import java.util.Locale;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Pure builder for {@link NltiRequestTelemetry} events from the chat path (Gate 1 emission).
+ *
+ * <p>Deterministic by design: {@code correlationId} and {@code timestamp} are supplied by the
+ * caller (never read from the clock or MDC here) so the mapping is fully unit-testable. It carries
+ * only the fields available synchronously at request completion — actor, prompt layers (Gate 1),
+ * selected tools, latency, and outcome. Routing tier/model (Gate 4), RAG doc scores (Gate 5), and
+ * write provenance (Gate 6) are left null until those gates wire their inputs through.
+ */
+public final class NltiRequestTelemetryFactory {
+
+    private NltiRequestTelemetryFactory() {}
+
+    /**
+     * Builds a {@code SUCCESS}/{@code ERROR} chat telemetry event. {@code selectedToolNames} is
+     * empty for the Tier-0 simple-chat path; {@code promptLayers} carries the layers composed by
+     * {@code RolePromptResolver.assemble(...)} (empty when no layered prompt was assembled).
+     */
+    public static @NonNull NltiRequestTelemetry forChatRequest(
+            @NonNull String correlationId,
+            @NonNull String timestamp,
+            @NonNull String primaryRole,
+            int permissionCodeCount,
+            @NonNull List<String> selectedToolNames,
+            @NonNull List<String> promptLayers,
+            boolean simpleChat,
+            @Nullable String simpleChatRule,
+            long totalMs,
+            @NonNull String status,
+            @Nullable String errorCode) {
+
+        Actor actor = new Actor(primaryRole, permissionCodeCount);
+
+        // Tier-0 rule path is the only tier known without the Gate 4 router; leave null otherwise.
+        Routing routing = simpleChat ? new Routing(null, null, null, null, Tier.T0_RULE, simpleChatRule) : null;
+
+        Tools tools = selectedToolNames.isEmpty()
+                ? null
+                : new Tools(List.copyOf(selectedToolNames), 0, selectedToolNames.size(), null);
+
+        List<PromptLayer> layers = promptLayers.stream()
+                .map(NltiRequestTelemetryFactory::toPromptLayer)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        Rag rag = layers.isEmpty() ? null : new Rag(null, layers);
+
+        Latency latency = new Latency(null, null, null, totalMs);
+        Outcome outcome = new Outcome(status, errorCode);
+
+        return new NltiRequestTelemetry(
+                NltiRequestTelemetry.SCHEMA_VERSION,
+                NltiRequestTelemetry.EVENT_TYPE,
+                correlationId,
+                null,
+                null,
+                timestamp,
+                actor,
+                routing,
+                null,
+                tools,
+                rag,
+                null,
+                null,
+                latency,
+                outcome);
+    }
+
+    private static @Nullable PromptLayer toPromptLayer(@NonNull String name) {
+        try {
+            return PromptLayer.valueOf(name.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException unknownLayer) {
+            return null;
+        }
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactory.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactory.java
@@ -40,14 +40,23 @@ public final class NltiRequestTelemetryFactory {
             @NonNull List<String> promptLayers,
             boolean simpleChat,
             @Nullable String simpleChatRule,
+            @Nullable String workflowState,
             long totalMs,
             @NonNull String status,
             @Nullable String errorCode) {
 
         Actor actor = new Actor(primaryRole, permissionCodeCount);
 
-        // Tier-0 rule path is the only tier known without the Gate 4 router; leave null otherwise.
-        Routing routing = simpleChat ? new Routing(null, null, null, null, Tier.T0_RULE, simpleChatRule) : null;
+        // Tier-0 rule path is the only tier known without the Gate 4 router; the tool path carries the
+        // resolved workflow state (Gate 2C) but no tier yet. Routing is omitted only when neither applies.
+        Routing routing;
+        if (simpleChat) {
+            routing = new Routing(null, null, null, null, Tier.T0_RULE, simpleChatRule, workflowState);
+        } else if (workflowState != null) {
+            routing = new Routing(null, null, null, null, null, null, workflowState);
+        } else {
+            routing = null;
+        }
 
         Tools tools = selectedToolNames.isEmpty()
                 ? null

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -26,6 +26,8 @@ import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
 import com.positivity.mcp.internal.orchestration.tools.InventoryFacadeTool;
 import com.positivity.mcp.internal.orchestration.tools.OrderFacadeTool;
 import com.positivity.mcp.internal.service.ToolRegistryService;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry;
+import com.positivity.mcp.internal.telemetry.NltiTelemetryEmitter;
 import com.positivity.mcp.service.CurrentUserContext;
 import com.positivity.mcp.service.RolePromptResolver;
 import dev.langchain4j.data.embedding.Embedding;
@@ -105,6 +107,9 @@ class SessionAgentManagerTest {
     @Mock
     private ScopedContentRetrieverFactory scopedContentRetrieverFactory;
 
+    @Mock
+    private NltiTelemetryEmitter telemetryEmitter;
+
     // Real instance required: Mockito subclasses cause @Tool duplicate registration
     // in LangChain4j
     private ExaWebSearchTool exaWebSearchTool;
@@ -129,6 +134,9 @@ class SessionAgentManagerTest {
                 .when(toolSelectionEngine.selectRoleTools(anyString(), anySet(), anyString()))
                 .thenReturn(new ToolSelectionEngine.ToolSelectionResult(List.of(), List.of()));
         lenient().when(rolePromptResolver.resolvePrompt(anyString())).thenReturn("Default role prompt");
+        lenient()
+                .when(rolePromptResolver.assemble(anyString(), anyString()))
+                .thenReturn(new RolePromptResolver.AssembledPrompt("prompt", List.of("BASE", "ROLE")));
         lenient().when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(new float[] {0.1f})));
         lenient().when(embeddingStore.search(any())).thenReturn(new EmbeddingSearchResult<>(List.of()));
         exaWebSearchTool = new ExaWebSearchTool(RestClient.builder(), "https://api.exa.ai", "", "auto", 5);
@@ -168,6 +176,7 @@ class SessionAgentManagerTest {
                 null, // sessionSummary
                 rolePromptResolver,
                 simpleChatClassifier,
+                telemetryEmitter,
                 30,
                 500,
                 50,
@@ -280,6 +289,38 @@ class SessionAgentManagerTest {
     }
 
     @Test
+    @DisplayName("chat emits one nlti.request.telemetry event with actor, tools, prompt layers, SUCCESS")
+    void chat_emitsRequestTelemetry() {
+        String message = "show stock for sku ABC";
+        ToolSelectionEngine realToolSelectionEngine = realToolSelectionEngine();
+        when(toolRegistry.resolveDomainTools("ROLE_ADMIN"))
+                .thenReturn(new ArrayList<>(List.of(orderFacadeTool, inventoryFacadeTool)));
+        when(toolRegistryService.resolveCandidateTools(any(ToolSelectionContext.class), eq(3)))
+                .thenReturn(List.of(inventoryToolMetadata()));
+        when(toolRegistry.resolveToolsByName(List.of("inventoryFacadeTool"))).thenReturn(List.of(inventoryFacadeTool));
+        when(chatModel.chat(any(ChatRequest.class)))
+                .thenReturn(ChatResponse.builder()
+                        .aiMessage(AiMessage.from("Stock found"))
+                        .build());
+        SessionAgentManager selectorManager = managerWithToolSelectionEngine(realToolSelectionEngine);
+
+        selectorManager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), message);
+
+        ArgumentCaptor<NltiRequestTelemetry> eventCaptor = ArgumentCaptor.forClass(NltiRequestTelemetry.class);
+        verify(telemetryEmitter).emit(eventCaptor.capture());
+        NltiRequestTelemetry event = eventCaptor.getValue();
+        assertThat(event.eventType()).isEqualTo(NltiRequestTelemetry.EVENT_TYPE);
+        assertThat(event.schemaVersion()).isEqualTo(NltiRequestTelemetry.SCHEMA_VERSION);
+        assertThat(event.actor().primaryRole()).isEqualTo("ROLE_ADMIN");
+        assertThat(event.outcome().status()).isEqualTo("SUCCESS");
+        assertThat(event.tools()).isNotNull();
+        assertThat(event.tools().selected()).contains("InventoryFacadeTool");
+        assertThat(event.rag()).isNotNull();
+        assertThat(event.rag().promptLayers())
+                .containsExactly(NltiRequestTelemetry.PromptLayer.BASE, NltiRequestTelemetry.PromptLayer.ROLE);
+    }
+
+    @Test
     @DisplayName("chat with empty shared selection falls back to full role tool set")
     void chat_withEmptySemanticSelection_usesFullRoleToolSet() {
         String message = "show stock for sku ABC";
@@ -321,6 +362,7 @@ class SessionAgentManagerTest {
                 null, // sessionSummary
                 rolePromptResolver,
                 simpleChatClassifier,
+                telemetryEmitter,
                 0,
                 500,
                 50,
@@ -356,6 +398,7 @@ class SessionAgentManagerTest {
                 null,
                 rolePromptResolver,
                 simpleChatClassifier,
+                telemetryEmitter,
                 30,
                 500,
                 50,

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -318,6 +318,9 @@ class SessionAgentManagerTest {
         assertThat(event.rag()).isNotNull();
         assertThat(event.rag().promptLayers())
                 .containsExactly(NltiRequestTelemetry.PromptLayer.BASE, NltiRequestTelemetry.PromptLayer.ROLE);
+        // Gate 2C: the resolved workflow state is surfaced (IDLE for this session-less lookup query).
+        assertThat(event.routing()).isNotNull();
+        assertThat(event.routing().workflowState()).isEqualTo("IDLE");
     }
 
     @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -27,6 +27,7 @@ import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
 import com.positivity.mcp.internal.orchestration.tools.InventoryFacadeTool;
 import com.positivity.mcp.internal.orchestration.tools.OrderFacadeTool;
 import com.positivity.mcp.internal.service.ToolRegistryService;
+import com.positivity.mcp.internal.telemetry.NltiTelemetryEmitter;
 import com.positivity.mcp.service.CurrentUserContext;
 import com.positivity.mcp.service.RolePromptResolver;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -101,6 +102,9 @@ class StreamingSessionAgentManagerTest {
     @Mock
     private ScopedContentRetrieverFactory scopedContentRetrieverFactory;
 
+    @Mock
+    private NltiTelemetryEmitter telemetryEmitter;
+
     // Real instance required to prevent @Tool duplicate registration
     private ExaWebSearchTool exaWebSearchTool;
     private InventoryFacadeTool inventoryFacadeTool;
@@ -121,6 +125,9 @@ class StreamingSessionAgentManagerTest {
         when(toolRegistry.resolveDomainTools(any())).thenAnswer(inv -> new ArrayList<>());
         when(toolRegistry.preloadableRoleIdentifiers()).thenReturn(Set.of("ROLE_CASHIER", "ROLE_MANAGER"));
         lenient().when(rolePromptResolver.resolvePrompt(any())).thenReturn("Default role prompt");
+        lenient()
+                .when(rolePromptResolver.assemble(any(), any()))
+                .thenReturn(new RolePromptResolver.AssembledPrompt("prompt", List.of("BASE", "ROLE")));
         lenient()
                 .when(toolSelectionEngine.selectRoleTools(any(), any(), any()))
                 .thenReturn(new ToolSelectionEngine.ToolSelectionResult(List.of(), List.of()));
@@ -156,6 +163,7 @@ class StreamingSessionAgentManagerTest {
                 scopedContentRetrieverFactory,
                 rolePromptResolver,
                 null, // toolAuditService
+                telemetryEmitter,
                 30,
                 500,
                 50,
@@ -324,6 +332,7 @@ class StreamingSessionAgentManagerTest {
                 scopedContentRetrieverFactory,
                 rolePromptResolver,
                 null,
+                telemetryEmitter,
                 30,
                 500,
                 50,
@@ -383,6 +392,7 @@ class StreamingSessionAgentManagerTest {
                 scopedContentRetrieverFactory,
                 rolePromptResolver,
                 null,
+                telemetryEmitter,
                 0,
                 500,
                 50,
@@ -412,6 +422,7 @@ class StreamingSessionAgentManagerTest {
                 scopedContentRetrieverFactory,
                 rolePromptResolver,
                 null,
+                telemetryEmitter,
                 30,
                 500,
                 50,

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactoryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactoryTest.java
@@ -1,0 +1,106 @@
+package com.positivity.mcp.internal.telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.PromptLayer;
+import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry.Tier;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NltiRequestTelemetryFactoryTest {
+
+    @Test
+    void forChatRequest_toolPath_populatesActorToolsLayersLatencyOutcome() {
+        NltiRequestTelemetry event = NltiRequestTelemetryFactory.forChatRequest(
+                "corr-1",
+                "2026-07-01T00:00:00Z",
+                "ROLE_ADMIN",
+                676,
+                List.of("WorkorderFacadeTool", "InventoryFacadeTool"),
+                List.of("BASE", "ROLE", "DOMAIN", "TOOL_USE"),
+                false,
+                null,
+                1234L,
+                "SUCCESS",
+                null);
+
+        assertThat(event.schemaVersion()).isEqualTo(NltiRequestTelemetry.SCHEMA_VERSION);
+        assertThat(event.eventType()).isEqualTo(NltiRequestTelemetry.EVENT_TYPE);
+        assertThat(event.correlationId()).isEqualTo("corr-1");
+        assertThat(event.actor().primaryRole()).isEqualTo("ROLE_ADMIN");
+        assertThat(event.actor().permissionCodeCount()).isEqualTo(676);
+        assertThat(event.tools()).isNotNull();
+        assertThat(event.tools().selected()).containsExactly("WorkorderFacadeTool", "InventoryFacadeTool");
+        assertThat(event.tools().candidateCount()).isEqualTo(2);
+        assertThat(event.rag()).isNotNull();
+        assertThat(event.rag().promptLayers())
+                .containsExactly(PromptLayer.BASE, PromptLayer.ROLE, PromptLayer.DOMAIN, PromptLayer.TOOL_USE);
+        assertThat(event.latency().totalMs()).isEqualTo(1234L);
+        assertThat(event.outcome().status()).isEqualTo("SUCCESS");
+        assertThat(event.outcome().errorCode()).isNull();
+        // Tier-0 routing is only set on the simple-chat path.
+        assertThat(event.routing()).isNull();
+    }
+
+    @Test
+    void forChatRequest_simpleChat_setsTier0AndRuleNoTools() {
+        NltiRequestTelemetry event = NltiRequestTelemetryFactory.forChatRequest(
+                "corr-2",
+                "2026-07-01T00:00:00Z",
+                "ROLE_USER",
+                3,
+                List.of(),
+                List.of(),
+                true,
+                "greeting",
+                42L,
+                "SUCCESS",
+                null);
+
+        assertThat(event.routing()).isNotNull();
+        assertThat(event.routing().tier()).isEqualTo(Tier.T0_RULE);
+        assertThat(event.routing().simpleChatRule()).isEqualTo("greeting");
+        assertThat(event.tools()).isNull();
+        assertThat(event.rag()).isNull();
+        assertThat(event.latency().totalMs()).isEqualTo(42L);
+    }
+
+    @Test
+    void forChatRequest_error_carriesErrorCodeAndStatus() {
+        NltiRequestTelemetry event = NltiRequestTelemetryFactory.forChatRequest(
+                "corr-3",
+                "2026-07-01T00:00:00Z",
+                "ROLE_ADMIN",
+                676,
+                List.of(),
+                List.of(),
+                false,
+                null,
+                10L,
+                "ERROR",
+                "RuntimeException");
+
+        assertThat(event.outcome().status()).isEqualTo("ERROR");
+        assertThat(event.outcome().errorCode()).isEqualTo("RuntimeException");
+        assertThat(event.tools()).isNull();
+    }
+
+    @Test
+    void forChatRequest_unknownPromptLayerIsDropped() {
+        NltiRequestTelemetry event = NltiRequestTelemetryFactory.forChatRequest(
+                "corr-4",
+                "2026-07-01T00:00:00Z",
+                "ROLE_ADMIN",
+                676,
+                List.of("WorkorderFacadeTool"),
+                List.of("BASE", "NOT_A_LAYER", "role"),
+                false,
+                null,
+                5L,
+                "SUCCESS",
+                null);
+
+        // Unknown names dropped; known names case-insensitively mapped.
+        assertThat(event.rag().promptLayers()).containsExactly(PromptLayer.BASE, PromptLayer.ROLE);
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactoryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactoryTest.java
@@ -20,6 +20,7 @@ class NltiRequestTelemetryFactoryTest {
                 List.of("BASE", "ROLE", "DOMAIN", "TOOL_USE"),
                 false,
                 null,
+                "CREATING_PO",
                 1234L,
                 "SUCCESS",
                 null);
@@ -38,8 +39,10 @@ class NltiRequestTelemetryFactoryTest {
         assertThat(event.latency().totalMs()).isEqualTo(1234L);
         assertThat(event.outcome().status()).isEqualTo("SUCCESS");
         assertThat(event.outcome().errorCode()).isNull();
-        // Tier-0 routing is only set on the simple-chat path.
-        assertThat(event.routing()).isNull();
+        // Tool path carries the workflow state (Gate 2C) but no tier yet.
+        assertThat(event.routing()).isNotNull();
+        assertThat(event.routing().workflowState()).isEqualTo("CREATING_PO");
+        assertThat(event.routing().tier()).isNull();
     }
 
     @Test
@@ -53,6 +56,7 @@ class NltiRequestTelemetryFactoryTest {
                 List.of(),
                 true,
                 "greeting",
+                null,
                 42L,
                 "SUCCESS",
                 null);
@@ -76,6 +80,7 @@ class NltiRequestTelemetryFactoryTest {
                 List.of(),
                 false,
                 null,
+                null,
                 10L,
                 "ERROR",
                 "RuntimeException");
@@ -95,6 +100,7 @@ class NltiRequestTelemetryFactoryTest {
                 List.of("WorkorderFacadeTool"),
                 List.of("BASE", "NOT_A_LAYER", "role"),
                 false,
+                null,
                 null,
                 5L,
                 "SUCCESS",


### PR DESCRIPTION
Builds out the **per-request telemetry-emission pipeline** — the shared dependency the 2026-07-01 checklist flags for Gate 1, Gate 2C, and Gate 4. Three stacked commits.

## 1 — Factory + blocking path (Gate 1)
- **`NltiRequestTelemetryFactory`** — pure, deterministic builder (`correlationId` + `timestamp` injected → unit-testable). Maps to the v1 event: `Actor`, `Tools`, `Rag.promptLayers` (Gate 1), `Latency`, `Outcome`; `Tier.T0_RULE` on simple-chat.
- **`SessionAgentManager`** emits at success / error / simple-chat. correlationId from MDC (UUID fallback); prompt layers via `RolePromptResolver.assemble(role, ragScope)`.

## 2 — Streaming path (Gate 1, both endpoints)
- **`StreamingSessionAgentManager`** emits on Reactor terminal signals (`doOnComplete`→SUCCESS, `doOnError`→ERROR). correlationId + layers captured on the **calling thread** (MDC/assembled prompt are gone on the scheduler thread) and closed over.

## 3 — Workflow state (Gate 2C)
- `ToolSelectionResult` now carries the resolved `WorkflowState` (2-arg compat ctor defaults IDLE); `NltiRequestTelemetry.Routing` gains a nullable `workflowState`; both managers thread it through. Closes the Gate 2C *"workflow transitions in telemetry"* item.
- `/v1/mcp/chat` is session-less, so the value reflects the message-heuristic `deriveWorkflowState` (IDLE / CREATING_PO / RECEIVING_ASN / …). Authoritative session-driven state on the NLTI-session path (`NltiRequestService`) remains the separate Gate 2C runtime-propagation item.

Both managers: emission never throws into the request path; no-op when no emitter configured (`@Nullable`).

## Tests
`NltiRequestTelemetryFactoryTest` (4) + `SessionAgentManagerTest` emission assertion (actor, tools, prompt layers, workflow state, SUCCESS). **Full offline gate suite green: 76 run, 0 fail, 1 skipped.**

## Coverage boundary
Streaming emission fires on Flux completion; the module has no `TokenStream` harness to drive completion in a unit test, so streaming is covered by compile + the existing 14 streaming tests (no regression) + the shared factory/blocking tests for the mapping. Completion-driven streaming emission test is a documented follow-up.

## Contract impact
**None.** Internal orchestration + internal telemetry helper. No controller, DTO, OpenAPI annotation, event contract, or config surface changed. No domain \`BACKEND_CONTRACT_GUIDE.md\` update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)