### PR TITLE
chore(observability): prune scrape jobs for undeployed services

### DIFF
--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -109,17 +109,6 @@ scrape_configs:
           service: 'pos-image'
           application: 'pos-image'
 
-  - job_name: 'pos-inquiry'
-    metrics_path: '/actuator/prometheus'
-    basic_auth:
-      username: 'prometheus_scraper'
-      password: 'durion-local-prom-scrape-password'
-    static_configs:
-      - targets: ['pos-inquiry:9004']
-        labels:
-          service: 'pos-inquiry'
-          application: 'pos-inquiry'
-
   - job_name: 'pos-inventory'
     metrics_path: '/actuator/prometheus'
     basic_auth:
@@ -152,17 +141,6 @@ scrape_configs:
         labels:
           service: 'pos-location'
           application: 'pos-location'
-
-  - job_name: 'pos-order'
-    metrics_path: '/actuator/prometheus'
-    basic_auth:
-      username: 'prometheus_scraper'
-      password: 'durion-local-prom-scrape-password'
-    static_configs:
-      - targets: ['pos-order:9007']
-        labels:
-          service: 'pos-order'
-          application: 'pos-order'
 
   - job_name: 'pos-people'
     metrics_path: '/actuator/prometheus'
@@ -208,17 +186,6 @@ scrape_configs:
           service: 'pos-shop-manager'
           application: 'pos-shop-manager'
 
-  - job_name: 'pos-vehicle-fitment'
-    metrics_path: '/actuator/prometheus'
-    basic_auth:
-      username: 'prometheus_scraper'
-      password: 'durion-local-prom-scrape-password'
-    static_configs:
-      - targets: ['pos-vehicle-fitment:8088']
-        labels:
-          service: 'pos-vehicle-fitment'
-          application: 'pos-vehicle-fitment'
-
   - job_name: 'pos-vehicle-inventory'
     metrics_path: '/actuator/prometheus'
     basic_auth:
@@ -240,39 +207,6 @@ scrape_configs:
         labels:
           service: 'pos-workorder'
           application: 'pos-workorder'
-
-  - job_name: 'pos-vehicle-reference-carapi'
-    metrics_path: '/actuator/prometheus'
-    basic_auth:
-      username: 'prometheus_scraper'
-      password: 'durion-local-prom-scrape-password'
-    static_configs:
-      - targets: ['pos-vehicle-reference-carapi:8091']
-        labels:
-          service: 'pos-vehicle-reference-carapi'
-          application: 'pos-vehicle-reference-carapi'
-
-  - job_name: 'pos-vehicle-reference-nhtsa'
-    metrics_path: '/actuator/prometheus'
-    basic_auth:
-      username: 'prometheus_scraper'
-      password: 'durion-local-prom-scrape-password'
-    static_configs:
-      - targets: ['pos-vehicle-reference-nhtsa:8092']
-        labels:
-          service: 'pos-vehicle-reference-nhtsa'
-          application: 'pos-vehicle-reference-nhtsa'
-
-  - job_name: 'pos-agent-framework'
-    metrics_path: '/actuator/prometheus'
-    basic_auth:
-      username: 'prometheus_scraper'
-      password: 'durion-local-prom-scrape-password'
-    static_configs:
-      - targets: ['pos-agent-framework:8080']
-        labels:
-          service: 'pos-agent-framework'
-          application: 'pos-agent-framework'
 
   # Kafka exporter (#838): topic depth (DLQ), consumer lag, manifest activity
   - job_name: 'kafka-exporter'


### PR DESCRIPTION
## What

Remove the six Prometheus scrape jobs whose services are **not** in the deployed alpha topology, so they stop showing as permanently `DOWN` (DNS `no such host`):

- `pos-order`
- `pos-inquiry`
- `pos-agent-framework`
- `pos-vehicle-fitment`
- `pos-vehicle-reference-carapi`
- `pos-vehicle-reference-nhtsa`

These are absent from the `ALL_SERVICES` set built + deployed by `.github/workflows/build-push-ecr.yml`, so Prometheus can never resolve their targets. Remaining scrape jobs: 15 `pos-*` + infra exporters.

## Why

Follow-up to #857. After #861 restored `/actuator/prometheus`, every *deployed* service reports `up=1`; these six were the only remaining `down` targets and are noise (they were flagged in #857 as "prune if they stay out of the alpha topology").

## Scope / caveat

The CI `deploy-alpha` job does **not** sync `observability/` to the alpha host — the running `prometheus.yml` there is hand-maintained. So this is a **repo-hygiene / reproducibility** change; it does not alter the live alpha config on its own.

Two known drifts in this file remain **out of scope** (deserve their own issue): the committed per-service scrape ports (`:9001`, `:8081`, …) and the local-dev scrape password don't match the alpha host copy (ports→`8080`, real secret). Fixing that properly means templating the scrape password at deploy and adding `observability/` to the S3 sync.

## Verification

- 6 target job blocks removed; 15 `pos-*` jobs remain.
- Seams and blank-line hygiene checked (no orphaned/duplicate separators). No YAML validator available on the box, but only complete top-level list items were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)