### PR TITLE
Manifest reconciliation (#840) + domain-event observability & retention (#838)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,20 @@ above is **audit-only** and is not a module-to-module channel. See
   ignore stale updates and detect gaps.
 - **Replicas**: read-only copies of another domain's data live in `ext_{owner}_{entity}` tables,
   written only by the event consumer, with minimum fields required.
+- **Reconciliation** (mandatory wherever a replica exists — "duplication without reconciliation is
+  not permitted"): the owner publishes a `ReconciliationManifestV1` per closed time window on
+  `{domain}.manifest.v1` (`DomainTopics.manifest(domain)`), summarizing the window's published
+  events (count + SHA-256 checksum over sorted eventIds, `ReconciliationManifestV1.checksumOf`).
+  Window membership is the UUIDv7 timestamp embedded in each `eventId`
+  (`UuidV7Timestamps.instantOf`) — identical on both sides, no shared clock needed. The consumer
+  recomputes the summary from its processing log (range-scan the eventId column with
+  `UuidV7Timestamps.minStringAt(windowStart/End)`), and on mismatch increments a `replica.drift`
+  counter (tags `owner`, `entity`) and publishes a `{domain}.outbox.replay-requested` command with
+  `payload.since = windowStartUtc`; the owner re-emits through its outbox and the consumer's
+  eventId dedupe makes the repair idempotent. Manifests are sent directly (not via outbox): a lost
+  manifest self-heals on the owner's next run, and zero-event windows still get manifests so
+  consumers can alert on absence. Reference pair: `pos-workorder` `ManifestPublisher` (owner) and
+  `pos-customer` `WorkorderManifestListener` (consumer).
 
 ```java
 DomainEventEnvelope<PartyUpdatedV1> event = DomainEventEnvelope.of(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,52 @@ services:
     networks:
       - pos-network
 
+  kafka-exporter:
+    # #838: topic depth (DLQ), consumer lag, and manifest-topic activity for Prometheus.
+    image: danielqsj/kafka-exporter:v1.8.0
+    container_name: kafka-exporter-positivity
+    command: [ "--kafka.server=kafka:29092" ]
+    ports:
+      - "127.0.0.1:9308:9308"
+    depends_on:
+      kafka:
+        condition: service_healthy
+    logging: *logging
+    networks:
+      - pos-network
+
+  kafka-topic-init:
+    # #838 Q6/Q7/Q9: provision domain-event topics with delete retention, 1 partition.
+    image: apache/kafka:3.9.0
+    container_name: kafka-topic-init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: [ "/bin/bash", "-c" ]
+    command:
+      - |
+        set -e
+        declare -A topics=(
+          ["workorder.events.v1"]=604800000
+          ["workorder.commands.v1"]=604800000
+          ["workorder.manifest.v1"]=259200000
+          ["workorder.events.v1.dlq"]=2592000000
+          ["workorder.manifest.v1.dlq"]=2592000000
+          ["payment.cleared.v1"]=604800000
+        )
+        for t in "$${!topics[@]}"; do
+          /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:29092 --create --if-not-exists \
+            --topic "$$t" --partitions 1 --replication-factor 1 || true
+          /opt/kafka/bin/kafka-configs.sh --bootstrap-server kafka:29092 --alter \
+            --entity-type topics --entity-name "$$t" \
+            --add-config "retention.ms=$${topics[$$t]},cleanup.policy=delete"
+        done
+        echo "topic init complete"
+    restart: "no"
+    logging: *logging
+    networks:
+      - pos-network
+
   ollama:
     image: ollama/ollama:latest
     container_name: ollama

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -419,6 +419,45 @@ Seeding a brand-new replica: create the consumer's `ext_*` tables (Flyway), star
 then call replay with `since` at the epoch (omit the parameter). Consumers skip anything already
 processed.
 
+### Reconciliation manifests and drift detection
+
+Owners publish a per-window summary (count + checksum of the window's eventIds) on
+`{domain}.manifest.v1`; consumers recompute it from their processing log and, on mismatch,
+publish a `{domain}.outbox.replay-requested` command themselves — repair is automatic and needs
+no operator action. Everything flows over the event channel; there are no synchronous
+domain-to-domain reconciliation calls (ADR-0044 §4). Reference pair: `pos-workorder`
+`ManifestPublisher` → `pos-customer` `WorkorderManifestListener`.
+
+Operational signals:
+
+- `replica_drift_total{owner,entity}` (consumer side) — one increment per mismatched window.
+  Occasional single increments self-heal via replay; a **steadily increasing** counter means the
+  repair loop is not converging (owner's command listener down, replay permission/topic issue, or
+  a poison message that can never be recorded) — check the consumer's warn log for the window
+  details (expected vs observed count/checksum) and the owner's `workorder.commands.v1` consumer.
+- `workorder.manifest.published` / `workorder.manifest.publish.failures` (owner side) — manifests
+  stopping entirely means the owner's scheduler or broker connection is down; consumers see no
+  drift while blind, so alert on manifest absence too.
+- Tuning: `workorder.manifest.window` (default `PT1H`), `workorder.manifest.grace` (default
+  `PT5M` — how long after a window closes before its manifest publishes; raise it if consumer lag
+  causes false-positive drift), `workorder.manifest.poll-interval-ms`.
+
+Manual drift drill (compose stack, both `WORKORDER_KAFKA_ENABLED=true` and
+`pos.customer.kafka.enabled=true`):
+
+1. Create/update a workorder so an event lands in `event_outbox` and the customer replica.
+2. Corrupt the consumer: `DELETE FROM processing_log WHERE event_id = '<eventId>'` (and the
+   projected row) in the customer schema.
+3. Wait one manifest cycle (or temporarily set `workorder.manifest.window=PT2M`,
+   `workorder.manifest.grace=PT30S`). The customer logs `Replica drift detected`, increments
+   `replica_drift_total`, and the owner re-emits; the event is reprocessed and the projection
+   restored within the following poll.
+4. Verify `replica_drift_total` stops increasing on subsequent windows.
+
+Until producers emit the full `DomainEventEnvelope` (with `aggregateVersion`), manifests detect
+**lost/undelivered events**, not corrupted-in-place replica rows; per-aggregate state comparison
+arrives with the envelope migration (Phase 1/2).
+
 ## Related Documentation
 
 - **Platform-level runbook**: `durion/docs/OPERATIONS_RUNBOOK.md`

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -391,6 +391,32 @@ publisher drains to Kafka (at-least-once). Operational signals:
 - The publisher halts its batch at the first failure to preserve order — one poisoned/oversized
   record blocks the drain; inspect the oldest unpublished row first.
 
+### Dashboards and alerts (#838)
+
+Grafana dashboard **"Domain Events (ADR-0044)"** (provisioned from
+`observability/grafana/provisioning/dashboards/json/domain-events.json`) charts outbox
+backlog/age, publish/failure rates, consumer lag, DLQ depth, replica drift, and manifest activity.
+`kafka-exporter` (compose service, :9308) supplies topic depth and consumer-group lag.
+
+Provisioned alert thresholds (dashboard-only delivery in alpha):
+
+| Signal | Warn | Critical |
+|---|---|---|
+| Oldest unpublished outbox row | > 5 min | > 15 min |
+| Consumer group lag | > 100 records for 5 min | — |
+| DLQ message | any | — |
+| `replica_drift_total` | any increase | — |
+| Manifest silence (`workorder.manifest.v1`) | > 2 h (2× window) | — |
+
+### Retention (#838)
+
+- Kafka topics (delete policy, provisioned by the `kafka-topic-init` compose job): `*.events.v1`
+  and `*.commands.v1` 7 d; `*.manifest.v1` 3 d; `*.dlq` 30 d. 1 partition per topic on the
+  single-node broker.
+- `event_outbox` table: published rows are purged after **90 days** (`OutboxPurgeJob`, nightly,
+  `workorder.outbox.retention-days`). Replay history equals this retention — a window older than
+  90 days can no longer be re-emitted. Unpublished rows are never purged.
+
 ### Consumers: retry and DLQ
 
 Consumers retry failed records with exponential backoff, then dead-letter to `{topic}.dlq`

--- a/observability/grafana/provisioning/alerting/domain-events-alerts.yml
+++ b/observability/grafana/provisioning/alerting/domain-events-alerts.yml
@@ -1,0 +1,154 @@
+# Grafana-provisioned alert rules for the ADR-0044 domain-event channel (issue #838 Q5).
+# Dashboard-only delivery for alpha (no contact points configured beyond the default).
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: domain-events
+    folder: Durion POS
+    interval: 1m
+    rules:
+      - uid: outbox-oldest-warn
+        title: Outbox drain lagging (oldest unpublished > 5m)
+        condition: C
+        for: 2m
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: Oldest unpublished event_outbox row is older than 5 minutes — drain is slow or stuck.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: max(workorder_outbox_oldest_age_seconds)
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [300] }
+      - uid: outbox-oldest-critical
+        title: Outbox drain stuck (oldest unpublished > 15m)
+        condition: C
+        for: 2m
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: Oldest unpublished event_outbox row is older than 15 minutes — inspect attempts/last_error on the head row.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: max(workorder_outbox_oldest_age_seconds)
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [900] }
+      - uid: consumer-lag-warn
+        title: Kafka consumer lag > 100 for 5m
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: A consumer group is more than 100 records behind for over 5 minutes.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: max(sum by (consumergroup) (kafka_consumergroup_lag))
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [100] }
+      - uid: dlq-message-warn
+        title: DLQ received a message
+        condition: C
+        for: 0s
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: A record was dead-lettered in the last 15 minutes — every DLQ message warrants a look (see OPERATIONS_RUNBOOK.md).
+        data:
+          - refId: A
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: sum(increase(kafka_topic_partition_current_offset{topic=~".*\\.dlq"}[15m]))
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+      - uid: replica-drift-warn
+        title: Replica drift detected
+        condition: C
+        for: 0s
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: A reconciliation manifest mismatched a replica in the last hour; a replay was auto-requested — verify it healed.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 3600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: sum(increase(replica_drift_total[1h]))
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+      - uid: manifest-silent-warn
+        title: Manifest publisher silent > 2h
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: No manifest published to workorder.manifest.v1 in 2 hours (2x window) — the owner's manifest job is down.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 7200, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: sum(increase(kafka_topic_partition_current_offset{topic="workorder.manifest.v1"}[2h]))
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }

--- a/observability/grafana/provisioning/dashboards/json/domain-events.json
+++ b/observability/grafana/provisioning/dashboards/json/domain-events.json
@@ -1,0 +1,98 @@
+{
+  "uid": "domain-events",
+  "title": "Domain Events (ADR-0044)",
+  "tags": ["kafka", "adr-0044", "outbox"],
+  "timezone": "utc",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Outbox pending (unpublished rows)",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "targets": [{ "expr": "sum(workorder_outbox_pending)", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 1000 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Oldest unpublished age",
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "targets": [{ "expr": "max(workorder_outbox_oldest_age_seconds)", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 300 },
+              { "color": "red", "value": 900 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Outbox publish rate / failures (per min)",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        { "expr": "sum(rate(workorder_outbox_published_total[5m])) * 60", "legendFormat": "published/min", "refId": "A" },
+        { "expr": "sum(rate(workorder_outbox_publish_failures_total[5m])) * 60", "legendFormat": "failures/min", "refId": "B" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Consumer group lag",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        { "expr": "sum by (consumergroup, topic) (kafka_consumergroup_lag)", "legendFormat": "{{consumergroup}} {{topic}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "DLQ messages (current offset by topic)",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        { "expr": "sum by (topic) (kafka_topic_partition_current_offset{topic=~\".*\\\\.dlq\"})", "legendFormat": "{{topic}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Replica drift detections (1h increase)",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        { "expr": "sum by (owner) (increase(replica_drift_total[1h]))", "legendFormat": "owner={{owner}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Manifest publications (2h increase — 0 means publisher silent)",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        { "expr": "sum(increase(kafka_topic_partition_current_offset{topic=\"workorder.manifest.v1\"}[2h]))", "legendFormat": "manifests/2h", "refId": "A" }
+      ]
+    }
+  ]
+}

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -4,6 +4,7 @@ apiVersion: 1
 datasources:
   # Prometheus Datasource
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -273,3 +273,10 @@ scrape_configs:
         labels:
           service: 'pos-agent-framework'
           application: 'pos-agent-framework'
+
+  # Kafka exporter (#838): topic depth (DLQ), consumer lag, manifest activity
+  - job_name: 'kafka-exporter'
+    static_configs:
+      - targets: ['kafka-exporter:9308']
+        labels:
+          service: 'kafka'

--- a/pos-customer/pom.xml
+++ b/pos-customer/pom.xml
@@ -184,6 +184,12 @@
             <artifactId>pos-shared-dtos</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Cross-module domain event contracts (ADR-0044) -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-domain-events</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.positivity</groupId>
             <artifactId>pos-bulk-ingest-lib</artifactId>

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/ProcessingLogRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/ProcessingLogRepository.java
@@ -1,16 +1,22 @@
 package com.positivity.customer.internal.repository;
 
 import com.positivity.customer.internal.entity.ProcessingLog;
+import com.positivity.customer.internal.enums.ProcessingStatus;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Spring Data JPA repository for {@link ProcessingLog} entities.
  *
  * <p>
  * Provides the idempotency-check query used by the workorder event handler
- * to detect duplicate event delivery.
+ * to detect duplicate event delivery, and the window scan used by the
+ * reconciliation-manifest comparison (ADR-0044 §4).
  * </p>
  */
 public interface ProcessingLogRepository extends JpaRepository<ProcessingLog, UUID> {
@@ -22,4 +28,19 @@ public interface ProcessingLogRepository extends JpaRepository<ProcessingLog, UU
      * @return an {@link Optional} containing the log entry if found
      */
     Optional<ProcessingLog> findByEventId(String eventId);
+
+    /**
+     * Event ids received in a reconciliation window. UUIDv7 strings sort lexicographically by
+     * their embedded timestamp, so the bounds are the window edges rendered via
+     * {@code UuidV7Timestamps.minStringAt} ({@code lowerBound} inclusive, {@code upperBound}
+     * exclusive). {@code SKIPPED_DUPLICATE} rows are excluded — their eventId is synthetic, not
+     * the envelope's.
+     */
+    @Query("select p.eventId from ProcessingLog p"
+            + " where p.eventId >= :lowerBound and p.eventId < :upperBound and p.status <> :excludedStatus")
+    @NonNull
+    List<String> findEventIdsInRange(
+            @Param("lowerBound") @NonNull String lowerBound,
+            @Param("upperBound") @NonNull String upperBound,
+            @Param("excludedStatus") @NonNull ProcessingStatus excludedStatus);
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderManifestListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderManifestListener.java
@@ -1,0 +1,132 @@
+package com.positivity.customer.internal.service;
+
+import com.positivity.customer.internal.enums.ProcessingStatus;
+import com.positivity.customer.internal.repository.ProcessingLogRepository;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Consumer-side reconciliation for the workorder replica (ADR-0044 §4, issue #840).
+ *
+ * <p>For every {@link ReconciliationManifestV1} on {@code workorder.manifest.v1}, recomputes the
+ * same count + checksum from {@code processing_log} — window membership is the UUIDv7 timestamp
+ * embedded in each recorded eventId, exactly the definition the owner used. On mismatch it
+ * increments {@code replica.drift} (Prometheus: {@code replica_drift_total{owner="workorder"}})
+ * and publishes a {@code workorder.outbox.replay-requested} command for the window; the replayed
+ * events are deduplicated by the unique {@code event_id} guard, so repair is idempotent.
+ *
+ * <p>The comparison is stateless: reprocessing a manifest (redelivery, owner re-publish after a
+ * restart) yields the same verdict, and a duplicate replay request only causes an idempotent
+ * re-delivery. A transient false positive (e.g. consumer still lagging inside the owner's grace
+ * period) therefore costs one harmless replay, never corruption.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
+public class WorkorderManifestListener {
+
+    private static final String REPLAY_COMMAND_TYPE = "workorder.outbox.replay-requested";
+
+    private final ProcessingLogRepository processingLogRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final Counter driftCounter;
+
+    @Value("${pos.customer.kafka.workorder-commands-topic:workorder.commands.v1}")
+    private String workorderCommandsTopic;
+
+    public WorkorderManifestListener(
+            ProcessingLogRepository processingLogRepository,
+            KafkaTemplate<String, String> kafkaTemplate,
+            ObjectMapper objectMapper,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.processingLogRepository = processingLogRepository;
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.driftCounter = registry == null
+                ? null
+                : Counter.builder("replica.drift")
+                        .description("Reconciliation manifests that did not match the local replica")
+                        .tag("owner", "workorder")
+                        .tag("entity", "workorder-events")
+                        .register(registry);
+    }
+
+    @KafkaListener(
+            topics = "${pos.customer.kafka.workorder-manifest-topic:workorder.manifest.v1}",
+            groupId = "${pos.customer.kafka.manifest-consumer-group:pos-customer-workorder-manifests}")
+    public void onManifest(@NonNull String message) {
+        ReconciliationManifestV1 manifest;
+        try {
+            JsonNode envelope = objectMapper.readTree(message);
+            manifest = objectMapper.treeToValue(envelope.path("payload"), ReconciliationManifestV1.class);
+        } catch (Exception e) {
+            // Malformed manifests are dropped, not retried: the next window repeats the check.
+            log.warn("Ignoring unparseable reconciliation manifest: {}", message, e);
+            return;
+        }
+
+        List<String> receivedIds = processingLogRepository.findEventIdsInRange(
+                UuidV7Timestamps.minStringAt(manifest.windowStartUtc()),
+                UuidV7Timestamps.minStringAt(manifest.windowEndUtc()),
+                ProcessingStatus.SKIPPED_DUPLICATE);
+        String observedChecksum = ReconciliationManifestV1.checksumOf(receivedIds);
+
+        if (manifest.matches(receivedIds.size(), observedChecksum)) {
+            log.debug(
+                    "Replica reconciled window=[{}, {}) events={}",
+                    manifest.windowStartUtc(),
+                    manifest.windowEndUtc(),
+                    manifest.eventCount());
+            return;
+        }
+
+        if (driftCounter != null) {
+            driftCounter.increment();
+        }
+        log.warn(
+                "Replica drift detected owner=workorder window=[{}, {}) expectedCount={} observedCount={}"
+                        + " expectedChecksum={} observedChecksum={} eventTypeCounts={} — requesting outbox replay",
+                manifest.windowStartUtc(),
+                manifest.windowEndUtc(),
+                manifest.eventCount(),
+                receivedIds.size(),
+                manifest.eventIdsChecksum(),
+                observedChecksum,
+                manifest.eventTypeCounts());
+        requestReplay(manifest);
+    }
+
+    private void requestReplay(@NonNull ReconciliationManifestV1 manifest) {
+        try {
+            String command = objectMapper.writeValueAsString(new ReplayCommand(
+                    REPLAY_COMMAND_TYPE,
+                    new ReplayCommand.Payload(manifest.windowStartUtc().toString())));
+            kafkaTemplate.send(workorderCommandsTopic, manifest.windowStartUtc().toString(), command);
+        } catch (Exception e) {
+            // Best effort: the drift metric already fired, and the next manifest re-detects.
+            log.warn("Failed to publish outbox replay request for window starting {}", manifest.windowStartUtc(), e);
+        }
+    }
+
+    /** Command envelope for the owner's {@code workorder.commands.v1} listener. */
+    record ReplayCommand(
+            @NonNull String commandType, @NonNull Payload payload) {
+        record Payload(@Nullable String since) {}
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderManifestListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderManifestListener.java
@@ -116,7 +116,9 @@ public class WorkorderManifestListener {
         try {
             String command = objectMapper.writeValueAsString(new ReplayCommand(
                     REPLAY_COMMAND_TYPE,
-                    new ReplayCommand.Payload(manifest.windowStartUtc().toString())));
+                    new ReplayCommand.Payload(
+                            manifest.windowStartUtc().toString(),
+                            manifest.windowEndUtc().toString())));
             kafkaTemplate.send(workorderCommandsTopic, manifest.windowStartUtc().toString(), command);
         } catch (Exception e) {
             // Best effort: the drift metric already fired, and the next manifest re-detects.
@@ -127,6 +129,6 @@ public class WorkorderManifestListener {
     /** Command envelope for the owner's {@code workorder.commands.v1} listener. */
     record ReplayCommand(
             @NonNull String commandType, @NonNull Payload payload) {
-        record Payload(@Nullable String since) {}
+        record Payload(@Nullable String since, @Nullable String until) {}
     }
 }

--- a/pos-customer/src/main/resources/application.yml
+++ b/pos-customer/src/main/resources/application.yml
@@ -75,6 +75,10 @@ pos:
   customer:
     kafka:
       workorder-events-topic: workorder-events
+      # Reconciliation manifests + drift-repair commands (ADR-0044)
+      workorder-manifest-topic: ${POS_CUSTOMER_WORKORDER_MANIFEST_TOPIC:workorder.manifest.v1}
+      workorder-commands-topic: ${POS_CUSTOMER_WORKORDER_COMMANDS_TOPIC:workorder.commands.v1}
+      manifest-consumer-group: ${POS_CUSTOMER_MANIFEST_CONSUMER_GROUP:pos-customer-workorder-manifests}
       enabled: false
   people:
     service-id: ${POS_PEOPLE_SERVICE_ID:people}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderManifestListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderManifestListenerTest.java
@@ -1,0 +1,167 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.enums.ProcessingStatus;
+import com.positivity.customer.internal.repository.ProcessingLogRepository;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+class WorkorderManifestListenerTest {
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T10:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T11:00:00Z");
+    private static final String IN_WINDOW_ID_1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+    private static final String IN_WINDOW_ID_2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+
+    private final ProcessingLogRepository repository = mock(ProcessingLogRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<MeterRegistry> meterRegistryProvider = mock(ObjectProvider.class);
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private WorkorderManifestListener listener;
+
+    @BeforeEach
+    void setUp() {
+        when(meterRegistryProvider.getIfAvailable()).thenReturn(meterRegistry);
+        listener = new WorkorderManifestListener(repository, kafkaTemplate, objectMapper, meterRegistryProvider);
+        ReflectionTestUtils.setField(listener, "workorderCommandsTopic", "workorder.commands.v1");
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private String manifestMessage(long eventCount, String checksum) {
+        return """
+                {
+                  "eventId": "%s",
+                  "eventType": "workorder.reconciliation.manifest",
+                  "schemaVersion": 1,
+                  "aggregateId": "00000000-0000-0000-0000-000000000001",
+                  "aggregateVersion": 1,
+                  "occurredAtUtc": "2026-07-08T11:05:00Z",
+                  "sourceService": "pos-workorder",
+                  "payload": {
+                    "windowStartUtc": "%s",
+                    "windowEndUtc": "%s",
+                    "eventCount": %d,
+                    "eventIdsChecksum": "%s",
+                    "eventTypeCounts": {"VehicleUpdated": %d}
+                  }
+                }
+                """.formatted(
+                        eventIdAt(Instant.parse("2026-07-08T11:05:00Z"), 9),
+                        WINDOW_START,
+                        WINDOW_END,
+                        eventCount,
+                        checksum,
+                        eventCount);
+    }
+
+    private double driftCount() {
+        return meterRegistry
+                .get("replica.drift")
+                .tags("owner", "workorder")
+                .counter()
+                .count();
+    }
+
+    @Test
+    @DisplayName("Matching count and checksum → no drift, no replay request")
+    void matchingManifestIsQuiet() {
+        List<String> ids = List.of(IN_WINDOW_ID_1, IN_WINDOW_ID_2);
+        when(repository.findEventIdsInRange(anyString(), anyString(), eq(ProcessingStatus.SKIPPED_DUPLICATE)))
+                .thenReturn(ids);
+
+        listener.onManifest(manifestMessage(2, ReconciliationManifestV1.checksumOf(ids)));
+
+        assertThat(driftCount()).isZero();
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("Missing event → drift metric + replay request for the window start")
+    void missingEventTriggersDriftAndReplay() throws Exception {
+        // Owner saw two events, we only recorded one.
+        when(repository.findEventIdsInRange(anyString(), anyString(), eq(ProcessingStatus.SKIPPED_DUPLICATE)))
+                .thenReturn(List.of(IN_WINDOW_ID_1));
+
+        listener.onManifest(
+                manifestMessage(2, ReconciliationManifestV1.checksumOf(List.of(IN_WINDOW_ID_1, IN_WINDOW_ID_2))));
+
+        assertThat(driftCount()).isEqualTo(1.0);
+        ArgumentCaptor<String> command = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq("workorder.commands.v1"), anyString(), command.capture());
+        JsonNode json = objectMapper.readTree(command.getValue());
+        assertThat(json.path("commandType").stringValue()).isEqualTo("workorder.outbox.replay-requested");
+        assertThat(json.path("payload").path("since").stringValue()).isEqualTo(WINDOW_START.toString());
+    }
+
+    @Test
+    @DisplayName("Same count but different ids (checksum mismatch) → drift")
+    void checksumMismatchTriggersDrift() {
+        when(repository.findEventIdsInRange(anyString(), anyString(), eq(ProcessingStatus.SKIPPED_DUPLICATE)))
+                .thenReturn(List.of(IN_WINDOW_ID_1));
+
+        listener.onManifest(manifestMessage(1, ReconciliationManifestV1.checksumOf(List.of(IN_WINDOW_ID_2))));
+
+        assertThat(driftCount()).isEqualTo(1.0);
+        verify(kafkaTemplate).send(eq("workorder.commands.v1"), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("Window bounds passed to the repository are the UUIDv7 range of the manifest window")
+    void queriesRepositoryWithWindowBounds() {
+        when(repository.findEventIdsInRange(anyString(), anyString(), eq(ProcessingStatus.SKIPPED_DUPLICATE)))
+                .thenReturn(List.of());
+
+        listener.onManifest(manifestMessage(0, ReconciliationManifestV1.checksumOf(List.of())));
+
+        ArgumentCaptor<String> lower = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> upper = ArgumentCaptor.forClass(String.class);
+        verify(repository)
+                .findEventIdsInRange(lower.capture(), upper.capture(), eq(ProcessingStatus.SKIPPED_DUPLICATE));
+        assertThat(lower.getValue()).isLessThan(IN_WINDOW_ID_1).isLessThan(upper.getValue());
+        assertThat(upper.getValue()).isGreaterThan(IN_WINDOW_ID_2);
+        assertThat(driftCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("Unparseable manifests are dropped without drift or replay")
+    void unparseableManifestIsDropped() {
+        listener.onManifest("{not json");
+        listener.onManifest("{\"payload\": {\"windowStartUtc\": \"oops\"}}");
+
+        assertThat(driftCount()).isZero();
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).findEventIdsInRange(anyString(), anyString(), any());
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderManifestListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderManifestListenerTest.java
@@ -123,6 +123,7 @@ class WorkorderManifestListenerTest {
         JsonNode json = objectMapper.readTree(command.getValue());
         assertThat(json.path("commandType").stringValue()).isEqualTo("workorder.outbox.replay-requested");
         assertThat(json.path("payload").path("since").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(json.path("payload").path("until").stringValue()).isEqualTo(WINDOW_END.toString());
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/DomainTopics.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/DomainTopics.java
@@ -20,6 +20,7 @@ public final class DomainTopics {
 
     public static final String WORKORDER_EVENTS_V1 = "workorder.events.v1";
     public static final String WORKORDER_COMMANDS_V1 = "workorder.commands.v1";
+    public static final String WORKORDER_MANIFEST_V1 = "workorder.manifest.v1";
 
     private DomainTopics() {}
 
@@ -31,6 +32,15 @@ public final class DomainTopics {
     /** Command topic for the given domain, version 1: {@code {domain}.commands.v1}. */
     public static @NonNull String commands(@NonNull String domain) {
         return validated(domain) + ".commands.v1";
+    }
+
+    /**
+     * Reconciliation-manifest topic for the given domain, version 1: {@code {domain}.manifest.v1}
+     * (ADR-0044 §4). Kept separate from the fact topic so consumers' business handlers never see
+     * manifests.
+     */
+    public static @NonNull String manifest(@NonNull String domain) {
+        return validated(domain) + ".manifest.v1";
     }
 
     /** Dead-letter topic for a fact or command topic: {@code {topic}.dlq} (ADR-0044 §4). */

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/ReconciliationManifestV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/ReconciliationManifestV1.java
@@ -1,0 +1,96 @@
+package com.positivity.domainevents;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reconciliation manifest for one closed time window of a domain's fact topic (ADR-0044 §4).
+ *
+ * <p>Owners publish one manifest per window to {@code {domain}.manifest.v1} (see
+ * {@link DomainTopics#manifest(String)}) summarizing the events they published whose
+ * {@code eventId} (UUIDv7) timestamp falls in {@code [windowStartUtc, windowEndUtc)}. Consumers
+ * recompute the same summary from their idempotency/processing log and, on mismatch, raise a drift
+ * metric and request an outbox replay for the window over the owner's command topic. Comparison is
+ * stateless and replay is idempotent, so reprocessing a manifest is always safe.
+ *
+ * <p>Window membership is defined by the timestamp embedded in the event's UUIDv7 {@code eventId}
+ * (see {@link UuidV7Timestamps}) — the only timestamp both sides observe identically — never by
+ * publish or consume time. A zero-event window still gets a manifest so consumers can also alert
+ * on manifest absence.
+ *
+ * @param windowStartUtc   inclusive start of the reconciled window
+ * @param windowEndUtc     exclusive end of the reconciled window
+ * @param eventCount       number of events published in the window
+ * @param eventIdsChecksum checksum over the window's eventIds, per {@link #checksumOf(Collection)}
+ * @param eventTypeCounts  optional per-eventType counts for drift diagnostics; may be null
+ */
+public record ReconciliationManifestV1(
+        @NonNull Instant windowStartUtc,
+        @NonNull Instant windowEndUtc,
+        long eventCount,
+        @NonNull String eventIdsChecksum,
+        @Nullable Map<String, Long> eventTypeCounts) {
+
+    /** Event-type suffix of manifest envelopes: {@code {domain}.reconciliation.manifest}. */
+    public static final String EVENT_TYPE_SUFFIX = "reconciliation.manifest";
+
+    public ReconciliationManifestV1 {
+        if (windowStartUtc == null || windowEndUtc == null) {
+            throw new IllegalArgumentException("windowStartUtc and windowEndUtc must not be null");
+        }
+        if (!windowStartUtc.isBefore(windowEndUtc)) {
+            throw new IllegalArgumentException(
+                    "windowStartUtc must be before windowEndUtc but was: " + windowStartUtc + " / " + windowEndUtc);
+        }
+        if (eventCount < 0) {
+            throw new IllegalArgumentException("eventCount must be >= 0 but was: " + eventCount);
+        }
+        if (eventIdsChecksum == null || eventIdsChecksum.isBlank()) {
+            throw new IllegalArgumentException("eventIdsChecksum must not be blank");
+        }
+    }
+
+    /** Envelope eventType for a domain's manifests, e.g. {@code workorder.reconciliation.manifest}. */
+    public static @NonNull String eventTypeFor(@NonNull String domain) {
+        return domain + "." + EVENT_TYPE_SUFFIX;
+    }
+
+    /**
+     * Canonical checksum both sides must use: lowercase hex SHA-256 over the lexicographically
+     * sorted eventId strings joined with {@code \n}. Sorting makes the checksum independent of
+     * publish/consume order.
+     */
+    public static @NonNull String checksumOf(@NonNull Collection<String> eventIds) {
+        List<String> sorted = new ArrayList<>(eventIds);
+        sorted.sort(null);
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+        boolean first = true;
+        for (String eventId : sorted) {
+            if (!first) {
+                digest.update((byte) '\n');
+            }
+            digest.update(eventId.getBytes(StandardCharsets.UTF_8));
+            first = false;
+        }
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    /** True when this manifest matches the consumer-side count and checksum. */
+    public boolean matches(long observedCount, @NonNull String observedChecksum) {
+        return eventCount == observedCount && eventIdsChecksum.equals(observedChecksum);
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/UuidV7Timestamps.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/UuidV7Timestamps.java
@@ -1,0 +1,50 @@
+package com.positivity.domainevents;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Timestamp arithmetic on UUIDv7 identifiers (RFC 9562) for reconciliation windowing
+ * (ADR-0044 §4).
+ *
+ * <p>A UUIDv7's top 48 bits are the Unix epoch milliseconds at generation time, so the
+ * {@code eventId} itself tells both producer and consumer which reconciliation window an event
+ * belongs to — no shared clock or extra column needed. The canonical lowercase string form sorts
+ * lexicographically by that timestamp, which lets consumers range-scan a varchar eventId column
+ * with the bounds from {@link #minStringAt(Instant)}.
+ */
+public final class UuidV7Timestamps {
+
+    private static final long MILLIS_MASK = 0xFFFF_FFFF_FFFFL;
+
+    private UuidV7Timestamps() {}
+
+    /** The generation instant (millisecond precision) embedded in a UUIDv7. */
+    public static @NonNull Instant instantOf(@NonNull UUID uuid) {
+        if (uuid.version() != 7) {
+            throw new IllegalArgumentException("Not a UUIDv7 (version " + uuid.version() + "): " + uuid);
+        }
+        return Instant.ofEpochMilli(uuid.getMostSignificantBits() >>> 16);
+    }
+
+    /** True when the UUIDv7's embedded timestamp is in {@code [startInclusive, endExclusive)}. */
+    public static boolean isInWindow(
+            @NonNull UUID uuid, @NonNull Instant startInclusive, @NonNull Instant endExclusive) {
+        Instant at = instantOf(uuid);
+        return !at.isBefore(startInclusive) && at.isBefore(endExclusive);
+    }
+
+    /**
+     * The smallest canonical UUIDv7 string with the given timestamp: use as an inclusive lower /
+     * exclusive upper bound when range-scanning stored eventId strings by window.
+     */
+    public static @NonNull String minStringAt(@NonNull Instant timestamp) {
+        long millis = timestamp.toEpochMilli();
+        if ((millis & ~MILLIS_MASK) != 0) {
+            throw new IllegalArgumentException("Timestamp out of UUIDv7 range: " + timestamp);
+        }
+        // All-zero version/variant/random bits sort before every real UUIDv7 sharing the timestamp.
+        return String.format("%08x-%04x-0000-0000-000000000000", millis >>> 16, millis & 0xFFFF);
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/DomainTopicsTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/DomainTopicsTest.java
@@ -14,11 +14,14 @@ class DomainTopicsTest {
         assertThat(DomainTopics.commands("invoice")).isEqualTo("invoice.commands.v1");
         assertThat(DomainTopics.dlq("invoice.commands.v1")).isEqualTo("invoice.commands.v1.dlq");
         assertThat(DomainTopics.events("workorder")).isEqualTo(DomainTopics.WORKORDER_EVENTS_V1);
+        assertThat(DomainTopics.manifest("workorder")).isEqualTo(DomainTopics.WORKORDER_MANIFEST_V1);
+        assertThat(DomainTopics.manifest("people-contact")).isEqualTo("people-contact.manifest.v1");
     }
 
     @Test
     void rejectsInvalidDomainNames() {
         assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.events("Customer"));
+        assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.manifest("Workorder"));
         assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.commands("pos_customer"));
         assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.dlq(" "));
         assertThatIllegalArgumentException().isThrownBy(() -> DomainTopics.dlq(null));

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/ReconciliationManifestV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/ReconciliationManifestV1Test.java
@@ -1,0 +1,67 @@
+package com.positivity.domainevents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReconciliationManifestV1Test {
+
+    private static final Instant START = Instant.parse("2026-07-08T10:00:00Z");
+    private static final Instant END = Instant.parse("2026-07-08T11:00:00Z");
+
+    @Test
+    void checksumIsOrderIndependentAndDeterministic() {
+        List<String> ids = List.of(
+                "01980a58-0000-7000-8000-000000000001",
+                "01980a58-0000-7000-8000-000000000002",
+                "01980a58-0000-7000-8000-000000000003");
+        List<String> shuffled = List.of(ids.get(2), ids.get(0), ids.get(1));
+
+        assertThat(ReconciliationManifestV1.checksumOf(ids))
+                .isEqualTo(ReconciliationManifestV1.checksumOf(shuffled))
+                .matches("[0-9a-f]{64}");
+    }
+
+    @Test
+    void checksumDistinguishesDifferentIdSets() {
+        String a = ReconciliationManifestV1.checksumOf(List.of("01980a58-0000-7000-8000-000000000001"));
+        String b = ReconciliationManifestV1.checksumOf(List.of("01980a58-0000-7000-8000-000000000002"));
+        String empty = ReconciliationManifestV1.checksumOf(List.of());
+
+        assertThat(a).isNotEqualTo(b).isNotEqualTo(empty);
+        // Joining with a separator keeps ["ab","c"] distinct from ["a","bc"].
+        assertThat(ReconciliationManifestV1.checksumOf(List.of("ab", "c")))
+                .isNotEqualTo(ReconciliationManifestV1.checksumOf(List.of("a", "bc")));
+    }
+
+    @Test
+    void matchesComparesCountAndChecksum() {
+        String checksum = ReconciliationManifestV1.checksumOf(List.of("x"));
+        ReconciliationManifestV1 manifest = new ReconciliationManifestV1(START, END, 1, checksum, Map.of("t", 1L));
+
+        assertThat(manifest.matches(1, checksum)).isTrue();
+        assertThat(manifest.matches(2, checksum)).isFalse();
+        assertThat(manifest.matches(1, "0".repeat(64))).isFalse();
+    }
+
+    @Test
+    void eventTypeForBuildsDottedType() {
+        assertThat(ReconciliationManifestV1.eventTypeFor("workorder")).isEqualTo("workorder.reconciliation.manifest");
+    }
+
+    @Test
+    void rejectsInvalidWindowsAndValues() {
+        String checksum = ReconciliationManifestV1.checksumOf(List.of());
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new ReconciliationManifestV1(END, START, 0, checksum, null));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new ReconciliationManifestV1(START, START, 0, checksum, null));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new ReconciliationManifestV1(START, END, -1, checksum, null));
+        assertThatIllegalArgumentException().isThrownBy(() -> new ReconciliationManifestV1(START, END, 0, " ", null));
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/UuidV7TimestampsTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/UuidV7TimestampsTest.java
@@ -1,0 +1,54 @@
+package com.positivity.domainevents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.positivity.shared.id.UUIDv7Generator;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UuidV7TimestampsTest {
+
+    @Test
+    void extractsGenerationInstantFromFreshUuidV7() {
+        Instant before = Instant.now().minusSeconds(1);
+        UUID id = UUIDv7Generator.generate();
+        Instant after = Instant.now().plusSeconds(1);
+
+        Instant embedded = UuidV7Timestamps.instantOf(id);
+        assertThat(embedded).isAfterOrEqualTo(before).isBeforeOrEqualTo(after);
+    }
+
+    @Test
+    void rejectsNonV7Uuids() {
+        assertThatIllegalArgumentException().isThrownBy(() -> UuidV7Timestamps.instantOf(UUID.randomUUID()));
+    }
+
+    @Test
+    void windowMembershipIsStartInclusiveEndExclusive() {
+        Instant start = Instant.parse("2026-07-08T10:00:00Z");
+        Instant end = Instant.parse("2026-07-08T11:00:00Z");
+        UUID atStart = UUID.fromString(UuidV7Timestamps.minStringAt(start).replace("-0000-0000-", "-7000-8000-"));
+        UUID atEnd = UUID.fromString(UuidV7Timestamps.minStringAt(end).replace("-0000-0000-", "-7000-8000-"));
+
+        assertThat(UuidV7Timestamps.isInWindow(atStart, start, end)).isTrue();
+        assertThat(UuidV7Timestamps.isInWindow(atEnd, start, end)).isFalse();
+    }
+
+    @Test
+    void minStringBoundsSortAroundRealUuidsOfTheWindow() {
+        Instant start = Instant.parse("2026-07-08T10:00:00Z");
+        Instant end = Instant.parse("2026-07-08T11:00:00Z");
+        String lower = UuidV7Timestamps.minStringAt(start);
+        String upper = UuidV7Timestamps.minStringAt(end);
+
+        // A real UUIDv7 generated now (far after the window) sorts above the upper bound...
+        String current = UUIDv7Generator.generate().toString();
+        assertThat(current).isGreaterThan(upper);
+        // ...and a synthetic in-window id sorts between the bounds.
+        String inWindow = lower.replace("-0000-0000-", "-7abc-8def-");
+        assertThat(inWindow).isGreaterThanOrEqualTo(lower).isLessThan(upper);
+        assertThat(UuidV7Timestamps.instantOf(UUID.fromString(inWindow))).isEqualTo(start);
+    }
+}

--- a/pos-workorder/pom.xml
+++ b/pos-workorder/pom.xml
@@ -78,6 +78,12 @@
             <artifactId>pos-shared-dtos</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Cross-module domain event contracts (ADR-0044) -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-domain-events</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- Eureka Client -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaCommandListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaCommandListener.java
@@ -4,11 +4,14 @@ import com.positivity.shared.id.UUIDv7Generator;
 import com.positivity.workorder.internal.dto.AssignmentUpdatedEvent;
 import com.positivity.workorder.service.OutboxReplayService;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -39,6 +42,13 @@ public class KafkaCommandListener {
     private static final String COMMAND_ASSIGNMENT_UPDATED = "ASSIGNMENT_UPDATED";
     /** Canonical dotted name normalized to command-type form: WORKORDER_OUTBOX_REPLAY_REQUESTED. */
     private static final String COMMAND_OUTBOX_REPLAY_REQUESTED = "WORKORDER_OUTBOX_REPLAY_REQUESTED";
+
+    /** Covers the sub-millisecond skew between outbox createdAt and the eventId timestamp. */
+    private static final Duration REPLAY_WINDOW_SLACK = Duration.ofSeconds(1);
+
+    /** Replay commands older than this are rejected (PR #849 review — bound repair cost). */
+    @Value("${workorder.outbox.replay.max-lookback:P30D}")
+    private Duration replayMaxLookback;
 
     private final Clock clock;
     private final ObjectMapper objectMapper;
@@ -100,19 +110,43 @@ public class KafkaCommandListener {
 
     private void handleOutboxReplayRequested(@NonNull JsonNode root) {
         JsonNode payloadNode = root.get(PAYLOAD);
-        String since = payloadNode == null ? null : payloadNode.path("since").stringValue(null);
-        if (since == null || since.isBlank()) {
-            log.warn("Ignoring outbox replay command with missing payload.since: {}", root);
+        Instant since = parseInstant(payloadNode, "since");
+        if (since == null) {
+            log.warn("Ignoring outbox replay command with missing/malformed payload.since: {}", root);
             return;
         }
-        Instant sinceInstant;
+        Instant lookbackLimit = Instant.now(clock).minus(replayMaxLookback);
+        if (since.isBefore(lookbackLimit)) {
+            // PR #849 review: a malformed or ancient `since` must not trigger a huge re-emit.
+            log.warn(
+                    "Ignoring outbox replay command: since={} exceeds max lookback {} (limit {})",
+                    since,
+                    replayMaxLookback,
+                    lookbackLimit);
+            return;
+        }
+        Instant until = parseInstant(payloadNode, "until");
+        int queued;
+        if (until != null && until.isAfter(since)) {
+            // Bounded window repair; +/- slack covers createdAt vs eventId-timestamp skew.
+            queued = outboxReplayService.replayBetween(
+                    since.minus(REPLAY_WINDOW_SLACK), until.plus(REPLAY_WINDOW_SLACK));
+        } else {
+            queued = outboxReplayService.replaySince(since.minus(REPLAY_WINDOW_SLACK));
+        }
+        log.info("Outbox replay command processed since={} until={} eventsQueued={}", since, until, queued);
+    }
+
+    private @Nullable Instant parseInstant(@Nullable JsonNode payloadNode, @NonNull String field) {
+        String value = payloadNode == null ? null : payloadNode.path(field).stringValue(null);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
         try {
-            sinceInstant = Instant.parse(since);
+            return Instant.parse(value);
         } catch (Exception e) {
-            log.warn("Ignoring outbox replay command with malformed payload.since={}", since);
-            return;
+            log.warn("Malformed payload.{}={} on outbox replay command", field, value);
+            return null;
         }
-        int queued = outboxReplayService.replaySince(sinceInstant);
-        log.info("Outbox replay command processed since={} eventsQueued={}", sinceInstant, queued);
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaCommandListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaCommandListener.java
@@ -2,6 +2,7 @@ package com.positivity.workorder.internal.config;
 
 import com.positivity.shared.id.UUIDv7Generator;
 import com.positivity.workorder.internal.dto.AssignmentUpdatedEvent;
+import com.positivity.workorder.service.OutboxReplayService;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Locale;
@@ -19,9 +20,12 @@ import tools.jackson.databind.ObjectMapper;
  * Kafka command listener for inbound workorder commands/events.
  *
  * <p>
- * Current supported command type:
+ * Current supported command types:
  * <ul>
  * <li>{@code ASSIGNMENT_UPDATED}</li>
+ * <li>{@code workorder.outbox.replay-requested} — consumer-initiated drift repair (ADR-0044 §4):
+ * re-queues published outbox events created at or after {@code payload.since} for
+ * re-publication; consumers dedupe by eventId so replay is idempotent.</li>
  * </ul>
  * </p>
  */
@@ -33,10 +37,13 @@ public class KafkaCommandListener {
 
     private static final String PAYLOAD = "payload";
     private static final String COMMAND_ASSIGNMENT_UPDATED = "ASSIGNMENT_UPDATED";
+    /** Canonical dotted name normalized to command-type form: WORKORDER_OUTBOX_REPLAY_REQUESTED. */
+    private static final String COMMAND_OUTBOX_REPLAY_REQUESTED = "WORKORDER_OUTBOX_REPLAY_REQUESTED";
 
     private final Clock clock;
     private final ObjectMapper objectMapper;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final OutboxReplayService outboxReplayService;
 
     @KafkaListener(
             topics = "${workorder.kafka.commands-topic:workorder.commands.v1}",
@@ -49,8 +56,18 @@ public class KafkaCommandListener {
             if (hasCommandType) {
                 String rawCommandType = root.get("commandType").stringValue();
                 if (rawCommandType != null && !rawCommandType.isBlank()) {
-                    commandType = rawCommandType.toUpperCase(Locale.ROOT);
+                    // Normalize dotted command names (workorder.outbox.replay-requested) and
+                    // legacy UPPER_SNAKE names to one form.
+                    commandType = rawCommandType
+                            .toUpperCase(Locale.ROOT)
+                            .replace('.', '_')
+                            .replace('-', '_');
                 }
+            }
+
+            if (COMMAND_OUTBOX_REPLAY_REQUESTED.equals(commandType)) {
+                handleOutboxReplayRequested(root);
+                return;
             }
 
             if (!COMMAND_ASSIGNMENT_UPDATED.equals(commandType)) {
@@ -79,5 +96,23 @@ public class KafkaCommandListener {
         } catch (Exception e) {
             log.error("Failed to process Kafka command message: {}", message, e);
         }
+    }
+
+    private void handleOutboxReplayRequested(@NonNull JsonNode root) {
+        JsonNode payloadNode = root.get(PAYLOAD);
+        String since = payloadNode == null ? null : payloadNode.path("since").stringValue(null);
+        if (since == null || since.isBlank()) {
+            log.warn("Ignoring outbox replay command with missing payload.since: {}", root);
+            return;
+        }
+        Instant sinceInstant;
+        try {
+            sinceInstant = Instant.parse(since);
+        } catch (Exception e) {
+            log.warn("Ignoring outbox replay command with malformed payload.since={}", since);
+            return;
+        }
+        int queued = outboxReplayService.replaySince(sinceInstant);
+        log.info("Outbox replay command processed since={} eventsQueued={}", sinceInstant, queued);
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/ManifestPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/ManifestPublisher.java
@@ -1,0 +1,197 @@
+package com.positivity.workorder.internal.config;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import com.positivity.workorder.internal.entity.OutboxEvent;
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Publishes reconciliation manifests for the workorder fact topic (ADR-0044 §4, issue #840).
+ *
+ * <p>Each closed window gets one {@link ReconciliationManifestV1} on
+ * {@code workorder.manifest.v1} summarizing the events published from {@code event_outbox} whose
+ * eventId (UUIDv7) timestamp falls in the window. Consumers recompute the summary from their
+ * processing log and request an outbox replay over {@code workorder.commands.v1} on drift.
+ *
+ * <p>Manifests are sent directly (no outbox): a lost manifest is self-healing — the next run
+ * re-publishes it, and consumers can additionally alert on manifest absence. Publication waits
+ * {@code grace} after window close so in-flight publishes and consumer lag settle before the
+ * comparison, avoiding false drift. Re-publishing the same window (e.g. after a restart) is
+ * harmless because the consumer-side comparison is stateless and idempotent.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
+public class ManifestPublisher {
+
+    /** Covers the sub-millisecond skew between outbox {@code createdAt} and the eventId timestamp. */
+    private static final Duration CREATED_AT_SLACK = Duration.ofSeconds(1);
+
+    private static final String DOMAIN = "workorder";
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+    private final Counter publishedCounter;
+    private final Counter failedCounter;
+
+    @Value("${workorder.kafka.events-topic:workorder.events.v1}")
+    private String eventsTopic;
+
+    @Value("${workorder.manifest.topic:workorder.manifest.v1}")
+    private String manifestTopic;
+
+    /** Reconciliation window length. */
+    @Value("${workorder.manifest.window:PT1H}")
+    private Duration window;
+
+    /** How long after a window closes before its manifest is published. */
+    @Value("${workorder.manifest.grace:PT5M}")
+    private Duration grace;
+
+    @Value("${workorder.manifest.send-timeout-ms:10000}")
+    private long sendTimeoutMs;
+
+    @Nullable
+    private Instant lastPublishedWindowEnd;
+
+    public ManifestPublisher(
+            OutboxEventRepository outboxEventRepository,
+            KafkaTemplate<String, String> kafkaTemplate,
+            ObjectMapper objectMapper,
+            Clock clock,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.publishedCounter = registry == null
+                ? null
+                : Counter.builder("workorder.manifest.published")
+                        .description("Reconciliation manifests published")
+                        .register(registry);
+        this.failedCounter = registry == null
+                ? null
+                : Counter.builder("workorder.manifest.publish.failures")
+                        .description("Reconciliation manifest publish attempts that failed")
+                        .register(registry);
+    }
+
+    @Scheduled(fixedDelayString = "${workorder.manifest.poll-interval-ms:300000}")
+    public void publishDueManifest() {
+        Instant windowEnd = latestClosedWindowEnd();
+        if (windowEnd == null || (lastPublishedWindowEnd != null && !windowEnd.isAfter(lastPublishedWindowEnd))) {
+            return;
+        }
+        Instant windowStart = windowEnd.minus(window);
+        try {
+            publishManifest(windowStart, windowEnd);
+            lastPublishedWindowEnd = windowEnd;
+            increment(publishedCounter);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            recordFailure(windowStart, windowEnd, e);
+        } catch (Exception e) {
+            recordFailure(windowStart, windowEnd, e);
+        }
+    }
+
+    /** End of the most recent window that closed at least {@code grace} ago, aligned to the window length. */
+    private @Nullable Instant latestClosedWindowEnd() {
+        long windowMillis = window.toMillis();
+        long cutoff = Instant.now(clock).minus(grace).toEpochMilli();
+        long aligned = Math.floorDiv(cutoff, windowMillis) * windowMillis;
+        return aligned <= 0 ? null : Instant.ofEpochMilli(aligned);
+    }
+
+    private void publishManifest(Instant windowStart, Instant windowEnd) throws Exception {
+        List<OutboxEvent> candidates = outboxEventRepository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(
+                eventsTopic, windowStart.minus(CREATED_AT_SLACK), windowEnd.plus(CREATED_AT_SLACK));
+
+        List<String> eventIds = new ArrayList<>();
+        TreeMap<String, Long> eventTypeCounts = new TreeMap<>();
+        for (OutboxEvent row : candidates) {
+            JsonNode envelope = objectMapper.readTree(row.getPayload());
+            String eventId = envelope.path("eventId").stringValue(null);
+            if (eventId == null || eventId.isBlank()) {
+                log.warn("Outbox row {} has no eventId in its payload; excluded from manifest", row.getId());
+                continue;
+            }
+            if (!UuidV7Timestamps.isInWindow(UUID.fromString(eventId), windowStart, windowEnd)) {
+                continue;
+            }
+            eventIds.add(eventId);
+            String eventType = envelope.path("eventType").stringValue(null);
+            eventTypeCounts.merge(eventType == null || eventType.isBlank() ? "unknown" : eventType, 1L, Long::sum);
+        }
+
+        ReconciliationManifestV1 manifest = new ReconciliationManifestV1(
+                windowStart,
+                windowEnd,
+                eventIds.size(),
+                ReconciliationManifestV1.checksumOf(eventIds),
+                eventTypeCounts.isEmpty() ? null : eventTypeCounts);
+
+        DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
+                ReconciliationManifestV1.eventTypeFor(DOMAIN),
+                1,
+                manifestAggregateId(windowStart),
+                windowStart.getEpochSecond(),
+                "pos-workorder",
+                null,
+                null,
+                manifest,
+                clock);
+
+        kafkaTemplate
+                .send(manifestTopic, envelope.recordKey(), objectMapper.writeValueAsString(envelope))
+                .get(sendTimeoutMs, TimeUnit.MILLISECONDS);
+        log.info(
+                "Published reconciliation manifest window=[{}, {}) events={} topic={}",
+                windowStart,
+                windowEnd,
+                eventIds.size(),
+                manifestTopic);
+    }
+
+    /** Deterministic per-window aggregate id, so re-published manifests key to the same partition. */
+    private UUID manifestAggregateId(Instant windowStart) {
+        return UUID.nameUUIDFromBytes(
+                (DOMAIN + ".manifest:" + eventsTopic + ":" + windowStart).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void recordFailure(Instant windowStart, Instant windowEnd, Exception e) {
+        increment(failedCounter);
+        log.warn("Reconciliation manifest publish failed window=[{}, {})", windowStart, windowEnd, e);
+    }
+
+    private void increment(@Nullable Counter counter) {
+        if (counter != null) {
+            counter.increment();
+        }
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/ManifestPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/ManifestPublisher.java
@@ -101,22 +101,40 @@ public class ManifestPublisher {
                         .register(registry);
     }
 
+    /** Catch-up bound per run — 24 windows covers a day-long outage at the default 1h window. */
+    private static final int MAX_WINDOWS_PER_RUN = 24;
+
     @Scheduled(fixedDelayString = "${workorder.manifest.poll-interval-ms:300000}")
     public void publishDueManifest() {
-        Instant windowEnd = latestClosedWindowEnd();
-        if (windowEnd == null || (lastPublishedWindowEnd != null && !windowEnd.isAfter(lastPublishedWindowEnd))) {
+        Instant latestClosed = latestClosedWindowEnd();
+        if (latestClosed == null || (lastPublishedWindowEnd != null && !latestClosed.isAfter(lastPublishedWindowEnd))) {
             return;
         }
-        Instant windowStart = windowEnd.minus(window);
-        try {
-            publishManifest(windowStart, windowEnd);
-            lastPublishedWindowEnd = windowEnd;
-            increment(publishedCounter);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            recordFailure(windowStart, windowEnd, e);
-        } catch (Exception e) {
-            recordFailure(windowStart, windowEnd, e);
+        // First run publishes only the latest closed window (no historic backfill on boot);
+        // afterwards every window is published in order so scheduler gaps cannot skip one
+        // permanently (PR #849 review).
+        Instant windowEnd = lastPublishedWindowEnd == null ? latestClosed : lastPublishedWindowEnd.plus(window);
+        int published = 0;
+        while (!windowEnd.isAfter(latestClosed) && published < MAX_WINDOWS_PER_RUN) {
+            Instant windowStart = windowEnd.minus(window);
+            try {
+                publishManifest(windowStart, windowEnd);
+                lastPublishedWindowEnd = windowEnd;
+                increment(publishedCounter);
+                published++;
+                windowEnd = windowEnd.plus(window);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                recordFailure(windowStart, windowEnd, e);
+                return;
+            } catch (Exception e) {
+                // Retry this window on the next poll; later windows stay queued behind it.
+                recordFailure(windowStart, windowEnd, e);
+                return;
+            }
+        }
+        if (!windowEnd.isAfter(latestClosed)) {
+            log.info("Manifest catch-up capped at {} windows this run; continuing next poll", MAX_WINDOWS_PER_RUN);
         }
     }
 
@@ -135,18 +153,24 @@ public class ManifestPublisher {
         List<String> eventIds = new ArrayList<>();
         TreeMap<String, Long> eventTypeCounts = new TreeMap<>();
         for (OutboxEvent row : candidates) {
-            JsonNode envelope = objectMapper.readTree(row.getPayload());
-            String eventId = envelope.path("eventId").stringValue(null);
-            if (eventId == null || eventId.isBlank()) {
-                log.warn("Outbox row {} has no eventId in its payload; excluded from manifest", row.getId());
-                continue;
+            // One malformed row must not block the window's manifest forever (PR #849 review):
+            // skip it with a warning; the consumer-side mismatch it may cause is visible drift.
+            try {
+                JsonNode envelope = objectMapper.readTree(row.getPayload());
+                String eventId = envelope.path("eventId").stringValue(null);
+                if (eventId == null || eventId.isBlank()) {
+                    log.warn("Outbox row {} has no eventId in its payload; excluded from manifest", row.getId());
+                    continue;
+                }
+                if (!UuidV7Timestamps.isInWindow(UUID.fromString(eventId), windowStart, windowEnd)) {
+                    continue;
+                }
+                eventIds.add(eventId);
+                String eventType = envelope.path("eventType").stringValue(null);
+                eventTypeCounts.merge(eventType == null || eventType.isBlank() ? "unknown" : eventType, 1L, Long::sum);
+            } catch (Exception e) {
+                log.warn("Outbox row {} has an unparsable payload/eventId; excluded from manifest", row.getId(), e);
             }
-            if (!UuidV7Timestamps.isInWindow(UUID.fromString(eventId), windowStart, windowEnd)) {
-                continue;
-            }
-            eventIds.add(eventId);
-            String eventType = envelope.path("eventType").stringValue(null);
-            eventTypeCounts.merge(eventType == null || eventType.isBlank() ? "unknown" : eventType, 1L, Long::sum);
         }
 
         ReconciliationManifestV1 manifest = new ReconciliationManifestV1(

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxMetrics.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxMetrics.java
@@ -1,0 +1,67 @@
+package com.positivity.workorder.internal.config;
+
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Outbox health gauges (issue #838, ADR-0044 §4 operational signals):
+ *
+ * <ul>
+ *   <li>{@code workorder.outbox.pending} — unpublished row count; sustained growth means the drain
+ *       is failing or stopped.
+ *   <li>{@code workorder.outbox.oldest.age.seconds} — age of the drain head; alert at 5 min (warn)
+ *       and 15 min (critical). Because the publisher stops its batch at the first failure, one
+ *       stuck row shows up here immediately.
+ * </ul>
+ *
+ * <p>Each gauge read issues one cheap query (count / first row on the partial unpublished index)
+ * per Prometheus scrape (15 s).
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
+public class OutboxMetrics {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final Clock clock;
+
+    public OutboxMetrics(
+            OutboxEventRepository outboxEventRepository, Clock clock, ObjectProvider<MeterRegistry> meterRegistry) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.clock = clock;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        if (registry == null) {
+            log.warn("No MeterRegistry available; outbox gauges not registered");
+            return;
+        }
+        Gauge.builder("workorder.outbox.pending", this, OutboxMetrics::pendingCount)
+                .description("Unpublished event_outbox rows awaiting Kafka publish")
+                .register(registry);
+        Gauge.builder("workorder.outbox.oldest.age.seconds", this, OutboxMetrics::oldestPendingAgeSeconds)
+                .description("Age in seconds of the oldest unpublished event_outbox row (0 when drained)")
+                .register(registry);
+    }
+
+    double pendingCount() {
+        return outboxEventRepository.countByPublishedAtIsNull();
+    }
+
+    double oldestPendingAgeSeconds() {
+        return outboxEventRepository
+                .findFirstByPublishedAtIsNullOrderByIdAsc()
+                .map(event -> Math.max(
+                        0,
+                        Duration.between(event.getCreatedAt(), Instant.now(clock))
+                                .toSeconds()))
+                .orElse(0L)
+                .doubleValue();
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxPurgeJob.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxPurgeJob.java
@@ -1,0 +1,43 @@
+package com.positivity.workorder.internal.config;
+
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Outbox retention (issue #838 decision Q8): purge published rows older than 90 days (default).
+ *
+ * <p>Unpublished rows are never touched. Purged windows can no longer be replayed via
+ * {@code POST /v1/outbox/replay} — replay history equals retention. Revisit when a snapshot-style
+ * re-emit lands (see #839).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
+public class OutboxPurgeJob {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final Clock clock;
+
+    @Value("${workorder.outbox.retention-days:90}")
+    private long retentionDays;
+
+    @Scheduled(cron = "${workorder.outbox.purge-cron:0 0 3 * * *}")
+    @Transactional
+    public void purge() {
+        Instant cutoff = Instant.now(clock).minus(Duration.ofDays(retentionDays));
+        int purged = outboxEventRepository.purgePublishedBefore(cutoff);
+        if (purged > 0) {
+            log.info("Outbox purge removed {} published rows older than {} ({} days)", purged, cutoff, retentionDays);
+        }
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
@@ -3,6 +3,7 @@ package com.positivity.workorder.internal.repository;
 import com.positivity.workorder.internal.entity.OutboxEvent;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,22 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> 
     /** Oldest unpublished rows first — UUIDv7 ids are time-ordered, preserving publish order. */
     @NonNull
     List<OutboxEvent> findTop100ByPublishedAtIsNullOrderByIdAsc();
+
+    /** Unpublished backlog size — exposed as the {@code workorder.outbox.pending} gauge. */
+    long countByPublishedAtIsNull();
+
+    /** Oldest unpublished row (drain head) — drives the {@code workorder.outbox.oldest.age} gauge. */
+    @NonNull
+    Optional<OutboxEvent> findFirstByPublishedAtIsNullOrderByIdAsc();
+
+    /**
+     * Purge published rows older than the retention cutoff (issue #838: 90 days). Unpublished rows
+     * are never deleted ({@code publishedAt < cutoff} excludes NULL). Replay of a purged window is
+     * no longer possible — see the retention note in OPERATIONS_RUNBOOK.md.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from OutboxEvent e where e.publishedAt is not null and e.publishedAt < :cutoff")
+    int purgePublishedBefore(@Param("cutoff") @NonNull Instant cutoff);
 
     /**
      * Published rows of one topic whose {@code createdAt} falls in the given range, for

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
@@ -51,4 +51,13 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> 
     @Query("update OutboxEvent e set e.publishedAt = null, e.attempts = 0, e.lastError = null"
             + " where e.publishedAt is not null and e.createdAt >= :since")
     int markForReplaySince(@Param("since") @NonNull Instant since);
+
+    /**
+     * Bounded variant for manifest-driven drift repair: re-queue only the drifted window instead
+     * of everything since {@code since} (PR #849 review).
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update OutboxEvent e set e.publishedAt = null, e.attempts = 0, e.lastError = null"
+            + " where e.publishedAt is not null and e.createdAt >= :since and e.createdAt < :until")
+    int markForReplayBetween(@Param("since") @NonNull Instant since, @Param("until") @NonNull Instant until);
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/OutboxEventRepository.java
@@ -17,6 +17,16 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> 
     List<OutboxEvent> findTop100ByPublishedAtIsNullOrderByIdAsc();
 
     /**
+     * Published rows of one topic whose {@code createdAt} falls in the given range, for
+     * reconciliation-manifest computation (ADR-0044 §4). Callers pass the window padded by a small
+     * slack and re-filter precisely by the eventId's UUIDv7 timestamp, since {@code createdAt} and
+     * the payload's eventId are stamped microseconds apart.
+     */
+    @NonNull
+    List<OutboxEvent> findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(
+            @NonNull String topic, @NonNull Instant from, @NonNull Instant to);
+
+    /**
      * Mark already-published events created at or after {@code since} for re-publication
      * (ADR-0044 backfill/drift repair). The publisher re-sends them; consumers dedupe by eventId.
      */

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/OutboxReplayServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/OutboxReplayServiceImpl.java
@@ -23,4 +23,12 @@ public class OutboxReplayServiceImpl implements OutboxReplayService {
         log.info("Outbox replay requested since={} eventsQueued={}", since, count);
         return count;
     }
+
+    @Override
+    @Transactional
+    public int replayBetween(@NonNull Instant since, @NonNull Instant until) {
+        int count = outboxEventRepository.markForReplayBetween(since, until);
+        log.info("Outbox replay requested window=[{}, {}) eventsQueued={}", since, until, count);
+        return count;
+    }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/OutboxReplayService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/OutboxReplayService.java
@@ -19,4 +19,13 @@ public interface OutboxReplayService {
      * @return the number of events queued for re-publication
      */
     int replaySince(@NonNull Instant since);
+
+    /**
+     * Mark published outbox events created in {@code [since, until)} for re-publication — the
+     * bounded form used by manifest-driven drift repair, so one drifted window never triggers a
+     * full-history replay.
+     *
+     * @return the number of events queued for re-publication
+     */
+    int replayBetween(@NonNull Instant since, @NonNull Instant until);
 }

--- a/pos-workorder/src/main/resources/application.yml
+++ b/pos-workorder/src/main/resources/application.yml
@@ -98,3 +98,10 @@ workorder:
     events-topic: ${WORKORDER_KAFKA_EVENTS_TOPIC:workorder.events.v1}
     commands-topic: ${WORKORDER_KAFKA_COMMANDS_TOPIC:workorder.commands.v1}
     consumer-group: ${WORKORDER_KAFKA_CONSUMER_GROUP:${spring.application.name}-commands}
+  # Reconciliation manifests (ADR-0044, one summary per closed window of the fact topic)
+  manifest:
+    topic: ${WORKORDER_MANIFEST_TOPIC:workorder.manifest.v1}
+    window: ${WORKORDER_MANIFEST_WINDOW:PT1H}
+    grace: ${WORKORDER_MANIFEST_GRACE:PT5M}
+    poll-interval-ms: ${WORKORDER_MANIFEST_POLL_INTERVAL_MS:300000}
+    send-timeout-ms: ${WORKORDER_MANIFEST_SEND_TIMEOUT_MS:10000}

--- a/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaCommandListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaCommandListenerTest.java
@@ -31,6 +31,8 @@ class WorkorderKafkaCommandListenerTest {
     @BeforeEach
     void setUp() {
         listener = new KafkaCommandListener(FIXED_CLOCK, objectMapper, eventPublisher, outboxReplayService);
+        org.springframework.test.util.ReflectionTestUtils.setField(
+                listener, "replayMaxLookback", java.time.Duration.ofDays(30));
     }
 
     @Test
@@ -96,14 +98,39 @@ class WorkorderKafkaCommandListenerTest {
     }
 
     @Test
-    @DisplayName("workorder.outbox.replay-requested triggers an outbox replay from payload.since")
+    @DisplayName("workorder.outbox.replay-requested without until replays from since (slack-padded)")
     void replayCommandTriggersOutboxReplay() {
         listener.onCommand("""
                 {"commandType":"workorder.outbox.replay-requested","payload":{"since":"2026-07-08T10:00:00Z"}}
                 """);
 
-        verify(outboxReplayService).replaySince(Instant.parse("2026-07-08T10:00:00Z"));
+        verify(outboxReplayService).replaySince(Instant.parse("2026-07-08T09:59:59Z"));
         verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("Replay command with until repairs only the window (slack-padded on both ends)")
+    void replayCommandWithUntilIsBounded() {
+        listener.onCommand("""
+                {"commandType":"workorder.outbox.replay-requested",
+                 "payload":{"since":"2026-07-08T10:00:00Z","until":"2026-07-08T11:00:00Z"}}
+                """);
+
+        verify(outboxReplayService)
+                .replayBetween(Instant.parse("2026-07-08T09:59:59Z"), Instant.parse("2026-07-08T11:00:01Z"));
+        verify(outboxReplayService, never()).replaySince(any());
+    }
+
+    @Test
+    @DisplayName("Replay command older than the max lookback is rejected")
+    void replayCommandBeyondLookbackIsIgnored() {
+        // Clock is 2024-01-01; since is >30 days earlier.
+        listener.onCommand("""
+                {"commandType":"workorder.outbox.replay-requested","payload":{"since":"2023-10-01T00:00:00Z"}}
+                """);
+
+        verify(outboxReplayService, never()).replaySince(any());
+        verify(outboxReplayService, never()).replayBetween(any(), any());
     }
 
     @Test

--- a/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaCommandListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaCommandListenerTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.verify;
 import com.positivity.workorder.internal.config.KafkaCommandListener;
 import com.positivity.workorder.internal.dto.AssignmentUpdatePayload;
 import com.positivity.workorder.internal.dto.AssignmentUpdatedEvent;
+import com.positivity.workorder.service.OutboxReplayService;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,12 +24,13 @@ class WorkorderKafkaCommandListenerTest {
             Clock.fixed(java.time.Instant.parse("2024-01-01T00:00:00Z"), java.time.ZoneOffset.UTC);
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ApplicationEventPublisher eventPublisher = org.mockito.Mockito.mock(ApplicationEventPublisher.class);
+    private final OutboxReplayService outboxReplayService = org.mockito.Mockito.mock(OutboxReplayService.class);
 
     private KafkaCommandListener listener;
 
     @BeforeEach
     void setUp() {
-        listener = new KafkaCommandListener(FIXED_CLOCK, objectMapper, eventPublisher);
+        listener = new KafkaCommandListener(FIXED_CLOCK, objectMapper, eventPublisher, outboxReplayService);
     }
 
     @Test
@@ -89,5 +92,30 @@ class WorkorderKafkaCommandListenerTest {
                 """);
 
         verify(eventPublisher, never()).publishEvent(any());
+        verify(outboxReplayService, never()).replaySince(any());
+    }
+
+    @Test
+    @DisplayName("workorder.outbox.replay-requested triggers an outbox replay from payload.since")
+    void replayCommandTriggersOutboxReplay() {
+        listener.onCommand("""
+                {"commandType":"workorder.outbox.replay-requested","payload":{"since":"2026-07-08T10:00:00Z"}}
+                """);
+
+        verify(outboxReplayService).replaySince(Instant.parse("2026-07-08T10:00:00Z"));
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("Replay command without a parseable payload.since is ignored")
+    void replayCommandWithoutSinceIsIgnored() {
+        listener.onCommand("""
+                {"commandType":"WORKORDER_OUTBOX_REPLAY_REQUESTED","payload":{}}
+                """);
+        listener.onCommand("""
+                {"commandType":"workorder.outbox.replay-requested","payload":{"since":"not-a-timestamp"}}
+                """);
+
+        verify(outboxReplayService, never()).replaySince(any());
     }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/ManifestPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/ManifestPublisherTest.java
@@ -1,0 +1,202 @@
+package com.positivity.workorder.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.workorder.internal.config.ManifestPublisher;
+import com.positivity.workorder.internal.entity.OutboxEvent;
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+class ManifestPublisherTest {
+
+    // 12:10 UTC: the [11:00, 12:00) window closed more than grace (5m) ago.
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:10:00Z"), ZoneOffset.UTC);
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<MeterRegistry> meterRegistry = mock(ObjectProvider.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ManifestPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        when(meterRegistry.getIfAvailable()).thenReturn(null);
+        publisher = new ManifestPublisher(repository, kafkaTemplate, objectMapper, TEST_CLOCK, meterRegistry);
+        ReflectionTestUtils.setField(publisher, "eventsTopic", "workorder.events.v1");
+        ReflectionTestUtils.setField(publisher, "manifestTopic", "workorder.manifest.v1");
+        ReflectionTestUtils.setField(publisher, "window", Duration.ofHours(1));
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(5));
+        ReflectionTestUtils.setField(publisher, "sendTimeoutMs", 1000L);
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private OutboxEvent row(String eventId, String eventType, Instant createdAt) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("workorder.events.v1")
+                .recordKey(eventId)
+                .payload("{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":{}}")
+                .createdAt(createdAt)
+                .publishedAt(createdAt.plusSeconds(1))
+                .build();
+    }
+
+    @Test
+    @DisplayName("Publishes a manifest for the latest closed window with count, checksum, and per-type counts")
+    void publishesManifestForClosedWindow() throws Exception {
+        String inWindow1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String inWindow2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+        // Fetched by the padded createdAt query but outside the window by eventId timestamp.
+        String beforeWindow = eventIdAt(WINDOW_START.minusMillis(1), 3);
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(List.of(
+                        row(beforeWindow, "VehicleUpdated", WINDOW_START.minusMillis(1)),
+                        row(inWindow1, "VehicleUpdated", WINDOW_START.plusSeconds(60)),
+                        row(inWindow2, "PartyNoteAdded", WINDOW_START.plusSeconds(120))));
+
+        publisher.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate)
+                .send(org.mockito.ArgumentMatchers.eq("workorder.manifest.v1"), anyString(), json.capture());
+
+        JsonNode envelope = objectMapper.readTree(json.getValue());
+        assertThat(envelope.path("eventType").stringValue()).isEqualTo("workorder.reconciliation.manifest");
+        assertThat(envelope.path("sourceService").stringValue()).isEqualTo("pos-workorder");
+        JsonNode manifest = envelope.path("payload");
+        assertThat(manifest.path("windowStartUtc").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo(WINDOW_END.toString());
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(2);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow1, inWindow2)));
+        assertThat(manifest.path("eventTypeCounts").path("VehicleUpdated").longValue())
+                .isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("PartyNoteAdded").longValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Publishes zero-count manifests so consumers can alert on manifest absence")
+    void publishesEmptyWindowManifest() throws Exception {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(List.of());
+
+        publisher.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(anyString(), anyString(), json.capture());
+        JsonNode manifest = objectMapper.readTree(json.getValue()).path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isZero();
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of()));
+    }
+
+    @Test
+    @DisplayName("Does not re-publish the same window twice in a row")
+    void skipsAlreadyPublishedWindow() {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(List.of());
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("Retries the window on the next run when the send fails")
+    void retriesWindowAfterSendFailure() {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("Waits for the grace period before publishing a just-closed window")
+    void respectsGracePeriod() {
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(15));
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(List.of());
+
+        publisher.publishDueManifest();
+
+        // 12:10 with 15m grace → [11:00, 12:00) not yet eligible; the eligible window is the
+        // previous one, so the manifest published covers [10:00, 11:00).
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(anyString(), anyString(), json.capture());
+        JsonNode manifest = objectMapper.readTree(json.getValue()).path("payload");
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo("2026-07-08T11:00:00Z");
+    }
+
+    @Test
+    @DisplayName("Rows without a parseable eventId are excluded rather than failing the manifest")
+    void skipsRowsWithoutEventId() throws Exception {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("workorder.events.v1")
+                .recordKey("k")
+                .payload("{\"eventType\":\"VehicleUpdated\"}")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(anyString(), anyString(), json.capture());
+        assertThat(objectMapper
+                        .readTree(json.getValue())
+                        .path("payload")
+                        .path("eventCount")
+                        .longValue())
+                .isZero();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/ManifestPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/ManifestPublisherTest.java
@@ -199,4 +199,59 @@ class ManifestPublisherTest {
                         .longValue())
                 .isZero();
     }
+
+    @Test
+    @DisplayName("Catches up every missed window in order after a scheduler gap (PR #849 review)")
+    void catchesUpMissedWindows() {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(List.of());
+        ReflectionTestUtils.setField(publisher, "lastPublishedWindowEnd", Instant.parse("2026-07-08T09:00:00Z"));
+
+        publisher.publishDueManifest();
+
+        ArgumentCaptor<String> messages = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate, times(3)).send(anyString(), anyString(), messages.capture());
+        List<String> ends = messages.getAllValues().stream()
+                .map(m -> objectMapper
+                        .readTree(m)
+                        .path("payload")
+                        .path("windowEndUtc")
+                        .stringValue())
+                .toList();
+        assertThat(ends).containsExactly("2026-07-08T10:00:00Z", "2026-07-08T11:00:00Z", "2026-07-08T12:00:00Z");
+    }
+
+    @Test
+    @DisplayName("A malformed outbox row is skipped, not fatal to the window's manifest (PR #849 review)")
+    void skipsMalformedRows() {
+        OutboxEvent good = row(
+                eventIdAt(WINDOW_START.plusSeconds(60), 1),
+                "workorder.work_session.started.v1",
+                WINDOW_START.plusSeconds(60));
+        OutboxEvent badJson = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("workorder.events.v1")
+                .recordKey("bad")
+                .payload("{not json")
+                .createdAt(WINDOW_START.plusSeconds(120))
+                .publishedAt(WINDOW_START.plusSeconds(121))
+                .build();
+        OutboxEvent badUuid = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("workorder.events.v1")
+                .recordKey("bad-uuid")
+                .payload("{\"eventId\":\"not-a-uuid\",\"eventType\":\"x.y\"}")
+                .createdAt(WINDOW_START.plusSeconds(180))
+                .publishedAt(WINDOW_START.plusSeconds(181))
+                .build();
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(List.of(good, badJson, badUuid));
+
+        publisher.publishDueManifest();
+
+        ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(anyString(), anyString(), message.capture());
+        JsonNode manifest = objectMapper.readTree(message.getValue()).path("payload");
+        assertThat(manifest.path("eventCount").intValue()).isEqualTo(1);
+    }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxMetricsAndPurgeTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxMetricsAndPurgeTest.java
@@ -1,0 +1,68 @@
+package com.positivity.workorder.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.config.OutboxMetrics;
+import com.positivity.workorder.internal.config.OutboxPurgeJob;
+import com.positivity.workorder.internal.entity.OutboxEvent;
+import com.positivity.workorder.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class OutboxMetricsAndPurgeTest {
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:00:00Z"), ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+
+    @Test
+    @DisplayName("Gauges report pending count and oldest unpublished age (0 when drained)")
+    void gaugesReportBacklogAndHeadAge() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        when(provider.getIfAvailable()).thenReturn(registry);
+        when(repository.countByPublishedAtIsNull()).thenReturn(7L);
+        when(repository.findFirstByPublishedAtIsNullOrderByIdAsc())
+                .thenReturn(Optional.of(OutboxEvent.builder()
+                        .createdAt(Instant.parse("2026-07-08T11:55:00Z"))
+                        .build()));
+
+        new OutboxMetrics(repository, TEST_CLOCK, provider);
+
+        assertThat(registry.get("workorder.outbox.pending").gauge().value()).isEqualTo(7.0);
+        assertThat(registry.get("workorder.outbox.oldest.age.seconds").gauge().value())
+                .isEqualTo(300.0);
+
+        when(repository.findFirstByPublishedAtIsNullOrderByIdAsc()).thenReturn(Optional.empty());
+        assertThat(registry.get("workorder.outbox.oldest.age.seconds").gauge().value())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("Purge deletes published rows older than the retention cutoff only")
+    void purgeUsesRetentionCutoff() {
+        when(repository.purgePublishedBefore(any())).thenReturn(3);
+        OutboxPurgeJob job = new OutboxPurgeJob(repository, TEST_CLOCK);
+        ReflectionTestUtils.setField(job, "retentionDays", 90L);
+
+        job.purge();
+
+        ArgumentCaptor<Instant> cutoff = ArgumentCaptor.forClass(Instant.class);
+        verify(repository).purgePublishedBefore(cutoff.capture());
+        assertThat(cutoff.getValue()).isEqualTo(Instant.parse("2026-04-09T12:00:00Z"));
+    }
+}


### PR DESCRIPTION
Two commits closing out ADR-0044 Phase 0.

## Commit 1 — `ffdcb0c`: manifest-based reconciliation (#840)
Drift detection over the event channel — no synchronous domain-to-domain calls, per the recorded design decision.
- **pos-domain-events**: `ReconciliationManifestV1` (closed window + event count + SHA-256 checksum over sorted eventIds), `DomainTopics.manifest()` → `{domain}.manifest.v1`, `UuidV7Timestamps` (window membership from the UUIDv7 eventId timestamp).
- **pos-workorder (owner)**: scheduled `ManifestPublisher` summarizes `event_outbox` per closed window; zero-event windows still publish so silence is alertable. `KafkaCommandListener` gains `workorder.outbox.replay-requested`, wiring `OutboxReplayService` (#839) as the async repair arm.
- **pos-customer (consumer)**: `WorkorderManifestListener` recomputes the window from `processing_log`, increments `replica_drift_total{owner="workorder"}` on mismatch, requests replay; unique `event_id` guard makes repair idempotent. Stateless — redelivery harmless, false positive costs one idempotent replay.
- Known limit (recorded on #840): detects lost events, not corrupted rows, until `aggregateVersion` is on the wire.

## Commit 2 — `1aae2f3`: observability + retention (#838 decisions Q1–Q9)
- **Gauges (Q3)**: `workorder.outbox.pending`, `workorder.outbox.oldest.age.seconds` (DB-backed).
- **kafka-exporter (Q4)**: compose sidecar + Prometheus scrape (topic depth, consumer lag).
- **Grafana (Q1/Q5)**: "Domain Events (ADR-0044)" dashboard + provisioned alert rules — outbox age 5 m warn / 15 m critical, lag > 100 for 5 m, any DLQ message, any drift increase, manifest silence > 2 h. Dashboard-only delivery in alpha (Q2). Prometheus datasource uid pinned.
- **Topic retention (Q6/Q7/Q9)**: `kafka-topic-init` compose job — events/commands 7 d, manifest 3 d, dlq 30 d, delete policy, 1 partition.
- **Outbox retention (Q8)**: `OutboxPurgeJob` purges published rows after 90 days (nightly, configurable); unpublished rows never purged; replay history equals retention.
- Runbook: alert-threshold table + retention section.

No new REST endpoints or permissions. Contract guide: [`durion/domains/workexec/.business-rules/BACKEND_CONTRACT_GUIDE.md`](https://github.com/louisburroughs/durion/blob/master/domains/workexec/.business-rules/BACKEND_CONTRACT_GUIDE.md).

## Verification (JDK 25.0.3)
- pos-domain-events **15/15**, pos-customer **170/170**, pos-workorder **325/325** (incl. new gauge + purge-cutoff tests)
- Spotless clean; `docker compose config` and provisioning YAML/JSON validate

Closes #840. Closes #838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgvvXoUwdpykGGKRXNLgrP