### PR TITLE
feat(observability): add Loki + Promtail log shipping (#858)

### DIFF
--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -47,6 +47,14 @@ services:
     restart: unless-stopped
     logging: *logging
 
+  loki:
+    restart: unless-stopped
+    logging: *logging
+
+  promtail:
+    restart: unless-stopped
+    logging: *logging
+
   # ── Ollama (Docker Hub image — no ECR) ─────────────────────────────────────
 
   ollama:

--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -51,6 +51,10 @@ services:
     restart: unless-stopped
     logging: *logging
 
+  docker-socket-proxy:
+    restart: unless-stopped
+    logging: *logging
+
   promtail:
     restart: unless-stopped
     logging: *logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,9 @@ services:
     image: grafana/loki:3.1.1
     container_name: loki
     ports:
-      - "3100:3100"
+      # Localhost only — Grafana/Promtail reach Loki over the pos-network;
+      # no need to expose all container logs on shared/remote host interfaces.
+      - "127.0.0.1:3100:3100"
     volumes:
       - ./observability/loki-config.yml:/etc/loki/loki-config.yml:ro
       - loki-data:/loki
@@ -119,20 +121,37 @@ services:
     networks:
       - pos-network
 
+  # docker-socket-proxy - Read-only, whitelisted Docker API for Promtail SD (#858)
+  # Promtail needs container metadata for labels but not root-equivalent socket
+  # access; the proxy exposes only GET /containers and /version over TCP.
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.3.0
+    container_name: docker-socket-proxy
+    environment:
+      CONTAINERS: 1   # allow GET /containers/* (SD target list)
+      NETWORKS: 1     # allow GET /networks/* (promtail computes network labels)
+      VERSION: 1      # allow GET /version (API negotiation)
+      # All other API groups (POST, exec, images, ...) denied by default.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    logging: *logging
+    networks:
+      - pos-network
+
   # Promtail - Ships Docker json-file logs to Loki (#858)
   promtail:
     image: grafana/promtail:3.1.1
     container_name: promtail
     volumes:
       - ./observability/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
-      # Container log files + Docker socket for service-discovery labels.
+      # Container log files (read directly; container metadata comes from the proxy).
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       # Persist read positions across container recreation.
       - promtail-positions:/promtail
     command: [ "-config.file=/etc/promtail/promtail-config.yml" ]
     depends_on:
       - loki
+      - docker-socket-proxy
     logging: *logging
     networks:
       - pos-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     depends_on:
       - prometheus
       - jaeger
+      - loki
     logging: *logging
     networks:
       - pos-network
@@ -95,6 +96,41 @@ services:
     depends_on:
       - jaeger
       - prometheus
+    logging: *logging
+    networks:
+      - pos-network
+
+  # Loki - Log aggregation (#858)
+  loki:
+    image: grafana/loki:3.1.1
+    container_name: loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./observability/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data:/loki
+    command: [ "-config.file=/etc/loki/loki-config.yml" ]
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -q -O /dev/null http://localhost:3100/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    logging: *logging
+    networks:
+      - pos-network
+
+  # Promtail - Ships Docker json-file logs to Loki (#858)
+  promtail:
+    image: grafana/promtail:3.1.1
+    container_name: promtail
+    volumes:
+      - ./observability/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      # Container log files + Docker socket for service-discovery labels.
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command: [ "-config.file=/etc/promtail/promtail-config.yml" ]
+    depends_on:
+      - loki
     logging: *logging
     networks:
       - pos-network
@@ -1089,6 +1125,8 @@ volumes:
   prometheus-data:
     driver: local
   grafana-data:
+    driver: local
+  loki-data:
     driver: local
   postgres-data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,8 @@ services:
       # Container log files + Docker socket for service-discovery labels.
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Persist read positions across container recreation.
+      - promtail-positions:/promtail
     command: [ "-config.file=/etc/promtail/promtail-config.yml" ]
     depends_on:
       - loki
@@ -1127,6 +1129,8 @@ volumes:
   grafana-data:
     driver: local
   loki-data:
+    driver: local
+  promtail-positions:
     driver: local
   postgres-data:
     driver: local

--- a/observability/README.md
+++ b/observability/README.md
@@ -8,6 +8,8 @@ This directory contains the observability infrastructure for the Durion Positivi
 - **Prometheus**: Time-series database for metrics collection
 - **Grafana**: Visualization and analytics platform
 - **OpenTelemetry Collector**: Unified telemetry data collection and processing
+- **Loki**: Log aggregation store, queryable in Grafana Explore and the Logs dashboard
+- **Promtail**: Ships every container's Docker `json-file` logs to Loki with `service`/`container` labels
 
 ## Architecture
 
@@ -28,7 +30,13 @@ This directory contains the observability infrastructure for the Durion Positivi
          │                      │
          │               ┌──────▼─────┐
          └──────────────→│  Grafana   │ (Visualization)
-                         └────────────┘
+                         └──────▲─────┘
+                                │ (Logs)
+┌─────────────────┐     ┌──────┴─────┐
+│ All containers  │────→│  Promtail  │────→ Loki
+│ (docker json-   │     └────────────┘
+│  file logs)     │
+└─────────────────┘
 ```
 
 ## Quick Start
@@ -42,7 +50,7 @@ From the repository root:
 docker-compose up -d
 
 # Or start only observability services
-docker-compose up -d jaeger prometheus grafana otel-collector
+docker-compose up -d jaeger prometheus grafana otel-collector loki promtail
 ```
 
 ### 2. Access the Dashboards
@@ -56,6 +64,10 @@ docker-compose up -d jaeger prometheus grafana otel-collector
 
 - **Prometheus**: <http://localhost:9090>
   - Query metrics and explore targets
+
+- **Loki**: <http://localhost:3100> (API only; query via Grafana)
+  - In Grafana: **Explore → Loki**, or open the **Durion Logs (Loki)** dashboard
+  - Example LogQL: `{job="docker", service="pos-order"} |= "ERROR"`
 
 - **OTEL Collector Health**: <http://localhost:13133>
   - Check collector status
@@ -111,6 +123,27 @@ Configures the OpenTelemetry Collector pipeline:
 - Jaeger: Traces via OTLP
 - Prometheus: Metrics on port 8889
 - Logging: Debug output
+
+### `loki-config.yml`
+
+Single-binary, filesystem-backed Loki (`grafana/loki:3.1.1`). Suitable for local dev and the
+alpha single-host EC2 box; not multi-tenant/clustered.
+
+- HTTP API: Port 3100 (`/ready`, `/loki/api/v1/push`, `/loki/api/v1/query_range`)
+- Retention: 168h (7 days), enforced by the compactor — matches Kafka event retention
+- Storage: `tsdb` index + filesystem chunks under the `loki-data` volume
+
+### `promtail-config.yml`
+
+Promtail (`grafana/promtail:3.1.1`) uses Docker service-discovery to tail the `json-file` logs of
+every container on the host and push them to Loki.
+
+**Labels applied** (from the Docker API): `container`, `service` (compose service name),
+`project`, `stream`, `job="docker"`, and a `level` extracted from the log line
+(`TRACE|DEBUG|INFO|WARN|ERROR|FATAL`).
+
+**Requires** host mounts (already wired in `docker-compose.yml`):
+`/var/lib/docker/containers:ro` and `/var/run/docker.sock:ro`.
 
 ### `application-observability.yml`
 

--- a/observability/grafana/provisioning/dashboards/json/logs.json
+++ b/observability/grafana/provisioning/dashboards/json/logs.json
@@ -1,0 +1,181 @@
+{
+  "uid": "durion-logs",
+  "title": "Durion Logs (Loki)",
+  "tags": ["logs", "loki", "observability"],
+  "timezone": "utc",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "label": "Service",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": "label_values({job=\"docker\"}, service)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "level",
+        "label": "Level",
+        "type": "custom",
+        "query": "TRACE,DEBUG,INFO,WARN,ERROR,FATAL",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "search",
+        "label": "Search",
+        "type": "textbox",
+        "query": "",
+        "current": { "text": "", "value": "" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Log lines / sec (selected services)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(rate({job=\"docker\", service=~\"$service\"}[$__rate_interval]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "logs", "color": { "mode": "thresholds" } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Error lines / sec",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(rate({job=\"docker\", service=~\"$service\", level=~\"ERROR|FATAL\"}[$__rate_interval]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "logs",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Warn lines / sec",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(rate({job=\"docker\", service=~\"$service\", level=\"WARN\"}[$__rate_interval]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "logs",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Log volume by service (lines/min)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (service) (count_over_time({job=\"docker\", service=~\"$service\"}[1m]))",
+          "legendFormat": "{{service}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "bars", "stacking": { "mode": "normal" } } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Error/Warn volume by service (lines/min)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (service) (count_over_time({job=\"docker\", service=~\"$service\", level=~\"ERROR|FATAL\"}[1m]))",
+          "legendFormat": "ERROR {{service}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (service) (count_over_time({job=\"docker\", service=~\"$service\", level=\"WARN\"}[1m]))",
+          "legendFormat": "WARN {{service}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "logs",
+      "title": "Live logs",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 13 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{job=\"docker\", service=~\"$service\", level=~\"$level\"} |~ \"(?i)$search\""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      }
+    }
+  ]
+}

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -43,6 +43,25 @@ datasources:
         datasourceUid: 'loki'
     version: 1
 
+  # Loki Datasource for logs (#858)
+  # uid 'loki' satisfies the Jaeger/Tempo tracesToLogs.datasourceUid references above.
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true
+    jsonData:
+      maxLines: 1000
+      # Correlate a log line back to a trace when it carries a traceId (Spring
+      # Boot MDC / Micrometer tracing writes traceId into the log message).
+      derivedFields:
+        - name: TraceID
+          matcherRegex: 'traceId=(\w+)'
+          url: '$${__value.raw}'
+          datasourceUid: 'jaeger'
+    version: 1
+
   # TestData Datasource for testing and demos
   - name: TestData
     type: testdata

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -53,11 +53,12 @@ datasources:
     editable: true
     jsonData:
       maxLines: 1000
-      # Correlate a log line back to a trace when it carries a traceId (Spring
-      # Boot MDC / Micrometer tracing writes traceId into the log message).
+      # Correlate a log line back to a trace. Spring Boot + Micrometer tracing
+      # emits the default pattern "[<app>,<traceId>,<spanId>]" (comma-delimited,
+      # app name may be empty or contain '.'/'-'); capture the middle traceId.
       derivedFields:
         - name: TraceID
-          matcherRegex: 'traceId=(\w+)'
+          matcherRegex: '\[[\w.\-]*,(\w+),\w*\]'
           url: '$${__value.raw}'
           datasourceUid: 'jaeger'
     version: 1

--- a/observability/loki-config.yml
+++ b/observability/loki-config.yml
@@ -1,0 +1,55 @@
+# Loki configuration for the Durion observability stack (#858).
+# Single-binary, filesystem-backed deployment sized for local dev + the alpha
+# single-host EC2 box. Not intended for multi-tenant / clustered use.
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-index
+    cache_location: /loki/tsdb-cache
+  filesystem:
+    directory: /loki/chunks
+
+limits_config:
+  retention_period: 168h        # 7 days — matches Kafka event retention
+  ingestion_rate_mb: 16
+  ingestion_burst_size_mb: 32
+  max_streams_per_user: 0
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  allow_structured_metadata: true
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+analytics:
+  reporting_enabled: false

--- a/observability/promtail-config.yml
+++ b/observability/promtail-config.yml
@@ -18,7 +18,8 @@ scrape_configs:
   # Discover every running container via the Docker daemon and tail its logs.
   - job_name: docker
     docker_sd_configs:
-      - host: unix:///var/run/docker.sock
+      # Via docker-socket-proxy (read-only, whitelisted API) — not the raw socket.
+      - host: tcp://docker-socket-proxy:2375
         refresh_interval: 15s
     relabel_configs:
       # container_name without the leading "/"

--- a/observability/promtail-config.yml
+++ b/observability/promtail-config.yml
@@ -7,7 +7,9 @@ server:
   log_level: warn
 
 positions:
-  filename: /tmp/positions.yaml
+  # Persisted on a named volume so alpha's --force-recreate deploys don't
+  # re-tail every container's log from the start (which re-ingests old lines).
+  filename: /promtail/positions.yaml
 
 clients:
   - url: http://loki:3100/loki/api/v1/push

--- a/observability/promtail-config.yml
+++ b/observability/promtail-config.yml
@@ -1,0 +1,50 @@
+# Promtail configuration for the Durion observability stack (#858).
+# Tails the Docker json-file logs of every container on the host and ships them
+# to Loki, enriched with container/service/compose labels from the Docker API.
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: warn
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # Discover every running container via the Docker daemon and tail its logs.
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 15s
+    relabel_configs:
+      # container_name without the leading "/"
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'container'
+      # compose service name (e.g. pos-order, grafana, postgres)
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: 'service'
+      # compose project (durion stack)
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: 'project'
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: 'stream'
+      - target_label: 'job'
+        replacement: 'docker'
+    pipeline_stages:
+      # Docker writes each line as {"log":"...","stream":"...","time":"..."}.
+      - docker: {}
+      # Extract a log-level token so LogQL can filter by level. Case-insensitive
+      # so it matches both Spring Boot/logback ("INFO", "ERROR") and lowercase
+      # infra logs (Loki/Promtail/Postgres emit "level=warn"). Normalised to
+      # uppercase so dashboard filters (level=~"ERROR|FATAL") are consistent.
+      # "WARN" also captures the "WARN" prefix of Postgres's "WARNING".
+      - regex:
+          expression: '(?i)(?P<level>TRACE|DEBUG|INFO|WARN|ERROR|FATAL)'
+      - template:
+          source: level
+          template: '{{ ToUpper .Value }}'
+      - labels:
+          level:


### PR DESCRIPTION
Closes #858

## What

Grafana had no logs backend — datasources were Prometheus/Jaeger/Tempo/TestData with **no Loki**, so the Jaeger `tracesToLogs.datasourceUid: 'loki'` reference was dangling and container/service logs were not viewable. This adds a full logs pipeline: **Promtail → Loki → Grafana**.

## Changes

- **Loki** (`grafana/loki:3.1.1`) — single-binary, filesystem-backed store, 7-day retention (matches Kafka event retention). Added to `docker-compose.yml` + alpha `docker-compose.prod.yml`, with a `loki-data` volume and `/ready` healthcheck.
- **Promtail** (`grafana/promtail:3.1.1`) — Docker service-discovery tails every container's `json-file` logs and ships to Loki, labelled `service` / `container` / `project` / `stream` / `job=docker` plus a `level` extracted case-insensitively and normalised to uppercase.
- **Loki datasource** (uid `loki`) added to Grafana provisioning — satisfies the existing Jaeger/Tempo `tracesToLogs` references; includes a `derivedField` to jump from a log line's `traceId` back to Jaeger.
- **Durion Logs (Loki)** dashboard — log/error/warn rate stats, log volume by service, error/warn volume by service, and a filterable live log panel (`service` / `level` / `search` template vars).
- **README** — documented Loki/Promtail, ports, example LogQL.

Chose Promtail tailing Docker `json-file` logs over an otel-collector Loki exporter: it captures **all** containers (including infra — postgres, kafka, grafana) without depending on each app emitting OTLP logs.

## Acceptance

- [x] Loki datasource present and healthy (`/ready` → `ready`).
- [x] Container/service logs queryable — verified `{job="docker"}` and `{job="docker", level=~"WARN|ERROR"}` return lines with `service`/`container`/`level` labels.
- [x] Jaeger `tracesToLogs` now resolves against the `loki` datasource uid.

Verified locally with `docker compose up -d loki promtail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)