### PR TITLE
[CAP:823] Grant vehicle-inventory registry authorities to CRM-facing roles

### DIFF
--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RoleAuthorityServiceImpl.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/RoleAuthorityServiceImpl.java
@@ -106,9 +106,13 @@ public class RoleAuthorityServiceImpl implements RoleAuthorityService {
         set.addAll(List.of(
                 // Party edit
                 "crm:party:edit",
-                // Vehicles create/edit
+                // Vehicle-party association (crm:vehicle:create guards the
+                // POST /parties/{partyId}/vehicles association endpoint, ADR-0012)
                 "crm:vehicle:create",
-                "crm:vehicle:edit",
+                // Vehicle registry writes live in pos-vehicle-inventory (ADR-0044 §6, #843)
+                "vehicle-inventory:registry:view",
+                "vehicle-inventory:registry:create",
+                "vehicle-inventory:registry:update",
                 // Associations manage
                 "crm:vehicle_party_association:create",
                 "crm:vehicle_party_association:edit",
@@ -127,7 +131,8 @@ public class RoleAuthorityServiceImpl implements RoleAuthorityService {
                 "crm:person:create",
                 "crm:contact:delete",
                 "crm:contact_role:revoke",
-                "crm:vehicle:deactivate",
+                // Vehicle deactivation moved to the registry (ADR-0044 §6, #843)
+                "vehicle-inventory:registry:delete",
                 "crm:integration:audit",
                 "crm:billing_rules:edit",
                 "crm:relationship:create",
@@ -376,7 +381,13 @@ public class RoleAuthorityServiceImpl implements RoleAuthorityService {
                 // approve/reject pay-period time entries.
                 "pricing:promotion:view",
                 "workorder:timeEntry:approve",
-                "workorder:timeEntry:reject"));
+                "workorder:timeEntry:reject",
+                // Estimate-create vehicle panel (ADR-0044 §6, #843): list customer
+                // vehicles from the CRM replica and register new ones in pos-vehicle-inventory.
+                "crm:vehicle:view",
+                "crm:vehicle:search",
+                "vehicle-inventory:registry:view",
+                "vehicle-inventory:registry:create"));
         return authorities;
     }
 

--- a/pos-security-service/src/test/java/com/positivity/securityservice/service/RoleAuthorityServiceTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/service/RoleAuthorityServiceTest.java
@@ -47,8 +47,10 @@ class RoleAuthorityServiceTest {
                         "crm:vehicle:view",
                         "crm:vehicle:search",
                         "crm:vehicle:create",
-                        "crm:vehicle:edit",
-                        "crm:vehicle:deactivate",
+                        "vehicle-inventory:registry:view",
+                        "vehicle-inventory:registry:create",
+                        "vehicle-inventory:registry:update",
+                        "vehicle-inventory:registry:delete",
                         "crm:vehicle_party_association:view",
                         "crm:vehicle_party_association:create",
                         "crm:vehicle_party_association:edit",
@@ -91,6 +93,9 @@ class RoleAuthorityServiceTest {
         assertThat(authorities)
                 .contains("ROLE_FLEET_MANAGER")
                 .contains("crm:vehicle:create")
+                .contains("vehicle-inventory:registry:create")
+                .contains("vehicle-inventory:registry:update")
+                .doesNotContain("crm:vehicle:edit", "vehicle-inventory:registry:delete")
                 .contains("crm:party:view")
                 .contains(MCP_CHAT_EXECUTE);
     }


### PR DESCRIPTION
## Summary
- Completes the last Phase 2 (#843) rollout step. Role→permission expansion for JWTs is code (`RoleAuthorityServiceImpl`), not the `role_permissions` table (empty on alpha) — so the "runtime grant" is this change plus a pos-security-service redeploy.
- `FLEET_MANAGER`: retired `crm:vehicle:edit` → `vehicle-inventory:registry:view/create/update`; keeps `crm:vehicle:create` (guards the surviving vehicle-party association endpoint, ADR-0012).
- `CUSTOMER` bundle: retired `crm:vehicle:deactivate` → `vehicle-inventory:registry:delete`.
- `SERVICE_ADVISOR` (+`LOCATION_MANAGER` via inheritance): adds `crm:vehicle:view/search` (CRM replica reads) and `vehicle-inventory:registry:view/create` for the estimate-create vehicle panel — the role previously had no vehicle authorities at all, so alpha service advisors (rachel.kim, tyrone.williams) could neither list nor register vehicles.
- No catalog change — all permissions are existing catalog v18 bits; no CATALOG_VERSION bump, no fleet redeploy. Only pos-security-service mints new perm bitsets.

## Testing
- `mvn -pl pos-security-service test` — 433/433 pass, including updated `RoleAuthorityServiceTest` expectations (FLEET_MANAGER gains registry perms, loses `crm:vehicle:edit`; ADMIN set updated).

Part of #823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)