### PR TITLE
feat(mcp-server): log discovered-op proxy call target + status (Gate 3 observability)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OperationProxyFactory.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OperationProxyFactory.java
@@ -100,11 +100,23 @@ public class OperationProxyFactory {
         if (body != null) {
             requestSpec.contentType(MediaType.APPLICATION_JSON);
         }
+        if (log.isDebugEnabled()) {
+            log.debug("Tool proxy calling {} {} ({})", method, targetUri, logContext);
+        }
         return requestSpec
                 .body(body != null ? BodyInserters.fromValue(body) : BodyInserters.empty())
                 .retrieve()
                 .toEntity(String.class)
-                .map(responseEntity -> successResult(responseEntity.getBody()))
+                .map(responseEntity -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug(
+                                "Tool proxy {} {} -> {}",
+                                method,
+                                targetUri,
+                                responseEntity.getStatusCode().value());
+                    }
+                    return successResult(responseEntity.getBody());
+                })
                 .onErrorResume(ex -> {
                     log.warn("Tool proxy failed for {} {}: {}", logContext, targetUri, ex.getMessage());
                     return Mono.just(errorResult(ex.getMessage()));


### PR DESCRIPTION
While chasing a live "404" from a discovered openapi op, `OperationProxyFactory` only logged on error — so a *successful* (or never-invoked) call was invisible. That made it hard to distinguish "op executed 200" from "the LLM invoked a facade tool instead".

## Investigation outcome (the route prefix is CORRECT)
- Direct curl of the persisted path `http://api-gateway:8080/event-receiver/v1/eventTypes/active` **with the caller's bearer token → 200**.
- The agent narrated "404" but **zero** `Tool proxy failed` log entries appeared → the openapi proxy did **not** error. The 404 came from a facade tool the LLM chose, or LLM misreporting — **not** a bridge defect.

So the openapi bridge (discover → persist → embed → select → provide → invoke → relay auth → execute via gateway) is correct end-to-end; the gap was observability.

## Change
Add DEBUG logs in `OperationProxyFactory.executeRequest`: one before the call (`method targetUri (context)`) and one on success (`method targetUri -> status`). Failures already log. Every discovered-op execution's real URL + result is now visible.

## Tests
Discovery suite green (30 run, 0 fail). Log-only change.

## Contract impact
**None.** Logging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)