### PR TITLE
fix(mcp): inject Clock into session agent managers instead of Instant.now() (#854)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -27,6 +27,7 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -78,6 +79,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
     private final @Nullable NltiTelemetryEmitter telemetryEmitter;
     private final @Nullable OpenApiToolProvider openApiToolProvider;
     private final @Nullable RequestScopedUserContext requestScopedUserContext;
+    private final Clock clock;
 
     private final int memoryMaxMessages;
     private final int rateLimitPerSession;
@@ -97,6 +99,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             @Nullable NltiTelemetryEmitter telemetryEmitter,
             @Nullable OpenApiToolProvider openApiToolProvider,
             @Nullable RequestScopedUserContext requestScopedUserContext,
+            @NonNull Clock clock,
             @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
             @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
             @Value("${mcp.agent.memory-max-messages:100}") int memoryMaxMessages,
@@ -115,6 +118,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         this.telemetryEmitter = telemetryEmitter;
         this.openApiToolProvider = openApiToolProvider;
         this.requestScopedUserContext = requestScopedUserContext;
+        this.clock = clock;
         this.memoryMaxMessages = memoryMaxMessages;
         this.rateLimitPerSession = rateLimitPerSession;
         this.requestCountCache = Caffeine.newBuilder()
@@ -451,7 +455,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                     : List.of();
             telemetryEmitter.emit(NltiRequestTelemetryFactory.forChatRequest(
                     correlationId,
-                    Instant.now().toString(),
+                    Instant.now(clock).toString(),
                     currentUserContext.primaryRole(),
                     currentUserContext.permissionCodes().size(),
                     selectedToolNames,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -22,6 +22,7 @@ import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.AiServices;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -75,6 +76,8 @@ public class StreamingSessionAgentManager
     @Nullable
     private final RequestScopedUserContext requestScopedUserContext;
 
+    private final Clock clock;
+
     private final int memoryMaxMessages;
     private final int rateLimitPerSession;
 
@@ -89,6 +92,7 @@ public class StreamingSessionAgentManager
             @Nullable NltiTelemetryEmitter telemetryEmitter,
             @Nullable OpenApiToolProvider openApiToolProvider,
             @Nullable RequestScopedUserContext requestScopedUserContext,
+            @NonNull Clock clock,
             @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
             @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
             @Value("${mcp.agent.memory-max-messages:100}") int memoryMaxMessages,
@@ -103,6 +107,7 @@ public class StreamingSessionAgentManager
         this.telemetryEmitter = telemetryEmitter;
         this.openApiToolProvider = openApiToolProvider;
         this.requestScopedUserContext = requestScopedUserContext;
+        this.clock = clock;
         this.memoryMaxMessages = memoryMaxMessages;
         this.rateLimitPerSession = rateLimitPerSession;
         int sanitizedMaxCachedAgents = Math.max(1, maxCachedAgents);
@@ -394,7 +399,7 @@ public class StreamingSessionAgentManager
         try {
             telemetryEmitter.emit(NltiRequestTelemetryFactory.forChatRequest(
                     correlationId,
-                    Instant.now().toString(),
+                    Instant.now(clock).toString(),
                     currentUserContext.primaryRole(),
                     currentUserContext.permissionCodes().size(),
                     selectedToolNames,

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -41,6 +41,9 @@ import dev.langchain4j.model.output.Response;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -82,6 +85,7 @@ import org.springframework.web.client.RestClient;
 class SessionAgentManagerTest {
 
     private static final UUID USER_ID = UUID.fromString("00000000-0000-7000-8000-000000000301");
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-04-13T02:00:00Z"), ZoneOffset.UTC);
 
     @Mock
     private ChatModel chatModel;
@@ -179,6 +183,7 @@ class SessionAgentManagerTest {
                 telemetryEmitter,
                 null,
                 null,
+                FIXED_CLOCK,
                 30,
                 500,
                 50,
@@ -370,6 +375,7 @@ class SessionAgentManagerTest {
                 telemetryEmitter,
                 null,
                 null,
+                FIXED_CLOCK,
                 0,
                 500,
                 50,
@@ -408,6 +414,7 @@ class SessionAgentManagerTest {
                 telemetryEmitter,
                 null,
                 null,
+                FIXED_CLOCK,
                 30,
                 500,
                 50,

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -37,6 +37,9 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
 import java.lang.reflect.Member;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -79,6 +82,7 @@ class StreamingSessionAgentManagerTest {
 
     private static final UUID USER_ID = UUID.fromString("00000000-0000-7000-8000-000000000302");
     private static final Set<String> PERMISSION_CODES = Set.of("AUTHENTICATED", "mcp:chat:stream");
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-04-13T02:00:00Z"), ZoneOffset.UTC);
 
     @Mock
     private StreamingChatModel streamingChatModel;
@@ -168,6 +172,7 @@ class StreamingSessionAgentManagerTest {
                 telemetryEmitter,
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
+                FIXED_CLOCK,
                 30,
                 500,
                 50,
@@ -339,6 +344,7 @@ class StreamingSessionAgentManagerTest {
                 telemetryEmitter,
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
+                FIXED_CLOCK,
                 30,
                 500,
                 50,
@@ -401,6 +407,7 @@ class StreamingSessionAgentManagerTest {
                 telemetryEmitter,
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
+                FIXED_CLOCK,
                 0,
                 500,
                 50,
@@ -433,6 +440,7 @@ class StreamingSessionAgentManagerTest {
                 telemetryEmitter,
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
+                FIXED_CLOCK,
                 30,
                 500,
                 50,
@@ -492,6 +500,7 @@ class StreamingSessionAgentManagerTest {
                 telemetryEmitter,
                 openApiToolProvider,
                 requestContext,
+                FIXED_CLOCK,
                 30,
                 500,
                 50,


### PR DESCRIPTION
SessionAgentManager and StreamingSessionAgentManager called the no-arg
Instant.now() when stamping telemetry events, bypassing the injectable
Clock bean provided by pos-events TimeConfig and violating the ArchUnit
rule productionCodeShouldNotUseNoArgNowCalls. Both managers now take a
Clock constructor dependency and use Instant.now(clock), matching the
convention used elsewhere in pos-mcp-server. Unit tests supply a fixed
clock.

Closes #854

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MUbj1Md3ZMRjEXPey1ZykM