### PR TITLE
feat(mcp-server): tag openapi-source tools in per-request telemetry (Gate 3)

### DIFF
--- a/pos-mcp-server/docs/implementation_checklist.md
+++ b/pos-mcp-server/docs/implementation_checklist.md
@@ -332,7 +332,7 @@ First live run against the deployed stack (`durion-alpha`, containers up, `pos_m
 - [x] Proxied calls include current user context — _ev: auth relay #799; op executed as caller → 200._
 - [~] Cached agents cannot expose prior higher-permission user's tools — _ev: per-request dynamic provider (design-safe); leakage not yet live-tested._
 - [x] Facade + OpenAPI tools coexist — _ev: facade selection + openapi provider both active in the same request (live logs)._
-- [ ] Telemetry distinguishes facade vs OpenAPI source — _ev: NOT wired — `nlti.request.telemetry` has no per-tool source tag._
+- [x] Telemetry distinguishes facade vs OpenAPI source — _ev: `NltiRequestTelemetry.Tools.discoveredOpenapi` lists openapi-source tools separately from facade `selected`; `OpenApiToolProvider` publishes the surfaced names request-scoped, `SessionAgentManager` includes them in the event. Unit-tested._
 
 ### Correctness tests
 - [x] E2E: execute a discovered op with no facade — _ev: 2026-07-01 live, `event-receiver_getactiveeventtypes` → gateway 200, agent returned 276 active event types._

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -446,12 +446,16 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             if (correlationId == null || correlationId.isBlank()) {
                 correlationId = UUID.randomUUID().toString();
             }
+            List<String> discoveredOpenapiTools = requestScopedUserContext != null
+                    ? requestScopedUserContext.currentDiscoveredOpenapiToolNames()
+                    : List.of();
             telemetryEmitter.emit(NltiRequestTelemetryFactory.forChatRequest(
                     correlationId,
                     Instant.now().toString(),
                     currentUserContext.primaryRole(),
                     currentUserContext.permissionCodes().size(),
                     selectedToolNames,
+                    discoveredOpenapiTools,
                     promptLayers,
                     simpleChat,
                     simpleChatRule,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -352,6 +352,8 @@ public class StreamingSessionAgentManager
                     currentUserContext.primaryRole(),
                     currentUserContext.permissionCodes().size(),
                     selectedToolNames,
+                    // Streaming is fail-closed for openapi tools (Reactor-context propagation deferred).
+                    List.of(),
                     promptLayers,
                     false,
                     null,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
@@ -137,6 +137,8 @@ public class OpenApiToolProvider implements ToolProvider {
                     .build();
             tools.put(spec, new OpenApiOperationExecutor(proxyFactory, op, objectMapper, executionTimeout, authHeader));
         }
+        userContext.recordDiscoveredOpenapiTools(
+                tools.keySet().stream().map(ToolSpecification::name).toList());
         LOGGER.debug(
                 "MCP openapi tool provider role={} permissionCount={} discoveredTools={}",
                 caller.primaryRole(),

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RequestScopedUserContext.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/RequestScopedUserContext.java
@@ -1,6 +1,7 @@
 package com.positivity.mcp.internal.service;
 
 import com.positivity.mcp.service.CurrentUserContext;
+import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -29,6 +30,10 @@ public class RequestScopedUserContext {
             CurrentUserContext context, @Nullable String authHeader) {}
 
     private static final ThreadLocal<Holder> HOLDER = new ThreadLocal<>();
+    // Names of the OpenAPI-discovered tools the provider surfaced this request, for telemetry
+    // (facade vs openapi source). Written by OpenApiToolProvider inside agent.chat, read by the
+    // manager when it emits the per-request telemetry event.
+    private static final ThreadLocal<List<String>> DISCOVERED_OPENAPI_TOOLS = new ThreadLocal<>();
 
     public void set(@NonNull CurrentUserContext context) {
         set(context, null);
@@ -38,8 +43,18 @@ public class RequestScopedUserContext {
         HOLDER.set(new Holder(context, authHeader));
     }
 
+    public void recordDiscoveredOpenapiTools(@NonNull List<String> toolNames) {
+        DISCOVERED_OPENAPI_TOOLS.set(List.copyOf(toolNames));
+    }
+
+    public @NonNull List<String> currentDiscoveredOpenapiToolNames() {
+        List<String> names = DISCOVERED_OPENAPI_TOOLS.get();
+        return names == null ? List.of() : names;
+    }
+
     public void clear() {
         HOLDER.remove();
+        DISCOVERED_OPENAPI_TOOLS.remove();
     }
 
     public @NonNull Optional<CurrentUserContext> current() {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetry.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetry.java
@@ -78,7 +78,8 @@ public record NltiRequestTelemetry(
             List<String> selected,
             int rejectedPermissionCount,
             int candidateCount,
-            @Nullable List<ToolInvocation> invoked) {}
+            @Nullable List<ToolInvocation> invoked,
+            @Nullable List<String> discoveredOpenapi) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record RagDoc(String docId, double score) {}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactory.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactory.java
@@ -37,6 +37,7 @@ public final class NltiRequestTelemetryFactory {
             @NonNull String primaryRole,
             int permissionCodeCount,
             @NonNull List<String> selectedToolNames,
+            @NonNull List<String> discoveredOpenapiTools,
             @NonNull List<String> promptLayers,
             boolean simpleChat,
             @Nullable String simpleChatRule,
@@ -58,9 +59,14 @@ public final class NltiRequestTelemetryFactory {
             routing = null;
         }
 
-        Tools tools = selectedToolNames.isEmpty()
+        Tools tools = (selectedToolNames.isEmpty() && discoveredOpenapiTools.isEmpty())
                 ? null
-                : new Tools(List.copyOf(selectedToolNames), 0, selectedToolNames.size(), null);
+                : new Tools(
+                        List.copyOf(selectedToolNames),
+                        0,
+                        selectedToolNames.size(),
+                        null,
+                        discoveredOpenapiTools.isEmpty() ? null : List.copyOf(discoveredOpenapiTools));
 
         List<PromptLayer> layers = promptLayers.stream()
                 .map(NltiRequestTelemetryFactory::toPromptLayer)

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolProviderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolProviderTest.java
@@ -82,5 +82,7 @@ class OpenApiToolProviderTest {
         assertThat(spec.description()).contains("GET", "/v1/workorders");
         assertThat(spec.parameters()).isNotNull();
         assertThat(spec.parameters().properties()).containsKeys("pathParams", "queryParams", "headers", "body");
+        // Provider publishes the surfaced openapi tool names for telemetry (facade vs openapi source).
+        assertThat(userContext.currentDiscoveredOpenapiToolNames()).containsExactly("workorders_getallworkorders");
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactoryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/telemetry/NltiRequestTelemetryFactoryTest.java
@@ -17,6 +17,7 @@ class NltiRequestTelemetryFactoryTest {
                 "ROLE_ADMIN",
                 676,
                 List.of("WorkorderFacadeTool", "InventoryFacadeTool"),
+                List.of("event-receiver_getactiveeventtypes"),
                 List.of("BASE", "ROLE", "DOMAIN", "TOOL_USE"),
                 false,
                 null,
@@ -32,6 +33,7 @@ class NltiRequestTelemetryFactoryTest {
         assertThat(event.actor().permissionCodeCount()).isEqualTo(676);
         assertThat(event.tools()).isNotNull();
         assertThat(event.tools().selected()).containsExactly("WorkorderFacadeTool", "InventoryFacadeTool");
+        assertThat(event.tools().discoveredOpenapi()).containsExactly("event-receiver_getactiveeventtypes");
         assertThat(event.tools().candidateCount()).isEqualTo(2);
         assertThat(event.rag()).isNotNull();
         assertThat(event.rag().promptLayers())
@@ -52,6 +54,7 @@ class NltiRequestTelemetryFactoryTest {
                 "2026-07-01T00:00:00Z",
                 "ROLE_USER",
                 3,
+                List.of(),
                 List.of(),
                 List.of(),
                 true,
@@ -78,6 +81,7 @@ class NltiRequestTelemetryFactoryTest {
                 676,
                 List.of(),
                 List.of(),
+                List.of(),
                 false,
                 null,
                 null,
@@ -98,6 +102,7 @@ class NltiRequestTelemetryFactoryTest {
                 "ROLE_ADMIN",
                 676,
                 List.of("WorkorderFacadeTool"),
+                List.of(),
                 List.of("BASE", "NOT_A_LAYER", "role"),
                 false,
                 null,


### PR DESCRIPTION
Closes the Gate 3 "telemetry distinguishes facade vs OpenAPI source" completeness item. The telemetry `Tools` record only listed facade `selected` names; openapi tools are added by `OpenApiToolProvider` **inside** the agent, invisible to the manager at emit time.

## Change
- `RequestScopedUserContext` gains a request-scoped slot for the openapi tool names the provider surfaced this request.
- `OpenApiToolProvider` publishes those names after building the tool map.
- `NltiRequestTelemetry.Tools` gains `discoveredOpenapi` (nullable); the factory sets it and builds `Tools` when either facade or openapi tools are present.
- `SessionAgentManager` reads the request-scoped names when emitting (before the finally-clear); `StreamingSessionAgentManager` passes empty (openapi fail-closed on the streaming path).

## Tests
Factory asserts `discoveredOpenapi`; provider asserts the names are published. Offline suite green (70 run, 0 fail, 1 skipped). Checklist item flipped with evidence.

## Contract impact
**None.** Additive telemetry field (`@JsonInclude(NON_NULL)`), internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)