### PR TITLE
ADR-0044 event-only domain walls: assessment, ADR, and Phase 0 foundations (#823)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web: provision JDK 25.
+#
+# The build requires Java 25 (enforced by maven-enforcer), but the remote
+# container ships JDK 21 and the network policy blocks SDKMAN/Adoptium.
+# download.oracle.com is reachable, so we install Oracle JDK 25 (NFTC
+# license) and export JAVA_HOME/PATH for the session. The extracted JDK is
+# cached with the container, so subsequent sessions skip the download.
+set -euo pipefail
+
+# Web sessions only — local developers use SDKMAN per .sdkmanrc.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+JDK_BASE="$HOME/.jdk"
+JDK_URL="https://download.oracle.com/java/25/latest/jdk-25_linux-x64_bin.tar.gz"
+
+find_jdk() {
+  ls -d "$JDK_BASE"/jdk-25* 2>/dev/null | sort -V | tail -1
+}
+
+JDK_HOME="$(find_jdk || true)"
+
+if [ -z "$JDK_HOME" ] || [ ! -x "$JDK_HOME/bin/javac" ]; then
+  echo "Installing JDK 25 from download.oracle.com..."
+  mkdir -p "$JDK_BASE"
+  curl -sSL -o "$JDK_BASE/jdk25.tar.gz" "$JDK_URL"
+  curl -sSL -o "$JDK_BASE/jdk25.sha256" "$JDK_URL.sha256"
+  (cd "$JDK_BASE" && echo "$(cat jdk25.sha256) jdk25.tar.gz" | sha256sum -c -)
+  tar -xzf "$JDK_BASE/jdk25.tar.gz" -C "$JDK_BASE"
+  rm -f "$JDK_BASE/jdk25.tar.gz" "$JDK_BASE/jdk25.sha256"
+  JDK_HOME="$(find_jdk)"
+fi
+
+"$JDK_HOME/bin/javac" -version
+
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export JAVA_HOME=\"$JDK_HOME\""
+    echo "export PATH=\"$JDK_HOME/bin:\$PATH\""
+  } >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "JDK 25 ready at $JDK_HOME"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,17 @@
     "allow": [
       "Bash(*)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,51 @@ Modules using `@EmitEvent` MUST include pos-events dependency in pom.xml:
 
 - Failing to register events results in silent audit failures and compliance violations.
 
+### Domain Events over Kafka (ADR-0044)
+
+Module-to-module communication is **events-only** — synchronous REST between domain modules is
+prohibited; only the utility modules (gateway, security-service, documents, image, tax,
+event-receiver, price) may be called synchronously. The `@EmitEvent`/pos-event-receiver pipeline
+above is **audit-only** and is not a module-to-module channel. See
+`docs/adr-0044-event-only-domain-walls.md` for the full rules.
+
+- **Contracts live in `pos-domain-events`** (importable by every module): the
+  `DomainEventEnvelope<T>` record and `DomainTopics` naming helpers. Payload DTOs are versioned
+  per domain (additive-only within a version; breaking changes require a `.v2` topic).
+- **Topics**: facts on `{domain}.events.v1` (published only by the owning module), commands on
+  `{domain}.commands.v1` (consumed only by the owning module), poison messages to `{topic}.dlq`.
+  Records are keyed by `aggregateId` (`envelope.recordKey()`), preserving per-aggregate order.
+- **Producing**: build envelopes with `DomainEventEnvelope.of(...)` using the module's injected
+  `Clock`; publish through the module's transactional outbox — never call `KafkaTemplate` directly
+  from a business transaction.
+- **Consuming**: record each `eventId` in the module's `processed_events` table in the same
+  transaction as the replica update (redelivery must be harmless), and use `aggregateVersion` to
+  ignore stale updates and detect gaps.
+- **Replicas**: read-only copies of another domain's data live in `ext_{owner}_{entity}` tables,
+  written only by the event consumer, with minimum fields required.
+
+```java
+DomainEventEnvelope<PartyUpdatedV1> event = DomainEventEnvelope.of(
+        "customer.party.updated",   // eventType: dotted lowercase
+        1,                          // schemaVersion
+        partyId,                    // aggregateId (also the Kafka key)
+        aggregateVersion,           // monotonic per-aggregate sequence
+        "pos-customer",             // sourceService
+        correlationId,              // nullable
+        actorUserId,                // nullable; audit only, never authorization
+        new PartyUpdatedV1(...),    // versioned payload DTO from pos-domain-events
+        clock);
+outbox.append(DomainTopics.events("customer"), event); // same transaction as the state change
+```
+
+```xml
+<dependency>
+    <groupId>com.positivity</groupId>
+    <artifactId>pos-domain-events</artifactId>
+    <version>${project.version}</version>
+</dependency>
+```
+
 ## Null Safety Standards
 
 ### ⚠️ MANDATORY: @NonNull Annotation for Null Safety

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,34 @@ services:
     networks:
       - pos-network
 
+  kafka:
+    # ADR-0044: Kafka is the domain-event backbone. Single-node KRaft broker for local dev.
+    image: apache/kafka:3.9.0
+    container_name: kafka-positivity
+    ports:
+      - "127.0.0.1:9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:29092,EXTERNAL://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    healthcheck:
+      test: [ "CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    logging: *logging
+    networks:
+      - pos-network
+
   ollama:
     image: ollama/ollama:latest
     container_name: ollama
@@ -192,6 +220,8 @@ services:
     ports:
       - "9001:8080"
     environment:
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       GATEWAY_URL: http://pos-api-gateway:8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_accounting_db
@@ -293,6 +323,8 @@ services:
     ports:
       - "8082:8080"
     environment:
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       GATEWAY_URL: http://pos-api-gateway:8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_customer_db
@@ -803,6 +835,8 @@ services:
     ports:
       - "8089:8080"
     environment:
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       GATEWAY_URL: http://pos-api-gateway:8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_vehicle_inventory_db
@@ -893,6 +927,8 @@ services:
     ports:
       - "8090:8080"
     environment:
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       GATEWAY_URL: http://pos-api-gateway:8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_workorder_db

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -366,6 +366,59 @@ public class PartyController {
 
 ---
 
+## Domain Events (Kafka, ADR-0044)
+
+Module-to-module communication flows over Kafka domain topics (`{domain}.events.v1` facts,
+`{domain}.commands.v1` commands). Contracts live in `pos-domain-events`; the full policy is
+`docs/adr-0044-event-only-domain-walls.md`.
+
+### Local broker
+
+`docker-compose up -d kafka` starts a single-node KRaft broker (`apache/kafka`). Services reach it
+at `kafka:29092` inside the compose network (host tools at `localhost:9092`). Kafka features remain
+opt-in per module (e.g. `WORKORDER_KAFKA_ENABLED=true`, `pos.customer.kafka.enabled=true`) until
+the Phase 0.4 tier-1 flip.
+
+### Transactional outbox (producers)
+
+Producers write events to their `event_outbox` table in the business transaction; a scheduled
+publisher drains to Kafka (at-least-once). Operational signals:
+
+- Metrics: `workorder.outbox.published`, `workorder.outbox.publish.failures` (counter deltas);
+  a growing gap means the drain is failing.
+- `SELECT count(*) FROM event_outbox WHERE published_at IS NULL` — sustained growth means the
+  broker is unreachable or the publisher is stopped; check `attempts`/`last_error` on stuck rows.
+- The publisher halts its batch at the first failure to preserve order — one poisoned/oversized
+  record blocks the drain; inspect the oldest unpublished row first.
+
+### Consumers: retry and DLQ
+
+Consumers retry failed records with exponential backoff, then dead-letter to `{topic}.dlq`
+(e.g. `workorder.events.v1.dlq`). Redelivery is safe: consumers deduplicate by `eventId`
+(unique-keyed processing log). To inspect a DLQ:
+
+```bash
+docker exec kafka-positivity /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 --topic workorder.events.v1.dlq --from-beginning --max-messages 10
+```
+
+To reprocess a DLQ'd record after fixing the cause, re-emit it from the owner's outbox (below) —
+do not hand-copy messages between topics.
+
+### Replica seeding and drift repair (replay)
+
+Owners expose an administrative re-emit endpoint (permission `{domain}:events:replay`), e.g.:
+
+```bash
+# Re-emit all workorder events created since July 1 (idempotent for consumers)
+curl -X POST "https://<gateway>/workorder/v1/outbox/replay?since=2026-07-01T00:00:00Z" \
+  -H "Authorization: Bearer $TOKEN" -H "X-API-Version: 1"
+```
+
+Seeding a brand-new replica: create the consumer's `ext_*` tables (Flyway), start the consumer,
+then call replay with `since` at the epoch (omit the parameter). Consumers skip anything already
+processed.
+
 ## Related Documentation
 
 - **Platform-level runbook**: `durion/docs/OPERATIONS_RUNBOOK.md`

--- a/docs/adr-0043-event-only-domain-walls.md
+++ b/docs/adr-0043-event-only-domain-walls.md
@@ -1,0 +1,206 @@
+# ADR-0043 Event-Only Domain Walls and Module Communication Policy
+
+- Status: **Proposed** (candidate — issue [#823](https://github.com/louisburroughs/durion-positivity-backend/issues/823))
+- Date: 2026-07-08
+- Supersedes: the domain-to-domain portions of the service-discovery client policy
+  (`docs/service-discovery-migration/client-policy-matrix.md`) and the undocumented
+  "do not replicate address data" platform rule (see §Changes to other ADRs)
+- Related: ADR-0011, ADR-0014, ADR-0016, ADR-0017, ADR-0021, ADR-0025, ADR-0026, ADR-0027,
+  ADR-0040, ADR-0042
+- Supporting analysis: `docs/module-coupling/issue-823-event-only-domain-walls-assessment.md`
+
+Once accepted, promote this document to the canonical ADR repository as
+`durion/docs/adr/0043-event-only-domain-walls.adr.md` and keep this copy as the backend-local
+reference.
+
+## Context
+
+Domain modules are coupled by ~24 synchronous REST clients across 10 modules (full matrix in the
+supporting analysis). Reads dominate (customer, location, and people reference data is fetched on
+nearly every workorder/invoice/shop-manager flow), but several edges are writes: accounting applies
+payments and credit memos against pos-invoice and triggers invoice regeneration in pos-workorder;
+pos-customer performs full vehicle CRUD against pos-vehicle-inventory; pos-security-service writes
+user↔person links into pos-people and pos-customer.
+
+This coupling means: a callee outage cascades into caller request failures; deployment ordering
+matters; and domain models leak across module boundaries through client DTOs.
+
+The platform already contains the seed of the alternative: pos-workorder publishes a versioned JSON
+event envelope to Kafka (`workorder.events.v1`), pos-customer consumes it, and pos-accounting /
+pos-vehicle-inventory have Kafka listeners for topics (`payment.cleared.v1`, `vehicle.updates`,
+`workorder.completed`) that nothing produces yet.
+
+## Decision
+
+Domain modules communicate with each other **only through asynchronous events on Kafka**.
+Synchronous REST between modules is reserved for a small, named set of **utility modules**.
+Consumers hold **read-only local replicas** of the reference data they need, kept in sync by events
+from the owning module. Cross-module writes become **command events** with result events and
+pending states.
+
+### 1. Module classification
+
+| Class | Modules | May be called synchronously? |
+|---|---|---|
+| **Utility** | `pos-api-gateway`, `pos-security-service`, `pos-documents`, `pos-image`, `pos-tax` (per ADR-0021), `pos-event-receiver`, `pos-price` | Yes — by any module |
+| **Domain** | `pos-accounting`, `pos-catalog`, `pos-customer`, `pos-inquiry`, `pos-inventory`, `pos-invoice`, `pos-location`, `pos-order`, `pos-people` (HR), `pos-people-contact` (new), `pos-shop-manager`, `pos-vehicle-inventory`, `pos-vehicle-fitment`, `pos-vehicle-reference-*`, `pos-workorder`, `pos-bulk-loader` | No — events only |
+| **Libraries / non-deployed** | `pos-events`, `pos-shared-dtos`, `pos-domain-events` (new), `pos-security-common`, `pos-tax-common`, `pos-bulk-ingest-lib`, `pos-document-helper`, `pos-dependencies`, `pos-archunit` | n/a |
+
+`pos-tax` and `pos-price` are utilities because they are stateless *computation* (tax and price
+determination), not data lookups — replicating their rule engines into callers would be worse than
+the call. `pos-mcp-server` is a gateway client (bearer-token relay) and follows client rules, not
+module rules.
+
+### 2. Rules of separation
+
+Normative language: MUST / MUST NOT / SHOULD per RFC 2119.
+
+- **R1 — No domain-to-domain synchronous calls.** A domain module MUST NOT call another domain
+  module's REST API, directly or via the gateway. This includes "just one small lookup."
+- **R2 — Utility calls allowed.** Any module MAY call a utility module synchronously (direct
+  Eureka discovery or the documented exception mechanism per the service-discovery policy).
+  Startup-infra registrations (permissions → pos-security-service per ADR-0025, event types →
+  pos-event-receiver, document templates → pos-documents) remain synchronous and best-effort.
+- **R3 — Reads use local replicas.** When a domain module needs another domain's data, it maintains
+  a read-only local replica populated exclusively by the owner's events. Replicas MUST copy the
+  minimum fields required, MUST be tolerant of staleness, and MUST NOT be written by anything
+  except the event consumer. Replica tables are named `ext_{owner}_{entity}` (e.g.
+  `ext_location_address`) so ownership is visible in every schema.
+- **R4 — Writes use command events.** When a domain module needs another domain to change state, it
+  publishes a command event to the owner's command topic. The owner is the sole writer of its data,
+  validates the command, and publishes a result event (applied/rejected). Initiating flows MUST
+  model a pending state and MUST carry an idempotency key.
+- **R5 — Kafka is the backbone.** Domain and command events flow over Kafka. The
+  `@EmitEvent` → `pos-event-receiver` pipeline remains **audit-only** and MUST NOT be used for
+  module-to-module data flow.
+- **R6 — One owner per fact.** Every data element has exactly one owning module; only the owner
+  publishes events about it. Consumers never re-publish replica data as their own events.
+
+### 3. Event contract standard
+
+A new non-deployed library **`pos-domain-events`** holds the envelope and all versioned payload
+DTOs. It is importable by every module (ArchUnit allowance identical to `pos-shared-dtos`).
+
+Envelope (extends the existing pos-workorder `KafkaProducer` envelope):
+
+```json
+{
+  "eventId":          "<UUIDv7>",
+  "eventType":        "customer.party.updated",
+  "schemaVersion":    1,
+  "aggregateId":      "<UUID of the owning aggregate>",
+  "aggregateVersion": 42,
+  "occurredAtUtc":    "2026-07-08T12:00:00Z",
+  "sourceService":    "pos-customer",
+  "correlationId":    "<propagated from the initiating request when available>",
+  "actor":            "<user id or service name, for audit only>",
+  "payload":          { }
+}
+```
+
+- Topics: `{domain}.events.v1` (facts) and `{domain}.commands.v1` (requests to the owner). Keyed by
+  `aggregateId` so per-aggregate ordering is preserved.
+- Identifiers in payloads are UUID-typed per ADR-0027; `eventId` is UUIDv7 per ADR-0013.
+- Payload changes within a version MUST be additive-only. Breaking changes require a new topic
+  version (`.v2`), with the owner dual-publishing during the migration window.
+- `aggregateVersion` is a monotonic per-aggregate sequence; consumers use it to detect gaps and to
+  ignore out-of-date updates.
+
+### 4. Reliability mechanisms (mandatory before a module migrates)
+
+- **Transactional outbox.** Producers MUST NOT publish directly from business transactions. Each
+  producer module adds an `event_outbox` table (Flyway) written in the same transaction as the
+  state change, drained by a background publisher. At-least-once delivery is the guarantee.
+- **Idempotent consumers.** Each consumer module keeps a `processed_events` table keyed by
+  `eventId` (checked in the same transaction as the replica update). Redelivery MUST be harmless.
+- **Retry and DLQ.** Transient consumer failures retry with backoff; poison messages go to
+  `{topic}.dlq` and alert. A DLQ'd command MUST surface as a failed/pending item, not silently drop.
+- **Bootstrap and backfill.** Owners MUST provide a replay mechanism (snapshot export endpoint or
+  administrative re-emit-all) to seed new replicas and repair drift.
+- **Reconciliation.** A scheduled job per consumer compares replica `aggregateVersion`s (or
+  count/checksum) against the owner and triggers targeted re-sync on drift. Duplication without
+  reconciliation is not permitted.
+- **Kafka as tier-1 infrastructure.** Kafka becomes a required runtime dependency for all domain
+  modules in docker/alpha/prod profiles (no more `@ConditionalOnProperty` opt-in for domain flows),
+  with consumer-lag and DLQ monitoring in the observability stack.
+
+### 5. Security model for the event channel
+
+Events bypass the gateway, so gateway JWT validation and `X-Authorities` (ADR-0011 / ADR-0040) do
+not apply on this channel. The trust model is:
+
+- The broker is reachable only on the internal network; there are no external producers or
+  consumers. Producer identity is asserted by `sourceService` and, where the deployment supports
+  it, broker ACLs restrict which service may produce to which topic.
+- Consumers authorize **command events by topic and producer**, not by user authorities. The
+  `actor` field is audit metadata only — it MUST NOT be used to bypass or re-derive permission
+  checks. User-permission enforcement happens once, at the edge where the initiating request
+  entered the system (gateway → controller `@PreAuthorize`).
+- Replica data inherits the read-permission posture of the consuming module's own endpoints.
+
+### 6. Domain-specific decisions
+
+- **Accounting is event-only** (inbound and outbound). Its customer/invoice/workorder clients are
+  retired; billing-rule and invoice read models are event-fed; payment application, payment
+  reversal, credit-memo application, and invoice regeneration become command events consumed by
+  pos-invoice / pos-workorder with result events back.
+- **Vehicle owns its writes.** Vehicle create/update/delete moves out of pos-customer CRM; the
+  frontend calls pos-vehicle-inventory through the gateway. pos-customer keeps a read-only vehicle
+  mirror fed by `vehicle.events.v1`. pos-vehicle-fitment and the vehicle-reference modules are
+  unchanged (external API lookups).
+- **People splits into contact and HR.** New module `pos-people-contact` owns `Person`,
+  `PersonContactPoint`, `UserPersonLink` and publishes contact events. `pos-people` retains HR
+  (Employee, timekeeping, availability, staffing, work sessions) and publishes availability and
+  assignment events. pos-security-service's user↔person linking becomes command + confirmation
+  events.
+- **Customer and location become publishers.** `customer.events.v1` and `location.events.v1`
+  (including address data — see ADR-0016 note below) replace all remaining customer/location REST
+  clients in inventory, invoice, people, shop-manager, and workorder.
+
+### 7. Enforcement
+
+- `pos-archunit` gains a cross-module rule: classes in `com.positivity.*.internal.client` MUST NOT
+  target domain services — RestClient base URLs / service-ids are restricted to the utility
+  whitelist. Rule ships report-only during migration and flips to build-failing when Phase 5
+  completes (phases in the supporting analysis).
+- Per-module `ArchitectureTest` classes gain the mirrored rule plus the `pos-domain-events` import
+  allowance.
+- The utility whitelist lives in one place (a constant list in `pos-archunit`) and changing it
+  requires amending this ADR.
+
+## Consequences
+
+**Positive.** Domain modules deploy, fail, and evolve independently; read paths keep working
+through producer outages; domain models stop leaking through client DTOs; the event stream becomes
+a first-class integration surface (audit, analytics, future consumers).
+
+**Negative / accepted.** Reads may lag the owner by seconds — validation against replicas is
+best-effort and command flows need pending/compensation UX; storage and migration cost per replica;
+event contracts become the platform's most rigid API and demand versioning discipline; Kafka
+becomes tier-1 operational surface (lag, DLQ, partition management); one frontend contract change
+(vehicle writes).
+
+**Explicitly rejected alternatives.** Routing domain events through `pos-event-receiver` (single
+point of failure, not designed as a broker); keeping sync reads with caching (does not remove the
+runtime dependency or the model leak); synchronous write exceptions (would leave the strongest
+coupling — accounting↔invoice/workorder — in place indefinitely).
+
+## Changes required in other ADRs
+
+| ADR | Subject (as referenced in this repo) | Required change |
+|---|---|---|
+| **ADR-0011** — API gateway security architecture | Gateway is the security boundary; JWT → `X-Authorities` | **Amend.** Add a section stating the gateway boundary governs synchronous/client traffic only; the asynchronous Kafka channel uses the trust model in ADR-0043 §5 (internal-only broker, producer identity, `actor` as audit metadata). No change to token or header semantics. |
+| **ADR-0014** — Gateway whitelist routing; pos-tax non-registration | Route whitelist; pos-tax internal-only, no Eureka | **Amend.** Add gateway routes for the new `pos-people-contact` module and confirm the `VEHICLE-INVENTORY` route covers the vehicle write endpoints that move frontend-facing. pos-tax stance unchanged (reaffirmed by ADR-0043 utility classification). |
+| **ADR-0016** — Location contract | Location domain contract (parent types, validation) | **Amend/supersede in part.** The platform rule "other services must not replicate address data: store the locationId and query pos-location" (currently embedded in `pos-invoice` `LocationServiceClient` and `pos-workorder` `LocationClient` javadoc, attributed to the location contract) is **reversed**: consumers MAY hold read-only address replicas fed by `location.events.v1` under ADR-0043 R3. If ADR-0016 codifies the rule, update its text; either way, update the two javadocs when those clients are retired. |
+| **ADR-0017** — Controller HTTP response-code standard | Semantics for 400/401/403/404/409/422/500 | **Amend.** Add `202 Accepted` semantics for endpoints whose effect is enqueuing a command event (response carries a tracking/idempotency reference and a pending-state resource), and a convention for exposing async failure states (result event rejected → surfaced via status resource, not a late HTTP error). |
+| **ADR-0021** — Tax API consumption policy | pos-tax internal-only direct calls | **No change.** Reaffirmed: pos-tax is classified as a utility; existing direct-call exception stands. |
+| **ADR-0025** — Permissions manifest registration policy | Startup permission registration | **No change.** Startup-infra registration is explicitly outside ADR-0043's event mandate (R2). New modules (`pos-people-contact`) follow the existing registration pattern. |
+| **ADR-0026** — Service contract boundary policy | Module boundaries: only `service.*` public; cross-module via REST or events | **Amend.** Narrow the cross-module interaction clause: domain↔domain is events-only; synchronous REST is limited to the ADR-0043 utility whitelist. Add `pos-domain-events` to the shared libraries modules may import (alongside `pos-shared-dtos`), and record the `ext_{owner}_{entity}` replica-table convention as part of the boundary contract. |
+| **ADR-0027** — UUID-typed identifier contract policy | UUID-typed IDs in contracts | **No change** (extend applicability note): event envelope and payload identifiers are UUID-typed; `eventId` is UUIDv7 (ADR-0013). |
+| **ADR-0040** — Authorization via trusted `X-Authorities` | Downstream services trust gateway-produced headers | **Amend.** Current text covers "standard internal API authorization flows." Add: event consumption is not authorized via `X-Authorities`; command events are authorized by topic/producer per ADR-0043 §5, with the initiating user's permission check performed at the original synchronous edge and the `actor` recorded for audit. |
+| **ADR-0042** — OpenAPI rollout baseline | OpenAPI coverage and validation for REST endpoints | **Amend.** (a) Vehicle write endpoints on `pos-vehicle-inventory` become frontend-facing and must join the OpenAPI enforcement waves; add `pos-people-contact` to the module inventory when created. (b) Note that async event contracts are out of OpenAPI scope — contract documentation for topics lives in `pos-domain-events` (AsyncAPI adoption may be proposed separately). |
+| **ADR-0013** — UUID v7 identifier strategy | UUIDv7 primary keys | **No change.** Envelope `eventId` complies. |
+
+Also superseded (non-ADR): `docs/service-discovery-migration/client-policy-matrix.md` — its
+`direct-discovery` classification no longer authorizes domain→domain calls; `startup-infra`,
+`gateway-exception`, `tax-exemption`, and `external` categories remain valid.

--- a/docs/adr-0044-event-only-domain-walls.md
+++ b/docs/adr-0044-event-only-domain-walls.md
@@ -1,6 +1,6 @@
 # ADR-0044 Event-Only Domain Walls and Module Communication Policy
 
-- Status: **Proposed** (candidate — issue [#823](https://github.com/louisburroughs/durion-positivity-backend/issues/823))
+- Status: **Accepted** (2026-07-08 — issue [#823](https://github.com/louisburroughs/durion-positivity-backend/issues/823))
 - Date: 2026-07-08
 - Supersedes: the domain-to-domain portions of the service-discovery client policy
   (`docs/service-discovery-migration/client-policy-matrix.md`) and the javadoc-only
@@ -9,9 +9,9 @@
   ADR-0021, ADR-0022, ADR-0025, ADR-0026, ADR-0027, ADR-0040, ADR-0042, ADR-0043
 - Supporting analysis: `docs/module-coupling/issue-823-event-only-domain-walls-assessment.md`
 
-Once accepted, promote this document to the canonical ADR repository as
-`durion/docs/adr/0044-event-only-domain-walls.adr.md` (0043 is taken by the user–person linkage
-authority ADR) and keep this copy as the backend-local reference.
+The canonical version of this ADR is
+[`durion/docs/adr/0044-platform-event-only-domain-walls.adr.md`](https://github.com/louisburroughs/durion/blob/master/docs/adr/0044-platform-event-only-domain-walls.adr.md);
+this file is the backend-local reference copy.
 
 ## Context
 

--- a/docs/adr-0044-event-only-domain-walls.md
+++ b/docs/adr-0044-event-only-domain-walls.md
@@ -120,7 +120,10 @@ Envelope (extends the existing pos-workorder `KafkaProducer` envelope):
   administrative re-emit-all) to seed new replicas and repair drift.
 - **Reconciliation.** A scheduled job per consumer compares replica `aggregateVersion`s (or
   count/checksum) against the owner and triggers targeted re-sync on drift. Duplication without
-  reconciliation is not permitted.
+  reconciliation is not permitted. Reconciliation itself flows over the event channel: owners
+  publish periodic reconciliation manifests on `{domain}.manifest.v1` and consumers request
+  targeted re-emit via the owner's command topic — reconciliation MUST NOT use synchronous
+  domain-to-domain calls (decided 2026-07-08, durion-positivity-backend#823/#840).
 - **Kafka as tier-1 infrastructure.** Kafka becomes a required runtime dependency for all domain
   modules in docker/alpha/prod profiles (no more `@ConditionalOnProperty` opt-in for domain flows),
   with consumer-lag and DLQ monitoring in the observability stack.

--- a/docs/adr-0044-event-only-domain-walls.md
+++ b/docs/adr-0044-event-only-domain-walls.md
@@ -1,17 +1,17 @@
-# ADR-0043 Event-Only Domain Walls and Module Communication Policy
+# ADR-0044 Event-Only Domain Walls and Module Communication Policy
 
 - Status: **Proposed** (candidate — issue [#823](https://github.com/louisburroughs/durion-positivity-backend/issues/823))
 - Date: 2026-07-08
 - Supersedes: the domain-to-domain portions of the service-discovery client policy
-  (`docs/service-discovery-migration/client-policy-matrix.md`) and the undocumented
+  (`docs/service-discovery-migration/client-policy-matrix.md`) and the javadoc-only
   "do not replicate address data" platform rule (see §Changes to other ADRs)
-- Related: ADR-0011, ADR-0014, ADR-0016, ADR-0017, ADR-0021, ADR-0025, ADR-0026, ADR-0027,
-  ADR-0040, ADR-0042
+- Related: ADR-0006, ADR-0009, ADR-0011, ADR-0012, ADR-0014, ADR-0015, ADR-0017, ADR-0020,
+  ADR-0021, ADR-0022, ADR-0025, ADR-0026, ADR-0027, ADR-0040, ADR-0042, ADR-0043
 - Supporting analysis: `docs/module-coupling/issue-823-event-only-domain-walls-assessment.md`
 
 Once accepted, promote this document to the canonical ADR repository as
-`durion/docs/adr/0043-event-only-domain-walls.adr.md` and keep this copy as the backend-local
-reference.
+`durion/docs/adr/0044-event-only-domain-walls.adr.md` (0043 is taken by the user–person linkage
+authority ADR) and keep this copy as the backend-local reference.
 
 ## Context
 
@@ -42,14 +42,15 @@ pending states.
 
 | Class | Modules | May be called synchronously? |
 |---|---|---|
-| **Utility** | `pos-api-gateway`, `pos-security-service`, `pos-documents`, `pos-image`, `pos-tax` (per ADR-0021), `pos-event-receiver`, `pos-price` | Yes — by any module |
+| **Utility** | `pos-api-gateway`, `pos-security-service`, `pos-documents` (per ADR-0020), `pos-image`, `pos-tax` (per ADR-0021), `pos-event-receiver`, `pos-price` | Yes — by any module |
 | **Domain** | `pos-accounting`, `pos-catalog`, `pos-customer`, `pos-inquiry`, `pos-inventory`, `pos-invoice`, `pos-location`, `pos-order`, `pos-people` (HR), `pos-people-contact` (new), `pos-shop-manager`, `pos-vehicle-inventory`, `pos-vehicle-fitment`, `pos-vehicle-reference-*`, `pos-workorder`, `pos-bulk-loader` | No — events only |
 | **Libraries / non-deployed** | `pos-events`, `pos-shared-dtos`, `pos-domain-events` (new), `pos-security-common`, `pos-tax-common`, `pos-bulk-ingest-lib`, `pos-document-helper`, `pos-dependencies`, `pos-archunit` | n/a |
 
 `pos-tax` and `pos-price` are utilities because they are stateless *computation* (tax and price
 determination), not data lookups — replicating their rule engines into callers would be worse than
-the call. `pos-mcp-server` is a gateway client (bearer-token relay) and follows client rules, not
-module rules.
+the call. `pos-documents` is a utility because ADR-0020 mandates centralized document creation via
+its render API. `pos-mcp-server` is a gateway client (bearer-token relay) and follows client rules,
+not module rules.
 
 ### 2. Rules of separation
 
@@ -144,18 +145,24 @@ not apply on this channel. The trust model is:
   retired; billing-rule and invoice read models are event-fed; payment application, payment
   reversal, credit-memo application, and invoice regeneration become command events consumed by
   pos-invoice / pos-workorder with result events back.
-- **Vehicle owns its writes.** Vehicle create/update/delete moves out of pos-customer CRM; the
-  frontend calls pos-vehicle-inventory through the gateway. pos-customer keeps a read-only vehicle
-  mirror fed by `vehicle.events.v1`. pos-vehicle-fitment and the vehicle-reference modules are
-  unchanged (external API lookups).
+- **Vehicle owns its writes.** Vehicle registry create/update/delete moves out of pos-customer CRM;
+  the frontend calls pos-vehicle-inventory through the gateway. pos-customer keeps a read-only
+  vehicle mirror fed by `vehicle.events.v1` to serve its cross-cutting queries. Per ADR-0012,
+  **vehicle-party associations remain owned by pos-customer** and party-association events continue
+  to originate there; only registry ownership of the vehicle record itself is affected.
+  pos-vehicle-fitment and the vehicle-reference modules are unchanged (external API lookups).
 - **People splits into contact and HR.** New module `pos-people-contact` owns `Person`,
-  `PersonContactPoint`, `UserPersonLink` and publishes contact events. `pos-people` retains HR
-  (Employee, timekeeping, availability, staffing, work sessions) and publishes availability and
-  assignment events. pos-security-service's user↔person linking becomes command + confirmation
-  events.
+  `PersonContactPoint`, and the authoritative `user_person_links` store (ADR-0015, ADR-0043) and
+  publishes contact/link events. `pos-people` retains HR (Employee, timekeeping per ADR-0006,
+  availability, staffing, work sessions) and publishes availability and assignment events.
+  pos-security-service's user↔person linking becomes command + confirmation events, and its
+  `users.person_id` becomes the event-fed projection that ADR-0043 §2 already sanctions as an
+  alternative (see §Changes to other ADRs).
 - **Customer and location become publishers.** `customer.events.v1` and `location.events.v1`
-  (including address data — see ADR-0016 note below) replace all remaining customer/location REST
-  clients in inventory, invoice, people, shop-manager, and workorder.
+  (including address data — see the note on the javadoc platform rule below) replace all remaining
+  customer/location REST clients in inventory, invoice, people, shop-manager, and workorder.
+  Callers of pos-tax source the `destinationAddress` required by ADR-0021 from their local
+  location replicas.
 
 ### 7. Enforcement
 
@@ -164,7 +171,7 @@ not apply on this channel. The trust model is:
   whitelist. Rule ships report-only during migration and flips to build-failing when Phase 5
   completes (phases in the supporting analysis).
 - Per-module `ArchitectureTest` classes gain the mirrored rule plus the `pos-domain-events` import
-  allowance.
+  allowance. This extends, and does not alter, the intra-module package boundary rules of ADR-0026.
 - The utility whitelist lives in one place (a constant list in `pos-archunit`) and changing it
   requires amending this ADR.
 
@@ -187,20 +194,39 @@ coupling — accounting↔invoice/workorder — in place indefinitely).
 
 ## Changes required in other ADRs
 
-| ADR | Subject (as referenced in this repo) | Required change |
-|---|---|---|
-| **ADR-0011** — API gateway security architecture | Gateway is the security boundary; JWT → `X-Authorities` | **Amend.** Add a section stating the gateway boundary governs synchronous/client traffic only; the asynchronous Kafka channel uses the trust model in ADR-0043 §5 (internal-only broker, producer identity, `actor` as audit metadata). No change to token or header semantics. |
-| **ADR-0014** — Gateway whitelist routing; pos-tax non-registration | Route whitelist; pos-tax internal-only, no Eureka | **Amend.** Add gateway routes for the new `pos-people-contact` module and confirm the `VEHICLE-INVENTORY` route covers the vehicle write endpoints that move frontend-facing. pos-tax stance unchanged (reaffirmed by ADR-0043 utility classification). |
-| **ADR-0016** — Location contract | Location domain contract (parent types, validation) | **Amend/supersede in part.** The platform rule "other services must not replicate address data: store the locationId and query pos-location" (currently embedded in `pos-invoice` `LocationServiceClient` and `pos-workorder` `LocationClient` javadoc, attributed to the location contract) is **reversed**: consumers MAY hold read-only address replicas fed by `location.events.v1` under ADR-0043 R3. If ADR-0016 codifies the rule, update its text; either way, update the two javadocs when those clients are retired. |
-| **ADR-0017** — Controller HTTP response-code standard | Semantics for 400/401/403/404/409/422/500 | **Amend.** Add `202 Accepted` semantics for endpoints whose effect is enqueuing a command event (response carries a tracking/idempotency reference and a pending-state resource), and a convention for exposing async failure states (result event rejected → surfaced via status resource, not a late HTTP error). |
-| **ADR-0021** — Tax API consumption policy | pos-tax internal-only direct calls | **No change.** Reaffirmed: pos-tax is classified as a utility; existing direct-call exception stands. |
-| **ADR-0025** — Permissions manifest registration policy | Startup permission registration | **No change.** Startup-infra registration is explicitly outside ADR-0043's event mandate (R2). New modules (`pos-people-contact`) follow the existing registration pattern. |
-| **ADR-0026** — Service contract boundary policy | Module boundaries: only `service.*` public; cross-module via REST or events | **Amend.** Narrow the cross-module interaction clause: domain↔domain is events-only; synchronous REST is limited to the ADR-0043 utility whitelist. Add `pos-domain-events` to the shared libraries modules may import (alongside `pos-shared-dtos`), and record the `ext_{owner}_{entity}` replica-table convention as part of the boundary contract. |
-| **ADR-0027** — UUID-typed identifier contract policy | UUID-typed IDs in contracts | **No change** (extend applicability note): event envelope and payload identifiers are UUID-typed; `eventId` is UUIDv7 (ADR-0013). |
-| **ADR-0040** — Authorization via trusted `X-Authorities` | Downstream services trust gateway-produced headers | **Amend.** Current text covers "standard internal API authorization flows." Add: event consumption is not authorized via `X-Authorities`; command events are authorized by topic/producer per ADR-0043 §5, with the initiating user's permission check performed at the original synchronous edge and the `actor` recorded for audit. |
-| **ADR-0042** — OpenAPI rollout baseline | OpenAPI coverage and validation for REST endpoints | **Amend.** (a) Vehicle write endpoints on `pos-vehicle-inventory` become frontend-facing and must join the OpenAPI enforcement waves; add `pos-people-contact` to the module inventory when created. (b) Note that async event contracts are out of OpenAPI scope — contract documentation for topics lives in `pos-domain-events` (AsyncAPI adoption may be proposed separately). |
-| **ADR-0013** — UUID v7 identifier strategy | UUIDv7 primary keys | **No change.** Envelope `eventId` complies. |
+Verified against the canonical texts in `durion/docs/adr/` (2026-07-08).
 
-Also superseded (non-ADR): `docs/service-discovery-migration/client-policy-matrix.md` — its
-`direct-discovery` classification no longer authorizes domain→domain calls; `startup-infra`,
-`gateway-exception`, `tax-exemption`, and `external` categories remain valid.
+### Amendments required
+
+| ADR | Subject | Required change |
+|---|---|---|
+| **ADR-0009** — Backend domain responsibilities guide | Domain responsibility matrix with "Integrates With" columns and integration patterns | Add a `pos-people-contact` row; split the current pos-people row into contact vs HR responsibilities; update "Integrates With" entries so domain↔domain integration is described as event topics rather than REST calls (e.g. pos-accounting integrates via `invoice.events.v1` / `accounting.commands.v1`, not REST to pos-order/pos-inventory); reflect accounting as event-only. |
+| **ADR-0011** — API gateway security architecture | Gateway-enforced security; pos-security-service ownership; trust model | Add a section stating the gateway trust model governs synchronous/client traffic only; the asynchronous Kafka channel uses the trust model in ADR-0044 §5 (internal-only broker, producer identity, `actor` as audit metadata). No change to token or header semantics. |
+| **ADR-0012** — Vehicle-party relationships belong in pos-customer | Associations owned by pos-customer; pos-customer references vehicle IDs | Association ownership is **unchanged**, but add a clarifying note: vehicle *registry* CRUD is no longer proxied through pos-customer — the frontend calls pos-vehicle-inventory via the gateway, and pos-customer serves its cross-cutting queries ("vehicles owned by a party") from a read-only `ext_vehicle_*` replica fed by `vehicle.events.v1`. Party-association events still originate from pos-customer. |
+| **ADR-0014** — Internal service security via gateway route control | Secure-by-default: no gateway route unless whitelisted | Add explicit routes for `pos-people-contact` and confirm the vehicle-inventory route covers the registry write endpoints that become frontend-facing. pos-tax non-registration stance unchanged. |
+| **ADR-0015** — Identity entity relationships | Person definition; Person↔User invariants (I5–I7) | Invariants unchanged; update the owning-module references: `Person`, `PersonContactPoint`, and `user_person_links` move from pos-people to `pos-people-contact`. |
+| **ADR-0017** — API controller HTTP response codes | Canonical response matrix (no 202 today) | Add `202 Accepted` semantics for endpoints whose effect is enqueuing a command event (response carries a tracking/idempotency reference and a pending-state resource), plus a convention for surfacing async rejection (result event rejected → status resource, not a late HTTP error). |
+| **ADR-0040** — Roles/JWT permission governance | Permission-based backend authorization; token claim contract | Add: event consumption is not authorized via permissions/`X-Authorities`; command events are authorized by topic/producer per ADR-0044 §5, with the initiating user's permission check performed at the original synchronous edge and `actor` recorded for audit. |
+| **ADR-0042** — OpenAPI annotation standards | Mandatory OpenAPI annotations, MCP discovery | Add `pos-people-contact` and the newly frontend-facing pos-vehicle-inventory write endpoints to the enforcement inventory (backend rollout baseline `docs/adr-0042-openapi-rollout-baseline.md` likewise). Note that async event contracts are out of OpenAPI scope — topic contracts live in `pos-domain-events`; AsyncAPI adoption may be proposed separately. |
+| **ADR-0043** — User–person linkage authority and translation | `pos-people.user_person_links` is sole source of truth; §2 prefers removing `users.person_id` and resolving via sync `GET /v1/people/users/{userId}/person` at token-issue time | Two amendments: (a) module references move from pos-people to `pos-people-contact` (link store ownership follows the split); (b) **flip the §2 preference** — under event-only walls, the *preferred* option becomes the one ADR-0043 already sanctions as the alternative: `pos-security-service.users.person_id` retained strictly as a projection written only from the link event (`people-contact.events.v1` link-changed), never by user-CRUD code. Link creation/removal initiated by security flows becomes command + confirmation events. Token-issue-time derivation then reads the local projection (no sync call), preserving the ADR-0022 claim contract and its fallback/metric rules. |
+
+### Reviewed — no change required (reaffirmed)
+
+| ADR | Why no change |
+|---|---|
+| **ADR-0006** — Workexec domain ownership boundaries | Timekeeping stays in the people/HR domain; the split does not move any ADR-0006 assignment. Cross-domain integration contracts it references now flow over events per this ADR. |
+| **ADR-0013** — UUID v7 identifier strategy | Envelope `eventId` complies. |
+| **ADR-0016** — Location entity semantics | Verified: it does **not** codify the "do not replicate address data" rule. That rule exists only as javadoc in `pos-invoice` `LocationServiceClient` and `pos-workorder` `LocationClient` ("Per the platform rule, other services must not replicate address data") and is superseded directly by R3; remove the javadoc when those clients are retired. |
+| **ADR-0020** — Documents centralized creation | Reaffirmed: pos-documents is a utility; synchronous render calls remain the mandated pattern. |
+| **ADR-0021** — Tax API consumption and internal access policy | Reaffirmed: pos-tax is a utility with direct internal calls; its `destinationAddress` contract is satisfied from callers' location replicas. |
+| **ADR-0022** — Stable person identifier claim policy | Claim contract unchanged; derivation flows through the amended ADR-0043 mechanism. Update the link-store module reference alongside ADR-0043's. |
+| **ADR-0025** — Permissions manifest registration policy | Startup-infra registration is explicitly exempt (R2); `pos-people-contact` follows the existing pattern. |
+| **ADR-0026** — Service contract boundary policy | Scope is intra-module package boundaries (`service` vs `internal`), which this ADR does not alter. Optionally add a pointer to ADR-0044 for cross-module transport rules. |
+| **ADR-0027** — UUID-typed identifier contract policy | Event payload identifiers are UUID-typed; compliant. |
+
+### Superseded non-ADR documents
+
+- `docs/service-discovery-migration/client-policy-matrix.md` — its `direct-discovery`
+  classification no longer authorizes domain→domain calls; `startup-infra`, `gateway-exception`,
+  `tax-exemption`, and `external` categories remain valid.
+- The javadoc "platform rule" against replicating address data (see ADR-0016 row above).

--- a/docs/module-coupling/issue-823-event-only-domain-walls-assessment.md
+++ b/docs/module-coupling/issue-823-event-only-domain-walls-assessment.md
@@ -1,0 +1,211 @@
+---
+title: "Issue #823 — Event-Only Domain Walls: Scope Scan & Feasibility Assessment"
+issue: 823
+status: assessment
+date: 2026-07-08
+---
+
+# Event-Only Domain Walls — Scope Scan & Feasibility Assessment
+
+Assessment for [issue #823](https://github.com/louisburroughs/durion-positivity-backend/issues/823):
+make communication with certain domain modules event-only, allow synchronous REST only toward
+dedicated utility modules, and accept read-only data duplication kept in sync by events from the
+owning module.
+
+## Verdict
+
+**Feasible and architecturally sound.** The proposal is classic event-carried state transfer, and
+the codebase already contains working precedents: `pos-workorder` publishes a versioned JSON event
+envelope to Kafka (`workorder.events.v1`), `pos-customer` consumes it, and `pos-accounting` /
+`pos-vehicle-inventory` already have Kafka listeners waiting for topics (`payment.cleared.v1`,
+`vehicle.updates`, `workorder.completed`) **that nothing produces yet** — the architecture has been
+drifting this direction; this issue finishes the job.
+
+The main costs are: (1) a set of platform mechanisms that do not exist yet (outbox, shared event
+contracts, consumer idempotency, backfill, reconciliation), (2) eventual consistency in flows that
+today validate synchronously, and (3) a handful of cross-module **writes** that read-model
+duplication cannot solve and that must become async command events.
+
+## Current module-to-module call graph (as scanned)
+
+Synchronous REST business calls between domain modules, excluding startup registration
+(permissions → security-service, event types → event-receiver) and external APIs (NHTSA, CarAPI,
+Exa, external tax provider):
+
+| Caller | Callee | Client class(es) | Read/Write |
+|---|---|---|---|
+| pos-accounting | pos-customer | `CustomerBillingRulesClient` | read |
+| pos-accounting | pos-invoice | `InvoiceServiceClient` | read + **write** (apply-payment, reverse-payment, apply-credit-memo) |
+| pos-accounting | pos-workorder | `WorkorderInvoiceClient` | **write** (generate-invoice) |
+| pos-catalog | pos-inventory | `InventoryClientImpl` | read |
+| pos-catalog | pos-price | `PricingClientImpl` | read (compute) |
+| pos-customer | pos-people | `PeopleClient` (resolve, by-ids, contact-points) | read |
+| pos-customer | pos-vehicle-inventory | `VehicleInventoryClient` | **full CRUD** (POST/GET/PUT/DELETE) |
+| pos-inventory | pos-location | `SiteDefaultsClient`, `StorageLocationValidationClient`, `LocationRosterClient`, `StorageLocationTopologyClient` | read |
+| pos-inventory | pos-workorder | `WorkorderValidationClient` | read |
+| pos-invoice | pos-customer | `CustomerReferenceClient` | read |
+| pos-invoice | pos-location | `LocationServiceClient` | read |
+| pos-invoice | pos-people + pos-security-service | `ManagerApprovalClient` | read |
+| pos-invoice | pos-workorder | `WorkorderReferenceClient` | read |
+| pos-invoice | pos-tax | `TaxServiceClient` | read (compute) — utility |
+| pos-invoice | pos-documents | `DocumentRenderClient` | utility |
+| pos-location | pos-inventory | `LocationInventoryInquiryClient` | read |
+| pos-location | pos-people | `PersonClient` | read |
+| pos-people | pos-location | `LocationReferenceClient` | read |
+| pos-people | pos-security-service | `SecurityServiceClient` | utility |
+| pos-people | pos-workorder | `WorkexecJobTimeClient` | read |
+| pos-security-service | pos-customer | `CustomerRegistrationClient` | read + **write** (registration/link) |
+| pos-security-service | pos-people | `PeopleRegistrationClient` | read + **write** (user↔person link) |
+| pos-shop-manager | pos-customer | `CrmCustomerClient`, `CrmVehicleClient` | read |
+| pos-shop-manager | pos-people | `PersonClient`, `HrAvailabilityClient` | read |
+| pos-shop-manager | pos-location | `LocationClient` | read |
+| pos-shop-manager | pos-catalog | `ServiceEntityClient` | read |
+| pos-workorder | pos-customer | `CustomerValidationClient` | read |
+| pos-workorder | pos-inventory | `InventoryPickClient` | read + write (pick) |
+| pos-workorder | pos-invoice | `InvoiceClient` | read + write |
+| pos-workorder | pos-people | `PeopleAvailabilityClient`, `PeopleLocationClient` | read |
+| pos-workorder | pos-location | `LocationClient` (tax address) | read |
+| pos-workorder | pos-shop-manager | `ShopmgrOperationalContextClient` | read |
+| pos-workorder | pos-tax | `TaxClient` | read (compute) — utility |
+| pos-workorder | pos-documents | `DocumentClient` | utility |
+
+Not affected:
+
+- **pos-order** — its `internal/client` "ports" (`BillingPort`, `InventoryPort`, `PricingPort`,
+  `SourceDocumentPort`, `WorkexecPort`) are in-memory default adapters; no live REST calls.
+- **pos-price** — `AccountDataProvider` / `VehicleDataProvider` are stubs.
+- **pos-mcp-server** — facade tools route through the gateway with end-user bearer tokens
+  (client-equivalent traffic; documented gateway-exception).
+- **pos-vehicle-fitment / pos-vehicle-reference-carapi / pos-vehicle-reference-nhtsa** — external
+  API callers only.
+- **pos-bulk-loader, pos-documents, pos-tax** — no outbound domain calls (startup-infra/external only).
+
+### Existing async messaging (Kafka)
+
+| Topic | Producer | Consumer(s) |
+|---|---|---|
+| `workorder.events.v1` | pos-workorder `KafkaProducer` (envelope: eventId UUIDv7, eventType, occurredAtUtc, sourceService, payload) | pos-customer `WorkorderEventHandler` |
+| `workorder.commands.v1` | *(none in repo)* | pos-workorder `KafkaCommandListener` |
+| `payment.cleared.v1` | **none** | pos-accounting `PaymentEventListenerConfig` |
+| `vehicle.updates` | **none** | pos-vehicle-inventory `EventListenerConfig` |
+| `workorder.completed` | **none** | pos-vehicle-inventory `EventListenerConfig` |
+
+The `@EmitEvent` / `pos-events` / `pos-event-receiver` pipeline is REST-based audit/analytics
+ingestion — it is **not** a module-to-module messaging channel and stays audit-only.
+
+## Decisions (confirmed 2026-07-08)
+
+1. **Event backbone: Kafka domain topics.** Each owning module publishes versioned topics
+   (`{domain}.events.v1`) using the existing workorder envelope pattern. `pos-event-receiver`
+   remains audit-only.
+2. **Write flows become async command events.** E.g. accounting publishes a payment-cleared event;
+   invoice consumes it, applies the payment, and emits `invoice.payment-applied` back. UI flows
+   must tolerate pending states.
+3. **Utility whitelist (sync calls allowed):** `pos-api-gateway`, `pos-security-service`,
+   `pos-documents`, `pos-image`, `pos-tax` (per ADR-0021, stateless compute), `pos-event-receiver`,
+   and `pos-price` (pricing is compute, not data lookup). Startup registrations (permissions,
+   event types, document templates) stay as-is.
+4. **Vehicle owns its writes.** Vehicle create/update/delete moves out of customer CRM entirely —
+   the frontend talks to pos-vehicle-inventory through the gateway (`lb://VEHICLE-INVENTORY` route
+   already exists); pos-customer keeps only a read-only vehicle mirror fed by vehicle events.
+   pos-vehicle-fitment and the vehicle-reference modules are unaffected (external lookups).
+
+## Gaps: mechanisms that must exist before any module migrates
+
+The issue explicitly calls out staying in sync. None of the following exists today:
+
+1. **Transactional outbox** — publishing to Kafka inside a `@Transactional` service method is not
+   atomic with the DB commit. Each producer module needs an outbox table (Flyway migration) and a
+   poller/publisher, or an equivalent reliable-publish mechanism. Without this, replicas silently
+   diverge.
+2. **Shared event contracts** — a new non-deployed library (e.g. `pos-domain-events`) holding the
+   envelope record (add `schemaVersion` and `aggregateVersion` to the workorder envelope) and
+   versioned payload DTOs per domain, so producers and consumers compile against the same contract.
+   Cross-module DTO sharing via this lib needs an explicit ArchUnit allowance (like
+   `pos-shared-dtos`).
+3. **Idempotent consumers** — a `processed_events` table keyed by `eventId` per consumer module,
+   plus retry and dead-letter-topic conventions. Kafka is at-least-once; replays must be harmless.
+4. **Bootstrap/backfill** — replicas start empty. Owning modules need a snapshot export (bulk
+   endpoint or re-emit-all), used both for initial seeding and for drift repair.
+   `aggregateVersion` on events lets consumers detect gaps and order updates.
+5. **Reconciliation** — a scheduled drift check (per-aggregate version/count/checksum comparison
+   against the owner) with automated re-sync, so duplication stays trustworthy long-term.
+6. **Kafka as a first-class runtime dependency** — today Kafka usage is optional
+   (`@ConditionalOnProperty`). Event-only modules make it mandatory in docker-compose/alpha/prod
+   for every participating service; ops/observability (lag monitoring, DLQ alerting) must follow.
+7. **ArchUnit enforcement** — a cross-module rule in `pos-archunit`: `internal/client` REST clients
+   may only target the utility whitelist. This makes the wall permanent rather than aspirational.
+
+## Conflicts with existing documentation (to be superseded by the ADR)
+
+- `pos-workorder .. LocationClient` javadoc states the platform rule: *"other services must not
+  replicate address data: they store the locationId and query pos-location for the full address."*
+  The new ADR **reverses** this rule — consumers hold read-only address/location mirrors.
+- `docs/service-discovery-migration/client-policy-matrix.md` classifies nearly all of the calls
+  above as `direct-discovery` (i.e. blessed sync calls). The ADR supersedes that classification for
+  domain-to-domain traffic; the matrix remains valid for utility and startup-infra categories.
+
+## Proposed phasing (module by module)
+
+**Phase 0 — Foundations** (no behavior change): ADR; `pos-domain-events` contract lib; outbox
+template + Flyway; consumer idempotency helper; DLQ/retry conventions; backfill pattern; Kafka in
+compose/alpha for all participating modules; ArchUnit rule added in report-only mode.
+
+**Phase 1 — Accounting event-only** (smallest blast radius; its listener already exists):
+- pos-customer publishes billing-rules/account events → accounting local mirror (retires
+  `CustomerBillingRulesClient`).
+- pos-invoice publishes invoice lifecycle events → accounting read model (retires the read half of
+  `InvoiceServiceClient`).
+- Accounting's writes become commands: payment-cleared / credit-memo events consumed by pos-invoice;
+  invoice-regeneration command consumed by pos-workorder; each emits a result event back.
+
+**Phase 2 — Vehicle**:
+- pos-vehicle-inventory publishes `vehicle.events.v1` (finally producing what its own listener
+  design anticipated).
+- Vehicle CRUD moves from pos-customer CRM to the frontend → gateway → pos-vehicle-inventory.
+- pos-customer builds a read-only vehicle mirror; retires `VehicleInventoryClient`.
+  (Frontend contract change — coordinate with durion frontend.)
+
+**Phase 3 — People split (contact vs HR)**:
+- New `pos-people-contact` module owning `Person`, `PersonContactPoint`, `UserPersonLink`
+  (identity + contact). `pos-people` keeps HR: `Employee`, timekeeping, availability, staffing,
+  work sessions.
+- Contact module publishes person/contact events; pos-customer, pos-invoice, pos-location,
+  pos-shop-manager, pos-workorder hold person-reference mirrors.
+- security-service user↔person linking becomes command + confirmation events.
+- people-HR publishes availability/assignment events for pos-workorder and pos-shop-manager;
+  pos-workorder's job-time data reaches people-HR via `workorder.events.v1` (retires
+  `WorkexecJobTimeClient`).
+
+**Phase 4 — Customer & location decoupling**:
+- pos-customer publishes `customer.events.v1` (party/account reference); pos-invoice,
+  pos-shop-manager, pos-workorder retire their customer clients.
+- pos-location publishes `location.events.v1` (profile, addresses, site defaults, storage
+  topology); pos-inventory (4 clients), pos-people, pos-shop-manager, pos-workorder, pos-invoice
+  retire their location clients.
+
+**Phase 5 — Remaining edges + enforcement**:
+- workorder↔invoice, workorder↔inventory (pick), inventory→workorder validation,
+  location→inventory inquiry, workorder→shop-manager context, catalog→inventory availability
+  (note: stock levels are high-churn; consider an event-fed cache with freshness bounds).
+- Flip the ArchUnit rule from report-only to failing.
+
+## Risks / trade-offs to state in the ADR
+
+- **Eventual consistency**: validations that were synchronous (customer exists? location valid?)
+  now read a local mirror that can lag by seconds; command flows need pending states and
+  compensation events. Product must accept this explicitly.
+- **Duplication overhead**: extra storage, migrations, and backfill per consumer — acceptable per
+  the issue, but each replica should copy the *minimum* fields needed, not whole aggregates.
+- **Schema evolution governance**: event contracts become the platform's most rigid API; versioning
+  discipline (`.v1` topics, additive-only payload changes) is mandatory.
+- **Operational surface**: Kafka becomes tier-1 infrastructure; consumer lag and DLQ monitoring are
+  new operational duties.
+
+## Estimated scope
+
+~24 REST client classes retired or replaced across 10 modules, 6 new event-producer surfaces
+(customer, invoice, location, people-contact, people-HR, vehicle-inventory — workorder already
+produces), command consumers in invoice/workorder/vehicle-inventory, one new module
+(`pos-people-contact`), one new shared library (`pos-domain-events`), outbox + idempotency + backfill
+infrastructure, one frontend contract change (vehicle writes), and one ADR.

--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-07-06T13:58:35.652199+00:00"
-root: "/home/n541342/IdeaProjects/durion-positivity-backend"
+generatedAt: "2026-07-08T15:18:37.438139+00:00"
+root: "/home/user/durion-positivity-backend"
 summary:
   manifestCount: 18
-  permissionCount: 327
-  uniquePermissionCount: 327
+  permissionCount: 328
+  uniquePermissionCount: 328
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -685,7 +685,7 @@ manifests:
     domain: "workorder"
     serviceName: "pos-workorder"
     version: "1.0"
-    permissionCount: 50
+    permissionCount: 51
     permissions:
       - name: "workorder:approval_config:create"
         description: "Create approval configurations"
@@ -739,6 +739,8 @@ manifests:
         description: "Create estimate snapshots"
       - name: "workorder:estimate_snapshot:view"
         description: "View estimate snapshot history"
+      - name: "workorder:events:replay"
+        description: "Re-emit published domain events from the outbox (replica seeding and drift repair)"
       - name: "workorder:invoice:create"
         description: "Create workorder invoices"
       - name: "workorder:invoice:view"
@@ -2602,6 +2604,12 @@ permissions:
     source: "pos-workorder/src/main/resources/permissions.yaml"
   - name: "workorder:estimate_snapshot:view"
     description: "View estimate snapshot history"
+    domain: "workorder"
+    serviceName: "pos-workorder"
+    module: "pos-workorder"
+    source: "pos-workorder/src/main/resources/permissions.yaml"
+  - name: "workorder:events:replay"
+    description: "Re-emit published domain events from the outbox (replica seeding and drift repair)"
     domain: "workorder"
     serviceName: "pos-workorder"
     module: "pos-workorder"

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@
 	<modules>
 		<module>pos-dependencies</module>
 		<module>pos-shared-dtos</module>
+		<module>pos-domain-events</module>
 		<module>pos-security-common</module>
 		<module>pos-tax-common</module>
 		<module>pos-archunit</module>

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 17;
+    public static final int CATALOG_VERSION = 18;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -377,7 +377,10 @@ public final class GatewayPermissionCatalog {
         "PERM_mcp:tool:view", // 348
 
         // ── New batch (bits 349–349) ──────────────────────────────────────────
-        "PERM_inventory:location:sync" // 349
+        "PERM_inventory:location:sync", // 349
+
+        // ── New batch (bits 350–350) ──────────────────────────────────────────
+        "PERM_workorder:events:replay" // 350
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 17")
+    @DisplayName("CATALOG_VERSION is 18")
     void catalogVersionIsSeventeen() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(17);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(18);
     }
 
     @Test
-    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 349")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 350")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1185,8 +1185,10 @@ class SecurityGatewayConfigTest {
         assertThat(GatewayPermissionCatalog.authorityForBit(348)).isEqualTo("PERM_mcp:tool:view");
         // catalog v17 (#818 checks): inventory location sync authority appended (bit 349)
         assertThat(GatewayPermissionCatalog.authorityForBit(349)).isEqualTo("PERM_inventory:location:sync");
+        // catalog v18 (#823/#839): outbox replay authority appended (bit 350)
+        assertThat(GatewayPermissionCatalog.authorityForBit(350)).isEqualTo("PERM_workorder:events:replay");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(350)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(351)).isNull();
     }
 
     @Test

--- a/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
@@ -1,0 +1,169 @@
+package com.positivity.archunit;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ADR-0044 domain-wall check: {@code internal.client} (and client-config) sources must not target
+ * other <em>domain</em> modules — synchronous REST is allowed only toward the utility whitelist.
+ *
+ * <p>Detection is source-based (RestClient base URLs, {@code *.service-id} / {@code *.base-url}
+ * config keys, {@code lb://} URIs) because the targets live in string literals and {@code @Value}
+ * defaults rather than in the type graph.
+ *
+ * <p><strong>Report-only during migration:</strong> violations are printed, not failed, until the
+ * ADR-0044 Phase 5 flip. Set {@code -Darchunit.domainWalls.enforce=true} to fail on violations.
+ * The utility whitelist below is the single source of truth; changing it requires amending
+ * ADR-0044.
+ */
+class DomainWallsTest {
+
+    private static final String ENFORCE_PROPERTY = "archunit.domainWalls.enforce";
+
+    /** ADR-0044 §1 utility modules (plus this repo's module-name aliases for them). */
+    private static final Set<String> UTILITY_MODULES = Set.of(
+            "pos-api-gateway",
+            "pos-security-service",
+            "pos-documents",
+            "pos-image",
+            "pos-tax",
+            "pos-event-receiver",
+            "pos-price",
+            // non-deployed libraries reachable via pos-* tokens in code
+            "pos-events",
+            "pos-shared-dtos",
+            "pos-domain-events",
+            "pos-document-helper");
+
+    /** Startup-infra classes exempt per ADR-0044 R2 (registration calls, best-effort at boot). */
+    private static final Pattern EXEMPT_FILES =
+            Pattern.compile(".*(EventTypeInitializer|PermissionRegistration|PermissionInitializer|PermissionRegistry"
+                    + "|TemplateInitializer|PermissionVersionStartupCheck)\\.java$");
+
+    private static final Pattern POS_SERVICE_TOKEN = Pattern.compile("\"[^\"]*?(pos-[a-z][a-z0-9-]*+)[^\"]*?\"");
+    private static final Pattern SERVICE_ID_DEFAULT = Pattern.compile("\\$\\{[a-z0-9.-]*service-id:([a-z][a-z0-9-]*)}");
+    private static final Pattern LOAD_BALANCED_URI = Pattern.compile("lb://([A-Za-z0-9-]+)");
+
+    @Test
+    void internalClientsShouldOnlyTargetUtilityModules() throws IOException {
+        Path repoRoot = repoRoot();
+        Map<String, Set<String>> violations = new TreeMap<>();
+
+        try (Stream<Path> modules = Files.list(repoRoot)) {
+            for (Path module : modules.filter(DomainWallsTest::isPosModule).toList()) {
+                String originModule = module.getFileName().toString();
+                for (Path source : clientSources(module)) {
+                    if (EXEMPT_FILES.matcher(source.toString()).matches()) {
+                        continue;
+                    }
+                    Set<String> targets = referencedServices(source);
+                    targets.removeIf(target -> target.equals(originModule)
+                            || UTILITY_MODULES.contains(target)
+                            || !isPosModule(repoRoot.resolve(target)));
+                    if (!targets.isEmpty()) {
+                        violations
+                                .computeIfAbsent(originModule, k -> new TreeSet<>())
+                                .add(repoRoot.relativize(source) + " -> " + String.join(", ", targets));
+                    }
+                }
+            }
+        }
+
+        StringBuilder report = new StringBuilder("ADR-0044 domain-wall report (sync REST toward domain modules):\n");
+        violations.forEach((module, entries) -> {
+            report.append("  ")
+                    .append(module)
+                    .append(" (")
+                    .append(entries.size())
+                    .append("):\n");
+            entries.forEach(entry -> report.append("    ").append(entry).append('\n'));
+        });
+        int total = violations.values().stream().mapToInt(Set::size).sum();
+        report.append("  total violating client sources: ").append(total);
+        System.out.println(report);
+
+        if (Boolean.getBoolean(ENFORCE_PROPERTY)) {
+            Assertions.assertTrue(
+                    violations.isEmpty(),
+                    "ADR-0044: internal.client sources may only target utility modules\n" + report);
+        }
+    }
+
+    /** internal/client sources plus internal/config client wiring (base URLs often live there). */
+    private static List<Path> clientSources(Path module) throws IOException {
+        Path srcRoot = module.resolve("src/main/java");
+        if (!Files.isDirectory(srcRoot)) {
+            return List.of();
+        }
+        List<Path> sources = new ArrayList<>();
+        try (Stream<Path> files = Files.walk(srcRoot)) {
+            files.filter(p -> p.toString().endsWith(".java"))
+                    .filter(p -> {
+                        String path = p.toString().replace('\\', '/');
+                        return path.contains("/internal/client/")
+                                || (path.contains("/internal/config/")
+                                        && p.getFileName().toString().contains("Client"));
+                    })
+                    .forEach(sources::add);
+        }
+        sources.sort(Comparator.naturalOrder());
+        return sources;
+    }
+
+    /** Extract pos-* service references from code lines (comments stripped to reduce noise). */
+    private static Set<String> referencedServices(Path source) throws IOException {
+        Set<String> targets = new LinkedHashSet<>();
+        for (String line : Files.readAllLines(source)) {
+            String code = line.strip();
+            if (code.startsWith("*") || code.startsWith("//") || code.startsWith("/*")) {
+                continue;
+            }
+            Matcher pos = POS_SERVICE_TOKEN.matcher(code);
+            while (pos.find()) {
+                targets.add(pos.group(1));
+            }
+            Matcher serviceId = SERVICE_ID_DEFAULT.matcher(code);
+            while (serviceId.find()) {
+                targets.add("pos-" + serviceId.group(1));
+            }
+            Matcher lb = LOAD_BALANCED_URI.matcher(code);
+            while (lb.find()) {
+                targets.add("pos-" + lb.group(1).toLowerCase(Locale.ROOT));
+            }
+        }
+        return targets;
+    }
+
+    private static boolean isPosModule(Path dir) {
+        return Files.isDirectory(dir)
+                && dir.getFileName().toString().startsWith("pos-")
+                && Files.exists(dir.resolve("pom.xml"));
+    }
+
+    private static Path repoRoot() {
+        Path dir = Path.of("").toAbsolutePath();
+        while (dir != null) {
+            if (Files.isDirectory(dir.resolve("pos-archunit")) && Files.exists(dir.resolve("pom.xml"))) {
+                return dir;
+            }
+            dir = dir.getParent();
+        }
+        throw new IllegalStateException("repository root with pos-archunit not found above "
+                + Path.of("").toAbsolutePath());
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/KafkaErrorHandlingConfig.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/KafkaErrorHandlingConfig.java
@@ -1,0 +1,54 @@
+package com.positivity.customer.internal.config;
+
+import java.util.function.BiFunction;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.ExponentialBackOff;
+
+/**
+ * Retry and dead-letter handling for the module's Kafka listeners (ADR-0044 §4).
+ *
+ * <p>Failed records are retried with exponential backoff; when retries are exhausted the record is
+ * published to {@code {topic}.dlq} so poison messages surface for alerting instead of silently
+ * blocking or dropping. Idempotency (the {@code processing_log} unique {@code event_id} guard in
+ * {@code WorkorderEventHandler}) makes the retries harmless.
+ *
+ * <p>Spring Boot wires a single {@code CommonErrorHandler} bean into the auto-configured listener
+ * container factory, so declaring the bean is sufficient.
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
+public class KafkaErrorHandlingConfig {
+
+    /** Route to {@code {topic}.dlq}; partition -1 lets the producer choose. */
+    static final BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> DLQ_DESTINATION =
+            (record, ex) -> new TopicPartition(record.topic() + ".dlq", -1);
+
+    @Bean
+    public DefaultErrorHandler kafkaErrorHandler(@SuppressWarnings("rawtypes") KafkaTemplate kafkaTemplate) {
+        @SuppressWarnings("unchecked")
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate, DLQ_DESTINATION);
+
+        ExponentialBackOff backOff = new ExponentialBackOff(1000L, 2.0);
+        backOff.setMaxInterval(30_000L);
+        backOff.setMaxAttempts(5);
+
+        DefaultErrorHandler handler = new DefaultErrorHandler(recoverer, backOff);
+        handler.setRetryListeners((record, ex, attempt) -> log.warn(
+                "Kafka record processing failed topic={} partition={} offset={} attempt={}",
+                record.topic(),
+                record.partition(),
+                record.offset(),
+                attempt,
+                ex));
+        return handler;
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CommunicationPreferenceServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CommunicationPreferenceServiceImpl.java
@@ -50,17 +50,17 @@ public class CommunicationPreferenceServiceImpl implements CommunicationPreferen
 
     private final CommunicationPreferenceRepository preferenceRepository;
     private final CommercialPartyRepository partyRepository;
-        private final PersonPartyRepository personPartyRepository;
+    private final PersonPartyRepository personPartyRepository;
 
     public CommunicationPreferenceServiceImpl(
             CommunicationPreferenceRepository preferenceRepository,
             CommercialPartyRepository partyRepository,
-                        PersonPartyRepository personPartyRepository,
+            PersonPartyRepository personPartyRepository,
             Clock clock) {
         this.clock = clock;
         this.preferenceRepository = preferenceRepository;
         this.partyRepository = partyRepository;
-                this.personPartyRepository = personPartyRepository;
+        this.personPartyRepository = personPartyRepository;
     }
 
     /**
@@ -78,7 +78,7 @@ public class CommunicationPreferenceServiceImpl implements CommunicationPreferen
     @NonNull
     @Transactional(readOnly = true)
     public GetCommunicationPreferencesResponse getCommunicationPreferences(@NonNull UUID partyId) {
-                assertPartyExists(partyId);
+        assertPartyExists(partyId);
 
         // Get preferences or return defaults
         return preferenceRepository
@@ -212,9 +212,9 @@ public class CommunicationPreferenceServiceImpl implements CommunicationPreferen
         return value.substring(0, 8) + "...";
     }
 
-        private void assertPartyExists(@NonNull UUID partyId) {
-                if (!partyRepository.existsById(partyId) && !personPartyRepository.existsById(partyId)) {
-                        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Party not found: " + partyId);
-                }
+    private void assertPartyExists(@NonNull UUID partyId) {
+        if (!partyRepository.existsById(partyId) && !personPartyRepository.existsById(partyId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Party not found: " + partyId);
         }
+    }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyRelationshipServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyRelationshipServiceImpl.java
@@ -179,8 +179,8 @@ public class PartyRelationshipServiceImpl implements PartyRelationshipService {
 
         log.debug("Getting contacts for commercial account: partyId={}, roles={}, status={}", partyId, roles, status);
 
-                // Validate party exists in the unified party model (commercial + person).
-                if (!partyRepository.existsById(partyId) && !personRepository.existsById(partyId)) {
+        // Validate party exists in the unified party model (commercial + person).
+        if (!partyRepository.existsById(partyId) && !personRepository.existsById(partyId)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Party not found");
         }
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -162,10 +162,9 @@ public class PartyServiceImpl implements PartyService {
                 .legalName(personName)
                 .displayName(personName)
                 .status(personParty.getStatus().toString())
-            .createdAt(ISO_FORMATTER.format(requireNonNullField(personParty.getCreatedAt(), "createdAt")))
-                .modifiedAt(personParty.getModifiedAt() != null
-                        ? ISO_FORMATTER.format(personParty.getModifiedAt())
-                        : null)
+                .createdAt(ISO_FORMATTER.format(requireNonNullField(personParty.getCreatedAt(), "createdAt")))
+                .modifiedAt(
+                        personParty.getModifiedAt() != null ? ISO_FORMATTER.format(personParty.getModifiedAt()) : null)
                 .build();
     }
 
@@ -885,8 +884,8 @@ public class PartyServiceImpl implements PartyService {
         SnapshotMetadata meta = createMetadata();
         AccountSummary acct = buildAccountSummary(personParty);
         List<CrmSnapshotDTO.VehicleSummary> vehicles = buildVehicleSummaries(personParty);
-        return new CrmSnapshotDTO(meta, acct, Collections.emptyList(), vehicles, buildBillingPreferences(),
-                BillingRuleRef.defaults());
+        return new CrmSnapshotDTO(
+                meta, acct, Collections.emptyList(), vehicles, buildBillingPreferences(), BillingRuleRef.defaults());
     }
 
     private SnapshotMetadata createMetadata() {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventHandler.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventHandler.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -108,6 +109,10 @@ public class WorkorderEventHandler {
                     .failureReason(truncateFailureReason("SCHEMA validation failed: " + ex.getMessage()))
                     .processedAt(Instant.now(clock))
                     .build());
+        } catch (TransientDataAccessException ex) {
+            // Let the container error handler retry with backoff / route to the DLQ (ADR-0044 §4)
+            // instead of committing a permanent failure log for a transient infrastructure error.
+            throw ex;
         } catch (Exception ex) {
             log.error("Unhandled exception while processing workorder event", ex);
             processingLogRepository.save(ProcessingLog.builder()
@@ -160,6 +165,8 @@ public class WorkorderEventHandler {
                     .status(ProcessingStatus.SUCCESS)
                     .processedAt(Instant.now(clock))
                     .build());
+        } catch (TransientDataAccessException ex) {
+            throw ex;
         } catch (Exception ex) {
             log.error(
                     "VehicleUpdated payload processing failed eventId={} eventType={}",
@@ -266,6 +273,8 @@ public class WorkorderEventHandler {
                     .status(ProcessingStatus.SUCCESS)
                     .processedAt(Instant.now(clock))
                     .build());
+        } catch (TransientDataAccessException ex) {
+            throw ex;
         } catch (Exception ex) {
             log.error(
                     "ContactPreferenceUpdated processing failed eventId={} eventType={}",
@@ -349,6 +358,8 @@ public class WorkorderEventHandler {
                     .status(ProcessingStatus.SUCCESS)
                     .processedAt(Instant.now(clock))
                     .build());
+        } catch (TransientDataAccessException ex) {
+            throw ex;
         } catch (Exception ex) {
             log.error(
                     "PartyNoteAdded processing failed eventId={} eventType={}",

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/KafkaErrorHandlingConfigTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/KafkaErrorHandlingConfigTest.java
@@ -1,0 +1,35 @@
+package com.positivity.customer.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+
+class KafkaErrorHandlingConfigTest {
+
+    @Test
+    @DisplayName("Failed records route to {topic}.dlq with producer-chosen partition")
+    void routesToDlqTopic() {
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("workorder.events.v1", 3, 42L, "key", "value");
+
+        TopicPartition destination =
+                KafkaErrorHandlingConfig.DLQ_DESTINATION.apply(record, new RuntimeException("boom"));
+
+        assertThat(destination.topic()).isEqualTo("workorder.events.v1.dlq");
+        assertThat(destination.partition()).isEqualTo(-1);
+    }
+
+    @Test
+    @DisplayName("Error handler bean is constructed with DLQ recoverer")
+    void buildsErrorHandler() {
+        DefaultErrorHandler handler =
+                new KafkaErrorHandlingConfig().kafkaErrorHandler(Mockito.mock(KafkaTemplate.class));
+
+        assertThat(handler).isNotNull();
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderEventHandlerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderEventHandlerTest.java
@@ -1,6 +1,7 @@
 package com.positivity.customer.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
 /**
@@ -581,5 +583,24 @@ class WorkorderEventHandlerTest {
                         "sourceWorkorderId",
                         UUID.fromString("00000000-0000-0000-0000-000000000001").toString()))
                 .build();
+    }
+
+    /**
+     * ADR-0044 §4: transient infrastructure errors must escape to the container
+     * error handler (retry with backoff, then DLQ) instead of being committed as
+     * permanent failure log entries.
+     */
+    @Test
+    void transientDataAccessErrorsPropagateForRetry() {
+        when(processingLogRepository.findByEventId(any())).thenReturn(Optional.empty());
+        when(vehicleProjectionRepository.findById(any())).thenThrow(new QueryTimeoutException("db timeout"));
+
+        String json = """
+                {"eventId":"11111111-1111-7111-8111-111111111111","eventType":"VehicleUpdated",
+                 "payload":{"vehicleId":"22222222-2222-7222-8222-222222222222","vin":"VIN1"}}
+                """;
+
+        assertThatExceptionOfType(QueryTimeoutException.class).isThrownBy(() -> handler.handleWorkorderEvent(json));
+        verify(vehicleProjectionRepository, never()).save(any());
     }
 }

--- a/pos-dependencies/pom.xml
+++ b/pos-dependencies/pom.xml
@@ -50,6 +50,13 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- Shared Domain Event Contracts (ADR-0044) -->
+            <dependency>
+                <groupId>com.positivity</groupId>
+                <artifactId>pos-domain-events</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- Shared Tax DTO and Validation Library -->
             <dependency>
                 <groupId>com.positivity</groupId>

--- a/pos-domain-events/pom.xml
+++ b/pos-domain-events/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.positivity</groupId>
+        <artifactId>positivity</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pos-domain-events</artifactId>
+    <name>pos-domain-events</name>
+    <description>Shared domain event contracts (envelope, topic naming, versioned payload DTOs) per ADR-0044</description>
+
+    <dependencies>
+        <!-- JSpecify for Nullness Annotations -->
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <!-- UUID v7 generation (ADR-0013) via the shared generator -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-shared-dtos</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Jackson annotations for JSON serialization control -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Jackson 3 databind for serialization round-trip tests only -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/DomainEventEnvelope.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/DomainEventEnvelope.java
@@ -1,0 +1,110 @@
+package com.positivity.domainevents;
+
+import com.positivity.shared.id.UUIDv7Generator;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Standard envelope for all cross-module domain and command events (ADR-0044 §3).
+ *
+ * <p>Every message on a {@code {domain}.events.v1} or {@code {domain}.commands.v1} topic is one
+ * serialized envelope. The payload type is a versioned DTO from this library so producers and
+ * consumers compile against the same contract; payload changes within a schema version must be
+ * additive-only.
+ *
+ * <p>The {@code actor} field is audit metadata only. Consumers must never use it to derive or
+ * bypass permission checks (ADR-0044 §5); user permissions are enforced at the synchronous edge
+ * where the initiating request entered the system.
+ *
+ * @param eventId          unique UUIDv7 id of this event (idempotency key for consumers)
+ * @param eventType        dotted lowercase type, e.g. {@code customer.party.updated}
+ * @param schemaVersion    payload schema version (>= 1); breaking changes require a new topic
+ * @param aggregateId      id of the owning aggregate; also used as the Kafka record key
+ * @param aggregateVersion monotonic per-aggregate sequence for gap and staleness detection
+ * @param occurredAtUtc    when the state change was committed by the owner
+ * @param sourceService    producing service name, e.g. {@code pos-customer}
+ * @param correlationId    correlation id propagated from the initiating request, if available
+ * @param actor            initiating user id or service name — audit only, never authorization
+ * @param payload          versioned payload DTO
+ * @param <T>              payload contract type
+ */
+public record DomainEventEnvelope<T>(
+        @NonNull UUID eventId,
+        @NonNull String eventType,
+        int schemaVersion,
+        @NonNull UUID aggregateId,
+        long aggregateVersion,
+        @NonNull Instant occurredAtUtc,
+        @NonNull String sourceService,
+        @Nullable String correlationId,
+        @Nullable String actor,
+        @NonNull T payload) {
+
+    private static final Pattern EVENT_TYPE_PATTERN = Pattern.compile("[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)+");
+    private static final Pattern SOURCE_SERVICE_PATTERN = Pattern.compile("pos-[a-z][a-z0-9-]*");
+
+    public DomainEventEnvelope {
+        requireNonNull(eventId, "eventId");
+        requireNonNull(eventType, "eventType");
+        requireNonNull(aggregateId, "aggregateId");
+        requireNonNull(occurredAtUtc, "occurredAtUtc");
+        requireNonNull(sourceService, "sourceService");
+        requireNonNull(payload, "payload");
+        if (!EVENT_TYPE_PATTERN.matcher(eventType).matches()) {
+            throw new IllegalArgumentException(
+                    "eventType must be dotted lowercase (e.g. customer.party.updated) but was: " + eventType);
+        }
+        if (schemaVersion < 1) {
+            throw new IllegalArgumentException("schemaVersion must be >= 1 but was: " + schemaVersion);
+        }
+        if (aggregateVersion < 0) {
+            throw new IllegalArgumentException("aggregateVersion must be >= 0 but was: " + aggregateVersion);
+        }
+        if (!SOURCE_SERVICE_PATTERN.matcher(sourceService).matches()) {
+            throw new IllegalArgumentException("sourceService must be a pos-* service name but was: " + sourceService);
+        }
+    }
+
+    /**
+     * Create an envelope with a freshly generated UUIDv7 {@code eventId} and the current time from
+     * the given clock. Producers should use their injected {@link Clock} so tests stay
+     * deterministic.
+     */
+    public static <T> @NonNull DomainEventEnvelope<T> of(
+            @NonNull String eventType,
+            int schemaVersion,
+            @NonNull UUID aggregateId,
+            long aggregateVersion,
+            @NonNull String sourceService,
+            @Nullable String correlationId,
+            @Nullable String actor,
+            @NonNull T payload,
+            @NonNull Clock clock) {
+        return new DomainEventEnvelope<>(
+                UUIDv7Generator.generate(),
+                eventType,
+                schemaVersion,
+                aggregateId,
+                aggregateVersion,
+                Instant.now(clock),
+                sourceService,
+                correlationId,
+                actor,
+                payload);
+    }
+
+    /** The Kafka record key: aggregateId, so per-aggregate ordering is preserved (ADR-0044 §3). */
+    public @NonNull String recordKey() {
+        return aggregateId.toString();
+    }
+
+    private static void requireNonNull(@Nullable Object value, String name) {
+        if (value == null) {
+            throw new IllegalArgumentException(name + " must not be null");
+        }
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/DomainTopics.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/DomainTopics.java
@@ -35,7 +35,7 @@ public final class DomainTopics {
 
     /** Dead-letter topic for a fact or command topic: {@code {topic}.dlq} (ADR-0044 §4). */
     public static @NonNull String dlq(@NonNull String topic) {
-        if (topic.isBlank()) {
+        if (topic == null || topic.isBlank()) {
             throw new IllegalArgumentException("topic must not be blank");
         }
         return topic + ".dlq";

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/DomainTopics.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/DomainTopics.java
@@ -1,0 +1,51 @@
+package com.positivity.domainevents;
+
+import java.util.regex.Pattern;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Topic naming for cross-module domain events (ADR-0044 §3).
+ *
+ * <p>Facts are published to {@code {domain}.events.v1} by the owning module only (one owner per
+ * fact, ADR-0044 R6). Requests for another domain to change state go to that owner's
+ * {@code {domain}.commands.v1} topic. Poison messages are routed to {@code {topic}.dlq}.
+ *
+ * <p>A new topic version ({@code .v2}) is required for breaking payload changes; the owner
+ * dual-publishes both versions during the migration window.
+ */
+public final class DomainTopics {
+
+    /** Domain segment, e.g. {@code customer}, {@code people-contact}, {@code vehicle}. */
+    private static final Pattern DOMAIN_PATTERN = Pattern.compile("[a-z][a-z0-9-]*");
+
+    public static final String WORKORDER_EVENTS_V1 = "workorder.events.v1";
+    public static final String WORKORDER_COMMANDS_V1 = "workorder.commands.v1";
+
+    private DomainTopics() {}
+
+    /** Fact topic for the given domain, version 1: {@code {domain}.events.v1}. */
+    public static @NonNull String events(@NonNull String domain) {
+        return validated(domain) + ".events.v1";
+    }
+
+    /** Command topic for the given domain, version 1: {@code {domain}.commands.v1}. */
+    public static @NonNull String commands(@NonNull String domain) {
+        return validated(domain) + ".commands.v1";
+    }
+
+    /** Dead-letter topic for a fact or command topic: {@code {topic}.dlq} (ADR-0044 §4). */
+    public static @NonNull String dlq(@NonNull String topic) {
+        if (topic.isBlank()) {
+            throw new IllegalArgumentException("topic must not be blank");
+        }
+        return topic + ".dlq";
+    }
+
+    private static String validated(String domain) {
+        if (domain == null || !DOMAIN_PATTERN.matcher(domain).matches()) {
+            throw new IllegalArgumentException(
+                    "domain must be lowercase kebab-case (e.g. customer, people-contact) but was: " + domain);
+        }
+        return domain;
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/DomainEventEnvelopeTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/DomainEventEnvelopeTest.java
@@ -1,0 +1,90 @@
+package com.positivity.domainevents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class DomainEventEnvelopeTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:00:00Z"), ZoneOffset.UTC);
+
+    record PartyUpdatedV1(UUID partyId, String displayName) {}
+
+    private DomainEventEnvelope<PartyUpdatedV1> envelope() {
+        UUID partyId = UUID.randomUUID();
+        return DomainEventEnvelope.of(
+                "customer.party.updated",
+                1,
+                partyId,
+                42L,
+                "pos-customer",
+                "corr-123",
+                "user-9",
+                new PartyUpdatedV1(partyId, "Acme"),
+                FIXED_CLOCK);
+    }
+
+    @Test
+    void factoryPopulatesUuidV7EventIdAndClockTime() {
+        DomainEventEnvelope<PartyUpdatedV1> event = envelope();
+
+        assertThat(event.eventId().version()).isEqualTo(7);
+        assertThat(event.occurredAtUtc()).isEqualTo(Instant.parse("2026-07-08T12:00:00Z"));
+        assertThat(event.recordKey()).isEqualTo(event.aggregateId().toString());
+    }
+
+    @Test
+    void serializationRoundTripPreservesAllFields() {
+        ObjectMapper mapper = JsonMapper.builder().findAndAddModules().build();
+        DomainEventEnvelope<PartyUpdatedV1> event = envelope();
+
+        String json = mapper.writeValueAsString(event);
+        DomainEventEnvelope<PartyUpdatedV1> read = mapper.readValue(
+                json, mapper.getTypeFactory().constructParametricType(DomainEventEnvelope.class, PartyUpdatedV1.class));
+
+        assertThat(read).isEqualTo(event);
+        assertThat(json)
+                .contains("\"eventType\":\"customer.party.updated\"")
+                .contains("\"schemaVersion\":1")
+                .contains("\"aggregateVersion\":42")
+                .contains("\"sourceService\":\"pos-customer\"");
+    }
+
+    @Test
+    void rejectsInvalidEventTypeSchemaVersionAndSourceService() {
+        UUID id = UUID.randomUUID();
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() ->
+                        DomainEventEnvelope.of("BadType", 1, id, 0L, "pos-customer", null, null, "p", FIXED_CLOCK))
+                .withMessageContaining("eventType");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DomainEventEnvelope.of(
+                        "customer.party.updated", 0, id, 0L, "pos-customer", null, null, "p", FIXED_CLOCK))
+                .withMessageContaining("schemaVersion");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DomainEventEnvelope.of(
+                        "customer.party.updated", 1, id, -1L, "pos-customer", null, null, "p", FIXED_CLOCK))
+                .withMessageContaining("aggregateVersion");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DomainEventEnvelope.of(
+                        "customer.party.updated", 1, id, 0L, "customer", null, null, "p", FIXED_CLOCK))
+                .withMessageContaining("sourceService");
+    }
+
+    @Test
+    void optionalCorrelationAndActorMayBeNull() {
+        DomainEventEnvelope<String> event = DomainEventEnvelope.of(
+                "location.profile.updated", 1, UUID.randomUUID(), 7L, "pos-location", null, null, "p", FIXED_CLOCK);
+
+        assertThat(event.correlationId()).isNull();
+        assertThat(event.actor()).isNull();
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/DomainTopicsTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/DomainTopicsTest.java
@@ -21,5 +21,6 @@ class DomainTopicsTest {
         assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.events("Customer"));
         assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.commands("pos_customer"));
         assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.dlq(" "));
+        assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.dlq(null));
     }
 }

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/DomainTopicsTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/DomainTopicsTest.java
@@ -1,0 +1,25 @@
+package com.positivity.domainevents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.Test;
+
+class DomainTopicsTest {
+
+    @Test
+    void buildsVersionedFactCommandAndDlqTopicNames() {
+        assertThat(DomainTopics.events("customer")).isEqualTo("customer.events.v1");
+        assertThat(DomainTopics.events("people-contact")).isEqualTo("people-contact.events.v1");
+        assertThat(DomainTopics.commands("invoice")).isEqualTo("invoice.commands.v1");
+        assertThat(DomainTopics.dlq("invoice.commands.v1")).isEqualTo("invoice.commands.v1.dlq");
+        assertThat(DomainTopics.events("workorder")).isEqualTo(DomainTopics.WORKORDER_EVENTS_V1);
+    }
+
+    @Test
+    void rejectsInvalidDomainNames() {
+        assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.events("Customer"));
+        assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.commands("pos_customer"));
+        assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.dlq(" "));
+    }
+}

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 17;
+    public static final int CATALOG_VERSION = 18;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -398,11 +398,14 @@ public final class DownstreamPermissionCatalog {
         "PERM_invoice:finalize:override", // 346
 
         // ── New batch (bits 347–348) ──────────────────────────────────────────
-        "PERM_mcp:tool:manage",                              // 347
-        "PERM_mcp:tool:view",                                // 348
+        "PERM_mcp:tool:manage", // 347
+        "PERM_mcp:tool:view", // 348
 
         // ── New batch (bits 349–349) ──────────────────────────────────────────
-        "PERM_inventory:location:sync"                      // 349
+        "PERM_inventory:location:sync", // 349
+
+        // ── New batch (bits 350–350) ──────────────────────────────────────────
+        "PERM_workorder:events:replay" // 350
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -454,13 +454,15 @@ public enum PermissionCode {
     MCP__TOOL__MANAGE(347, "mcp:tool:manage"),
     MCP__TOOL__VIEW(348, "mcp:tool:view"),
     // ── Inventory (new) ────────────────────────────────────────────────────────
-    INVENTORY__LOCATION__SYNC(349, "inventory:location:sync");
+    INVENTORY__LOCATION__SYNC(349, "inventory:location:sync"),
+    // ── Workorder (new) ────────────────────────────────────────────────────────
+    WORKORDER__EVENTS__REPLAY(350, "workorder:events:replay");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 17;
+    public static final int CATALOG_VERSION = 18;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 350;
-    private static final int EXPECTED_CATALOG_VERSION = 17;
+    private static final int EXPECTED_PERMISSION_COUNT = 351;
+    private static final int EXPECTED_CATALOG_VERSION = 18;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — 350 entries
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("catalog contains exactly 350 permissions")
+    @DisplayName("catalog contains exactly 351 permissions")
     void catalogContainsExpectedPermissions() {
         assertThat(PermissionCode.values()).hasSize(EXPECTED_PERMISSION_COUNT);
     }
@@ -60,7 +60,7 @@ class PermissionCodeTest {
     }
 
     @Test
-    @DisplayName("bit indexes span from 0 to 346 with no gaps")
+    @DisplayName("bit indexes span the full catalog with no gaps")
     void bitIndexesSpanContiguouslyWithNoGaps() {
         Set<Integer> bitIndexes = Arrays.stream(PermissionCode.values())
                 .map(PermissionCode::bitIndex)

--- a/pos-workorder/pom.xml
+++ b/pos-workorder/pom.xml
@@ -140,6 +140,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Testcontainers: run the real Flyway migration chain against Postgres so entity/DDL drift fails in CI -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
@@ -40,6 +40,12 @@ public final class EventTypes {
             .apiVersion("1")
             .build();
 
+    /** Re-emit published outbox events for replica seeding / drift repair (ADR-0044) */
+    public static final EventTypeRegistration WORKORDER_OUTBOX_REPLAY = EventTypeRegistration.write(
+                    "WORKORDER_OUTBOX_REPLAY", "Re-emit published domain events from the outbox")
+            .apiVersion("1")
+            .build();
+
     /** Delete a workorder */
     public static final EventTypeRegistration WORKORDER_DELETE = EventTypeRegistration.write(
                     "WORKORDER_DELETE", "Delete a workorder by ID")
@@ -510,6 +516,7 @@ public final class EventTypes {
             WORKORDER_SEARCH,
             WORKORDER_NUMBER_RESOLVE,
             WORKORDER_CREATE,
+            WORKORDER_OUTBOX_REPLAY,
             WORKORDER_DELETE,
             WORKORDER_START,
             WORKORDER_OPERATIONAL_CONTEXT_OVERRIDE,

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaEventRelay.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaEventRelay.java
@@ -16,7 +16,11 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
- * Relays committed domain events to Kafka.
+ * Relays domain events into the transactional outbox (ADR-0044 §4).
+ *
+ * <p>Listeners run BEFORE_COMMIT so the outbox row joins the business transaction: the event is
+ * recorded if and only if the state change commits. {@code OutboxPublisher} performs the actual
+ * Kafka send.
  */
 @Slf4j
 @Component
@@ -24,48 +28,48 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
 public class KafkaEventRelay {
 
-    private final KafkaProducer producer;
+    private final OutboxEventWriter producer;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onWorkSessionStarted(WorkSessionStartedEvent event) {
         producer.publish(
                 "workorder.work_session.started.v1", event.workSessionId().toString(), event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onWorkSessionStopped(WorkSessionStoppedEvent event) {
         producer.publish(
                 "workorder.work_session.stopped.v1", event.workSessionId().toString(), event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTravelSegmentStarted(TravelSegmentStartedEvent event) {
         producer.publish(
                 "workorder.travel_segment.started.v1", event.travelSegmentId().toString(), event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTravelSegmentStopped(TravelSegmentStoppedEvent event) {
         producer.publish(
                 "workorder.travel_segment.stopped.v1", event.travelSegmentId().toString(), event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTimeEntryApproved(TimeEntryApprovedEvent event) {
         producer.publish("workorder.time_entry.approved.v1", event.timeEntryId().toString(), event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTimeEntryRejected(TimeEntryRejectedEvent event) {
         producer.publish("workorder.time_entry.rejected.v1", event.timeEntryId().toString(), event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onEstimateCreated(EstimateCreatedEvent event) {
         producer.publish("workorder.estimate.created.v1", event.getEstimateId().toString(), event);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onEstimateRevised(EstimateRevisedEvent event) {
         if (event.getWorkorderId() == null) {
             log.debug(

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxEventWriter.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxEventWriter.java
@@ -1,6 +1,8 @@
 package com.positivity.workorder.internal.config;
 
 import com.positivity.shared.id.UUIDv7Generator;
+import com.positivity.workorder.internal.entity.OutboxEvent;
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -10,48 +12,51 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.ObjectMapper;
 
 /**
- * Kafka producer for workorder domain events.
+ * Transactional-outbox writer for workorder domain events (ADR-0044 §4).
  *
- * <p>
- * Messages are emitted as JSON envelopes to support uniform consumer parsing
- * across domains.
- * </p>
+ * <p>Replaces the previous direct {@code KafkaTemplate} producer: the serialized event is stored
+ * in {@code event_outbox} within the caller's transaction, so an event exists if and only if the
+ * business state change committed. {@link OutboxPublisher} drains the table to Kafka with
+ * at-least-once delivery.
+ *
+ * <p>The JSON envelope shape (eventId, eventType, occurredAtUtc, sourceService, payload) is
+ * unchanged from the previous producer, so existing consumers (pos-customer's workorder event
+ * handler) keep working.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
-public class KafkaProducer {
-    private final Clock clock;
-
+public class OutboxEventWriter {
     private static final String SOURCE_SERVICE = "pos-workorder";
 
-    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final Clock clock;
     private final ObjectMapper objectMapper;
+    private final OutboxEventRepository outboxEventRepository;
 
     @Value("${workorder.kafka.events-topic:workorder.events.v1}")
     private String eventsTopic;
 
+    /**
+     * Queue a domain event for publication as part of the current transaction. Must be called
+     * inside the business transaction ({@code MANDATORY}) — that is the whole point of the outbox.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
     public void publish(@NonNull String eventType, @NonNull String key, @NonNull Object payload) {
-        String message = serializeEnvelope(eventType, payload);
-        kafkaTemplate.send(eventsTopic, key, message).whenComplete((result, ex) -> {
-            if (ex != null) {
-                log.error("Failed to publish Kafka event type={} topic={} key={}", eventType, eventsTopic, key, ex);
-                return;
-            }
-            log.debug(
-                    "Published Kafka event type={} topic={} key={} partition={} offset={}",
-                    eventType,
-                    eventsTopic,
-                    key,
-                    result.getRecordMetadata().partition(),
-                    result.getRecordMetadata().offset());
-        });
+        OutboxEvent event = OutboxEvent.builder()
+                .topic(eventsTopic)
+                .recordKey(key)
+                .payload(serializeEnvelope(eventType, payload))
+                .createdAt(Instant.now(clock))
+                .build();
+        outboxEventRepository.save(event);
+        log.debug("Queued outbox event type={} topic={} key={}", eventType, eventsTopic, key);
     }
 
     private String serializeEnvelope(String eventType, Object payload) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxPublisher.java
@@ -15,16 +15,16 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Drains {@code event_outbox} to Kafka (ADR-0044 §4).
  *
- * <p>At-least-once: a row is marked published only after the broker acknowledges the send, so a
- * crash between send and mark re-sends on the next poll — consumers must be idempotent by
- * {@code eventId}. Rows are processed in id order (UUIDv7 = insertion time); the batch stops at
- * the first failure so a struggling broker cannot reorder events, and failed rows retry on every
- * poll with {@code attempts}/{@code last_error} recorded for alerting.
+ * <p>At-least-once: a row is marked published (in its own short transaction, so no DB connection
+ * is held across the blocking broker send) only after the broker acknowledges, and a crash between
+ * send and mark re-sends on the next poll — consumers must be idempotent by {@code eventId}. Rows
+ * are processed in id order (UUIDv7 = insertion time); the batch stops at the first failure so a
+ * struggling broker cannot reorder events, and failed rows retry on every poll with
+ * {@code attempts}/{@code last_error} recorded for alerting.
  */
 @Slf4j
 @Component
@@ -62,7 +62,6 @@ public class OutboxPublisher {
     }
 
     @Scheduled(fixedDelayString = "${workorder.outbox.poll-interval-ms:1000}")
-    @Transactional
     public void publishPending() {
         List<OutboxEvent> pending = outboxEventRepository.findTop100ByPublishedAtIsNullOrderByIdAsc();
         for (OutboxEvent event : pending) {
@@ -79,6 +78,7 @@ public class OutboxPublisher {
                     .send(event.getTopic(), event.getRecordKey(), event.getPayload())
                     .get(sendTimeoutMs, TimeUnit.MILLISECONDS);
             event.setPublishedAt(Instant.now(clock));
+            event.setAttempts(0);
             event.setLastError(null);
             outboxEventRepository.save(event);
             increment(publishedCounter);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxPublisher.java
@@ -1,0 +1,116 @@
+package com.positivity.workorder.internal.config;
+
+import com.positivity.workorder.internal.entity.OutboxEvent;
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Drains {@code event_outbox} to Kafka (ADR-0044 §4).
+ *
+ * <p>At-least-once: a row is marked published only after the broker acknowledges the send, so a
+ * crash between send and mark re-sends on the next poll — consumers must be idempotent by
+ * {@code eventId}. Rows are processed in id order (UUIDv7 = insertion time); the batch stops at
+ * the first failure so a struggling broker cannot reorder events, and failed rows retry on every
+ * poll with {@code attempts}/{@code last_error} recorded for alerting.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
+public class OutboxPublisher {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final Clock clock;
+    private final Counter publishedCounter;
+    private final Counter failedCounter;
+
+    @Value("${workorder.outbox.send-timeout-ms:10000}")
+    private long sendTimeoutMs;
+
+    public OutboxPublisher(
+            OutboxEventRepository outboxEventRepository,
+            KafkaTemplate<String, String> kafkaTemplate,
+            Clock clock,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.kafkaTemplate = kafkaTemplate;
+        this.clock = clock;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.publishedCounter = registry == null
+                ? null
+                : Counter.builder("workorder.outbox.published")
+                        .description("Outbox events successfully published to Kafka")
+                        .register(registry);
+        this.failedCounter = registry == null
+                ? null
+                : Counter.builder("workorder.outbox.publish.failures")
+                        .description("Outbox publish attempts that failed")
+                        .register(registry);
+    }
+
+    @Scheduled(fixedDelayString = "${workorder.outbox.poll-interval-ms:1000}")
+    @Transactional
+    public void publishPending() {
+        List<OutboxEvent> pending = outboxEventRepository.findTop100ByPublishedAtIsNullOrderByIdAsc();
+        for (OutboxEvent event : pending) {
+            if (!publish(event)) {
+                // Stop at the first failure to preserve publish order; retry next poll.
+                break;
+            }
+        }
+    }
+
+    private boolean publish(OutboxEvent event) {
+        try {
+            kafkaTemplate
+                    .send(event.getTopic(), event.getRecordKey(), event.getPayload())
+                    .get(sendTimeoutMs, TimeUnit.MILLISECONDS);
+            event.setPublishedAt(Instant.now(clock));
+            event.setLastError(null);
+            outboxEventRepository.save(event);
+            increment(publishedCounter);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            recordFailure(event, e);
+            return false;
+        } catch (Exception e) {
+            recordFailure(event, e);
+            return false;
+        }
+    }
+
+    private void recordFailure(OutboxEvent event, Exception e) {
+        event.setAttempts(event.getAttempts() + 1);
+        String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+        event.setLastError(message.length() > 2000 ? message.substring(0, 2000) : message);
+        outboxEventRepository.save(event);
+        increment(failedCounter);
+        log.warn(
+                "Outbox publish failed id={} topic={} key={} attempts={}",
+                event.getId(),
+                event.getTopic(),
+                event.getRecordKey(),
+                event.getAttempts(),
+                e);
+    }
+
+    private void increment(Counter counter) {
+        if (counter != null) {
+            counter.increment();
+        }
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/OutboxAdminController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/OutboxAdminController.java
@@ -1,0 +1,63 @@
+package com.positivity.workorder.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.workorder.service.OutboxReplayService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Administrative outbox operations (ADR-0044 §4 backfill/bootstrap).
+ */
+@RestController
+@RequiredArgsConstructor
+@Tag(
+        name = "Outbox Administration",
+        description = "Re-emit published domain events to seed or repair consumer replicas")
+public class OutboxAdminController {
+
+    private final OutboxReplayService outboxReplayService;
+
+    @PostMapping("/v1/outbox/replay")
+    @PreAuthorize("hasAuthority('workorder:events:replay')")
+    @EmitEvent(id = "WORKORDER_OUTBOX_REPLAY", apiVersion = "1")
+    @Operation(
+            summary = "Re-emit published domain events",
+            description = "Marks already-published outbox events created at or after the given instant for"
+                    + " re-publication to Kafka. Used to seed a new consumer replica or repair drift"
+                    + " (ADR-0044). Consumers deduplicate by eventId, so replay is safe.")
+    @ApiResponse(responseCode = "200", description = "Replay queued; body reports how many events were re-queued")
+    @ApiResponse(responseCode = "400", description = "Malformed 'since' timestamp")
+    @ApiResponse(responseCode = "401", description = "Missing or invalid authentication")
+    @ApiResponse(responseCode = "403", description = "Caller lacks workorder:events:replay")
+    public ResponseEntity<OutboxReplayResponse> replay(
+            @Parameter(
+                            description = "Re-emit events created at or after this instant (ISO-8601)."
+                                    + " Defaults to the epoch, i.e. replay everything.",
+                            example = "2026-07-01T00:00:00Z")
+                    @RequestParam(name = "since", required = false)
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                    Instant since) {
+        Instant effectiveSince = since == null ? Instant.EPOCH : since;
+        int queued = outboxReplayService.replaySince(effectiveSince);
+        return ResponseEntity.ok(new OutboxReplayResponse(effectiveSince, queued));
+    }
+
+    @Schema(description = "Result of an outbox replay request")
+    public record OutboxReplayResponse(
+            @Schema(description = "Effective lower bound used for the replay")
+            Instant since,
+
+            @Schema(description = "Number of events re-queued for publication")
+            int eventsQueued) {}
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/OutboxEvent.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/OutboxEvent.java
@@ -1,0 +1,54 @@
+package com.positivity.workorder.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Transactional-outbox row (ADR-0044 §4): a serialized Kafka event written in the same
+ * transaction as the business state change and drained by {@code OutboxPublisher}.
+ */
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "event_outbox")
+public class OutboxEvent {
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(name = "record_key", nullable = false)
+    private String recordKey;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String payload;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "published_at")
+    private Instant publishedAt;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private int attempts = 0;
+
+    @Column(name = "last_error", columnDefinition = "text")
+    private String lastError;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
@@ -1,14 +1,27 @@
 package com.positivity.workorder.internal.repository;
 
 import com.positivity.workorder.internal.entity.OutboxEvent;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
 
     /** Oldest unpublished rows first — UUIDv7 ids are time-ordered, preserving publish order. */
     @NonNull
     List<OutboxEvent> findTop100ByPublishedAtIsNullOrderByIdAsc();
+
+    /**
+     * Mark already-published events created at or after {@code since} for re-publication
+     * (ADR-0044 backfill/drift repair). The publisher re-sends them; consumers dedupe by eventId.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update OutboxEvent e set e.publishedAt = null, e.attempts = 0, e.lastError = null"
+            + " where e.publishedAt is not null and e.createdAt >= :since")
+    int markForReplaySince(@Param("since") @NonNull Instant since);
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
@@ -1,0 +1,14 @@
+package com.positivity.workorder.internal.repository;
+
+import com.positivity.workorder.internal.entity.OutboxEvent;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+
+    /** Oldest unpublished rows first — UUIDv7 ids are time-ordered, preserving publish order. */
+    @NonNull
+    List<OutboxEvent> findTop100ByPublishedAtIsNullOrderByIdAsc();
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/OutboxReplayServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/OutboxReplayServiceImpl.java
@@ -1,0 +1,26 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import com.positivity.workorder.service.OutboxReplayService;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxReplayServiceImpl implements OutboxReplayService {
+
+    private final OutboxEventRepository outboxEventRepository;
+
+    @Override
+    @Transactional
+    public int replaySince(@NonNull Instant since) {
+        int count = outboxEventRepository.markForReplaySince(since);
+        log.info("Outbox replay requested since={} eventsQueued={}", since, count);
+        return count;
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/OutboxReplayService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/OutboxReplayService.java
@@ -1,0 +1,22 @@
+package com.positivity.workorder.service;
+
+import java.time.Instant;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Administrative re-emit of already-published outbox events (ADR-0044 §4 backfill/bootstrap).
+ *
+ * <p>Used to seed a new consumer replica or repair drift: matching rows are marked unpublished so
+ * the outbox publisher re-sends them. Consumers are idempotent by {@code eventId}, so replay is
+ * harmless to consumers that already processed the events.
+ */
+public interface OutboxReplayService {
+
+    /**
+     * Mark published outbox events created at or after {@code since} for re-publication.
+     *
+     * @param since lower bound (inclusive) on event creation time
+     * @return the number of events queued for re-publication
+     */
+    int replaySince(@NonNull Instant since);
+}

--- a/pos-workorder/src/main/resources/db/migration/V5__create_event_outbox.sql
+++ b/pos-workorder/src/main/resources/db/migration/V5__create_event_outbox.sql
@@ -1,0 +1,17 @@
+-- ADR-0044 §4: transactional outbox for domain events.
+-- Rows are written in the same transaction as the business state change and
+-- drained to Kafka by a background publisher (at-least-once delivery).
+CREATE TABLE event_outbox (
+    id uuid NOT NULL,
+    topic character varying(255) NOT NULL,
+    record_key character varying(255) NOT NULL,
+    payload text NOT NULL,
+    created_at timestamp(6) with time zone NOT NULL,
+    published_at timestamp(6) with time zone,
+    attempts integer NOT NULL DEFAULT 0,
+    last_error text,
+    CONSTRAINT event_outbox_pkey PRIMARY KEY (id)
+);
+
+-- Drain scans: unpublished rows in id order (UUIDv7 ids are time-ordered).
+CREATE INDEX idx_event_outbox_unpublished ON event_outbox (id) WHERE published_at IS NULL;

--- a/pos-workorder/src/main/resources/permissions.yaml
+++ b/pos-workorder/src/main/resources/permissions.yaml
@@ -54,6 +54,8 @@ permissions:
     description: "Create estimate snapshots"
   - name: "workorder:estimate_snapshot:view"
     description: "View estimate snapshot history"
+  - name: "workorder:events:replay"
+    description: "Re-emit published domain events from the outbox (replica seeding and drift repair)"
   - name: "workorder:invoice:create"
     description: "Create workorder invoices"
   - name: "workorder:invoice:view"

--- a/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaEventRelayTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaEventRelayTest.java
@@ -4,7 +4,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.positivity.workorder.internal.config.KafkaEventRelay;
-import com.positivity.workorder.internal.config.KafkaProducer;
+import com.positivity.workorder.internal.config.OutboxEventWriter;
 import com.positivity.workorder.internal.domain.WorkSessionStartedEvent;
 import com.positivity.workorder.internal.event.EstimateRevisedEvent;
 import java.time.Clock;
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 class WorkorderKafkaEventRelayTest {
     private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
-    private final KafkaProducer producer = org.mockito.Mockito.mock(KafkaProducer.class);
+    private final OutboxEventWriter producer = org.mockito.Mockito.mock(OutboxEventWriter.class);
     private final KafkaEventRelay relay = new KafkaEventRelay(producer);
 
     @Test

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.positivity.workorder.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.positivity.workorder.internal.config.OutboxEventWriter;
+import com.positivity.workorder.internal.entity.OutboxEvent;
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.IllegalTransactionStateException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Proves the ADR-0044 outbox guarantee: an event row exists if and only if the business
+ * transaction commits, and writing outside a transaction fails fast (MANDATORY propagation).
+ */
+@DataJpaTest(properties = {"workorder.kafka.enabled=true", "spring.flyway.enabled=false"})
+@Import(OutboxEventWriter.class)
+class OutboxEventWriterIntegrationTest {
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        Clock clock() {
+            return Clock.fixed(Instant.parse("2026-07-08T12:00:00Z"), ZoneOffset.UTC);
+        }
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return JsonMapper.builder().build();
+        }
+    }
+
+    @Autowired
+    private OutboxEventWriter writer;
+
+    @Autowired
+    private OutboxEventRepository repository;
+
+    @Test
+    @DisplayName("Outbox row is persisted when the business transaction commits")
+    void persistsRowOnCommit() {
+        writer.publish("workorder.work_session.started.v1", "wo-key-1", Map.of("workorderId", "wo-1"));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        List<OutboxEvent> rows = repository.findTop100ByPublishedAtIsNullOrderByIdAsc();
+        assertThat(rows).hasSize(1);
+        OutboxEvent row = rows.getFirst();
+        assertThat(row.getTopic()).isEqualTo("workorder.events.v1");
+        assertThat(row.getRecordKey()).isEqualTo("wo-key-1");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getCreatedAt()).isEqualTo(Instant.parse("2026-07-08T12:00:00Z"));
+        // Wire format unchanged from the previous direct producer (pos-customer consumer contract).
+        assertThat(row.getPayload())
+                .contains("\"eventId\"")
+                .contains("\"eventType\":\"workorder.work_session.started.v1\"")
+                .contains("\"occurredAtUtc\"")
+                .contains("\"sourceService\":\"pos-workorder\"")
+                .contains("\"payload\"");
+
+        repository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("No outbox row survives when the business transaction rolls back")
+    void discardsRowOnRollback() {
+        writer.publish("workorder.work_session.stopped.v1", "wo-key-2", Map.of("workorderId", "wo-2"));
+        TestTransaction.flagForRollback();
+        TestTransaction.end();
+
+        assertThat(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Writing outside a transaction fails fast (MANDATORY propagation)")
+    void rejectsPublishOutsideTransaction() {
+        TestTransaction.end();
+
+        assertThatExceptionOfType(IllegalTransactionStateException.class)
+                .isThrownBy(() -> writer.publish("workorder.time_entry.approved.v1", "wo-key-3", Map.of()));
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxPublisherTest.java
@@ -1,0 +1,93 @@
+package com.positivity.workorder.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.config.OutboxPublisher;
+import com.positivity.workorder.internal.entity.OutboxEvent;
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class OutboxPublisherTest {
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:00:00Z"), ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<MeterRegistry> meterRegistry = mock(ObjectProvider.class);
+
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        when(meterRegistry.getIfAvailable()).thenReturn(null);
+        publisher = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, meterRegistry);
+        ReflectionTestUtils.setField(publisher, "sendTimeoutMs", 1000L);
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("workorder.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(Instant.parse("2026-07-08T11:59:00Z"))
+                .build();
+    }
+
+    @Test
+    @DisplayName("Marks row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("workorder.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(Instant.parse("2026-07-08T12:00:00Z"));
+        assertThat(row.getAttempts()).isZero();
+        verify(repository).save(row);
+    }
+
+    @Test
+    @DisplayName("On failure: records attempt and error, keeps row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(1);
+        assertThat(first.getLastError()).contains("broker down");
+        // Batch stops at the first failure to preserve publish order: only k1 was attempted.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("workorder.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isZero();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxPublisherTest.java
@@ -52,6 +52,8 @@ class OutboxPublisherTest {
                 .recordKey(key)
                 .payload("{\"eventId\":\"" + key + "\"}")
                 .createdAt(Instant.parse("2026-07-08T11:59:00Z"))
+                .attempts(2)
+                .lastError("previous failure")
                 .build();
     }
 
@@ -68,6 +70,7 @@ class OutboxPublisherTest {
         verify(kafkaTemplate).send("workorder.events.v1", "k1", row.getPayload());
         assertThat(row.getPublishedAt()).isEqualTo(Instant.parse("2026-07-08T12:00:00Z"));
         assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
         verify(repository).save(row);
     }
 
@@ -83,11 +86,11 @@ class OutboxPublisherTest {
         publisher.publishPending();
 
         assertThat(first.getPublishedAt()).isNull();
-        assertThat(first.getAttempts()).isEqualTo(1);
+        assertThat(first.getAttempts()).isEqualTo(3);
         assertThat(first.getLastError()).contains("broker down");
         // Batch stops at the first failure to preserve publish order: only k1 was attempted.
         verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
         verify(kafkaTemplate).send("workorder.events.v1", "k1", first.getPayload());
-        assertThat(second.getAttempts()).isZero();
+        assertThat(second.getAttempts()).isEqualTo(2);
     }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxReplayServiceImplIntegrationTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxReplayServiceImplIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.positivity.workorder.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.workorder.internal.entity.OutboxEvent;
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import com.positivity.workorder.internal.service.OutboxReplayServiceImpl;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+/**
+ * ADR-0044 backfill: replaying re-queues only published events in the window; unpublished and
+ * older events are untouched, and replayed rows reset their retry bookkeeping.
+ */
+@DataJpaTest(properties = "spring.flyway.enabled=false")
+@Import(OutboxReplayServiceImpl.class)
+class OutboxReplayServiceImplIntegrationTest {
+
+    @Autowired
+    private OutboxReplayServiceImpl service;
+
+    @Autowired
+    private OutboxEventRepository repository;
+
+    private OutboxEvent save(String key, Instant createdAt, Instant publishedAt, int attempts) {
+        return repository.save(OutboxEvent.builder()
+                .topic("workorder.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(createdAt)
+                .publishedAt(publishedAt)
+                .attempts(attempts)
+                .lastError(attempts > 0 ? "previous failure" : null)
+                .build());
+    }
+
+    @Test
+    @DisplayName("Replays only published events at or after the cutoff and resets retry state")
+    void replaysPublishedEventsInWindow() {
+        Instant cutoff = Instant.parse("2026-07-01T00:00:00Z");
+        OutboxEvent oldPublished = save("old", Instant.parse("2026-06-01T00:00:00Z"), Instant.now(), 2);
+        OutboxEvent recentPublished = save("recent", Instant.parse("2026-07-02T00:00:00Z"), Instant.now(), 3);
+        OutboxEvent recentUnpublished = save("pending", Instant.parse("2026-07-03T00:00:00Z"), null, 1);
+
+        int queued = service.replaySince(cutoff);
+
+        assertThat(queued).isEqualTo(1);
+        List<OutboxEvent> all = repository.findAll();
+        OutboxEvent old = all.stream()
+                .filter(e -> e.getRecordKey().equals("old"))
+                .findFirst()
+                .orElseThrow();
+        OutboxEvent recent = all.stream()
+                .filter(e -> e.getRecordKey().equals("recent"))
+                .findFirst()
+                .orElseThrow();
+        OutboxEvent pending = all.stream()
+                .filter(e -> e.getRecordKey().equals("pending"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(old.getPublishedAt()).isNotNull();
+        assertThat(recent.getPublishedAt()).isNull();
+        assertThat(recent.getAttempts()).isZero();
+        assertThat(recent.getLastError()).isNull();
+        assertThat(pending.getPublishedAt()).isNull();
+        assertThat(pending.getAttempts()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Implements the analysis and Phase 0 foundations for #823 (event-only domain walls). 12 commits, 42 files. The canonical ADR and its amendments to nine sibling ADRs are already merged in the durion repo (`38cee7d`).

**Contract guide:** the new replay endpoint follows the workexec domain contract guide — [`durion/domains/workexec/.business-rules/BACKEND_CONTRACT_GUIDE.md`](https://github.com/louisburroughs/durion/blob/master/domains/workexec/.business-rules/BACKEND_CONTRACT_GUIDE.md).

## Documentation
- **Assessment** (`docs/module-coupling/issue-823-event-only-domain-walls-assessment.md`): full module-to-module call matrix (~24 sync REST clients across 10 modules), existing Kafka precedents, feasibility verdict, five-phase migration plan.
- **ADR-0044** (`docs/adr-0044-event-only-domain-walls.md`, Accepted): utility whitelist, rules of separation R1–R6, Kafka event contract standard, mandatory reliability mechanisms, event-channel security model, required amendments to other ADRs; reconciliation flows over the event channel (manifest events) per the #840 decision.
- **OPERATIONS_RUNBOOK.md**: new "Domain Events (Kafka, ADR-0044)" section — outbox monitoring, DLQ inspection, replay/seeding procedure.
- **AGENTS.md**: producer/consumer templates for the new event contracts.

## Phase 0 implementation
- **#835 — `pos-domain-events`** (new library): `DomainEventEnvelope<T>` (UUIDv7 eventId, schemaVersion, aggregateId, aggregateVersion, audit-only actor) + `DomainTopics` naming (`{domain}.events.v1` / `{domain}.commands.v1` / `{topic}.dlq`); registered in reactor + BOM.
- **#836 — transactional outbox in pos-workorder**: `event_outbox` (V5 migration); relay listeners moved AFTER_COMMIT → BEFORE_COMMIT writing via `OutboxEventWriter` (`MANDATORY` propagation — event exists iff the business tx committed); `OutboxPublisher` drains with broker-ack-then-mark (at-least-once, per-row short transactions), order-preserving batch stop on failure, Micrometer counters. Wire format unchanged; `KafkaProducer` removed.
- **#837 — consumer hardening in pos-customer**: `DefaultErrorHandler` with exponential backoff (1s→30s, 5 attempts) + `DeadLetterPublishingRecoverer` → `{topic}.dlq`; `WorkorderEventHandler` now propagates `TransientDataAccessException` for retry instead of committing a permanent failure log (fixes silent event loss on transient DB errors). Idempotency already existed via unique `processing_log.event_id`.
- **#839 — replay/backfill**: `POST /v1/outbox/replay?since=…` on pos-workorder re-queues published outbox rows through the standard publisher; secured with new `workorder:events:replay` permission (**permission catalog v18, bit 350** — fleet-coordinated deploy per catalog policy), audited via `@EmitEvent(WORKORDER_OUTBOX_REPLAY)`, OpenAPI-annotated.
- **#841 — ArchUnit domain wall (report-only)**: `DomainWallsTest` in pos-archunit scans `internal/client` + client-config sources for non-whitelisted domain targets; currently reports 32 violating sources across 10 modules (matches the assessment matrix); flips to build-failing via `-Darchunit.domainWalls.enforce=true` in Phase 5 (#846).
- **#838 (partial) — local Kafka**: single-node KRaft broker in docker-compose with healthcheck; bootstrap-server defaults wired into the four Kafka-touching services. Alpha broker provisioning + dashboards remain (ops decisions).

## Tooling
- **SessionStart hook** (`.claude/hooks/session-start.sh`): installs Oracle JDK 25 (sha256-verified, container-cached) in Claude Code web sessions, since the build enforces Java 25 and the remote image ships JDK 21. No-ops locally.

## Review + CI follow-ups (already pushed)
- `ad95cef`: Copilot review — no transaction held across blocking broker sends; attempts reset on success; `DomainTopics.dlq(null)` throws IAE.
- `577aa52`: permission catalog synced via `scripts/generate-permissions.sh --sync` (v18, bit 350) with pinned contract tests updated.

## Verification (all on real JDK 25.0.3)
- pos-domain-events 6/6, pos-workorder **315/315**, pos-customer **165/165**, pos-security-service **189/189**, pos-api-gateway + pos-security-common green
- Spotless/Checkstyle clean on touched modules; `docker compose config` validates; CI unit-test matrix green across all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgvvXoUwdpykGGKRXNLgrP