### PR TITLE
feat(mcp-server): surface DiscoveredOperation coords from OpenApiToolMapper (Gate 3 G3.1)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
@@ -1,6 +1,7 @@
 package com.positivity.mcp.internal.discovery;
 
 import com.positivity.mcp.internal.config.McpServerProperties;
+import com.positivity.mcp.internal.domain.DiscoveredOperation;
 import com.positivity.shared.id.UUIDv7Generator;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -76,6 +77,51 @@ public class OpenApiToolMapper {
             addAggregateOperation(specs, gatewayBaseUri, path, pathItem.getPatch(), HttpMethod.PATCH);
         });
         return specs;
+    }
+
+    /**
+     * Gate 3 (G3.1): surfaces the execution coordinates of each allow-listed aggregate operation as
+     * {@link DiscoveredOperation}s, so they can be persisted as {@code mcp_tool} rows
+     * ({@code source='openapi'}). Same allow/deny filtering as {@link #toAggregateToolSpecifications}.
+     *
+     * <p>{@code serviceId} is supplied by the caller (the gateway service id) because aggregate-first
+     * discovery routes every operation through the gateway. {@code inputSchema} is left null here and
+     * populated by the persistence step. This method builds no proxy handlers — it is pure metadata.
+     */
+    @NonNull
+    public List<DiscoveredOperation> toDiscoveredOperations(@NonNull String serviceId, @NonNull OpenAPI openApi) {
+        var operations = new ArrayList<DiscoveredOperation>();
+        if (openApi.getPaths() == null) {
+            return operations;
+        }
+        openApi.getPaths().forEach((path, pathItem) -> {
+            if (!properties.includesPath(path) || properties.excludesPath(path)) {
+                return;
+            }
+            addDiscoveredOperation(operations, serviceId, path, pathItem.getGet(), HttpMethod.GET);
+            addDiscoveredOperation(operations, serviceId, path, pathItem.getPost(), HttpMethod.POST);
+            addDiscoveredOperation(operations, serviceId, path, pathItem.getPut(), HttpMethod.PUT);
+            addDiscoveredOperation(operations, serviceId, path, pathItem.getDelete(), HttpMethod.DELETE);
+            addDiscoveredOperation(operations, serviceId, path, pathItem.getPatch(), HttpMethod.PATCH);
+        });
+        return operations;
+    }
+
+    private void addDiscoveredOperation(
+            @NonNull List<DiscoveredOperation> operations,
+            @NonNull String serviceId,
+            @NonNull String path,
+            Operation operation,
+            @NonNull HttpMethod method) {
+        if (operation == null) {
+            return;
+        }
+        String domain = extractDomain(path);
+        String operationId = buildOperationId(operation);
+        String toolName = sanitizeName(domain + "_" + operationId);
+        String title = Optional.ofNullable(operation.getSummary()).orElse(operationId);
+        String description = Optional.ofNullable(operation.getDescription()).orElse(title);
+        operations.add(new DiscoveredOperation(toolName, description, method.name(), path, serviceId, null));
     }
 
     private void addAggregateOperation(

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiToolMapperTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiToolMapperTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.positivity.mcp.internal.config.McpServerProperties;
+import com.positivity.mcp.internal.domain.DiscoveredOperation;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -113,6 +114,41 @@ class OpenApiToolMapperTest {
     }
 
     // --- helpers ---
+
+    @Test
+    @DisplayName("toDiscoveredOperations surfaces method/path/serviceId execution coordinates (Gate 3 G3.1)")
+    void toDiscoveredOperations_surfacesExecutionCoordinates() {
+        OperationProxyFactory mockFactory = mock(OperationProxyFactory.class);
+        OpenApiToolMapper mapper = new OpenApiToolMapper(propertiesWithExclusions(List.of()), mockFactory);
+        OpenAPI openApi = openApiWith(Map.of("/v1/accounting/invoices", getItem("listInvoices", "List invoices")));
+
+        List<DiscoveredOperation> ops = mapper.toDiscoveredOperations("pos-api-gateway", openApi);
+
+        assertThat(ops).hasSize(1);
+        DiscoveredOperation op = ops.getFirst();
+        assertThat(op.name()).isEqualTo("accounting_listinvoices");
+        assertThat(op.description()).isEqualTo("List invoices");
+        assertThat(op.httpMethod()).isEqualTo("GET");
+        assertThat(op.httpPath()).isEqualTo("/v1/accounting/invoices");
+        assertThat(op.serviceId()).isEqualTo("pos-api-gateway");
+        assertThat(op.inputSchema()).isNull();
+        assertThat(op.isExecutable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("toDiscoveredOperations applies the same exclusion filtering as spec generation")
+    void toDiscoveredOperations_excludesConfiguredFragments() {
+        OperationProxyFactory mockFactory = mock(OperationProxyFactory.class);
+        McpServerProperties props = propertiesWithExclusions(List.of("/admin/"));
+        OpenApiToolMapper mapper = new OpenApiToolMapper(props, mockFactory);
+        OpenAPI openApi = openApiWith(Map.of(
+                "/v1/accounting/invoices", getItem("listInvoices", "List invoices"),
+                "/v1/admin/settings", getItem("getSettings", "Get settings")));
+
+        List<DiscoveredOperation> ops = mapper.toDiscoveredOperations("pos-api-gateway", openApi);
+
+        assertThat(ops).extracting(DiscoveredOperation::name).containsExactly("accounting_listinvoices");
+    }
 
     private static McpServerProperties propertiesWithExclusions(List<String> excludedFragments) {
         return new McpServerProperties(


### PR DESCRIPTION
First **offline-buildable** slice of Gate 3 step-1 (persist discovered openapi ops). The design doc (`gate3-openapi-bridge-design.md` G3.1) names this exact prerequisite: *"Surface method/path/serviceId from OpenApiToolMapper — today only McpSchema.Tool is returned; add a coord-carrying result."*

## Change
`OpenApiToolMapper.toDiscoveredOperations(serviceId, openApi)` → `List<DiscoveredOperation>` with `name` (`{domain}_{operationId}`), `description`, `httpMethod`, `httpPath`, `serviceId`. Same allow/deny path filtering as `toAggregateToolSpecifications`, but pure metadata — builds no proxy handlers.

- `serviceId` is supplied by the caller (the gateway service id) because aggregate-first discovery routes every op through the gateway.
- `inputSchema` left null here; populated by the persistence step.

## Tests
`OpenApiToolMapperTest` +2 (coordinate surfacing, exclusion-fragment filtering). **7 run, 0 fail.**

## Roadmap (Gate 3 step-1 remaining — live-dependent)
Per the design doc, these need the live stack (pgvector embedding writes are not offline-testable):
1. Persist each `DiscoveredOperation` as an `mcp_tool` row (`source='openapi'`, coords, `input_schema`) + an **embedding** via the model.
2. Seed `mcp_tool_permission` for discovered ops (else fail-closed → never selected).
3. Wire `OpenApiToolProvider` into both managers + request-scoped context propagation.
4. **Open design point:** execution routing — the executor uses `proxyFactory.handler(serviceId)` (load-balancer/direct-to-service via Eureka) while discovery uses the gateway. The persisted `serviceId` + path must reconcile these (persist the gateway service id vs. per-op service id + de-prefixed path). To be settled during live G3.2/G3.3.

## Contract impact
**None.** Internal discovery mapping only. No controller, DTO, OpenAPI annotation, event, or config surface changed. No domain \`BACKEND_CONTRACT_GUIDE.md\` update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)