### PR TITLE
[CAP:823] Explicit operationIds on legacy vehicle controller

### DIFF
--- a/pos-vehicle-inventory/openapi.yaml
+++ b/pos-vehicle-inventory/openapi.yaml
@@ -168,7 +168,7 @@ paths:
       - Vehicle API
       summary: Get vehicle by ID
       description: Retrieve a vehicle by its unique ID.
-      operationId: getVehicle
+      operationId: getVehicleLegacy
       parameters:
       - name: id
         in: path
@@ -200,7 +200,7 @@ paths:
       - Vehicle API
       summary: Update vehicle by ID
       description: Update an existing vehicle's details by its ID.
-      operationId: updateVehicle
+      operationId: updateVehicleLegacy
       parameters:
       - name: id
         in: path
@@ -238,7 +238,7 @@ paths:
       - Vehicle API
       summary: Delete vehicle by ID
       description: Delete a vehicle from the inventory by its ID.
-      operationId: deleteVehicle
+      operationId: deleteVehicleLegacy
       parameters:
       - name: id
         in: path
@@ -355,7 +355,7 @@ paths:
       - Vehicle Registry API
       summary: Get vehicle by ID
       description: Retrieve a vehicle by its unique ID
-      operationId: getVehicle_1
+      operationId: getVehicle
       parameters:
       - name: vehicleId
         in: path
@@ -386,7 +386,7 @@ paths:
       - Vehicle Registry API
       summary: Update vehicle
       description: Update an existing vehicle by ID
-      operationId: updateVehicle_1
+      operationId: updateVehicle
       parameters:
       - name: vehicleId
         in: path
@@ -429,7 +429,7 @@ paths:
       - Vehicle Registry API
       summary: Delete vehicle
       description: Deactivate a vehicle by ID
-      operationId: deleteVehicle_1
+      operationId: deleteVehicle
       parameters:
       - name: vehicleId
         in: path
@@ -578,7 +578,7 @@ paths:
       - Vehicle API
       summary: Create a new vehicle
       description: Add a new vehicle to the inventory.
-      operationId: createVehicle
+      operationId: createVehicleLegacy
       requestBody:
         content:
           application/json:
@@ -626,7 +626,7 @@ paths:
       - Vehicle Registry API
       summary: Create vehicle
       description: Create a new vehicle registry record
-      operationId: createVehicle_1
+      operationId: createVehicle
       requestBody:
         content:
           application/json:

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleController.java
@@ -33,7 +33,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class VehicleController {
     private final VehicleLegacyService vehicleLegacyService;
 
-    @Operation(summary = "Create a new vehicle", description = "Add a new vehicle to the inventory.")
+    @Operation(
+            operationId = "createVehicleLegacy",
+            summary = "Create a new vehicle",
+            description = "Add a new vehicle to the inventory.")
     @ApiResponse(responseCode = "200", description = "Vehicle created successfully.")
     @EmitEvent(id = "VEHICLE_CREATE", apiVersion = "1")
     @PostMapping
@@ -47,7 +50,10 @@ public class VehicleController {
         }
     }
 
-    @Operation(summary = "Get vehicle by ID", description = "Retrieve a vehicle by its unique ID.")
+    @Operation(
+            operationId = "getVehicleLegacy",
+            summary = "Get vehicle by ID",
+            description = "Retrieve a vehicle by its unique ID.")
     @ApiResponse(responseCode = "200", description = "Vehicle found and returned.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @GetMapping("/{id}")
@@ -66,7 +72,10 @@ public class VehicleController {
         return vehicleLegacyService.getAllVehicles();
     }
 
-    @Operation(summary = "Update vehicle by ID", description = "Update an existing vehicle's details by its ID.")
+    @Operation(
+            operationId = "updateVehicleLegacy",
+            summary = "Update vehicle by ID",
+            description = "Update an existing vehicle's details by its ID.")
     @ApiResponse(responseCode = "200", description = "Vehicle updated successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_UPDATE", apiVersion = "1")
@@ -83,7 +92,10 @@ public class VehicleController {
         }
     }
 
-    @Operation(summary = "Delete vehicle by ID", description = "Delete a vehicle from the inventory by its ID.")
+    @Operation(
+            operationId = "deleteVehicleLegacy",
+            summary = "Delete vehicle by ID",
+            description = "Delete a vehicle from the inventory by its ID.")
     @ApiResponse(responseCode = "204", description = "Vehicle deleted successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_DELETE", apiVersion = "1")


### PR DESCRIPTION
## Summary
- The legacy `/v1/vehicles-legacy` controller and the new `/v1/vehicle-registry` controller (ADR-0044 Phase 2, #843 / PR #865) shared Java method names, so springdoc dedup-suffixed the registry operations (`createVehicle_1`, `getVehicle_1`, `updateVehicle_1`, `deleteVehicle_1`). The generated Angular SDK exposed mangled method names (`createVehicle1`, …) on `VehicleRegistryAPIService`, blocking the frontend contract switch.
- Adds explicit `operationId = "*Legacy"` to the four colliding legacy operations so the canonical registry API keeps the clean names.
- `openapi.yaml` regenerated via `scripts/generate-openapi.sh pos-vehicle-inventory`; OpenAPI validation (report mode) passed.

## Testing
- `mvn -pl pos-vehicle-inventory test` — 25/25 pass.
- Angular SDK regenerated from the new spec; frontend typecheck + affected specs (27) pass against it.

Part of #823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)