### PR TITLE
fix(observability): make app metrics pull-only via /actuator/prometheus (#867)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://localhost:8761/eureka/
 API_GATEWAY_BASE_URL=http://localhost:8080
 
 # Optional: Observability
+# Traces/logs only — app metrics are pull-only via /actuator/prometheus (#867);
+# docker-compose sets OTEL_METRICS_EXPORTER=none per service.
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 OTEL_SERVICE_VERSION=0.1.0-SNAPSHOT
 GF_SECURITY_ADMIN_USER=admin

--- a/application-observability.yml
+++ b/application-observability.yml
@@ -35,11 +35,10 @@ otel:
       # Sample all traces in development, adjust for production
       probability: ${OTEL_TRACES_SAMPLER_PROBABILITY:1.0}
 
-  # Metrics Configuration
+  # Metrics Configuration — app metrics are PULL-ONLY (#867): Prometheus scrapes
+  # /actuator/prometheus per service. Do not push OTLP metrics to the collector.
   metrics:
-    exporter: otlp
-    export:
-      interval: 60s
+    exporter: none
 
   # Logs Configuration
   logs:
@@ -141,10 +140,6 @@ otel:
   traces:
     sampler:
       probability: 0.1 # Sample 10% of traces in production
-
-  metrics:
-    export:
-      interval: 60s
 
 management:
   endpoint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,6 @@ services:
       - "4317:4317" # OTLP gRPC receiver
       - "4318:4318" # OTLP HTTP receiver
       - "8888:8888" # Prometheus metrics exposed by the collector
-      - "8889:8889" # Prometheus exporter metrics
       - "13133:13133" # Health check extension
     volumes:
       - ./observability/otel-collector-config.yml:/etc/otel-collector-config.yml:ro
@@ -349,6 +348,7 @@ services:
       # Configure Eureka to use its Docker Compose service name for registration
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://localhost:8761/eureka/
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
     depends_on:
       postgres:
@@ -384,6 +384,7 @@ services:
       POS_ACCOUNTING_CREDIT_MEMO_AR_ACCOUNT_ID: ${POS_ACCOUNTING_CREDIT_MEMO_AR_ACCOUNT_ID}
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -418,6 +419,7 @@ services:
       POS_VEHICLE_FITMENT_BASE_URL: http://pos-vehicle-fitment:8080
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -449,6 +451,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -483,6 +486,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -520,6 +524,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -551,6 +556,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -580,6 +586,7 @@ services:
   #     SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
   #     POS_EVENTS_API_SECRET: ${POS_EVENTS_API_SECRET}
   #     OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+  #     OTEL_METRICS_EXPORTER: none
   #     SERVER_PORT: 8080
   #     MANAGEMENT_SERVER_PORT: 8080
   #   depends_on:
@@ -606,6 +613,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -635,6 +643,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
       # Domain events (ADR-0044, #842) — opt-in until the tier-1 flip.
@@ -667,6 +676,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8091
       MANAGEMENT_SERVER_PORT: 8091
       SPRING_FLYWAY_ENABLED: "false"
@@ -697,6 +707,7 @@ services:
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8092
       MANAGEMENT_SERVER_PORT: 8092
     depends_on:
@@ -729,6 +740,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -776,6 +788,7 @@ services:
       MCP_RAG_MAX_OVERLAP_SIZE: ${MCP_RAG_MAX_OVERLAP_SIZE:-200}
       EXA_API_KEY: ${EXA_API_KEY:-}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8086
       MANAGEMENT_SERVER_PORT: 8086
     depends_on:
@@ -813,6 +826,7 @@ services:
   #     SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
   #     POS_EVENTS_API_SECRET: ${POS_EVENTS_API_SECRET}
   #     OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+  #     OTEL_METRICS_EXPORTER: none
   #     SERVER_PORT: 8080
   #     MANAGEMENT_SERVER_PORT: 8080
   #   depends_on:
@@ -841,6 +855,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -870,6 +885,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -906,6 +922,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -939,6 +956,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -970,6 +988,7 @@ services:
   #     SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
   #     POS_EVENTS_API_SECRET: ${POS_EVENTS_API_SECRET}
   #     OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+  #     OTEL_METRICS_EXPORTER: none
   #     SERVER_PORT: 8080
   #     MANAGEMENT_SERVER_PORT: 8080
   #   depends_on:
@@ -999,6 +1018,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
       SPRING_KAFKA_LISTENER_AUTO_STARTUP: ${SPRING_KAFKA_LISTENER_AUTO_STARTUP:-false}
@@ -1035,6 +1055,7 @@ services:
   #     SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
   #     POS_EVENTS_API_SECRET: ${POS_EVENTS_API_SECRET}
   #     OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+  #     OTEL_METRICS_EXPORTER: none
   #     SERVER_PORT: 8080
   #     MANAGEMENT_SERVER_PORT: 8080
   #   depends_on:
@@ -1063,6 +1084,7 @@ services:
   #     SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
   #     POS_EVENTS_API_SECRET: ${POS_EVENTS_API_SECRET}
   #     OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+  #     OTEL_METRICS_EXPORTER: none
   #     SERVER_PORT: 8080
   #     MANAGEMENT_SERVER_PORT: 8080
   #   depends_on:
@@ -1092,6 +1114,7 @@ services:
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8080
       MANAGEMENT_SERVER_PORT: 8080
     depends_on:
@@ -1119,6 +1142,7 @@ services:
       SECURITY_JWT_SECRET: ${SECURITY_JWT_SECRET}
       <<: [ *pos-security-client-env, *pos-events-client-env ]
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
     depends_on:
       eureka-server:
         condition: service_healthy
@@ -1146,6 +1170,7 @@ services:
       NG_ALLOWED_HOSTS: ${NG_ALLOWED_HOSTS}
       OTEL_SERVICE_NAME: pos-frontend
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       OTEL_RESOURCE_ATTRIBUTES: "service.name=pos-frontend,service.namespace=durion-g\
         roup,deployment.environment=pre-production"
     depends_on:

--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -266,6 +266,14 @@ docker-compose up -d jaeger prometheus grafana otel-collector
 # Prometheus:  http://localhost:9090
 ```
 
+### Metrics path — single authority (#867)
+
+Application metrics are **pull-only**: Prometheus scrapes each service's
+`/actuator/prometheus` endpoint under a per-service `job` label (see
+`observability/prometheus.yml`). The OTel collector carries traces and logs only —
+it has no metrics pipeline, and services run with `OTEL_METRICS_EXPORTER=none` so the
+Java agent does not push OTLP metrics. See `observability/README.md` for details.
+
 ### OpenTelemetry Configuration
 
 All Dockerfiles include Grafana OpenTelemetry Java Agent v2.9.0:

--- a/observability/README.md
+++ b/observability/README.md
@@ -103,13 +103,13 @@ Defines scrape jobs for all POS services. Each service exposes metrics at `/actu
 
 ### `otel-collector-config.yml`
 
-Configures the OpenTelemetry Collector pipeline:
+Configures the OpenTelemetry Collector pipeline. The collector carries **traces and logs
+only** — application metrics are pull-only (see below).
 
 **Receivers**:
 
 - OTLP gRPC: Port 4317
 - OTLP HTTP: Port 4318
-- Prometheus: Self-scraping
 
 **Processors**:
 
@@ -121,8 +121,21 @@ Configures the OpenTelemetry Collector pipeline:
 **Exporters**:
 
 - Jaeger: Traces via OTLP
-- Prometheus: Metrics on port 8889
 - Logging: Debug output
+
+#### Metrics path — single authority (#867)
+
+Application metrics reach Prometheus **only** by pull: Prometheus scrapes each service's
+`/actuator/prometheus` endpoint (basic-auth) under a per-service `job` label
+(`pos-workorder`, `pos-order`, ...). Metric names are the plain Micrometer/Prometheus
+names (`jvm_memory_used_bytes`, `http_server_requests_seconds_*`, ...).
+
+The collector has **no metrics pipeline** and no `prometheus` exporter (`:8889` removed);
+it must not re-export app metrics. Services run with `OTEL_METRICS_EXPORTER=none` so the
+`grafana-opentelemetry-java` agent doesn't push OTLP metrics. Collector-internal telemetry
+(`otelcol_*`) is exposed on `:8888` and scraped under `job="otel-collector"`.
+
+Traces are unaffected: OTLP → collector → Jaeger.
 
 ### `loki-config.yml`
 

--- a/observability/otel-collector-config.yml
+++ b/observability/otel-collector-config.yml
@@ -1,4 +1,12 @@
 # OpenTelemetry Collector Configuration for Durion POS Backend
+#
+# Metrics policy (#867): application metrics are PULL-ONLY — Prometheus scrapes
+# each service's /actuator/prometheus endpoint directly (see prometheus.yml).
+# The collector carries traces (OTLP -> Jaeger) and logs only; it has no metrics
+# pipeline and does not re-export app metrics. Services must run with
+# OTEL_METRICS_EXPORTER=none so the javaagent doesn't push OTLP metrics here.
+# Collector-internal telemetry is exposed on :8888 (service.telemetry below)
+# and scraped directly by Prometheus under job="otel-collector".
 receivers:
   # OTLP Receiver - Primary receiver for OpenTelemetry Protocol
   otlp:
@@ -10,15 +18,6 @@ receivers:
         cors:
           allowed_origins:
             - "*"
-
-  # Prometheus Receiver - Scrape metrics from services
-  prometheus:
-    config:
-      scrape_configs:
-        - job_name: 'otel-collector'
-          scrape_interval: 10s
-          static_configs:
-            - targets: ['localhost:8888']
 
 processors:
   # Batch Processor - Batch telemetry data for better performance
@@ -60,15 +59,6 @@ exporters:
     tls:
       insecure: true
 
-  # Prometheus Exporter - Expose metrics for Prometheus scraping
-  prometheus:
-    endpoint: "0.0.0.0:8889"
-    namespace: pos
-    # NB: do not add an `environment` const_label here — the attributes processor
-    # already inserts an `environment` datapoint attribute, and defining it in both
-    # places makes prometheusexporter drop every metric with
-    # "duplicate label names in constant and variable labels".
-
   # Logging Exporter - Output telemetry to collector logs (for debugging)
   logging:
     loglevel: debug
@@ -104,12 +94,9 @@ service:
       processors: [memory_limiter, batch, resource, attributes]
       exporters: [otlp/jaeger, logging]
     
-    # Metrics Pipeline
-    metrics:
-      receivers: [otlp, prometheus]
-      processors: [memory_limiter, batch, resource, attributes]
-      exporters: [prometheus, logging]
-    
+    # No metrics pipeline (#867): app metrics are scraped by Prometheus from
+    # /actuator/prometheus; collector-internal metrics are served on :8888.
+
     # Logs Pipeline
     logs:
       receivers: [otlp]

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -22,10 +22,12 @@ scrape_configs:
         labels:
           service: 'prometheus'
 
-  # OTEL Collector metrics
+  # OTEL Collector internal telemetry (otelcol_*) on :8888.
+  # App metrics come ONLY from the per-service /actuator/prometheus jobs below (#867);
+  # the collector no longer re-exports them (its :8889 prometheus exporter was removed).
   - job_name: 'otel-collector'
     static_configs:
-      - targets: ['otel-collector:8888', 'otel-collector:8889']
+      - targets: ['otel-collector:8888']
         labels:
           service: 'otel-collector'
 

--- a/pos-accounting/pom.xml
+++ b/pos-accounting/pom.xml
@@ -67,11 +67,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-otlp</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <version>${opentelemetry.version}</version>


### PR DESCRIPTION
## Summary

Fixes #867 by adopting **Option A — pull only**: Prometheus's per-service `/actuator/prometheus` scrape jobs are now the single authority for application metrics, and the OTLP push path for metrics is removed end to end.

App metrics were reaching Prometheus twice — once via the pull scrape (`jvm_memory_used_bytes{job="pos-*"}`) and once via javaagent OTLP push re-exported by the collector's `prometheusexporter` on `:8889` (`pos_jvm_memory_used_bytes{job="otel-collector"}`). This duplicated storage, made queries ambiguous, and risked double-counted aggregations.

## Changes

- **observability/otel-collector-config.yml** — removed the metrics pipeline, the `prometheus` self-scrape receiver, and the `:8889` `prometheus` exporter. The collector now carries traces (OTLP → Jaeger) and logs only. Documented the policy at the top of the file. Validated with `otelcol-contrib:0.93.0 validate`.
- **observability/prometheus.yml** — `otel-collector` job scrapes `:8888` (collector-internal `otelcol_*` telemetry) only; dropped the `:8889` target.
- **docker-compose.yml** — `OTEL_METRICS_EXPORTER: none` on every service (incl. commented-out templates) so the `grafana-opentelemetry-java` agent stops pushing OTLP metrics; removed the collector's `8889` port mapping. `docker compose config -q` passes.
- **pos-accounting/pom.xml** — removed `micrometer-registry-otlp` (the only in-app OTLP metrics push registry in the repo); `micrometer-registry-prometheus` remains. `./mvnw -pl pos-accounting -am package` passes.
- **application-observability.yml** — `otel.metrics.exporter: none` with rationale.
- **Docs** — metric-path convention documented in `observability/README.md` and `docs/ARCHITECTURE_GUIDE.md`: app metrics = unprefixed Micrometer names under `job=pos-*`; collector-internal = `otelcol_*` under `job=otel-collector`.

## Acceptance criteria mapping

- ✅ Each app metric exists once in Prometheus, under a documented name + `job` convention.
- ✅ Dashboards/alerts already reference pull-path names (`workorder_outbox_*`, `kafka_*`, unprefixed) — verified no `pos_`-prefixed queries exist, so no dashboard changes needed and no double-counting remains.
- ✅ otel-collector metrics pipeline documented as removed; collector scoped to traces/logs + `:8888` self-telemetry.

Traces and the OTLP tracing bridge are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)