### PR TITLE
fix(bulk-loader,gateway): make TUS resumable uploads work through the…

### DIFF
--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -373,11 +373,11 @@ public final class GatewayPermissionCatalog {
         "PERM_invoice:finalize:override", // 346
 
         // ── New batch (bits 347–348) ──────────────────────────────────────────
-        "PERM_mcp:tool:manage",                              // 347
-        "PERM_mcp:tool:view",                                // 348
+        "PERM_mcp:tool:manage", // 347
+        "PERM_mcp:tool:view", // 348
 
         // ── New batch (bits 349–349) ──────────────────────────────────────────
-        "PERM_inventory:location:sync"                      // 349
+        "PERM_inventory:location:sync" // 349
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/SecurityGatewayConfig.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/SecurityGatewayConfig.java
@@ -118,8 +118,21 @@ public class SecurityGatewayConfig {
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
                         .allowedOriginPatterns("*")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+                        // HEAD is required by the TUS resumable-upload protocol (offset probe on resume).
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD")
                         .allowedHeaders("*")
+                        // Response headers browser JS must be able to read. A wildcard is not
+                        // usable here because allowCredentials(true) disables '*' expansion.
+                        // Location + Upload-* / Tus-* are required by TUS upload clients.
+                        .exposedHeaders(
+                                "Location",
+                                "Upload-Offset",
+                                "Upload-Length",
+                                "Upload-Expires",
+                                "Tus-Resumable",
+                                "Tus-Version",
+                                "Tus-Max-Size",
+                                "Tus-Extension")
                         .allowCredentials(true)
                         .maxAge(3600);
             }

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-        @DisplayName("CATALOG_VERSION is 17")
-        void catalogVersionIsSeventeen() {
-                assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(17);
+    @DisplayName("CATALOG_VERSION is 17")
+    void catalogVersionIsSeventeen() {
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(17);
     }
 
     @Test
-        @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 349")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 349")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/config/BulkLoaderEventTypes.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/config/BulkLoaderEventTypes.java
@@ -21,6 +21,13 @@ public final class BulkLoaderEventTypes {
                         .build(),
                 EventTypeRegistration.approval("BULK_LOADER_MAPPING_APPROVE", "Column mappings approved by operator")
                         .build(),
+                EventTypeRegistration.write("BULK_LOADER_TUS_UPLOAD_CREATE", "Create a TUS resumable upload")
+                        .build(),
+                EventTypeRegistration.write(
+                                "BULK_LOADER_TUS_UPLOAD_CHUNK_APPEND", "Append a chunk to a TUS resumable upload")
+                        .build(),
+                EventTypeRegistration.write("BULK_LOADER_TUS_UPLOAD_CANCEL", "Cancel a TUS resumable upload")
+                        .build(),
                 EventTypeRegistration.write("BULK_LOADER_TUS_UPLOAD_COMPLETE", "TUS resumable upload completed")
                         .build(),
                 EventTypeRegistration.write("BULK_LOADER_JOB_RETRY", "Retry a failed bulk load job")

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/TusUploadController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/TusUploadController.java
@@ -75,7 +75,9 @@ public class TusUploadController {
     @Operation(
             summary = "Create a resumable upload",
             description = "Creates a new TUS upload scoped to a bulk load job. "
-                    + "Returns a Location header with the upload URL for subsequent HEAD and PATCH requests.")
+                    + "Returns a Location header with the upload URL for subsequent HEAD and PATCH requests. "
+                    + "The Location is a relative reference (RFC 3986) that clients must resolve against the "
+                    + "creation request URL, so it stays correct behind the API gateway and any proxy prefix.")
     @ApiResponse(responseCode = "201", description = "Upload created")
     @ApiResponse(responseCode = "412", description = "Unsupported TUS version")
     @ApiResponse(responseCode = "413", description = "Upload-Length exceeds server maximum")
@@ -83,8 +85,7 @@ public class TusUploadController {
             @PathVariable @NonNull UUID jobId,
             @RequestHeader(value = TUS_RESUMABLE, required = false) @Nullable String tusResumable,
             @RequestHeader("Upload-Length") long uploadLength,
-            @RequestHeader(value = "Upload-Metadata", required = false) @Nullable String uploadMetadata,
-            HttpServletRequest request) {
+            @RequestHeader(value = "Upload-Metadata", required = false) @Nullable String uploadMetadata) {
 
         ResponseEntity<Void> versionError = rejectIfUnsupportedVersion(tusResumable);
         if (versionError != null) return versionError;
@@ -99,8 +100,12 @@ public class TusUploadController {
         TusUploadService.Created created =
                 tusUploadService.createUpload(jobId, fileName, uploadLength, resolveOperatorId());
 
-        String location = resolveBaseUrl(request) + "/v1/tus/" + created.id();
-        return ResponseEntity.created(URI.create(location))
+        // Relative to this creation URL (…/v1/bulk-jobs/{jobId}/tus): resolves to …/v1/tus/{id}
+        // under whatever public prefix the gateway/proxy exposes, without trusting
+        // X-Forwarded-* headers. The service's own request URL must NOT be used here — it is
+        // the internal address with the gateway prefix already stripped.
+        URI location = URI.create("../../tus/" + created.id());
+        return ResponseEntity.created(location)
                 .header(TUS_RESUMABLE, TUS_VERSION)
                 .header(UPLOAD_OFFSET, "0")
                 .header("Upload-Expires", formatRfc1123(created.expiresAt()))
@@ -209,12 +214,6 @@ public class TusUploadController {
             }
         }
         return "upload.bin";
-    }
-
-    private String resolveBaseUrl(HttpServletRequest request) {
-        String url = request.getRequestURL().toString();
-        int idx = url.indexOf("/v1/");
-        return idx >= 0 ? url.substring(0, idx) : "";
     }
 
     private String formatRfc1123(Instant instant) {

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/TusUploadController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/TusUploadController.java
@@ -1,6 +1,7 @@
 package com.positivity.bulkloader.internal.controller;
 
 import com.positivity.bulkloader.service.TusUploadService;
+import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -72,6 +73,7 @@ public class TusUploadController {
 
     @PostMapping("/bulk-jobs/{jobId}/tus")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
+    @EmitEvent(id = "BULK_LOADER_TUS_UPLOAD_CREATE", apiVersion = "1")
     @Operation(
             summary = "Create a resumable upload",
             description = "Creates a new TUS upload scoped to a bulk load job. "
@@ -139,6 +141,7 @@ public class TusUploadController {
 
     @PatchMapping("/tus/{uploadId}")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
+    @EmitEvent(id = "BULK_LOADER_TUS_UPLOAD_CHUNK_APPEND", apiVersion = "1")
     @Operation(
             summary = "Upload a chunk",
             description = "Appends a byte range to an in-progress TUS upload. "
@@ -176,6 +179,7 @@ public class TusUploadController {
 
     @DeleteMapping("/tus/{uploadId}")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
+    @EmitEvent(id = "BULK_LOADER_TUS_UPLOAD_CANCEL", apiVersion = "1")
     @Operation(summary = "Cancel an upload", description = "Permanently deletes a TUS upload and its temporary file.")
     @ApiResponse(responseCode = "204", description = "Upload deleted")
     @ApiResponse(responseCode = "404", description = "Upload not found")

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/TusUploadControllerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/TusUploadControllerTest.java
@@ -1,0 +1,85 @@
+package com.positivity.bulkloader.internal.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.bulkloader.config.TestSecurityConfig;
+import com.positivity.bulkloader.service.TusUploadService;
+import java.net.URI;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TusUploadController.class)
+@Import(TestSecurityConfig.class)
+@ActiveProfiles("test")
+@SuppressWarnings({"java:S6813", "java:S100"})
+class TusUploadControllerTest {
+
+    private static final UUID JOB_ID = UUID.fromString("00000000-0000-0000-0000-000000000051");
+    private static final UUID UPLOAD_ID = UUID.fromString("00000000-0000-0000-0000-000000000052");
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    TusUploadService tusUploadService;
+
+    @Test
+    @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+    void createUpload_returnsGatewaySafeRelativeLocation() throws Exception {
+        when(tusUploadService.createUpload(eq(JOB_ID), eq("upload.bin"), anyLong(), eq("test-operator")))
+                .thenReturn(new TusUploadService.Created(UPLOAD_ID, Instant.parse("2026-07-08T12:00:00Z")));
+
+        mockMvc.perform(post("/v1/bulk-jobs/{jobId}/tus", JOB_ID)
+                        .header("Tus-Resumable", "1.0.0")
+                        .header("Upload-Length", "1024"))
+                .andExpect(status().isCreated())
+                // Relative reference: resolves against the public creation URL regardless of
+                // gateway/proxy path prefixes.
+                .andExpect(header().string("Location", "../../tus/" + UPLOAD_ID))
+                .andExpect(header().string("Tus-Resumable", "1.0.0"))
+                .andExpect(header().string("Upload-Offset", "0"));
+    }
+
+    @Test
+    @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+    void createUpload_relativeLocation_resolvesToPublicTusUrl() throws Exception {
+        when(tusUploadService.createUpload(eq(JOB_ID), eq("upload.bin"), anyLong(), eq("test-operator")))
+                .thenReturn(new TusUploadService.Created(UPLOAD_ID, Instant.parse("2026-07-08T12:00:00Z")));
+
+        String location = mockMvc.perform(post("/v1/bulk-jobs/{jobId}/tus", JOB_ID)
+                        .header("Tus-Resumable", "1.0.0")
+                        .header("Upload-Length", "1024"))
+                .andReturn()
+                .getResponse()
+                .getHeader("Location");
+
+        // RFC 3986 resolution against the gateway-facing creation URL must land on the
+        // public TUS resource URL, keeping the /api/bulk-loader prefix intact.
+        URI publicCreationUrl = URI.create("https://durionpos.org/api/bulk-loader/v1/bulk-jobs/" + JOB_ID + "/tus");
+        URI resolved = publicCreationUrl.resolve(location);
+        org.assertj.core.api.Assertions.assertThat(resolved)
+                .hasToString("https://durionpos.org/api/bulk-loader/v1/tus/" + UPLOAD_ID);
+    }
+
+    @Test
+    @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+    void createUpload_unsupportedTusVersion_returns412() throws Exception {
+        mockMvc.perform(post("/v1/bulk-jobs/{jobId}/tus", JOB_ID)
+                        .header("Tus-Resumable", "0.2.2")
+                        .header("Upload-Length", "1024"))
+                .andExpect(status().isPreconditionFailed());
+    }
+}


### PR DESCRIPTION
… API gateway

Two issues prevented the TUS upload flow from completing when accessed through the gateway (e.g. https://durionpos.org/api/bulk-loader/...):

- TusUploadController built the creation response's Location header from the service's own request URL, which is the internal address with the gateway's /bulk-loader prefix already stripped. Clients then PATCHed an unreachable URL. The Location is now a relative reference (../../tus/{id}) per RFC 3986 / TUS 1.0.0, which resolves correctly against the public creation URL under any proxy prefix without trusting X-Forwarded-* headers.

- The gateway's CORS policy did not allow the HEAD method (used by TUS clients to probe the current offset when resuming) and exposed no response headers, so browser JS could not read Location, Upload-Offset, or the other Tus-*/Upload-* headers (a wildcard is unavailable with allowCredentials). HEAD is now allowed and the TUS headers are explicitly exposed.

Note: the 401 reported from alpha is a separate frontend issue — the TUS client must be configured to send the Authorization bearer header on its own requests; the gateway rejects unauthenticated /bulk-loader/** paths.


Claude-Session: https://claude.ai/code/session_01E5eApn6ScgskSRdbdCKUoc