### PR TITLE
fix(mcp-server): cap embedding input length to stop 500 on long chat messages

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/OllamaEmbeddingModelConfiguration.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/OllamaEmbeddingModelConfiguration.java
@@ -76,11 +76,15 @@ public class OllamaEmbeddingModelConfiguration {
 
         @Override
         public @NonNull Response<List<Embedding>> embedAll(@NonNull List<TextSegment> textSegments) {
-            List<String> inputs = textSegments.stream().map(TextSegment::text).toList();
+            List<String> inputs = textSegments.stream()
+                    .map(TextSegment::text)
+                    .map(OllamaEmbeddingModelConfiguration::capToContext)
+                    .toList();
             Map<String, Object> body = new LinkedHashMap<>();
             body.put("model", modelName);
             body.put("input", inputs);
             body.put("dimensions", knownDimension());
+            body.put("truncate", true);
 
             EmbedResponse response = restClient
                     .post()
@@ -119,6 +123,19 @@ public class OllamaEmbeddingModelConfiguration {
         public @NonNull String modelName() {
             return modelName;
         }
+    }
+
+    // nomic-embed-text has a ~2048-token context; a long chat message (tool-selection embeds the raw
+    // user text) otherwise makes the embed endpoint reject the request with 400 "the input length
+    // exceeds the context length", surfacing as a 500 on /v1/mcp/chat. Cap conservatively (~4 chars per
+    // token) and also ask Ollama to truncate server-side.
+    static final int MAX_INPUT_CHARS = 8000;
+
+    static String capToContext(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.length() <= MAX_INPUT_CHARS ? text : text.substring(0, MAX_INPUT_CHARS);
     }
 
     private record EmbedResponse(

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/OllamaEmbeddingModelConfigurationTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/OllamaEmbeddingModelConfigurationTest.java
@@ -1,0 +1,28 @@
+package com.positivity.mcp.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class OllamaEmbeddingModelConfigurationTest {
+
+    @Test
+    void capToContext_leavesShortTextUnchanged() {
+        String text = "What tools are available?";
+        assertThat(OllamaEmbeddingModelConfiguration.capToContext(text)).isEqualTo(text);
+    }
+
+    @Test
+    void capToContext_truncatesOverlongTextToTheCap() {
+        String text = "x".repeat(OllamaEmbeddingModelConfiguration.MAX_INPUT_CHARS + 500);
+
+        String capped = OllamaEmbeddingModelConfiguration.capToContext(text);
+
+        assertThat(capped).hasSize(OllamaEmbeddingModelConfiguration.MAX_INPUT_CHARS);
+    }
+
+    @Test
+    void capToContext_nullBecomesEmpty() {
+        assertThat(OllamaEmbeddingModelConfiguration.capToContext(null)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Symptom
`POST /mcp-server/v1/mcp/chat` → **HTTP 500 INTERNAL_SERVER_ERROR** (correlation `019f1fdd-dcb8-7186-a4a1-805c8988ba18`) on a long chat message.

## Root cause
```
Caused by: 400 Bad Request: {"error":"the input length exceeds the context length"}
  at HostedOllamaEmbeddingModel.embedAll(:96)
  at dev.langchain4j...ToolService.refreshDynamicProviders(:485)
```
Tool selection embeds the **raw user message**; a long message exceeds nomic-embed-text's ~2048-token context, so Ollama 400s → surfaces as 500.

## Fix
Central guard in the shared embedding model — protects **every** caller (facade selection, RAG, Gate 3 dynamic provider):
- cap each input to `MAX_INPUT_CHARS` (8000 ≈ 2000 tokens) before the request, and
- send Ollama `"truncate": true` as a server-side backstop.

## Tests
`capToContext` unchanged/short, truncates overlong to the cap, null → empty (3 green).

## Contract impact
None — internal embedding request shaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)