### PR TITLE
chore(logging): apply ADR-0046 environment log level policy across modules

### DIFF
--- a/pos-accounting/src/main/resources/application-alpha.yml
+++ b/pos-accounting/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-accounting/src/main/resources/application-dev.yml
+++ b/pos-accounting/src/main/resources/application-dev.yml
@@ -42,3 +42,10 @@ stripe:
   api-key: ${STRIPE_API_KEY:DUMMY_STRIPE_API_KEY}
   connect-account: ${STRIPE_CONNECT_ACCOUNT:DUMMY_CONNECT_ACCOUNT_FOR_DEV}
   idempotency-window-hours: ${STRIPE_IDEMPOTENCY_WINDOW_HOURS:24}
+
+# ADR-0046: developer-only DEBUG loggers moved out of application.yml
+logging:
+  level:
+    org:
+      springframework:
+        security: DEBUG

--- a/pos-accounting/src/main/resources/application-indus.yml
+++ b/pos-accounting/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-accounting/src/main/resources/application-prod.yml
+++ b/pos-accounting/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-accounting/src/main/resources/application.yml
+++ b/pos-accounting/src/main/resources/application.yml
@@ -94,7 +94,6 @@ logging:
                 ConfigClusterResolver: WARN
     org:
       springframework:
-        security: DEBUG
         web: INFO
       hibernate:
         SQL: INFO

--- a/pos-api-gateway/src/main/resources/application-alpha.yml
+++ b/pos-api-gateway/src/main/resources/application-alpha.yml
@@ -11,6 +11,8 @@ eureka:
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-api-gateway/src/main/resources/application-dev.yml
+++ b/pos-api-gateway/src/main/resources/application-dev.yml
@@ -8,3 +8,14 @@ eureka:
   client:
     serviceUrl:
       defaultZone: http://localhost:8761/eureka/
+
+# ADR-0046: developer-only DEBUG loggers moved out of application.yml
+logging:
+  level:
+    org:
+      springframework:
+        cloud:
+          gateway: DEBUG
+    com:
+      positivity:
+        gateway: DEBUG

--- a/pos-api-gateway/src/main/resources/application-indus.yml
+++ b/pos-api-gateway/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-api-gateway/src/main/resources/application-prod.yml
+++ b/pos-api-gateway/src/main/resources/application-prod.yml
@@ -8,3 +8,15 @@ eureka:
   client:
     serviceUrl:
       defaultZone: ${EUREKA_SERVER_URL}
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-api-gateway/src/main/resources/application.yml
+++ b/pos-api-gateway/src/main/resources/application.yml
@@ -231,10 +231,10 @@ logging:
     org:
       springframework:
         cloud:
-          gateway: DEBUG
+          gateway: INFO
     com:
       positivity:
-        gateway: DEBUG
+        gateway: INFO
 
       netflix:
         discovery:

--- a/pos-archunit/src/main/resources/application-alpha.yml
+++ b/pos-archunit/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-archunit/src/main/resources/application-dev.yml
+++ b/pos-archunit/src/main/resources/application-dev.yml
@@ -1,1 +1,10 @@
 # Developer workstation profile intentionally minimal.
+
+# ADR-0046: developer-only DEBUG loggers moved out of application.yml
+logging:
+  level:
+    org:
+      springframework:
+        modulith: DEBUG
+    com:
+      positivity: DEBUG

--- a/pos-archunit/src/main/resources/application-indus.yml
+++ b/pos-archunit/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-archunit/src/main/resources/application-prod.yml
+++ b/pos-archunit/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-archunit/src/main/resources/application.yml
+++ b/pos-archunit/src/main/resources/application.yml
@@ -17,9 +17,9 @@ logging:
     root: INFO
     org:
       springframework:
-        modulith: DEBUG
+        modulith: INFO
     com:
-      positivity: DEBUG
+      positivity: INFO
       netflix:
         discovery:
           shared:

