### PR TITLE
feat(mcp-server): persistence layer for discovered openapi ops (Gate 3 G3.1)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
@@ -4,6 +4,7 @@ import com.positivity.mcp.internal.domain.DiscoveredOperation;
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 
 public interface ToolMetadataRepository {
@@ -20,6 +21,21 @@ public interface ToolMetadataRepository {
             int limit,
             @NonNull Set<String> permissionCodes,
             @NonNull String workflowState);
+
+    /**
+     * Gate 3 (G3.1): upserts a discovered OpenAPI operation as a {@code source='openapi'}
+     * {@code mcp_tool} row (execution coordinates + embedding), keyed by tool name. Returns the row id
+     * so the caller can link workflow states and permissions. Facade rows are untouched.
+     */
+    @NonNull
+    UUID upsertDiscoveredOperation(
+            @NonNull DiscoveredOperation operation, @NonNull String domain, float @NonNull [] embedding);
+
+    /** Gate 3 (G3.1): maps a tool to a workflow state (by name) so it is selectable there. Idempotent. */
+    void linkToolToWorkflow(@NonNull UUID toolId, @NonNull String workflowState);
+
+    /** Gate 3 (G3.1): grants a tool a required permission code (fail-closed gating input). Idempotent. */
+    void addToolPermission(@NonNull UUID toolId, @NonNull String permissionCode);
 
     /**
      * Returns enabled tools authorized for {@code workflowState} where the caller holds at

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.positivity.mcp.internal.domain.ToolMetadata;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -141,6 +142,59 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                     ps.setInt(4, limit);
                 },
                 this::mapDiscovered);
+    }
+
+    @Override
+    public @NonNull UUID upsertDiscoveredOperation(
+            @NonNull DiscoveredOperation operation, @NonNull String domain, float @NonNull [] embedding) {
+        String sql = """
+                INSERT INTO mcp_tool (name, display_name, description, domain, source,
+                                      http_method, http_path, service_id, input_schema, embedding, enabled)
+                VALUES (?, ?, ?, ?, 'openapi', ?, ?, ?, ?, ?::vector, true)
+                ON CONFLICT (name) DO UPDATE SET
+                    display_name = EXCLUDED.display_name,
+                    description  = EXCLUDED.description,
+                    domain       = EXCLUDED.domain,
+                    source       = 'openapi',
+                    http_method  = EXCLUDED.http_method,
+                    http_path    = EXCLUDED.http_path,
+                    service_id   = EXCLUDED.service_id,
+                    input_schema = EXCLUDED.input_schema,
+                    embedding    = EXCLUDED.embedding,
+                    enabled      = true
+                RETURNING id
+                """;
+        UUID id = jdbcTemplate.queryForObject(
+                sql,
+                UUID.class,
+                operation.name(),
+                operation.name(),
+                operation.description(),
+                domain,
+                operation.httpMethod(),
+                operation.httpPath(),
+                operation.serviceId(),
+                operation.inputSchema(),
+                toVectorPGobject(embedding));
+        return Objects.requireNonNull(id, "upsertDiscoveredOperation returned no id");
+    }
+
+    @Override
+    public void linkToolToWorkflow(@NonNull UUID toolId, @NonNull String workflowState) {
+        jdbcTemplate.update("""
+                INSERT INTO mcp_tool_workflow (tool_id, workflow_state_id)
+                SELECT ?, id FROM mcp_workflow_state WHERE name = ?
+                ON CONFLICT DO NOTHING
+                """, toolId, workflowState);
+    }
+
+    @Override
+    public void addToolPermission(@NonNull UUID toolId, @NonNull String permissionCode) {
+        jdbcTemplate.update("""
+                INSERT INTO mcp_tool_permission (tool_id, permission_code)
+                VALUES (?, ?)
+                ON CONFLICT DO NOTHING
+                """, toolId, permissionCode);
     }
 
     private DiscoveredOperation mapDiscovered(ResultSet rs, int rowNum) throws SQLException {

--- a/pos-mcp-server/src/main/resources/db/h2-migration/V21__mcp_tool_handler_bean_nullable.sql
+++ b/pos-mcp-server/src/main/resources/db/h2-migration/V21__mcp_tool_handler_bean_nullable.sql
@@ -1,0 +1,3 @@
+-- Gate 3 (G3.1 persistence): OpenAPI-discovered operations have no handler_bean (H2 variant of pg
+-- V23). Relax the NOT NULL constraint; facade rows keep supplying it.
+ALTER TABLE mcp_tool ALTER COLUMN handler_bean SET NULL;

--- a/pos-mcp-server/src/main/resources/db/migration/V23__mcp_tool_handler_bean_nullable.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V23__mcp_tool_handler_bean_nullable.sql
@@ -1,0 +1,4 @@
+-- Gate 3 (G3.1 persistence): OpenAPI-discovered operations (source='openapi') are executed from
+-- their persisted coordinates via OpenApiOperationExecutor, not from a Spring bean, so they have no
+-- handler_bean. Relax the NOT NULL constraint; facade rows keep supplying it.
+ALTER TABLE mcp_tool ALTER COLUMN handler_bean DROP NOT NULL;

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
@@ -82,6 +82,24 @@ public class SessionAgentManagerTestConfiguration {
                             float[] embedding, int limit, java.util.Set<String> permissionCodes, String workflowState) {
                 return List.of();
             }
+
+            @Override
+            public java.util.UUID upsertDiscoveredOperation(
+                    com.positivity.mcp.internal.domain.DiscoveredOperation operation,
+                    String domain,
+                    float[] embedding) {
+                return java.util.UUID.fromString("00000000-0000-0000-0000-000000000000");
+            }
+
+            @Override
+            public void linkToolToWorkflow(java.util.UUID toolId, String workflowState) {
+                // no-op stub
+            }
+
+            @Override
+            public void addToolPermission(java.util.UUID toolId, String permissionCode) {
+                // no-op stub
+            }
         };
     }
 }


### PR DESCRIPTION
Second slice of Gate 3 step-1 (after #793's coord surfacing): the DB write path to turn discovered OpenAPI operations into `source='openapi'` `mcp_tool` rows.

## Change
- **Migration V23 (pg) / V21 (h2):** drop `mcp_tool.handler_bean` `NOT NULL`. OpenAPI ops execute from persisted coordinates via `OpenApiOperationExecutor`, not a Spring bean — so no `handler_bean`. Facade rows unaffected. (The registry loader's `findEnabledByWorkflow` JOINs `mcp_tool_workflow`, so openapi rows without a workflow mapping are naturally excluded from bean loading — no sentinel needed.)
- **`ToolMetadataRepository`:** `upsertDiscoveredOperation` (`INSERT … ON CONFLICT (name) DO UPDATE`, `source='openapi'`, coords + embedding), `linkToolToWorkflow`, `addToolPermission` (idempotent). Reuses the existing pgvector `PGobject` helper.

## Live verification (alpha, rolled-back transaction)
Verified the whole persist→select→fail-closed chain on the deployed `pos_mcp` DB, then `ROLLBACK` (alpha untouched):
```
embedding_dims=768                       ✓ matches vector(768)
INSERT mcp_tool (openapi, handler_bean NULL, embedding) ✓
INSERT mcp_tool_workflow (IDLE) + mcp_tool_permission   ✓
findDiscoveredCandidatesForPermissions → accounting_listinvoices GET /v1/accounting/invoices svc=pos-api-gateway ✓
mismatched permission → 0 rows           ✓ fail-closed
post_rollback openapi count = 0          ✓ alpha untouched
```
The Java repo methods mirror the verified SQL exactly.

## Tests
Repository is `@Profile("!test")` (pgvector) → H2 never runs `ON CONFLICT`/`::vector`; the h2 migration keeps schema parity only. Offline suite green (31 run, 0 fail, 1 skipped); test-config `ToolMetadataRepository` stub updated for the new methods.

## Next slice (needs a deploy cycle for E2E)
Wire `ToolRegistrationServiceImpl` to embed + upsert + link each `DiscoveredOperation`, add the gateway `serviceId` config, then confirm a discovered op is selectable and executes via the gateway. Permission seeding source (spec `x-required-permissions` / admin #785) tracked there.

## Contract impact
**None.** Internal persistence + a DDL constraint relax. No controller, DTO, OpenAPI annotation, event, or config surface changed. No domain \`BACKEND_CONTRACT_GUIDE.md\` update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)