### PR TITLE
feat(catalog): enriched product search returns lifecycle + active MSRP inline (#828)

### DIFF
--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -1738,7 +1738,7 @@ paths:
       tags:
       - Products API
       summary: Search catalog products
-      description: Cursor-based product search with optional free-text query and exact filters for brand, category, and SKU.
+      description: Cursor-based product search with optional free-text query and exact filters for brand, category, and SKU. Pass detailed=true to enrich each row inline with lifecycle state + effective instant and the product's active MSRP (amount, currency, effective window), resolved server-side in a single request. Products without an active MSRP return null price fields.
       operationId: searchProducts
       parameters:
       - name: q
@@ -1777,6 +1777,13 @@ paths:
         required: false
         schema:
           type: string
+      - name: detailed
+        in: query
+        description: When true, enrich each row with lifecycle state, effective instant, and active MSRP
+        required: false
+        schema:
+          type: boolean
+          default: false
       responses:
         '200':
           description: Search results
@@ -3990,6 +3997,43 @@ components:
           type: string
           description: Manufacturer brand name
           example: AcmePro
+        lifecycleState:
+          type: string
+          description: Lifecycle state; only populated for detailed search
+          enum:
+          - ACTIVE
+          - INACTIVE
+          - DISCONTINUED
+          example: ACTIVE
+          nullable: true
+        lifecycleStateEffectiveAt:
+          type: string
+          format: date-time
+          description: UTC instant the current lifecycle state took effect; only populated for detailed search
+          example: 2026-01-15 09:30:00+00:00
+          nullable: true
+        msrpAmount:
+          type: string
+          description: Active MSRP amount; null when the product has no active MSRP or for lean search
+          example: '99.99'
+          nullable: true
+        msrpCurrency:
+          type: string
+          description: Active MSRP ISO 4217 currency code; null when no active MSRP or for lean search
+          example: USD
+          nullable: true
+        msrpEffectiveStartDate:
+          type: string
+          format: date
+          description: Start of the active MSRP effective window; null when no active MSRP or for lean search
+          example: 2026-01-15
+          nullable: true
+        msrpEffectiveEndDate:
+          type: string
+          format: date
+          description: End of the active MSRP effective window; null for open-ended, no active MSRP, or lean search
+          example: 2026-12-31
+          nullable: true
     EffectiveLocationPriceResponseDto:
       type: object
       description: Effective location-specific price for a product

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -4010,7 +4010,7 @@ components:
           type: string
           format: date-time
           description: UTC instant the current lifecycle state took effect; only populated for detailed search
-          example: 2026-01-15 09:30:00+00:00
+          example: '2026-01-15T09:30:00Z'
           nullable: true
         msrpAmount:
           type: string

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
@@ -187,7 +187,10 @@ public class ProductController {
     @Operation(
             summary = "Search catalog products",
             description =
-                    "Cursor-based product search with optional free-text query and exact filters for brand, category, and SKU.")
+                    "Cursor-based product search with optional free-text query and exact filters for brand, category, and SKU. "
+                            + "Pass detailed=true to enrich each row inline with lifecycle state + effective instant and the "
+                            + "product's active MSRP (amount, currency, effective window), resolved server-side in a single "
+                            + "request. Products without an active MSRP return null price fields.")
     @ApiResponse(
             responseCode = "200",
             description = "Search results",
@@ -210,9 +213,13 @@ public class ProductController {
                     String sku,
             @Parameter(description = "Pagination cursor from previous response") @RequestParam(required = false)
                     String cursor,
-            @Parameter(description = "Maximum number of results (1–100)") @RequestParam(defaultValue = "20")
-                    int limit) {
-        return ResponseEntity.ok(productSearchService.searchProducts(q, brand, category, sku, cursor, limit));
+            @Parameter(description = "Maximum number of results (1–100)") @RequestParam(defaultValue = "20") int limit,
+            @Parameter(
+                            description =
+                                    "When true, enrich each row with lifecycle state, effective instant, and active MSRP")
+                    @RequestParam(defaultValue = "false")
+                    boolean detailed) {
+        return ResponseEntity.ok(productSearchService.searchProducts(q, brand, category, sku, cursor, limit, detailed));
     }
 
     @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductSummary.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductSummary.java
@@ -1,6 +1,9 @@
 package com.positivity.catalog.internal.dto;
 
+import com.positivity.catalog.internal.entity.ProductLifecycleState;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,10 +12,17 @@ import lombok.NoArgsConstructor;
 
 /**
  * Lightweight product summary returned by the catalog search endpoint.
- * Contains display-ready fields for listing views; does NOT include pricing
- * or availability (those are aggregated by the detail endpoint).
+ * Contains display-ready fields for listing views.
  *
- * Issue: CAP-247 Story #17
+ * <p>
+ * When the search endpoint is called with {@code detailed=true}, the enriched
+ * lifecycle and active-MSRP fields below are resolved server-side and populated
+ * inline, avoiding a per-row {@code getProductById} + {@code getActiveMsrp}
+ * fan-out on the client. In the default (lean) mode these enriched fields are
+ * {@code null} and the payload matches the historical lean shape, so existing
+ * consumers are unaffected.
+ *
+ * Issue: CAP-247 Story #17; enriched fields: #828
  */
 @Data
 @Builder
@@ -38,4 +48,47 @@ public class ProductSummary {
 
     @Schema(description = "Manufacturer brand name", example = "AcmePro")
     private String manufacturerBrand;
+
+    // -----------------------------------------------------------------------
+    // Enriched fields — populated only when the search is requested with
+    // detailed=true. Null/absent in the default lean response (#828).
+    // -----------------------------------------------------------------------
+
+    @Schema(
+            description = "Lifecycle state; only populated for detailed search",
+            example = "ACTIVE",
+            implementation = ProductLifecycleState.class,
+            nullable = true)
+    private ProductLifecycleState lifecycleState;
+
+    @Schema(
+            description = "UTC instant the current lifecycle state took effect; only populated for detailed search",
+            example = "2026-01-15T09:30:00Z",
+            nullable = true)
+    private Instant lifecycleStateEffectiveAt;
+
+    @Schema(
+            description = "Active MSRP amount; null when the product has no active MSRP or for lean search",
+            example = "99.99",
+            nullable = true)
+    private String msrpAmount;
+
+    @Schema(
+            description = "Active MSRP ISO 4217 currency code; null when no active MSRP or for lean search",
+            example = "USD",
+            nullable = true)
+    private String msrpCurrency;
+
+    @Schema(
+            description = "Start of the active MSRP effective window; null when no active MSRP or for lean search",
+            example = "2026-01-15",
+            nullable = true)
+    private LocalDate msrpEffectiveStartDate;
+
+    @Schema(
+            description =
+                    "End of the active MSRP effective window; null for open-ended, no active MSRP, or lean search",
+            example = "2026-12-31",
+            nullable = true)
+    private LocalDate msrpEffectiveEndDate;
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ProductMsrpRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ProductMsrpRepository.java
@@ -2,6 +2,7 @@ package com.positivity.catalog.internal.repository;
 
 import com.positivity.catalog.internal.entity.ProductMsrpEntity;
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -36,6 +37,23 @@ public interface ProductMsrpRepository extends JpaRepository<ProductMsrpEntity, 
     default Optional<ProductMsrpEntity> findActive(UUID productId, LocalDate asOf) {
         return findActiveCandidates(productId, asOf).stream().findFirst();
     }
+
+    /**
+     * Batch variant of {@link #findActiveCandidates} for enriched catalog search
+     * (#828): returns every MSRP record active as of {@code asOf} across the given
+     * products in a single query, ordered so the winning record per product (most
+     * recently started, tie-broken by id) appears first. Callers pick the first
+     * record encountered per product id to mirror {@link #findActive}.
+     */
+    @Query("""
+            select m from ProductMsrpEntity m
+            where m.product.id in :productIds
+              and m.effectiveStartDate <= :asOf
+              and (m.effectiveEndDate is null or m.effectiveEndDate >= :asOf)
+            order by m.product.id asc, m.effectiveStartDate desc, m.msrpId asc
+            """)
+    List<ProductMsrpEntity> findActiveForProducts(
+            @Param("productIds") Collection<UUID> productIds, @Param("asOf") LocalDate asOf);
 
     List<ProductMsrpEntity> findByProduct_IdOrderByEffectiveStartDateDesc(UUID productId);
 

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductSearchServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductSearchServiceImpl.java
@@ -3,11 +3,19 @@ package com.positivity.catalog.internal.service;
 import com.positivity.catalog.internal.dto.CatalogSearchResultDto;
 import com.positivity.catalog.internal.dto.ProductSummary;
 import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.ProductMsrpEntity;
+import com.positivity.catalog.internal.repository.ProductMsrpRepository;
 import com.positivity.catalog.internal.repository.ProductRepository;
 import com.positivity.catalog.service.ProductSearchService;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -39,12 +47,14 @@ public class ProductSearchServiceImpl implements ProductSearchService {
     private static final int MAX_LIMIT = 100;
 
     private final ProductRepository productRepository;
+    private final ProductMsrpRepository productMsrpRepository;
+    private final Clock clock;
 
     @Override
     @NonNull
     @Transactional(readOnly = true)
     public CatalogSearchResultDto searchProducts(
-            String q, String brand, String category, String sku, String cursor, int limit) {
+            String q, String brand, String category, String sku, String cursor, int limit, boolean detailed) {
 
         int effectiveLimit = Math.clamp(limit, 1, MAX_LIMIT);
         int pageNumber = decodeCursor(cursor);
@@ -56,24 +66,33 @@ public class ProductSearchServiceImpl implements ProductSearchService {
         String normalizedCategory = (category == null || category.isBlank()) ? null : category.strip();
 
         log.debug(
-                "Catalog search: q={}, brand={}, category={}, sku={}, page={}, limit={}",
+                "Catalog search: q={}, brand={}, category={}, sku={}, page={}, limit={}, detailed={}",
                 normalizedQ,
                 normalizedBrand,
                 normalizedCategory,
                 normalizedSku,
                 pageNumber,
-                effectiveLimit);
+                effectiveLimit,
+                detailed);
 
         var typedSort = Sort.sort(ProductEntity.class);
         PageRequest pageable = PageRequest.of(
                 pageNumber,
                 effectiveLimit,
-                typedSort.by(ProductEntity::getName).ascending().and(typedSort.by(ProductEntity::getId).ascending()));
+                typedSort
+                        .by(ProductEntity::getName)
+                        .ascending()
+                        .and(typedSort.by(ProductEntity::getId).ascending()));
         Page<ProductEntity> page = productRepository.searchProductsFiltered(
                 normalizedQ, normalizedSku, normalizedBrand, normalizedCategory, pageable);
 
-        List<ProductSummary> data = page.getContent().stream()
-                .map(ProductSearchServiceImpl::toSummary)
+        List<ProductEntity> products = page.getContent();
+        Map<UUID, ProductMsrpEntity> activeMsrpByProduct = detailed ? loadActiveMsrps(products) : Map.of();
+
+        List<ProductSummary> data = products.stream()
+                .map(entity -> detailed
+                        ? toDetailedSummary(entity, activeMsrpByProduct.get(entity.getId()))
+                        : toSummary(entity))
                 .toList();
 
         String nextCursor = page.hasNext() ? encodeCursor(pageNumber + 1) : null;
@@ -133,5 +152,48 @@ public class ProductSearchServiceImpl implements ProductSearchService {
                 .thumbnailUrl(thumbnailUrl)
                 .manufacturerBrand(entity.getManufacturerBrand())
                 .build();
+    }
+
+    // -----------------------------------------------------------------------
+    // Enrichment (detailed=true) — #828
+    // -----------------------------------------------------------------------
+
+    /**
+     * Batch-loads the active MSRP (as of today) for every product on the current
+     * page in a single query, returning the winning record per product id. Mirrors
+     * {@link ProductMsrpRepository#findActive} selection semantics (most recently
+     * started, tie-broken by id) without an N+1 fan-out.
+     */
+    private Map<UUID, ProductMsrpEntity> loadActiveMsrps(List<ProductEntity> products) {
+        if (products.isEmpty()) {
+            return Map.of();
+        }
+        List<UUID> productIds = products.stream().map(ProductEntity::getId).toList();
+        LocalDate asOf = LocalDate.now(clock);
+        // Query orders by (productId, effectiveStartDate desc, msrpId asc); the first
+        // record seen for each product id is therefore the winning active MSRP.
+        return productMsrpRepository.findActiveForProducts(productIds, asOf).stream()
+                .collect(Collectors.toMap(m -> m.getProduct().getId(), Function.identity(), (first, later) -> first));
+    }
+
+    /**
+     * Maps a {@link ProductEntity} plus its resolved active MSRP (nullable) to an
+     * enriched {@link ProductSummary}. A null MSRP leaves all price fields null,
+     * matching the client's graceful-degradation behavior.
+     */
+    static ProductSummary toDetailedSummary(ProductEntity entity, ProductMsrpEntity activeMsrp) {
+        ProductSummary summary = toSummary(entity);
+        summary.setLifecycleState(entity.getLifecycleState());
+        summary.setLifecycleStateEffectiveAt(entity.getLifecycleStateEffectiveAt());
+        if (activeMsrp != null) {
+            summary.setMsrpAmount(
+                    activeMsrp.getAmount() == null
+                            ? null
+                            : activeMsrp.getAmount().toPlainString());
+            summary.setMsrpCurrency(activeMsrp.getCurrency());
+            summary.setMsrpEffectiveStartDate(activeMsrp.getEffectiveStartDate());
+            summary.setMsrpEffectiveEndDate(activeMsrp.getEffectiveEndDate());
+        }
+        return summary;
     }
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/ProductSearchService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/ProductSearchService.java
@@ -26,9 +26,14 @@ public interface ProductSearchService {
      * @param cursor   opaque pagination cursor from previous response; null for
      *                 first page
      * @param limit    maximum number of results to return (1–100)
+     * @param detailed when {@code true}, each result row is enriched inline with
+     *                 lifecycle state + effective instant and the product's active
+     *                 MSRP (amount, currency, effective window), resolved
+     *                 server-side in a single query. When {@code false}, the lean
+     *                 summary is returned and the enriched fields are null (#828)
      * @return cursor-based search result
      */
     @NonNull
     CatalogSearchResultDto searchProducts(
-            String q, String brand, String category, String sku, String cursor, int limit);
+            String q, String brand, String category, String sku, String cursor, int limit, boolean detailed);
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/ProductSearchService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/ProductSearchService.java
@@ -28,9 +28,10 @@ public interface ProductSearchService {
      * @param limit    maximum number of results to return (1–100)
      * @param detailed when {@code true}, each result row is enriched inline with
      *                 lifecycle state + effective instant and the product's active
-     *                 MSRP (amount, currency, effective window), resolved
-     *                 server-side in a single query. When {@code false}, the lean
-     *                 summary is returned and the enriched fields are null (#828)
+     *                 MSRP (amount, currency, effective window). Enrichment is
+     *                 batched (one additional MSRP query for the whole page, no
+     *                 N+1 fan-out). When {@code false}, the lean summary is
+     *                 returned and the enriched fields are null (#828)
      * @return cursor-based search result
      */
     @NonNull

--- a/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductSearchDetailedContractBehaviorIT.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductSearchDetailedContractBehaviorIT.java
@@ -1,0 +1,188 @@
+package com.positivity.catalog.contract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.catalog.BaseContractIntegrationTest;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Contract behavioral tests for the enriched (detailed=true) catalog search
+ * endpoint that returns lifecycle state, effective instant, and active MSRP
+ * inline so the frontend can drop its per-row getProductById + getActiveMsrp
+ * fan-out.
+ *
+ * Issue: #828
+ */
+@DisplayName("Product Search (detailed) Contract Behavioral Tests")
+class ProductSearchDetailedContractBehaviorIT extends BaseContractIntegrationTest {
+
+    private static final String SEARCH_PATH = "/v1/products/search";
+    private static final Clock TEST_CLOCK = Clock.systemUTC();
+    private static final UUID ACTOR = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    // -----------------------------------------------------------------------
+    // #828-001: detailed=true enriches each row with lifecycle + active MSRP;
+    // a product with no active MSRP returns null price fields (not an error).
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("#828-001: detailed search returns lifecycle + active MSRP inline; null price when no MSRP")
+    void detailedSearch_returnsLifecycleAndActiveMsrpInline() throws Exception {
+        String namePrefix = "DetailedSearch-" + UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+        UUID withMsrp = createProductAndGetId(
+                namePrefix + " Priced",
+                "SKU-828-PRICED-" + UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                "MPN-828-PRICED");
+        createProductAndGetId(
+                namePrefix + " Unpriced",
+                "SKU-828-UNPRICED-" + UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                "MPN-828-UNPRICED");
+
+        // Give exactly one product an open-ended MSRP active as of today.
+        mockMvc.perform(withAuth(post("/v1/products/{productId}/msrp", withMsrp)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "amount",
+                                "129.9900",
+                                "currency",
+                                "USD",
+                                "effectiveStartDate",
+                                LocalDate.now(TEST_CLOCK).minusDays(1).toString(),
+                                "createdByUserId",
+                                ACTOR.toString())))))
+                .andExpect(status().isCreated());
+
+        MvcResult result = mockMvc.perform(withAuth(MockMvcRequestBuilders.get(SEARCH_PATH)
+                        .param("q", namePrefix)
+                        .param("detailed", "true")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andReturn();
+
+        JsonNode data =
+                objectMapper.readTree(result.getResponse().getContentAsString()).get("data");
+        assertThat(data.size()).as("Both products should be returned").isEqualTo(2);
+
+        JsonNode priced = findByProductId(data, withMsrp);
+        assertThat(priced).as("Priced product present in results").isNotNull();
+        assertThat(priced.get("lifecycleState").asString()).isEqualTo("ACTIVE");
+        assertThat(priced.get("msrpAmount").asString()).isEqualTo("129.9900");
+        assertThat(priced.get("msrpCurrency").asString()).isEqualTo("USD");
+        assertThat(priced.get("msrpEffectiveStartDate").asString())
+                .isEqualTo(LocalDate.now(TEST_CLOCK).minusDays(1).toString());
+        assertThat(priced.get("msrpEffectiveEndDate").isNull())
+                .as("open-ended MSRP has null end date")
+                .isTrue();
+
+        // The unpriced product must have null price fields rather than erroring.
+        JsonNode unpriced = null;
+        for (JsonNode row : data) {
+            if (!row.get("productId").asString().equals(withMsrp.toString())) {
+                unpriced = row;
+            }
+        }
+        assertThat(unpriced).as("Unpriced product present in results").isNotNull();
+        assertThat(unpriced.get("lifecycleState").asString()).isEqualTo("ACTIVE");
+        assertThat(unpriced.get("msrpAmount").isNull())
+                .as("Product without active MSRP returns null amount")
+                .isTrue();
+        assertThat(unpriced.get("msrpCurrency").isNull()).isTrue();
+    }
+
+    // -----------------------------------------------------------------------
+    // #828-002: default (lean) search is unchanged — enriched fields absent/null.
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("#828-002: lean search (default) does not populate enriched fields")
+    void leanSearch_doesNotPopulateEnrichedFields() throws Exception {
+        String namePrefix = "LeanSearch-" + UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+        UUID productId = createProductAndGetId(
+                namePrefix + " Model",
+                "SKU-828-LEAN-" + UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                "MPN-828-LEAN");
+
+        mockMvc.perform(withAuth(post("/v1/products/{productId}/msrp", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "amount",
+                                "59.9900",
+                                "currency",
+                                "USD",
+                                "effectiveStartDate",
+                                LocalDate.now(TEST_CLOCK).minusDays(1).toString(),
+                                "createdByUserId",
+                                ACTOR.toString())))))
+                .andExpect(status().isCreated());
+
+        MvcResult result = mockMvc.perform(
+                        withAuth(MockMvcRequestBuilders.get(SEARCH_PATH).param("q", namePrefix)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode data =
+                objectMapper.readTree(result.getResponse().getContentAsString()).get("data");
+        JsonNode row = findByProductId(data, productId);
+        assertThat(row).as("Product present in lean results").isNotNull();
+        // Enriched fields are serialized as null in lean mode (backward compatible).
+        assertThat(row.get("msrpAmount") == null || row.get("msrpAmount").isNull())
+                .as("Lean search must not populate MSRP amount")
+                .isTrue();
+        assertThat(row.get("lifecycleState") == null
+                        || row.get("lifecycleState").isNull())
+                .as("Lean search must not populate lifecycle state")
+                .isTrue();
+    }
+
+    private static JsonNode findByProductId(JsonNode data, UUID productId) {
+        for (JsonNode row : data) {
+            if (row.get("productId").asString().equals(productId.toString())) {
+                return row;
+            }
+        }
+        return null;
+    }
+
+    private UUID createProductAndGetId(String name, String sku, String mpn) throws Exception {
+        Map<String, Object> payload = Map.of(
+                "name",
+                name,
+                "description",
+                "Product for detailed catalog search contract test",
+                "unitOfMeasure",
+                "EA",
+                "manufacturerId",
+                UUID.fromString("00000000-0000-0000-0000-000000000001").toString(),
+                "sku",
+                sku,
+                "mpn",
+                mpn,
+                "upc",
+                "1000000000000",
+                "attributes",
+                "{}");
+
+        MvcResult result = mockMvc.perform(withAuth(post("/v1/products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode response = objectMapper.readTree(result.getResponse().getContentAsString());
+        return UUID.fromString(response.get("id").asString());
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductSearchDetailedContractBehaviorIT.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductSearchDetailedContractBehaviorIT.java
@@ -83,8 +83,9 @@ class ProductSearchDetailedContractBehaviorIT extends BaseContractIntegrationTes
         assertThat(priced.get("msrpCurrency").asString()).isEqualTo("USD");
         assertThat(priced.get("msrpEffectiveStartDate").asString())
                 .isEqualTo(LocalDate.now(TEST_CLOCK).minusDays(1).toString());
-        assertThat(priced.get("msrpEffectiveEndDate").isNull())
-                .as("open-ended MSRP has null end date")
+        JsonNode pricedEnd = priced.get("msrpEffectiveEndDate");
+        assertThat(pricedEnd == null || pricedEnd.isNull())
+                .as("open-ended MSRP has null/absent end date")
                 .isTrue();
 
         // The unpriced product must have null price fields rather than erroring.
@@ -96,10 +97,14 @@ class ProductSearchDetailedContractBehaviorIT extends BaseContractIntegrationTes
         }
         assertThat(unpriced).as("Unpriced product present in results").isNotNull();
         assertThat(unpriced.get("lifecycleState").asString()).isEqualTo("ACTIVE");
-        assertThat(unpriced.get("msrpAmount").isNull())
-                .as("Product without active MSRP returns null amount")
+        JsonNode unpricedAmount = unpriced.get("msrpAmount");
+        assertThat(unpricedAmount == null || unpricedAmount.isNull())
+                .as("Product without active MSRP returns null/absent amount")
                 .isTrue();
-        assertThat(unpriced.get("msrpCurrency").isNull()).isTrue();
+        JsonNode unpricedCurrency = unpriced.get("msrpCurrency");
+        assertThat(unpricedCurrency == null || unpricedCurrency.isNull())
+                .as("Product without active MSRP returns null/absent currency")
+                .isTrue();
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #828.

Adds a **unified enriched catalog search** so the product list can be populated in a single request, eliminating the frontend's ~2N `getProductById` + `getActiveMsrp` fan-out.

`GET /v1/products/search?detailed=true` now returns, per row, the fields the list needs — enriched server-side (batched, no N+1):

| Field | Source |
|---|---|
| `lifecycleState` | `ProductEntity.lifecycleState` (already loaded by search) |
| `lifecycleStateEffectiveAt` | `ProductEntity.lifecycleStateEffectiveAt` |
| `msrpAmount` / `msrpCurrency` | active `ProductMsrpEntity` |
| `msrpEffectiveStartDate` / `msrpEffectiveEndDate` | active MSRP window |

The default (lean) response is unchanged.

## Contract

This change is contract-relevant (extends `GET /v1/products/search` and the `ProductSummary` schema). Changes follow `BACKEND_CONTRACT_GUIDE.md`:

- The change is **additive and backward compatible** — a new optional `detailed` query param (default `false`) and additive, nullable fields on `ProductSummary`. Existing lean consumers see the historical shape unchanged.
- The module contract artifact `pos-catalog/openapi.yaml` is updated in the same PR so the downstream SDK can be regenerated.

## Changes

- **`ProductSummary`** — additive, nullable enriched fields (`lifecycleState`, `lifecycleStateEffectiveAt`, `msrpAmount`, `msrpCurrency`, `msrpEffectiveStartDate`, `msrpEffectiveEndDate`).
- **`ProductMsrpRepository.findActiveForProducts(...)`** — batch active-MSRP lookup for the page's product ids in one query (no backend N+1); the winning record per product mirrors `findActive` selection semantics (most recent start, tie-broken by id).
- **`ProductSearchServiceImpl`** — enriches only when `detailed=true`. Products with no active MSRP get null price fields (graceful degradation), never an error.
- **`ProductController`** — new `detailed` query param (default `false`); cursor pagination unchanged.
- **`pos-catalog/openapi.yaml`** — updated with the new param and enriched schema so the SDK can be regenerated.

## Acceptance criteria

- [x] A single search/list call returns lifecycle state + effective date and active MSRP (amount, currency, effective window) per row.
- [x] Products without an active MSRP return null/absent price fields rather than erroring.
- [x] Response stays cursor-based (`nextCursor`, `limit`).
- [x] Backward compatible — enriched fields are additive/nullable; lean consumers see the historical shape.
- [x] OpenAPI spec updated so the frontend SDK can be regenerated and drop the per-row fan-out.

## Tests

Added `ProductSearchDetailedContractBehaviorIT`:
- `detailed=true` populates lifecycle + active MSRP inline; a product with no active MSRP returns null/absent price fields.
- lean (default) search leaves the enriched fields unpopulated.

## Verification note

This repo requires **Java 25** (enforced by the Maven build). The web session environment only has Java 21 and the egress policy blocks the JDK download hosts, so I could not compile/run the build locally — CI exercises it. The `openapi.yaml` was updated by hand and validated to parse. `openapi.json` is a stale snapshot that predates the search feature (no `ProductSummary`/`/search` entries), so it was left untouched rather than fabricating content into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NHVRc9YCrXrHz7wKQ4den