--- a/pos-bulk-loader/src/main/resources/application-alpha.yml
+++ b/pos-bulk-loader/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-bulk-loader/src/main/resources/application-indus.yml
+++ b/pos-bulk-loader/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-bulk-loader/src/main/resources/application-prod.yml
+++ b/pos-bulk-loader/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-catalog/src/main/resources/application-alpha.yml
+++ b/pos-catalog/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-catalog/src/main/resources/application-indus.yml
+++ b/pos-catalog/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-catalog/src/main/resources/application-prod.yml
+++ b/pos-catalog/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-customer/src/main/resources/application-alpha.yml
+++ b/pos-customer/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-customer/src/main/resources/application-indus.yml
+++ b/pos-customer/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-customer/src/main/resources/application-prod.yml
+++ b/pos-customer/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-documents/src/main/resources/application-alpha.yml
+++ b/pos-documents/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-documents/src/main/resources/application-indus.yml
+++ b/pos-documents/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-documents/src/main/resources/application-prod.yml
+++ b/pos-documents/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-event-receiver/src/main/resources/application-alpha.yml
+++ b/pos-event-receiver/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-event-receiver/src/main/resources/application-indus.yml
+++ b/pos-event-receiver/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-event-receiver/src/main/resources/application-prod.yml
+++ b/pos-event-receiver/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-events/src/main/resources/application-alpha.yml
+++ b/pos-events/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-events/src/main/resources/application-indus.yml
+++ b/pos-events/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-events/src/main/resources/application-prod.yml
+++ b/pos-events/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Production runtime inherits base configuration for this internal service.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-image/src/main/resources/application-alpha.yml
+++ b/pos-image/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-image/src/main/resources/application-indus.yml
+++ b/pos-image/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-image/src/main/resources/application-prod.yml
+++ b/pos-image/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-inquiry/src/main/resources/application-alpha.yml
+++ b/pos-inquiry/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-inquiry/src/main/resources/application-indus.yml
+++ b/pos-inquiry/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-inquiry/src/main/resources/application-prod.yml
+++ b/pos-inquiry/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-inventory/src/main/resources/application-alpha.yml
+++ b/pos-inventory/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-inventory/src/main/resources/application-dev.yml
+++ b/pos-inventory/src/main/resources/application-dev.yml
@@ -32,3 +32,10 @@ eureka:
   instance:
     prefer-ip-address: true
     instance-id: ${spring.application.name}:${random.uuid}
+
+# ADR-0046: developer-only DEBUG loggers moved out of application.yml
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: DEBUG

--- a/pos-inventory/src/main/resources/application-indus.yml
+++ b/pos-inventory/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-inventory/src/main/resources/application-prod.yml
+++ b/pos-inventory/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-inventory/src/main/resources/application.yml
+++ b/pos-inventory/src/main/resources/application.yml
@@ -56,8 +56,6 @@ logging:
     org:
       springframework:
         web: INFO
-      hibernate:
-        SQL: DEBUG
 springdoc:
   api-docs:
     enabled: true

--- a/pos-invoice/src/main/resources/application-alpha.yml
+++ b/pos-invoice/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-invoice/src/main/resources/application-indus.yml
+++ b/pos-invoice/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-invoice/src/main/resources/application-prod.yml
+++ b/pos-invoice/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-location/src/main/resources/application-alpha.yml
+++ b/pos-location/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-location/src/main/resources/application-indus.yml
+++ b/pos-location/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-location/src/main/resources/application-prod.yml
+++ b/pos-location/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-mcp-server/src/main/resources/application-alpha.yml
+++ b/pos-mcp-server/src/main/resources/application-alpha.yml
@@ -137,12 +137,9 @@ exa:
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
-      positivity:
-        mcp:
-          internal:
-            orchestration: DEBUG
-
       netflix:
         discovery:
           shared:

