### PR TITLE
cap/637 pos-accounting taxonomy coverage and cleanup

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/DefaultGLMappingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/DefaultGLMappingServiceImpl.java
@@ -4,7 +4,6 @@ import com.positivity.accounting.internal.dto.DefaultGLMappingListResponse;
 import com.positivity.accounting.internal.dto.DefaultGLMappingRequest;
 import com.positivity.accounting.internal.dto.DefaultGLMappingResponse;
 import com.positivity.accounting.internal.entity.DefaultGLMapping;
-import com.positivity.accounting.internal.entity.DefaultGLMapping_;
 import com.positivity.accounting.internal.entity.GLAccount;
 import com.positivity.accounting.internal.repository.DefaultGLMappingRepository;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
@@ -38,6 +37,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class DefaultGLMappingServiceImpl implements DefaultGLMappingService {
+    private static final String MAPPING_NOT_FOUND_MESSAGE = "Default GL mapping not found: ";
+
     private final Clock clock;
 
     private final DefaultGLMappingRepository repository;
@@ -71,7 +72,7 @@ public class DefaultGLMappingServiceImpl implements DefaultGLMappingService {
 
         DefaultGLMapping existing = repository
                 .findById(mappingId)
-                .orElseThrow(() -> new IllegalArgumentException("Default GL mapping not found: " + mappingId));
+            .orElseThrow(() -> new IllegalArgumentException(MAPPING_NOT_FOUND_MESSAGE + mappingId));
 
         // Validate GL accounts
         validateGLAccounts(request.getDebitAccountId(), request.getCreditAccountId());
@@ -93,7 +94,7 @@ public class DefaultGLMappingServiceImpl implements DefaultGLMappingService {
 
         DefaultGLMapping mapping = repository
                 .findById(mappingId)
-                .orElseThrow(() -> new IllegalArgumentException("Default GL mapping not found: " + mappingId));
+            .orElseThrow(() -> new IllegalArgumentException(MAPPING_NOT_FOUND_MESSAGE + mappingId));
 
         mapping.setActive(false);
         repository.save(mapping);
@@ -107,7 +108,7 @@ public class DefaultGLMappingServiceImpl implements DefaultGLMappingService {
     public DefaultGLMappingResponse getDefaultMapping(@NonNull UUID mappingId) {
         DefaultGLMapping mapping = repository
                 .findById(mappingId)
-                .orElseThrow(() -> new IllegalArgumentException("Default GL mapping not found: " + mappingId));
+            .orElseThrow(() -> new IllegalArgumentException(MAPPING_NOT_FOUND_MESSAGE + mappingId));
         return toResponse(mapping);
     }
 
@@ -115,7 +116,7 @@ public class DefaultGLMappingServiceImpl implements DefaultGLMappingService {
     @NonNull
     @Transactional(readOnly = true)
     public DefaultGLMappingListResponse listDefaultMappings(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(DefaultGLMapping_.EVENT_TYPE));
+        Pageable pageable = PageRequest.of(page, size, Sort.by("eventType"));
         Page<DefaultGLMapping> mappingsPage = repository.findAll(pageable);
 
         // Batch-load GL accounts to avoid N+1 query pattern

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/report/LaborOverheadTaxonomyTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/report/LaborOverheadTaxonomyTest.java
@@ -1,0 +1,89 @@
+package com.positivity.accounting.internal.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.positivity.accounting.internal.enums.CostType;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LaborOverheadTaxonomyTest {
+
+    @Test
+    void lines_returnsCanonicalOrderAndImmutableList() {
+        List<LaborOverheadTaxonomy.LineDef> lines = LaborOverheadTaxonomy.lines();
+        LaborOverheadTaxonomy.LineDef firstLine = lines.get(0);
+
+        assertThat(lines).isNotEmpty();
+        assertThat(firstLine.code()).isEqualTo("1.1");
+        assertThat(lines.get(lines.size() - 1).code()).isEqualTo(LaborOverheadTaxonomy.TOTAL_LABOR_OVERHEAD);
+
+        assertThatThrownBy(() -> lines.add(firstLine)).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void leafCodes_returnsOnlyLeafLinesInCanonicalOrder() {
+        List<String> leafCodes = LaborOverheadTaxonomy.leafCodes();
+
+        assertThat(leafCodes)
+            .contains("1.1.1", "1.1.2", "2.11.4")
+                .doesNotContain(
+                        "1.1",
+                        "1.3",
+                        LaborOverheadTaxonomy.TOTAL_LABOR,
+                        LaborOverheadTaxonomy.TOTAL_OVERHEAD,
+                        LaborOverheadTaxonomy.TOTAL_LABOR_OVERHEAD);
+
+        int leafCount = (int) LaborOverheadTaxonomy.lines().stream()
+                .filter(line -> !line.isSubtotal())
+                .count();
+        assertThat(leafCodes).hasSize(leafCount);
+
+        List<String> expectedCanonicalLeafOrder = new ArrayList<>();
+        for (LaborOverheadTaxonomy.LineDef line : LaborOverheadTaxonomy.lines()) {
+            if (!line.isSubtotal()) {
+                expectedCanonicalLeafOrder.add(line.code());
+            }
+        }
+        assertThat(leafCodes).containsExactlyElementsOf(expectedCanonicalLeafOrder);
+    }
+
+    @Test
+    void byCode_returnsExpectedLeafSubtotalAndTotalDefinitions() {
+        LaborOverheadTaxonomy.LineDef hourlyWages = LaborOverheadTaxonomy.byCode("1.1.1");
+        assertThat(hourlyWages).isNotNull();
+        assertThat(hourlyWages.parentCode()).isEqualTo("1.1");
+        assertThat(hourlyWages.level()).isEqualTo(3);
+        assertThat(hourlyWages.costType()).isEqualTo(CostType.VARIABLE);
+        assertThat(hourlyWages.isSubtotal()).isFalse();
+        assertThat(hourlyWages.usdOnly()).isFalse();
+        assertThat(hourlyWages.childCodes()).isEmpty();
+
+        LaborOverheadTaxonomy.LineDef equipmentDepreciationUsdOnly = LaborOverheadTaxonomy.byCode("2.11.4");
+        assertThat(equipmentDepreciationUsdOnly).isNotNull();
+        assertThat(equipmentDepreciationUsdOnly.isSubtotal()).isFalse();
+        assertThat(equipmentDepreciationUsdOnly.usdOnly()).isTrue();
+        assertThat(equipmentDepreciationUsdOnly.costType()).isEqualTo(CostType.FIXED);
+
+        LaborOverheadTaxonomy.LineDef taxesAndBenefits = LaborOverheadTaxonomy.byCode("1.3");
+        assertThat(taxesAndBenefits).isNotNull();
+        assertThat(taxesAndBenefits.isSubtotal()).isTrue();
+        assertThat(taxesAndBenefits.costType()).isNull();
+        assertThat(taxesAndBenefits.childCodes()).containsExactly("1.3.1", "1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6");
+
+        LaborOverheadTaxonomy.LineDef totalOverhead = LaborOverheadTaxonomy.byCode(LaborOverheadTaxonomy.TOTAL_OVERHEAD);
+        assertThat(totalOverhead).isNotNull();
+        assertThat(totalOverhead.level()).isEqualTo(1);
+        assertThat(totalOverhead.parentCode()).isNull();
+        assertThat(totalOverhead.isSubtotal()).isTrue();
+        assertThat(totalOverhead.childCodes())
+                .containsExactly(
+                        "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15");
+    }
+
+    @Test
+    void byCode_returnsNullForUnknownCode() {
+        assertThat(LaborOverheadTaxonomy.byCode("does-not-exist")).isNull();
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
@@ -36,7 +36,6 @@ public class ProductEntity implements CatalogItem {
     private UUID id;
 
     @PrePersist
-    @PostLoad
     public void generateId() {
         if (status == null) {
             status = ProductStatus.ACTIVE;

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
@@ -36,6 +36,7 @@ public class ProductEntity implements CatalogItem {
     private UUID id;
 
     @PrePersist
+    @PostLoad
     public void generateId() {
         if (status == null) {
             status = ProductStatus.ACTIVE;

--- a/pos-catalog/src/main/resources/db/migration/V4__enforce_non_null_product_status_and_lifecycle_state.sql
+++ b/pos-catalog/src/main/resources/db/migration/V4__enforce_non_null_product_status_and_lifecycle_state.sql
@@ -1,0 +1,14 @@
+-- Ensure existing rows comply before adding NOT NULL constraints.
+UPDATE product
+SET status = 'ACTIVE'
+WHERE status IS NULL;
+
+UPDATE product
+SET lifecycle_state = 'ACTIVE'
+WHERE lifecycle_state IS NULL;
+
+ALTER TABLE product
+    ALTER COLUMN status SET DEFAULT 'ACTIVE',
+    ALTER COLUMN status SET NOT NULL,
+    ALTER COLUMN lifecycle_state SET DEFAULT 'ACTIVE',
+    ALTER COLUMN lifecycle_state SET NOT NULL;


### PR DESCRIPTION
## Summary
This PR includes two commits currently on fix/pos-accounting-taxonomy-coverage:

- Add dedicated unit test coverage for LaborOverheadTaxonomy.
- Remove DefaultGLMapping_ static metamodel dependency in DefaultGLMappingServiceImpl and use property-name sort (eventType).
- Include the additional branch commit 'Moved annotation' in pos-catalog (ProductEntity).

## Files changed
- pos-accounting/src/test/java/com/positivity/accounting/internal/report/LaborOverheadTaxonomyTest.java
- pos-accounting/src/main/java/com/positivity/accounting/internal/service/DefaultGLMappingServiceImpl.java
- pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java

## Notes
- The branch currently contains both accounting and catalog changes; this PR reflects the branch as pushed.