### PR TITLE
Fix main-branch CI: stale perm-bit catalog v16 tests, missing restclient test dep

### DIFF
--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 15")
-    void catalogVersionIsFifteen() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(15);
+    @DisplayName("CATALOG_VERSION is 16")
+    void catalogVersionIsSixteen() {
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(16);
     }
 
     @Test
-    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 346")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 348")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1180,8 +1180,11 @@ class SecurityGatewayConfigTest {
         assertThat(GatewayPermissionCatalog.authorityForBit(345)).isEqualTo("PERM_workorder:labor:add_on_behalf");
         // catalog v15 (#762/CAP-007): invoice finalize-override authority appended (bit 346)
         assertThat(GatewayPermissionCatalog.authorityForBit(346)).isEqualTo("PERM_invoice:finalize:override");
+        // catalog v16 (#809): mcp tool authorities appended (bits 347-348)
+        assertThat(GatewayPermissionCatalog.authorityForBit(347)).isEqualTo("PERM_mcp:tool:manage");
+        assertThat(GatewayPermissionCatalog.authorityForBit(348)).isEqualTo("PERM_mcp:tool:view");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(347)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(349)).isNull();
     }
 
     @Test

--- a/pos-people/pom.xml
+++ b/pos-people/pom.xml
@@ -130,6 +130,12 @@
             <artifactId>spring-boot-resttestclient</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- TestRestTemplateTestAutoConfiguration needs RestTemplateBuilder at runtime -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webmvc-test</artifactId>


### PR DESCRIPTION
Fixes the two failures breaking every push/schedule build on `main` (both predate #814 — they never show on PR builds because the affected jobs only run on push/schedule events).

## 1. Stale perm-bit catalog tests (Full Coverage SonarCloud Analysis job)

`SecurityGatewayConfigTest.catalogVersionIsFifteen` and `authorityByBitCoversNewEntries` were not updated when #809 bumped the permission catalog to v16 (adding `mcp:tool:view` / `mcp:tool:manage` at bits 347–348):

- `catalogVersionIsFifteen` asserted `CATALOG_VERSION == 15`; it is 16
- `authorityByBitCoversNewEntries` expected bit 347 to be beyond the array; v16 put `PERM_mcp:tool:manage` there

The catalog itself is consistent: `GatewayPermissionCatalog.AUTHORITY_BY_BIT` and the security-service `PermissionCode` enum are verified identical (349 permissions, bits 0–348, both v16) — only the test expectations were stale. Updated to assert version 16, the two new bit entries, and the null boundary at bit 349. All 49 tests pass.

## 2. Missing `spring-boot-restclient` test dependency (Integration Tests (pos-people) job)

`UserPersonLinkControllerIT` failed to load its context with `NoClassDefFoundError: org/springframework/boot/restclient/RestTemplateBuilder`. The pom (from #754) declares `spring-boot-resttestclient` but Spring Boot 4's modularization requires its runtime companion `spring-boot-restclient` explicitly for `TestRestTemplateTestAutoConfiguration`. Added it test-scoped; the IT goes from 10 context-load errors to 10/10 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQPX7ihAsbZutFG35TXf69

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQPX7ihAsbZutFG35TXf69)_