### PR TITLE
feat(mcp-server): admin endpoint to manage discovered-tool permissions (#785)

### DIFF
--- a/pos-mcp-server/docs/implementation_checklist.md
+++ b/pos-mcp-server/docs/implementation_checklist.md
@@ -393,7 +393,7 @@ the Permission lock. So it is specified implementation-ready and verified live t
 - [ ] Argument-schema validation — persist `input_schema` and build the `ToolSpecification`'s `JsonObjectSchema` from it (currently name+description only).
 - [ ] Telemetry facade-vs-openapi source tag on the per-tool record.
 - [ ] Streaming Reactor-context propagation (blocking is done).
-- [ ] Permission-seeding source (admin tooling / #785) — ops fail-closed until a permission is granted.
+- [x] Permission-seeding source (admin tooling / #785) — `ToolPermissionController` (`/v1/tools/{toolName}/permissions` GET/POST/DELETE, gated by `mcp:tool:view` / `mcp:tool:manage`) grants/lists/revokes an openapi tool's `mcp_tool_permission` rows, replacing manual SQL. Controller + `openapi.yaml` regenerated; unit + slice tested (11) + live contract test. _Deploy notes:_ (a) the new `mcp:tool:view`/`mcp:tool:manage` codes need a perm-bits catalog sync ([[perm-bits-catalog-gotcha]]) before an admin can be granted them; (b) SDK regen is the downstream step ([[controller-change-openapi-sdk-chain]])._
 
 ---
 

--- a/pos-mcp-server/openapi.yaml
+++ b/pos-mcp-server/openapi.yaml
@@ -16,6 +16,8 @@ tags:
   description: NLTI Audit Ledger Query
 - name: NLTI
   description: Natural Language Task Interface
+- name: MCP Tool Permissions
+  description: Manage the permission codes that gate discovered OpenAPI tools
 paths:
   /v1/prompts/{id}:
     get:
@@ -454,8 +456,107 @@ paths:
       security:
       - bearerAuth:
         - mcp:document:ingest
+  /v1/tools/{toolName}/permissions:
+    get:
+      tags:
+      - MCP Tool Permissions
+      summary: List a tool's permission grants
+      description: Return the permission codes currently granted to a discovered OpenAPI tool.
+      operationId: listToolPermissions
+      parameters:
+      - name: toolName
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolPermissionsResponse'
+      security:
+      - bearerAuth:
+        - mcp:tool:view
+    post:
+      tags:
+      - MCP Tool Permissions
+      summary: Grant a permission to a tool
+      description: Grant a permission code to a discovered OpenAPI tool so callers holding it can select the tool. Idempotent. Returns the tool's full permission set.
+      operationId: grantToolPermission
+      parameters:
+      - name: toolName
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToolPermissionRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolPermissionsResponse'
+      security:
+      - bearerAuth:
+        - mcp:tool:manage
+    delete:
+      tags:
+      - MCP Tool Permissions
+      summary: Revoke a permission from a tool
+      description: Revoke a permission code from a discovered OpenAPI tool. Idempotent.
+      operationId: revokeToolPermission
+      parameters:
+      - name: toolName
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: permissionCode
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OK
+      security:
+      - bearerAuth:
+        - mcp:tool:manage
 components:
   schemas:
+    ToolPermissionRequest:
+      type: object
+      description: Request to grant a permission code to a discovered OpenAPI tool
+      properties:
+        permissionCode:
+          type: string
+          description: Permission code that must be held for the tool to be selectable. Either the literal AUTHENTICATED or a domain:resource:action code.
+          example: event-receiver:event_type:view
+          pattern: AUTHENTICATED|[a-z0-9-]+:[a-z0-9_-]+:[a-z0-9_-]+
+          minLength: 1
+      required:
+      - permissionCode
+    ToolPermissionsResponse:
+      type: object
+      description: The permission codes currently granted to a discovered OpenAPI tool
+      properties:
+        toolName:
+          type: string
+          description: Unique tool name
+          example: event-receiver_getactiveeventtypes
+        permissionCodes:
+          type: array
+          items:
+            type: string
+          description: Granted permission codes (a caller holding any one may select the tool)
     SystemPromptRequest:
       type: object
       description: Request to create or update a reusable system prompt

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/ToolPermissionController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/ToolPermissionController.java
@@ -1,0 +1,88 @@
+package com.positivity.mcp.internal.controller;
+
+import com.positivity.mcp.internal.dto.ToolPermissionRequest;
+import com.positivity.mcp.internal.dto.ToolPermissionsResponse;
+import com.positivity.mcp.internal.security.McpPermissions;
+import com.positivity.mcp.internal.service.ToolPermissionAdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Gate 3 (#785): admin management of the permission codes that gate discovered OpenAPI tools.
+ * Discovered ops are fail-closed until a permission is granted here, so this endpoint is the
+ * supported alternative to editing {@code mcp_tool_permission} by hand.
+ */
+@RestController
+@RequestMapping("/v1/tools")
+@Validated
+@Tag(name = "MCP Tool Permissions", description = "Manage the permission codes that gate discovered OpenAPI tools")
+class ToolPermissionController {
+
+    private final ToolPermissionAdminService service;
+
+    ToolPermissionController(@NonNull ToolPermissionAdminService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/{toolName}/permissions")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {McpPermissions.TOOL_VIEW})
+    @PreAuthorize("hasAuthority('" + McpPermissions.TOOL_VIEW + "')")
+    @Operation(
+            operationId = "listToolPermissions",
+            summary = "List a tool's permission grants",
+            description = "Return the permission codes currently granted to a discovered OpenAPI tool.",
+            tags = {"MCP Tool Permissions"})
+    ResponseEntity<ToolPermissionsResponse> list(@PathVariable @NonNull String toolName) {
+        return ResponseEntity.ok(service.listPermissions(toolName));
+    }
+
+    @PostMapping("/{toolName}/permissions")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {McpPermissions.TOOL_MANAGE})
+    @PreAuthorize("hasAuthority('" + McpPermissions.TOOL_MANAGE + "')")
+    @Operation(
+            operationId = "grantToolPermission",
+            summary = "Grant a permission to a tool",
+            description = "Grant a permission code to a discovered OpenAPI tool so callers holding it can select "
+                    + "the tool. Idempotent. Returns the tool's full permission set.",
+            tags = {"MCP Tool Permissions"})
+    ResponseEntity<ToolPermissionsResponse> grant(
+            @PathVariable @NonNull String toolName, @RequestBody @Validated @NonNull ToolPermissionRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(service.grantPermission(toolName, request.permissionCode()));
+    }
+
+    @DeleteMapping("/{toolName}/permissions")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {McpPermissions.TOOL_MANAGE})
+    @PreAuthorize("hasAuthority('" + McpPermissions.TOOL_MANAGE + "')")
+    @Operation(
+            operationId = "revokeToolPermission",
+            summary = "Revoke a permission from a tool",
+            description = "Revoke a permission code from a discovered OpenAPI tool. Idempotent.",
+            tags = {"MCP Tool Permissions"})
+    ResponseEntity<Void> revoke(
+            @PathVariable @NonNull String toolName, @RequestParam("permissionCode") @NotBlank @NonNull String code) {
+        service.revokePermission(toolName, code);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/ToolPermissionExceptionHandler.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/ToolPermissionExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.positivity.mcp.internal.controller;
+
+import com.positivity.shared.error.ApiError;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = ToolPermissionController.class)
+class ToolPermissionExceptionHandler {
+
+    private final Clock clock;
+
+    ToolPermissionExceptionHandler(ObjectProvider<Clock> clockProvider) {
+        this.clock = clockProvider.getIfAvailable(Clock::systemUTC);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        UUID correlationId = NltiCorrelationIdSupport.resolveFromRequest(request);
+        List<ApiError.FieldError> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> new ApiError.FieldError(
+                        fe.getField(), fe.getDefaultMessage() != null ? fe.getDefaultMessage() : "Invalid value"))
+                .toList();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .header(NltiCorrelationIdSupport.CORRELATION_ID_HEADER, correlationId.toString())
+                .body(ApiError.withFieldErrors(
+                        "VALIDATION_ERROR",
+                        "Request validation failed",
+                        HttpStatus.BAD_REQUEST.value(),
+                        Instant.now(clock).toString(),
+                        correlationId.toString(),
+                        fieldErrors));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    ResponseEntity<ApiError> handleConstraintViolation(ConstraintViolationException ex, HttpServletRequest request) {
+        UUID correlationId = NltiCorrelationIdSupport.resolveFromRequest(request);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .header(NltiCorrelationIdSupport.CORRELATION_ID_HEADER, correlationId.toString())
+                .body(ApiError.of(
+                        "VALIDATION_ERROR",
+                        ex.getMessage(),
+                        HttpStatus.BAD_REQUEST.value(),
+                        Instant.now(clock).toString(),
+                        correlationId.toString()));
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    ResponseEntity<ApiError> handleNotFound(NoSuchElementException ex, HttpServletRequest request) {
+        UUID correlationId = NltiCorrelationIdSupport.resolveFromRequest(request);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .header(NltiCorrelationIdSupport.CORRELATION_ID_HEADER, correlationId.toString())
+                .body(ApiError.of(
+                        "TOOL_NOT_FOUND",
+                        ex.getMessage(),
+                        HttpStatus.NOT_FOUND.value(),
+                        Instant.now(clock).toString(),
+                        correlationId.toString()));
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/dto/ToolPermissionRequest.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/dto/ToolPermissionRequest.java
@@ -1,0 +1,22 @@
+package com.positivity.mcp.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import org.jspecify.annotations.NonNull;
+
+@Schema(description = "Request to grant a permission code to a discovered OpenAPI tool")
+public record ToolPermissionRequest(
+        @Schema(
+                description = "Permission code that must be held for the tool to be selectable. Either the "
+                        + "literal AUTHENTICATED or a domain:resource:action code.",
+                example = "event-receiver:event_type:view",
+                requiredMode = REQUIRED)
+        @NonNull
+        @NotBlank
+        @Pattern(
+                regexp = "AUTHENTICATED|[a-z0-9-]+:[a-z0-9_-]+:[a-z0-9_-]+",
+                message = "must be AUTHENTICATED or a domain:resource:action code")
+        String permissionCode) {}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/dto/ToolPermissionsResponse.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/dto/ToolPermissionsResponse.java
@@ -1,0 +1,13 @@
+package com.positivity.mcp.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+
+@Schema(description = "The permission codes currently granted to a discovered OpenAPI tool")
+public record ToolPermissionsResponse(
+        @Schema(description = "Unique tool name", example = "event-receiver_getactiveeventtypes") @NonNull
+        String toolName,
+
+        @Schema(description = "Granted permission codes (a caller holding any one may select the tool)") @NonNull
+        List<String> permissionCodes) {}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.repository;
 import com.positivity.mcp.internal.domain.DiscoveredOperation;
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -37,6 +38,20 @@ public interface ToolMetadataRepository {
 
     /** Gate 3 (G3.1): grants a tool a required permission code (fail-closed gating input). Idempotent. */
     void addToolPermission(@NonNull UUID toolId, @NonNull String permissionCode);
+
+    /**
+     * Gate 3 (#785): resolves a discovered ({@code source='openapi'}) tool id by its unique name.
+     * Empty when no such openapi tool exists. Facade rows are never returned.
+     */
+    @NonNull
+    Optional<UUID> findDiscoveredToolIdByName(@NonNull String name);
+
+    /** Gate 3 (#785): the permission codes currently granted to a tool, ascending. */
+    @NonNull
+    List<String> listToolPermissions(@NonNull UUID toolId);
+
+    /** Gate 3 (#785): revokes a permission code from a tool. Idempotent (no-op if absent). */
+    void removeToolPermission(@NonNull UUID toolId, @NonNull String permissionCode);
 
     /**
      * Returns enabled tools authorized for {@code workflowState} where the caller holds at

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -198,6 +199,29 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                 VALUES (?, ?)
                 ON CONFLICT DO NOTHING
                 """, toolId, permissionCode);
+    }
+
+    @Override
+    public @NonNull Optional<UUID> findDiscoveredToolIdByName(@NonNull String name) {
+        List<UUID> ids = jdbcTemplate.query(
+                "SELECT id FROM mcp_tool WHERE name = ? AND source = 'openapi'",
+                (rs, rowNum) -> rs.getObject("id", UUID.class),
+                name);
+        return ids.isEmpty() ? Optional.empty() : Optional.of(ids.get(0));
+    }
+
+    @Override
+    public @NonNull List<String> listToolPermissions(@NonNull UUID toolId) {
+        return jdbcTemplate.queryForList(
+                "SELECT permission_code FROM mcp_tool_permission WHERE tool_id = ? ORDER BY permission_code",
+                String.class,
+                toolId);
+    }
+
+    @Override
+    public void removeToolPermission(@NonNull UUID toolId, @NonNull String permissionCode) {
+        jdbcTemplate.update(
+                "DELETE FROM mcp_tool_permission WHERE tool_id = ? AND permission_code = ?", toolId, permissionCode);
     }
 
     private DiscoveredOperation mapDiscovered(ResultSet rs, int rowNum) throws SQLException {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/security/McpPermissions.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/security/McpPermissions.java
@@ -15,6 +15,9 @@ public final class McpPermissions {
     public static final String SYSTEM_PROMPT_UPDATE = "mcp:system_prompt:update";
     public static final String SYSTEM_PROMPT_DELETE = "mcp:system_prompt:delete";
 
+    public static final String TOOL_VIEW = "mcp:tool:view";
+    public static final String TOOL_MANAGE = "mcp:tool:manage";
+
     public static final String NLTI_REQUEST_SUBMIT = "nlti:request:submit";
     public static final String NLTI_REQUEST_READ = "nlti:request:read";
     public static final String NLTI_AUDIT_READ = "nlti:audit:read";

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolPermissionAdminService.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolPermissionAdminService.java
@@ -1,0 +1,45 @@
+package com.positivity.mcp.internal.service;
+
+import com.positivity.mcp.internal.dto.ToolPermissionsResponse;
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+
+/**
+ * Gate 3 (#785): admin management of the {@code mcp_tool_permission} grants that gate discovered
+ * ({@code source='openapi'}) tools. Ops are fail-closed until an admin grants a permission code,
+ * so this is the supported alternative to editing the table by hand.
+ */
+@Service
+public class ToolPermissionAdminService {
+
+    private final ToolMetadataRepository repository;
+
+    public ToolPermissionAdminService(@NonNull ToolMetadataRepository repository) {
+        this.repository = repository;
+    }
+
+    public @NonNull ToolPermissionsResponse listPermissions(@NonNull String toolName) {
+        UUID toolId = resolve(toolName);
+        return new ToolPermissionsResponse(toolName, repository.listToolPermissions(toolId));
+    }
+
+    public @NonNull ToolPermissionsResponse grantPermission(@NonNull String toolName, @NonNull String permissionCode) {
+        UUID toolId = resolve(toolName);
+        repository.addToolPermission(toolId, permissionCode);
+        return new ToolPermissionsResponse(toolName, repository.listToolPermissions(toolId));
+    }
+
+    public void revokePermission(@NonNull String toolName, @NonNull String permissionCode) {
+        UUID toolId = resolve(toolName);
+        repository.removeToolPermission(toolId, permissionCode);
+    }
+
+    private @NonNull UUID resolve(@NonNull String toolName) {
+        return repository
+                .findDiscoveredToolIdByName(toolName)
+                .orElseThrow(() -> new NoSuchElementException("No discovered OpenAPI tool named: " + toolName));
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
@@ -98,6 +98,21 @@ public class SessionAgentManagerTestConfiguration {
             public void addToolPermission(java.util.UUID toolId, String permissionCode) {
                 // no-op stub
             }
+
+            @Override
+            public java.util.Optional<java.util.UUID> findDiscoveredToolIdByName(String name) {
+                return java.util.Optional.empty();
+            }
+
+            @Override
+            public java.util.List<String> listToolPermissions(java.util.UUID toolId) {
+                return List.of();
+            }
+
+            @Override
+            public void removeToolPermission(java.util.UUID toolId, String permissionCode) {
+                // no-op stub
+            }
         };
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpOpenApiContractTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/McpOpenApiContractTest.java
@@ -46,6 +46,9 @@ class McpOpenApiContractTest {
         assertOperationDescription(paths, "/v1/nlt/requests", "post");
         assertOperationDescription(paths, "/v1/mcp/chat", "post");
         assertOperationDescription(paths, "/v1/mcp/chat/stream", "post");
+        assertOperationSummaryAndDescription(paths, "/v1/tools/{toolName}/permissions", "get");
+        assertOperationSummaryAndDescription(paths, "/v1/tools/{toolName}/permissions", "post");
+        assertOperationSummaryAndDescription(paths, "/v1/tools/{toolName}/permissions", "delete");
     }
 
     @SuppressWarnings("unchecked")

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/ToolPermissionControllerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/ToolPermissionControllerTest.java
@@ -1,0 +1,146 @@
+package com.positivity.mcp.internal.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.mcp.internal.dto.ToolPermissionsResponse;
+import com.positivity.mcp.internal.service.ToolPermissionAdminService;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** Controller slice tests for ToolPermissionController (Gate 3 / #785). */
+@WebMvcTest(ToolPermissionController.class)
+@ActiveProfiles("test")
+class ToolPermissionControllerTest {
+
+    private static final String TOOL = "event-receiver_getactiveeventtypes";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ToolPermissionAdminService service;
+
+    @Test
+    @WithMockUser(authorities = "mcp:tool:view")
+    @DisplayName("GET permissions with view authority → 200")
+    void list_withViewAuthority_returns200() throws Exception {
+        when(service.listPermissions(TOOL)).thenReturn(new ToolPermissionsResponse(TOOL, List.of("AUTHENTICATED")));
+
+        mockMvc.perform(get("/v1/tools/{toolName}/permissions", TOOL))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.toolName").value(TOOL))
+                .andExpect(jsonPath("$.permissionCodes[0]").value("AUTHENTICATED"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "mcp:tool:manage")
+    @DisplayName("POST grant with manage authority → 201")
+    void grant_withManageAuthority_returns201() throws Exception {
+        when(service.grantPermission(eq(TOOL), eq("event-receiver:event_type:view")))
+                .thenReturn(
+                        new ToolPermissionsResponse(TOOL, List.of("AUTHENTICATED", "event-receiver:event_type:view")));
+
+        mockMvc.perform(post("/v1/tools/{toolName}/permissions", TOOL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"permissionCode\":\"event-receiver:event_type:view\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.permissionCodes[1]").value("event-receiver:event_type:view"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "mcp:tool:manage")
+    @DisplayName("POST grant with an invalid permission code → 400")
+    void grant_withInvalidCode_returns400() throws Exception {
+        mockMvc.perform(post("/v1/tools/{toolName}/permissions", TOOL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"permissionCode\":\"NOT A CODE\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(authorities = "mcp:tool:manage")
+    @DisplayName("DELETE revoke with manage authority → 204")
+    void revoke_withManageAuthority_returns204() throws Exception {
+        mockMvc.perform(delete("/v1/tools/{toolName}/permissions", TOOL).param("permissionCode", "AUTHENTICATED"))
+                .andExpect(status().isNoContent());
+
+        verify(service).revokePermission(TOOL, "AUTHENTICATED");
+    }
+
+    @Test
+    @WithMockUser(authorities = "mcp:tool:view")
+    @DisplayName("GET permissions for an unknown tool → 404")
+    void list_unknownTool_returns404() throws Exception {
+        when(service.listPermissions("nope"))
+                .thenThrow(new NoSuchElementException("No discovered OpenAPI tool named: nope"));
+
+        mockMvc.perform(get("/v1/tools/{toolName}/permissions", "nope")).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(authorities = "other:authority")
+    @DisplayName("POST grant without manage authority → 403")
+    void grant_withoutAuthority_returns403() throws Exception {
+        mockMvc.perform(post("/v1/tools/{toolName}/permissions", TOOL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"permissionCode\":\"AUTHENTICATED\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET permissions unauthenticated → 401")
+    void list_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(get("/v1/tools/{toolName}/permissions", TOOL)).andExpect(status().isUnauthorized());
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity(prePostEnabled = true)
+    static class SliceTestConfig {
+
+        @Bean
+        SecurityExceptionControllerAdvice securityExceptionControllerAdvice() {
+            return new SecurityExceptionControllerAdvice();
+        }
+    }
+
+    @ControllerAdvice
+    static class SecurityExceptionControllerAdvice {
+
+        @ExceptionHandler(AccessDeniedException.class)
+        @ResponseStatus(HttpStatus.FORBIDDEN)
+        void handleAccessDenied() {
+            // 403 via @ResponseStatus
+        }
+
+        @ExceptionHandler(AuthenticationException.class)
+        @ResponseStatus(HttpStatus.UNAUTHORIZED)
+        void handleAuthenticationException() {
+            // 401 via @ResponseStatus
+        }
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolPermissionAdminServiceTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolPermissionAdminServiceTest.java
@@ -1,0 +1,69 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ToolPermissionAdminServiceTest {
+
+    private static final UUID TOOL_ID = UUID.fromString("00000000-0000-7000-8000-000000000901");
+    private static final String TOOL = "event-receiver_getactiveeventtypes";
+
+    @Mock
+    private ToolMetadataRepository repository;
+
+    private ToolPermissionAdminService service() {
+        return new ToolPermissionAdminService(repository);
+    }
+
+    @Test
+    void grant_addsPermissionAndReturnsFullSet() {
+        when(repository.findDiscoveredToolIdByName(TOOL)).thenReturn(Optional.of(TOOL_ID));
+        when(repository.listToolPermissions(TOOL_ID))
+                .thenReturn(List.of("AUTHENTICATED", "event-receiver:event_type:view"));
+
+        var response = service().grantPermission(TOOL, "event-receiver:event_type:view");
+
+        verify(repository).addToolPermission(TOOL_ID, "event-receiver:event_type:view");
+        assertThat(response.toolName()).isEqualTo(TOOL);
+        assertThat(response.permissionCodes()).containsExactly("AUTHENTICATED", "event-receiver:event_type:view");
+    }
+
+    @Test
+    void revoke_removesPermission() {
+        when(repository.findDiscoveredToolIdByName(TOOL)).thenReturn(Optional.of(TOOL_ID));
+
+        service().revokePermission(TOOL, "AUTHENTICATED");
+
+        verify(repository).removeToolPermission(TOOL_ID, "AUTHENTICATED");
+    }
+
+    @Test
+    void list_returnsGrantedCodes() {
+        when(repository.findDiscoveredToolIdByName(TOOL)).thenReturn(Optional.of(TOOL_ID));
+        when(repository.listToolPermissions(TOOL_ID)).thenReturn(List.of("AUTHENTICATED"));
+
+        assertThat(service().listPermissions(TOOL).permissionCodes()).containsExactly("AUTHENTICATED");
+    }
+
+    @Test
+    void unknownTool_throwsNotFound() {
+        when(repository.findDiscoveredToolIdByName("nope")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().listPermissions("nope"))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessageContaining("nope");
+    }
+}


### PR DESCRIPTION
Discovered OpenAPI tools are **fail-closed** until an admin grants them an `mcp_tool_permission` — until now only via manual SQL. This adds the supported admin surface (#785), the last practical blocker to using the 348 discovered ops.

## Endpoints — `ToolPermissionController` (`/v1/tools/{toolName}/permissions`)
| Method | Purpose | Authority | Success |
|---|---|---|---|
| GET | list a tool's permission grants | `mcp:tool:view` | 200 |
| POST | grant `{permissionCode}` (idempotent) | `mcp:tool:manage` | 201 |
| DELETE | revoke `?permissionCode=` (idempotent) | `mcp:tool:manage` | 204 |

Scoped to `source='openapi'` tools; unknown tool → 404. New repo methods (`findDiscoveredToolIdByName`, `listToolPermissions`, `removeToolPermission`), new `mcp:tool:view` / `mcp:tool:manage` constants.

## Contract chain
- **Controller annotations** ✅ (`@Operation` + `@SecurityRequirement`, explicit operationIds).
- **`openapi.yaml`** ✅ regenerated (new path + `ToolPermissionRequest`/`ToolPermissionsResponse` schemas); `McpOpenApiContractTest` boots the app and asserts the live `/v3/api-docs` carries the three ops.
- **Angular SDK** — downstream: generated in the SDK pipeline from this `openapi.yaml` (`.sdk-src` is CI-populated, not locally regenerable). New API surface: `listToolPermissions` / `grantToolPermission` / `revokeToolPermission`.

## Tests
Service (grant/list/revoke/not-found) + controller slice (200/201/204/400/403/401/404) + contract test. Full module suite green (**449, 1 skipped**).

## Deploy follow-through (outside this repo)
1. **Perm-bits catalog sync** — `mcp:tool:view`/`mcp:tool:manage` are new codes; until the catalog is synced (`generate-permissions.py --sync`) and `CATALOG_VERSION` bumped (fleet redeploy), the authority is silently dropped → 403.
2. **SDK regen** from the updated spec.

## Contract impact
No business-domain behavior change (mcp-server is infra; no domain `BACKEND_CONTRACT_GUIDE.md` applies). Additive API only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)