### PR TITLE
feat(mcp-server): relay caller auth to discovered openapi op execution (Gate 3)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiOperationExecutor.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiOperationExecutor.java
@@ -8,6 +8,7 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.net.URI;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -27,26 +28,32 @@ public class OpenApiOperationExecutor implements ToolExecutor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenApiOperationExecutor.class);
 
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String HEADERS_ARG = "headers";
+
     private final OperationProxyFactory proxyFactory;
     private final DiscoveredOperation operation;
     private final ObjectMapper objectMapper;
     private final Duration timeout;
+    private final @Nullable String authHeader;
 
     public OpenApiOperationExecutor(
             @NonNull OperationProxyFactory proxyFactory,
             @NonNull DiscoveredOperation operation,
             @NonNull ObjectMapper objectMapper,
-            @NonNull Duration timeout) {
+            @NonNull Duration timeout,
+            @Nullable String authHeader) {
         this.proxyFactory = proxyFactory;
         this.operation = operation;
         this.objectMapper = objectMapper;
         this.timeout = timeout;
+        this.authHeader = authHeader;
     }
 
     @Override
     public String execute(@NonNull ToolExecutionRequest request, @Nullable Object memoryId) {
         try {
-            Map<String, Object> arguments = parseArguments(request.arguments());
+            Map<String, Object> arguments = withRelayedAuth(parseArguments(request.arguments()));
             McpSchema.CallToolRequest call = new McpSchema.CallToolRequest(operation.name(), arguments);
             HttpMethod method = HttpMethod.valueOf(operation.httpMethod());
             // Route via the gateway base URI (service_id holds it), not the load-balancer: alpha's
@@ -67,6 +74,25 @@ public class OpenApiOperationExecutor implements ToolExecutor {
                     exception);
             return "Error: tool execution failed (" + exception.getClass().getSimpleName() + ")";
         }
+    }
+
+    /**
+     * Relays the caller's {@code Authorization} header into the outbound call so the gateway executes
+     * the discovered op as the caller (facade tools relay the bearer token the same way). An explicit
+     * {@code headers.Authorization} in the tool arguments is left untouched.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> withRelayedAuth(@NonNull Map<String, Object> arguments) {
+        if (authHeader == null || authHeader.isBlank()) {
+            return arguments;
+        }
+        Map<String, Object> merged = new HashMap<>(arguments);
+        Object existing = merged.get(HEADERS_ARG);
+        Map<String, Object> headers =
+                existing instanceof Map<?, ?> map ? new HashMap<>((Map<String, Object>) map) : new HashMap<>();
+        headers.putIfAbsent(AUTHORIZATION, authHeader);
+        merged.put(HEADERS_ARG, headers);
+        return merged;
     }
 
     private Map<String, Object> parseArguments(@Nullable String json) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -42,6 +42,8 @@ import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Component
 @Profile("alpha")
@@ -131,8 +133,8 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
     }
 
     /**
-     * Returns a cached role agent, creating one if absent. User-specific
-     * conversation state is resolved later by the chat memory provider.
+     * Returns a cached role agent, creating one if absent. User-specific conversation state is
+     * resolved later by the chat memory provider.
      */
     @NonNull
     PosAssistant getOrCreateAgent(@NonNull String userId, @NonNull String role) {
@@ -195,10 +197,12 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                         messagePreview);
             }
             PosAssistant agent = getOrCreateAgent(role, cacheKey, selection.roleTools(), selection.fallbackTools());
-            // Gate 3 (G3.3): publish the caller so the dynamic OpenApiToolProvider (running inside the
-            // cached agent) resolves this request's permission-eligible tools; cleared in finally.
+            // Gate 3 (G3.3): publish the caller so the dynamic OpenApiToolProvider
+            // (running inside the
+            // cached agent) resolves this request's permission-eligible tools; cleared
+            // in finally.
             if (requestScopedUserContext != null) {
-                requestScopedUserContext.set(currentUserContext);
+                requestScopedUserContext.set(currentUserContext, currentAuthorizationHeader());
             }
             long agentStartNanos = System.nanoTime();
             String response = agent.chat(memoryKey(username, role), message, formatUserContext(currentUserContext));
@@ -264,6 +268,15 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         return roleAgentCache.estimatedSize();
     }
 
