### PR TITLE
feat(bulk-loader): flexible catalog upload with header/structure discovery

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -62,7 +62,10 @@ jobs:
         run: |
           # --https-only refuses to follow any redirect to a non-HTTPS URL, so the
           # binary can only ever be fetched over TLS. (Sonar secrets/redirect hotspot)
-          wget --https-only --max-redirect=0 -O /usr/local/bin/hadolint \
+          # GitHub release assets are served via one HTTPS redirect to
+          # release-assets.githubusercontent.com, so cap redirects at 2 instead of
+          # disallowing them entirely (which made every download fail with exit 8).
+          wget --https-only --max-redirect=2 -O /usr/local/bin/hadolint \
             https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
           chmod +x /usr/local/bin/hadolint
       

--- a/pos-bulk-loader/openapi.yaml
+++ b/pos-bulk-loader/openapi.yaml
@@ -917,6 +917,45 @@ components:
       - fileName
       - id
       - status
+    ContentDetectionResult:
+      type: object
+      description: Result of content detection over an uploaded file, used to infer the target domain and mappings
+      properties:
+        detectedDomain:
+          type: string
+          description: Domain detected from the file content
+          enum:
+          - CATALOG_PRODUCT
+          - INVENTORY_STOCK_COUNT
+          - LOCATION
+          - CUSTOMER
+          - PERSON
+          - BASE_PRICE
+          - VEHICLE
+          - VEHICLE_FITMENT
+          example: CATALOG_PRODUCT
+        confidence:
+          type: number
+          format: double
+          description: Confidence score of the detection, between 0 and 1
+          example: 0.92
+        suggestedColumnMappings:
+          type: object
+          additionalProperties:
+            type: string
+          description: Suggested mappings from source column names to target field names
+          example:
+            Product SKU: sku
+            Price: basePrice
+        llmFallbackUsed:
+          type: boolean
+          default: false
+          description: Whether an LLM fallback was used to perform the detection
+          example: false
+      required:
+      - confidence
+      - detectedDomain
+      - llmFallbackUsed
     FileUploadResponse:
       type: object
       description: Result of uploading a source file for a bulk load job
@@ -939,6 +978,8 @@ components:
           format: int64
           description: Size of the uploaded file in bytes
           example: 204800
+        detection:
+          $ref: '#/components/schemas/ContentDetectionResult'
       required:
       - fileName
       - jobId

--- a/pos-bulk-loader/pom.xml
+++ b/pos-bulk-loader/pom.xml
@@ -114,6 +114,19 @@
       <version>5.9</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.poi</groupId>
+      <artifactId>poi-ooxml</artifactId>
+      <version>5.4.1</version>
+    </dependency>
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/config/BatchConfiguration.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/config/BatchConfiguration.java
@@ -13,8 +13,12 @@ import com.positivity.bulkloader.internal.domain.VehicleBulkRecord;
 import com.positivity.bulkloader.internal.domain.VehicleFitmentLoaderStrategy;
 import com.positivity.bulkloader.internal.domain.VehicleFitmentRecord;
 import com.positivity.bulkloader.internal.domain.VehicleLoaderStrategy;
+import com.positivity.bulkloader.internal.enums.DomainType;
+import com.positivity.bulkloader.internal.parser.FlexibleRecordItemReader;
+import com.positivity.bulkloader.internal.parser.RecordFileParserRegistry;
 import com.positivity.bulkloader.internal.service.BulkLoadAuthorizationContext;
 import com.positivity.bulkloader.internal.service.BulkLoadJobExecutionListener;
+import com.positivity.bulkloader.service.ColumnMappingService;
 import com.positivity.security.common.GatewaySecurityConstants;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
@@ -29,6 +33,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.batch.infrastructure.item.ItemStreamReader;
 import org.springframework.batch.infrastructure.item.ItemWriter;
 import org.springframework.batch.infrastructure.item.file.FlatFileItemReader;
 import org.springframework.batch.infrastructure.item.file.builder.FlatFileItemReaderBuilder;
