### PR TITLE
feat(mcp-server): give discovered openapi tools a request parameter schema (Gate 3)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
@@ -8,6 +8,7 @@ import com.positivity.mcp.internal.domain.WorkflowState;
 import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import com.positivity.mcp.service.CurrentUserContext;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
@@ -38,6 +39,39 @@ import org.springframework.stereotype.Component;
 public class OpenApiToolProvider implements ToolProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenApiToolProvider.class);
+
+    /**
+     * The generic call envelope the {@link OperationProxyFactory} reads. Method/path are fixed from
+     * the persisted coordinates (surfaced in the tool description), so the model only supplies the
+     * request parameters. Per-parameter typing from the OpenAPI operation is a follow-up refinement.
+     */
+    private static final JsonObjectSchema REQUEST_ENVELOPE_SCHEMA = JsonObjectSchema.builder()
+            .description("Parameters for the gateway operation named in the tool description.")
+            .addProperty(
+                    "pathParams",
+                    JsonObjectSchema.builder()
+                            .description("Path template parameters keyed by name, e.g. {\"productId\": \"...\"}.")
+                            .build())
+            .addProperty(
+                    "queryParams",
+                    JsonObjectSchema.builder()
+                            .description("Query-string parameters.")
+                            .build())
+            .addProperty(
+                    "headers",
+                    JsonObjectSchema.builder()
+                            .description("Extra HTTP headers (auth is relayed automatically).")
+                            .build())
+            .addProperty(
+                    "body",
+                    JsonObjectSchema.builder()
+                            .description("Request body payload, for write operations.")
+                            .build())
+            .build();
+
+    private static String describeOperation(@NonNull DiscoveredOperation op) {
+        return op.description() + " [" + op.httpMethod() + " " + op.httpPath() + "]";
+    }
 
     private final ToolMetadataRepository repository;
     private final EmbeddingModel embeddingModel;
@@ -98,7 +132,8 @@ public class OpenApiToolProvider implements ToolProvider {
             }
             ToolSpecification spec = ToolSpecification.builder()
                     .name(op.name())
-                    .description(op.description())
+                    .description(describeOperation(op))
+                    .parameters(REQUEST_ENVELOPE_SCHEMA)
                     .build();
             tools.put(spec, new OpenApiOperationExecutor(proxyFactory, op, objectMapper, executionTimeout, authHeader));
         }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolProviderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolProviderTest.java
@@ -76,6 +76,11 @@ class OpenApiToolProviderTest {
 
         // Only the executable op (with coordinates) is exposed.
         assertThat(result.tools()).hasSize(1);
-        assertThat(result.tools().keySet().iterator().next().name()).isEqualTo("workorders_getallworkorders");
+        var spec = result.tools().keySet().iterator().next();
+        assertThat(spec.name()).isEqualTo("workorders_getallworkorders");
+        // Description surfaces method+path so the model knows the template; envelope gives the params.
+        assertThat(spec.description()).contains("GET", "/v1/workorders");
+        assertThat(spec.parameters()).isNotNull();
+        assertThat(spec.parameters().properties()).containsKeys("pathParams", "queryParams", "headers", "body");
     }
 }


### PR DESCRIPTION
Highest-value open Gate 3 item from the reconciled checklist (argument schema). Discovered ops were exposed with **name + description only** — no parameters — so the model could only call **no-arg** ops (event-types worked; the other ~348 with path/query params could not be invoked correctly).

## Change
Build the `ToolSpecification` with:
- the **generic call envelope** `OperationProxyFactory` reads — `pathParams`, `queryParams`, `headers`, `body` (`JsonObjectSchema`), so the model knows where to put arguments, and
- a **description that surfaces the method + path template** (`... [GET /event-receiver/v1/eventTypes/active]`), so the model knows which path params to fill.

Method/path stay fixed from the persisted coordinates (the executor ignores any model-supplied ones) — the no-arbitrary-URL guarantee holds.

## Tests
Exposed tool carries `pathParams`/`queryParams`/`headers`/`body` + a method+path-bearing description. Offline suite green (65 run, 0 fail, 1 skipped).

## Follow-up (not this PR)
Per-parameter typing from the OpenAPI operation (`operation.getParameters()` → typed schemas) instead of the generic envelope. This PR is the structural unlock; typed validation is the refinement.

## Contract impact
**None.** Internal tool-schema construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)