### PR TITLE
ci: don't fail PR check on SonarCloud PR-decoration failure (stopgap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,6 +537,12 @@ jobs:
           path: sonar-coverage
 
       - name: SonarCloud Scan
+        # Stopgap: PR-mode analysis currently fails at PR decoration because SonarCloud cannot
+        # resolve the pull request via its GitHub App / DevOps-platform binding ("Something went
+        # wrong while trying to get the pullrequest with key 'N'"). Until that binding is fixed in
+        # SonarCloud, do not let a PR-decoration failure fail this check. The push/main-branch scan
+        # (else branch below) stays strict and remains the authoritative quality gate.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

Stopgap to stop every PR showing a red **`Incremental Code Quality Analysis`** check.

PR-mode SonarCloud analysis currently fails at the **PR-decoration** step — SonarCloud can't resolve the pull request via its GitHub App / DevOps-platform binding:

```
[INFO] Load branch configuration
[ERROR] Something went wrong while trying to get the pullrequest with key 'N'
```

Evidence this is systemic (not per-PR): SonarCloud's API shows `project_pull_requests/list` → **empty** (no PR has ever analyzed successfully), while `main` branch analysis works normally. Branch/main scans only *upload* results (just need `SONAR_TOKEN`); PR mode additionally requires the GitHub App binding to fetch the PR, and that binding is missing/broken.

## Change

Add `continue-on-error: ${{ github.event_name == 'pull_request' }}` to the **SonarCloud Scan** step, so a PR-decoration failure no longer fails the check on `pull_request` events. The `push`/`main`-branch scan (the `else` branch of the step) stays strict and remains the **authoritative quality gate**. `continue-on-error` is already used on several other steps in this workflow.

## Not a real fix

The underlying issue is fixed in **SonarCloud + GitHub settings**, not here:
1. Grant the SonarCloud GitHub App access to `durion-positivity-backend` (GitHub → Settings → Applications → SonarCloud → Configure → Repository access).
2. Verify/re-create the project's binding to the GitHub repo (SonarCloud → project → Administration → Pull Requests / DevOps Platform Integration).
3. Ensure App permissions: Pull requests R/W, Checks R/W, Contents R, Metadata R.

Once PR analysis works again, this `continue-on-error` line should be reverted so PR quality gates are enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011i2njkeJft6EJpn9ggBc1N

---
_Generated by [Claude Code](https://claude.ai/code/session_011i2njkeJft6EJpn9ggBc1N)_