### PR TITLE
fix(mcp-server): execute discovered openapi ops via gateway base URI, not Eureka LB (Gate 3 G3.2)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiOperationExecutor.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiOperationExecutor.java
@@ -6,8 +6,10 @@ import com.positivity.mcp.internal.domain.DiscoveredOperation;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.service.tool.ToolExecutor;
 import io.modelcontextprotocol.spec.McpSchema;
+import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -47,8 +49,13 @@ public class OpenApiOperationExecutor implements ToolExecutor {
             Map<String, Object> arguments = parseArguments(request.arguments());
             McpSchema.CallToolRequest call = new McpSchema.CallToolRequest(operation.name(), arguments);
             HttpMethod method = HttpMethod.valueOf(operation.httpMethod());
+            // Route via the gateway base URI (service_id holds it), not the load-balancer: alpha's
+            // Eureka registry is empty, so loadBalancerClient.choose(serviceId) resolves nothing.
+            // Facade tools reach the gateway by base URL too. See gate3-openapi-bridge-design.md.
+            URI gatewayBaseUri =
+                    URI.create(Objects.requireNonNull(operation.serviceId(), "openapi op missing service_id"));
             McpSchema.CallToolResult result = proxyFactory
-                    .handler(operation.serviceId(), method, operation.httpPath())
+                    .handlerForBaseUri(gatewayBaseUri, method, operation.httpPath())
                     .apply(null, call)
                     .block(timeout);
             return render(result);

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiOperationExecutorTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiOperationExecutorTest.java
@@ -1,0 +1,80 @@
+package com.positivity.mcp.internal.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.positivity.mcp.internal.domain.DiscoveredOperation;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpMethod;
+import reactor.core.publisher.Mono;
+
+class OpenApiOperationExecutorTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    @Test
+    @DisplayName("execute routes via the gateway base URI (service_id), not the load balancer, and renders text")
+    void execute_routesViaGatewayBaseUri() {
+        OperationProxyFactory proxyFactory = mock(OperationProxyFactory.class);
+        McpSchema.CallToolResult ok = McpSchema.CallToolResult.builder()
+                .content(List.of(new McpSchema.TextContent("[]")))
+                .build();
+        when(proxyFactory.handlerForBaseUri(any(URI.class), eq(HttpMethod.GET), eq("/v1/accounting/invoices")))
+                .thenReturn((exchange, request) -> Mono.just(ok));
+
+        DiscoveredOperation operation = new DiscoveredOperation(
+                "accounting_listinvoices",
+                "List invoices",
+                "GET",
+                "/v1/accounting/invoices",
+                "http://api-gateway:8080",
+                null);
+        OpenApiOperationExecutor executor =
+                new OpenApiOperationExecutor(proxyFactory, operation, new ObjectMapper(), TIMEOUT);
+
+        String result = executor.execute(
+                ToolExecutionRequest.builder()
+                        .name("accounting_listinvoices")
+                        .arguments("{}")
+                        .build(),
+                null);
+
+        assertThat(result).isEqualTo("[]");
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(proxyFactory).handlerForBaseUri(uriCaptor.capture(), eq(HttpMethod.GET), eq("/v1/accounting/invoices"));
+        assertThat(uriCaptor.getValue()).isEqualTo(URI.create("http://api-gateway:8080"));
+    }
+
+    @Test
+    @DisplayName("execute returns a controlled error (no proxy call) when service_id is missing")
+    void execute_missingServiceId_returnsControlledError() {
+        OperationProxyFactory proxyFactory = mock(OperationProxyFactory.class);
+        DiscoveredOperation operation = new DiscoveredOperation(
+                "accounting_listinvoices", "List invoices", "GET", "/v1/accounting/invoices", null, null);
+        OpenApiOperationExecutor executor =
+                new OpenApiOperationExecutor(proxyFactory, operation, new ObjectMapper(), TIMEOUT);
+
+        String result = executor.execute(
+                ToolExecutionRequest.builder()
+                        .name("accounting_listinvoices")
+                        .arguments("{}")
+                        .build(),
+                null);
+
+        assertThat(result).startsWith("Error:");
+        verifyNoInteractions(proxyFactory);
+    }
+}


### PR DESCRIPTION
The Gate 3 executor bridge. `OpenApiOperationExecutor` routed via `proxyFactory.handler(serviceId, ...)` → `loadBalancerClient.choose(serviceId)` (Eureka).

## Why
Alpha's Eureka registry is **empty** (verified live: `eureka/apps` → zero `<applications>`), so the LB path resolves nothing and every discovered-op call would fail. Facade tools reach the gateway by **base URL**, not LB.

## Change
Route via `proxyFactory.handlerForBaseUri(URI.create(serviceId), method, path)`. The persisted `service_id` holds the gateway base URI (`http://api-gateway:8080`, set by the discovery wiring in #795). Missing `service_id` now fails as a controlled error with no proxy call (no fabricated success).

## Tests
`OpenApiOperationExecutorTest` (2): routes via the captured base URI; missing `service_id` → controlled error, no proxy interaction. 2 run, 0 fail.

## Remaining for Gate 3 E2E
- **G3.3:** wire `OpenApiToolProvider` into both chat managers + request-scoped user-context propagation (so the agent actually receives discovered tools).
- Deploy → seed one `mcp_tool_permission` → confirm a `source='openapi'` op selects **and** executes through the gateway; negative/leakage; streaming parity.
- Permission-seeding source (`x-required-permissions` / admin #785).

## Contract impact
**None.** Internal execution routing. No controller, DTO, OpenAPI annotation, event, or config-surface contract changed. No domain \`BACKEND_CONTRACT_GUIDE.md\` update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)