### PR TITLE
Add caveman output-compression style (default on)

### DIFF
--- a/.claude/skills/caveman/SKILL.md
+++ b/.claude/skills/caveman/SKILL.md
@@ -1,0 +1,30 @@
+---
+description: Toggle or tune the repo-default caveman output-compression style (terse, token-cheap chat responses). Use when the user says "caveman on/off", "be terse", "verbose mode", or asks about the output style.
+---
+
+# Caveman — output compression
+
+Dependency-free adaptation of Caveman (github.com/JuliusBrussee/caveman, unreachable from web
+sessions) per the durion `token-stack` skill. The rules live in `CLAUDE.md` ("Output Style —
+Caveman") and are **default ON** for chat output in this repo.
+
+## Rules (same as CLAUDE.md)
+
+1. Answer first; no preamble, no restated question, no sign-off.
+2. Telegraphic prose. Fragments fine. Filler dropped.
+3. Lists/tables over paragraphs; ~1 line per point.
+4. Cite `path:line`; never echo file contents, diffs, or logs unasked.
+5. One-line status updates. No emoji. No headers on short answers.
+
+## Scope
+
+Chat responses only. Commits, PR/issue bodies, code, comments, docs, ADRs: normal conventions,
+full quality. Correctness beats brevity — if compression would blur a nuanced finding, use
+normal prose for that part.
+
+## Toggling
+
+- "caveman off" / "verbose" / "explain in detail" → normal prose until the user re-enables or
+  the session ends.
+- "caveman on" → re-apply the rules above.
+- Per-turn override always wins over the default.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,21 @@ on startup against `pos-security-service` (`POST /security-service/v1/permission
 `@PreAuthorize("hasAuthority('" + SomePermissions.SOME_ACTION + "')")`. See `docs/OPERATIONS_RUNBOOK.md`
 ("Permission Registration").
 
+## Output Style — Caveman (token compression, default ON)
+
+Chat responses in this repo default to compressed "caveman" style (adopted from the durion
+`token-stack` skill; see `.claude/skills/caveman/SKILL.md`):
+
+- Answer first. No preamble, no restating the question, no closing summary or sign-off.
+- Telegraphic prose: short sentences, fragments fine, filler words dropped.
+- Lists/tables over paragraphs; aim for one line per point.
+- Don't echo file contents, diffs, or logs — cite `path:line` instead.
+- Routine status updates: one line max. No emoji, no headers on short answers.
+- **Scope: chat output only.** Commit messages, PR/issue bodies, code, comments, docs, and ADRs
+  keep normal repo conventions and full quality.
+- **Override:** drop to normal prose when the user asks ("verbose", "explain"), or when
+  compression would make a nuanced finding ambiguous — correctness beats brevity.
+
 ## Further Reading
 
 - `AGENTS.md` — full code templates for the patterns above (event registries, initializers, ArchUnit rules)


### PR DESCRIPTION
Dependency-free adaptation of Caveman (github.com/JuliusBrussee/caveman) per the durion `token-stack` skill — the upstream installer is unreachable from Claude web sessions (network policy), so the rules are committed directly.

- `CLAUDE.md`: "Output Style — Caveman" section, **default ON** for agent chat output. Scope: chat only — commit messages, PR/issue bodies, code, comments, docs, ADRs keep normal repo conventions. Override with "verbose"/"caveman off".
- `.claude/skills/caveman/SKILL.md`: toggle semantics + rules.

Docs/config only; no code changes. Contract guide: not applicable (no API changes) — BACKEND_CONTRACT_GUIDE.md referenced for the contract-sync gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgvvXoUwdpykGGKRXNLgrP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgvvXoUwdpykGGKRXNLgrP)_