@@ -66,6 +71,8 @@ public class BatchConfiguration {
     private final VehicleFitmentLoaderStrategy vehicleFitmentLoaderStrategy;
     private final BulkLoadAuthorizationContext bulkLoadAuthorizationContext;
     private final BulkLoadJobExecutionListener bulkLoadJobExecutionListener;
+    private final RecordFileParserRegistry recordFileParserRegistry;
+    private final ColumnMappingService columnMappingService;
 
     @Value("${pos.catalog.base-url:http://localhost:8082}")
     private String catalogBaseUrl;
@@ -98,13 +105,13 @@ public class BatchConfiguration {
 
     @Bean
     public Step catalogBulkLoadStep(
-            FlatFileItemReader<CatalogProductRecord> catalogCsvReader,
+            ItemStreamReader<CatalogProductRecord> catalogFlexibleReader,
             ItemProcessor<CatalogProductRecord, CatalogProductRecord> catalogItemProcessor,
             ItemWriter<CatalogProductRecord> catalogBulkIngestWriter) {
         return new StepBuilder("catalogBulkLoadStep", jobRepository)
                 .<CatalogProductRecord, CatalogProductRecord>chunk(500)
                 .transactionManager(transactionManager)
-                .reader(catalogCsvReader)
+                .reader(catalogFlexibleReader)
                 .processor(catalogItemProcessor)
                 .writer(catalogBulkIngestWriter)
                 .faultTolerant()
@@ -113,10 +120,32 @@ public class BatchConfiguration {
                 .build();
     }
 
+    /**
+     * Header/structure-driven reader for catalog uploads: supports delimited text (CSV/TSV/pipe),
+     * spreadsheets (xlsx/xls), JSON, YAML, and XML. Columns are discovered from the file itself
+     * and mapped to catalog fields via job-approved mappings or rule-based inference.
+     */
     @Bean
     @StepScope
-    public FlatFileItemReader<CatalogProductRecord> catalogCsvReader(
-            @Value("#{jobParameters['storagePath']}") String storagePath) {
+    public ItemStreamReader<CatalogProductRecord> catalogFlexibleReader(
+            @Value("#{jobParameters['storagePath']}") String storagePath,
+            @Value("#{jobParameters['jobId'] ?: null}") String jobIdParam) {
+        java.nio.file.Path resolved = resolveStoragePath(storagePath);
+        String fileName = resolved.getFileName().toString();
+        UUID jobId = parseUuidOrNull(jobIdParam);
+        return new FlexibleRecordItemReader<>(
+                () -> {
+                    try {
+                        return recordFileParserRegistry.open(java.nio.file.Files.newInputStream(resolved), fileName);
+                    } catch (java.io.IOException e) {
+                        throw new java.io.UncheckedIOException("Failed to open uploaded file: " + fileName, e);
+                    }
+                },
+                headers -> columnMappingService.resolveEffectiveMappings(jobId, headers, DomainType.CATALOG_PRODUCT),
+                catalogLoaderStrategy::mapRow);
+    }
+
+    private java.nio.file.Path resolveStoragePath(String storagePath) {
         if (storagePath == null || storagePath.isBlank()) {
             throw new IllegalArgumentException("storagePath job parameter must not be null or blank");
         }
@@ -125,17 +154,18 @@ public class BatchConfiguration {
         if (!resolved.startsWith(base)) {
             throw new IllegalArgumentException("Invalid storage path: attempted path traversal");
         }
+        return resolved;
+    }
 
-        BeanWrapperFieldSetMapper<CatalogProductRecord> mapper = new BeanWrapperFieldSetMapper<>();
-        mapper.setTargetType(CatalogProductRecord.class);
-        return new FlatFileItemReaderBuilder<CatalogProductRecord>()
-                .name("catalogCsvReader")
-                .resource(new FileSystemResource(resolved))
-                .delimited()
-                .names("sku", "upc", "name", "description", "categoryName", "subcategoryName", "price")
-                .fieldSetMapper(mapper)
-                .linesToSkip(1)
-                .build();
+    private UUID parseUuidOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException _) {
+            return null;
+        }
     }
 
     @Bean
@@ -220,14 +250,7 @@ public class BatchConfiguration {
     @StepScope
     public FlatFileItemReader<CustomerPersonRecord> customerCsvReader(
             @Value("#{jobParameters['storagePath']}") String storagePath) {
-        if (storagePath == null || storagePath.isBlank()) {
-            throw new IllegalArgumentException("storagePath job parameter must not be null or blank");
-        }
-        java.nio.file.Path base = java.nio.file.Path.of(storageRoot).normalize().toAbsolutePath();
-        java.nio.file.Path resolved = base.resolve(storagePath).normalize();
-        if (!resolved.startsWith(base)) {
-            throw new IllegalArgumentException("Invalid storage path: attempted path traversal");
-        }
+        java.nio.file.Path resolved = resolveStoragePath(storagePath);
 
         BeanWrapperFieldSetMapper<CustomerPersonRecord> mapper = new BeanWrapperFieldSetMapper<>();
         mapper.setTargetType(CustomerPersonRecord.class);
@@ -323,14 +346,7 @@ public class BatchConfiguration {
     @StepScope
     public FlatFileItemReader<PersonRecord> peopleCsvReader(
             @Value("#{jobParameters['storagePath']}") String storagePath) {
-        if (storagePath == null || storagePath.isBlank()) {
-            throw new IllegalArgumentException("storagePath job parameter must not be null or blank");
-        }
-        java.nio.file.Path base = java.nio.file.Path.of(storageRoot).normalize().toAbsolutePath();
-        java.nio.file.Path resolved = base.resolve(storagePath).normalize();
-        if (!resolved.startsWith(base)) {
-            throw new IllegalArgumentException("Invalid storage path: attempted path traversal");
-        }
+        java.nio.file.Path resolved = resolveStoragePath(storagePath);
 
         BeanWrapperFieldSetMapper<PersonRecord> mapper = new BeanWrapperFieldSetMapper<>();
         mapper.setTargetType(PersonRecord.class);
@@ -425,14 +441,7 @@ public class BatchConfiguration {
     @StepScope
     public FlatFileItemReader<BasePriceRecord> priceCsvReader(
             @Value("#{jobParameters['storagePath']}") String storagePath) {
-        if (storagePath == null || storagePath.isBlank()) {
-            throw new IllegalArgumentException("storagePath job parameter must not be null or blank");
-        }
-        java.nio.file.Path base = java.nio.file.Path.of(storageRoot).normalize().toAbsolutePath();
-        java.nio.file.Path resolved = base.resolve(storagePath).normalize();
-        if (!resolved.startsWith(base)) {
-            throw new IllegalArgumentException("Invalid storage path: attempted path traversal");
-        }
+        java.nio.file.Path resolved = resolveStoragePath(storagePath);
 
         BeanWrapperFieldSetMapper<BasePriceRecord> mapper = new BeanWrapperFieldSetMapper<>();
         mapper.setTargetType(BasePriceRecord.class);
@@ -527,14 +536,7 @@ public class BatchConfiguration {
     @StepScope
     public FlatFileItemReader<VehicleBulkRecord> vehicleCsvReader(
             @Value("#{jobParameters['storagePath']}") String storagePath) {
-        if (storagePath == null || storagePath.isBlank()) {
-            throw new IllegalArgumentException("storagePath job parameter must not be null or blank");
-        }
-        java.nio.file.Path base = java.nio.file.Path.of(storageRoot).normalize().toAbsolutePath();
-        java.nio.file.Path resolved = base.resolve(storagePath).normalize();
-        if (!resolved.startsWith(base)) {
-            throw new IllegalArgumentException("Invalid storage path: attempted path traversal");
-        }
+        java.nio.file.Path resolved = resolveStoragePath(storagePath);
 
         BeanWrapperFieldSetMapper<VehicleBulkRecord> mapper = new BeanWrapperFieldSetMapper<>();
         mapper.setTargetType(VehicleBulkRecord.class);
@@ -641,14 +643,7 @@ public class BatchConfiguration {
     @StepScope
     public FlatFileItemReader<VehicleFitmentRecord> vehicleFitmentCsvReader(
             @Value("#{jobParameters['storagePath']}") String storagePath) {
-        if (storagePath == null || storagePath.isBlank()) {
-            throw new IllegalArgumentException("storagePath job parameter must not be null or blank");
-        }
-        java.nio.file.Path base = java.nio.file.Path.of(storageRoot).normalize().toAbsolutePath();
-        java.nio.file.Path resolved = base.resolve(storagePath).normalize();
-        if (!resolved.startsWith(base)) {
-            throw new IllegalArgumentException("Invalid storage path: attempted path traversal");
-        }
+        java.nio.file.Path resolved = resolveStoragePath(storagePath);
 
         BeanWrapperFieldSetMapper<VehicleFitmentRecord> mapper = new BeanWrapperFieldSetMapper<>();
         mapper.setTargetType(VehicleFitmentRecord.class);

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/FileUploadController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/FileUploadController.java
@@ -63,8 +63,16 @@ public class FileUploadController {
         String originalFileName = file.getOriginalFilename() == null ? "upload.csv" : file.getOriginalFilename();
         String storagePath = fileStorageService.store(jobId, originalFileName, file.getInputStream(), file.getSize());
         bulkLoadJobService.markUploadStored(jobId, operatorId, storagePath);
-        ContentDetectionResult detection =
-                columnMappingService.detectUploadedFile(jobId, operatorId, storagePath, originalFileName);
+        ContentDetectionResult detection = null;
+        try {
+            detection = columnMappingService.detectUploadedFile(jobId, operatorId, storagePath, originalFileName);
+        } catch (RuntimeException ex) {
+            log.warn(
+                    "Content detection failed for job {} file {}; upload succeeded anyway",
+                    jobId,
+                    originalFileName,
+                    ex);
+        }
         FileUploadResponse response = FileUploadResponse.builder()
                 .jobId(jobId)
                 .storagePath(storagePath)

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/FileUploadController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/FileUploadController.java
@@ -1,8 +1,10 @@
 package com.positivity.bulkloader.internal.controller;
 
 import com.positivity.bulkloader.internal.dto.BulkLoadJobResponse;
+import com.positivity.bulkloader.internal.dto.ContentDetectionResult;
 import com.positivity.bulkloader.internal.dto.FileUploadResponse;
 import com.positivity.bulkloader.service.BulkLoadJobService;
+import com.positivity.bulkloader.service.ColumnMappingService;
 import com.positivity.bulkloader.service.FileStorageService;
 import com.positivity.events.EmitEvent;
 import com.positivity.security.common.GatewaySecurityConstants;
@@ -42,6 +44,7 @@ public class FileUploadController {
 
     private final BulkLoadJobService bulkLoadJobService;
     private final FileStorageService fileStorageService;
+    private final ColumnMappingService columnMappingService;
 
     @PostMapping("/{jobId}/upload")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
@@ -60,11 +63,14 @@ public class FileUploadController {
         String originalFileName = file.getOriginalFilename() == null ? "upload.csv" : file.getOriginalFilename();
         String storagePath = fileStorageService.store(jobId, originalFileName, file.getInputStream(), file.getSize());
         bulkLoadJobService.markUploadStored(jobId, operatorId, storagePath);
+        ContentDetectionResult detection =
+                columnMappingService.detectUploadedFile(jobId, operatorId, storagePath, originalFileName);
         FileUploadResponse response = FileUploadResponse.builder()
                 .jobId(jobId)
                 .storagePath(storagePath)
                 .fileName(originalFileName)
                 .sizeBytes(file.getSize())
+                .detection(detection)
                 .build();
         log.info(
                 "File uploaded for job {} by operator {}: {} ({} bytes)",

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/domain/CatalogLoaderStrategy.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/domain/CatalogLoaderStrategy.java
@@ -21,10 +21,12 @@ public class CatalogLoaderStrategy implements DomainLoaderStrategy<CatalogProduc
         CatalogProductRecord catalogProduct = new CatalogProductRecord();
         catalogProduct.setSku(row.get("sku"));
         catalogProduct.setUpc(row.get("upc"));
-        catalogProduct.setName(row.getOrDefault("name", row.get("description")));
+        catalogProduct.setName(firstNonBlank(row.get("name"), row.get("description")));
         catalogProduct.setDescription(row.get("description"));
         catalogProduct.setCategoryName(row.get("categoryName"));
         catalogProduct.setSubcategoryName(row.get("subcategoryName"));
+        catalogProduct.setMpn(row.get("mpn"));
+        catalogProduct.setUnitOfMeasure(row.get("unitOfMeasure"));
         String priceStr = row.get("price");
         if (priceStr != null && !priceStr.isBlank()) {
             try {
@@ -34,6 +36,10 @@ public class CatalogLoaderStrategy implements DomainLoaderStrategy<CatalogProduc
             }
         }
         return catalogProduct;
+    }
+
+    private String firstNonBlank(String primary, String fallback) {
+        return primary != null && !primary.isBlank() ? primary : fallback;
     }
 
     @Override

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/domain/CatalogProductRecord.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/domain/CatalogProductRecord.java
@@ -13,4 +13,6 @@ public class CatalogProductRecord {
     private String categoryName;
     private String subcategoryName;
     private BigDecimal price;
+    private String mpn;
+    private String unitOfMeasure;
 }

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/dto/FileUploadResponse.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/dto/FileUploadResponse.java
@@ -36,4 +36,10 @@ public class FileUploadResponse {
 
     @Schema(description = "Size of the uploaded file in bytes", example = "204800", requiredMode = REQUIRED)
     private long sizeBytes;
+
+    @Schema(
+            description = "Content detection result for the uploaded file (detected domain, confidence, and"
+                    + " suggested column mappings). Absent when the file structure could not be parsed.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private ContentDetectionResult detection;
 }

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/DelimitedRecordFileParser.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/DelimitedRecordFileParser.java
@@ -1,0 +1,164 @@
+package com.positivity.bulkloader.internal.parser;
+
+import com.opencsv.CSVParserBuilder;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvValidationException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Header-driven parser for delimited text files. The delimiter is sniffed from the header line
+ * (comma, tab, semicolon, or pipe) and columns are addressed by header name, so column order and
+ * extra columns do not matter.
+ */
+@Component
+public class DelimitedRecordFileParser implements RecordFileParser {
+
+    private static final Set<String> EXTENSIONS = Set.of("csv", "tsv", "txt", "psv");
+    private static final char[] CANDIDATE_DELIMITERS = {',', '\t', ';', '|'};
+    private static final int HEADER_MARK_LIMIT = 1 << 20;
+
+    @Override
+    public boolean supports(@NonNull String fileName) {
+        return EXTENSIONS.contains(FileNames.extension(fileName));
+    }
+
+    @Override
+    @NonNull
+    public RecordSource open(@NonNull InputStream content, @NonNull String fileName) {
+        try {
+            BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(content, StandardCharsets.UTF_8), HEADER_MARK_LIMIT);
+            reader.mark(HEADER_MARK_LIMIT);
+            String headerLine = reader.readLine();
+            if (headerLine == null || headerLine.isBlank()) {
+                reader.close();
+                throw new RecordFileParseException("Delimited file has no header line: " + fileName);
+            }
+            char delimiter = sniffDelimiter(headerLine);
+            reader.reset();
+
+            CSVReader csvReader = new CSVReaderBuilder(reader)
+                    .withCSVParser(
+                            new CSVParserBuilder().withSeparator(delimiter).build())
+                    .build();
+            String[] headerRow = csvReader.readNext();
+            if (headerRow == null || headerRow.length == 0) {
+                csvReader.close();
+                throw new RecordFileParseException("Delimited file has no header row: " + fileName);
+            }
+            List<String> headers = normalizeHeaders(headerRow);
+            return new CsvRecordSource(headers, csvReader);
+        } catch (IOException | CsvValidationException e) {
+            throw new RecordFileParseException("Failed to read delimited file: " + fileName, e);
+        }
+    }
+
+    private char sniffDelimiter(String headerLine) {
+        char best = ',';
+        int bestCount = -1;
+        for (char candidate : CANDIDATE_DELIMITERS) {
+            int count = countOutsideQuotes(headerLine, candidate);
+            if (count > bestCount) {
+                bestCount = count;
+                best = candidate;
+            }
+        }
+        return best;
+    }
+
+    private int countOutsideQuotes(String line, char delimiter) {
+        int count = 0;
+        boolean inQuotes = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (c == '"') {
+                inQuotes = !inQuotes;
+            } else if (c == delimiter && !inQuotes) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private List<String> normalizeHeaders(String[] headerRow) {
+        List<String> headers = new ArrayList<>(headerRow.length);
+        for (int i = 0; i < headerRow.length; i++) {
+            String header = headerRow[i] == null ? "" : headerRow[i].trim();
+            if (i == 0 && header.startsWith("﻿")) {
+                header = header.substring(1).trim();
+            }
+            headers.add(header.isEmpty() ? "column_" + (i + 1) : header);
+        }
+        return headers;
+    }
+
+    private static final class CsvRecordSource implements RecordSource {
+
+        private final List<String> headers;
+        private final CSVReader csvReader;
+
+        private CsvRecordSource(List<String> headers, CSVReader csvReader) {
+            this.headers = List.copyOf(headers);
+            this.csvReader = csvReader;
+        }
+
+        @Override
+        @NonNull
+        public List<String> headers() {
+            return headers;
+        }
+
+        @Override
+        @Nullable
+        public Map<String, String> nextRecord() {
+            try {
+                String[] row;
+                while ((row = csvReader.readNext()) != null) {
+                    if (isBlankRow(row)) {
+                        continue;
+                    }
+                    Map<String, String> mapped = LinkedHashMap.newLinkedHashMap(headers.size());
+                    for (int i = 0; i < headers.size() && i < row.length; i++) {
+                        mapped.put(headers.get(i), row[i] == null ? "" : row[i].trim());
+                    }
+                    return mapped;
+                }
+                return null;
+            } catch (IOException | CsvValidationException e) {
+                throw new RecordFileParseException("Failed to read delimited record", e);
+            }
+        }
+
+        private boolean isBlankRow(String[] row) {
+            for (String cell : row) {
+                if (cell != null && !cell.isBlank()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public void close() {
+            try {
+                csvReader.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to close delimited file reader", e);
+            }
+        }
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/FileNames.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/FileNames.java
@@ -1,0 +1,14 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.util.Locale;
+import org.jspecify.annotations.NonNull;
+
+final class FileNames {
+
+    private FileNames() {}
+
+    static String extension(@NonNull String fileName) {
+        int dot = fileName.lastIndexOf('.');
+        return dot < 0 ? "" : fileName.substring(dot + 1).toLowerCase(Locale.ROOT);
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/FlexibleRecordItemReader.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/FlexibleRecordItemReader.java
@@ -22,12 +22,15 @@ import org.springframework.batch.infrastructure.item.ItemStreamReader;
 @Slf4j
 public class FlexibleRecordItemReader<T> implements ItemStreamReader<T> {
 
+    private static final String READ_COUNT_KEY = "flexibleRecordItemReader.readCount";
+
     private final Supplier<RecordSource> sourceSupplier;
     private final Function<List<String>, Map<String, String>> mappingResolver;
     private final Function<Map<String, String>, T> rowMapper;
 
     private RecordSource source;
     private Map<String, String> columnMappings;
+    private long readCount;
 
     public FlexibleRecordItemReader(
             @NonNull Supplier<RecordSource> sourceSupplier,
@@ -52,7 +55,20 @@ public class FlexibleRecordItemReader<T> implements ItemStreamReader<T> {
             closeQuietly();
             throw new ItemStreamException("No source columns could be mapped to target fields; headers=" + headers);
         }
+        skipAlreadyProcessedRecords(executionContext);
         log.info("Opened flexible record reader with column mappings {}", columnMappings);
+    }
+
+    /** On a restarted execution, fast-forwards past the records already read by the failed run. */
+    private void skipAlreadyProcessedRecords(ExecutionContext executionContext) {
+        readCount = 0;
+        long alreadyRead = executionContext.getLong(READ_COUNT_KEY, 0L);
+        while (readCount < alreadyRead && source.nextRecord() != null) {
+            readCount++;
+        }
+        if (alreadyRead > 0) {
+            log.info("Restarted flexible record reader: skipped {} already-processed records", readCount);
+        }
     }
 
     @Override
@@ -62,6 +78,7 @@ public class FlexibleRecordItemReader<T> implements ItemStreamReader<T> {
         if (row == null) {
             return null;
         }
+        readCount++;
         Map<String, String> canonical = LinkedHashMap.newLinkedHashMap(columnMappings.size());
         for (Map.Entry<String, String> mapping : columnMappings.entrySet()) {
             String value = row.get(mapping.getKey());
@@ -74,7 +91,7 @@ public class FlexibleRecordItemReader<T> implements ItemStreamReader<T> {
 
     @Override
     public void update(@NonNull ExecutionContext executionContext) {
-        // No restart state: the reader always re-reads from the start of the file.
+        executionContext.putLong(READ_COUNT_KEY, readCount);
     }
 
     @Override

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/FlexibleRecordItemReader.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/FlexibleRecordItemReader.java
@@ -1,0 +1,96 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ItemStreamException;
+import org.springframework.batch.infrastructure.item.ItemStreamReader;
+
+/**
+ * Spring Batch reader over a {@link RecordSource}: the file structure is discovered from headers
+ * (or document shape), source columns are renamed to canonical target fields via the resolved
+ * mapping, and each canonical row is converted to a domain record.
+ *
+ * @param <T> domain record type produced per row
+ */
+@Slf4j
+public class FlexibleRecordItemReader<T> implements ItemStreamReader<T> {
+
+    private final Supplier<RecordSource> sourceSupplier;
+    private final Function<List<String>, Map<String, String>> mappingResolver;
+    private final Function<Map<String, String>, T> rowMapper;
+
+    private RecordSource source;
+    private Map<String, String> columnMappings;
+
+    public FlexibleRecordItemReader(
+            @NonNull Supplier<RecordSource> sourceSupplier,
+            @NonNull Function<List<String>, Map<String, String>> mappingResolver,
+            @NonNull Function<Map<String, String>, T> rowMapper) {
+        this.sourceSupplier = sourceSupplier;
+        this.mappingResolver = mappingResolver;
+        this.rowMapper = rowMapper;
+    }
+
+    @Override
+    public void open(@NonNull ExecutionContext executionContext) {
+        try {
+            source = sourceSupplier.get();
+            columnMappings = mappingResolver.apply(source.headers());
+        } catch (RuntimeException e) {
+            closeQuietly();
+            throw new ItemStreamException("Failed to open uploaded file for reading", e);
+        }
+        if (columnMappings.isEmpty()) {
+            List<String> headers = source.headers();
+            closeQuietly();
+            throw new ItemStreamException("No source columns could be mapped to target fields; headers=" + headers);
+        }
+        log.info("Opened flexible record reader with column mappings {}", columnMappings);
+    }
+
+    @Override
+    @Nullable
+    public T read() {
+        Map<String, String> row = source.nextRecord();
+        if (row == null) {
+            return null;
+        }
+        Map<String, String> canonical = LinkedHashMap.newLinkedHashMap(columnMappings.size());
+        for (Map.Entry<String, String> mapping : columnMappings.entrySet()) {
+            String value = row.get(mapping.getKey());
+            if (value != null) {
+                canonical.put(mapping.getValue(), value);
+            }
+        }
+        return rowMapper.apply(canonical);
+    }
+
+    @Override
+    public void update(@NonNull ExecutionContext executionContext) {
+        // No restart state: the reader always re-reads from the start of the file.
+    }
+
+    @Override
+    public void close() {
+        closeQuietly();
+    }
+
+    private void closeQuietly() {
+        if (source != null) {
+            try {
+                source.close();
+            } catch (RuntimeException e) {
+                log.warn("Failed to close record source: {}", e.getMessage());
+            } finally {
+                source = null;
+            }
+        }
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/JsonRecordFileParser.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/JsonRecordFileParser.java
@@ -1,0 +1,35 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.io.InputStream;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Structure-discovering parser for JSON files: records are taken from the root array, or from the
+ * largest array of objects found anywhere in the document.
+ */
+@Component
+public class JsonRecordFileParser implements RecordFileParser {
+
+    private final JsonMapper mapper = JsonMapper.builder().build();
+
+    @Override
+    public boolean supports(@NonNull String fileName) {
+        return "json".equals(FileNames.extension(fileName));
+    }
+
+    @Override
+    @NonNull
+    public RecordSource open(@NonNull InputStream content, @NonNull String fileName) {
+        try (content) {
+            Object tree = mapper.readValue(content, Object.class);
+            return StructuredRecords.toRecordSource(tree, fileName);
+        } catch (JacksonException e) {
+            throw new RecordFileParseException("Failed to parse JSON file: " + fileName, e);
+        } catch (java.io.IOException e) {
+            throw new RecordFileParseException("Failed to read JSON file: " + fileName, e);
+        }
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/ListBackedRecordSource.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/ListBackedRecordSource.java
@@ -1,0 +1,36 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/** Record source over records that were fully materialized during parsing. */
+final class ListBackedRecordSource implements RecordSource {
+
+    private final List<String> headers;
+    private final Iterator<Map<String, String>> records;
+
+    ListBackedRecordSource(@NonNull List<String> headers, @NonNull List<Map<String, String>> records) {
+        this.headers = List.copyOf(headers);
+        this.records = records.iterator();
+    }
+
+    @Override
+    @NonNull
+    public List<String> headers() {
+        return headers;
+    }
+
+    @Override
+    @Nullable
+    public Map<String, String> nextRecord() {
+        return records.hasNext() ? records.next() : null;
+    }
+
+    @Override
+    public void close() {
+        // Nothing to release; content is already materialized.
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/RecordFileParseException.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/RecordFileParseException.java
@@ -1,0 +1,13 @@
+package com.positivity.bulkloader.internal.parser;
+
+/** Raised when an uploaded file cannot be parsed into records. */
+public class RecordFileParseException extends RuntimeException {
+
+    public RecordFileParseException(String message) {
+        super(message);
+    }
+
+    public RecordFileParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/RecordFileParser.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/RecordFileParser.java
@@ -1,0 +1,17 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.io.InputStream;
+import org.jspecify.annotations.NonNull;
+
+/** Parses one physical file format (by extension) into a {@link RecordSource}. */
+public interface RecordFileParser {
+
+    boolean supports(@NonNull String fileName);
+
+    /**
+     * Opens the given content as a record source. Ownership of the stream passes to the returned
+     * source; closing the source closes the stream.
+     */
+    @NonNull
+    RecordSource open(@NonNull InputStream content, @NonNull String fileName);
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/RecordFileParserRegistry.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/RecordFileParserRegistry.java
@@ -1,0 +1,30 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.io.InputStream;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/** Selects the {@link RecordFileParser} for an uploaded file by its file name. */
+@Component
+@RequiredArgsConstructor
+public class RecordFileParserRegistry {
+
+    private final List<RecordFileParser> parsers;
+
+    public boolean supports(@NonNull String fileName) {
+        return parsers.stream().anyMatch(parser -> parser.supports(fileName));
+    }
+
+    @NonNull
+    public RecordSource open(@NonNull InputStream content, @NonNull String fileName) {
+        return parsers.stream()
+                .filter(parser -> parser.supports(fileName))
+                .findFirst()
+                .orElseThrow(() -> new RecordFileParseException(
+                        "Unsupported file type: %s (supported: csv, tsv, txt, psv, xlsx, xlsm, xls, json, yaml, yml, xml)"
+                                .formatted(fileName)))
+                .open(content, fileName);
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/RecordSource.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/RecordSource.java
@@ -1,0 +1,24 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Forward-only cursor over the records discovered in an uploaded file, independent of the physical
+ * file format. Keys of each record are the source column names (CSV/spreadsheet headers) or the
+ * flattened field paths (JSON/YAML/XML).
+ */
+public interface RecordSource extends AutoCloseable {
+
+    @NonNull
+    List<String> headers();
+
+    /** Returns the next record as source-column-to-raw-value pairs, or {@code null} when exhausted. */
+    @Nullable
+    Map<String, String> nextRecord();
+
+    @Override
+    void close();
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/SpreadsheetRecordFileParser.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/SpreadsheetRecordFileParser.java
@@ -1,0 +1,127 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Header-driven parser for Excel workbooks. Each sheet's header row is the first non-empty row;
+ * the sheet with the most data rows is treated as the record sheet, so companion sheets
+ * (instructions, data dictionaries, summaries) are ignored.
+ */
+@Component
+@Slf4j
+public class SpreadsheetRecordFileParser implements RecordFileParser {
+
+    private static final Set<String> EXTENSIONS = Set.of("xlsx", "xlsm", "xls");
+
+    @Override
+    public boolean supports(@NonNull String fileName) {
+        return EXTENSIONS.contains(FileNames.extension(fileName));
+    }
+
+    @Override
+    @NonNull
+    public RecordSource open(@NonNull InputStream content, @NonNull String fileName) {
+        try (content;
+                Workbook workbook = WorkbookFactory.create(content)) {
+            DataFormatter formatter = new DataFormatter();
+            FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
+
+            ParsedSheet best = null;
+            for (Sheet sheet : workbook) {
+                ParsedSheet parsed = parseSheet(sheet, formatter, evaluator);
+                if (parsed != null
+                        && (best == null
+                                || parsed.records().size() > best.records().size())) {
+                    best = parsed;
+                }
+            }
+            if (best == null) {
+                throw new RecordFileParseException("Workbook contains no sheet with a header row: " + fileName);
+            }
+            log.debug(
+                    "Selected sheet '{}' with {} records from workbook {}",
+                    best.sheetName(),
+                    best.records().size(),
+                    fileName);
+            return new ListBackedRecordSource(best.headers(), best.records());
+        } catch (IOException e) {
+            throw new RecordFileParseException("Failed to read spreadsheet file: " + fileName, e);
+        }
+    }
+
+    @Nullable
+    private ParsedSheet parseSheet(Sheet sheet, DataFormatter formatter, FormulaEvaluator evaluator) {
+        Row headerRow = findHeaderRow(sheet, formatter, evaluator);
+        if (headerRow == null) {
+            return null;
+        }
+
+        List<String> headers = new ArrayList<>();
+        int lastHeaderCell = headerRow.getLastCellNum();
+        for (int column = 0; column < lastHeaderCell; column++) {
+            String value = cellText(headerRow.getCell(column), formatter, evaluator);
+            headers.add(value.isEmpty() ? "column_" + (column + 1) : value);
+        }
+
+        List<Map<String, String>> records = new ArrayList<>();
+        for (int rowIndex = headerRow.getRowNum() + 1; rowIndex <= sheet.getLastRowNum(); rowIndex++) {
+            Row row = sheet.getRow(rowIndex);
+            if (row == null) {
+                continue;
+            }
+            Map<String, String> record = LinkedHashMap.newLinkedHashMap(headers.size());
+            boolean hasValue = false;
+            for (int column = 0; column < headers.size(); column++) {
+                String value = cellText(row.getCell(column), formatter, evaluator);
+                hasValue = hasValue || !value.isEmpty();
+                record.put(headers.get(column), value);
+            }
+            if (hasValue) {
+                records.add(record);
+            }
+        }
+        return new ParsedSheet(sheet.getSheetName(), headers, records);
+    }
+
+    @Nullable
+    private Row findHeaderRow(Sheet sheet, DataFormatter formatter, FormulaEvaluator evaluator) {
+        for (int rowIndex = sheet.getFirstRowNum(); rowIndex <= sheet.getLastRowNum(); rowIndex++) {
+            Row row = sheet.getRow(rowIndex);
+            if (row == null) {
+                continue;
+            }
+            for (Cell cell : row) {
+                if (!cellText(cell, formatter, evaluator).isEmpty()) {
+                    return row;
+                }
+            }
+        }
+        return null;
+    }
+
+    private String cellText(@Nullable Cell cell, DataFormatter formatter, FormulaEvaluator evaluator) {
+        if (cell == null) {
+            return "";
+        }
+        return formatter.formatCellValue(cell, evaluator).trim();
+    }
+
+    private record ParsedSheet(String sheetName, List<String> headers, List<Map<String, String>> records) {}
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/StructuredRecords.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/StructuredRecords.java
@@ -1,0 +1,111 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Discovers the record list inside a generic object tree (maps, lists, scalars — as produced by
+ * JSON/YAML/XML parsing) and flattens each record into string key/value pairs. Nested objects are
+ * flattened with dot-separated paths; lists of scalars are joined with {@code "; "}.
+ */
+final class StructuredRecords {
+
+    private StructuredRecords() {}
+
+    static RecordSource toRecordSource(Object tree, @NonNull String fileName) {
+        List<Map<?, ?>> recordNodes = findRecordList(tree);
+        if (recordNodes.isEmpty()) {
+            throw new RecordFileParseException("Could not locate a list of records in structured file: " + fileName);
+        }
+        List<Map<String, String>> records = new ArrayList<>(recordNodes.size());
+        Set<String> headers = new LinkedHashSet<>();
+        for (Map<?, ?> node : recordNodes) {
+            Map<String, String> flattened = new LinkedHashMap<>();
+            flatten("", node, flattened);
+            headers.addAll(flattened.keySet());
+            records.add(flattened);
+        }
+        return new ListBackedRecordSource(new ArrayList<>(headers), records);
+    }
+
+    /**
+     * Locates the list of records: the root itself when it is a list of maps, otherwise the largest
+     * list-of-maps found anywhere in the tree (breadth-first). A root map with no such list is
+     * treated as a single record.
+     */
+    private static List<Map<?, ?>> findRecordList(Object root) {
+        List<Map<?, ?>> best = List.of();
+        Deque<Object> queue = new ArrayDeque<>();
+        if (root != null) {
+            queue.add(root);
+        }
+        while (!queue.isEmpty()) {
+            Object node = queue.poll();
+            if (node instanceof List<?> list) {
+                List<Map<?, ?>> maps = asListOfMaps(list);
+                if (maps.size() > best.size()) {
+                    best = maps;
+                }
+                if (maps.isEmpty()) {
+                    queue.addAll(
+                            list.stream().filter(java.util.Objects::nonNull).toList());
+                }
+            } else if (node instanceof Map<?, ?> map) {
+                for (Object value : map.values()) {
+                    if (value != null) {
+                        queue.add(value);
+                    }
+                }
+            }
+        }
+        if (best.isEmpty() && root instanceof Map<?, ?> single) {
+            return List.of(single);
+        }
+        return best;
+    }
+
+    private static List<Map<?, ?>> asListOfMaps(List<?> list) {
+        if (list.isEmpty()) {
+            return List.of();
+        }
+        List<Map<?, ?>> maps = new ArrayList<>(list.size());
+        for (Object element : list) {
+            if (!(element instanceof Map<?, ?> map)) {
+                return List.of();
+            }
+            maps.add(map);
+        }
+        return maps;
+    }
+
+    private static void flatten(String prefix, Map<?, ?> node, Map<String, String> target) {
+        for (Map.Entry<?, ?> entry : node.entrySet()) {
+            String key = prefix.isEmpty() ? String.valueOf(entry.getKey()) : prefix + "." + entry.getKey();
+            Object value = entry.getValue();
+            switch (value) {
+                case null -> target.put(key, "");
+                case Map<?, ?> nested -> flatten(key, nested, target);
+                case List<?> list -> target.put(key, joinScalars(list));
+                default -> target.put(key, String.valueOf(value).trim());
+            }
+        }
+    }
+
+    private static String joinScalars(List<?> list) {
+        StringJoiner joiner = new StringJoiner("; ");
+        for (Object element : list) {
+            if (element != null && !(element instanceof Map) && !(element instanceof List)) {
+                joiner.add(String.valueOf(element).trim());
+            }
+        }
+        return joiner.toString();
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/XmlRecordFileParser.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/XmlRecordFileParser.java
@@ -1,0 +1,104 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Structure-discovering parser for XML files. The document is converted into a generic map/list
+ * tree (repeated sibling elements become lists, attributes become fields) and the record list is
+ * discovered the same way as for JSON/YAML.
+ */
+@Component
+public class XmlRecordFileParser implements RecordFileParser {
+
+    @Override
+    public boolean supports(@NonNull String fileName) {
+        return "xml".equals(FileNames.extension(fileName));
+    }
+
+    @Override
+    @NonNull
+    public RecordSource open(@NonNull InputStream content, @NonNull String fileName) {
+        try (content) {
+            Document document =
+                    secureDocumentBuilderFactory().newDocumentBuilder().parse(content);
+            Object tree = toTree(document.getDocumentElement());
+            return StructuredRecords.toRecordSource(tree, fileName);
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new RecordFileParseException("Failed to parse XML file: " + fileName, e);
+        } catch (IOException e) {
+            throw new RecordFileParseException("Failed to read XML file: " + fileName, e);
+        }
+    }
+
+    private DocumentBuilderFactory secureDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory;
+    }
+
+    /** Converts an element into a scalar (text-only element) or a map of attributes and children. */
+    private Object toTree(Element element) {
+        List<Element> children = childElements(element);
+        if (children.isEmpty() && element.getAttributes().getLength() == 0) {
+            return element.getTextContent().trim();
+        }
+
+        Map<String, Object> node = new LinkedHashMap<>();
+        for (int i = 0; i < element.getAttributes().getLength(); i++) {
+            Node attribute = element.getAttributes().item(i);
+            node.put(attribute.getNodeName(), attribute.getNodeValue());
+        }
+        if (children.isEmpty()) {
+            node.put("value", element.getTextContent().trim());
+            return node;
+        }
+
+        Map<String, List<Element>> byTag = new LinkedHashMap<>();
+        for (Element child : children) {
+            byTag.computeIfAbsent(child.getTagName(), tag -> new ArrayList<>()).add(child);
+        }
+        for (Map.Entry<String, List<Element>> entry : byTag.entrySet()) {
+            if (entry.getValue().size() == 1) {
+                node.put(entry.getKey(), toTree(entry.getValue().getFirst()));
+            } else {
+                List<Object> values = new ArrayList<>(entry.getValue().size());
+                for (Element repeated : entry.getValue()) {
+                    values.add(toTree(repeated));
+                }
+                node.put(entry.getKey(), values);
+            }
+        }
+        return node;
+    }
+
+    private List<Element> childElements(Element element) {
+        NodeList childNodes = element.getChildNodes();
+        List<Element> children = new ArrayList<>();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            if (childNodes.item(i) instanceof Element child) {
+                children.add(child);
+            }
+        }
+        return children;
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/YamlRecordFileParser.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/parser/YamlRecordFileParser.java
@@ -1,0 +1,41 @@
+package com.positivity.bulkloader.internal.parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.error.YAMLException;
+
+/**
+ * Structure-discovering parser for YAML files: records are taken from the root sequence, or from
+ * the largest sequence of mappings found anywhere in the document. Uses SnakeYAML's safe
+ * constructor so uploaded files cannot instantiate arbitrary types.
+ */
+@Component
+public class YamlRecordFileParser implements RecordFileParser {
+
+    private static final Set<String> EXTENSIONS = Set.of("yaml", "yml");
+
+    @Override
+    public boolean supports(@NonNull String fileName) {
+        return EXTENSIONS.contains(FileNames.extension(fileName));
+    }
+
+    @Override
+    @NonNull
+    public RecordSource open(@NonNull InputStream content, @NonNull String fileName) {
+        try (content) {
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+            Object tree = yaml.load(content);
+            return StructuredRecords.toRecordSource(tree, fileName);
+        } catch (YAMLException e) {
+            throw new RecordFileParseException("Failed to parse YAML file: " + fileName, e);
+        } catch (IOException e) {
+            throw new RecordFileParseException("Failed to read YAML file: " + fileName, e);
+        }
+    }
+}

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/ColumnMappingServiceImpl.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/ColumnMappingServiceImpl.java
@@ -29,6 +29,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +43,7 @@ public class ColumnMappingServiceImpl implements ColumnMappingService {
     private final ContentDetectionService contentDetectionService;
     private final FileStorageService fileStorageService;
     private final RecordFileParserRegistry recordFileParserRegistry;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
     @Transactional(readOnly = true)
@@ -107,8 +109,9 @@ public class ColumnMappingServiceImpl implements ColumnMappingService {
         return effective;
     }
 
+    // Deliberately not @Transactional: file parsing can be slow and must not hold a DB
+    // connection. Only the suggestion persistence below runs in a transaction.
     @Override
-    @Transactional
     @Nullable
     public ContentDetectionResult detectUploadedFile(
             @NonNull UUID jobId, @NonNull String operatorId, @NonNull String storagePath, @NonNull String fileName) {
@@ -126,7 +129,7 @@ public class ColumnMappingServiceImpl implements ColumnMappingService {
                         .toList());
             }
         } catch (RuntimeException e) {
-            log.warn("Content detection skipped for job {} file {}: {}", jobId, fileName, e.getMessage());
+            log.warn("Content detection skipped for job {} file {}", jobId, fileName, e);
             return null;
         }
 
@@ -142,11 +145,17 @@ public class ColumnMappingServiceImpl implements ColumnMappingService {
         Map<String, String> suggestions = contentDetectionService.suggestMappings(headers, mappingDomain);
         result.setSuggestedColumnMappings(suggestions);
 
+        transactionTemplate.executeWithoutResult(_ -> persistSuggestions(jobId, result, suggestions));
+        return result;
+    }
+
+    private void persistSuggestions(
+            @NonNull UUID jobId, @NonNull ContentDetectionResult result, @NonNull Map<String, String> suggestions) {
         boolean hasUserApprovedMappings = mappingRepository.findByJobId(jobId).stream()
                 .anyMatch(mapping -> Boolean.TRUE.equals(mapping.getOverriddenByUser()));
         if (hasUserApprovedMappings) {
             log.info("Keeping user-approved column mappings for job {}; suggestions not persisted", jobId);
-            return result;
+            return;
         }
 
         mappingRepository.deleteByJobId(jobId);
@@ -165,7 +174,6 @@ public class ColumnMappingServiceImpl implements ColumnMappingService {
                 result.getConfidence(),
                 jobId,
                 suggestions.size());
-        return result;
     }
 
     private ColumnMappingResponse toResponse(@NonNull BulkLoadColumnMapping mapping) {

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/ColumnMappingServiceImpl.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/ColumnMappingServiceImpl.java
@@ -3,18 +3,30 @@ package com.positivity.bulkloader.internal.service;
 import com.positivity.bulkloader.internal.dto.ColumnMappingApproveRequest;
 import com.positivity.bulkloader.internal.dto.ColumnMappingResponse;
 import com.positivity.bulkloader.internal.dto.ColumnMappingUpdateRequest;
+import com.positivity.bulkloader.internal.dto.ContentDetectionResult;
 import com.positivity.bulkloader.internal.entity.BulkLoadColumnMapping;
+import com.positivity.bulkloader.internal.entity.BulkLoadJob;
+import com.positivity.bulkloader.internal.enums.DomainType;
 import com.positivity.bulkloader.internal.exception.JobOwnershipViolationException;
+import com.positivity.bulkloader.internal.parser.RecordFileParserRegistry;
+import com.positivity.bulkloader.internal.parser.RecordSource;
 import com.positivity.bulkloader.internal.repository.BulkLoadColumnMappingRepository;
 import com.positivity.bulkloader.internal.repository.BulkLoadJobRepository;
 import com.positivity.bulkloader.service.ColumnMappingService;
+import com.positivity.bulkloader.service.ContentDetectionService;
+import com.positivity.bulkloader.service.FileStorageService;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,8 +35,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ColumnMappingServiceImpl implements ColumnMappingService {
 
+    private static final int SAMPLE_ROW_LIMIT = 20;
+
     private final BulkLoadColumnMappingRepository mappingRepository;
     private final BulkLoadJobRepository jobRepository;
+    private final ContentDetectionService contentDetectionService;
+    private final FileStorageService fileStorageService;
+    private final RecordFileParserRegistry recordFileParserRegistry;
 
     @Override
     @Transactional(readOnly = true)
@@ -57,6 +74,100 @@ public class ColumnMappingServiceImpl implements ColumnMappingService {
         return saved.stream().map(this::toResponse).toList();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    @NonNull
+    public Map<String, String> resolveEffectiveMappings(
+            @Nullable UUID jobId, @NonNull List<String> columnHeaders, @NonNull DomainType domainType) {
+        Map<String, String> stored = new LinkedHashMap<>();
+        if (jobId != null) {
+            for (BulkLoadColumnMapping mapping : mappingRepository.findByJobId(jobId)) {
+                stored.putIfAbsent(mapping.getSourceColumn(), mapping.getTargetField());
+            }
+        }
+        Map<String, String> suggested = contentDetectionService.suggestMappings(columnHeaders, domainType);
+
+        Map<String, String> effective = new LinkedHashMap<>();
+        Set<String> claimedTargets = new HashSet<>();
+        for (String header : columnHeaders) {
+            String target = stored.get(header);
+            if (target != null && claimedTargets.add(target)) {
+                effective.put(header, target);
+            }
+        }
+        for (String header : columnHeaders) {
+            if (effective.containsKey(header)) {
+                continue;
+            }
+            String target = suggested.get(header);
+            if (target != null && claimedTargets.add(target)) {
+                effective.put(header, target);
+            }
+        }
+        return effective;
+    }
+
+    @Override
+    @Transactional
+    @Nullable
+    public ContentDetectionResult detectUploadedFile(
+            @NonNull UUID jobId, @NonNull String operatorId, @NonNull String storagePath, @NonNull String fileName) {
+        BulkLoadJob job = verifyOwnership(jobId, operatorId);
+
+        List<String> headers;
+        List<List<String>> sampleRows = new ArrayList<>();
+        try (RecordSource source = recordFileParserRegistry.open(fileStorageService.retrieve(storagePath), fileName)) {
+            headers = source.headers();
+            Map<String, String> row;
+            while (sampleRows.size() < SAMPLE_ROW_LIMIT && (row = source.nextRecord()) != null) {
+                Map<String, String> currentRow = row;
+                sampleRows.add(headers.stream()
+                        .map(header -> currentRow.getOrDefault(header, ""))
+                        .toList());
+            }
+        } catch (RuntimeException e) {
+            log.warn("Content detection skipped for job {} file {}: {}", jobId, fileName, e.getMessage());
+            return null;
+        }
+
+        ContentDetectionResult result = contentDetectionService.detect(headers, sampleRows);
+        DomainType mappingDomain = job.getDomainType() != null ? job.getDomainType() : result.getDetectedDomain();
+        if (job.getDomainType() != null && result.getDetectedDomain() != job.getDomainType()) {
+            log.warn(
+                    "Detected domain {} differs from job domain {} for job {}; suggesting mappings for the job domain",
+                    result.getDetectedDomain(),
+                    job.getDomainType(),
+                    jobId);
+        }
+        Map<String, String> suggestions = contentDetectionService.suggestMappings(headers, mappingDomain);
+        result.setSuggestedColumnMappings(suggestions);
+
+        boolean hasUserApprovedMappings = mappingRepository.findByJobId(jobId).stream()
+                .anyMatch(mapping -> Boolean.TRUE.equals(mapping.getOverriddenByUser()));
+        if (hasUserApprovedMappings) {
+            log.info("Keeping user-approved column mappings for job {}; suggestions not persisted", jobId);
+            return result;
+        }
+
+        mappingRepository.deleteByJobId(jobId);
+        for (Map.Entry<String, String> suggestion : suggestions.entrySet()) {
+            BulkLoadColumnMapping mapping = new BulkLoadColumnMapping();
+            mapping.setJobId(jobId);
+            mapping.setSourceColumn(suggestion.getKey());
+            mapping.setTargetField(suggestion.getValue());
+            mapping.setConfidence(result.getConfidence());
+            mapping.setOverriddenByUser(false);
+            mappingRepository.save(mapping);
+        }
+        log.info(
+                "Detected {} with confidence {} for job {}; persisted {} suggested column mappings",
+                result.getDetectedDomain(),
+                result.getConfidence(),
+                jobId,
+                suggestions.size());
+        return result;
+    }
+
     private ColumnMappingResponse toResponse(@NonNull BulkLoadColumnMapping mapping) {
         return ColumnMappingResponse.builder()
                 .id(mapping.getId())
@@ -69,12 +180,13 @@ public class ColumnMappingServiceImpl implements ColumnMappingService {
                 .build();
     }
 
-    private void verifyOwnership(@NonNull UUID jobId, @NonNull String operatorId) {
-        var job = jobRepository
+    private BulkLoadJob verifyOwnership(@NonNull UUID jobId, @NonNull String operatorId) {
+        BulkLoadJob job = jobRepository
                 .findById(jobId)
                 .orElseThrow(() -> new NoSuchElementException("BulkLoadJob not found: " + jobId));
         if (!job.getOperatorId().equals(operatorId)) {
             throw new JobOwnershipViolationException(jobId.toString());
         }
+        return job;
     }
 }

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/RuleBasedContentDetectionServiceImpl.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/RuleBasedContentDetectionServiceImpl.java
@@ -4,7 +4,7 @@ import com.positivity.bulkloader.internal.dto.ContentDetectionResult;
 import com.positivity.bulkloader.internal.enums.DomainType;
 import com.positivity.bulkloader.service.ContentDetectionService;
 import java.util.EnumMap;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -31,7 +31,10 @@ public class RuleBasedContentDetectionServiceImpl implements ContentDetectionSer
                     PRICE_FIELD,
                     "name",
                     "manufacturer",
+                    "brand",
+                    "part_no",
                     "part_number",
+                    "uom",
                     "weight"),
             DomainType.INVENTORY_STOCK_COUNT,
             Set.of("sku", QUANTITY_FIELD, "qty", "stock", "on_hand", "location_code", "bin", "unit_cost", "warehouse"),
@@ -58,7 +61,7 @@ public class RuleBasedContentDetectionServiceImpl implements ContentDetectionSer
             }
             int score = 0;
             for (String header : columnHeaders) {
-                String normalized = header.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "_");
+                String normalized = normalize(header);
                 if (normalized.isEmpty()) {
                     continue;
                 }
@@ -75,7 +78,7 @@ public class RuleBasedContentDetectionServiceImpl implements ContentDetectionSer
                 .orElse(DomainType.CATALOG_PRODUCT);
         int maxScore = scores.getOrDefault(best, 0);
         double confidence = columnHeaders.isEmpty() ? 0.0 : (double) maxScore / columnHeaders.size();
-        Map<String, String> suggestedMappings = buildSuggestedMappings(columnHeaders, best);
+        Map<String, String> suggestedMappings = suggestMappings(columnHeaders, best);
 
         log.debug("Content detection: domain={} confidence={} headers={}", best, confidence, columnHeaders);
         return ContentDetectionResult.builder()
@@ -86,28 +89,57 @@ public class RuleBasedContentDetectionServiceImpl implements ContentDetectionSer
                 .build();
     }
 
-    private Map<String, String> buildSuggestedMappings(List<String> headers, DomainType domain) {
-        Map<String, String> mappings = new HashMap<>();
-        for (String header : headers) {
-            String normalized = header.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "_");
-            String target = inferTargetField(normalized, domain);
-            if (target != null) {
+    @Override
+    @NonNull
+    public Map<String, String> suggestMappings(@NonNull List<String> columnHeaders, @NonNull DomainType domainType) {
+        Map<String, String> mappings = new LinkedHashMap<>();
+        for (String header : columnHeaders) {
+            String target = inferTargetField(normalize(header), domainType);
+            if (target != null && !mappings.containsValue(target)) {
                 mappings.put(header, target);
             }
         }
         return mappings;
     }
 
+    private String normalize(String header) {
+        return header.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "_")
+                .replaceAll("^_+", "")
+                .replaceAll("_+$", "");
+    }
+
     private String inferTargetField(String normalized, DomainType domain) {
         return switch (domain) {
             case CATALOG_PRODUCT ->
                 switch (normalized) {
-                    case "sku", "item_number", "item_no", "part_no" -> "sku";
-                    case "upc", "barcode", "ean" -> "upc";
-                    case "name", "item_name", "product_name", "description" -> "name";
-                    case PRICE_FIELD, "list_price", "retail_price" -> PRICE_FIELD;
-                    case "category", "category_name" -> "categoryName";
-                    case "subcategory", "subcategory_name" -> "subcategoryName";
+                    case "sku",
+                            "item_number",
+                            "item_no",
+                            "item_sku",
+                            "item_code",
+                            "part_no",
+                            "part_number",
+                            "product_code",
+                            "sku_number",
+                            "supplier_sku",
+                            "vendor_sku" -> "sku";
+                    case "upc", "upc_code", "barcode", "ean", "gtin" -> "upc";
+                    case "name", "item_name", "product_name", "product", "product_title", "title" -> "name";
+                    case "description", "desc", "product_description", "long_description", "item_description" ->
+                        "description";
+                    case PRICE_FIELD, "list_price", "retail_price", "unit_price", "msrp", "selling_price" ->
+                        PRICE_FIELD;
+                    case "category", "category_name", "categoryname", "product_category" -> "categoryName";
+                    case "subcategory", "sub_category", "subcategory_name", "subcategoryname" -> "subcategoryName";
+                    case "mpn",
+                            "manufacturer_part_no",
+                            "manufacturer_part_number",
+                            "mfr_part_no",
+                            "mfr_part_number",
+                            "mfg_part_no",
+                            "mfg_part_number" -> "mpn";
+                    case "uom", "unit_of_measure", "unitofmeasure", "sell_uom" -> "unitOfMeasure";
                     default -> null;
                 };
             case INVENTORY_STOCK_COUNT ->

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/service/ColumnMappingService.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/service/ColumnMappingService.java
@@ -2,9 +2,13 @@ package com.positivity.bulkloader.service;
 
 import com.positivity.bulkloader.internal.dto.ColumnMappingApproveRequest;
 import com.positivity.bulkloader.internal.dto.ColumnMappingResponse;
+import com.positivity.bulkloader.internal.dto.ContentDetectionResult;
+import com.positivity.bulkloader.internal.enums.DomainType;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public interface ColumnMappingService {
 
@@ -14,4 +18,24 @@ public interface ColumnMappingService {
     @NonNull
     List<ColumnMappingResponse> approveMappings(
             @NonNull UUID jobId, @NonNull String operatorId, @NonNull ColumnMappingApproveRequest request);
+
+    /**
+     * Resolves the source-column-to-target-field mappings to use when processing a file with the
+     * given headers: mappings persisted for the job (user-approved or previously suggested) take
+     * priority; headers not covered fall back to rule-based inference for the domain. Each target
+     * field is claimed by at most one source column.
+     */
+    @NonNull
+    Map<String, String> resolveEffectiveMappings(
+            @Nullable UUID jobId, @NonNull List<String> columnHeaders, @NonNull DomainType domainType);
+
+    /**
+     * Parses the uploaded file's structure (headers or document shape), runs content detection,
+     * and persists suggested column mappings for the job unless the operator has already approved
+     * mappings. Returns {@code null} when the file cannot be parsed — detection is best-effort and
+     * must never fail the upload.
+     */
+    @Nullable
+    ContentDetectionResult detectUploadedFile(
+            @NonNull UUID jobId, @NonNull String operatorId, @NonNull String storagePath, @NonNull String fileName);
 }

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/service/ContentDetectionService.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/service/ContentDetectionService.java
@@ -1,10 +1,20 @@
 package com.positivity.bulkloader.service;
 
 import com.positivity.bulkloader.internal.dto.ContentDetectionResult;
+import com.positivity.bulkloader.internal.enums.DomainType;
 import java.util.List;
+import java.util.Map;
 import org.jspecify.annotations.NonNull;
 
 public interface ContentDetectionService {
 
     ContentDetectionResult detect(@NonNull List<String> columnHeaders, @NonNull List<List<String>> sampleRows);
+
+    /**
+     * Suggests source-column-to-target-field mappings for the given headers and domain. Headers
+     * that cannot be inferred are omitted; each target field is claimed by at most one header
+     * (first match wins).
+     */
+    @NonNull
+    Map<String, String> suggestMappings(@NonNull List<String> columnHeaders, @NonNull DomainType domainType);
 }

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/config/BatchConfigurationWriterTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/config/BatchConfigurationWriterTest.java
@@ -114,6 +114,8 @@ class BatchConfigurationWriterTest {
                 vehicleLoaderStrategy,
                 vehicleFitmentLoaderStrategy,
                 bulkLoadAuthorizationContext,
+                null,
+                null,
                 null);
     }
 

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/FileUploadControllerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/FileUploadControllerTest.java
@@ -15,6 +15,7 @@ import com.positivity.bulkloader.internal.dto.BulkLoadJobResponse;
 import com.positivity.bulkloader.internal.enums.DomainType;
 import com.positivity.bulkloader.internal.enums.JobStatus;
 import com.positivity.bulkloader.service.BulkLoadJobService;
+import com.positivity.bulkloader.service.ColumnMappingService;
 import com.positivity.bulkloader.service.FileStorageService;
 import com.positivity.security.common.GatewaySecurityConstants;
 import java.util.UUID;
@@ -46,6 +47,9 @@ class FileUploadControllerTest {
     @MockitoBean
     FileStorageService fileStorageService;
 
+    @MockitoBean
+    ColumnMappingService columnMappingService;
+
     // ─── POST /v1/bulk-jobs/{jobId}/upload ───────────────────────────────────
 
     @Test
@@ -66,6 +70,8 @@ class FileUploadControllerTest {
                 .andExpect(jsonPath("$.fileName").value("products.csv"));
 
         verify(bulkLoadJobService).markUploadStored(JOB_ID, "test-operator", "/uploads/products.csv");
+        verify(columnMappingService)
+                .detectUploadedFile(JOB_ID, "test-operator", "/uploads/products.csv", "products.csv");
     }
 
     @Test

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/FileUploadProcessEndToEndTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/FileUploadProcessEndToEndTest.java
@@ -15,6 +15,7 @@ import com.positivity.bulkingest.BulkIngestRequest;
 import com.positivity.bulkloader.PosBlkLoaderApplication;
 import com.positivity.bulkloader.internal.config.BulkLoaderEventTypeInitializer;
 import com.positivity.bulkloader.internal.config.PermissionRegistration;
+import com.positivity.bulkloader.internal.domain.CatalogProductRecord;
 import com.positivity.bulkloader.internal.entity.BulkLoadJob;
 import com.positivity.bulkloader.internal.enums.DomainType;
 import com.positivity.bulkloader.internal.enums.JobStatus;
@@ -22,9 +23,13 @@ import com.positivity.bulkloader.internal.repository.BulkLoadJobRepository;
 import com.positivity.bulkloader.internal.service.BulkLoadAuthorizationContext;
 import com.positivity.security.common.GatewaySecurityConstants;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -160,5 +165,124 @@ class FileUploadProcessEndToEndTest {
         assertThat(request.getOperatorId()).isEqualTo("test-operator");
         assertThat(request.getRecords()).hasSize(1);
         assertThat(bulkLoadAuthorizationContext.getAuthorizationHeader()).isNull();
+    }
+
+    @Test
+    @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+    void startProcessing_vendorFormatCsv_discoversColumnsByHeader() throws Exception {
+        // Vendor price-file layout: different header names, different column order, extra columns.
+        String relativeStoragePath = JOB_ID + "/vendor-parts-catalog.csv";
+        Files.createDirectories(STORAGE_ROOT.resolve(JOB_ID.toString()));
+        Files.writeString(STORAGE_ROOT.resolve(relativeStoragePath), """
+                vendor_id,vendor_name,supplier_sku,manufacturer_part_no,upc,category,subcategory,brand,product_name,description,uom,list_price,dealer_cost,currency
+                VEND-MIC-001,Michelin North America,MIC-000001,3A3ZMF8MD,822676000001,Wheels,Steel Wheel,Maxion,Maxion Steel Wheel 15x6,Steel Wheel test item,EA,242.81,174.89,USD
+                VEND-NAT-005,National Tire Supply,NAT-000004,IIUC039TE,896474000004,TPMS,Valve Stem,Dill,Dill Valve Stem Programmable,Programmable valve stem,KIT,96.26,62.07,USD
+                """);
+
+        saveJob("vendor-parts-catalog.csv", relativeStoragePath);
+
+        mockMvc.perform(post("/v1/bulk-jobs/{jobId}/process", JOB_ID)
+                        .header(GatewaySecurityConstants.HEADER_TOKEN, "token-e2e"))
+                .andExpect(status().isOk());
+
+        BulkIngestRequest<CatalogProductRecord> request = capturedCatalogRequest();
+        assertThat(request.getRecords()).hasSize(2);
+        CatalogProductRecord first = request.getRecords().get(0);
+        assertThat(first.getSku()).isEqualTo("MIC-000001");
+        assertThat(first.getMpn()).isEqualTo("3A3ZMF8MD");
+        assertThat(first.getUpc()).isEqualTo("822676000001");
+        assertThat(first.getName()).isEqualTo("Maxion Steel Wheel 15x6");
+        assertThat(first.getDescription()).isEqualTo("Steel Wheel test item");
+        assertThat(first.getCategoryName()).isEqualTo("Wheels");
+        assertThat(first.getSubcategoryName()).isEqualTo("Steel Wheel");
+        assertThat(first.getUnitOfMeasure()).isEqualTo("EA");
+        assertThat(first.getPrice()).isEqualByComparingTo(new BigDecimal("242.81"));
+    }
+
+    @Test
+    @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+    void startProcessing_xlsxWorkbook_selectsDataSheetAndDiscoversColumns() throws Exception {
+        String relativeStoragePath = JOB_ID + "/vendor-parts-catalog.xlsx";
+        Files.createDirectories(STORAGE_ROOT.resolve(JOB_ID.toString()));
+        try (XSSFWorkbook workbook = new XSSFWorkbook();
+                var out = Files.newOutputStream(STORAGE_ROOT.resolve(relativeStoragePath))) {
+            Sheet importMap = workbook.createSheet("Import_Map");
+            writeRow(importMap, 0, "Target POS Field", "Source Column");
+            writeRow(importMap, 1, "SKU", "supplier_sku");
+
+            Sheet catalog = workbook.createSheet("Catalog");
+            writeRow(catalog, 0, "supplier_sku", "product_name", "category", "uom", "list_price");
+            writeRow(catalog, 1, "MIC-000001", "Maxion Steel Wheel 15x6", "Wheels", "EA", "242.81");
+            writeRow(catalog, 2, "NAT-000004", "Dill Valve Stem", "TPMS", "KIT", "96.26");
+            workbook.write(out);
+        }
+
+        saveJob("vendor-parts-catalog.xlsx", relativeStoragePath);
+
+        mockMvc.perform(post("/v1/bulk-jobs/{jobId}/process", JOB_ID)
+                        .header(GatewaySecurityConstants.HEADER_TOKEN, "token-e2e"))
+                .andExpect(status().isOk());
+
+        BulkIngestRequest<CatalogProductRecord> request = capturedCatalogRequest();
+        assertThat(request.getRecords()).hasSize(2);
+        assertThat(request.getRecords().get(0).getSku()).isEqualTo("MIC-000001");
+        assertThat(request.getRecords().get(1).getName()).isEqualTo("Dill Valve Stem");
+    }
+
+    @Test
+    @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+    void startProcessing_jsonFile_discoversRecordsByStructure() throws Exception {
+        String relativeStoragePath = JOB_ID + "/vendor-parts-catalog.json";
+        Files.createDirectories(STORAGE_ROOT.resolve(JOB_ID.toString()));
+        Files.writeString(STORAGE_ROOT.resolve(relativeStoragePath), """
+                {
+                  "vendor": "Michelin North America",
+                  "items": [
+                    {"supplier_sku": "MIC-000001", "product_name": "Maxion Steel Wheel 15x6", "uom": "EA", "list_price": 242.81},
+                    {"supplier_sku": "NAT-000004", "product_name": "Dill Valve Stem", "uom": "KIT", "list_price": 96.26}
+                  ]
+                }
+                """);
+
+        saveJob("vendor-parts-catalog.json", relativeStoragePath);
+
+        mockMvc.perform(post("/v1/bulk-jobs/{jobId}/process", JOB_ID)
+                        .header(GatewaySecurityConstants.HEADER_TOKEN, "token-e2e"))
+                .andExpect(status().isOk());
+
+        BulkIngestRequest<CatalogProductRecord> request = capturedCatalogRequest();
+        assertThat(request.getRecords()).hasSize(2);
+        CatalogProductRecord first = request.getRecords().get(0);
+        assertThat(first.getSku()).isEqualTo("MIC-000001");
+        assertThat(first.getUnitOfMeasure()).isEqualTo("EA");
+        assertThat(first.getPrice()).isEqualByComparingTo(new BigDecimal("242.81"));
+    }
+
+    private void saveJob(String fileName, String relativeStoragePath) {
+        BulkLoadJob job = new BulkLoadJob();
+        job.setId(JOB_ID);
+        job.setOperatorId("test-operator");
+        job.setLocationId(LOCATION_ID);
+        job.setFileName(fileName);
+        job.setOriginalFilePath(relativeStoragePath);
+        job.setDomainType(DomainType.CATALOG_PRODUCT);
+        job.setStatus(JobStatus.UPLOADING);
+        bulkLoadJobRepository.saveAndFlush(job);
+    }
+
+    @SuppressWarnings("unchecked")
+    private BulkIngestRequest<CatalogProductRecord> capturedCatalogRequest() {
+        verify(requestBodyUriSpec, timeout(2000)).uri("/v1/catalog/bulk-ingest");
+        ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(requestBodySpec, timeout(2000)).body(bodyCaptor.capture());
+        assertThat(bodyCaptor.getValue()).isInstanceOf(BulkIngestRequest.class);
+        return (BulkIngestRequest<CatalogProductRecord>) bodyCaptor.getValue();
+    }
+
+    private void writeRow(Sheet sheet, int rowIndex, String... values) {
+        Row row = sheet.createRow(rowIndex);
+        for (int i = 0; i < values.length; i++) {
+            row.createCell(i).setCellValue(values[i]);
+        }
     }
 }

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/domain/CatalogLoaderStrategyTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/domain/CatalogLoaderStrategyTest.java
@@ -1,0 +1,51 @@
+package com.positivity.bulkloader.internal.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class CatalogLoaderStrategyTest {
+
+    private final CatalogLoaderStrategy strategy = new CatalogLoaderStrategy();
+
+    @Test
+    void mapRow_mapsAllCanonicalFields() {
+        CatalogProductRecord record = strategy.mapRow(Map.of(
+                "sku", "MIC-000001",
+                "upc", "822676000001",
+                "name", "Maxion Steel Wheel",
+                "description", "Steel Wheel test item",
+                "categoryName", "Wheels",
+                "subcategoryName", "Steel Wheel",
+                "price", "$242.81",
+                "mpn", "3A3ZMF8MD",
+                "unitOfMeasure", "EA"));
+
+        assertThat(record.getSku()).isEqualTo("MIC-000001");
+        assertThat(record.getUpc()).isEqualTo("822676000001");
+        assertThat(record.getName()).isEqualTo("Maxion Steel Wheel");
+        assertThat(record.getDescription()).isEqualTo("Steel Wheel test item");
+        assertThat(record.getCategoryName()).isEqualTo("Wheels");
+        assertThat(record.getSubcategoryName()).isEqualTo("Steel Wheel");
+        assertThat(record.getPrice()).isEqualByComparingTo(new BigDecimal("242.81"));
+        assertThat(record.getMpn()).isEqualTo("3A3ZMF8MD");
+        assertThat(record.getUnitOfMeasure()).isEqualTo("EA");
+    }
+
+    @Test
+    void mapRow_blankName_fallsBackToDescription() {
+        CatalogProductRecord record = strategy.mapRow(Map.of("sku", "A-1", "name", " ", "description", "Widget"));
+
+        assertThat(record.getName()).isEqualTo("Widget");
+    }
+
+    @Test
+    void validate_missingSkuAndName_reportsErrors() {
+        CatalogProductRecord record = strategy.mapRow(Map.of("description", ""));
+
+        assertThat(strategy.validate(record)).containsExactly("sku is required", "name is required");
+    }
+}

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/DelimitedRecordFileParserTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/DelimitedRecordFileParserTest.java
@@ -1,0 +1,130 @@
+package com.positivity.bulkloader.internal.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class DelimitedRecordFileParserTest {
+
+    private final DelimitedRecordFileParser parser = new DelimitedRecordFileParser();
+
+    @Test
+    void supports_delimitedExtensions() {
+        assertThat(parser.supports("catalog.csv")).isTrue();
+        assertThat(parser.supports("catalog.TSV")).isTrue();
+        assertThat(parser.supports("catalog.txt")).isTrue();
+        assertThat(parser.supports("catalog.psv")).isTrue();
+        assertThat(parser.supports("catalog.xlsx")).isFalse();
+        assertThat(parser.supports("catalog")).isFalse();
+    }
+
+    @Test
+    void open_vendorStyleHeaders_readsRecordsByHeaderName() {
+        String csv = """
+                vendor_id,supplier_sku,manufacturer_part_no,upc,category,subcategory,product_name,description,uom,list_price
+                VEND-MIC-001,MIC-000001,3A3ZMF8MD,822676000001,Wheels,Steel Wheel,Maxion Steel Wheel 15x6,Steel Wheel test item,EA,242.81
+                VEND-NAT-005,NAT-000004,IIUC039TE,896474000004,TPMS,Valve Stem,Dill Valve Stem,Programmable valve stem,KIT,96.26
+                """;
+
+        try (RecordSource source = parser.open(stream(csv), "vendor_catalog.csv")) {
+            assertThat(source.headers())
+                    .containsExactly(
+                            "vendor_id",
+                            "supplier_sku",
+                            "manufacturer_part_no",
+                            "upc",
+                            "category",
+                            "subcategory",
+                            "product_name",
+                            "description",
+                            "uom",
+                            "list_price");
+            Map<String, String> first = source.nextRecord();
+            assertThat(first)
+                    .containsEntry("supplier_sku", "MIC-000001")
+                    .containsEntry("product_name", "Maxion Steel Wheel 15x6")
+                    .containsEntry("list_price", "242.81");
+            Map<String, String> second = source.nextRecord();
+            assertThat(second).containsEntry("supplier_sku", "NAT-000004");
+            assertThat(source.nextRecord()).isNull();
+        }
+    }
+
+    @Test
+    void open_sniffsPipeDelimiter() {
+        String psv = """
+                sku|name|price
+                ABC-1|Widget|9.99
+                """;
+
+        try (RecordSource source = parser.open(stream(psv), "catalog.psv")) {
+            assertThat(source.headers()).containsExactly("sku", "name", "price");
+            assertThat(source.nextRecord()).containsEntry("name", "Widget");
+        }
+    }
+
+    @Test
+    void open_sniffsTabDelimiter() {
+        String tsv = "sku\tname\tprice\nABC-1\tWidget\t9.99\n";
+
+        try (RecordSource source = parser.open(stream(tsv), "catalog.txt")) {
+            assertThat(source.headers()).containsExactly("sku", "name", "price");
+            assertThat(source.nextRecord()).containsEntry("price", "9.99");
+        }
+    }
+
+    @Test
+    void open_handlesQuotedValuesAndBlankRows() {
+        String csv = """
+                sku,name,description
+                ABC-1,"Widget, deluxe","Includes ""spare"" parts"
+
+                ABC-2,Gadget,Basic gadget
+                """;
+
+        try (RecordSource source = parser.open(stream(csv), "catalog.csv")) {
+            List<Map<String, String>> records = drain(source);
+            assertThat(records).hasSize(2);
+            assertThat(records.get(0))
+                    .containsEntry("name", "Widget, deluxe")
+                    .containsEntry("description", "Includes \"spare\" parts");
+        }
+    }
+
+    @Test
+    void open_stripsBomFromFirstHeader() {
+        String csv = "﻿sku,name\nABC-1,Widget\n";
+
+        try (RecordSource source = parser.open(stream(csv), "catalog.csv")) {
+            assertThat(source.headers()).containsExactly("sku", "name");
+        }
+    }
+
+    @Test
+    void open_emptyFile_throws() {
+        assertThatThrownBy(() -> parser.open(stream(""), "catalog.csv"))
+                .isInstanceOf(RecordFileParseException.class)
+                .hasMessageContaining("no header");
+    }
+
+    private InputStream stream(String content) {
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private List<Map<String, String>> drain(RecordSource source) {
+        List<Map<String, String>> records = new ArrayList<>();
+        Map<String, String> row;
+        while ((row = source.nextRecord()) != null) {
+            records.add(row);
+        }
+        return records;
+    }
+}

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/JsonRecordFileParserTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/JsonRecordFileParserTest.java
@@ -1,0 +1,97 @@
+package com.positivity.bulkloader.internal.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class JsonRecordFileParserTest {
+
+    private final JsonRecordFileParser parser = new JsonRecordFileParser();
+
+    @Test
+    void supports_jsonOnly() {
+        assertThat(parser.supports("catalog.json")).isTrue();
+        assertThat(parser.supports("catalog.yaml")).isFalse();
+    }
+
+    @Test
+    void open_rootArray_readsRecords() {
+        String json = """
+                [
+                  {"supplier_sku": "MIC-000001", "product_name": "Steel Wheel", "list_price": 242.81},
+                  {"supplier_sku": "NAT-000004", "product_name": "Valve Stem", "list_price": 96.26}
+                ]
+                """;
+
+        try (RecordSource source = parser.open(stream(json), "catalog.json")) {
+            assertThat(source.headers()).containsExactly("supplier_sku", "product_name", "list_price");
+            Map<String, String> first = source.nextRecord();
+            assertThat(first).containsEntry("supplier_sku", "MIC-000001").containsEntry("list_price", "242.81");
+            assertThat(source.nextRecord()).isNotNull();
+            assertThat(source.nextRecord()).isNull();
+        }
+    }
+
+    @Test
+    void open_nestedRecordArray_discoversRecordsAndFlattensObjects() {
+        String json = """
+                {
+                  "vendor": "Michelin North America",
+                  "generated": "2026-03-04",
+                  "catalog": {
+                    "items": [
+                      {
+                        "sku": "MIC-000001",
+                        "name": "Steel Wheel",
+                        "pricing": {"list": 242.81, "dealer": 174.89},
+                        "tags": ["wheels", "steel"]
+                      },
+                      {
+                        "sku": "NAT-000004",
+                        "name": "Valve Stem",
+                        "pricing": {"list": 96.26, "dealer": 62.07},
+                        "tags": ["tpms"]
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        try (RecordSource source = parser.open(stream(json), "catalog.json")) {
+            assertThat(source.headers()).containsExactly("sku", "name", "pricing.list", "pricing.dealer", "tags");
+            Map<String, String> first = source.nextRecord();
+            assertThat(first)
+                    .containsEntry("sku", "MIC-000001")
+                    .containsEntry("pricing.list", "242.81")
+                    .containsEntry("tags", "wheels; steel");
+        }
+    }
+
+    @Test
+    void open_noRecordList_treatsRootObjectAsSingleRecord() {
+        String json = """
+                {"sku": "MIC-000001", "name": "Steel Wheel"}
+                """;
+
+        try (RecordSource source = parser.open(stream(json), "catalog.json")) {
+            assertThat(source.nextRecord()).containsEntry("sku", "MIC-000001");
+            assertThat(source.nextRecord()).isNull();
+        }
+    }
+
+    @Test
+    void open_malformedJson_throws() {
+        assertThatThrownBy(() -> parser.open(stream("{not json"), "catalog.json"))
+                .isInstanceOf(RecordFileParseException.class);
+    }
+
+    private InputStream stream(String content) {
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/SpreadsheetRecordFileParserTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/SpreadsheetRecordFileParserTest.java
@@ -1,0 +1,102 @@
+package com.positivity.bulkloader.internal.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class SpreadsheetRecordFileParserTest {
+
+    private final SpreadsheetRecordFileParser parser = new SpreadsheetRecordFileParser();
+
+    @Test
+    void supports_spreadsheetExtensions() {
+        assertThat(parser.supports("catalog.xlsx")).isTrue();
+        assertThat(parser.supports("catalog.XLSX")).isTrue();
+        assertThat(parser.supports("catalog.xls")).isTrue();
+        assertThat(parser.supports("catalog.csv")).isFalse();
+    }
+
+    @Test
+    void open_multiSheetWorkbook_selectsSheetWithMostRecords() throws IOException {
+        byte[] workbook = vendorStyleWorkbook();
+
+        try (RecordSource source = parser.open(new ByteArrayInputStream(workbook), "vendor_catalog.xlsx")) {
+            assertThat(source.headers())
+                    .containsExactly("supplier_sku", "product_name", "category", "uom", "list_price");
+
+            Map<String, String> first = source.nextRecord();
+            assertThat(first)
+                    .containsEntry("supplier_sku", "MIC-000001")
+                    .containsEntry("product_name", "Maxion Steel Wheel 15x6")
+                    .containsEntry("uom", "EA");
+            // Numeric cells must render as displayed text, not scientific notation.
+            assertThat(first.get("list_price")).isEqualTo("242.81");
+
+            Map<String, String> second = source.nextRecord();
+            assertThat(second).containsEntry("supplier_sku", "NAT-000004");
+            Map<String, String> third = source.nextRecord();
+            assertThat(third).containsEntry("supplier_sku", "COO-000007");
+            assertThat(source.nextRecord()).isNull();
+        }
+    }
+
+    /**
+     * Mirrors the structure of the vendor example file: an instructional sheet first, the catalog
+     * data sheet second, and a summary sheet last — the parser must pick the data sheet.
+     */
+    private byte[] vendorStyleWorkbook() throws IOException {
+        try (XSSFWorkbook workbook = new XSSFWorkbook();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Sheet importMap = workbook.createSheet("Import_Map");
+            writeRow(importMap, 0, "Target POS Field", "Source Column");
+            writeRow(importMap, 1, "SKU", "supplier_sku");
+
+            Sheet catalog = workbook.createSheet("Catalog");
+            writeRow(catalog, 0, "supplier_sku", "product_name", "category", "uom", "list_price");
+            Row row1 = writeRow(catalog, 1, "MIC-000001", "Maxion Steel Wheel 15x6", "Wheels", "EA");
+            row1.createCell(4).setCellValue(242.81);
+            writeRow(catalog, 2, "NAT-000004", "Dill Valve Stem", "TPMS", "KIT", "96.26");
+            writeRow(catalog, 3, "COO-000007", "Cooper Transforce HT2", "Tires", "EA", "565.94");
+
+            Sheet summary = workbook.createSheet("Summary");
+            writeRow(summary, 0, "Metric", "Value");
+            writeRow(summary, 1, "Generated rows", "3");
+
+            workbook.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private Row writeRow(Sheet sheet, int rowIndex, String... values) {
+        Row row = sheet.createRow(rowIndex);
+        for (int i = 0; i < values.length; i++) {
+            row.createCell(i).setCellValue(values[i]);
+        }
+        return row;
+    }
+
+    @Test
+    void open_emptyWorkbook_throws() throws IOException {
+        byte[] bytes;
+        try (XSSFWorkbook workbook = new XSSFWorkbook();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            workbook.createSheet("Blank");
+            workbook.write(out);
+            bytes = out.toByteArray();
+        }
+        InputStream stream = new ByteArrayInputStream(bytes);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> parser.open(stream, "empty.xlsx"))
+                .isInstanceOf(RecordFileParseException.class)
+                .hasMessageContaining("no sheet with a header row");
+    }
+}

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/XmlRecordFileParserTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/XmlRecordFileParserTest.java
@@ -1,0 +1,76 @@
+package com.positivity.bulkloader.internal.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class XmlRecordFileParserTest {
+
+    private final XmlRecordFileParser parser = new XmlRecordFileParser();
+
+    @Test
+    void supports_xmlOnly() {
+        assertThat(parser.supports("catalog.xml")).isTrue();
+        assertThat(parser.supports("catalog.json")).isFalse();
+    }
+
+    @Test
+    void open_repeatedElements_readsRecordsWithAttributesAndNestedElements() {
+        String xml = """
+                <catalog vendor="Michelin North America">
+                  <generated>2026-03-04</generated>
+                  <items>
+                    <item id="1">
+                      <supplier_sku>MIC-000001</supplier_sku>
+                      <product_name>Maxion Steel Wheel</product_name>
+                      <pricing><list>242.81</list><dealer>174.89</dealer></pricing>
+                    </item>
+                    <item id="2">
+                      <supplier_sku>NAT-000004</supplier_sku>
+                      <product_name>Dill Valve Stem</product_name>
+                      <pricing><list>96.26</list><dealer>62.07</dealer></pricing>
+                    </item>
+                  </items>
+                </catalog>
+                """;
+
+        try (RecordSource source = parser.open(stream(xml), "catalog.xml")) {
+            assertThat(source.headers())
+                    .containsExactly("id", "supplier_sku", "product_name", "pricing.list", "pricing.dealer");
+            Map<String, String> first = source.nextRecord();
+            assertThat(first)
+                    .containsEntry("id", "1")
+                    .containsEntry("supplier_sku", "MIC-000001")
+                    .containsEntry("pricing.list", "242.81");
+            assertThat(source.nextRecord()).containsEntry("supplier_sku", "NAT-000004");
+            assertThat(source.nextRecord()).isNull();
+        }
+    }
+
+    @Test
+    void open_doctypeDeclaration_isRejected() {
+        String xml = """
+                <?xml version="1.0"?>
+                <!DOCTYPE catalog [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+                <catalog><item><sku>&xxe;</sku></item></catalog>
+                """;
+
+        assertThatThrownBy(() -> parser.open(stream(xml), "catalog.xml")).isInstanceOf(RecordFileParseException.class);
+    }
+
+    @Test
+    void open_malformedXml_throws() {
+        assertThatThrownBy(() -> parser.open(stream("<catalog><item>"), "catalog.xml"))
+                .isInstanceOf(RecordFileParseException.class);
+    }
+
+    private InputStream stream(String content) {
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/YamlRecordFileParserTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/parser/YamlRecordFileParserTest.java
@@ -1,0 +1,76 @@
+package com.positivity.bulkloader.internal.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class YamlRecordFileParserTest {
+
+    private final YamlRecordFileParser parser = new YamlRecordFileParser();
+
+    @Test
+    void supports_yamlExtensions() {
+        assertThat(parser.supports("catalog.yaml")).isTrue();
+        assertThat(parser.supports("catalog.yml")).isTrue();
+        assertThat(parser.supports("catalog.json")).isFalse();
+    }
+
+    @Test
+    void open_nestedSequence_readsRecords() {
+        String yaml = """
+                vendor: National Tire Supply
+                products:
+                  - supplier_sku: NAT-000004
+                    product_name: Dill Valve Stem
+                    uom: KIT
+                    list_price: 96.26
+                  - supplier_sku: MIC-000001
+                    product_name: Maxion Steel Wheel
+                    uom: EA
+                    list_price: 242.81
+                """;
+
+        try (RecordSource source = parser.open(stream(yaml), "catalog.yaml")) {
+            assertThat(source.headers()).containsExactly("supplier_sku", "product_name", "uom", "list_price");
+            Map<String, String> first = source.nextRecord();
+            assertThat(first)
+                    .containsEntry("supplier_sku", "NAT-000004")
+                    .containsEntry("uom", "KIT")
+                    .containsEntry("list_price", "96.26");
+            assertThat(source.nextRecord()).isNotNull();
+            assertThat(source.nextRecord()).isNull();
+        }
+    }
+
+    @Test
+    void open_rootSequence_readsRecords() {
+        String yaml = """
+                - sku: A-1
+                  name: Widget
+                - sku: A-2
+                  name: Gadget
+                """;
+
+        try (RecordSource source = parser.open(stream(yaml), "catalog.yml")) {
+            assertThat(source.nextRecord()).containsEntry("sku", "A-1");
+            assertThat(source.nextRecord()).containsEntry("name", "Gadget");
+            assertThat(source.nextRecord()).isNull();
+        }
+    }
+
+    @Test
+    void open_malformedYaml_throws() {
+        assertThatThrownBy(() -> parser.open(stream("items: [unclosed"), "catalog.yaml"))
+                .isInstanceOf(RecordFileParseException.class);
+    }
+
+    private InputStream stream(String content) {
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/ColumnMappingServiceImplTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/ColumnMappingServiceImplTest.java
@@ -12,9 +12,13 @@ import com.positivity.bulkloader.internal.entity.BulkLoadColumnMapping;
 import com.positivity.bulkloader.internal.entity.BulkLoadJob;
 import com.positivity.bulkloader.internal.enums.DomainType;
 import com.positivity.bulkloader.internal.enums.JobStatus;
+import com.positivity.bulkloader.internal.parser.RecordFileParserRegistry;
 import com.positivity.bulkloader.internal.repository.BulkLoadColumnMappingRepository;
 import com.positivity.bulkloader.internal.repository.BulkLoadJobRepository;
+import com.positivity.bulkloader.service.ContentDetectionService;
+import com.positivity.bulkloader.service.FileStorageService;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -36,6 +40,15 @@ class ColumnMappingServiceImplTest {
 
     @Mock
     BulkLoadJobRepository jobRepository;
+
+    @Mock
+    ContentDetectionService contentDetectionService;
+
+    @Mock
+    FileStorageService fileStorageService;
+
+    @Mock
+    RecordFileParserRegistry recordFileParserRegistry;
 
     @InjectMocks
     ColumnMappingServiceImpl service;
@@ -91,6 +104,49 @@ class ColumnMappingServiceImplTest {
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).getSourceColumn()).isEqualTo("name");
         assertThat(responses.get(0).getOverriddenByUser()).isTrue();
+    }
+
+    // ─── resolveEffectiveMappings ────────────────────────────────────────────
+
+    @Test
+    void resolveEffectiveMappings_storedMappingsTakePriorityOverSuggestions() {
+        List<String> headers = List.of("supplier_sku", "product_name", "custom_col");
+        BulkLoadColumnMapping stored = columnMapping(MAPPING_ID, JOB_ID, "custom_col", "sku");
+
+        when(mappingRepository.findByJobId(JOB_ID)).thenReturn(List.of(stored));
+        when(contentDetectionService.suggestMappings(headers, DomainType.CATALOG_PRODUCT))
+                .thenReturn(Map.of("supplier_sku", "sku", "product_name", "name"));
+
+        Map<String, String> effective = service.resolveEffectiveMappings(JOB_ID, headers, DomainType.CATALOG_PRODUCT);
+
+        // "sku" is claimed by the stored mapping; the suggested supplier_sku->sku must be dropped.
+        assertThat(effective).containsEntry("custom_col", "sku").containsEntry("product_name", "name");
+        assertThat(effective).doesNotContainKey("supplier_sku");
+    }
+
+    @Test
+    void resolveEffectiveMappings_withoutJobId_usesSuggestionsOnly() {
+        List<String> headers = List.of("supplier_sku", "product_name");
+        when(contentDetectionService.suggestMappings(headers, DomainType.CATALOG_PRODUCT))
+                .thenReturn(Map.of("supplier_sku", "sku", "product_name", "name"));
+
+        Map<String, String> effective = service.resolveEffectiveMappings(null, headers, DomainType.CATALOG_PRODUCT);
+
+        assertThat(effective).containsEntry("supplier_sku", "sku").containsEntry("product_name", "name");
+    }
+
+    @Test
+    void resolveEffectiveMappings_storedMappingForAbsentHeader_isIgnored() {
+        List<String> headers = List.of("supplier_sku");
+        BulkLoadColumnMapping stored = columnMapping(MAPPING_ID, JOB_ID, "old_column", "name");
+
+        when(mappingRepository.findByJobId(JOB_ID)).thenReturn(List.of(stored));
+        when(contentDetectionService.suggestMappings(headers, DomainType.CATALOG_PRODUCT))
+                .thenReturn(Map.of("supplier_sku", "sku"));
+
+        Map<String, String> effective = service.resolveEffectiveMappings(JOB_ID, headers, DomainType.CATALOG_PRODUCT);
+
+        assertThat(effective).containsOnly(Map.entry("supplier_sku", "sku"));
     }
 
     // ─── helpers ─────────────────────────────────────────────────────────────

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/ColumnMappingServiceImplTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/ColumnMappingServiceImplTest.java
@@ -50,6 +50,9 @@ class ColumnMappingServiceImplTest {
     @Mock
     RecordFileParserRegistry recordFileParserRegistry;
 
+    @Mock
+    org.springframework.transaction.support.TransactionTemplate transactionTemplate;
+
     @InjectMocks
     ColumnMappingServiceImpl service;
 

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/RuleBasedContentDetectionServiceImplTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/RuleBasedContentDetectionServiceImplTest.java
@@ -1,0 +1,124 @@
+package com.positivity.bulkloader.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.bulkloader.internal.dto.ContentDetectionResult;
+import com.positivity.bulkloader.internal.enums.DomainType;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S100")
+class RuleBasedContentDetectionServiceImplTest {
+
+    /** Full header row of the synthetic vendor parts catalog used as the alpha test file. */
+    private static final List<String> VENDOR_FILE_HEADERS = List.of(
+            "vendor_id",
+            "vendor_name",
+            "supplier_sku",
+            "manufacturer_part_no",
+            "upc",
+            "category",
+            "subcategory",
+            "brand",
+            "product_name",
+            "description",
+            "size_or_spec",
+            "load_speed_rating",
+            "position_or_fitment",
+            "uom",
+            "case_pack",
+            "min_order_qty",
+            "order_multiple",
+            "warehouse",
+            "stock_status",
+            "lead_time_days",
+            "list_price",
+            "dealer_cost",
+            "map_price",
+            "core_charge",
+            "fet",
+            "eco_fee",
+            "currency",
+            "tax_code",
+            "effective_date",
+            "expiration_date",
+            "discontinued",
+            "supersedes_sku",
+            "replaced_by_sku",
+            "weight_lb",
+            "length_in",
+            "width_in",
+            "height_in",
+            "country_of_origin",
+            "warranty_months",
+            "hazmat",
+            "notes");
+
+    private final RuleBasedContentDetectionServiceImpl service = new RuleBasedContentDetectionServiceImpl();
+
+    @Test
+    void detect_vendorFileHeaders_identifiesCatalogProduct() {
+        ContentDetectionResult result = service.detect(VENDOR_FILE_HEADERS, List.of());
+
+        assertThat(result.getDetectedDomain()).isEqualTo(DomainType.CATALOG_PRODUCT);
+        assertThat(result.getConfidence()).isPositive();
+        assertThat(result.getSuggestedColumnMappings()).containsEntry("supplier_sku", "sku");
+    }
+
+    @Test
+    void suggestMappings_vendorFileHeaders_mapsAllCatalogFields() {
+        Map<String, String> mappings = service.suggestMappings(VENDOR_FILE_HEADERS, DomainType.CATALOG_PRODUCT);
+
+        assertThat(mappings)
+                .containsEntry("supplier_sku", "sku")
+                .containsEntry("manufacturer_part_no", "mpn")
+                .containsEntry("upc", "upc")
+                .containsEntry("category", "categoryName")
+                .containsEntry("subcategory", "subcategoryName")
+                .containsEntry("product_name", "name")
+                .containsEntry("description", "description")
+                .containsEntry("uom", "unitOfMeasure")
+                .containsEntry("list_price", "price");
+        // Cost/fee columns that have no catalog target must not be mapped.
+        assertThat(mappings).doesNotContainKeys("dealer_cost", "map_price", "core_charge", "vendor_id", "notes");
+    }
+
+    @Test
+    void suggestMappings_legacyFixedFormatHeaders_stillMap() {
+        List<String> legacyHeaders =
+                List.of("sku", "upc", "name", "description", "categoryName", "subcategoryName", "price");
+
+        Map<String, String> mappings = service.suggestMappings(legacyHeaders, DomainType.CATALOG_PRODUCT);
+
+        assertThat(mappings)
+                .containsEntry("sku", "sku")
+                .containsEntry("upc", "upc")
+                .containsEntry("name", "name")
+                .containsEntry("description", "description")
+                .containsEntry("categoryName", "categoryName")
+                .containsEntry("subcategoryName", "subcategoryName")
+                .containsEntry("price", "price");
+    }
+
+    @Test
+    void suggestMappings_messyHeaderPunctuation_normalizes() {
+        Map<String, String> mappings = service.suggestMappings(
+                List.of("Supplier SKU", "Product Name", "List Price ($)", "Unit-of-Measure"),
+                DomainType.CATALOG_PRODUCT);
+
+        assertThat(mappings)
+                .containsEntry("Supplier SKU", "sku")
+                .containsEntry("Product Name", "name")
+                .containsEntry("List Price ($)", "price")
+                .containsEntry("Unit-of-Measure", "unitOfMeasure");
+    }
+
+    @Test
+    void suggestMappings_duplicateTargets_firstHeaderWins() {
+        Map<String, String> mappings =
+                service.suggestMappings(List.of("sku", "supplier_sku", "part_number"), DomainType.CATALOG_PRODUCT);
+
+        assertThat(mappings).containsExactly(Map.entry("sku", "sku"));
+    }
+}

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -3667,6 +3667,14 @@ components:
           type: number
           description: List price for the item
           example: 29.99
+        mpn:
+          type: string
+          description: Manufacturer part number; falls back to the SKU when absent
+          example: MPN-98765
+        unitOfMeasure:
+          type: string
+          description: Unit of measure for the item; defaults to EA when absent
+          example: EA
       required:
       - name
       - sku

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogBulkIngestController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogBulkIngestController.java
@@ -99,8 +99,9 @@ public class CatalogBulkIngestController extends AbstractBulkIngestController<Ca
         request.setUpc(ingestRecord.getUpc());
         request.setName(ingestRecord.getName());
         request.setDescription(firstNonBlank(ingestRecord.getDescription(), ingestRecord.getName()));
-        request.setUnitOfMeasure(DEFAULT_UNIT_OF_MEASURE);
-        request.setMpn(firstNonBlank(ingestRecord.getSku(), ingestRecord.getName()));
+        request.setUnitOfMeasure(firstNonBlank(ingestRecord.getUnitOfMeasure(), DEFAULT_UNIT_OF_MEASURE));
+        request.setMpn(
+                firstNonBlank(ingestRecord.getMpn(), firstNonBlank(ingestRecord.getSku(), ingestRecord.getName())));
         return request;
     }
 

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/CatalogBulkIngestRecord.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/CatalogBulkIngestRecord.java
@@ -40,4 +40,16 @@ public class CatalogBulkIngestRecord {
 
     @Schema(description = "List price for the item", example = "29.99", requiredMode = NOT_REQUIRED)
     private BigDecimal price;
+
+    @Schema(
+            description = "Manufacturer part number; falls back to the SKU when absent",
+            example = "MPN-98765",
+            requiredMode = NOT_REQUIRED)
+    private String mpn;
+
+    @Schema(
+            description = "Unit of measure for the item; defaults to EA when absent",
+            example = "EA",
+            requiredMode = NOT_REQUIRED)
+    private String unitOfMeasure;
 }

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/controller/CatalogBulkIngestControllerTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/controller/CatalogBulkIngestControllerTest.java
@@ -81,6 +81,47 @@ class CatalogBulkIngestControllerTest {
 
     @Test
     @WithMockUser(authorities = {"catalog:product:create"})
+    void bulkIngest_forwardsMpnAndUnitOfMeasure_withFallbacks() throws Exception {
+        CatalogBulkIngestRecord withValues = new CatalogBulkIngestRecord();
+        withValues.setSku("ABC-001");
+        withValues.setName("Widget");
+        withValues.setMpn("MPN-42");
+        withValues.setUnitOfMeasure("KIT");
+
+        CatalogBulkIngestRecord withoutValues = new CatalogBulkIngestRecord();
+        withoutValues.setSku("ABC-002");
+        withoutValues.setName("Gadget");
+
+        BulkIngestRequest<CatalogBulkIngestRecord> request = new BulkIngestRequest<>();
+        request.setJobId(JOB_ID);
+        request.setLocationId(LOCATION_ID);
+        request.setRecords(List.of(withValues, withoutValues));
+
+        ProductDto productDto = new ProductDto();
+        productDto.setId(PRODUCT_ID);
+        when(productMasterDataService.createProduct(any())).thenReturn(productDto);
+
+        mockMvc.perform(post("/v1/catalog/bulk-ingest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.successCount").value(2));
+
+        var captor =
+                org.mockito.ArgumentCaptor.forClass(com.positivity.catalog.internal.dto.ProductCreateRequestDto.class);
+        org.mockito.Mockito.verify(productMasterDataService, org.mockito.Mockito.times(2))
+                .createProduct(captor.capture());
+        var requests = captor.getAllValues();
+        org.assertj.core.api.Assertions.assertThat(requests.get(0).getMpn()).isEqualTo("MPN-42");
+        org.assertj.core.api.Assertions.assertThat(requests.get(0).getUnitOfMeasure())
+                .isEqualTo("KIT");
+        org.assertj.core.api.Assertions.assertThat(requests.get(1).getMpn()).isEqualTo("ABC-002");
+        org.assertj.core.api.Assertions.assertThat(requests.get(1).getUnitOfMeasure())
+                .isEqualTo("EA");
+    }
+
+    @Test
+    @WithMockUser(authorities = {"catalog:product:create"})
     void bulkIngest_whenServiceThrows_recordsAsFailure() throws Exception {
         CatalogBulkIngestRecord catalogRecord = new CatalogBulkIngestRecord();
         catalogRecord.setSku("BAD-001");


### PR DESCRIPTION
## Summary

Catalog bulk uploads previously required a CSV with exactly seven columns in a fixed order. Vendor price files come in many shapes, so the catalog load path now discovers each file's structure instead — from **headers** for CSV/TSV/pipe-delimited text and Excel workbooks, and from **document shape** for JSON, YAML, and XML.

### New parser layer (`pos-bulk-loader/internal/parser`)

- **Delimited text** (`.csv`, `.tsv`, `.txt`, `.psv`) — delimiter sniffed from the header line (comma/tab/semicolon/pipe); columns addressed by header name so order and extra columns don't matter; streams rows; handles quoted values and BOM.
- **Excel** (`.xlsx`, `.xlsm`, `.xls`, via Apache POI) — every sheet is scanned and the one with the most data rows is treated as the record sheet, so companion sheets (Import_Map, Data_Dictionary, Summary, …) are ignored. Numeric cells render as displayed text, so UPCs don't come out as scientific notation.
- **JSON / YAML / XML** — structure discovery: records are the root array or the largest array of objects found anywhere in the document; nested objects flatten to dot paths (`pricing.list`), XML attributes become fields. XML parsing is XXE-hardened (doctype declarations rejected); YAML uses SnakeYAML's `SafeConstructor`.

### Column mapping

- Job-approved column mappings take priority; unmapped headers fall back to rule-based inference with an extended synonym table (`supplier_sku`→sku, `manufacturer_part_no`→mpn, `product_name`→name, `list_price`→price, `uom`→unitOfMeasure, `category`/`subcategory`, etc.). Each target field is claimed by at most one column.
- The legacy fixed-format headers (`sku,upc,name,description,categoryName,subcategoryName,price`) keep working through the same inference — no migration needed for existing files.

### Pipeline changes

- The catalog Spring Batch job uses a new `FlexibleRecordItemReader` over the parser layer instead of the positional `FlatFileItemReader`. The reader is restartable: its read count is checkpointed to the step `ExecutionContext` and already-processed records are skipped on a restarted execution.
- `POST /v1/bulk-jobs/{jobId}/upload` now runs content detection (best-effort — a detection failure never fails the upload): suggested column mappings are persisted for review (never overwriting user-approved mappings) and returned in the upload response as a new `detection` field. File parsing runs outside the transaction; only suggestion persistence is transactional.
- `CatalogProductRecord` / `CatalogBulkIngestRecord` gain `mpn` and `unitOfMeasure`, so vendor part numbers and UOMs flow into product creation (previous SKU/`EA` fallbacks preserved).
- Both modules' `openapi.yaml` updated for the new fields.
- CI fix: the Validate Dockerfiles job's hadolint download failed on every PR because `--max-redirect=0` blocks the single HTTPS redirect GitHub release assets require; redirects are now capped at 2 with `--https-only` kept.

### Contract impact (per BACKEND_CONTRACT_GUIDE.md)

Additive, backward-compatible changes only: two optional request fields on the catalog bulk-ingest contract (`mpn`, `unitOfMeasure`) and one optional response field on the bulk-loader upload contract (`detection`). No existing fields changed or removed; existing consumers are unaffected.

## Testing

- **196/196 pos-bulk-loader tests pass**, including new unit tests for all five parsers, mapping inference, and end-to-end Spring Batch tests that process vendor-format CSV, multi-sheet XLSX, and JSON files and assert the exact records posted to `/v1/catalog/bulk-ingest`. pos-catalog tests pass (incl. new mpn/UOM pass-through test).
- Verified against the real synthetic 750-row vendor parts catalog in both CSV and XLSX form: all 750 records parse, map, and validate in each format, with the correct data sheet auto-selected from the 5-sheet workbook. These files are the planned alpha test files.
- Cross-module ArchUnit: the only failure is pre-existing and unrelated (`Instant.now()` usage in `pos-mcp-server`).

## Notes

- Files are matched to a parser by extension, so uploads need a sensible filename.
- Only the catalog job uses the flexible reader so far; the reader is generic and can be extended to customer/people/price/vehicle loads in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5eApn6ScgskSRdbdCKUoc