--- a/pos-mcp-server/src/main/resources/application-dev.yml
+++ b/pos-mcp-server/src/main/resources/application-dev.yml
@@ -51,3 +51,10 @@ pos:
     employee-uri-template: ${POS_HR_EMPLOYEE_URI_TEMPLATE:/{employeeId}}
     search-uri-template: ${POS_HR_SEARCH_URI_TEMPLATE:?q={query}}
     schedule-uri-template: ${POS_HR_SCHEDULE_URI_TEMPLATE:/availability?employeeId={employeeId}}
+
+# ADR-0046: developer-only DEBUG loggers moved out of application.yml
+logging:
+  level:
+    com:
+      positivity:
+        mcp: DEBUG

--- a/pos-mcp-server/src/main/resources/application-indus.yml
+++ b/pos-mcp-server/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-mcp-server/src/main/resources/application-prod.yml
+++ b/pos-mcp-server/src/main/resources/application-prod.yml
@@ -20,3 +20,15 @@ eureka:
     enabled: true
     service-url:
       defaultZone: ${EUREKA_SERVER_URL}
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -273,7 +273,7 @@ logging:
   level:
     com:
       positivity:
-        mcp: DEBUG
+        mcp: INFO
       netflix:
         discovery:
           shared:

--- a/pos-order/src/main/resources/application-alpha.yml
+++ b/pos-order/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-order/src/main/resources/application-indus.yml
+++ b/pos-order/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-order/src/main/resources/application-prod.yml
+++ b/pos-order/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-people/src/main/resources/application-alpha.yml
+++ b/pos-people/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-people/src/main/resources/application-indus.yml
+++ b/pos-people/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-people/src/main/resources/application-prod.yml
+++ b/pos-people/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-price/src/main/resources/application-alpha.yml
+++ b/pos-price/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-price/src/main/resources/application-indus.yml
+++ b/pos-price/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-price/src/main/resources/application-prod.yml
+++ b/pos-price/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-security-service/src/main/resources/application-alpha.yml
+++ b/pos-security-service/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-security-service/src/main/resources/application-docker.yml
+++ b/pos-security-service/src/main/resources/application-docker.yml
@@ -41,4 +41,4 @@ logging:
       springframework: INFO
     com:
       positivity:
-        security: DEBUG
+        security: INFO

--- a/pos-security-service/src/main/resources/application-indus.yml
+++ b/pos-security-service/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-security-service/src/main/resources/application-prod.yml
+++ b/pos-security-service/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-service-discovery/src/main/resources/application-alpha.yml
+++ b/pos-service-discovery/src/main/resources/application-alpha.yml
@@ -3,6 +3,8 @@ server:
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-service-discovery/src/main/resources/application-indus.yml
+++ b/pos-service-discovery/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-service-discovery/src/main/resources/application-prod.yml
+++ b/pos-service-discovery/src/main/resources/application-prod.yml
@@ -1,2 +1,14 @@
 server:
   port: ${SERVER_PORT:8761}
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-shop-manager/src/main/resources/application-alpha.yml
+++ b/pos-shop-manager/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-shop-manager/src/main/resources/application-indus.yml
+++ b/pos-shop-manager/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-shop-manager/src/main/resources/application-prod.yml
+++ b/pos-shop-manager/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-tax/src/main/resources/application-alpha.yml
+++ b/pos-tax/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-tax/src/main/resources/application-indus.yml
+++ b/pos-tax/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-tax/src/main/resources/application-prod.yml
+++ b/pos-tax/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-vehicle-fitment/src/main/resources/application-alpha.yml
+++ b/pos-vehicle-fitment/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-vehicle-fitment/src/main/resources/application-indus.yml
+++ b/pos-vehicle-fitment/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-vehicle-fitment/src/main/resources/application-prod.yml
+++ b/pos-vehicle-fitment/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-vehicle-inventory/src/main/resources/application-alpha.yml
+++ b/pos-vehicle-inventory/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-vehicle-inventory/src/main/resources/application-indus.yml
+++ b/pos-vehicle-inventory/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-vehicle-inventory/src/main/resources/application-prod.yml
+++ b/pos-vehicle-inventory/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-vehicle-reference-carapi/src/main/resources/application-alpha.yml
+++ b/pos-vehicle-reference-carapi/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-vehicle-reference-carapi/src/main/resources/application-indus.yml
+++ b/pos-vehicle-reference-carapi/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-vehicle-reference-carapi/src/main/resources/application-prod.yml
+++ b/pos-vehicle-reference-carapi/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-vehicle-reference-nhtsa/src/main/resources/application-alpha.yml
+++ b/pos-vehicle-reference-nhtsa/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-vehicle-reference-nhtsa/src/main/resources/application-indus.yml
+++ b/pos-vehicle-reference-nhtsa/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-vehicle-reference-nhtsa/src/main/resources/application-prod.yml
+++ b/pos-vehicle-reference-nhtsa/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-workorder/src/main/resources/application-alpha.yml
+++ b/pos-workorder/src/main/resources/application-alpha.yml
@@ -2,6 +2,8 @@
 
 logging:
   level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
     com:
       netflix:
         discovery:

