### PR TITLE
feat(alpha): deploy the Kafka broker with the alpha stack (#838)

### DIFF
--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -64,6 +64,11 @@ OBSERVABILITY_SERVICES=(
   grafana
 )
 
+KAFKA_SERVICES=(
+  kafka
+  kafka-exporter
+)
+
 BACKEND_SERVICES=(
   eureka-server
   pos-accounting
@@ -148,6 +153,21 @@ docker compose "${COMPOSE_ARGS[@]}" pull --quiet "${OBSERVABILITY_SERVICES[@]}"
 
 echo "Starting observability services: ${OBSERVABILITY_SERVICES[*]}"
 docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate "${OBSERVABILITY_SERVICES[@]}"
+
+# Kafka domain-event backbone (ADR-0044, #838). Broker data lives on the
+# kafka-data volume, so --force-recreate is safe. --wait blocks on the
+# compose healthcheck before topics are provisioned.
+echo "Pulling Kafka services: ${KAFKA_SERVICES[*]}"
+docker compose "${COMPOSE_ARGS[@]}" pull --quiet "${KAFKA_SERVICES[@]}" kafka-topic-init
+
+echo "Starting Kafka broker"
+docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate --wait kafka
+
+echo "Provisioning Kafka topics"
+docker compose "${COMPOSE_ARGS[@]}" run --rm --no-deps kafka-topic-init
+
+echo "Starting Kafka exporter"
+docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate kafka-exporter
 
 echo "Pulling backend services: ${BACKEND_SERVICES[*]}"
 docker compose "${COMPOSE_ARGS[@]}" pull --quiet "${BACKEND_SERVICES[@]}"

--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -21,6 +21,18 @@ services:
     restart: unless-stopped
     logging: *logging
 
+  # ── Kafka domain-event backbone (ADR-0044, #838) ───────────────────────────
+
+  kafka:
+    restart: unless-stopped
+    logging: *logging
+
+  kafka-exporter:
+    restart: unless-stopped
+    logging: *logging
+
+  # kafka-topic-init runs once (restart: no) — no override needed.
+
   # ── Observability ──────────────────────────────────────────────────────────
 
   prometheus:
@@ -54,6 +66,9 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-accounting:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
+    # #838 flag flip — uncomment in the second deploy, after the broker is verified healthy:
+    # environment:
+    #   POS_ACCOUNTING_KAFKA_ENABLED: "true"
 
   pos-api-gateway:
     image: ${ECR_REGISTRY}/durion/pos-api-gateway:${BACKEND_TAG}
@@ -74,6 +89,9 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-customer:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
+    # #838 flag flip — uncomment in the second deploy, after the broker is verified healthy:
+    # environment:
+    #   POS_CUSTOMER_KAFKA_ENABLED: "true"
 
   pos-event-receiver:
     image: ${ECR_REGISTRY}/durion/pos-event-receiver:${BACKEND_TAG}
@@ -94,6 +112,9 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-invoice:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
+    # #838 flag flip — uncomment in the second deploy, after the broker is verified healthy:
+    # environment:
+    #   POS_INVOICE_KAFKA_ENABLED: "true"
 
   pos-location:
     image: ${ECR_REGISTRY}/durion/pos-location:${BACKEND_TAG}
@@ -144,6 +165,9 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-workorder:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
+    # #838 flag flip — uncomment in the second deploy, after the broker is verified healthy:
+    # environment:
+    #   WORKORDER_KAFKA_ENABLED: "true"
 
   # ── Frontend ───────────────────────────────────────────────────────────────
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,11 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      # Persist log segments so a container recreate (alpha deploys use
+      # --force-recreate) does not wipe topics, offsets, and consumer state.
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+    volumes:
+      - kafka-data:/var/lib/kafka/data
     healthcheck:
       test: [ "CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1" ]
       interval: 10s
@@ -180,7 +185,12 @@ services:
           ["workorder.commands.v1"]=604800000
           ["workorder.manifest.v1"]=259200000
           ["workorder.events.v1.dlq"]=2592000000
+          ["workorder.commands.v1.dlq"]=2592000000
           ["workorder.manifest.v1.dlq"]=2592000000
+          ["customer.events.v1"]=604800000
+          ["customer.events.v1.dlq"]=2592000000
+          ["invoice.events.v1"]=604800000
+          ["invoice.events.v1.dlq"]=2592000000
           ["payment.cleared.v1"]=604800000
         )
         for t in "$${!topics[@]}"; do
@@ -283,9 +293,6 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
-      # Domain events (ADR-0044, #842) — opt-in until the tier-1 flip
-      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
-      POS_INVOICE_KAFKA_ENABLED: ${POS_INVOICE_KAFKA_ENABLED:-false}
     depends_on:
       eureka-server:
         condition: service_healthy
@@ -536,6 +543,10 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
+      # Domain events (ADR-0044, #842) — opt-in until the tier-1 flip
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
+      POS_INVOICE_KAFKA_ENABLED: ${POS_INVOICE_KAFKA_ENABLED:-false}
     depends_on:
       eureka-server:
         condition: service_healthy
@@ -1070,6 +1081,8 @@ networks:
 
 # Docker Volumes for Observability Data Persistence
 volumes:
+  kafka-data:
+    driver: local
   prometheus-data:
     driver: local
   grafana-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -543,9 +543,10 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
-      # Domain events (ADR-0044, #842) — opt-in until the tier-1 flip
+      # Domain events (ADR-0044, #842) — opt-in until the tier-1 flip.
+      # application.yml binds spring.kafka.bootstrap-servers from KAFKA_BOOTSTRAP_SERVERS,
+      # so that single variable is the source of truth here.
       KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
       POS_INVOICE_KAFKA_ENABLED: ${POS_INVOICE_KAFKA_ENABLED:-false}
     depends_on:
       eureka-server:


### PR DESCRIPTION
## Summary

Wires the ADR-0044 Kafka event backbone (#838) into the alpha EC2 deployment, and fixes a deploy blocker that slipped into #850.

### Broker rollout
- **`deployment/alpha/deploy-backend.sh`** — new Kafka phase between observability and backend services: start the broker with `--wait` (blocks on the compose healthcheck), provision topics via a one-shot `kafka-topic-init` run (`docker compose run --rm`, exit code propagates under `set -e`), then start `kafka-exporter`
- **`deployment/alpha/docker-compose.prod.yml`** — `restart: unless-stopped` + logging stanzas for `kafka` and `kafka-exporter`; the four per-service flag flips (`WORKORDER_KAFKA_ENABLED`, `POS_CUSTOMER_KAFKA_ENABLED`, `POS_INVOICE_KAFKA_ENABLED`, `POS_ACCOUNTING_KAFKA_ENABLED`) are staged as comments for a **second deploy** after the broker is verified healthy — merging this is a runtime no-op for the services
- **`docker-compose.yml`** — broker data persisted on a `kafka-data` volume (`KAFKA_LOG_DIRS=/var/lib/kafka/data`) so the alpha deploy's `--force-recreate` cannot wipe topics, offsets, or consumer-group state; `kafka-topic-init` extended with the #842 topics (`customer.events.v1`, `invoice.events.v1`, their `.dlq`s at 30d) and `workorder.commands.v1.dlq`

### Deploy blocker fixed (from #850)
The pos-invoice domain-event env block was accidentally inserted into **pos-accounting**, duplicating `KAFKA_BOOTSTRAP_SERVERS` there — `docker compose config` rejects the file on current main, which would fail the next alpha deploy at compose-parse time — and pos-invoice was left without Kafka configuration. The block now lives under pos-invoice.

No REST contract changes (`BACKEND_CONTRACT_GUIDE.md` untouched) — deployment configuration only.

## Testing
- `docker compose -f docker-compose.yml config --quiet` — valid (fails on current main)
- `docker compose -f docker-compose.yml -f deployment/alpha/docker-compose.prod.yml config --quiet` — valid
- `bash -n deployment/alpha/deploy-backend.sh` — clean

## Rollout plan
1. Merge → deploy: broker + exporter + topics come up, flags stay off (no behavior change)
2. Verify: broker healthcheck green, `kafka-topics.sh --list` shows the domain topics, Grafana domain-events dashboard receives exporter metrics
3. Second deploy: uncomment the four flag flips in `docker-compose.prod.yml`; watch `*.outbox.pending` drain and the `ext_*` replicas populate
4. Note: first boot formats KRaft storage on the new volume — verify the broker writes to `/var/lib/kafka/data` (image runs as a non-root user; if the volume mount is root-owned on first boot, the fix is a one-time `chown` on the volume)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgvvXoUwdpykGGKRXNLgrP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgvvXoUwdpykGGKRXNLgrP)_