### PR TITLE
docs(mcp): mark Gate 3 negative permission-gating verified live

### DIFF
--- a/pos-mcp-server/docs/implementation_checklist.md
+++ b/pos-mcp-server/docs/implementation_checklist.md
@@ -336,7 +336,7 @@ First live run against the deployed stack (`durion-alpha`, containers up, `pos_m
 
 ### Correctness tests
 - [x] E2E: execute a discovered op with no facade — _ev: 2026-07-01 live, `event-receiver_getactiveeventtypes` → gateway 200, agent returned 276 active event types._
-- [ ] Lower-permission user cannot call higher-permission op — _ev: NOT live-tested (only positive path proven; needs a low-perm user run)._
+- [x] Lower-permission user cannot call higher-permission op — _ev: 2026-07-01 live (alpha) — an op seeded with a permission the caller LACKS (`gate3:negative:notheld`) is excluded by the gating filter, while an op with a held permission (`AUTHENTICATED`) is eligible; caller-perms ∩ `mcp_tool_permission` fail-closed confirmed with real data. (Two-distinct-user + cached-agent leakage still covered only by design — see `[~]` above.)_
 - [x] Permission re-checked at call time, not only cache-build — _ev: `provideTools` (isDynamic) queries `caller.permissionCodes()` per request, not at agent build._
 - [ ] Arguments schema-validated before proxy call — _ev: NOT wired — `input_schema` persisted null; `ToolSpecification` built with name+description only, no JsonObjectSchema._
 - [x] Failed proxy → controlled error, not hallucinated success — _ev: `OpenApiOperationExecutor` renders controlled error string; unit-tested (missing service_id → controlled error)._


### PR DESCRIPTION
Live proof on alpha (`sha-5c7e41b`): an openapi op seeded with a permission the caller **lacks** (`gate3:negative:notheld`) is **excluded** by the gating filter, while an op with a **held** permission (`AUTHENTICATED`) is eligible.

```
gating filter (caller perms = {AUTHENTICATED}):
  ELIGIBLE: event-receiver_getactiveeventtypes   (held)
  image_getimagebyid excluded                    (not-held perm)
```

Confirms caller-perms ∩ `mcp_tool_permission` fail-closed with real data — closes the "lower-permission cannot call higher-permission op" correctness item. (Two-distinct-user + cached-agent leakage remain design-covered only, `[~]`.)

## Contract impact
**None.** Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)