### PR TITLE
feat(mcp-server): persist discovered openapi ops during discovery (Gate 3 G3.1)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/ToolEmbeddingInitializer.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/ToolEmbeddingInitializer.java
@@ -11,11 +11,15 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+// Gate 3 (G3.1): runs after ToolBootstrapRunner (@Order 10) so it also backfills embeddings for
+// openapi rows persisted during discovery in the same startup.
 @Component
 @Profile("!test")
+@Order(20)
 public class ToolEmbeddingInitializer implements ApplicationRunner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ToolEmbeddingInitializer.class);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiToolMapper.java
@@ -154,7 +154,7 @@ public class OpenApiToolMapper {
                 .build());
     }
 
-    static String extractDomain(@NonNull String path) {
+    public static String extractDomain(@NonNull String path) {
         for (String segment : path.split("/")) {
             if (segment.isBlank() || segment.matches("v\\d+")) {
                 continue;

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/ToolBootstrapRunner.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/ToolBootstrapRunner.java
@@ -6,9 +6,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
+// Gate 3 (G3.1): must run before ToolEmbeddingInitializer so newly persisted openapi rows
+// (embedding NULL) are picked up by the embedding backfill in the same startup.
 @Component
+@Order(10)
 public class ToolBootstrapRunner implements ApplicationRunner {
 
     private static final Logger log = LoggerFactory.getLogger(ToolBootstrapRunner.class);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
@@ -24,12 +24,13 @@ public interface ToolMetadataRepository {
 
     /**
      * Gate 3 (G3.1): upserts a discovered OpenAPI operation as a {@code source='openapi'}
-     * {@code mcp_tool} row (execution coordinates + embedding), keyed by tool name. Returns the row id
-     * so the caller can link workflow states and permissions. Facade rows are untouched.
+     * {@code mcp_tool} row (execution coordinates), keyed by tool name. Returns the row id so the
+     * caller can link workflow states and permissions. The embedding is left null for
+     * {@code ToolEmbeddingInitializer} to backfill; {@code ON CONFLICT} preserves an existing one.
+     * Facade rows are untouched.
      */
     @NonNull
-    UUID upsertDiscoveredOperation(
-            @NonNull DiscoveredOperation operation, @NonNull String domain, float @NonNull [] embedding);
+    UUID upsertDiscoveredOperation(@NonNull DiscoveredOperation operation, @NonNull String domain);
 
     /** Gate 3 (G3.1): maps a tool to a workflow state (by name) so it is selectable there. Idempotent. */
     void linkToolToWorkflow(@NonNull UUID toolId, @NonNull String workflowState);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -145,12 +145,14 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
     }
 
     @Override
-    public @NonNull UUID upsertDiscoveredOperation(
-            @NonNull DiscoveredOperation operation, @NonNull String domain, float @NonNull [] embedding) {
+    public @NonNull UUID upsertDiscoveredOperation(@NonNull DiscoveredOperation operation, @NonNull String domain) {
+        // Embedding is intentionally NOT written here: it is owned by ToolEmbeddingInitializer, which
+        // backfills rows WHERE embedding IS NULL. ON CONFLICT preserves any existing embedding so
+        // re-discovery on restart does not clear it (and does not re-embed ~hundreds of ops each boot).
         String sql = """
                 INSERT INTO mcp_tool (name, display_name, description, domain, source,
-                                      http_method, http_path, service_id, input_schema, embedding, enabled)
-                VALUES (?, ?, ?, ?, 'openapi', ?, ?, ?, ?, ?::vector, true)
+                                      http_method, http_path, service_id, input_schema, enabled)
+                VALUES (?, ?, ?, ?, 'openapi', ?, ?, ?, ?, true)
                 ON CONFLICT (name) DO UPDATE SET
                     display_name = EXCLUDED.display_name,
                     description  = EXCLUDED.description,
@@ -160,7 +162,6 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                     http_path    = EXCLUDED.http_path,
                     service_id   = EXCLUDED.service_id,
                     input_schema = EXCLUDED.input_schema,
-                    embedding    = EXCLUDED.embedding,
                     enabled      = true
                 RETURNING id
                 """;
@@ -174,8 +175,7 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                 operation.httpMethod(),
                 operation.httpPath(),
                 operation.serviceId(),
-                operation.inputSchema(),
-                toVectorPGobject(embedding));
+                operation.inputSchema());
         return Objects.requireNonNull(id, "upsertDiscoveredOperation returned no id");
     }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
@@ -3,36 +3,54 @@ package com.positivity.mcp.internal.service;
 import com.positivity.mcp.internal.config.McpServerProperties;
 import com.positivity.mcp.internal.discovery.OpenApiDocumentFetcher;
 import com.positivity.mcp.internal.discovery.OpenApiToolMapper;
+import com.positivity.mcp.internal.domain.DiscoveredOperation;
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import com.positivity.mcp.service.ToolRegistrationService;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
+import io.swagger.v3.oas.models.OpenAPI;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @Service
 public class ToolRegistrationServiceImpl implements ToolRegistrationService {
 
     private static final Logger log = LoggerFactory.getLogger(ToolRegistrationServiceImpl.class);
 
+    private static final String DISCOVERED_WORKFLOW_STATE = "IDLE";
+
     private final McpServerProperties properties;
     private final OpenApiDocumentFetcher openApiDocumentFetcher;
     private final OpenApiToolMapper openApiToolMapper;
     private final McpAsyncServer mcpAsyncServer;
+    private final ToolMetadataRepository toolMetadataRepository;
+    private final String gatewayBaseUrl;
 
     public ToolRegistrationServiceImpl(
             @NonNull McpServerProperties properties,
             @NonNull OpenApiDocumentFetcher openApiDocumentFetcher,
             @NonNull OpenApiToolMapper openApiToolMapper,
-            @NonNull McpAsyncServer mcpAsyncServer) {
+            @NonNull McpAsyncServer mcpAsyncServer,
+            @NonNull ToolMetadataRepository toolMetadataRepository,
+            @Value("${mcp.server.gateway-base-url:http://api-gateway:8080}") @NonNull String gatewayBaseUrl) {
         this.properties = properties;
         this.openApiDocumentFetcher = openApiDocumentFetcher;
         this.openApiToolMapper = openApiToolMapper;
         this.mcpAsyncServer = mcpAsyncServer;
+        this.toolMetadataRepository = toolMetadataRepository;
+        // Persisted as each discovered op's service_id. Routing is via the gateway base URI (not a
+        // Eureka service id): alpha's Eureka registry is empty, and facade tools already reach the
+        // gateway by base URL. The Gate 3 executor (G3.2) will call handlerForBaseUri(this).
+        this.gatewayBaseUrl = gatewayBaseUrl;
     }
 
     @Override
@@ -64,9 +82,10 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
                             specifications.size(),
                             toolNames);
 
-                    return Flux.fromIterable(specifications)
-                            .flatMap(this::addToolWithTiming)
-                            .then(mcpAsyncServer.notifyToolsListChanged())
+                    return persistDiscoveredOperations(discovered.openApi())
+                            .then(Flux.fromIterable(specifications)
+                                    .flatMap(this::addToolWithTiming)
+                                    .then(mcpAsyncServer.notifyToolsListChanged()))
                             .doOnSuccess(ignored -> log.info(
                                     "Registered MCP tools from gateway aggregate spec in {} ms",
                                     elapsedMs(totalStartNanos)));
@@ -78,6 +97,45 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
                             ex.getMessage());
                     return Mono.empty();
                 });
+    }
+
+    /**
+     * Gate 3 (G3.1): persists each discovered operation as a {@code source='openapi'} {@code mcp_tool}
+     * row and maps it to the IDLE workflow so it can be selected. Runs off the event loop
+     * (boundedElastic) because the upsert is blocking JDBC. Embeddings are backfilled by
+     * {@code ToolEmbeddingInitializer}; required permissions are seeded separately (admin / #785), so
+     * until then discovered ops are fail-closed (never selected without a permission grant).
+     */
+    private @NonNull Mono<Void> persistDiscoveredOperations(@NonNull OpenAPI openApi) {
+        return Mono.fromRunnable(() -> {
+                    List<DiscoveredOperation> operations =
+                            openApiToolMapper.toDiscoveredOperations(gatewayBaseUrl, openApi);
+                    int persisted = 0;
+                    for (DiscoveredOperation operation : operations) {
+                        String path = operation.httpPath();
+                        if (path == null) {
+                            continue;
+                        }
+                        try {
+                            UUID toolId = toolMetadataRepository.upsertDiscoveredOperation(
+                                    operation, OpenApiToolMapper.extractDomain(path));
+                            toolMetadataRepository.linkToolToWorkflow(toolId, DISCOVERED_WORKFLOW_STATE);
+                            persisted++;
+                        } catch (RuntimeException exception) {
+                            log.warn(
+                                    "Failed to persist discovered openapi op {}: {}",
+                                    operation.name(),
+                                    exception.getMessage());
+                        }
+                    }
+                    log.info(
+                            "Persisted {} discovered openapi ops (source='openapi', {} workflow); "
+                                    + "embeddings backfilled by ToolEmbeddingInitializer, permissions seeded separately",
+                            persisted,
+                            DISCOVERED_WORKFLOW_STATE);
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .then();
     }
 
     private void warnIfIncludedServicesDeprecated() {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
@@ -85,9 +85,7 @@ public class SessionAgentManagerTestConfiguration {
 
             @Override
             public java.util.UUID upsertDiscoveredOperation(
-                    com.positivity.mcp.internal.domain.DiscoveredOperation operation,
-                    String domain,
-                    float[] embedding) {
+                    com.positivity.mcp.internal.domain.DiscoveredOperation operation, String domain) {
                 return java.util.UUID.fromString("00000000-0000-0000-0000-000000000000");
             }
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImplTest.java
@@ -2,6 +2,7 @@ package com.positivity.mcp.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,6 +13,7 @@ import ch.qos.logback.core.read.ListAppender;
 import com.positivity.mcp.internal.config.McpServerProperties;
 import com.positivity.mcp.internal.discovery.OpenApiDocumentFetcher;
 import com.positivity.mcp.internal.discovery.OpenApiToolMapper;
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -142,7 +144,13 @@ class ToolRegistrationServiceImplTest {
                 List.of(),
                 "http://gateway.test/v3/api-docs",
                 List.of());
-        return new ToolRegistrationServiceImpl(properties, openApiDocumentFetcher, openApiToolMapper, mcpAsyncServer);
+        return new ToolRegistrationServiceImpl(
+                properties,
+                openApiDocumentFetcher,
+                openApiToolMapper,
+                mcpAsyncServer,
+                mock(ToolMetadataRepository.class),
+                "http://api-gateway:8080");
     }
 
     private ToolRegistrationServiceImpl serviceWithIncludedServices(List<String> includedServices) {
@@ -156,7 +164,13 @@ class ToolRegistrationServiceImplTest {
                 List.of(),
                 "http://gateway.test/v3/api-docs",
                 List.of());
-        return new ToolRegistrationServiceImpl(properties, openApiDocumentFetcher, openApiToolMapper, mcpAsyncServer);
+        return new ToolRegistrationServiceImpl(
+                properties,
+                openApiDocumentFetcher,
+                openApiToolMapper,
+                mcpAsyncServer,
+                mock(ToolMetadataRepository.class),
+                "http://api-gateway:8080");
     }
 
     private static ListAppender<ILoggingEvent> attachLogAppender() {


### PR DESCRIPTION
Wires the persistence layer (#794) into the discovery flow (`ToolRegistrationServiceImpl`) so aggregate-spec operations become selectable `source='openapi'` `mcp_tool` rows at startup. Third slice of Gate 3 step-1 (after #793 coords, #794 persistence).

## Change
- **Discovery flow** — after mapping MCP specs, also map `DiscoveredOperation`s and upsert each (row + IDLE workflow link) off the event loop (`Schedulers.boundedElastic`). New config `mcp.server.gateway-base-url` (default `http://api-gateway:8080`).
- **Embedding ownership** — `upsertDiscoveredOperation` no longer takes an embedding: `ToolEmbeddingInitializer` backfills `WHERE embedding IS NULL`, and `ON CONFLICT` preserves any existing one (re-discovery on restart neither clears nor re-embeds). `ToolBootstrapRunner` `@Order(10)` now runs before `ToolEmbeddingInitializer` `@Order(20)`.
- `OpenApiToolMapper.extractDomain` made public.

## Routing corrected with live evidence
Investigating execution revealed **alpha's Eureka registry is empty** (`eureka/apps` → zero `<applications>`), so the executor's `loadBalancerClient.choose(serviceId)` path resolves nothing. Facade tools reach the gateway by **base URL**; discovered ops do the same. So `service_id` holds the gateway base URI (`http://api-gateway:8080`), and the **G3.2 executor must switch to `handlerForBaseUri(URI.create(serviceId), ...)`**. (This supersedes the earlier LB-based routing note.)

## Verification
- Full offline gate suite green: **69 run, 0 fail, 1 skipped**.
- The persist→select→fail-closed SQL chain was verified live on alpha (rolled-back transaction) in #794.
- Not yet deployed: startup persistence + execution E2E are bundled with the **G3.2 executor** slice (which the empty-Eureka finding requires) so E2E can actually be exercised.

## Next (G3.2 + G3.3)
1. Executor → `handlerForBaseUri` (empty-Eureka routing).
2. Wire `OpenApiToolProvider` into both managers + request-scoped propagation.
3. Deploy → seed one permission → confirm a discovered op selects + executes via the gateway.
4. Permission-seeding source (`x-required-permissions` / admin #785).

## Contract impact
**None.** Internal discovery/persistence + a config default. No controller, DTO, OpenAPI annotation, event, or config-surface contract changed. No domain \`BACKEND_CONTRACT_GUIDE.md\` update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)