### PR TITLE
chore: standardize Kafka bootstrap-server env var to KAFKA_BOOTSTRAP_SERVERS (#853)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,7 +277,6 @@ services:
       - "9001:8080"
     environment:
       KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       GATEWAY_URL: http://pos-api-gateway:8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_accounting_db
@@ -380,7 +379,6 @@ services:
       - "8082:8080"
     environment:
       KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       GATEWAY_URL: http://pos-api-gateway:8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_customer_db
@@ -897,7 +895,6 @@ services:
       - "8089:8080"
     environment:
       KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       GATEWAY_URL: http://pos-api-gateway:8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_vehicle_inventory_db
@@ -989,7 +986,6 @@ services:
       - "8090:8080"
     environment:
       KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       GATEWAY_URL: http://pos-api-gateway:8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_workorder_db

--- a/pos-accounting/src/main/resources/application.yml
+++ b/pos-accounting/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: accounting
+  kafka:
+    bootstrap-servers:
+      - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
   datasource:
     url: ${SPRING_DATASOURCE_URL:}
     username: ${SPRING_DATASOURCE_USERNAME:}

--- a/pos-vehicle-inventory/src/main/resources/application.yml
+++ b/pos-vehicle-inventory/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: vehicle-inventory
+  kafka:
+    bootstrap-servers:
+      - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
   datasource:
     url: ${SPRING_DATASOURCE_URL:}
     username: ${SPRING_DATASOURCE_USERNAME:}

--- a/pos-workorder/src/main/resources/application.yml
+++ b/pos-workorder/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: workorder
+  kafka:
+    bootstrap-servers:
+      - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
   datasource:
     url: ${SPRING_DATASOURCE_URL:}
     username: ${SPRING_DATASOURCE_USERNAME:}


### PR DESCRIPTION
Four compose services carried both KAFKA_BOOTSTRAP_SERVERS and
SPRING_KAFKA_BOOTSTRAP_SERVERS, with a different one load-bearing per
service — an operator overriding only one of them could be silently
ignored or shadowed depending on the service.

- Bind spring.kafka.bootstrap-servers from KAFKA_BOOTSTRAP_SERVERS in
  the application.yml of pos-accounting, pos-workorder, and
  pos-vehicle-inventory (matching the pos-customer/pos-invoice pattern)
- Drop SPRING_KAFKA_BOOTSTRAP_SERVERS from all compose stanzas
- Verified with docker compose config (base + alpha overlay merge) that
  all five Kafka-enabled services resolve the broker from the single
  variable (default kafka:29092 unchanged)

Follow-up from PR #852 (#838 / ADR-0044).

Closes #853

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015KPxNXu8FAZrPis3SJEhYW