### PR TITLE
Fix nullable values flowing into @NonNull parameters

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/StaticRagPreloadServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/StaticRagPreloadServiceImpl.java
@@ -16,7 +16,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -62,11 +61,12 @@ public class StaticRagPreloadServiceImpl implements StaticRagPreloadService {
             List<StaticRagPreloadProperties.StaticDocEntry> docs = preloadProperties.docs();
             for (StaticRagPreloadProperties.StaticDocEntry entry : docs) {
                 try {
+                    List<String> requiredPermissions = entry.requiredPermissions();
                     preloadDocument(
                             entry.id(),
                             entry.sourcePath(),
                             entry.ragScope(),
-                            Objects.requireNonNullElse(entry.requiredPermissions(), List.of()));
+                            requiredPermissions != null ? requiredPermissions : List.of());
                 } catch (Exception exception) {
                     String hash = resolveHashOrNull(entry.sourcePath());
                     persistFailedRecord(entry.id(), hash, entry.sourcePath(), entry.ragScope());

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerReferenceService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerReferenceService.java
@@ -124,9 +124,8 @@ public class CustomerReferenceService {
                     continue;
                 }
                 UUID id = UUID.fromString(partyId.trim());
-                String displayName = Objects.requireNonNullElse(
-                        firstNonBlank(extract(row, "displayName"), extract(row, "legalName"), "customer-" + id),
-                        "customer-" + id);
+                String resolvedName = firstNonBlank(extract(row, "displayName"), extract(row, "legalName"));
+                String displayName = resolvedName != null ? resolvedName : "customer-" + id;
                 refs.add(new CustomerRef(id, displayName));
             }
             return refs;


### PR DESCRIPTION
## Summary

Fixes two static-analysis findings where a `@Nullable` value was reported flowing into a `@NonNull` parameter. In both cases the value was already null-safe at runtime because it was wrapped in `Objects.requireNonNullElse(...)`, but flow-based null analysis does not model that method's non-null guarantee. Each fix expresses the same null substitution with an explicit null check, which flow analysis understands, proving the `@NonNull` contract is satisfied. Behavior is unchanged in both.

## Changes

**`pos-mcp-server` — `StaticRagPreloadServiceImpl.java`**
- The `preloadDocument(...)` call passed `Objects.requireNonNullElse(entry.requiredPermissions(), List.of())` into its `@NonNull requiredPermissions` parameter. `entry.requiredPermissions()` is declared `@Nullable`.
- Replaced with a local variable and an explicit `!= null` check.
- Removed the now-unused `java.util.Objects` import.

**`pos-workorder` — `CustomerReferenceService.java`**
- The `new CustomerRef(id, displayName)` call passed a `displayName` derived from `Objects.requireNonNullElse(firstNonBlank(...), "customer-" + id)` into the `@NonNull customerName` parameter. `firstNonBlank(...)` is declared `@Nullable`.
- Replaced with a local variable and an explicit `!= null` check; dropped the redundant `"customer-" + id` argument to `firstNonBlank` (it is now the ternary fallback).
- The `Objects` import is retained (still used elsewhere).

## Testing

Not built locally: this environment has Java 21, while the project's Maven enforcer requires Java 25 (`.sdkmanrc` pins `25.0.2-tem`) and Java 25 is not installed here. Both changes are small, self-contained, and behavior-preserving; CI on the branch validates the full build (Checkstyle/Spotless/SpotBugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CnmikhZMBwTWFT6yLK6PJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015CnmikhZMBwTWFT6yLK6PJ)_