### PR TITLE
fix(bulk-loader,gateway): return absolute TUS Location header via X-Forwarded-* (#833)

### DIFF
--- a/pos-api-gateway/src/main/java/com/positivity/gateway/filter/ApiVersionHeaderToPathFilter.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/filter/ApiVersionHeaderToPathFilter.java
@@ -53,7 +53,10 @@ import reactor.core.publisher.Mono;
  * <h2>/api Prefix Stripping</h2>
  * Paths that start with {@code /api/} are normalised (prefix stripped) before
  * all other processing. This covers direct gateway access from clients that
- * mirror the front-end Node.js proxy mount point.
+ * mirror the front-end Node.js proxy mount point. The stripped {@code /api}
+ * prefix is appended to the {@code X-Forwarded-Prefix} header so downstream
+ * services can rebuild public absolute URLs (e.g. the bulk-loader TUS
+ * {@code Location} header).
  *
  * <h2>Already-Versioned Paths</h2>
  * If the inbound path already matches
@@ -97,7 +100,13 @@ public class ApiVersionHeaderToPathFilter implements GlobalFilter, Ordered {
         if (rawPath != null && rawPath.startsWith("/api/")) {
             rawPath = rawPath.substring("/api".length());
             final var normalizedPath = rawPath;
-            exchange = exchange.mutate().request(r -> r.path(normalizedPath)).build();
+            // Record the stripped prefix in X-Forwarded-Prefix (appended after any value set by
+            // an outer proxy) so downstream services can rebuild public absolute URLs — e.g. the
+            // bulk-loader TUS Location header. XForwardedHeadersFilter later appends the route
+            // prefix removed by StripPrefix to the same header.
+            exchange = exchange.mutate()
+                    .request(r -> r.path(normalizedPath).headers(h -> h.add("X-Forwarded-Prefix", "/api")))
+                    .build();
             log.debug("Stripped /api prefix; effective path={}", rawPath);
         }
 

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/filter/ApiVersionHeaderToPathFilterTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/filter/ApiVersionHeaderToPathFilterTest.java
@@ -107,6 +107,68 @@ class ApiVersionHeaderToPathFilterTest {
     }
 
     @Test
+    void shouldStripApiPrefixAndRecordItInXForwardedPrefix() {
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.patch("/api/bulk-loader/v1/tus/00000000-0000-0000-0000-000000000052")
+                        .build());
+        AtomicReference<String> downstreamPath = new AtomicReference<>();
+        AtomicReference<String> downstreamForwardedPrefix = new AtomicReference<>();
+        GatewayFilterChain chain = chainedExchange -> {
+            downstreamPath.set(chainedExchange
+                    .getRequest()
+                    .getPath()
+                    .pathWithinApplication()
+                    .value());
+            downstreamForwardedPrefix.set(
+                    chainedExchange.getRequest().getHeaders().getFirst("X-Forwarded-Prefix"));
+            return Mono.empty();
+        };
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(exchange.getResponse().getStatusCode()).isNull();
+        // Already-versioned path passes through unchanged apart from the /api strip,
+        // which is preserved for downstream URL reconstruction via X-Forwarded-Prefix.
+        assertThat(downstreamPath.get()).isEqualTo("/bulk-loader/v1/tus/00000000-0000-0000-0000-000000000052");
+        assertThat(downstreamForwardedPrefix.get()).isEqualTo("/api");
+    }
+
+    @Test
+    void shouldAppendApiPrefixAfterOuterProxyForwardedPrefix() {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/api/customer/v1/crm/accounts")
+                .header("X-Forwarded-Prefix", "/outer")
+                .build());
+        AtomicReference<java.util.List<String>> downstreamForwardedPrefixes = new AtomicReference<>();
+        GatewayFilterChain chain = chainedExchange -> {
+            downstreamForwardedPrefixes.set(
+                    chainedExchange.getRequest().getHeaders().get("X-Forwarded-Prefix"));
+            return Mono.empty();
+        };
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(exchange.getResponse().getStatusCode()).isNull();
+        assertThat(downstreamForwardedPrefixes.get()).containsExactly("/outer", "/api");
+    }
+
+    @Test
+    void shouldNotAddXForwardedPrefixWhenNoApiPrefixIsStripped() {
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/customer/v1/crm/accounts").build());
+        AtomicReference<String> downstreamForwardedPrefix = new AtomicReference<>();
+        GatewayFilterChain chain = chainedExchange -> {
+            downstreamForwardedPrefix.set(
+                    chainedExchange.getRequest().getHeaders().getFirst("X-Forwarded-Prefix"));
+            return Mono.empty();
+        };
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(exchange.getResponse().getStatusCode()).isNull();
+        assertThat(downstreamForwardedPrefix.get()).isNull();
+    }
+
+    @Test
     void shouldNotRewriteAlreadyVersionedPath() {
         var exchange = MockServerWebExchange.from(
                 MockServerHttpRequest.get("/customer/v1/crm/accounts").build());

--- a/pos-bulk-loader/openapi.yaml
+++ b/pos-bulk-loader/openapi.yaml
@@ -205,7 +205,7 @@ paths:
       tags:
       - TUS Resumable Upload API
       summary: Create a resumable upload
-      description: Creates a new TUS upload scoped to a bulk load job. Returns a Location header with the upload URL for subsequent HEAD and PATCH requests.
+      description: Creates a new TUS upload scoped to a bulk load job. Returns a Location header with the absolute upload URL for subsequent HEAD and PATCH requests. The URL is reconstructed from the X-Forwarded-Proto/Host/Port/Prefix headers supplied by the API gateway / reverse-proxy chain, so it reflects the public address (including any proxy path prefix) rather than this service's internal one.
       operationId: createUpload
       parameters:
       - name: jobId

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/TusUploadController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/TusUploadController.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
 @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -77,9 +78,10 @@ public class TusUploadController {
     @Operation(
             summary = "Create a resumable upload",
             description = "Creates a new TUS upload scoped to a bulk load job. "
-                    + "Returns a Location header with the upload URL for subsequent HEAD and PATCH requests. "
-                    + "The Location is a relative reference (RFC 3986) that clients must resolve against the "
-                    + "creation request URL, so it stays correct behind the API gateway and any proxy prefix.")
+                    + "Returns a Location header with the absolute upload URL for subsequent HEAD and PATCH "
+                    + "requests. The URL is reconstructed from the X-Forwarded-Proto/Host/Port/Prefix headers "
+                    + "supplied by the API gateway / reverse-proxy chain, so it reflects the public address "
+                    + "(including any proxy path prefix) rather than this service's internal one.")
     @ApiResponse(responseCode = "201", description = "Upload created")
     @ApiResponse(responseCode = "412", description = "Unsupported TUS version")
     @ApiResponse(responseCode = "413", description = "Upload-Length exceeds server maximum")
@@ -102,11 +104,16 @@ public class TusUploadController {
         TusUploadService.Created created =
                 tusUploadService.createUpload(jobId, fileName, uploadLength, resolveOperatorId());
 
-        // Relative to this creation URL (…/v1/bulk-jobs/{jobId}/tus): resolves to …/v1/tus/{id}
-        // under whatever public prefix the gateway/proxy exposes, without trusting
-        // X-Forwarded-* headers. The service's own request URL must NOT be used here — it is
-        // the internal address with the gateway prefix already stripped.
-        URI location = URI.create("../../tus/" + created.id());
+        // Absolute URL, as in the tus spec's own examples: relative Location references break
+        // tus clients whose endpoint is a bare path, and stale copies of them resolve against
+        // the page URL instead of the API (see issue #833). ForwardedHeaderFilter
+        // (server.forward-headers-strategy: framework) has already rebuilt this request from the
+        // X-Forwarded-Proto/Host/Port/Prefix headers set by the gateway/proxy chain, so the
+        // base below is the public address (e.g. https://host/bulk-loader), not the internal
+        // one with the gateway prefix stripped.
+        URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/v1/tus/{uploadId}")
+                .build(created.id());
         return ResponseEntity.created(location)
                 .header(TUS_RESUMABLE, TUS_VERSION)
                 .header(UPLOAD_OFFSET, "0")

--- a/pos-bulk-loader/src/main/resources/application.yml
+++ b/pos-bulk-loader/src/main/resources/application.yml
@@ -27,6 +27,9 @@ spring:
 
 server:
   port: 0
+  # Honor X-Forwarded-Proto/Host/Port/Prefix from the gateway/reverse-proxy chain so absolute
+  # URLs built from the current request (e.g. the TUS Location header) use the public address.
+  forward-headers-strategy: framework
   tomcat:
     max-http-header-size: 65536
 

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/TusUploadControllerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/TusUploadControllerTest.java
@@ -9,23 +9,38 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.positivity.bulkloader.config.TestSecurityConfig;
 import com.positivity.bulkloader.service.TusUploadService;
-import java.net.URI;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 
 @WebMvcTest(TusUploadController.class)
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, TusUploadControllerTest.ForwardedHeaderTestConfig.class})
 @ActiveProfiles("test")
 @SuppressWarnings({"java:S6813", "java:S100"})
 class TusUploadControllerTest {
+
+    /**
+     * The production app registers {@link ForwardedHeaderFilter} via
+     * {@code server.forward-headers-strategy: framework} (web-server auto-configuration, not part
+     * of the {@code @WebMvcTest} slice), so register it here to exercise X-Forwarded-* handling.
+     */
+    @TestConfiguration
+    static class ForwardedHeaderTestConfig {
+        @Bean
+        ForwardedHeaderFilter forwardedHeaderFilter() {
+            return new ForwardedHeaderFilter();
+        }
+    }
 
     private static final UUID JOB_ID = UUID.fromString("00000000-0000-0000-0000-000000000051");
     private static final UUID UPLOAD_ID = UUID.fromString("00000000-0000-0000-0000-000000000052");
@@ -38,7 +53,7 @@ class TusUploadControllerTest {
 
     @Test
     @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
-    void createUpload_returnsGatewaySafeRelativeLocation() throws Exception {
+    void createUpload_withoutForwardedHeaders_returnsAbsoluteLocationForThisServer() throws Exception {
         when(tusUploadService.createUpload(eq(JOB_ID), eq("upload.bin"), anyLong(), eq("test-operator")))
                 .thenReturn(new TusUploadService.Created(UPLOAD_ID, Instant.parse("2026-07-08T12:00:00Z")));
 
@@ -46,32 +61,43 @@ class TusUploadControllerTest {
                         .header("Tus-Resumable", "1.0.0")
                         .header("Upload-Length", "1024"))
                 .andExpect(status().isCreated())
-                // Relative reference: resolves against the public creation URL regardless of
-                // gateway/proxy path prefixes.
-                .andExpect(header().string("Location", "../../tus/" + UPLOAD_ID))
+                .andExpect(header().string("Location", "http://localhost/v1/tus/" + UPLOAD_ID))
                 .andExpect(header().string("Tus-Resumable", "1.0.0"))
                 .andExpect(header().string("Upload-Offset", "0"));
     }
 
     @Test
     @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
-    void createUpload_relativeLocation_resolvesToPublicTusUrl() throws Exception {
+    void createUpload_withForwardedHeaders_returnsPublicAbsoluteLocation() throws Exception {
         when(tusUploadService.createUpload(eq(JOB_ID), eq("upload.bin"), anyLong(), eq("test-operator")))
                 .thenReturn(new TusUploadService.Created(UPLOAD_ID, Instant.parse("2026-07-08T12:00:00Z")));
 
-        String location = mockMvc.perform(post("/v1/bulk-jobs/{jobId}/tus", JOB_ID)
+        // Headers as set by the reverse proxy (/api) + API gateway (/bulk-loader StripPrefix):
+        // the Location must be the public TUS resource URL with the full prefix chain intact.
+        mockMvc.perform(post("/v1/bulk-jobs/{jobId}/tus", JOB_ID)
                         .header("Tus-Resumable", "1.0.0")
-                        .header("Upload-Length", "1024"))
-                .andReturn()
-                .getResponse()
-                .getHeader("Location");
+                        .header("Upload-Length", "1024")
+                        .header("X-Forwarded-Proto", "https")
+                        .header("X-Forwarded-Host", "durionpos.org")
+                        .header("X-Forwarded-Prefix", "/api,/bulk-loader"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "https://durionpos.org/api/bulk-loader/v1/tus/" + UPLOAD_ID));
+    }
 
-        // RFC 3986 resolution against the gateway-facing creation URL must land on the
-        // public TUS resource URL, keeping the /api/bulk-loader prefix intact.
-        URI publicCreationUrl = URI.create("https://durionpos.org/api/bulk-loader/v1/bulk-jobs/" + JOB_ID + "/tus");
-        URI resolved = publicCreationUrl.resolve(location);
-        org.assertj.core.api.Assertions.assertThat(resolved)
-                .hasToString("https://durionpos.org/api/bulk-loader/v1/tus/" + UPLOAD_ID);
+    @Test
+    @WithMockUser(username = "test-operator", authorities = "bulkImport:upload:execute")
+    void createUpload_withGatewayOnlyForwardedHeaders_returnsGatewayAbsoluteLocation() throws Exception {
+        when(tusUploadService.createUpload(eq(JOB_ID), eq("upload.bin"), anyLong(), eq("test-operator")))
+                .thenReturn(new TusUploadService.Created(UPLOAD_ID, Instant.parse("2026-07-08T12:00:00Z")));
+
+        mockMvc.perform(post("/v1/bulk-jobs/{jobId}/tus", JOB_ID)
+                        .header("Tus-Resumable", "1.0.0")
+                        .header("Upload-Length", "1024")
+                        .header("X-Forwarded-Proto", "http")
+                        .header("X-Forwarded-Host", "gateway:8080")
+                        .header("X-Forwarded-Prefix", "/bulk-loader"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "http://gateway:8080/bulk-loader/v1/tus/" + UPLOAD_ID));
     }
 
     @Test


### PR DESCRIPTION
The TUS creation endpoint returned a relative Location ("../../tus/{id}"),
which tus-js-client 4.x cannot resolve when its endpoint is a bare path,
and stale localStorage copies of it resolved against the page URL, landing
on the SPA fallback with a 200 instead of the upload resource.

Bulk-loader now returns an absolute Location, as in the tus spec examples:

- Enable server.forward-headers-strategy: framework so ForwardedHeaderFilter
  rebuilds the request from X-Forwarded-Proto/Host/Port/Prefix set by the
  gateway/proxy chain.
- Build the Location from the forwarded-aware request
  (ServletUriComponentsBuilder.fromCurrentContextPath), yielding e.g.
  https://host/api/bulk-loader/v1/tus/{id} behind the /api proxy + gateway,
  or the direct service URL when no forwarded headers are present.

Gateway changes:

- ApiVersionHeaderToPathFilter now records the /api prefix it strips by
  appending it to X-Forwarded-Prefix, so downstream URL reconstruction
  keeps the full public prefix chain. Spring Cloud Gateway's
  XForwardedHeadersFilter already appends the /bulk-loader route prefix
  removed by StripPrefix (collapsed into one comma-delimited value), and
  Spring's ForwardedHeaderFilter concatenates the chain into the context
  path.

Routing verification requested in #833: /bulk-loader/v1/tus/** is already
routed by the bulk-loader route (Path=/bulk-loader/** with StripPrefix=1,
lb://POS-BULK-LOADER) in pos-api-gateway application.yml, and the JWT auth
GlobalFilter applies to it (the path is not in the public-path bypass
list), so PATCH/HEAD/DELETE on the upload resource reach the service
authenticated. No route change was needed.

## Contract impact

Per BACKEND_CONTRACT_GUIDE.md: no request/response schema, endpoint path,
or status-code changes. The only OpenAPI delta is the prose `description`
of `POST /v1/bulk-jobs/{jobId}/tus`, documenting that the `Location`
response header is now an absolute URL (previously a relative reference).
Clients that already resolve `Location` per RFC 3986 (as tus clients must)
are unaffected, so no companion contract PR is required.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nqmyev4cCEDJK1UP5f2s7w