### PR TITLE
feat(mcp-server): retry transient per-service spec fetches during discovery (Gate 3)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcher.java
@@ -9,9 +9,11 @@ import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -20,8 +22,11 @@ import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 @Component
 public class OpenApiDocumentFetcher {
@@ -31,6 +36,11 @@ public class OpenApiDocumentFetcher {
     private static final URI LOCAL_GATEWAY_FALLBACK = URI.create("http://localhost:8080");
     private static final String SWAGGER_CONFIG_SUFFIX = "/swagger-config";
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    // Discovery runs at startup; a cold service mesh returns 503 / times out on the first hit. Retry
+    // transient failures with backoff so a warming service is picked up without a full app restart.
+    private static final int DISCOVERY_RETRY_ATTEMPTS = 3;
+    private static final Duration DISCOVERY_RETRY_MIN_BACKOFF = Duration.ofSeconds(2);
+    private static final Duration DISCOVERY_RETRY_MAX_BACKOFF = Duration.ofSeconds(10);
 
     private final DiscoveryClient discoveryClient;
     private final WebClient webClient;
@@ -230,6 +240,9 @@ public class OpenApiDocumentFetcher {
                 .retrieve()
                 .bodyToMono(String.class)
                 .timeout(properties.discoveryTimeout())
+                .retryWhen(Retry.backoff(DISCOVERY_RETRY_ATTEMPTS, DISCOVERY_RETRY_MIN_BACKOFF)
+                        .maxBackoff(DISCOVERY_RETRY_MAX_BACKOFF)
+                        .filter(OpenApiDocumentFetcher::isTransient))
                 .map(raw -> deserialize(doc.routingPrefix(), raw))
                 .map(result -> prefixPaths(result.getOpenAPI(), doc.routingPrefix()))
                 .doOnNext(paths -> log.info(
@@ -238,6 +251,18 @@ public class OpenApiDocumentFetcher {
                     log.warn("Could not fetch/merge service spec at {}: {}", docUri, ex.getMessage());
                     return Mono.just(new Paths());
                 });
+    }
+
+    /**
+     * Transient failures worth retrying during startup discovery: request timeouts, connection
+     * errors, and 5xx (a service still warming up returns 503). A 4xx (e.g. 404) is not retried.
+     */
+    static boolean isTransient(@NonNull Throwable ex) {
+        if (ex instanceof TimeoutException || ex instanceof WebClientRequestException) {
+            return true;
+        }
+        return ex instanceof WebClientResponseException response
+                && response.getStatusCode().is5xxServerError();
     }
 
     /**

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OperationProxyFactory.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/discovery/OperationProxyFactory.java
@@ -100,11 +100,23 @@ public class OperationProxyFactory {
         if (body != null) {
             requestSpec.contentType(MediaType.APPLICATION_JSON);
         }
+        if (log.isDebugEnabled()) {
+            log.debug("Tool proxy calling {} {} ({})", method, targetUri, logContext);
+        }
         return requestSpec
                 .body(body != null ? BodyInserters.fromValue(body) : BodyInserters.empty())
                 .retrieve()
                 .toEntity(String.class)
-                .map(responseEntity -> successResult(responseEntity.getBody()))
+                .map(responseEntity -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug(
+                                "Tool proxy {} {} -> {}",
+                                method,
+                                targetUri,
+                                responseEntity.getStatusCode().value());
+                    }
+                    return successResult(responseEntity.getBody());
+                })
                 .onErrorResume(ex -> {
                     log.warn("Tool proxy failed for {} {}: {}", logContext, targetUri, ex.getMessage());
                     return Mono.just(errorResult(ex.getMessage()));

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherSwaggerConfigTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/discovery/OpenApiDocumentFetcherSwaggerConfigTest.java
@@ -7,8 +7,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 class OpenApiDocumentFetcherSwaggerConfigTest {
 
@@ -63,5 +66,19 @@ class OpenApiDocumentFetcherSwaggerConfigTest {
         assertThat(OpenApiDocumentFetcher.prefixPaths(null, "/accounting")).isEmpty();
         assertThat(OpenApiDocumentFetcher.prefixPaths(new OpenAPI(), "/accounting"))
                 .isEmpty();
+    }
+
+    @Test
+    @DisplayName("isTransient retries timeouts and 5xx (cold service), not 4xx or non-network errors")
+    void isTransient_classifiesRetryableFailures() {
+        assertThat(OpenApiDocumentFetcher.isTransient(new TimeoutException())).isTrue();
+        assertThat(OpenApiDocumentFetcher.isTransient(
+                        new WebClientResponseException(503, "Service Unavailable", HttpHeaders.EMPTY, null, null)))
+                .isTrue();
+        assertThat(OpenApiDocumentFetcher.isTransient(
+                        new WebClientResponseException(404, "Not Found", HttpHeaders.EMPTY, null, null)))
+                .isFalse();
+        assertThat(OpenApiDocumentFetcher.isTransient(new IllegalStateException("boom")))
+                .isFalse();
     }
 }


### PR DESCRIPTION
Live deploys showed discovery running while the mesh was still cold right after a mass restart: most per-service spec fetches returned **503** or timed out at 5s → partial openapi set (2 ops) until a warm re-run (348). No app change should need a manual restart to get full discovery.

## Change
Add a backoff **retry** (3 attempts, 2s→10s) to `OpenApiDocumentFetcher.fetchAndPrefixService`, retrying only **transient** failures — request timeouts, connection errors, and **5xx** (a warming service returns 503). A **4xx** (e.g. 404) is not retried. After retries exhaust, the existing `onErrorResume` still drops that one service to empty paths, so a single stuck service never blocks the rest of the aggregate.

## Tests
`isTransient` classifies `TimeoutException` + 5xx as retryable; 4xx and generic errors as not. Fetcher suite green (5 + 9).

## Contract impact
**None.** Internal discovery resilience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)