+    /** The caller's raw {@code Authorization} header from the current servlet request, if present. */
+    private @Nullable String currentAuthorizationHeader() {
+        var attributes = RequestContextHolder.getRequestAttributes();
+        if (attributes instanceof ServletRequestAttributes servletAttributes) {
+            return servletAttributes.getRequest().getHeader("Authorization");
+        }
+        return null;
+    }
+
     private PosAssistant buildAgent(@NonNull String role) {
         return buildAgent(role, toolRegistry.resolveDomainTools(role), toolSelectionEngine.fullFallbackTools());
     }
@@ -304,9 +317,12 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                         memoryId -> rolePromptResolver.assemble(role, ragScope).text())
                 .chatMemoryProvider(this::chatMemoryFor);
         if (openApiToolProvider != null) {
-            // Gate 3 (G3.3): dynamic, permission-gated OpenAPI-discovered tools resolved per request
-            // from RequestScopedUserContext (set around agent.chat below). A cached agent never
-            // captures a caller's permissions, so it cannot leak a prior caller's tools.
+            // Gate 3 (G3.3): dynamic, permission-gated OpenAPI-discovered tools
+            // resolved per request
+            // from RequestScopedUserContext (set around agent.chat below). A cached
+            // agent never
+            // captures a caller's permissions, so it cannot leak a prior caller's
+            // tools.
             agentBuilder.toolProvider(openApiToolProvider);
         }
         PosAssistant agent = agentBuilder.build();
