### PR TITLE
feat(mcp-server): type discovered-tool path params from the path template (Gate 3)

### DIFF
--- a/pos-mcp-server/docs/implementation_checklist.md
+++ b/pos-mcp-server/docs/implementation_checklist.md
@@ -338,7 +338,7 @@ First live run against the deployed stack (`durion-alpha`, containers up, `pos_m
 - [x] E2E: execute a discovered op with no facade — _ev: 2026-07-01 live, `event-receiver_getactiveeventtypes` → gateway 200, agent returned 276 active event types._
 - [x] Lower-permission user cannot call higher-permission op — _ev: 2026-07-01 live (alpha) — an op seeded with a permission the caller LACKS (`gate3:negative:notheld`) is excluded by the gating filter, while an op with a held permission (`AUTHENTICATED`) is eligible; caller-perms ∩ `mcp_tool_permission` fail-closed confirmed with real data. (Two-distinct-user + cached-agent leakage still covered only by design — see `[~]` above.)_
 - [x] Permission re-checked at call time, not only cache-build — _ev: `provideTools` (isDynamic) queries `caller.permissionCodes()` per request, not at agent build._
-- [ ] Arguments schema-validated before proxy call — _ev: NOT wired — `input_schema` persisted null; `ToolSpecification` built with name+description only, no JsonObjectSchema._
+- [~] Arguments schema-validated before proxy call — _ev: `OpenApiToolProvider.buildParameterSchema` builds a `JsonObjectSchema` envelope; **path params are typed + required** from the path template (`/v1/workorders/{workorderId}` → required string `workorderId`), so langchain4j validates them. Query/header/body stay free-form objects (per-field query typing from `operation.getParameters()` is the remaining refinement)._
 - [x] Failed proxy → controlled error, not hallucinated success — _ev: `OpenApiOperationExecutor` renders controlled error string; unit-tested (missing service_id → controlled error)._
 - [~] Blocking & streaming support bridge identically — _ev: blocking wired + live-proven; streaming stays fail-closed (Reactor-context propagation deferred)._
 
@@ -346,7 +346,7 @@ First live run against the deployed stack (`durion-alpha`, containers up, `pos_m
 - [x] Verified: not all 500+ ops exposed without candidate selection — _ev: embedding topK (candidateLimit) + permission gate; 348 ops exist, only permission-eligible topK surface._
 - [x] Verified: OpenAPI ops do not bypass permission checks — _ev: fail-closed — 0 permission rows → discoveredTools=0; op selected only after a permission seed._
 - [x] Verified: LLM cannot choose arbitrary URLs/ops outside registry — _ev: executor calls only the persisted method/path of a selected, gated op; no LLM-supplied URL._
-- [ ] Verified: tool schemas include argument validation — _ev: NOT met — input_schema not persisted/applied (see Correctness above)._
+- [x] Verified: tool schemas include argument validation — _ev: discovered-tool `ToolSpecification`s carry a `JsonObjectSchema` with typed, required path params (from the template) + query/header/body objects; unit-tested (`OpenApiToolProviderTest`)._
 - [x] Verified: facade behavior not regressed — _ev: #788 facade regression PASS; facade + openapi coexist live._
 
 ### Cross-phase locks — [x] run & recorded (design preserves Permission lock: per-call permission re-check, no LLM-chosen URLs, gated candidate selection)
@@ -388,12 +388,12 @@ the Permission lock. So it is specified implementation-ready and verified live t
 - [x] **Regression found + fixed (PR #788):** the shared selection path bound `selectedTools=0` for **every** role — gated+scored tool names were resolved via `resolveDomainTools(role, names)`, but callable beans are bucketed by **domain**, not role, so resolution always returned empty (facade tools were fully severed from the chat agent, not just openapi). Fix: `MasterAgentRegistry.resolveToolsByName(names)` resolves across the full registered set; `ToolSelectionEngine` repointed; both blocking + streaming managers covered. Unit-tested; merged; deployed; live-verified above.
 - [x] **openapi bridge E2E — PASS (positive path) 2026-07-01, image `sha-5c7e41b`:** `SELECT count(*) FROM mcp_tool WHERE source='openapi'` = **348** (was 0). Seeded `AUTHENTICATED` on `event-receiver_getactiveeventtypes`; chat as `admin.alpha` → op selected (semantic score 1.000) → `OpenApiToolProvider` surfaced it → agent invoked → **auth relayed → gateway `GET /event-receiver/v1/eventTypes/active -> 200`** → agent returned **276 active event types** (real data). Proxy target+status now logged (#801). Fail-closed confirmed: with 0 permission rows, `discoveredTools=0`.
 
-**STILL OPEN for Gate 3 Pass:**
-- [ ] Negative/leakage E2E — a lower-permission user cannot call/see a higher-permission op (incl. cached-agent reuse). Positive path only, so far.
-- [ ] Argument-schema validation — persist `input_schema` and build the `ToolSpecification`'s `JsonObjectSchema` from it (currently name+description only).
-- [ ] Telemetry facade-vs-openapi source tag on the per-tool record.
-- [ ] Streaming Reactor-context propagation (blocking is done).
-- [x] Permission-seeding source (admin tooling / #785) — `ToolPermissionController` (`/v1/tools/{toolName}/permissions` GET/POST/DELETE, gated by `mcp:tool:view` / `mcp:tool:manage`) grants/lists/revokes an openapi tool's `mcp_tool_permission` rows, replacing manual SQL. Controller + `openapi.yaml` regenerated; unit + slice tested (11) + live contract test. _Deploy notes:_ (a) the new `mcp:tool:view`/`mcp:tool:manage` codes need a perm-bits catalog sync ([[perm-bits-catalog-gotcha]]) before an admin can be granted them; (b) SDK regen is the downstream step ([[controller-change-openapi-sdk-chain]])._
+**Gate 3 Pass — status (updated 2026-07-01):**
+- [x] Negative permission-gating — an op behind a not-held permission is excluded (live, #805). _Remaining:_ cached-agent reuse across two distinct users is still design-covered only (`[~]`), not live-tested.
+- [~] Argument-schema validation — path params typed + required from the template; query/header/body free-form (per-field query typing from `operation.getParameters()` is the remaining refinement).
+- [x] Telemetry facade-vs-openapi source tag (#806).
+- [ ] Streaming Reactor-context propagation (blocking is done) — the last substantive open item.
+- [x] Permission-seeding source (admin tooling / #785) — `ToolPermissionController` (`/v1/tools/{toolName}/permissions` GET/POST/DELETE, gated by `mcp:tool:view` / `mcp:tool:manage`) grants/lists/revokes an openapi tool's `mcp_tool_permission` rows, replacing manual SQL (#807). Perm-bits registered (bits 347/348, catalog v16, #809). _Deploy:_ fleet redeploy for catalog v16, then grant `mcp:tool:manage` to an admin role; SDK regen is downstream ([[controller-change-openapi-sdk-chain]])._
 
 ---
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
@@ -15,11 +15,15 @@ import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,34 +44,55 @@ public class OpenApiToolProvider implements ToolProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenApiToolProvider.class);
 
-    /**
-     * The generic call envelope the {@link OperationProxyFactory} reads. Method/path are fixed from
-     * the persisted coordinates (surfaced in the tool description), so the model only supplies the
-     * request parameters. Per-parameter typing from the OpenAPI operation is a follow-up refinement.
-     */
-    private static final JsonObjectSchema REQUEST_ENVELOPE_SCHEMA = JsonObjectSchema.builder()
-            .description("Parameters for the gateway operation named in the tool description.")
-            .addProperty(
-                    "pathParams",
-                    JsonObjectSchema.builder()
-                            .description("Path template parameters keyed by name, e.g. {\"productId\": \"...\"}.")
-                            .build())
-            .addProperty(
-                    "queryParams",
-                    JsonObjectSchema.builder()
-                            .description("Query-string parameters.")
-                            .build())
-            .addProperty(
-                    "headers",
-                    JsonObjectSchema.builder()
-                            .description("Extra HTTP headers (auth is relayed automatically).")
-                            .build())
-            .addProperty(
-                    "body",
-                    JsonObjectSchema.builder()
-                            .description("Request body payload, for write operations.")
-                            .build())
+    private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{([^}/]+)}");
+
+    private static final JsonObjectSchema QUERY_PARAMS_SCHEMA =
+            JsonObjectSchema.builder().description("Query-string parameters.").build();
+    private static final JsonObjectSchema HEADERS_SCHEMA = JsonObjectSchema.builder()
+            .description("Extra HTTP headers (auth is relayed automatically).")
             .build();
+    private static final JsonObjectSchema BODY_SCHEMA = JsonObjectSchema.builder()
+            .description("Request body payload, for write operations.")
+            .build();
+
+    /**
+     * The request envelope {@link OperationProxyFactory} reads. Path parameters are typed from the
+     * operation's path template ({@code /v1/products/{productId}} → a required string
+     * {@code productId}), so the model knows exactly which path values to supply; query/header/body
+     * stay free-form objects. Method/path themselves are fixed from the persisted coordinates.
+     */
+    private static JsonObjectSchema buildParameterSchema(@NonNull DiscoveredOperation op) {
+        List<String> pathParams = extractPathParams(op.httpPath());
+        JsonObjectSchema.Builder pathParamsSchema = JsonObjectSchema.builder().description("Path template parameters.");
+        for (String name : pathParams) {
+            pathParamsSchema.addStringProperty(name, "Path parameter " + name);
+        }
+        if (!pathParams.isEmpty()) {
+            pathParamsSchema.required(pathParams);
+        }
+        return JsonObjectSchema.builder()
+                .description("Parameters for the gateway operation named in the tool description.")
+                .addProperty("pathParams", pathParamsSchema.build())
+                .addProperty("queryParams", QUERY_PARAMS_SCHEMA)
+                .addProperty("headers", HEADERS_SCHEMA)
+                .addProperty("body", BODY_SCHEMA)
+                .build();
+    }
+
+    private static List<String> extractPathParams(@Nullable String path) {
+        if (path == null) {
+            return List.of();
+        }
+        List<String> params = new ArrayList<>();
+        Matcher matcher = PATH_PARAM_PATTERN.matcher(path);
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            if (!params.contains(name)) {
+                params.add(name);
+            }
+        }
+        return params;
+    }
 
     private static String describeOperation(@NonNull DiscoveredOperation op) {
         return op.description() + " [" + op.httpMethod() + " " + op.httpPath() + "]";
@@ -133,7 +158,7 @@ public class OpenApiToolProvider implements ToolProvider {
             ToolSpecification spec = ToolSpecification.builder()
                     .name(op.name())
                     .description(describeOperation(op))
-                    .parameters(REQUEST_ENVELOPE_SCHEMA)
+                    .parameters(buildParameterSchema(op))
                     .build();
             tools.put(spec, new OpenApiOperationExecutor(proxyFactory, op, objectMapper, executionTimeout, authHeader));
         }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolProviderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolProviderTest.java
@@ -15,6 +15,7 @@ import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import com.positivity.mcp.service.CurrentUserContext;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.service.tool.ToolProviderRequest;
@@ -65,7 +66,12 @@ class OpenApiToolProviderTest {
                 Set.of("workorder:workorder:view")));
         when(embeddingModel.embed(anyString())).thenReturn(Response.from(Embedding.from(new float[] {0.1f, 0.2f})));
         DiscoveredOperation executable = new DiscoveredOperation(
-                "workorders_getallworkorders", "List workorders", "GET", "/v1/workorders", "pos-workorder", null);
+                "workorders_getallworkorders",
+                "List workorders",
+                "GET",
+                "/v1/workorders/{workorderId}",
+                "pos-workorder",
+                null);
         DiscoveredOperation notExecutable =
                 new DiscoveredOperation("broken_op", "missing coords", null, null, null, null);
         lenient()
@@ -82,6 +88,10 @@ class OpenApiToolProviderTest {
         assertThat(spec.description()).contains("GET", "/v1/workorders");
         assertThat(spec.parameters()).isNotNull();
         assertThat(spec.parameters().properties()).containsKeys("pathParams", "queryParams", "headers", "body");
+        // Path params are typed from the template: {workorderId} → a required string property.
+        var pathParams = (JsonObjectSchema) spec.parameters().properties().get("pathParams");
+        assertThat(pathParams.properties()).containsKey("workorderId");
+        assertThat(pathParams.required()).contains("workorderId");
         // Provider publishes the surfaced openapi tool names for telemetry (facade vs openapi source).
         assertThat(userContext.currentDiscoveredOpenapiToolNames()).containsExactly("workorders_getallworkorders");
     }


### PR DESCRIPTION
#804 gave discovered tools a **generic** parameter envelope (`pathParams`/`queryParams`/`headers`/`body` as free-form objects) — the model still had to guess which path values a template needs. This types them.

## Change
`OpenApiToolProvider.buildParameterSchema` parses `{tokens}` from the operation's path template and builds `pathParams` as a `JsonObjectSchema` with a **required string property per token** (`/v1/workorders/{workorderId}` → required `workorderId`), so langchain4j validates path args before the proxy call. Query/header/body stay free-form (per-field query typing from `operation.getParameters()` is a further refinement).

## Closes
- Drift item "tool schemas include argument validation" → met.
- Correctness "arguments schema-validated" → met for path params (`[~]`, query/body free-form).

## Tests
Exposed tool's `pathParams` carries a typed, required `workorderId`. Suite green (65).

## Contract impact
None — internal tool-schema construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)