### PR TITLE
fix(mcp-server): exclude openapi rows from facade/bean queries (boot crash-loop)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -39,6 +39,7 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                 JOIN mcp_tool_workflow tw ON t.id = tw.tool_id
                 JOIN mcp_workflow_state ws ON tw.workflow_state_id = ws.id
                 WHERE t.enabled = true
+                  AND t.source <> 'openapi'
                   AND tp.permission_code = ANY(?)
                   AND ws.name = ?
                 """;
@@ -66,6 +67,7 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                 JOIN mcp_tool_workflow tw ON t.id = tw.tool_id
                 JOIN mcp_workflow_state ws ON tw.workflow_state_id = ws.id
                 WHERE t.enabled = true
+                  AND t.source <> 'openapi'
                   AND ws.name = ?
                 ORDER BY lower(t.domain), t.name
                 """;
@@ -93,6 +95,7 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                 JOIN mcp_tool_workflow tw ON t.id = tw.tool_id
                 JOIN mcp_workflow_state ws ON tw.workflow_state_id = ws.id
                 WHERE t.enabled = true
+                  AND t.source <> 'openapi'
                   AND t.embedding IS NOT NULL
                   AND ws.name = ?
                   AND t.id IN (SELECT tool_id FROM mcp_tool_permission WHERE permission_code = ANY(?))
@@ -215,6 +218,7 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                        avg_latency_ms, enabled, handler_bean
                 FROM mcp_tool
                 WHERE enabled = true
+                  AND source <> 'openapi'
                   AND embedding IS NOT NULL
                 ORDER BY embedding <=> ?::vector, id
                 LIMIT ?

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/MasterAgentRegistryLoader.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/MasterAgentRegistryLoader.java
@@ -75,6 +75,12 @@ public class MasterAgentRegistryLoader {
     }
 
     private Object loadToolBean(@NonNull ToolMetadata tool) {
+        // Openapi-discovered rows have no handler_bean (they execute via OpenApiToolProvider, not a
+        // bean); they are excluded by the repository query, but guard defensively so a null never
+        // reaches getBean (which throws "'name' must not be null" and fails context init).
+        if (tool.handlerBean() == null || tool.handlerBean().isBlank()) {
+            return null;
+        }
         try {
             return applicationContext.getBean(tool.handlerBean());
         } catch (NoSuchBeanDefinitionException e) {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/MasterAgentRegistryLoaderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/MasterAgentRegistryLoaderTest.java
@@ -56,6 +56,21 @@ class MasterAgentRegistryLoaderTest {
     }
 
     @Test
+    void toolWithNullHandlerBeanIsSkippedNotCrashing() {
+        // Regression: openapi-discovered rows have no handler_bean. If one reaches the loader it must
+        // be skipped, not passed to getBean(null) (which throws "'name' must not be null" and crashes
+        // context init — the mcp-server crash-loop on 2026-07-01).
+        ToolMetadata openapiTool = tool("event-receiver_getactiveeventtypes", "event-receiver", null);
+        when(repository.findEnabledByWorkflow("IDLE")).thenReturn(List.of(openapiTool));
+
+        MasterAgentRegistryLoader loader = new MasterAgentRegistryLoader(repository, applicationContext, "idle");
+        MasterAgentRegistryLoader.LoadedMasterAgentRegistry loaded = loader.loadRegistryDefinition();
+
+        assertThat(loaded.sharedTools()).isEmpty();
+        assertThat(loaded.domainToolAssignments()).isEmpty();
+    }
+
+    @Test
     void sharedOnlyWorkflowYieldsNoDomainOrRoleAssignments() {
         ToolMetadata masterTool = tool("ExaWebSearchTool", "master", "exaWebSearchTool");
         Object sharedBean = new Object();


### PR DESCRIPTION
**Hotfix** — deploying the openapi bridge (#799) crash-looped the mcp-server on alpha (33 restarts):
```
Failed to instantiate MasterAgentRegistry: 'name' must not be null
```
The registry loader's `findEnabledByWorkflow` JOINs `mcp_tool_workflow`; the persisted `source='openapi'` rows now carry IDLE workflow mappings (added so they're selectable), so the loader picked them up and called `applicationContext.getBean(handler_bean=null)` → context-init failure.

## Fix
- Exclude `source='openapi'` from the facade/bean-loading queries (`findEnabledByWorkflow`, `findEnabledByPermissionsAndWorkflow`, `findTopKByEmbeddingForPermissions`, `findTopKByEmbedding`). Openapi ops are provided via `OpenApiToolProvider` (`findDiscoveredCandidatesForPermissions`), never as beans — so they must not appear in facade paths (also stops them polluting facade candidate selection).
- Defensive guard in `MasterAgentRegistryLoader.loadToolBean`: skip null/blank `handler_bean` instead of `getBean(null)`.

## Tests
Regression: a tool with null `handler_bean` is skipped, not crashing. Loader suite 3/3.

## Ops
The 99 persisted openapi rows were deleted on alpha to break the running crash-loop. With this fix the loader tolerates them (discovery re-persists on boot).

## Contract impact
**None.** Internal repository/loader. No contract surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)