@@ -336,8 +352,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
     }
 
     /**
-     * Evicts a user's conversation state and rate counter. Role agents remain
-     * cached.
+     * Evicts a user's conversation state and rate counter. Role agents remain cached.
      */
     @Override
     public void evict(@NonNull String userId) {
@@ -350,7 +365,8 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         int prebuilt = 0;
         for (String role : toolRegistry.preloadableRoleIdentifiers()) {
             try {
-                // No CurrentUserContext is available during startup warm-up, so prebuild
+                // No CurrentUserContext is available during startup warm-up, so
+                // prebuild
                 // with the AUTHENTICATED-only permission set; callers whose actual
                 // permissionCodes differ get a cache miss and build on demand via
                 // getOrCreateAgent (its key already varies with toolCacheKey).
@@ -407,9 +423,10 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
     }
 
     /**
-     * Emits one {@code nlti.request.telemetry} event for a completed chat request (Gate 1). Never
-     * throws into the request path — a telemetry failure is logged and swallowed. No-op when no
-     * emitter is configured. {@code correlationId} is taken from the request MDC when present.
+     * Emits one {@code nlti.request.telemetry} event for a completed chat request (Gate 1).
+     * Never throws into the request path — a telemetry failure is logged and swallowed. No-op
+     * when no emitter is configured. {@code correlationId} is taken from the request MDC when
+     * present.
      */
     private void emitChatTelemetry(
             @NonNull CurrentUserContext currentUserContext,
@@ -453,10 +470,10 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
 
     private static @NonNull String formatUserContext(@NonNull CurrentUserContext currentUserContext) {
         return "Authenticated user context: username=" + currentUserContext.username()
-                + ", userId=" + currentUserContext.userId()
-                + ", primaryRole=" + currentUserContext.primaryRole()
-                + ", roles=" + currentUserContext.roles()
-                + ", authorityCount=" + currentUserContext.authorities().size()
+                + ", userId=" + currentUserContext.userId() + ", primaryRole="
+                + currentUserContext.primaryRole() + ", roles="
+                + currentUserContext.roles() + ", authorityCount="
+                + currentUserContext.authorities().size()
                 + ". Interpret references to 'me', 'my', or 'current user' as this authenticated user."
                 + " If a question depends on the user's exact permissions, prefer a self-service permissions tool before asking for identifiers.";
     }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
@@ -77,6 +77,7 @@ public class OpenApiToolProvider implements ToolProvider {
             return new ToolProviderResult(Map.of());
         }
         CurrentUserContext caller = maybe.get();
+        String authHeader = userContext.currentAuthHeader().orElse(null);
         String userMessage =
                 request.userMessage() == null ? "" : request.userMessage().singleText();
         if (userMessage == null || userMessage.isBlank()) {
@@ -99,7 +100,7 @@ public class OpenApiToolProvider implements ToolProvider {
                     .name(op.name())
                     .description(op.description())
                     .build();
-            tools.put(spec, new OpenApiOperationExecutor(proxyFactory, op, objectMapper, executionTimeout));
+            tools.put(spec, new OpenApiOperationExecutor(proxyFactory, op, objectMapper, executionTimeout, authHeader));
         }
         LOGGER.debug(
                 "MCP openapi tool provider role={} permissionCount={} discoveredTools={}",

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RequestScopedUserContext.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RequestScopedUserContext.java
@@ -3,28 +3,39 @@ package com.positivity.mcp.internal.service;
 import com.positivity.mcp.service.CurrentUserContext;
 import java.util.Optional;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
- * Request-scoped holder for the current caller's {@link CurrentUserContext} (Gate 3).
+ * Request-scoped holder for the current caller's {@link CurrentUserContext} and raw
+ * {@code Authorization} header (Gate 3).
  *
- * <p>The OpenAPI {@code ToolProvider} runs inside the cached agent and has no access to the HTTP
- * request, so the calling thread publishes the caller here before invoking the agent and clears it
- * afterwards. Reading it per request (rather than capturing permissions at agent-build time) is what
- * prevents a cached agent from exposing a prior, higher-permission caller's tools.
+ * <p>The OpenAPI {@code ToolProvider} and its executors run inside the cached agent and have no
+ * access to the HTTP request, so the calling thread publishes the caller (and its bearer token)
+ * here before invoking the agent and clears it afterwards. Reading it per request (rather than
+ * capturing at agent-build time) is what prevents a cached agent from exposing a prior, higher-
+ * permission caller's tools; relaying the token is what lets a discovered op call the gateway as
+ * the caller (otherwise the gateway rejects it with 401).
  *
- * <p><strong>Threading:</strong> backed by a {@link ThreadLocal}, so it is correct for the
- * synchronous blocking path only. The streaming (Reactor) path executes on different threads; until
- * Reactor-context propagation is implemented and verified, the provider treats an empty holder as
- * "no discovered tools" (fail-closed) rather than risk leakage.
+ * <p><strong>Threading:</strong> backed by a {@link ThreadLocal}, correct for the synchronous
+ * blocking path only. The streaming (Reactor) path executes on different threads; until Reactor-
+ * context propagation is implemented, the provider treats an empty holder as "no discovered tools"
+ * (fail-closed).
  */
 @Component
 public class RequestScopedUserContext {
 
-    private static final ThreadLocal<CurrentUserContext> HOLDER = new ThreadLocal<>();
+    private record Holder(
+            CurrentUserContext context, @Nullable String authHeader) {}
+
+    private static final ThreadLocal<Holder> HOLDER = new ThreadLocal<>();
 
     public void set(@NonNull CurrentUserContext context) {
-        HOLDER.set(context);
+        set(context, null);
+    }
+
+    public void set(@NonNull CurrentUserContext context, @Nullable String authHeader) {
+        HOLDER.set(new Holder(context, authHeader));
     }
 
     public void clear() {
@@ -32,6 +43,13 @@ public class RequestScopedUserContext {
     }
 
     public @NonNull Optional<CurrentUserContext> current() {
-        return Optional.ofNullable(HOLDER.get());
+        Holder holder = HOLDER.get();
+        return holder == null ? Optional.empty() : Optional.of(holder.context());
+    }
+
+    /** The caller's raw {@code Authorization} header, for relaying to downstream gateway calls. */
+    public @NonNull Optional<String> currentAuthHeader() {
+        Holder holder = HOLDER.get();
+        return holder == null ? Optional.empty() : Optional.ofNullable(holder.authHeader());
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiOperationExecutorTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiOperationExecutorTest.java
@@ -15,6 +15,8 @@ import io.modelcontextprotocol.spec.McpSchema;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -43,7 +45,7 @@ class OpenApiOperationExecutorTest {
                 "http://api-gateway:8080",
                 null);
         OpenApiOperationExecutor executor =
-                new OpenApiOperationExecutor(proxyFactory, operation, new ObjectMapper(), TIMEOUT);
+                new OpenApiOperationExecutor(proxyFactory, operation, new ObjectMapper(), TIMEOUT, null);
 
         String result = executor.execute(
                 ToolExecutionRequest.builder()
@@ -59,13 +61,51 @@ class OpenApiOperationExecutorTest {
     }
 
     @Test
+    @DisplayName("execute relays the caller's Authorization header into the outbound call")
+    void execute_relaysAuthorizationHeader() {
+        OperationProxyFactory proxyFactory = mock(OperationProxyFactory.class);
+        McpSchema.CallToolResult ok = McpSchema.CallToolResult.builder()
+                .content(List.of(new McpSchema.TextContent("[]")))
+                .build();
+        AtomicReference<McpSchema.CallToolRequest> captured = new AtomicReference<>();
+        when(proxyFactory.handlerForBaseUri(any(URI.class), eq(HttpMethod.GET), eq("/v1/accounting/invoices")))
+                .thenReturn((exchange, request) -> {
+                    captured.set(request);
+                    return Mono.just(ok);
+                });
+        DiscoveredOperation operation = new DiscoveredOperation(
+                "accounting_listinvoices",
+                "List invoices",
+                "GET",
+                "/v1/accounting/invoices",
+                "http://api-gateway:8080",
+                null);
+        OpenApiOperationExecutor executor =
+                new OpenApiOperationExecutor(proxyFactory, operation, new ObjectMapper(), TIMEOUT, "Bearer test-token");
+
+        executor.execute(
+                ToolExecutionRequest.builder()
+                        .name("accounting_listinvoices")
+                        .arguments("{}")
+                        .build(),
+                null);
+
+        assertThat(captured.get()).isNotNull();
+        Object headers = captured.get().arguments().get("headers");
+        assertThat(headers).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> headerMap = (Map<String, Object>) headers;
+        assertThat(headerMap).containsEntry("Authorization", "Bearer test-token");
+    }
+
+    @Test
     @DisplayName("execute returns a controlled error (no proxy call) when service_id is missing")
     void execute_missingServiceId_returnsControlledError() {
         OperationProxyFactory proxyFactory = mock(OperationProxyFactory.class);
         DiscoveredOperation operation = new DiscoveredOperation(
                 "accounting_listinvoices", "List invoices", "GET", "/v1/accounting/invoices", null, null);
         OpenApiOperationExecutor executor =
-                new OpenApiOperationExecutor(proxyFactory, operation, new ObjectMapper(), TIMEOUT);
+                new OpenApiOperationExecutor(proxyFactory, operation, new ObjectMapper(), TIMEOUT, null);
 
         String result = executor.execute(
                 ToolExecutionRequest.builder()


### PR DESCRIPTION
The final Gate 3 slice. Live E2E (#798) proved a discovered op **selects + executes** via the gateway — but the gateway returned **401** because the execution call didn't forward the caller's `Authorization` header. Facade tools relay the bearer token via `BearerTokenRelayInterceptor`; the openapi executor uses `OperationProxyFactory`'s WebClient, which has no such relay.

## Change
- **`RequestScopedUserContext`** also holds the raw `Authorization` header (set alongside `CurrentUserContext`); adds `currentAuthHeader()`.
- **`SessionAgentManager`** captures the servlet request's `Authorization` header (via `RequestContextHolder`, on the calling thread) and publishes it when setting the request-scoped context around `agent.chat`.
- **`OpenApiToolProvider`** passes the header into each `OpenApiOperationExecutor`.
- **`OpenApiOperationExecutor`** injects it into the outbound call's `headers` arg (leaving any explicit `headers.Authorization` untouched), so `OperationProxyFactory` forwards it to the gateway — the op executes **as the caller**.

## Tests
`execute_relaysAuthorizationHeader` asserts the captured outbound request carries the caller's `Authorization`. Full offline gate suite green: **80 run, 0 fail, 1 skipped**.

## After merge — the fully-closed E2E
Deploy → seed a permission for a read op → chat as `admin.alpha` → the discovered op should now return **real gateway data** (not 401). That closes Gate 3's openapi execution bridge end-to-end.

## Contract impact
**None.** Internal orchestration/discovery. No controller, DTO, OpenAPI annotation, event, or config-surface contract changed. No domain \`BACKEND_CONTRACT_GUIDE.md\` update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)