### PR TITLE
fix(vehicle-inventory): don't kill startup when the Kafka broker is unavailable

### DIFF
--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/config/EventListenerConfig.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/config/EventListenerConfig.java
@@ -37,8 +37,19 @@ public class EventListenerConfig {
     public void startKafkaListeners(ApplicationReadyEvent event) {
         KafkaListenerEndpointRegistry registry =
                 event.getApplicationContext().getBean(KafkaListenerEndpointRegistry.class);
-        registry.start();
-        log.info("Kafka listeners started after application ready");
+        try {
+            registry.start();
+            log.info("Kafka listeners started after application ready");
+        } catch (Exception e) {
+            // An unresolvable/unavailable broker (e.g. bootstrap servers pointing at a Kafka
+            // container that is not deployed yet) must not kill the service — the REST API works
+            // without event ingestion. Consumer construction fails fast on unresolvable DNS, so
+            // this is reachable, not just theoretical.
+            log.error(
+                    "Kafka listeners could not be started; continuing without event ingestion. "
+                            + "Check spring.kafka.bootstrap-servers / broker availability.",
+                    e);
+        }
     }
 
     /**

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/config/EventListenerConfig.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/config/EventListenerConfig.java
@@ -40,11 +40,12 @@ public class EventListenerConfig {
         try {
             registry.start();
             log.info("Kafka listeners started after application ready");
-        } catch (Exception e) {
+        } catch (org.apache.kafka.common.KafkaException | org.springframework.kafka.KafkaException e) {
             // An unresolvable/unavailable broker (e.g. bootstrap servers pointing at a Kafka
             // container that is not deployed yet) must not kill the service — the REST API works
             // without event ingestion. Consumer construction fails fast on unresolvable DNS, so
-            // this is reachable, not just theoretical.
+            // this is reachable, not just theoretical. Narrowed to Kafka exceptions so genuine
+            // listener misconfiguration still fails startup loudly.
             log.error(
                     "Kafka listeners could not be started; continuing without event ingestion. "
                             + "Check spring.kafka.bootstrap-servers / broker availability.",

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/EventListenerConfigTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/EventListenerConfigTest.java
@@ -1,0 +1,47 @@
+package com.positivity.vehicle.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.kafka.common.KafkaException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+
+class EventListenerConfigTest {
+
+    private final KafkaListenerEndpointRegistry registry = mock(KafkaListenerEndpointRegistry.class);
+    private final ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+    private final ApplicationReadyEvent event = mock(ApplicationReadyEvent.class);
+
+    private final EventListenerConfig config = new EventListenerConfig();
+
+    @Test
+    @DisplayName("Starts the Kafka listener registry once the application is ready")
+    void startsListeners() {
+        when(event.getApplicationContext()).thenReturn(context);
+        when(context.getBean(KafkaListenerEndpointRegistry.class)).thenReturn(registry);
+
+        config.startKafkaListeners(event);
+
+        verify(registry).start();
+    }
+
+    @Test
+    @DisplayName("Broker failure while starting listeners must not kill the service")
+    void brokerFailureDoesNotPropagate() {
+        when(event.getApplicationContext()).thenReturn(context);
+        when(context.getBean(KafkaListenerEndpointRegistry.class)).thenReturn(registry);
+        // Same failure mode as an unresolvable bootstrap server (deploy without a broker).
+        doThrow(new KafkaException("Failed to construct kafka consumer"))
+                .when(registry)
+                .start();
+
+        assertThatCode(() -> config.startKafkaListeners(event)).doesNotThrowAnyException();
+    }
+}

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/EventListenerConfigTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/EventListenerConfigTest.java
@@ -43,5 +43,7 @@ class EventListenerConfigTest {
                 .start();
 
         assertThatCode(() -> config.startKafkaListeners(event)).doesNotThrowAnyException();
+        // The registry start must still have been attempted — fail-open, not skipped.
+        verify(registry).start();
     }
 }


### PR DESCRIPTION
## Summary

Fixes the failing alpha deployment ([run 29004672058](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/29004672058/job/86076543582)).

**Root cause:** pos-vehicle-inventory's `EventListenerConfig` force-starts its Kafka listener containers on `ApplicationReadyEvent` with no feature flag and no error handling — it's the only Kafka consumer in the fleet that isn't gated. When #838/#850 gave the compose service `KAFKA_BOOTSTRAP_SERVERS` defaulting to `kafka:29092`, a deploy without the broker container makes the `kafka` hostname unresolvable; the Kafka client fails consumer construction fast (`ConfigException: No resolvable bootstrap urls given in bootstrap.servers`), the ready-event listener rethrows, `SpringApplication.run` fails, and the container exits.

**Fix:** wrap `registry.start()` in a try/catch that logs and continues — the REST API works without event ingestion, and ingestion resumes on the next restart once the broker exists. This matches the fail-open startup pattern used by the event-type and permission initializers (startup must never block on an unavailable dependency). Once the broker container lands on the alpha EC2 instance (#838), behavior is unchanged from before.

No contract changes — startup behavior only (`BACKEND_CONTRACT_GUIDE.md` untouched).

## Testing
- New `EventListenerConfigTest`: registry starts on ready; a `KafkaException` during start (the deployment's exact failure mode) no longer propagates
- `pos-vehicle-inventory`: 21/21 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgvvXoUwdpykGGKRXNLgrP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgvvXoUwdpykGGKRXNLgrP)_