### PR TITLE
feat(mcp-server): aggregate discovery via springdoc swagger-config (Gate 3 discovery source)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
@@ -1,19 +1,26 @@
 package com.positivity.mcp.internal.discovery;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.positivity.mcp.internal.config.McpServerProperties;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -22,6 +29,8 @@ public class OpenApiDocumentFetcher {
     private static final Logger log = LoggerFactory.getLogger(OpenApiDocumentFetcher.class);
     private static final String GATEWAY_SERVICE_ID = "pos-api-gateway";
     private static final URI LOCAL_GATEWAY_FALLBACK = URI.create("http://localhost:8080");
+    private static final String SWAGGER_CONFIG_SUFFIX = "/swagger-config";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final DiscoveryClient discoveryClient;
     private final WebClient webClient;
@@ -150,7 +159,14 @@ public class OpenApiDocumentFetcher {
                     OpenAPI openAPI = result.getOpenAPI();
                     if (openAPI == null) {
                         log.warn("Failed to parse aggregate OpenAPI from {}: {}", specUri, result.getMessages());
-                        return Mono.<DiscoveredOpenApi>empty();
+                        return aggregateViaSwaggerConfig(specUri, baseUri);
+                    }
+                    if (openAPI.getPaths() == null || openAPI.getPaths().isEmpty()) {
+                        log.info(
+                                "Aggregate spec at {} exposes no paths (springdoc gateway); "
+                                        + "aggregating per-service specs via swagger-config",
+                                specUri);
+                        return aggregateViaSwaggerConfig(specUri, baseUri);
                     }
                     return Mono.just(new DiscoveredOpenApi("aggregate", baseUri, openAPI));
                 })
@@ -159,6 +175,128 @@ public class OpenApiDocumentFetcher {
                     return Mono.empty();
                 });
     }
+
+    /**
+     * Fallback discovery for a springdoc gateway that does not serve a single merged OpenAPI at
+     * {@code /v3/api-docs} but instead exposes {@code /v3/api-docs/swagger-config} — an index of
+     * per-service doc URLs. Fetches each per-service spec and merges their paths, prefixing every
+     * path with the service's gateway routing segment (the first segment of its doc URL, e.g.
+     * {@code /accounting/v3/api-docs} → prefix {@code /accounting}) so the merged paths are the
+     * full gateway paths (matching how facade tools address the gateway).
+     */
+    private Mono<DiscoveredOpenApi> aggregateViaSwaggerConfig(URI specUri, URI baseUri) {
+        URI swaggerConfigUri = URI.create(specUri.toString() + SWAGGER_CONFIG_SUFFIX);
+        String gatewayOwnDocPath = specUri.getPath();
+        return webClient
+                .get()
+                .uri(swaggerConfigUri)
+                .retrieve()
+                .bodyToMono(String.class)
+                .timeout(properties.discoveryTimeout())
+                .flatMap(json -> {
+                    List<ServiceDoc> docs = parseServiceDocs(json, gatewayOwnDocPath);
+                    if (docs.isEmpty()) {
+                        log.warn("swagger-config at {} listed no per-service specs", swaggerConfigUri);
+                        return Mono.<DiscoveredOpenApi>empty();
+                    }
+                    return Flux.fromIterable(docs)
+                            .flatMap(doc -> fetchAndPrefixService(baseUri, doc))
+                            .reduce(new Paths(), (merged, servicePaths) -> {
+                                merged.putAll(servicePaths);
+                                return merged;
+                            })
+                            .map(mergedPaths -> {
+                                OpenAPI merged = new OpenAPI();
+                                merged.setPaths(mergedPaths);
+                                log.info(
+                                        "Aggregated {} service specs via swagger-config from {} → {} paths",
+                                        docs.size(),
+                                        swaggerConfigUri,
+                                        mergedPaths.size());
+                                return new DiscoveredOpenApi("aggregate", baseUri, merged);
+                            });
+                })
+                .onErrorResume(ex -> {
+                    log.warn("swagger-config aggregation failed at {}: {}", swaggerConfigUri, ex.getMessage());
+                    return Mono.empty();
+                });
+    }
+
+    private Mono<Paths> fetchAndPrefixService(URI baseUri, ServiceDoc doc) {
+        URI docUri = baseUri.resolve(doc.url());
+        return webClient
+                .get()
+                .uri(docUri)
+                .retrieve()
+                .bodyToMono(String.class)
+                .timeout(properties.discoveryTimeout())
+                .map(raw -> deserialize(doc.routingPrefix(), raw))
+                .map(result -> prefixPaths(result.getOpenAPI(), doc.routingPrefix()))
+                .doOnNext(paths -> log.info(
+                        "Fetched service spec {} → {} paths (prefix {})", docUri, paths.size(), doc.routingPrefix()))
+                .onErrorResume(ex -> {
+                    log.warn("Could not fetch/merge service spec at {}: {}", docUri, ex.getMessage());
+                    return Mono.just(new Paths());
+                });
+    }
+
+    /**
+     * Parses a springdoc {@code swagger-config} JSON body into the per-service docs to aggregate,
+     * skipping the gateway's own (empty) spec. Each doc's routing prefix is the first path segment
+     * of its doc URL. Pure/testable.
+     */
+    static List<ServiceDoc> parseServiceDocs(@NonNull String swaggerConfigJson, @NonNull String gatewayOwnDocPath) {
+        List<ServiceDoc> docs = new ArrayList<>();
+        JsonNode urls;
+        try {
+            urls = MAPPER.readTree(swaggerConfigJson).get("urls");
+        } catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
+            log.warn("Malformed swagger-config JSON: {}", ex.getMessage());
+            return docs;
+        }
+        if (urls == null || !urls.isArray()) {
+            return docs;
+        }
+        for (JsonNode entry : urls) {
+            JsonNode urlNode = entry.get("url");
+            if (urlNode == null || urlNode.asText().isBlank()) {
+                continue;
+            }
+            String url = urlNode.asText();
+            if (url.equals(gatewayOwnDocPath)) {
+                continue; // the gateway's own (empty) spec
+            }
+            String prefix = firstPathSegment(url);
+            if (prefix.isEmpty()) {
+                continue;
+            }
+            docs.add(new ServiceDoc(url, prefix));
+        }
+        return docs;
+    }
+
+    /** Returns a copy of {@code serviceSpec}'s paths with {@code routingPrefix} prepended to each. */
+    static @NonNull Paths prefixPaths(@Nullable OpenAPI serviceSpec, @NonNull String routingPrefix) {
+        Paths prefixed = new Paths();
+        if (serviceSpec == null || serviceSpec.getPaths() == null) {
+            return prefixed;
+        }
+        for (var entry : serviceSpec.getPaths().entrySet()) {
+            prefixed.addPathItem(routingPrefix + entry.getKey(), entry.getValue());
+        }
+        return prefixed;
+    }
+
+    private static String firstPathSegment(@NonNull String url) {
+        String path = url.startsWith("http") ? URI.create(url).getPath() : url;
+        String trimmed = path.startsWith("/") ? path.substring(1) : path;
+        int slash = trimmed.indexOf('/');
+        String segment = slash > 0 ? trimmed.substring(0, slash) : trimmed;
+        return segment.isBlank() ? "" : "/" + segment;
+    }
+
+    /** A per-service OpenAPI doc discovered via swagger-config: its (gateway-relative) URL and routing prefix. */
+    record ServiceDoc(@NonNull String url, @NonNull String routingPrefix) {}
 
     public @NonNull Mono<DiscoveredOpenApi> fetchForService(@NonNull String serviceId) {
         var instance = pickInstance(serviceId);

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherSwaggerConfigTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherSwaggerConfigTest.java
@@ -1,0 +1,67 @@
+package com.positivity.mcp.internal.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.mcp.internal.discovery.OpenApiDocumentFetcher.ServiceDoc;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OpenApiDocumentFetcherSwaggerConfigTest {
+
+    @Test
+    @DisplayName("parseServiceDocs returns per-service docs with routing prefixes, skipping the gateway's own spec")
+    void parseServiceDocs_extractsServicesAndPrefixes_skipsGateway() {
+        String json = """
+                {"configUrl":"/v3/api-docs/swagger-config",
+                 "urls":[
+                   {"url":"/accounting/v3/api-docs","name":"Accounting"},
+                   {"url":"/v3/api-docs","name":"Gateway"},
+                   {"url":"/catalog/v3/api-docs","name":"Catalog"}
+                 ]}
+                """;
+
+        List<ServiceDoc> docs = OpenApiDocumentFetcher.parseServiceDocs(json, "/v3/api-docs");
+
+        assertThat(docs)
+                .extracting(ServiceDoc::url, ServiceDoc::routingPrefix)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("/accounting/v3/api-docs", "/accounting"),
+                        org.assertj.core.groups.Tuple.tuple("/catalog/v3/api-docs", "/catalog"));
+    }
+
+    @Test
+    @DisplayName("parseServiceDocs returns empty for malformed JSON or missing urls array")
+    void parseServiceDocs_malformedOrEmpty_returnsEmpty() {
+        assertThat(OpenApiDocumentFetcher.parseServiceDocs("not json", "/v3/api-docs"))
+                .isEmpty();
+        assertThat(OpenApiDocumentFetcher.parseServiceDocs("{}", "/v3/api-docs"))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("prefixPaths prepends the routing segment to each service-local path")
+    void prefixPaths_prependsRoutingSegment() {
+        OpenAPI serviceSpec = new OpenAPI()
+                .paths(new Paths()
+                        .addPathItem("/v1/accounting/invoices", new PathItem())
+                        .addPathItem("/v1/accounting/journal-entries/{id}", new PathItem()));
+
+        Paths prefixed = OpenApiDocumentFetcher.prefixPaths(serviceSpec, "/accounting");
+
+        assertThat(prefixed.keySet())
+                .containsExactlyInAnyOrder(
+                        "/accounting/v1/accounting/invoices", "/accounting/v1/accounting/journal-entries/{id}");
+    }
+
+    @Test
+    @DisplayName("prefixPaths tolerates a null spec or null paths")
+    void prefixPaths_nullSafe() {
+        assertThat(OpenApiDocumentFetcher.prefixPaths(null, "/accounting")).isEmpty();
+        assertThat(OpenApiDocumentFetcher.prefixPaths(new OpenAPI(), "/accounting"))
+                .isEmpty();
+    }
+}


### PR DESCRIPTION
Unblocks live Gate 3 discovery. **Live E2E on alpha** (after #797) showed the gateway does **not** serve a merged OpenAPI at `/v3/api-docs` — that returns the gateway's own empty spec (`paths: []`, ~1957 bytes). springdoc instead exposes `/v3/api-docs/swagger-config`, an index of per-service doc URLs. Each per-service spec is rich (accounting = **76 paths**), but discovery fetched the empty root → 0 ops persisted.

## Change
`OpenApiDocumentFetcher` falls back to **swagger-config aggregation** when the configured aggregate spec has no paths:
1. fetch `{specUri}/swagger-config`, parse the per-service doc URLs (skip the gateway's own spec),
2. fetch each per-service spec and merge their paths — **prefixing** each with the service's gateway routing segment (first segment of the doc URL: `/accounting/v3/api-docs` → prefix `/accounting`).

Per-service specs carry service-local paths (`/v1/accounting/...`); the gateway routes them under the service prefix (`/accounting/v1/accounting/...`, matching how facade tools address the gateway). The merged, prefixed paths feed the existing `toDiscoveredOperations → persist → select → execute` chain unchanged.

**Backward compatible:** a real merged aggregate spec (non-empty paths) is used as before; swagger-config is only taken when the root spec is empty.

## Tests
`parseServiceDocs` + `prefixPaths` are pure/static and unit-tested (skip-gateway, prefix derivation, malformed JSON, null-safety). Full offline suite green: **49 run, 0 fail, 1 skipped**.

## After merge — the deferred E2E finally runs
Auto-deploy → on alpha: `source='openapi'` rows go `0 → N` (accounting + other services), embeddings backfill, then seed one `mcp_tool_permission` and chat to confirm a discovered op **selects + executes** via the gateway.

## Contract impact
**None.** Internal discovery. No controller, DTO, OpenAPI annotation, event, or config-surface contract changed. No domain \`BACKEND_CONTRACT_GUIDE.md\` update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)