--- a/pos-workorder/src/main/resources/application-indus.yml
+++ b/pos-workorder/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-workorder/src/main/resources/application-prod.yml
+++ b/pos-workorder/src/main/resources/application-prod.yml
@@ -1,1 +1,13 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN


### PR DESCRIPTION
## Summary

Applies the log-level portion of ADR-0046 (Environment Log Level Policy) across all 27 `pos-*` modules. Deployed environments now run an explicit INFO baseline with named framework loggers capped at WARN, and no standing DEBUG/TRACE loggers remain in any deployed profile.

## Changes

- **Alpha profiles (27)**: explicit `logging.level.root: INFO` with an ADR-0046 comment; existing Eureka `ConfigClusterResolver: WARN` cap retained. Removed the standing `com.positivity.mcp.internal.orchestration: DEBUG` from the pos-mcp-server alpha profile.
- **Prod profiles (27)**: added a logging block with `root: INFO` and the Eureka resolver WARN cap (previously inherited base config with no explicit levels).
- **Indus profiles (27, new files)**: created `application-indus.yml` with the same deployed baseline as prod.
- **Base `application.yml` (5)**: removed standing DEBUG loggers that leaked into deployed profiles:
  - pos-accounting: `org.springframework.security: DEBUG` removed
  - pos-api-gateway: `org.springframework.cloud.gateway` and `com.positivity.gateway` DEBUG → INFO
  - pos-archunit: `org.springframework.modulith` and `com.positivity` DEBUG → INFO
  - pos-inventory: `org.hibernate.SQL: DEBUG` removed (payload-leaking SQL statement logging)
  - pos-mcp-server: `com.positivity.mcp: DEBUG` → INFO
- **Dev profiles (5)**: the removed DEBUG loggers moved into `application-dev.yml`, where ADR-0046 permits them.
- **pos-security-service docker profile**: `com.positivity.security: DEBUG` → INFO per the docker-profile baseline.

## Out of scope (planned follow-ups per ADR-0046)

- Structured JSON logging in deployed profiles (sub-decision 6)
- Ingestion-side cost controls: retention tiers, sampling, budgets (sub-decision 5)
- CI/ArchUnit enforcement of per-profile levels

## Verification

- All 141 `application*.yml` files parse as valid YAML
- Grep confirms zero DEBUG/TRACE entries in any alpha/prod/indus/docker profile or base `application.yml`
- Test-profile and dev-profile DEBUG loggers intentionally retained (permitted by the ADR)

## References

- ADR-0046: Environment Log Level Policy (`durion/docs/adr/0046-environment-log-level-policy.adr.md`, ACCEPTED 2026-07-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)