### PR TITLE
fix(observability): remove duplicate environment label from otel prometheus exporter

### DIFF
--- a/observability/otel-collector-config.yml
+++ b/observability/otel-collector-config.yml
@@ -64,8 +64,10 @@ exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
     namespace: pos
-    const_labels:
-      environment: development
+    # NB: do not add an `environment` const_label here — the attributes processor
+    # already inserts an `environment` datapoint attribute, and defining it in both
+    # places makes prometheusexporter drop every metric with
+    # "duplicate label names in constant and variable labels".
 
   # Logging Exporter - Output telemetry to collector logs (for debugging)
   logging:


### PR DESCRIPTION
## Problem

otel-collector logs spam this on every push-path metric:

```
error prometheusexporter ... failed to convert metric jvm.cpu.recent_utilization:
duplicate label names in constant and variable labels for metric "pos_jvm_cpu_recent_utilization_ratio"
```

`environment` was defined **twice** in `observability/otel-collector-config.yml`:
- attributes processor inserts it as a datapoint attribute (`environment=local`)
- prometheus exporter re-declared it in `const_labels` (`environment=development`)

The exporter sees `environment` as both a constant and a variable label → drops the metric.

## Fix

Remove the `const_labels.environment` entry, leaving the single attributes-processor `environment` label. The two even disagreed (`development` vs `local`).

## Impact

- **No dashboard/data impact** — the pull path (`/actuator/prometheus`, live since #861) already supplies these app metrics; only the redundant OTLP push-path copies were being dropped.
- Clears the collector log spam and restores the dropped push-path series.

## Follow-up (not in this PR)

App metrics are now double-collected (pull via per-service scrape + push via collector `:8889`). Worth deciding whether the push path for app metrics is still needed, or should be scoped to only otelcol/infra metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)