### PR TITLE
feat(people-contact): create pos-people-contact identity/contact/link authority module (Phase 3.1, ADR-0044)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -872,6 +872,44 @@ services:
       timeout: 3s
       retries: 20
 
+  pos-people-contact:
+    build:
+      context: ./pos-people-contact
+      dockerfile: Dockerfile
+    ports:
+      - "8095:8080"
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
+      EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
+      GATEWAY_URL: http://pos-api-gateway:8080
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_people_contact_db
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+      SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
+      <<: [ *pos-security-client-env, *pos-events-client-env ]
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
+      SERVER_PORT: 8080
+      MANAGEMENT_SERVER_PORT: 8080
+      SPRING_KAFKA_LISTENER_AUTO_STARTUP: ${SPRING_KAFKA_LISTENER_AUTO_STARTUP:-false}
+      MANAGEMENT_HEALTH_KAFKA_ENABLED: ${MANAGEMENT_HEALTH_KAFKA_ENABLED:-false}
+      # ADR-0044 #874: people-contact.events.v1 outbox producer + commands/manifest loop
+      POS_PEOPLE_CONTACT_KAFKA_ENABLED: ${POS_PEOPLE_CONTACT_KAFKA_ENABLED:-false}
+    depends_on:
+      eureka-server:
+        condition: service_healthy
+      pos-security-service:
+        condition: service_healthy
+    logging: *logging
+    networks:
+      - pos-network
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 90s
+
   pos-price:
     build:
       context: ./pos-price

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,7 @@
 		<module>pos-vehicle-reference-carapi</module>
 		<module>pos-security-service</module>
 		<module>pos-people</module>
+		<module>pos-people-contact</module>
 		<module>pos-location</module>
 		<module>pos-tax</module>
 		<module>pos-documents</module>

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 18;
+    public static final int CATALOG_VERSION = 19;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -380,7 +380,17 @@ public final class GatewayPermissionCatalog {
         "PERM_inventory:location:sync", // 349
 
         // ── New batch (bits 350–350) ──────────────────────────────────────────
-        "PERM_workorder:events:replay" // 350
+        "PERM_workorder:events:replay", // 350
+        // ── People Contact (bits 351–359, ADR-0044 Phase 3 split #874) ────────
+        "PERM_people-contact:person:view", // 351
+        "PERM_people-contact:person:create", // 352
+        "PERM_people-contact:person:edit", // 353
+        "PERM_people-contact:person:delete", // 354
+        "PERM_people-contact:role:view", // 355
+        "PERM_people-contact:role:assign", // 356
+        "PERM_people-contact:role:revoke", // 357
+        "PERM_people-contact:userLink:view", // 358
+        "PERM_people-contact:userLink:write" // 359
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/main/resources/application.yml
+++ b/pos-api-gateway/src/main/resources/application.yml
@@ -82,6 +82,12 @@ spring:
                 - Path=/people/**
               filters:
                 - StripPrefix=1
+            - id: people-contact
+              uri: lb://PEOPLE-CONTACT
+              predicates:
+                - Path=/people-contact/**
+              filters:
+                - StripPrefix=1
             - id: security-service
               uri: lb://SECURITY-SERVICE
               predicates:
@@ -211,6 +217,8 @@ springdoc:
         url: /order/v3/api-docs
       - name: People
         url: /people/v3/api-docs
+      - name: People Contact
+        url: /people-contact/v3/api-docs
       - name: Price
         url: /price/v3/api-docs
       - name: Security Service

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,9 +1142,9 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 18")
-    void catalogVersionIsSeventeen() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(18);
+    @DisplayName("CATALOG_VERSION is 19")
+    void catalogVersionIsNineteen() {
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(19);
     }
 
     @Test
@@ -1187,8 +1187,11 @@ class SecurityGatewayConfigTest {
         assertThat(GatewayPermissionCatalog.authorityForBit(349)).isEqualTo("PERM_inventory:location:sync");
         // catalog v18 (#823/#839): outbox replay authority appended (bit 350)
         assertThat(GatewayPermissionCatalog.authorityForBit(350)).isEqualTo("PERM_workorder:events:replay");
+        // catalog v19 (#823/#874): people-contact authorities appended (bits 351-359)
+        assertThat(GatewayPermissionCatalog.authorityForBit(351)).isEqualTo("PERM_people-contact:person:view");
+        assertThat(GatewayPermissionCatalog.authorityForBit(359)).isEqualTo("PERM_people-contact:userLink:write");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(351)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(360)).isNull();
     }
 
     @Test

--- a/pos-archunit/pom.xml
+++ b/pos-archunit/pom.xml
@@ -90,6 +90,11 @@
         </dependency>
         <dependency>
             <groupId>com.positivity</groupId>
+            <artifactId>pos-people-contact</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.positivity</groupId>
             <artifactId>pos-workorder</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
@@ -35,7 +35,8 @@ class EntityStandardsArchitectureTest {
         "com.positivity.accounting.internal.entity..",
         "com.positivity.invoice.internal.entity..",
         "com.positivity.order.internal.entity..",
-        "com.positivity.people.internal.entity.."
+        "com.positivity.people.internal.entity..",
+        "com.positivity.peoplecontact.internal.entity.."
     };
 
     private static final String ENTITY_ANNOTATION = "jakarta.persistence.Entity";

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/peoplecontact/PersonDeletedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/peoplecontact/PersonDeletedV1.java
@@ -1,0 +1,17 @@
+package com.positivity.domainevents.peoplecontact;
+
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Payload for {@code people-contact.person.deleted} v1 on {@code people-contact.events.v1}
+ * (ADR-0044 §6, #874).
+ *
+ * <p>Published when a person record is hard-deleted from the identity authority. Consumers
+ * remove (or tombstone) the corresponding {@code ext_people_contact_person} replica row.
+ */
+public record PersonDeletedV1(@NonNull UUID personId) {
+
+    public static final String EVENT_TYPE = "people-contact.person.deleted";
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/peoplecontact/PersonUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/peoplecontact/PersonUpdatedV1.java
@@ -1,0 +1,37 @@
+package com.positivity.domainevents.peoplecontact;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Payload for {@code people-contact.person.updated} v1 on {@code people-contact.events.v1}
+ * (ADR-0044 §6, #874).
+ *
+ * <p>Published by pos-people-contact after every person mutation (create, update, resolve-create,
+ * contact-point replacement). Carries the full identity snapshot pos-people-contact owns, including
+ * the person's typed contact points, so consumers can maintain {@code ext_people_contact_person}
+ * replicas without callbacks. Hard deletes are signalled by {@link PersonDeletedV1}.
+ *
+ * <p>The envelope's {@code aggregateVersion} is the emission timestamp in epoch milliseconds
+ * (the person row carries no optimistic-lock version); consumers should treat it as a
+ * last-writer-wins ordering hint per personId.
+ */
+public record PersonUpdatedV1(
+        @NonNull UUID personId,
+        @Nullable String firstName,
+        @Nullable String lastName,
+        @Nullable String preferredName,
+        @NonNull List<ContactPointV1> contactPoints,
+        @Nullable Instant createdAt,
+        @Nullable Instant updatedAt) {
+
+    public static final String EVENT_TYPE = "people-contact.person.updated";
+    public static final int SCHEMA_VERSION = 1;
+
+    /** One typed contact point (email or phone) owned by the person (ADR-0015 I2). */
+    public record ContactPointV1(
+            @NonNull String contactType, @NonNull String value, boolean primary) {}
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/peoplecontact/UserPersonLinkRemovedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/peoplecontact/UserPersonLinkRemovedV1.java
@@ -1,0 +1,20 @@
+package com.positivity.domainevents.peoplecontact;
+
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Payload for {@code people-contact.user-person-link.removed} v1 on
+ * {@code people-contact.events.v1} (ADR-0044 §6 / amended ADR-0043, #874).
+ *
+ * <p>Published when a user-person link is removed. pos-security-service clears the
+ * {@code users.person_id} projection for the affected username.
+ */
+public record UserPersonLinkRemovedV1(
+        @NonNull UUID linkId,
+        @NonNull UUID personId,
+        @NonNull String username) {
+
+    public static final String EVENT_TYPE = "people-contact.user-person-link.removed";
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/peoplecontact/UserPersonLinkUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/peoplecontact/UserPersonLinkUpdatedV1.java
@@ -1,0 +1,28 @@
+package com.positivity.domainevents.peoplecontact;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Payload for {@code people-contact.user-person-link.updated} v1 on
+ * {@code people-contact.events.v1} (ADR-0044 §6 / amended ADR-0043, #874).
+ *
+ * <p>Published after a user-person link is created or its attributes change. pos-security-service
+ * projects {@code users.person_id} exclusively from these facts (link fact events are the only
+ * writer of that projection per the amended ADR-0043 §2). The link aggregate is keyed by
+ * {@code linkId}; {@code username} is unique across links.
+ */
+public record UserPersonLinkUpdatedV1(
+        @NonNull UUID linkId,
+        @NonNull UUID personId,
+        @NonNull String username,
+        @NonNull String status,
+        @Nullable String linkType,
+        @Nullable Instant createdAt,
+        @Nullable Instant updatedAt) {
+
+    public static final String EVENT_TYPE = "people-contact.user-person-link.updated";
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-people-contact/Dockerfile
+++ b/pos-people-contact/Dockerfile
@@ -17,5 +17,5 @@ ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Default endpoint (otel-collector:4318) does not require authentication
 
 COPY target/pos-people-contact.jar pos-people-contact.jar
-EXPOSE 8095
+EXPOSE 8080
 ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-people-contact.jar"]

--- a/pos-people-contact/Dockerfile
+++ b/pos-people-contact/Dockerfile
@@ -1,0 +1,21 @@
+FROM eclipse-temurin:25-jdk-alpine
+VOLUME /tmp
+
+# Download Grafana OpenTelemetry Java Agent
+ARG GRAFANA_OTEL_AGENT_VERSION=v2.9.0
+ADD https://github.com/grafana/grafana-opentelemetry-java/releases/download/${GRAFANA_OTEL_AGENT_VERSION}/grafana-opentelemetry-java.jar /opt/grafana-opentelemetry-java.jar
+
+# OpenTelemetry configuration (override at runtime as needed)
+ARG JAVA_OPTS
+ENV JAVA_OPTS=$JAVA_OPTS
+ENV OTEL_RESOURCE_ATTRIBUTES="service.name=DURION-POSITIVITY-BACKEND,service.namespace=durion-group,deployment.environment=pre-production"
+ENV OTEL_SERVICE_NAME=pos-people-contact
+ARG OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
+ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# Optional: Set OTEL_EXPORTER_OTLP_HEADERS at runtime if your OTLP endpoint requires authentication
+# Default endpoint (otel-collector:4318) does not require authentication
+
+COPY target/pos-people-contact.jar pos-people-contact.jar
+EXPOSE 8095
+ENTRYPOINT ["sh", "-c", "exec java -javaagent:/opt/grafana-opentelemetry-java.jar $JAVA_OPTS -jar pos-people-contact.jar"]

--- a/pos-people-contact/README.md
+++ b/pos-people-contact/README.md
@@ -1,0 +1,37 @@
+# pos-people-contact
+
+Identity, contact, and user-link authority service for the Durion Positivity platform
+(ADR-0044 §6 Phase 3, issue #874). Split out of pos-people, which retains the HR domain
+(employees, timekeeping, availability, staffing).
+
+## Responsibilities
+
+- Own `Person`, `PersonContactPoint`, and `UserPersonLink` records (ADR-0015)
+- Person directory search (name / email) and weighted person resolution
+- Typed contact-point management (email, phone) — source of truth for contacts
+- User ↔ person link management (keyed by username; ADR-0043)
+- Person → role assignment proxying to pos-security-service (utility sync call,
+  allowed by the ADR-0044 whitelist)
+
+## Eventing (ADR-0044)
+
+- Publishes identity facts to `people-contact.events.v1` via a transactional outbox:
+  `people-contact.person.updated`, `people-contact.person.deleted`,
+  `people-contact.user-person-link.updated`, `people-contact.user-person-link.removed`
+- Publishes reconciliation manifests to `people-contact.manifest.v1`
+- Consumes `people-contact.commands.v1` (`people-contact.outbox.replay-requested`
+  for replica bootstrap / drift repair)
+- Feature flag: `pos.people-contact.kafka.enabled` (`POS_PEOPLE_CONTACT_KAFKA_ENABLED`)
+
+## Permissions
+
+`people-contact:person:{view,create,edit,delete}`, `people-contact:role:{view,assign,revoke}`,
+`people-contact:userLink:{view,write}` — registered with pos-security-service at startup.
+
+## Notes
+
+- Gateway route: `/people-contact/**` → `lb://PEOPLE-CONTACT`
+- Employment data (employee status, assignments) lives in pos-people; this service's
+  directory search has no employment filters.
+- Consumers needing person reference data maintain `ext_people_contact_person` replicas
+  fed from `people-contact.events.v1` (Phases 3.2–3.4: #875, #876, #877).

--- a/pos-people-contact/pom.xml
+++ b/pos-people-contact/pom.xml
@@ -1,0 +1,355 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.positivity</groupId>
+        <artifactId>positivity</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>pos-people-contact</artifactId>
+    <name>pos-people-contact</name>
+    <description>Identity/contact/user-link authority module (ADR-0044 Phase 3)</description>
+    <packaging>jar</packaging>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>maven-central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>springdoc-repo</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+
+    <dependencies>
+        <!-- Spring Boot Starter Data JPA -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <!-- Spring Boot Starter Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <!-- Bean validation for @Valid DTO constraints -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <!-- H2 Database -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- SLF4J for logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <!-- Eureka Client -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <!-- Prometheus scrape endpoint: /actuator/prometheus (ADR observability) -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Springdoc OpenAPI Starter WebMVC UI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc-openapi.version}</version>
+        </dependency>
+        <!-- Kotlin Reflect - required by springdoc-openapi 2.8+ -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Spring Security (for Authentication/GrantedAuthority types) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <!-- PostgreSQL Driver -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-flyway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+        <!-- Jackson for JSON -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <!-- Spring Boot Starter Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Testcontainers: run the Flyway baseline + repeatable seeds against real Postgres in CI,
+             with ddl-auto=validate, so migrations/seeds/entities are exercised (H2 tests skip Flyway). -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-resttestclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TestRestTemplateTestAutoConfiguration needs RestTemplateBuilder at runtime -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Spring Boot Logging (includes SLF4J + Logback) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+        <!-- pos-events for EmitEvent annotations -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-events</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- pos-security-common for gateway authentication -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-security-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- pos-shared-dtos for shared DTOs -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-shared-dtos</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.f4b6a3</groupId>
+            <artifactId>uuid-creator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-bulk-ingest-lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- Domain event contracts + Kafka for the transactional outbox (ADR-0044) -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-domain-events</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-stream-kafka</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-maven-plugin</artifactId>
+                <version>${springdoc-openapi-maven-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>openapi</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <jmxPort>9113</jmxPort>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>start-for-openapi</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>
+                                        <argument>--server.port=8086</argument>
+                                        <argument>--spring.profiles.active=dev</argument>
+                                        <argument>--spring.jpa.hibernate.ddl-auto=update</argument>
+                                        <argument>--spring.datasource.url=jdbc:h2:mem:openapi;MODE=PostgreSQL;DB_CLOSE_DELAY=-1</argument>
+                                        <argument>--spring.datasource.driver-class-name=org.h2.Driver</argument>
+                                        <argument>--spring.jpa.database-platform=org.hibernate.dialect.H2Dialect</argument>
+                                        <argument>--spring.flyway.enabled=false</argument>
+                                        <argument>--eureka.client.enabled=false</argument>
+                                        <argument>--spring.boot.admin.client.enabled=false</argument>
+                                        <argument>--logging.level.root=WARN</argument>
+                                        <argument>--logging.level.org.hibernate.SQL=ERROR</argument>
+                                    </arguments>
+                                    <wait>8000</wait>
+                                    <maxAttempts>180</maxAttempts>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-after-openapi</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-maven-plugin</artifactId>
+                        <version>${springdoc-openapi-maven-plugin.version}</version>
+                        <configuration>
+                            <apiDocsUrl>http://localhost:8086/v3/api-docs.yaml</apiDocsUrl>
+                            <outputFileName>openapi.yaml</outputFileName>
+                            <outputDir>${project.basedir}</outputDir>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>generate-openapi-profile</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sanitize-openapi</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <exec executable="python3" failonerror="false">
+                                            <arg value="${maven.multiModuleProjectDirectory}/scripts/sanitize-openapi.py"/>
+                                            <arg value="${project.basedir}/openapi.yaml"/>
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/PosPeopleContactApplication.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/PosPeopleContactApplication.java
@@ -1,0 +1,16 @@
+package com.positivity.peoplecontact;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+// @EnableScheduling drives the outbox drain and reconciliation-manifest publishers (ADR-0044 §4).
+@EnableScheduling
+@SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
+public class PosPeopleContactApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PosPeopleContactApplication.class, args);
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/SecurityServiceClient.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/SecurityServiceClient.java
@@ -1,0 +1,351 @@
+package com.positivity.peoplecontact.internal.client;
+
+import com.positivity.peoplecontact.internal.client.dto.Role;
+import com.positivity.peoplecontact.internal.client.dto.RoleAssignment;
+import com.positivity.peoplecontact.internal.client.dto.RoleAssignmentRequest;
+import com.positivity.peoplecontact.internal.client.dto.RoleDto;
+import com.positivity.peoplecontact.internal.client.dto.ScopeType;
+import com.positivity.peoplecontact.internal.client.dto.User;
+import com.positivity.peoplecontact.internal.client.dto.UserRoleAssignmentRequest;
+import com.positivity.peoplecontact.internal.client.dto.UserRoleDto;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class SecurityServiceClient {
+
+    private static final Logger log = LoggerFactory.getLogger(SecurityServiceClient.class);
+
+    private final Clock clock;
+
+    private final RestClient restClient;
+
+    public SecurityServiceClient(@Qualifier("securityServiceRestClient") RestClient restClient, Clock clock) {
+        this.restClient = restClient;
+        this.clock = clock;
+    }
+
+    @NonNull
+    public Optional<User> getUserByUsername(@NonNull String username) {
+        log.debug("Fetching user by username: {}", username);
+
+        List<User> users = restClient
+                .get()
+                .uri("/v1/users")
+                .retrieve()
+                .onStatus(statusCode -> statusCode.value() == 400, (request, response) -> {
+                    throw new IllegalArgumentException("Invalid username for security lookup: " + username);
+                })
+                .onStatus(statusCode -> statusCode.value() == 401 || statusCode.value() == 403, (request, response) -> {
+                    int statusCode = response.getStatusCode().value();
+                    throw new SecurityServiceException("Not authorized to query users in security service", statusCode);
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    int statusCode = response.getStatusCode().value();
+                    throw new SecurityServiceException("Security service failed while fetching users", statusCode);
+                })
+                .body(new ParameterizedTypeReference<List<User>>() {});
+
+        if (users == null) {
+            throw new IllegalStateException("Security service returned null response for user lookup");
+        }
+
+        return users.stream()
+                .filter(user -> user.getUsername() != null && username.equalsIgnoreCase(user.getUsername()))
+                .findFirst();
+    }
+
+    /**
+     * Get a role by its name to obtain its UUID
+     */
+    @NonNull
+    private Role getRoleByName(@NonNull String roleName) {
+        log.debug("Fetching role by name: {}", roleName);
+
+        Role role = restClient
+                .get()
+                .uri("/v1/roles/by-name/{name}", roleName)
+                .retrieve()
+                .onStatus(statusCode -> statusCode.value() == 404, (request, response) -> {
+                    throw new jakarta.persistence.EntityNotFoundException(
+                            "Role not found in security service: " + roleName);
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    int statusCode = response.getStatusCode().value();
+                    throw new SecurityServiceException("Security service failed while fetching role", statusCode);
+                })
+                .body(Role.class);
+
+        if (role == null) {
+            throw new IllegalStateException("Security service returned null response for role: " + roleName);
+        }
+
+        return role;
+    }
+
+    @NonNull
+    public List<RoleDto> getAvailableRoles(@NonNull String scope) {
+        log.debug("Fetching available roles for scope: {}", scope);
+
+        List<RoleDto> roles = restClient
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1/roles")
+                        .queryParam("scopeType", scope)
+                        .build())
+                .retrieve()
+                .onStatus(statusCode -> statusCode.value() == 400, (request, response) -> {
+                    throw new IllegalArgumentException("Invalid scope for role lookup: " + scope);
+                })
+                .onStatus(statusCode -> statusCode.value() == 404, (request, response) -> {
+                    throw new jakarta.persistence.EntityNotFoundException(
+                            "Roles endpoint not found in security service");
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    int statusCode = response.getStatusCode().value();
+                    throw new SecurityServiceException("Security service failed while listing roles", statusCode);
+                })
+                .body(new ParameterizedTypeReference<List<RoleDto>>() {});
+
+        if (roles == null) {
+            throw new IllegalStateException(
+                    "Security service returned null response for roles lookup with scope: " + scope);
+        }
+
+        return roles;
+    }
+
+    @NonNull
+    public List<UserRoleDto> getUserRoleAssignments(
+            @NonNull UUID userId, Boolean includeHistory, LocalDateTime endDate) {
+        log.debug(
+                "Fetching role assignments for userId: {}, includeHistory: {}, endDate: {}",
+                userId,
+                includeHistory,
+                endDate);
+
+        List<UserRoleDto> assignments = restClient
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1/roles/assignments/user/{userId}")
+                        .queryParam("includeHistory", includeHistory)
+                        .queryParam("endDate", endDate)
+                        .build(userId))
+                .retrieve()
+                .onStatus(statusCode -> statusCode.value() == 400, (request, response) -> {
+                    throw new IllegalArgumentException(
+                            "Invalid request while listing assignments for userId: " + userId);
+                })
+                .onStatus(statusCode -> statusCode.value() == 404, (request, response) -> {
+                    throw new jakarta.persistence.EntityNotFoundException(
+                            "No role assignments found for userId: " + userId);
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    int statusCode = response.getStatusCode().value();
+                    throw new SecurityServiceException(
+                            "Security service failed while listing role assignments", statusCode);
+                })
+                .body(new ParameterizedTypeReference<List<UserRoleDto>>() {});
+
+        if (assignments == null) {
+            throw new IllegalStateException("Security service returned empty response for user role assignments");
+        }
+
+        return assignments;
+    }
+
+    @NonNull
+    public UserRoleDto assignRole(@NonNull UserRoleAssignmentRequest request) {
+        log.debug("Assigning role {} to userId: {}", request.getRoleCode(), request.getUserId());
+
+        // First, get the role by name to obtain its UUID
+        Role role = getRoleByName(request.getRoleCode());
+
+        // Parse and validate userId
+        UUID userIdUuid;
+        try {
+            userIdUuid = request.getUserId();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid userId format: " + request.getUserId(), e);
+        }
+
+        // Build the proper RoleAssignmentRequest matching the API contract
+        Set<String> scopeLocationIds = request.getLocationIds() != null
+                        && !request.getLocationIds().isEmpty()
+                ? request.getLocationIds().stream().map(UUID::toString).collect(java.util.stream.Collectors.toSet())
+                : request.getLocationId() != null
+                        ? Set.of(request.getLocationId().toString())
+                        : null;
+        RoleAssignmentRequest apiRequest = new RoleAssignmentRequest(
+                userIdUuid,
+                role.getId(),
+                scopeLocationIds != null ? ScopeType.LOCATION : ScopeType.GLOBAL,
+                scopeLocationIds,
+                request.getStartDate() != null ? request.getStartDate().toLocalDate() : null,
+                request.getEndDate() != null ? request.getEndDate().toLocalDate() : null);
+
+        RoleAssignment assignment = restClient
+                .post()
+                .uri("/v1/roles/assignments")
+                .body(apiRequest)
+                .retrieve()
+                .onStatus(statusCode -> statusCode.value() == 400, (httpRequest, httpResponse) -> {
+                    throw new IllegalArgumentException(
+                            "Invalid role assignment request for userId: " + request.getUserId());
+                })
+                .onStatus(statusCode -> statusCode.value() == 404, (httpRequest, httpResponse) -> {
+                    throw new jakarta.persistence.EntityNotFoundException(
+                            "User or role not found for assignment request");
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (httpRequest, httpResponse) -> {
+                    int statusCode = httpResponse.getStatusCode().value();
+                    throw new SecurityServiceException("Security service failed while assigning role", statusCode);
+                })
+                .body(RoleAssignment.class);
+
+        if (assignment == null) {
+            throw new IllegalStateException("Security service returned empty response for role assignment creation");
+        }
+
+        // Map RoleAssignment to UserRoleDto for backward compatibility
+        return mapToUserRoleDto(assignment, request.getRoleCode());
+    }
+
+    public void revokeRole(@NonNull UUID userId, @NonNull String roleCode, LocalDateTime endDate) {
+        log.debug("Revoking role {} from userId: {} with endDate: {}", roleCode, userId, endDate);
+
+        // First, get the role by name to obtain its UUID
+        Role role = getRoleByName(roleCode);
+
+        // Get all assignments for the user with full RoleAssignment objects
+
+        List<RoleAssignment> fullAssignments = restClient
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1/roles/assignments/user/{userId}")
+                        .queryParam("includeHistory", true)
+                        .build(userId))
+                .retrieve()
+                .onStatus(statusCode -> statusCode.value() == 404, (request, response) -> {
+                    throw new jakarta.persistence.EntityNotFoundException(
+                            "No role assignments found for userId: " + userId);
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    int statusCode = response.getStatusCode().value();
+                    throw new SecurityServiceException(
+                            "Security service failed while listing role assignments in revokeRole", statusCode);
+                })
+                .body(new ParameterizedTypeReference<List<RoleAssignment>>() {});
+
+        if (fullAssignments == null) {
+            throw new IllegalStateException("Security service returned null response");
+        }
+
+        java.time.LocalDate today = java.time.LocalDate.now(clock);
+        List<RoleAssignment> currentAndFutureAssignments = fullAssignments.stream()
+                .filter(assignment -> assignment.getEffectiveEndDate() == null
+                        || !assignment.getEffectiveEndDate().isBefore(today))
+                .toList();
+
+        // Find the assignment for this specific role
+        java.util.UUID assignmentId = currentAndFutureAssignments.stream()
+                .filter(fa -> role.getId().equals(fa.getRole().getId()))
+                .map(RoleAssignment::getId)
+                .findFirst()
+                .orElseThrow(() -> new jakarta.persistence.EntityNotFoundException(
+                        "Role assignment not found for userId: " + userId + ", roleCode: " + roleCode));
+
+        java.time.LocalDate revocationDate = endDate != null ? endDate.toLocalDate() : java.time.LocalDate.now(clock);
+
+        restClient
+                .delete()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1/roles/assignments/{assignmentId}")
+                        .queryParam("endDate", revocationDate)
+                        .build(assignmentId))
+                .retrieve()
+                .onStatus(statusCode -> statusCode.value() == 400, (request, response) -> {
+                    throw new IllegalArgumentException(
+                            "Invalid role revocation request for userId: " + userId + ", roleCode: " + roleCode);
+                })
+                .onStatus(statusCode -> statusCode.value() == 404, (request, response) -> {
+                    throw new jakarta.persistence.EntityNotFoundException(
+                            "Role assignment not found for userId: " + userId + ", roleCode: " + roleCode);
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    int statusCode = response.getStatusCode().value();
+                    throw new SecurityServiceException(
+                            "Security service failed while revoking role assignment", statusCode);
+                })
+                .toBodilessEntity();
+    }
+
+    /**
+     * Helper method to map RoleAssignment to UserRoleDto.
+     *
+     * Note: If a RoleAssignment contains multiple scopeLocationIds, only the first one is
+     * mapped to UserRoleDto.locationId. The remaining IDs are ignored.
+     */
+    private UserRoleDto mapToUserRoleDto(RoleAssignment assignment, String roleCode) {
+        UUID locationId = null;
+        if (assignment.getScopeType() == ScopeType.LOCATION
+                && assignment.getScopeLocationIds() != null
+                && !assignment.getScopeLocationIds().isEmpty()) {
+            if (assignment.getScopeLocationIds().size() > 1) {
+                // Note: The API supports multiple scopeLocationIds, but UserRoleDto
+                // currently
+                // exposes
+                // a single locationId.
+                // Log to make this limitation visible when multi-location assignments are
+                // encountered.
+                UUID userId =
+                        assignment.getUser() != null ? assignment.getUser().getId() : null;
+                log.warn(
+                        "RoleAssignment {} for user {} and role {} has multiple scopeLocationIds; only the first will be used.",
+                        assignment.getId(),
+                        userId,
+                        roleCode);
+            }
+
+            locationId = assignment.getScopeLocationIds().stream()
+                    .findFirst()
+                    .orElseThrow(() -> new SecurityServiceException("Empty location ID set in role assignment", 502));
+        }
+
+        return UserRoleDto.builder()
+                .userId(assignment.getUser().getId().toString())
+                .roleCode(roleCode)
+                .locationId(locationId)
+                .startDate(assignment.getEffectiveStartDate())
+                .endDate(assignment.getEffectiveEndDate())
+                .active(isAssignmentActive(assignment))
+                .build();
+    }
+
+    /**
+     * Helper method to determine if an assignment is currently active
+     */
+    private boolean isAssignmentActive(RoleAssignment assignment) {
+        java.time.LocalDate today = java.time.LocalDate.now(clock);
+        java.time.LocalDate startDate = assignment.getEffectiveStartDate();
+        java.time.LocalDate endDate = assignment.getEffectiveEndDate();
+
+        // Active if started and not yet ended
+        boolean hasStarted = startDate == null || !startDate.isAfter(today);
+        boolean hasNotEnded = endDate == null || today.isBefore(endDate);
+
+        return hasStarted && hasNotEnded;
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/SecurityServiceException.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/SecurityServiceException.java
@@ -1,0 +1,93 @@
+package com.positivity.peoplecontact.internal.client;
+
+/**
+ * Exception thrown when Security service integration fails. Indicates that a
+ * cross-service call to the Security module encountered an error.
+ *
+ * Scenarios: - Security service is unavailable (circuit breaker open, timeout, connection
+ * refused) - User or role not found (404) - Invalid request (400) - Server error (5xx)
+ */
+public class SecurityServiceException extends RuntimeException {
+
+    private final int httpStatus;
+
+    /**
+     * Create exception with message and optional cause.
+     * @param message error description
+     */
+    public SecurityServiceException(String message) {
+        super(message);
+        this.httpStatus = 500;
+    }
+
+    /**
+     * Create exception with message and HTTP status code.
+     * @param message error description
+     * @param httpStatus HTTP status code from security service (or 503 for unavailable)
+     */
+    public SecurityServiceException(String message, int httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    /**
+     * Create exception with message, HTTP status, and underlying cause.
+     * @param message error description
+     * @param httpStatus HTTP status code
+     * @param cause underlying exception
+     */
+    public SecurityServiceException(String message, int httpStatus, Throwable cause) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    /**
+     * Create exception with message and underlying cause.
+     * @param message error description
+     * @param cause underlying exception
+     */
+    public SecurityServiceException(String message, Throwable cause) {
+        super(message, cause);
+        this.httpStatus = 500;
+    }
+
+    /**
+     * Get HTTP status code associated with this error.
+     * @return HTTP status code
+     */
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    /**
+     * Check if error is due to service unavailability (circuit breaker, timeout, etc).
+     * @return true if status is 503, 504, or 0 (connection failure)
+     */
+    public boolean isServiceUnavailable() {
+        return httpStatus == 503 || httpStatus == 504 || httpStatus == 0;
+    }
+
+    /**
+     * Check if error is due to resource not found.
+     * @return true if status is 404
+     */
+    public boolean isNotFound() {
+        return httpStatus == 404;
+    }
+
+    /**
+     * Check if error is a client error (4xx).
+     * @return true if status is 4xx
+     */
+    public boolean isClientError() {
+        return httpStatus >= 400 && httpStatus < 500;
+    }
+
+    /**
+     * Check if error is a server error (5xx).
+     * @return true if status is 5xx
+     */
+    public boolean isServerError() {
+        return httpStatus >= 500 && httpStatus < 600;
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/Role.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/Role.java
@@ -1,0 +1,31 @@
+package com.positivity.peoplecontact.internal.client.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Role reference as returned by the security service")
+public class Role {
+
+    @Schema(description = "Role identifier", example = "01960011-0000-7000-8000-000000000020", requiredMode = REQUIRED)
+    private UUID id;
+
+    @Schema(description = "Human-readable role name", example = "Technician", requiredMode = NOT_REQUIRED)
+    private String name;
+
+    @Schema(
+            description = "Description of the role",
+            example = "Performs service work on vehicles",
+            requiredMode = NOT_REQUIRED)
+    private String description;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/RoleAssignment.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/RoleAssignment.java
@@ -1,0 +1,58 @@
+package com.positivity.peoplecontact.internal.client.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Role assignment as returned by the security service")
+public class RoleAssignment {
+
+    @Schema(
+            description = "Role assignment identifier",
+            example = "01960011-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    private UUID id;
+
+    @Schema(description = "User the role is assigned to", requiredMode = NOT_REQUIRED)
+    private User user;
+
+    @Schema(description = "Role that was assigned", requiredMode = NOT_REQUIRED)
+    private Role role;
+
+    @Schema(description = "Scope at which the role applies", example = "LOCATION", requiredMode = NOT_REQUIRED)
+    private ScopeType scopeType;
+
+    @Schema(
+            description = "Location identifiers the role is scoped to when scopeType is LOCATION",
+            example = "[\"01960011-0000-7000-8000-000000000010\"]",
+            requiredMode = NOT_REQUIRED)
+    private Set<UUID> scopeLocationIds;
+
+    @Schema(description = "Date the assignment becomes effective", example = "2026-01-01", requiredMode = NOT_REQUIRED)
+    private LocalDate effectiveStartDate;
+
+    @Schema(description = "Date the assignment ends", example = "2026-12-31", requiredMode = NOT_REQUIRED)
+    private LocalDate effectiveEndDate;
+
+    @Schema(description = "Creation timestamp in UTC", example = "2026-01-15T09:30:00Z", requiredMode = NOT_REQUIRED)
+    private Instant createdAt;
+
+    @Schema(
+            description = "Identifier of the actor that created the assignment",
+            example = "manager.user",
+            requiredMode = NOT_REQUIRED)
+    private String createdBy;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/RoleAssignmentRequest.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/RoleAssignmentRequest.java
@@ -1,0 +1,48 @@
+package com.positivity.peoplecontact.internal.client.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to assign a role to a user in the security service")
+public class RoleAssignmentRequest {
+
+    @Schema(
+            description = "User identifier the role is assigned to",
+            example = "01960011-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
+    private UUID userId;
+
+    @NotNull(message = "roleId is required")
+    @Schema(
+            description = "Role identifier to assign",
+            example = "01960011-0000-7000-8000-000000000020",
+            requiredMode = REQUIRED)
+    private UUID roleId;
+
+    @Schema(description = "Scope at which the role applies", example = "GLOBAL", requiredMode = NOT_REQUIRED)
+    private ScopeType scopeType = ScopeType.GLOBAL;
+
+    @Schema(
+            description = "Location identifiers the role is scoped to when scopeType is LOCATION",
+            example = "[\"01960011-0000-7000-8000-000000000010\"]",
+            requiredMode = NOT_REQUIRED)
+    private Set<String> scopeLocationIds;
+
+    @Schema(description = "Date the assignment becomes effective", example = "2026-01-01", requiredMode = NOT_REQUIRED)
+    private LocalDate effectiveStartDate;
+
+    @Schema(description = "Date the assignment ends", example = "2026-12-31", requiredMode = NOT_REQUIRED)
+    private LocalDate effectiveEndDate;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/RoleDto.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/RoleDto.java
@@ -1,0 +1,35 @@
+package com.positivity.peoplecontact.internal.client.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Role definition as exposed by the security service")
+public class RoleDto {
+
+    @Schema(description = "Stable role code", example = "TECHNICIAN", requiredMode = NOT_REQUIRED)
+    private String code;
+
+    @Schema(description = "Human-readable role name", example = "Technician", requiredMode = NOT_REQUIRED)
+    private String name;
+
+    @Schema(
+            description = "Description of the role",
+            example = "Performs service work on vehicles",
+            requiredMode = NOT_REQUIRED)
+    private String description;
+
+    @Schema(description = "Scope at which the role applies", example = "LOCATION", requiredMode = NOT_REQUIRED)
+    private String scopeType;
+
+    @Schema(description = "Whether the role is active", example = "true", requiredMode = NOT_REQUIRED)
+    private Boolean active;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/ScopeType.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/ScopeType.java
@@ -1,0 +1,9 @@
+package com.positivity.peoplecontact.internal.client.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Scope at which a role assignment applies")
+public enum ScopeType {
+    GLOBAL,
+    LOCATION
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/User.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/User.java
@@ -1,0 +1,25 @@
+package com.positivity.peoplecontact.internal.client.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "User reference as returned by the security service")
+public class User {
+
+    @Schema(description = "User identifier", example = "01960011-0000-7000-8000-000000000001", requiredMode = REQUIRED)
+    private UUID id;
+
+    @Schema(description = "Username", example = "jane.smith", requiredMode = NOT_REQUIRED)
+    private String username;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/UserRoleAssignmentRequest.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/UserRoleAssignmentRequest.java
@@ -1,0 +1,53 @@
+package com.positivity.peoplecontact.internal.client.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to assign a role to a user by role code in the security service")
+public class UserRoleAssignmentRequest {
+
+    @Schema(
+            description = "User identifier the role is assigned to",
+            example = "01960011-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
+    private UUID userId;
+
+    @Schema(description = "Stable role code to assign", example = "TECHNICIAN", requiredMode = NOT_REQUIRED)
+    private String roleCode;
+
+    @Schema(
+            description = "Location identifiers the role is scoped to",
+            example = "[\"01960011-0000-7000-8000-000000000010\"]",
+            requiredMode = NOT_REQUIRED)
+    private Set<UUID> locationIds;
+
+    @Schema(
+            description = "Single location identifier the role is scoped to",
+            example = "01960011-0000-7000-8000-000000000010",
+            requiredMode = NOT_REQUIRED)
+    private UUID locationId;
+
+    @Schema(
+            description = "Date and time the assignment becomes effective",
+            example = "2026-01-01T00:00:00",
+            requiredMode = NOT_REQUIRED)
+    private LocalDateTime startDate;
+
+    @Schema(
+            description = "Date and time the assignment ends",
+            example = "2026-12-31T23:59:59",
+            requiredMode = NOT_REQUIRED)
+    private LocalDateTime endDate;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/UserRoleDto.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/client/dto/UserRoleDto.java
@@ -1,0 +1,43 @@
+package com.positivity.peoplecontact.internal.client.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "User role assignment as exposed by the security service")
+public class UserRoleDto {
+
+    @Schema(
+            description = "User identifier",
+            example = "01960011-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
+    private String userId;
+
+    @Schema(description = "Stable role code", example = "TECHNICIAN", requiredMode = NOT_REQUIRED)
+    private String roleCode;
+
+    @Schema(
+            description = "Location identifier the role is scoped to",
+            example = "01960011-0000-7000-8000-000000000010",
+            requiredMode = NOT_REQUIRED)
+    private UUID locationId;
+
+    @Schema(description = "Date the assignment becomes effective", example = "2026-01-01", requiredMode = NOT_REQUIRED)
+    private LocalDate startDate;
+
+    @Schema(description = "Date the assignment ends", example = "2026-12-31", requiredMode = NOT_REQUIRED)
+    private LocalDate endDate;
+
+    @Schema(description = "Whether the assignment is active", example = "true", requiredMode = NOT_REQUIRED)
+    private Boolean active;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/EventListenerConfig.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/EventListenerConfig.java
@@ -1,0 +1,42 @@
+package com.positivity.peoplecontact.internal.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+
+/**
+ * Kafka listener lifecycle for this module.
+ *
+ * <p>Listeners are declared with {@code autoStartup = "false"} so consumer-group initialization
+ * does not block the main startup sequence; containers are started once the application context
+ * is fully ready.
+ *
+ * <p>This module's inbound surface is {@code people-contact.commands.v1}
+ * ({@link PeopleContactCommandListener}).
+ */
+@Slf4j
+@Configuration
+public class EventListenerConfig {
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void startKafkaListeners(ApplicationReadyEvent event) {
+        KafkaListenerEndpointRegistry registry =
+                event.getApplicationContext().getBean(KafkaListenerEndpointRegistry.class);
+        try {
+            registry.start();
+            log.info("Kafka listeners started after application ready");
+        } catch (org.apache.kafka.common.KafkaException | org.springframework.kafka.KafkaException e) {
+            // An unresolvable/unavailable broker (e.g. bootstrap servers pointing at a Kafka
+            // container that is not deployed yet) must not kill the service — the REST API works
+            // without event ingestion. Consumer construction fails fast on unresolvable DNS, so
+            // this is reachable, not just theoretical. Narrowed to Kafka exceptions so genuine
+            // listener misconfiguration still fails startup loudly.
+            log.error(
+                    "Kafka listeners could not be started; continuing without event ingestion. "
+                            + "Check spring.kafka.bootstrap-servers / broker availability.",
+                    e);
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/EventTypeInitializer.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/EventTypeInitializer.java
@@ -1,0 +1,69 @@
+package com.positivity.peoplecontact.internal.config;
+
+import com.positivity.events.EventTypeInitializerSupport;
+import com.positivity.events.EventTypeRegistration;
+import com.positivity.events.EventsApiConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Initializes all event types for the pos-people-contact module on application startup.
+ * Uses the
+ * pos-events upsert endpoint for idempotent registration.
+ */
+@Component
+public class EventTypeInitializer implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(EventTypeInitializer.class);
+
+    private final RestClient restClient;
+
+    private final EventTypeInitializerSupport initializerSupport;
+
+    private final String apiSecret;
+
+    public EventTypeInitializer(
+            RestClient.Builder restClientBuilder,
+            @Value("${pos.events.base-url:http://pos-event-receiver:8080}") String eventServiceBaseUrl,
+            @Value("${pos.events.api-secret:}") String apiSecret) {
+        this.restClient = restClientBuilder
+                .baseUrl(eventServiceBaseUrl + "/v1/eventTypes/code")
+                .build();
+        this.initializerSupport = new EventTypeInitializerSupport("pos-people-contact");
+        this.apiSecret = apiSecret;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("Registering {} people-contact event types", EventTypes.all().size());
+
+        initializerSupport.registerEventTypes(EventTypes.all(), this::registerEventType);
+
+        log.info("People-contact event type registration complete");
+    }
+
+    private void registerEventType(EventTypeRegistration registration) {
+        try {
+            var request = restClient
+                    .put()
+                    .uri("/{typeCode}", registration.getTypeCode())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(registration);
+
+            if (EventsApiConstants.hasSecret(apiSecret)) {
+                request.header(EventsApiConstants.SECRET_HEADER, apiSecret);
+            }
+
+            request.retrieve().toBodilessEntity();
+            log.debug("Registered event type: {}", registration.getTypeCode());
+        } catch (Exception e) {
+            log.warn("Failed to register event type {}: {}", registration.getTypeCode(), e.getMessage());
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/EventTypes.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/EventTypes.java
@@ -29,10 +29,6 @@ public final class EventTypes {
                 EventTypeRegistration.write("PEOPLE_CONTACT_PERSON_DELETE", "Delete an existing person record")
                         .build(),
 
-                // PersonBulkIngestController
-                EventTypeRegistration.write("PEOPLE_CONTACT_BULK_INGEST", "Bulk import person records")
-                        .build(),
-
                 // UserPersonLinkController
                 EventTypeRegistration.write("PEOPLE_CONTACT_USER_LINK_CREATE", "Link user to person")
                         .build(),

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/EventTypes.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/EventTypes.java
@@ -1,0 +1,58 @@
+package com.positivity.peoplecontact.internal.config;
+
+import com.positivity.events.EventTypeRegistration;
+import java.util.List;
+
+/**
+ * Registry of all event types emitted by the pos-people-contact module, registered with
+ * pos-event-receiver at startup with performance thresholds matching each operation's latency
+ * characteristics.
+ */
+public final class EventTypes {
+
+    private EventTypes() {
+        // Utility class
+    }
+
+    /** All event type registrations for the people-contact module. */
+    public static List<EventTypeRegistration> all() {
+        return List.of(
+                // PersonController
+                EventTypeRegistration.write("PEOPLE_CONTACT_PERSON_CREATE", "Create a new person record")
+                        .build(),
+                EventTypeRegistration.write("PEOPLE_CONTACT_PERSON_UPDATE", "Update an existing person record")
+                        .build(),
+                EventTypeRegistration.write(
+                                "PEOPLE_CONTACT_PERSON_RESOLVE",
+                                "Resolve person by weighted match or create a new record")
+                        .build(),
+                EventTypeRegistration.write("PEOPLE_CONTACT_PERSON_DELETE", "Delete an existing person record")
+                        .build(),
+
+                // PersonBulkIngestController
+                EventTypeRegistration.write("PEOPLE_CONTACT_BULK_INGEST", "Bulk import person records")
+                        .build(),
+
+                // UserPersonLinkController
+                EventTypeRegistration.write("PEOPLE_CONTACT_USER_LINK_CREATE", "Link user to person")
+                        .build(),
+                EventTypeRegistration.fastRead("PEOPLE_CONTACT_USER_LINK_GET", "Get user links by person")
+                        .build(),
+                EventTypeRegistration.write("PEOPLE_CONTACT_USER_PERSON_LINK_DELETE", "Unlink user from person")
+                        .build(),
+
+                // PersonAccessController
+                EventTypeRegistration.fastRead(
+                                "PEOPLE_CONTACT_ACCESS_ROLES_LIST", "List available access roles for people")
+                        .build(),
+                EventTypeRegistration.fastRead(
+                                "PEOPLE_CONTACT_ACCESS_ASSIGNMENTS_LIST", "List role assignments for a person")
+                        .build(),
+                EventTypeRegistration.write(
+                                "PEOPLE_CONTACT_ACCESS_ASSIGNMENT_CREATE", "Create role assignment for a person")
+                        .build(),
+                EventTypeRegistration.write(
+                                "PEOPLE_CONTACT_ACCESS_ASSIGNMENT_REVOKE", "Revoke role assignment for a person")
+                        .build());
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/FlywayConfig.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/FlywayConfig.java
@@ -1,0 +1,38 @@
+package com.positivity.peoplecontact.internal.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.AbstractDependsOnBeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnClass(Flyway.class)
+@ConditionalOnProperty(prefix = "spring.flyway", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class FlywayConfig {
+
+    @Bean(initMethod = "migrate")
+    @ConditionalOnMissingBean(Flyway.class)
+    public Flyway mcpFlyway(DataSource dataSource) {
+        return Flyway.configure()
+                .dataSource(dataSource)
+                .locations("classpath:db/migration")
+                .load();
+    }
+
+    @Bean
+    public static FlywayEntityManagerFactoryDependsOnPostProcessor flywayEntityManagerFactoryDependsOnPostProcessor() {
+        return new FlywayEntityManagerFactoryDependsOnPostProcessor();
+    }
+
+    static class FlywayEntityManagerFactoryDependsOnPostProcessor extends AbstractDependsOnBeanFactoryPostProcessor {
+
+        FlywayEntityManagerFactoryDependsOnPostProcessor() {
+            super(EntityManagerFactory.class, Flyway.class);
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/JpaAuditingConfig.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/JpaAuditingConfig.java
@@ -1,0 +1,19 @@
+package com.positivity.peoplecontact.internal.config;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+public class JpaAuditingConfig {
+
+    @Bean
+    DateTimeProvider auditingDateTimeProvider(Clock clock) {
+        return () -> Optional.of(Instant.now(clock));
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/KafkaErrorHandlingConfig.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/KafkaErrorHandlingConfig.java
@@ -1,0 +1,53 @@
+package com.positivity.peoplecontact.internal.config;
+
+import java.util.function.BiFunction;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.ExponentialBackOff;
+
+/**
+ * Retry and dead-letter handling for the module's Kafka listeners (ADR-0044 §4).
+ *
+ * <p>Failed records are retried with exponential backoff; when retries are exhausted the record is
+ * published to {@code {topic}.dlq} so poison messages surface for alerting instead of silently
+ * blocking or dropping. Replay commands are idempotent, so the retries are harmless.
+ *
+ * <p>Spring Boot wires a single {@code CommonErrorHandler} bean into the auto-configured listener
+ * container factory, so declaring the bean is sufficient.
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(prefix = "pos.people-contact.kafka", name = "enabled", havingValue = "true")
+public class KafkaErrorHandlingConfig {
+
+    /** Route to {@code {topic}.dlq}; partition -1 lets the producer choose. */
+    static final BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> DLQ_DESTINATION =
+            (record, ex) -> new TopicPartition(record.topic() + ".dlq", -1);
+
+    @Bean
+    public DefaultErrorHandler kafkaErrorHandler(@SuppressWarnings("rawtypes") KafkaTemplate kafkaTemplate) {
+        @SuppressWarnings("unchecked")
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate, DLQ_DESTINATION);
+
+        ExponentialBackOff backOff = new ExponentialBackOff(1000L, 2.0);
+        backOff.setMaxInterval(30_000L);
+        backOff.setMaxAttempts(5);
+
+        DefaultErrorHandler handler = new DefaultErrorHandler(recoverer, backOff);
+        handler.setRetryListeners((record, ex, attempt) -> log.warn(
+                "Kafka record processing failed topic={} partition={} offset={} attempt={}",
+                record.topic(),
+                record.partition(),
+                record.offset(),
+                attempt,
+                ex));
+        return handler;
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/ManifestPublisher.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/ManifestPublisher.java
@@ -1,0 +1,221 @@
+package com.positivity.peoplecontact.internal.config;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import com.positivity.peoplecontact.internal.entity.OutboxEvent;
+import com.positivity.peoplecontact.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Publishes reconciliation manifests for the people-contact fact topic (ADR-0044 §4, issue #874).
+ *
+ * <p>Each closed window gets one {@link ReconciliationManifestV1} on
+ * {@code people-contact.manifest.v1} summarizing the events published from {@code event_outbox} whose
+ * eventId (UUIDv7) timestamp falls in the window. Consumers recompute the summary from their
+ * processed-events log and request an outbox replay over {@code people-contact.commands.v1} on drift.
+ *
+ * <p>Manifests are sent directly (no outbox): a lost manifest is self-healing — the next run
+ * re-publishes it, and consumers can additionally alert on manifest absence. Publication waits
+ * {@code grace} after window close so in-flight publishes and consumer lag settle before the
+ * comparison, avoiding false drift. Re-publishing the same window (e.g. after a restart) is
+ * harmless because the consumer-side comparison is stateless and idempotent.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "pos.people-contact.kafka", name = "enabled", havingValue = "true")
+public class ManifestPublisher {
+
+    /** Covers the sub-millisecond skew between outbox {@code createdAt} and the eventId timestamp. */
+    private static final Duration CREATED_AT_SLACK = Duration.ofSeconds(1);
+
+    private static final String DOMAIN = "people-contact";
+
+    /** Catch-up bound per run — 24 windows covers a day-long outage at the default 1h window. */
+    private static final int MAX_WINDOWS_PER_RUN = 24;
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+    private final Counter publishedCounter;
+    private final Counter failedCounter;
+
+    @Value("${pos.people-contact.kafka.events-topic:people-contact.events.v1}")
+    private String eventsTopic;
+
+    @Value("${pos.people-contact.manifest.topic:people-contact.manifest.v1}")
+    private String manifestTopic;
+
+    /** Reconciliation window length. */
+    @Value("${pos.people-contact.manifest.window:PT1H}")
+    private Duration window;
+
+    /** How long after a window closes before its manifest is published. */
+    @Value("${pos.people-contact.manifest.grace:PT5M}")
+    private Duration grace;
+
+    @Value("${pos.people-contact.manifest.send-timeout-ms:10000}")
+    private long sendTimeoutMs;
+
+    @Nullable
+    private Instant lastPublishedWindowEnd;
+
+    public ManifestPublisher(
+            OutboxEventRepository outboxEventRepository,
+            KafkaTemplate<String, String> kafkaTemplate,
+            ObjectMapper objectMapper,
+            Clock clock,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.publishedCounter = registry == null
+                ? null
+                : Counter.builder("people_contact.manifest.published")
+                        .description("Reconciliation manifests published")
+                        .register(registry);
+        this.failedCounter = registry == null
+                ? null
+                : Counter.builder("people_contact.manifest.publish.failures")
+                        .description("Reconciliation manifest publish attempts that failed")
+                        .register(registry);
+    }
+
+    @Scheduled(fixedDelayString = "${pos.people-contact.manifest.poll-interval-ms:300000}")
+    public void publishDueManifest() {
+        Instant latestClosed = latestClosedWindowEnd();
+        if (latestClosed == null || (lastPublishedWindowEnd != null && !latestClosed.isAfter(lastPublishedWindowEnd))) {
+            return;
+        }
+        // First run publishes only the latest closed window (no historic backfill on boot);
+        // afterwards every window is published in order so scheduler gaps cannot skip one
+        // permanently.
+        Instant windowEnd = lastPublishedWindowEnd == null ? latestClosed : lastPublishedWindowEnd.plus(window);
+        int published = 0;
+        while (!windowEnd.isAfter(latestClosed) && published < MAX_WINDOWS_PER_RUN) {
+            Instant windowStart = windowEnd.minus(window);
+            try {
+                publishManifest(windowStart, windowEnd);
+                lastPublishedWindowEnd = windowEnd;
+                increment(publishedCounter);
+                published++;
+                windowEnd = windowEnd.plus(window);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                recordFailure(windowStart, windowEnd, e);
+                return;
+            } catch (Exception e) {
+                // Retry this window on the next poll; later windows stay queued behind it.
+                recordFailure(windowStart, windowEnd, e);
+                return;
+            }
+        }
+        if (!windowEnd.isAfter(latestClosed)) {
+            log.info("Manifest catch-up capped at {} windows this run; continuing next poll", MAX_WINDOWS_PER_RUN);
+        }
+    }
+
+    /** End of the most recent window that closed at least {@code grace} ago, aligned to the window length. */
+    private @Nullable Instant latestClosedWindowEnd() {
+        long windowMillis = window.toMillis();
+        long cutoff = Instant.now(clock).minus(grace).toEpochMilli();
+        long aligned = Math.floorDiv(cutoff, windowMillis) * windowMillis;
+        return aligned <= 0 ? null : Instant.ofEpochMilli(aligned);
+    }
+
+    private void publishManifest(Instant windowStart, Instant windowEnd) throws Exception {
+        List<OutboxEvent> candidates = outboxEventRepository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(
+                eventsTopic, windowStart.minus(CREATED_AT_SLACK), windowEnd.plus(CREATED_AT_SLACK));
+
+        List<String> eventIds = new ArrayList<>();
+        TreeMap<String, Long> eventTypeCounts = new TreeMap<>();
+        for (OutboxEvent row : candidates) {
+            // One malformed row must not block the window's manifest forever: skip it with a
+            // warning; the consumer-side mismatch it may cause is visible drift.
+            try {
+                JsonNode envelope = objectMapper.readTree(row.getPayload());
+                String eventId = envelope.path("eventId").stringValue(null);
+                if (eventId == null || eventId.isBlank()) {
+                    log.warn("Outbox row {} has no eventId in its payload; excluded from manifest", row.getId());
+                    continue;
+                }
+                if (!UuidV7Timestamps.isInWindow(UUID.fromString(eventId), windowStart, windowEnd)) {
+                    continue;
+                }
+                eventIds.add(eventId);
+                String eventType = envelope.path("eventType").stringValue(null);
+                eventTypeCounts.merge(eventType == null || eventType.isBlank() ? "unknown" : eventType, 1L, Long::sum);
+            } catch (Exception e) {
+                log.warn("Outbox row {} has an unparsable payload/eventId; excluded from manifest", row.getId(), e);
+            }
+        }
+
+        ReconciliationManifestV1 manifest = new ReconciliationManifestV1(
+                windowStart,
+                windowEnd,
+                eventIds.size(),
+                ReconciliationManifestV1.checksumOf(eventIds),
+                eventTypeCounts.isEmpty() ? null : eventTypeCounts);
+
+        DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
+                ReconciliationManifestV1.eventTypeFor(DOMAIN),
+                1,
+                manifestAggregateId(windowStart),
+                windowStart.getEpochSecond(),
+                "pos-people-contact",
+                null,
+                null,
+                manifest,
+                clock);
+
+        kafkaTemplate
+                .send(manifestTopic, envelope.recordKey(), objectMapper.writeValueAsString(envelope))
+                .get(sendTimeoutMs, TimeUnit.MILLISECONDS);
+        log.info(
+                "Published reconciliation manifest window=[{}, {}) events={} topic={}",
+                windowStart,
+                windowEnd,
+                eventIds.size(),
+                manifestTopic);
+    }
+
+    /** Deterministic per-window aggregate id, so re-published manifests key to the same partition. */
+    private UUID manifestAggregateId(Instant windowStart) {
+        return UUID.nameUUIDFromBytes(
+                (DOMAIN + ".manifest:" + eventsTopic + ":" + windowStart).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void recordFailure(Instant windowStart, Instant windowEnd, Exception e) {
+        increment(failedCounter);
+        log.warn("Reconciliation manifest publish failed window=[{}, {})", windowStart, windowEnd, e);
+    }
+
+    private void increment(@Nullable Counter counter) {
+        if (counter != null) {
+            counter.increment();
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/OpenApiConfig.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/OpenApiConfig.java
@@ -1,0 +1,108 @@
+package com.positivity.peoplecontact.internal.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.tags.Tag;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.method.HandlerMethod;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final Pattern AUTHORITY_PATTERN = Pattern.compile("'([^']+)'");
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("POS People Contact Service API")
+                        .description("Identity, contact, and user-link authority service (ADR-0044 Phase 3)")
+                        .version("v1")
+                        .contact(
+                                new Contact().email("louis.burroughs@gmail.com").name("Durion Support Services")))
+                .tags(Arrays.asList(
+                        new Tag().name("People API").description("Operations related to person identity records"),
+                        new Tag()
+                                .name("User Person Links API")
+                                .description("Operations for managing user-person links"),
+                        new Tag()
+                                .name("Person Access API")
+                                .description("Person role assignments (proxied to pos-security-service)")))
+                .components(new Components()
+                        .addSecuritySchemes(
+                                "bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+
+    /**
+     * Produces an {@link OperationCustomizer} that reads
+     * {@link org.springframework.security.access.prepost.PreAuthorize} annotations from
+     * both the controller class and the handler method, extracts every {@code hasAuthority}
+     * / {@code hasAnyAuthority} argument, and attaches them as the
+     * {@code x-required-permissions} extension on the corresponding OpenAPI operation.
+     *
+     * @return an {@link OperationCustomizer} that populates {@code x-required-permissions}
+     */
+    @Bean
+    public OperationCustomizer requiredPermissionsOperationCustomizer() {
+        return (operation, handlerMethod) -> {
+            var requiredPermissions = extractRequiredPermissions(handlerMethod);
+            if (!requiredPermissions.isEmpty()) {
+                operation.addExtension("x-required-permissions", requiredPermissions);
+            }
+            return operation;
+        };
+    }
+
+    private static List<String> extractRequiredPermissions(HandlerMethod handlerMethod) {
+        var requiredPermissions = new LinkedHashSet<String>();
+        collectAuthorities(
+                requiredPermissions,
+                AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getBeanType(), PreAuthorize.class));
+        collectAuthorities(
+                requiredPermissions,
+                AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getMethod(), PreAuthorize.class));
+        if (requiredPermissions.isEmpty() && isAuthenticatedOrAbsent(handlerMethod)) {
+            requiredPermissions.add("AUTHENTICATED");
+        }
+        return new ArrayList<>(requiredPermissions);
+    }
+
+    private static boolean isAuthenticatedOrAbsent(HandlerMethod handlerMethod) {
+        PreAuthorize methodLevel =
+                AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getMethod(), PreAuthorize.class);
+        if (methodLevel != null) {
+            return "isAuthenticated()".equals(methodLevel.value());
+        }
+        PreAuthorize classLevel =
+                AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getBeanType(), PreAuthorize.class);
+        return classLevel == null || "isAuthenticated()".equals(classLevel.value());
+    }
+
+    private static void collectAuthorities(LinkedHashSet<String> requiredPermissions, PreAuthorize preAuthorize) {
+        if (preAuthorize == null) {
+            return;
+        }
+
+        Matcher matcher = AUTHORITY_PATTERN.matcher(preAuthorize.value());
+        while (matcher.find()) {
+            requiredPermissions.add(matcher.group(1));
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/OutboxEventWriter.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/OutboxEventWriter.java
@@ -1,0 +1,57 @@
+package com.positivity.peoplecontact.internal.config;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.peoplecontact.internal.entity.OutboxEvent;
+import com.positivity.peoplecontact.internal.repository.OutboxEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Transactional-outbox writer for people-contact domain events (ADR-0044 §4, issue #874).
+ *
+ * <p>Serializes a full {@link DomainEventEnvelope} into {@code event_outbox} within the caller's
+ * transaction, so an event exists if and only if the business state change committed.
+ * {@link OutboxPublisher} drains the table to Kafka with at-least-once delivery.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.people-contact.kafka", name = "enabled", havingValue = "true")
+public class OutboxEventWriter {
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final OutboxEventRepository outboxEventRepository;
+
+    /**
+     * Queue an envelope for publication as part of the current transaction. Must be called inside
+     * the business transaction ({@code MANDATORY}) — that is the whole point of the outbox.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void publish(@NonNull String topic, @NonNull DomainEventEnvelope<?> envelope) {
+        OutboxEvent event = OutboxEvent.builder()
+                .topic(topic)
+                .recordKey(envelope.recordKey())
+                .payload(serialize(envelope))
+                .createdAt(Instant.now(clock))
+                .build();
+        outboxEventRepository.save(event);
+        log.debug("Queued outbox event type={} topic={} key={}", envelope.eventType(), topic, envelope.recordKey());
+    }
+
+    private String serialize(DomainEventEnvelope<?> envelope) {
+        try {
+            return objectMapper.writeValueAsString(envelope);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to serialize event envelope for type: " + envelope.eventType(), e);
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/OutboxPublisher.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/OutboxPublisher.java
@@ -1,0 +1,116 @@
+package com.positivity.peoplecontact.internal.config;
+
+import com.positivity.peoplecontact.internal.entity.OutboxEvent;
+import com.positivity.peoplecontact.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Drains {@code event_outbox} to Kafka (ADR-0044 §4).
+ *
+ * <p>At-least-once: a row is marked published (in its own short transaction, so no DB connection
+ * is held across the blocking broker send) only after the broker acknowledges, and a crash between
+ * send and mark re-sends on the next poll — consumers must be idempotent by {@code eventId}. Rows
+ * are processed in id order (UUIDv7 = insertion time); the batch stops at the first failure so a
+ * struggling broker cannot reorder events, and failed rows retry on every poll with
+ * {@code attempts}/{@code last_error} recorded for alerting.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "pos.people-contact.kafka", name = "enabled", havingValue = "true")
+public class OutboxPublisher {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final Clock clock;
+    private final Counter publishedCounter;
+    private final Counter failedCounter;
+
+    @Value("${pos.people-contact.outbox.send-timeout-ms:10000}")
+    private long sendTimeoutMs;
+
+    public OutboxPublisher(
+            OutboxEventRepository outboxEventRepository,
+            KafkaTemplate<String, String> kafkaTemplate,
+            Clock clock,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.kafkaTemplate = kafkaTemplate;
+        this.clock = clock;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.publishedCounter = registry == null
+                ? null
+                : Counter.builder("people_contact.outbox.published")
+                        .description("Outbox events successfully published to Kafka")
+                        .register(registry);
+        this.failedCounter = registry == null
+                ? null
+                : Counter.builder("people_contact.outbox.publish.failures")
+                        .description("Outbox publish attempts that failed")
+                        .register(registry);
+    }
+
+    @Scheduled(fixedDelayString = "${pos.people-contact.outbox.poll-interval-ms:1000}")
+    public void publishPending() {
+        List<OutboxEvent> pending = outboxEventRepository.findTop100ByPublishedAtIsNullOrderByIdAsc();
+        for (OutboxEvent event : pending) {
+            if (!publish(event)) {
+                // Stop at the first failure to preserve publish order; retry next poll.
+                break;
+            }
+        }
+    }
+
+    private boolean publish(OutboxEvent event) {
+        try {
+            kafkaTemplate
+                    .send(event.getTopic(), event.getRecordKey(), event.getPayload())
+                    .get(sendTimeoutMs, TimeUnit.MILLISECONDS);
+            event.setPublishedAt(Instant.now(clock));
+            event.setAttempts(0);
+            event.setLastError(null);
+            outboxEventRepository.save(event);
+            increment(publishedCounter);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            recordFailure(event, e);
+            return false;
+        } catch (Exception e) {
+            recordFailure(event, e);
+            return false;
+        }
+    }
+
+    private void recordFailure(OutboxEvent event, Exception e) {
+        event.setAttempts(event.getAttempts() + 1);
+        String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+        event.setLastError(message.length() > 2000 ? message.substring(0, 2000) : message);
+        outboxEventRepository.save(event);
+        increment(failedCounter);
+        log.warn(
+                "Outbox publish failed id={} topic={} key={} attempts={}",
+                event.getId(),
+                event.getTopic(),
+                event.getRecordKey(),
+                event.getAttempts(),
+                e);
+    }
+
+    private void increment(Counter counter) {
+        if (counter != null) {
+            counter.increment();
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/PeopleContactCommandListener.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/PeopleContactCommandListener.java
@@ -1,0 +1,124 @@
+package com.positivity.peoplecontact.internal.config;
+
+import com.positivity.peoplecontact.service.OutboxReplayService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Kafka command listener for {@code people-contact.commands.v1} (ADR-0044 §4, issue #874).
+ *
+ * <p>Supported command types:
+ * <ul>
+ * <li>{@code people-contact.outbox.replay-requested} — consumer-initiated drift repair and replica
+ * bootstrap: re-queues published outbox events created in the requested window for
+ * re-publication; consumers dedupe by eventId so replay is idempotent.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.people-contact.kafka", name = "enabled", havingValue = "true")
+public class PeopleContactCommandListener {
+
+    private static final String PAYLOAD = "payload";
+
+    /** Canonical dotted name normalized to command-type form: PEOPLE_CONTACT_OUTBOX_REPLAY_REQUESTED. */
+    private static final String COMMAND_OUTBOX_REPLAY_REQUESTED = "PEOPLE_CONTACT_OUTBOX_REPLAY_REQUESTED";
+
+    /** Covers the sub-millisecond skew between outbox createdAt and the eventId timestamp. */
+    private static final Duration REPLAY_WINDOW_SLACK = Duration.ofSeconds(1);
+
+    /** Replay commands older than this are rejected — bounds repair cost. */
+    @Value("${pos.people-contact.outbox.replay.max-lookback:P30D}")
+    private Duration replayMaxLookback;
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final OutboxReplayService outboxReplayService;
+
+    @KafkaListener(
+            topics = "${pos.people-contact.kafka.commands-topic:people-contact.commands.v1}",
+            groupId = "${pos.people-contact.kafka.commands-consumer-group:pos-people-contact-commands}")
+    public void onCommand(@NonNull String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            String rawCommandType = root.path("commandType").stringValue(null);
+            if (rawCommandType == null || rawCommandType.isBlank()) {
+                log.debug("Ignoring command without commandType: {}", message);
+                return;
+            }
+            // Normalize dotted command names (people-contact.outbox.replay-requested) to one form.
+            String commandType =
+                    rawCommandType.toUpperCase(Locale.ROOT).replace('.', '_').replace('-', '_');
+
+            if (COMMAND_OUTBOX_REPLAY_REQUESTED.equals(commandType)) {
+                handleOutboxReplayRequested(root);
+                return;
+            }
+            log.debug("Ignoring unsupported commandType={} message={}", commandType, message);
+        } catch (TransientDataAccessException e) {
+            // Let the container error handler retry with backoff and route to {topic}.dlq
+            // (ADR-0044 §4) — replay is idempotent, so redelivery is harmless (PR #865 review).
+            throw e;
+        } catch (Exception e) {
+            // Malformed/unsupported commands are permanent failures: retrying cannot fix them,
+            // so log and drop instead of poisoning the partition.
+            log.error("Failed to process Kafka command message: {}", message, e);
+        }
+    }
+
+    private void handleOutboxReplayRequested(@NonNull JsonNode root) {
+        JsonNode payloadNode = root.get(PAYLOAD);
+        Instant since = parseInstant(payloadNode, "since");
+        if (since == null) {
+            log.warn("Ignoring outbox replay command with missing/malformed payload.since: {}", root);
+            return;
+        }
+        Instant lookbackLimit = Instant.now(clock).minus(replayMaxLookback);
+        if (since.isBefore(lookbackLimit)) {
+            // A malformed or ancient `since` must not trigger a huge re-emit.
+            log.warn(
+                    "Ignoring outbox replay command: since={} exceeds max lookback {} (limit {})",
+                    since,
+                    replayMaxLookback,
+                    lookbackLimit);
+            return;
+        }
+        Instant until = parseInstant(payloadNode, "until");
+        int queued;
+        if (until != null && until.isAfter(since)) {
+            // Bounded window repair; +/- slack covers createdAt vs eventId-timestamp skew.
+            queued = outboxReplayService.replayBetween(
+                    since.minus(REPLAY_WINDOW_SLACK), until.plus(REPLAY_WINDOW_SLACK));
+        } else {
+            queued = outboxReplayService.replaySince(since.minus(REPLAY_WINDOW_SLACK));
+        }
+        log.info("Outbox replay command processed since={} until={} eventsQueued={}", since, until, queued);
+    }
+
+    private @Nullable Instant parseInstant(@Nullable JsonNode payloadNode, @NonNull String field) {
+        String value = payloadNode == null ? null : payloadNode.path(field).stringValue(null);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(value);
+        } catch (Exception _) {
+            log.warn("Malformed payload.{}={} on outbox replay command", field, value);
+            return null;
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/PeopleContactEventPublisher.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/PeopleContactEventPublisher.java
@@ -1,0 +1,144 @@
+package com.positivity.peoplecontact.internal.config;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.peoplecontact.PersonDeletedV1;
+import com.positivity.domainevents.peoplecontact.PersonUpdatedV1;
+import com.positivity.domainevents.peoplecontact.UserPersonLinkRemovedV1;
+import com.positivity.domainevents.peoplecontact.UserPersonLinkUpdatedV1;
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Emits people-contact identity facts to the outbox after mutations (ADR-0044 §6, #874).
+ *
+ * <p>No-op when the Kafka feature flag ({@code pos.people-contact.kafka.enabled}) is off — the
+ * {@link OutboxEventWriter} bean is conditional, so this publisher degrades gracefully. Must be
+ * called inside the mutating transaction (the writer requires {@code MANDATORY} propagation).
+ *
+ * <p>Person and link rows carry no optimistic-lock version, so the envelope's
+ * {@code aggregateVersion} is the emission timestamp in epoch milliseconds — a last-writer-wins
+ * ordering hint per aggregate, monotonic under the single-writer transaction model.
+ */
+@Slf4j
+@Component
+public class PeopleContactEventPublisher {
+
+    private final Clock clock;
+    private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+    private final String eventsTopic;
+
+    public PeopleContactEventPublisher(
+            Clock clock,
+            ObjectProvider<OutboxEventWriter> outboxEventWriter,
+            // Same property ManifestPublisher scans event_outbox by, so an override can never
+            // desync the outbox rows from the manifest computation.
+            @Value("${pos.people-contact.kafka.events-topic:people-contact.events.v1}") String eventsTopic) {
+        this.clock = clock;
+        this.outboxEventWriter = outboxEventWriter;
+        this.eventsTopic = eventsTopic;
+    }
+
+    public void publishPersonUpdated(@NonNull Person person, @NonNull List<PersonContactPoint> contactPoints) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        PersonUpdatedV1 payload = new PersonUpdatedV1(
+                person.getId(),
+                person.getFirstName(),
+                person.getLastName(),
+                person.getPreferredName(),
+                contactPoints.stream()
+                        .map(cp -> new PersonUpdatedV1.ContactPointV1(
+                                cp.getContactType().name(), cp.getValue(), cp.isPrimary()))
+                        .toList(),
+                person.getCreatedAt(),
+                person.getUpdatedAt());
+        writer.publish(
+                eventsTopic,
+                envelope(PersonUpdatedV1.EVENT_TYPE, PersonUpdatedV1.SCHEMA_VERSION, person.getId(), payload));
+        log.debug("Queued people-contact.person.updated personId={}", person.getId());
+    }
+
+    public void publishPersonDeleted(@NonNull UUID personId) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        writer.publish(
+                eventsTopic,
+                envelope(
+                        PersonDeletedV1.EVENT_TYPE,
+                        PersonDeletedV1.SCHEMA_VERSION,
+                        personId,
+                        new PersonDeletedV1(personId)));
+        log.debug("Queued people-contact.person.deleted personId={}", personId);
+    }
+
+    public void publishLinkUpdated(@NonNull UserPersonLink link) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        UserPersonLinkUpdatedV1 payload = new UserPersonLinkUpdatedV1(
+                link.getId(),
+                link.getPersonId(),
+                link.getUsername(),
+                link.getStatus() == null ? "ACTIVE" : link.getStatus().name(),
+                link.getLinkType(),
+                link.getCreatedAt(),
+                link.getUpdatedAt());
+        writer.publish(
+                eventsTopic,
+                envelope(
+                        UserPersonLinkUpdatedV1.EVENT_TYPE,
+                        UserPersonLinkUpdatedV1.SCHEMA_VERSION,
+                        link.getId(),
+                        payload));
+        log.debug(
+                "Queued people-contact.user-person-link.updated linkId={} username={}",
+                link.getId(),
+                link.getUsername());
+    }
+
+    public void publishLinkRemoved(@NonNull UserPersonLink link) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        writer.publish(
+                eventsTopic,
+                envelope(
+                        UserPersonLinkRemovedV1.EVENT_TYPE,
+                        UserPersonLinkRemovedV1.SCHEMA_VERSION,
+                        link.getId(),
+                        new UserPersonLinkRemovedV1(link.getId(), link.getPersonId(), link.getUsername())));
+        log.debug(
+                "Queued people-contact.user-person-link.removed linkId={} username={}",
+                link.getId(),
+                link.getUsername());
+    }
+
+    private <T> DomainEventEnvelope<T> envelope(String eventType, int schemaVersion, UUID aggregateId, T payload) {
+        return DomainEventEnvelope.of(
+                eventType,
+                schemaVersion,
+                aggregateId,
+                Instant.now(clock).toEpochMilli(),
+                "pos-people-contact",
+                null,
+                null,
+                payload,
+                clock);
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/PermissionRegistration.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/PermissionRegistration.java
@@ -1,0 +1,20 @@
+package com.positivity.peoplecontact.internal.config;
+
+import com.positivity.security.common.PermissionRegistrationSupport;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Registers people permissions with pos-security-service at startup.
+ */
+@Component
+public class PermissionRegistration extends PermissionRegistrationSupport {
+
+    public PermissionRegistration(
+            RestClient.Builder restClientBuilder,
+            @Value("${pos.security.base-url:http://pos-security-service:8080}") String securityServiceUrl,
+            @Value("${pos.security.permission-registration.enabled:true}") boolean enabled) {
+        super(restClientBuilder, securityServiceUrl, enabled, "permissions.yaml");
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/RestClientConfig.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/RestClientConfig.java
@@ -1,0 +1,44 @@
+package com.positivity.peoplecontact.internal.config;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    @Primary
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
+    }
+
+    @Bean
+    @LoadBalanced
+    public RestClient.Builder loadBalancedRestClientBuilder() {
+        return RestClient.builder();
+    }
+
+    @Bean
+    public RestClient securityServiceRestClient(
+            @Qualifier("loadBalancedRestClientBuilder") RestClient.Builder builder,
+            @Value("${pos.security-service.service-id:security-service}") String serviceId,
+            @Value("${pos.restclient.connect.timeout:3000}") int connectTimeoutMs,
+            @Value("${pos.restclient.read.timeout:5000}") int readTimeoutMs) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofMillis(connectTimeoutMs));
+        factory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
+
+        return builder.requestFactory(factory)
+                .baseUrl("http://" + serviceId)
+                .defaultHeader("X-User", "pos-people-contact")
+                .defaultHeader("X-Authorities", "security:user:view,security:role:view,security:role:assign")
+                .build();
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/SecurityConfig.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.positivity.peoplecontact.internal.config;
+
+import com.positivity.security.common.GatewaySecurityConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * People Service Security Configuration.
+ *
+ * <p>
+ * Imports {@link GatewaySecurityConfig} which provides:
+ * </p>
+ * <ul>
+ * <li>Gateway-based authentication via X-Authorities and X-User headers</li>
+ * <li>Stateless session management (JWT-based)</li>
+ * <li>Method-level security (@PreAuthorize support)</li>
+ * <li>Public access to actuator, swagger endpoints</li>
+ * </ul>
+ *
+ * @see GatewaySecurityConfig
+ */
+@Configuration
+@Import(GatewaySecurityConfig.class)
+public class SecurityConfig {
+
+    // Gateway-based authentication is configured by GatewaySecurityConfig
+
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PeopleExceptionHandler.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PeopleExceptionHandler.java
@@ -1,0 +1,203 @@
+package com.positivity.peoplecontact.internal.controller;
+
+import com.positivity.peoplecontact.internal.client.SecurityServiceException;
+import com.positivity.peoplecontact.internal.exception.NotFoundException;
+import com.positivity.peoplecontact.internal.exception.PersonNotFoundException;
+import com.positivity.peoplecontact.internal.exception.SemanticValidationException;
+import com.positivity.peoplecontact.internal.exception.UserAlreadyLinkedException;
+import com.positivity.peoplecontact.internal.exception.UserPersonLinkNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class PeopleExceptionHandler {
+
+    private final Clock clock;
+
+    private static final String TIMESTAMP_PROPERTY = "timestamp";
+
+    @ExceptionHandler(PersonNotFoundException.class)
+    public ProblemDetail handlePersonNotFound(PersonNotFoundException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(UserPersonLinkNotFoundException.class)
+    public ProblemDetail handleLinkNotFound(UserPersonLinkNotFoundException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(UserAlreadyLinkedException.class)
+    public ProblemDetail handleUserAlreadyLinked(UserAlreadyLinkedException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ProblemDetail handleNotFound(NotFoundException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ProblemDetail handleEntityNotFound(EntityNotFoundException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ProblemDetail handleIllegalArgument(IllegalArgumentException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ProblemDetail handleIllegalState(IllegalStateException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(SemanticValidationException.class)
+    public ProblemDetail handleSemanticValidation(SemanticValidationException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.UNPROCESSABLE_CONTENT, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ProblemDetail handleAccessDenied(AccessDeniedException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    // Without these handlers, Spring MVC's routing/binding exceptions fall through to the
+    // Exception catch-all below and every unknown path or malformed parameter surfaces as a
+    // 500 (issue #820). The details deliberately do not echo request data (path, parameter
+    // values): reflecting user-controlled input is flagged as XSS-prone (SonarCloud S5131),
+    // and the request path is already available in the ProblemDetail `instance` field.
+    @ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class})
+    public ProblemDetail handleNoEndpoint() {
+        ProblemDetail problem =
+                ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "No endpoint for the requested path");
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ProblemDetail handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST, "Invalid value for parameter '" + ex.getName() + "'");
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ProblemDetail handleMissingParameter(MissingServletRequestParameterException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST, "Missing required parameter '" + ex.getParameterName() + "'");
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handleValidation(MethodArgumentNotValidException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Validation failed");
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Map<String, Object>> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex, HttpServletRequest request) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put(TIMESTAMP_PROPERTY, Instant.now(clock));
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        body.put("error", "Bad Request");
+        body.put("path", request.getRequestURI());
+        body.put("message", "Malformed JSON request");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(SecurityServiceException.class)
+    public ProblemDetail handleSecurityServiceException(SecurityServiceException ex) {
+        HttpStatus status = determineHttpStatus(ex);
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(status, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ProblemDetail handleResponseStatusException(ResponseStatusException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.valueOf(ex.getStatusCode().value()),
+                ex.getReason() == null ? ex.getMessage() : ex.getReason());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleUnexpectedException(Exception ex) {
+        log.error("Unhandled exception in People API", ex);
+        ProblemDetail problem =
+                ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    private HttpStatus determineHttpStatus(SecurityServiceException ex) {
+        int statusCode = ex.getHttpStatus();
+
+        return determineHttpStatus(statusCode);
+    }
+
+    private HttpStatus determineHttpStatus(int statusCode) {
+
+        return switch (statusCode) {
+            case 400 -> HttpStatus.BAD_REQUEST;
+            case 401 -> HttpStatus.UNAUTHORIZED;
+            case 403 -> HttpStatus.FORBIDDEN;
+            case 404 -> HttpStatus.NOT_FOUND;
+            case 409 -> HttpStatus.CONFLICT;
+            case 503 -> HttpStatus.SERVICE_UNAVAILABLE;
+            default -> {
+                if (statusCode >= 500 && statusCode < 600) {
+                    yield HttpStatus.INTERNAL_SERVER_ERROR;
+                }
+                if (statusCode >= 400 && statusCode < 500) {
+                    yield HttpStatus.BAD_REQUEST;
+                }
+                yield HttpStatus.INTERNAL_SERVER_ERROR;
+            }
+        };
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonAccessController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonAccessController.java
@@ -1,0 +1,146 @@
+package com.positivity.peoplecontact.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.peoplecontact.internal.client.dto.RoleDto;
+import com.positivity.peoplecontact.internal.client.dto.UserRoleDto;
+import com.positivity.peoplecontact.internal.dto.PersonRoleAssignmentRequest;
+import com.positivity.peoplecontact.service.PeopleAccessControlService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/people")
+@Tag(
+        name = "People - Access Control",
+        description = "APIs for managing person-to-role assignments for access control and permissions (CAP-120)")
+public class PersonAccessController {
+
+    private final PeopleAccessControlService peopleAccessControlService;
+
+    @GetMapping("/{personUuid}/access/roles")
+    @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ROLES_LIST", apiVersion = "1")
+    @Operation(summary = "Get available roles", description = "Retrieve list of roles that can be assigned to people")
+    @ApiResponse(responseCode = "200", description = "Roles retrieved successfully")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:role:view"})
+    @PreAuthorize("hasAuthority('people-contact:role:view')")
+    public ResponseEntity<List<RoleDto>> getRoles(@PathVariable UUID personUuid) {
+        return ResponseEntity.ok(peopleAccessControlService.getAvailableRolesForPerson(personUuid));
+    }
+
+    @GetMapping("/{personUuid}/access/assignments")
+    @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ASSIGNMENTS_LIST", apiVersion = "1")
+    @Operation(
+            summary = "Get role assignments",
+            description = "Retrieve role assignments for a person with optional history and date filtering")
+    @ApiResponse(responseCode = "200", description = "Assignments retrieved successfully")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:role:view"})
+    @PreAuthorize("hasAuthority('people-contact:role:view')")
+    public ResponseEntity<List<UserRoleDto>> getAssignments(
+            @PathVariable UUID personUuid,
+            @RequestParam(required = false) Boolean includeHistory,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+        return ResponseEntity.ok(peopleAccessControlService.getPersonRoleAssignments(
+                personUuid, Boolean.TRUE.equals(includeHistory), endDate));
+    }
+
+    @PostMapping("/{personUuid}/access/assignments")
+    @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ASSIGNMENT_CREATE", apiVersion = "1")
+    @Operation(
+            summary = "Assign role to person",
+            description = "Assign a role to a person with optional location scope and date range")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Role assignment created successfully",
+                        content = @Content(schema = @Schema(implementation = UserRoleDto.class))),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid request",
+                        content =
+                                @Content(
+                                        mediaType = "application/problem+json",
+                                        schema = @Schema(implementation = ProblemDetail.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "Person or role not found",
+                        content =
+                                @Content(
+                                        mediaType = "application/problem+json",
+                                        schema = @Schema(implementation = ProblemDetail.class)))
+            })
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:role:assign"})
+    @PreAuthorize("hasAuthority('people-contact:role:assign')")
+    public ResponseEntity<UserRoleDto> createAssignment(
+            @PathVariable UUID personUuid, @Valid @RequestBody PersonRoleAssignmentRequest request) {
+        if (request.getRoleCode() == null || request.getRoleCode().isBlank()) {
+            throw new IllegalArgumentException("roleCode is required");
+        }
+        UserRoleDto created = peopleAccessControlService.assignRoleToPerson(
+                personUuid,
+                request.getRoleCode(),
+                request.getLocationId(),
+                request.getStartDate(),
+                request.getEndDate());
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @DeleteMapping("/{personUuid}/access/assignments/{roleCode}")
+    @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ASSIGNMENT_REVOKE", apiVersion = "1")
+    @Operation(summary = "Revoke role assignment", description = "Revoke a role assignment from a person")
+    @ApiResponse(responseCode = "204", description = "Role assignment revoked successfully")
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid request for revoking role assignment",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Person or role assignment not found",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:role:revoke"})
+    @PreAuthorize("hasAuthority('people-contact:role:revoke')")
+    public ResponseEntity<Void> revokeAssignment(
+            @PathVariable UUID personUuid,
+            @PathVariable String roleCode,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+        peopleAccessControlService.revokeRoleFromPerson(personUuid, roleCode, endDate);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonController.java
@@ -1,0 +1,204 @@
+package com.positivity.peoplecontact.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.peoplecontact.internal.dto.Person;
+import com.positivity.peoplecontact.internal.dto.ResolvePersonRequest;
+import com.positivity.peoplecontact.internal.dto.ResolvePersonResponse;
+import com.positivity.peoplecontact.service.PersonService;
+import com.positivity.peoplecontact.service.UserPersonTranslationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "People API", description = "Operations related to people records")
+@RestController
+@RequestMapping("/v1/people")
+@RequiredArgsConstructor
+public class PersonController {
+
+    private final PersonService personService;
+
+    private final UserPersonTranslationService userPersonTranslationService;
+
+    @Operation(
+            summary = "Get current user's person record",
+            description = "Resolve the authenticated user to their linked person record. Returns 404 when the user"
+                    + " has no person link or the linked person no longer exists.")
+    @ApiResponse(responseCode = "200", description = "Person found and returned.")
+    @ApiResponse(
+            responseCode = "404",
+            description = "No person linked to the current user.",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @GetMapping("/me")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:person:view"})
+    @PreAuthorize("hasAuthority('people-contact:person:view')")
+    public Person getCurrentPerson() {
+        UUID personId = userPersonTranslationService.getPersonUuidForCurrentUser();
+        return personService
+                .getPersonById(personId)
+                .orElseThrow(() -> new EntityNotFoundException("No person found for id: " + personId));
+    }
+
+    @Operation(summary = "Get all people", description = "Retrieve people with optional type and text filters.")
+    @Parameter(
+            name = "type",
+            description = "Filter by person type: EMPLOYEE, ACTIVE, INACTIVE, or ALL (default).",
+            schema = @Schema(allowableValues = {"ALL", "EMPLOYEE", "ACTIVE", "INACTIVE"}))
+    @Parameter(name = "q", description = "Case-insensitive text search on firstName, lastName, primaryEmail, username.")
+    @ApiResponse(responseCode = "200", description = "List of people returned successfully.")
+    @GetMapping
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:person:view"})
+    @PreAuthorize("hasAuthority('people-contact:person:view')")
+    public List<Person> getAllPeople(@RequestParam(name = "q", required = false) String q) {
+        return personService.getAllPeople(q);
+    }
+
+    @Operation(summary = "Get person by ID", description = "Retrieve a person by their unique ID.")
+    @ApiResponse(responseCode = "200", description = "Person found and returned.")
+    @ApiResponse(responseCode = "404", description = "Person not found.")
+    @GetMapping("/{personId}")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:person:view"})
+    @PreAuthorize("hasAuthority('people-contact:person:view')")
+    public ResponseEntity<Person> getPersonById(
+            @Parameter(description = "ID of the person to retrieve", example = "123e4567-e89b-12d3-a456-426614174000")
+                    @PathVariable
+                    UUID personId) {
+        return personService
+                .getPersonById(personId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @Operation(
+            summary = "Get people by IDs",
+            description = "Batch-resolve persons by id in one request. Unknown ids are omitted; the result may be"
+                    + " smaller than the request. Used for cross-service identity reads (ADR-0015).")
+    @ApiResponse(responseCode = "200", description = "Persons resolved.")
+    @PostMapping("/by-ids")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:person:view"})
+    @PreAuthorize("hasAuthority('people-contact:person:view')")
+    public List<Person> getPeopleByIds(@Parameter(description = "Person ids to resolve") @RequestBody List<UUID> ids) {
+        return personService.getPeopleByIds(ids);
+    }
+
+    @Operation(
+            summary = "Replace a person's contact points",
+            description =
+                    "Replaces all typed contact points (email/phone) for a person. pos-people-contact is the source of"
+                            + " truth for contacts (ADR-0015).")
+    @ApiResponse(responseCode = "204", description = "Contact points replaced.")
+    @PutMapping("/{personId}/contact-points")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:person:edit"})
+    @PreAuthorize("hasAuthority('people-contact:person:edit')")
+    public ResponseEntity<Void> replaceContactPoints(
+            @Parameter(description = "Person id") @PathVariable UUID personId,
+            @RequestBody List<Person.ContactPointDto> contactPoints) {
+        personService.replaceContactPoints(personId, contactPoints);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Create a new person", description = "Add a new person to the system.")
+    @ApiResponse(responseCode = "201", description = "Person created successfully.")
+    @EmitEvent(id = "PEOPLE_CONTACT_PERSON_CREATE", apiVersion = "1")
+    @PostMapping
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:person:create"})
+    @PreAuthorize("hasAuthority('people-contact:person:create')")
+    public ResponseEntity<Person> createPerson(
+            @Parameter(description = "Person object to be created") @Valid @RequestBody Person person) {
+        Person saved = personService.savePerson(person);
+        return ResponseEntity.status(201).body(saved);
+    }
+
+    @Operation(summary = "Resolve person", description = "Find best matching person by score or create a new person")
+    @ApiResponse(responseCode = "200", description = "Person resolved successfully.")
+    @EmitEvent(id = "PEOPLE_CONTACT_PERSON_RESOLVE", apiVersion = "1")
+    @PostMapping("/resolve")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:person:create"})
+    @PreAuthorize("hasAuthority('people-contact:person:create')")
+    public ResponseEntity<ResolvePersonResponse> resolvePerson(
+            @Parameter(description = "Resolve criteria") @Valid @RequestBody ResolvePersonRequest request) {
+        ResolvePersonResponse resolved = personService.resolvePerson(request);
+        return ResponseEntity.ok(resolved);
+    }
+
+    @Operation(summary = "Update an existing person", description = "Update the details of an existing person.")
+    @ApiResponse(responseCode = "200", description = "Person updated successfully.")
+    @ApiResponse(responseCode = "404", description = "Person not found.")
+    @EmitEvent(id = "PEOPLE_CONTACT_PERSON_UPDATE", apiVersion = "1")
+    @PutMapping("/{personId}")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:person:edit"})
+    @PreAuthorize("hasAuthority('people-contact:person:edit')")
+    public ResponseEntity<Person> updatePerson(
+            @Parameter(description = "ID of the person to update", example = "123e4567-e89b-12d3-a456-426614174000")
+                    @PathVariable
+                    UUID personId,
+            @Parameter(description = "Updated person object") @Valid @RequestBody Person person) {
+        if (personService.getPersonById(personId).isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        person.setId(personId);
+        Person updated = personService.savePerson(person);
+        return ResponseEntity.ok(updated);
+    }
+
+    @Operation(summary = "Delete a person", description = "Delete a person by their unique ID.")
+    @ApiResponse(responseCode = "204", description = "Person deleted successfully.")
+    @ApiResponse(responseCode = "404", description = "Person not found.")
+    @EmitEvent(id = "PEOPLE_CONTACT_PERSON_DELETE", apiVersion = "1")
+    @DeleteMapping("/{personId}")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:person:delete"})
+    @PreAuthorize("hasAuthority('people-contact:person:delete')")
+    public ResponseEntity<Void> deletePerson(
+            @Parameter(description = "ID of the person to delete", example = "123e4567-e89b-12d3-a456-426614174000")
+                    @PathVariable
+                    UUID personId) {
+        if (personService.getPersonById(personId).isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        personService.deletePerson(personId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
@@ -152,7 +152,7 @@ public class UserPersonLinkController {
             name = "bearerAuth",
             scopes = {"people-contact:userLink:view"})
     @PreAuthorize("hasAuthority('people-contact:userLink:view')")
-    public ResponseEntity<List<UserPersonLinkResponse>> getLinkByPersonId(
+    public ResponseEntity<List<UserPersonLinkResponse>> getLinksByPersonId(
             @Parameter(description = "Person ID", required = true) @PathVariable UUID personId) {
         return ResponseEntity.ok(linkService.getUserLinks(personId));
     }

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
@@ -1,0 +1,159 @@
+package com.positivity.peoplecontact.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.peoplecontact.internal.dto.CreateUserLinkRequest;
+import com.positivity.peoplecontact.internal.dto.LinkUserToPersonRequest;
+import com.positivity.peoplecontact.internal.dto.PersonResponse;
+import com.positivity.peoplecontact.internal.dto.UserPersonLinkResponse;
+import com.positivity.peoplecontact.service.UserPersonLinkService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/people")
+@Tag(name = "User-Person Linking API", description = "Link authentication users to person records")
+public class UserPersonLinkController {
+
+    private final UserPersonLinkService linkService;
+
+    @PostMapping("/users/link")
+    @EmitEvent(id = "PEOPLE_CONTACT_USER_LINK_CREATE", apiVersion = "1")
+    @Operation(
+            summary = "Link user to person",
+            description = "Create a link between an authentication user and a person record")
+    @ApiResponse(
+            responseCode = "201",
+            description = "Link created successfully",
+            content = @Content(schema = @Schema(implementation = UserPersonLinkResponse.class)))
+    @ApiResponse(
+            responseCode = "200",
+            description = "Link already exists and is returned",
+            content = @Content(schema = @Schema(implementation = UserPersonLinkResponse.class)))
+    @ApiResponse(responseCode = "400", description = "Invalid request")
+    @ApiResponse(responseCode = "404", description = "Person not found")
+    @ApiResponse(responseCode = "409", description = "User already linked to different person")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:userLink:write"})
+    @PreAuthorize("hasAuthority('people-contact:userLink:write')")
+    public ResponseEntity<UserPersonLinkResponse> linkUserToPerson(
+            @Valid @RequestBody LinkUserToPersonRequest request) {
+
+        boolean alreadyLinked =
+                linkService.linkExistsByUsernameAndPersonId(request.getUsername(), request.getPersonId());
+
+        UserPersonLinkResponse response = linkService.linkUserToPerson(request);
+        return alreadyLinked
+                ? ResponseEntity.ok(response)
+                : ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/user-links")
+    @EmitEvent(id = "PEOPLE_CONTACT_USER_LINK_CREATE", apiVersion = "1")
+    @Operation(
+            summary = "Create user-person link (admin)",
+            description = "Create a link between an authentication user and a person record")
+    @ApiResponse(
+            responseCode = "201",
+            description = "Link created successfully",
+            content = @Content(schema = @Schema(implementation = UserPersonLinkResponse.class)))
+    @ApiResponse(
+            responseCode = "200",
+            description = "Link already exists and is returned",
+            content = @Content(schema = @Schema(implementation = UserPersonLinkResponse.class)))
+    @ApiResponse(responseCode = "400", description = "Invalid request")
+    @ApiResponse(responseCode = "404", description = "Person not found")
+    @ApiResponse(responseCode = "409", description = "User already linked to different person")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:userLink:write"})
+    @PreAuthorize("hasAuthority('people-contact:userLink:write')")
+    public ResponseEntity<UserPersonLinkResponse> createUserPersonLink(
+            @Valid @RequestBody CreateUserLinkRequest request) {
+        boolean alreadyLinked =
+                linkService.linkExistsByUsernameAndPersonId(request.getUsername(), request.getPersonId());
+        UserPersonLinkResponse response = linkService.createUserLink(request.getUsername(), request.getPersonId());
+        return alreadyLinked
+                ? ResponseEntity.ok(response)
+                : ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @DeleteMapping("/users/{username}/link")
+    @EmitEvent(id = "PEOPLE_CONTACT_USER_PERSON_LINK_DELETE", apiVersion = "1")
+    @Operation(summary = "Unlink user from person", description = "Remove the link between a user and person")
+    @ApiResponse(responseCode = "204", description = "Link deleted successfully")
+    @ApiResponse(responseCode = "404", description = "Link not found")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:userLink:write"})
+    @PreAuthorize("hasAuthority('people-contact:userLink:write')")
+    public ResponseEntity<Void> unlinkUserFromPerson(
+            @Parameter(description = "Username", required = true) @PathVariable String username) {
+
+        linkService.unlinkUserFromPerson(username);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/users/{username}/person")
+    @Operation(summary = "Get person by username", description = "Retrieve the person record linked to a user")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Person found",
+            content = @Content(schema = @Schema(implementation = PersonResponse.class)))
+    @ApiResponse(responseCode = "404", description = "Link or person not found")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:userLink:view"})
+    @PreAuthorize("hasAuthority('people-contact:userLink:view')")
+    public ResponseEntity<PersonResponse> getPersonByUsername(
+            @Parameter(description = "Username", required = true) @PathVariable String username) {
+
+        PersonResponse person = linkService.findPersonByUsername(username);
+        return ResponseEntity.ok(person);
+    }
+
+    @GetMapping("/{personId}/users")
+    @Operation(summary = "Get users linked to person", description = "Retrieve all usernames linked to a person record")
+    @ApiResponse(responseCode = "200", description = "Usernames returned")
+    @ApiResponse(responseCode = "404", description = "Person not found")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:userLink:view"})
+    @PreAuthorize("hasAuthority('people-contact:userLink:view')")
+    public ResponseEntity<List<String>> getUsernamesByPersonId(
+            @Parameter(description = "Person ID", required = true) @PathVariable UUID personId) {
+
+        List<String> usernames = linkService.findUsernamesByPersonId(personId);
+        return ResponseEntity.ok(usernames);
+    }
+
+    @GetMapping("/user-links/{personId}")
+    @EmitEvent(id = "PEOPLE_CONTACT_USER_LINK_GET", apiVersion = "1")
+    @Operation(summary = "Get links by person ID", description = "Retrieve user-person links for person")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Links found",
+            content = @Content(schema = @Schema(implementation = UserPersonLinkResponse.class)))
+    @ApiResponse(responseCode = "404", description = "Link or person not found")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"people-contact:userLink:view"})
+    @PreAuthorize("hasAuthority('people-contact:userLink:view')")
+    public ResponseEntity<List<UserPersonLinkResponse>> getLinkByPersonId(
+            @Parameter(description = "Person ID", required = true) @PathVariable UUID personId) {
+        return ResponseEntity.ok(linkService.getUserLinks(personId));
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/CreateUserLinkRequest.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/CreateUserLinkRequest.java
@@ -1,0 +1,25 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request to link a user account to a person record")
+public class CreateUserLinkRequest {
+
+    @NotNull(message = "username is required")
+    @Schema(
+            description = "Username of the security user account",
+            example = "marcus.webb",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String username;
+
+    @NotNull(message = "personId is required")
+    @Schema(
+            description = "Person identifier",
+            example = "01960011-0000-7000-8000-000000000002",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID personId;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/ErrorResponse.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/ErrorResponse.java
@@ -1,0 +1,88 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.Map;
+
+@Schema(description = "Machine-readable error payload returned on failed requests")
+public class ErrorResponse {
+
+    @Schema(
+            description = "Stable machine-readable error code",
+            example = "VALIDATION_FAILED",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String errorCode;
+
+    @Schema(
+            description = "Human-readable error message",
+            example = "Request validation failed",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String message;
+
+    @Schema(
+            description = "Correlation identifier echoed from the request",
+            example = "01960011-0000-7000-8000-0000000000aa",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String correlationId;
+
+    @Schema(
+            description = "Timestamp the error occurred",
+            example = "2026-02-16T17:00:00Z",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private Instant timestamp;
+
+    @Schema(
+            description = "Per-field validation errors keyed by field name",
+            example = "{\"employeeNumber\":\"must not be blank\"}",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Map<String, String> fieldErrors;
+
+    public ErrorResponse() {}
+
+    public ErrorResponse(String errorCode, String message, String correlationId, Instant timestamp) {
+        this.errorCode = errorCode;
+        this.message = message;
+        this.correlationId = correlationId;
+        this.timestamp = timestamp;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Map<String, String> getFieldErrors() {
+        return fieldErrors;
+    }
+
+    public void setFieldErrors(Map<String, String> fieldErrors) {
+        this.fieldErrors = fieldErrors;
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/LinkUserToPersonRequest.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/LinkUserToPersonRequest.java
@@ -1,0 +1,46 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to link a user account to a person record")
+public class LinkUserToPersonRequest {
+
+    @NotNull(message = "username is required")
+    @Schema(
+            description = "Username of the security user account",
+            example = "marcus.webb",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String username;
+
+    @NotNull(message = "personId is required")
+    @Schema(
+            description = "Person identifier",
+            example = "01960011-0000-7000-8000-000000000002",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID personId;
+
+    @Schema(
+            description = "Type of link between user and person",
+            example = "PRIMARY",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String linkType = "PRIMARY";
+
+    @Schema(
+            description = "Optional notes describing the link",
+            example = "Linked during onboarding",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String notes;
+
+    public LinkUserToPersonRequest(String username, UUID personId) {
+        this.username = username;
+        this.personId = personId;
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/Person.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/Person.java
@@ -1,0 +1,173 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.UUID;
+
+public class Person {
+
+    @Schema(
+            description = "Unique identifier for the person",
+            example = "01960011-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private UUID id;
+
+    @NotBlank(message = "firstName is required")
+    @Schema(description = "First name of the person", example = "Jane", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String firstName;
+
+    @NotBlank(message = "lastName is required")
+    @Schema(description = "Last name of the person", example = "Smith", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String lastName;
+
+    @Schema(
+            description = "Primary email address",
+            example = "jane.smith@example.com",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String primaryEmail;
+
+    @Schema(
+            description = "Secondary email address",
+            example = "jane.alt@example.com",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String secondaryEmail;
+
+    @Schema(
+            description = "Phone numbers on record",
+            example = "[\"+1-555-123-4567\"]",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<String> phoneNumbers;
+
+    @Schema(
+            description = "Linked username, if any",
+            example = "jane.smith",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String username;
+
+    @Schema(
+            description = "Typed contact points (email, phone). Populated on batch by-id lookups.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<ContactPointDto> contactPoints;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getPrimaryEmail() {
+        return primaryEmail;
+    }
+
+    public void setPrimaryEmail(String primaryEmail) {
+        this.primaryEmail = primaryEmail;
+    }
+
+    public String getSecondaryEmail() {
+        return secondaryEmail;
+    }
+
+    public void setSecondaryEmail(String secondaryEmail) {
+        this.secondaryEmail = secondaryEmail;
+    }
+
+    public List<String> getPhoneNumbers() {
+        return phoneNumbers;
+    }
+
+    public void setPhoneNumbers(List<String> phoneNumbers) {
+        this.phoneNumbers = phoneNumbers;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public List<ContactPointDto> getContactPoints() {
+        return contactPoints;
+    }
+
+    public void setContactPoints(List<ContactPointDto> contactPoints) {
+        this.contactPoints = contactPoints;
+    }
+
+    /** Typed contact point (email, phone) for a person. */
+    @Schema(description = "Typed contact point (email, phone) for a person")
+    public static class ContactPointDto {
+        @Schema(description = "Type of contact point", example = "EMAIL", requiredMode = Schema.RequiredMode.REQUIRED)
+        private ContactPointType contactType;
+
+        @Schema(
+                description = "Contact point value",
+                example = "jane.smith@example.com",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private String value;
+
+        // Pin the JSON name to "primary" for BOTH directions. The isPrimary() getter
+        // serializes as "primary", but without this the field deserializes from
+        // "isPrimary" — an asymmetry that 400'd the contact-point write endpoint.
+        @JsonProperty("primary")
+        @Schema(
+                description = "Whether this is the primary contact point of its type",
+                example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private boolean isPrimary;
+
+        public ContactPointDto() {}
+
+        public ContactPointDto(ContactPointType contactType, String value, boolean isPrimary) {
+            this.contactType = contactType;
+            this.value = value;
+            this.isPrimary = isPrimary;
+        }
+
+        public ContactPointType getContactType() {
+            return contactType;
+        }
+
+        public void setContactType(ContactPointType contactType) {
+            this.contactType = contactType;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public boolean isPrimary() {
+            return isPrimary;
+        }
+
+        public void setPrimary(boolean primary) {
+            this.isPrimary = primary;
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/PersonResponse.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/PersonResponse.java
@@ -1,0 +1,49 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Schema(description = "Person summary returned by person read operations")
+public class PersonResponse {
+
+    @Schema(
+            description = "Person identifier",
+            example = "01960011-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID id;
+
+    @Schema(description = "First name of the person", example = "Jane", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String firstName;
+
+    @Schema(description = "Last name of the person", example = "Smith", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String lastName;
+
+    @Schema(
+            description = "Primary email address",
+            example = "jane.smith@example.com",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String primaryEmail;
+
+    @Schema(
+            description = "Secondary email address",
+            example = "jane.alt@example.com",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String secondaryEmail;
+
+    @Schema(
+            description = "Phone numbers on record",
+            example = "[\"+1-555-123-4567\"]",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<String> phoneNumbers;
+
+    @Schema(
+            description = "Linked username, if any",
+            example = "jane.smith",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String username;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/PersonRoleAssignmentRequest.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/PersonRoleAssignmentRequest.java
@@ -1,0 +1,43 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to assign a role to a person")
+public class PersonRoleAssignmentRequest {
+
+    @NotBlank
+    @Schema(
+            description = "Stable role code to assign",
+            example = "TECHNICIAN",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String roleCode;
+
+    @Schema(
+            description = "Location identifier the role is scoped to",
+            example = "01960011-0000-7000-8000-000000000010",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private UUID locationId;
+
+    @Schema(
+            description = "Date and time the assignment becomes effective",
+            example = "2026-01-01T00:00:00",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private LocalDateTime startDate;
+
+    @Schema(
+            description = "Date and time the assignment ends",
+            example = "2026-12-31T23:59:59",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private LocalDateTime endDate;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/ResolvePersonRequest.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/ResolvePersonRequest.java
@@ -1,0 +1,48 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request payload to resolve (match or create) a person record.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Resolve person request with weighted matching inputs")
+public class ResolvePersonRequest {
+
+    @Schema(
+            description = "Email used for matching",
+            example = "jane.smith@example.com",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String email;
+
+    @Schema(
+            description = "Phone number used for matching",
+            example = "+1-555-123-4567",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String phone;
+
+    @Schema(
+            description = "Last name used for matching",
+            example = "Smith",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String lastName;
+
+    @Schema(
+            description = "First name used for matching",
+            example = "Jane",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String firstName;
+
+    @Schema(
+            description = "Optional score threshold override",
+            example = "30",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Integer threshold;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/ResolvePersonResponse.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/ResolvePersonResponse.java
@@ -1,0 +1,65 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response payload for person resolve (match or create).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Resolve person result")
+public class ResolvePersonResponse {
+
+    @Schema(
+            description = "Canonical person ID",
+            example = "01960011-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID personId;
+
+    @Schema(
+            description = "True when an existing person matched threshold",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private boolean matchedExisting;
+
+    @Schema(
+            description = "Score of selected match (0 when created)",
+            example = "85",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private int score;
+
+    @Schema(description = "Threshold used for decision", example = "30", requiredMode = Schema.RequiredMode.REQUIRED)
+    private int thresholdApplied;
+
+    @Schema(
+            description = "Which fields contributed to the winning match",
+            example = "[\"email\",\"lastName\"]",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<String> matchedBy;
+
+    @Schema(description = "Resolved first name", example = "Jane", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String firstName;
+
+    @Schema(description = "Resolved last name", example = "Smith", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String lastName;
+
+    @Schema(
+            description = "Resolved primary email",
+            example = "jane.smith@example.com",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String primaryEmail;
+
+    @Schema(
+            description = "Resolved phone numbers",
+            example = "[\"+1-555-123-4567\"]",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private List<String> phoneNumbers;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/UserPersonLinkResponse.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/dto/UserPersonLinkResponse.java
@@ -1,0 +1,55 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Schema(description = "Response describing a link between a user account and a person record")
+public class UserPersonLinkResponse {
+
+    @Schema(
+            description = "Link identifier",
+            example = "01960011-0000-7000-8000-000000000001",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID linkId;
+
+    @Schema(
+            description = "Username of the security user account",
+            example = "marcus.webb",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String username;
+
+    @Schema(
+            description = "Person identifier",
+            example = "01960011-0000-7000-8000-000000000003",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private UUID personId;
+
+    @Schema(
+            description = "Type of link between user and person",
+            example = "PRIMARY",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String linkType;
+
+    @Schema(
+            description = "Creation timestamp in UTC",
+            example = "2026-01-15T09:30:00Z",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Instant createdAt;
+
+    @Schema(
+            description = "Identifier of the actor that created the link",
+            example = "admin.user",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String createdBy;
+
+    @Schema(
+            description = "Optional notes describing the link",
+            example = "Linked during onboarding",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String notes;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/OutboxEvent.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/OutboxEvent.java
@@ -1,0 +1,54 @@
+package com.positivity.peoplecontact.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Transactional-outbox row (ADR-0044 §4): a serialized Kafka event written in the same
+ * transaction as the business state change and drained by {@code OutboxPublisher}.
+ */
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "event_outbox")
+public class OutboxEvent {
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(name = "record_key", nullable = false)
+    private String recordKey;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String payload;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "published_at")
+    private Instant publishedAt;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private int attempts = 0;
+
+    @Column(name = "last_error", columnDefinition = "text")
+    private String lastError;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/Person.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/Person.java
@@ -1,0 +1,53 @@
+package com.positivity.peoplecontact.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Person identity. Employment attributes (employee number, status, hire/termination dates)
+ * live on {@code employee.person_id} in pos-people (ADR-0044 §6). Email + phone consolidated into
+ * person_contact_point (EMAIL / PHONE_WORK); username is owned by pos-security and resolved
+ * via user_person_link.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Person {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    private String firstName;
+
+    private String lastName;
+
+    @Column(name = "preferred_name")
+    private String preferredName;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/PersonContactPoint.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/PersonContactPoint.java
@@ -1,0 +1,71 @@
+package com.positivity.peoplecontact.internal.entity;
+
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Typed contact point (email, phone) owned by a {@link Person}. pos-people-contact is the
+ * source of truth for person contact data (ADR-0015 I2); consolidates the contact
+ * taxonomy previously held only in pos-customer.contact_point.
+ */
+@Entity
+@Table(
+        name = "person_contact_point",
+        indexes = {
+            @Index(name = "idx_person_contact_point_person", columnList = "person_id"),
+            @Index(name = "idx_person_contact_point_type", columnList = "contact_type")
+        })
+@EntityListeners(AuditingEntityListener.class)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PersonContactPoint {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "id", columnDefinition = "UUID", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "person_id", nullable = false)
+    private UUID personId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contact_type", nullable = false, length = 20)
+    private ContactPointType contactType;
+
+    // `value` is a reserved word in H2 (and some dialects); backtick-quote so Hibernate
+    // emits a dialect-quoted identifier that maps to the existing lowercase `value` column.
+    @Column(name = "`value`", nullable = false, length = 255)
+    private String value;
+
+    @Column(name = "is_primary", nullable = false)
+    private boolean isPrimary;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/UserPersonLink.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/UserPersonLink.java
@@ -1,0 +1,81 @@
+package com.positivity.peoplecontact.internal.entity;
+
+import com.positivity.peoplecontact.internal.enums.UserLinkStatus;
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Entity representing a link between a security user and a person. The user is identified by
+ * its {@code username} (the credential identifier owned by pos-security), enforced unique to
+ * keep a one-to-one mapping between users and persons. Resolving a person's username reads
+ * this link directly — no pos-security round-trip.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "user_person_links",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uq_user_person_links_username",
+                        columnNames = {"username"}),
+        indexes = @Index(name = "idx_user_person_links_person_id", columnList = "person_id"))
+@Getter
+@Setter
+public class UserPersonLink {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(name = "username", nullable = false, unique = true, length = 255)
+    @NonNull
+    private String username;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "person_id", nullable = false)
+    @NonNull
+    private Person person;
+
+    public UUID getPersonId() {
+        return person != null ? person.getId() : null;
+    }
+
+    @Column(name = "link_type", length = 50)
+    private String linkType = "PRIMARY";
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    @NonNull
+    private UserLinkStatus status;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @Column(name = "created_by", length = 255)
+    private String createdBy;
+
+    @Column(name = "notes", length = 1000)
+    private String notes;
+
+    @PrePersist
+    protected void onCreate() {
+        if (status == null) {
+            status = UserLinkStatus.ACTIVE;
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/enums/ContactPointType.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/enums/ContactPointType.java
@@ -1,0 +1,12 @@
+package com.positivity.peoplecontact.internal.enums;
+
+/**
+ * Type of a person contact point. Mirrors the customer-domain contact taxonomy
+ * so contact data can be consolidated in pos-people-contact (ADR-0015 I2, ADR-0044 §6).
+ */
+public enum ContactPointType {
+    EMAIL,
+    PHONE_MOBILE,
+    PHONE_HOME,
+    PHONE_WORK
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/enums/DuplicatePolicy.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/enums/DuplicatePolicy.java
@@ -1,0 +1,6 @@
+package com.positivity.peoplecontact.internal.enums;
+
+public enum DuplicatePolicy {
+    STRICT,
+    BALANCED
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/enums/UserLinkStatus.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/enums/UserLinkStatus.java
@@ -1,0 +1,15 @@
+package com.positivity.peoplecontact.internal.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Status of a user-person link.
+ */
+@Schema(description = "Status of a user-person link")
+public enum UserLinkStatus {
+    @Schema(description = "Link is active - user is currently associated with person")
+    ACTIVE,
+
+    @Schema(description = "Link is inactive - historical association that is no longer active")
+    INACTIVE
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/NotFoundException.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.positivity.peoplecontact.internal.exception;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/PersonNotFoundException.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/PersonNotFoundException.java
@@ -1,0 +1,10 @@
+package com.positivity.peoplecontact.internal.exception;
+
+import java.util.UUID;
+
+public class PersonNotFoundException extends RuntimeException {
+
+    public PersonNotFoundException(UUID personId) {
+        super("Person not found with id: " + personId);
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/SemanticValidationException.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/SemanticValidationException.java
@@ -1,0 +1,8 @@
+package com.positivity.peoplecontact.internal.exception;
+
+public class SemanticValidationException extends RuntimeException {
+
+    public SemanticValidationException(String message) {
+        super(message);
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/UserAlreadyLinkedException.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/UserAlreadyLinkedException.java
@@ -1,0 +1,15 @@
+package com.positivity.peoplecontact.internal.exception;
+
+import java.util.UUID;
+
+public class UserAlreadyLinkedException extends RuntimeException {
+
+    public UserAlreadyLinkedException(String username) {
+        super("User " + username + " is already linked to a person");
+    }
+
+    public UserAlreadyLinkedException(String username, UUID currentPersonId, UUID requestedPersonId) {
+        super("User " + username + " is already linked to person " + currentPersonId
+                + " and cannot be linked to person " + requestedPersonId);
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/UserPersonLinkNotFoundException.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/UserPersonLinkNotFoundException.java
@@ -1,0 +1,14 @@
+package com.positivity.peoplecontact.internal.exception;
+
+import java.util.UUID;
+
+public class UserPersonLinkNotFoundException extends RuntimeException {
+
+    public UserPersonLinkNotFoundException(String username) {
+        super("No person link found for user: " + username);
+    }
+
+    public UserPersonLinkNotFoundException(UUID personId) {
+        super("No person link found for person: " + personId);
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/OutboxEventRepository.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/OutboxEventRepository.java
@@ -1,0 +1,46 @@
+package com.positivity.peoplecontact.internal.repository;
+
+import com.positivity.peoplecontact.internal.entity.OutboxEvent;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+
+    /** Oldest unpublished rows first — UUIDv7 ids are time-ordered, preserving publish order. */
+    @NonNull
+    List<OutboxEvent> findTop100ByPublishedAtIsNullOrderByIdAsc();
+
+    /**
+     * Published rows of one topic whose {@code createdAt} falls in the given range, for
+     * reconciliation-manifest computation (ADR-0044 §4). Callers pass the window padded by a small
+     * slack and re-filter precisely by the eventId's UUIDv7 timestamp, since {@code createdAt} and
+     * the payload's eventId are stamped microseconds apart.
+     */
+    @NonNull
+    List<OutboxEvent> findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(
+            @NonNull String topic, @NonNull Instant from, @NonNull Instant to);
+
+    /**
+     * Mark already-published events created at or after {@code since} for re-publication
+     * (ADR-0044 backfill/drift repair). The publisher re-sends them; consumers dedupe by eventId.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update OutboxEvent e set e.publishedAt = null, e.attempts = 0, e.lastError = null"
+            + " where e.publishedAt is not null and e.createdAt >= :since")
+    int markForReplaySince(@Param("since") @NonNull Instant since);
+
+    /**
+     * Bounded variant for manifest-driven drift repair: re-queue only the drifted window instead
+     * of everything since {@code since}.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update OutboxEvent e set e.publishedAt = null, e.attempts = 0, e.lastError = null"
+            + " where e.publishedAt is not null and e.createdAt >= :since and e.createdAt < :until")
+    int markForReplayBetween(@Param("since") @NonNull Instant since, @Param("until") @NonNull Instant until);
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/PersonContactPointRepository.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/PersonContactPointRepository.java
@@ -1,0 +1,39 @@
+package com.positivity.peoplecontact.internal.repository;
+
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Repository for {@link PersonContactPoint}. Supports batch loading by person id
+ * for the people directory and cross-service identity reads.
+ */
+public interface PersonContactPointRepository extends JpaRepository<PersonContactPoint, UUID> {
+
+    List<PersonContactPoint> findByPersonId(@NonNull UUID personId);
+
+    List<PersonContactPoint> findByPersonIdIn(@NonNull Collection<UUID> personIds);
+
+    List<PersonContactPoint> findByPersonIdAndContactType(
+            @NonNull UUID personId, @NonNull ContactPointType contactType);
+
+    List<PersonContactPoint> findByContactTypeAndValue(@NonNull ContactPointType contactType, @NonNull String value);
+
+    List<PersonContactPoint> findByContactTypeAndValueIgnoreCase(
+            @NonNull ContactPointType contactType, @NonNull String value);
+
+    List<PersonContactPoint> findByContactTypeAndIsPrimaryAndValueIgnoreCase(
+            @NonNull ContactPointType contactType, boolean isPrimary, @NonNull String value);
+
+    void deleteByPersonId(@NonNull UUID personId);
+
+    @Modifying
+    @Transactional
+    void deleteByPersonIdAndContactType(@NonNull UUID personId, @NonNull ContactPointType contactType);
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/PersonRepository.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/PersonRepository.java
@@ -1,0 +1,14 @@
+package com.positivity.peoplecontact.internal.repository;
+
+import com.positivity.peoplecontact.internal.entity.Person;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface PersonRepository extends JpaRepository<Person, UUID>, JpaSpecificationExecutor<Person> {
+
+    List<Person> findByLastNameIgnoreCase(String lastName);
+
+    List<Person> findByFirstNameIgnoreCase(String firstName);
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/PersonSpecifications.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/PersonSpecifications.java
@@ -1,0 +1,48 @@
+package com.positivity.peoplecontact.internal.repository;
+
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.domain.Specification;
+
+public final class PersonSpecifications {
+
+    private PersonSpecifications() {}
+
+    /**
+     * Directory search over identity data only. Employment lives in pos-people (ADR-0044 §6),
+     * so employment-status filtering is not available here — HR-facing directory views query
+     * pos-people instead.
+     */
+    public static Specification<Person> directoryFilter(String q) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (q != null && !q.isBlank()) {
+                String pattern = "%" + q.trim().toLowerCase() + "%";
+                // Email lives in person_contact_point; match it via a correlated subquery
+                // on EMAIL contact-point values. Username is owned by pos-security (resolved
+                // via user_person_link) and is not a Person column, so it is not searchable here.
+                Subquery<UUID> emailMatch = query.subquery(UUID.class);
+                Root<PersonContactPoint> cp = emailMatch.from(PersonContactPoint.class);
+                emailMatch
+                        .select(cp.get("personId"))
+                        .where(cb.and(
+                                cb.equal(cp.get("contactType"), ContactPointType.EMAIL),
+                                cb.like(cb.lower(cp.get("value")), pattern)));
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("firstName")), pattern),
+                        cb.like(cb.lower(root.get("lastName")), pattern),
+                        root.get("id").in(emailMatch)));
+            }
+
+            return predicates.isEmpty() ? cb.conjunction() : cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/UserPersonLinkRepository.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/UserPersonLinkRepository.java
@@ -1,0 +1,30 @@
+package com.positivity.peoplecontact.internal.repository;
+
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import com.positivity.peoplecontact.internal.enums.UserLinkStatus;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPersonLinkRepository extends JpaRepository<UserPersonLink, UUID> {
+
+    Optional<UserPersonLink> findByUsername(@NonNull String username);
+
+    List<UserPersonLink> findByPerson_Id(@NonNull UUID personId);
+
+    List<UserPersonLink> findByPerson_IdIn(@NonNull Collection<UUID> personIds);
+
+    Optional<UserPersonLink> findByPerson_IdAndStatus(@NonNull UUID personId, @NonNull UserLinkStatus status);
+
+    Optional<UserPersonLink> findFirstByPerson_IdAndStatusOrderByCreatedAtDesc(
+            @NonNull UUID personId, @NonNull UserLinkStatus status);
+
+    boolean existsByUsername(@NonNull String username);
+
+    boolean existsByUsernameAndPerson_Id(@NonNull String username, @NonNull UUID personId);
+
+    void deleteByUsername(@NonNull String username);
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/OutboxReplayServiceImpl.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/OutboxReplayServiceImpl.java
@@ -1,0 +1,34 @@
+package com.positivity.peoplecontact.internal.service;
+
+import com.positivity.peoplecontact.internal.repository.OutboxEventRepository;
+import com.positivity.peoplecontact.service.OutboxReplayService;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxReplayServiceImpl implements OutboxReplayService {
+
+    private final OutboxEventRepository outboxEventRepository;
+
+    @Override
+    @Transactional
+    public int replaySince(@NonNull Instant since) {
+        int count = outboxEventRepository.markForReplaySince(since);
+        log.info("Outbox replay requested since={} eventsQueued={}", since, count);
+        return count;
+    }
+
+    @Override
+    @Transactional
+    public int replayBetween(@NonNull Instant since, @NonNull Instant until) {
+        int count = outboxEventRepository.markForReplayBetween(since, until);
+        log.info("Outbox replay requested window=[{}, {}) eventsQueued={}", since, until, count);
+        return count;
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PeopleAccessControlServiceImpl.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PeopleAccessControlServiceImpl.java
@@ -1,0 +1,109 @@
+package com.positivity.peoplecontact.internal.service;
+
+import com.positivity.peoplecontact.internal.client.SecurityServiceClient;
+import com.positivity.peoplecontact.internal.client.dto.RoleDto;
+import com.positivity.peoplecontact.internal.client.dto.UserRoleAssignmentRequest;
+import com.positivity.peoplecontact.internal.client.dto.UserRoleDto;
+import com.positivity.peoplecontact.internal.exception.PersonNotFoundException;
+import com.positivity.peoplecontact.internal.repository.PersonRepository;
+import com.positivity.peoplecontact.service.PeopleAccessControlService;
+import com.positivity.peoplecontact.service.UserPersonTranslationService;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class PeopleAccessControlServiceImpl implements PeopleAccessControlService {
+
+    private static final String LOCATION_SCOPE = "LOCATION";
+
+    private static final String GLOBAL_SCOPE = "GLOBAL";
+
+    private final UserPersonTranslationService userPersonTranslationService;
+
+    private final SecurityServiceClient securityServiceClient;
+
+    private final PersonRepository personRepository;
+
+    public PeopleAccessControlServiceImpl(
+            @NonNull UserPersonTranslationService userPersonTranslationService,
+            @NonNull SecurityServiceClient securityServiceClient,
+            @NonNull PersonRepository personRepository) {
+        this.userPersonTranslationService = userPersonTranslationService;
+        this.securityServiceClient = securityServiceClient;
+        this.personRepository = personRepository;
+    }
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public List<RoleDto> getAvailableRolesForPerson(@NonNull UUID personUuid) {
+        // Validate that the person exists
+        if (!personRepository.existsById(personUuid)) {
+            throw new PersonNotFoundException(personUuid);
+        }
+
+        List<RoleDto> allRoles = new ArrayList<>();
+        allRoles.addAll(securityServiceClient.getAvailableRoles(LOCATION_SCOPE));
+        allRoles.addAll(securityServiceClient.getAvailableRoles(GLOBAL_SCOPE));
+        return allRoles;
+    }
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public List<UserRoleDto> getPersonRoleAssignments(
+            @NonNull UUID personUuid, boolean includeHistory, LocalDateTime endDate) {
+        UUID userId = resolveUserId(personUuid);
+        return securityServiceClient.getUserRoleAssignments(userId, includeHistory, endDate);
+    }
+
+    @Override
+    @NonNull
+    public UserRoleDto assignRoleToPerson(
+            @NonNull UUID personUuid,
+            @NonNull String roleCode,
+            UUID locationId,
+            LocalDateTime startDate,
+            LocalDateTime endDate) {
+        validateDateWindow(startDate, endDate);
+        UUID userId = resolveUserId(personUuid);
+        UserRoleAssignmentRequest request = UserRoleAssignmentRequest.builder()
+                .userId(userId)
+                .roleCode(roleCode)
+                .locationId(locationId)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+        return securityServiceClient.assignRole(request);
+    }
+
+    @Override
+    public void revokeRoleFromPerson(@NonNull UUID personUuid, @NonNull String roleCode, LocalDateTime endDate) {
+        UUID userId = resolveUserId(personUuid);
+        securityServiceClient.revokeRole(userId, roleCode, endDate);
+    }
+
+    @NonNull
+    private UUID resolveUserId(@NonNull UUID personUuid) {
+        String username = userPersonTranslationService
+                .getUsernameForPerson(personUuid)
+                .orElseThrow(() -> new EntityNotFoundException("No user link found for personUuid: " + personUuid));
+        return securityServiceClient
+                .getUserByUsername(username)
+                .map(com.positivity.peoplecontact.internal.client.dto.User::getId)
+                .orElseThrow(() -> new EntityNotFoundException("No security user found for username: " + username));
+    }
+
+    private void validateDateWindow(LocalDateTime startDate, LocalDateTime endDate) {
+        if (startDate != null && endDate != null && endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("endDate must be greater than or equal to startDate");
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonEmailService.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonEmailService.java
@@ -1,0 +1,90 @@
+package com.positivity.peoplecontact.internal.service;
+
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import com.positivity.peoplecontact.internal.repository.PersonContactPointRepository;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Reads and writes a person's primary/secondary email through {@link PersonContactPoint}
+ * rows of type {@link ContactPointType#EMAIL} (primary = {@code isPrimary} true),
+ * replacing the former primary_email / secondary_email columns on Person.
+ */
+@Service
+@RequiredArgsConstructor
+public class PersonEmailService {
+
+    private final PersonContactPointRepository contactPointRepository;
+
+    /** Primary + secondary email for a person. */
+    public record EmailPair(
+            @Nullable String primary, @Nullable String secondary) {}
+
+    public @NonNull EmailPair getEmails(@NonNull UUID personId) {
+        List<PersonContactPoint> points =
+                contactPointRepository.findByPersonIdAndContactType(personId, ContactPointType.EMAIL);
+        String primary = points.stream()
+                .filter(PersonContactPoint::isPrimary)
+                .map(PersonContactPoint::getValue)
+                .findFirst()
+                .orElseGet(() -> points.stream()
+                        .map(PersonContactPoint::getValue)
+                        .findFirst()
+                        .orElse(null));
+        String secondary = points.stream()
+                .filter(p -> !p.isPrimary())
+                .map(PersonContactPoint::getValue)
+                .filter(value -> !Objects.equals(value, primary))
+                .findFirst()
+                .orElse(null);
+        return new EmailPair(primary, secondary);
+    }
+
+    /** Replace a person's email contact points with the given primary/secondary (blanks skipped). */
+    @Transactional
+    public void replaceEmails(@NonNull UUID personId, @Nullable String primary, @Nullable String secondary) {
+        contactPointRepository.deleteByPersonIdAndContactType(personId, ContactPointType.EMAIL);
+        if (primary != null && !primary.isBlank()) {
+            contactPointRepository.save(build(personId, primary.trim(), true));
+        }
+        if (secondary != null && !secondary.isBlank()) {
+            contactPointRepository.save(build(personId, secondary.trim(), false));
+        }
+    }
+
+    /** Person ids that hold the given value as any EMAIL contact point (case-insensitive). */
+    public @NonNull List<UUID> findPersonIdsByEmail(@NonNull String email) {
+        return contactPointRepository.findByContactTypeAndValueIgnoreCase(ContactPointType.EMAIL, email).stream()
+                .map(PersonContactPoint::getPersonId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    /** Person ids that hold the given value as a PRIMARY email (case-insensitive); duplicate detection. */
+    public @NonNull List<UUID> findPersonIdsByPrimaryEmail(@NonNull String email) {
+        return contactPointRepository
+                .findByContactTypeAndIsPrimaryAndValueIgnoreCase(ContactPointType.EMAIL, true, email)
+                .stream()
+                .map(PersonContactPoint::getPersonId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private PersonContactPoint build(UUID personId, String value, boolean primary) {
+        return PersonContactPoint.builder()
+                .personId(personId)
+                .contactType(ContactPointType.EMAIL)
+                .value(value)
+                .isPrimary(primary)
+                .build();
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonServiceImpl.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonServiceImpl.java
@@ -1,0 +1,344 @@
+package com.positivity.peoplecontact.internal.service;
+
+import com.positivity.peoplecontact.internal.config.PeopleContactEventPublisher;
+import com.positivity.peoplecontact.internal.dto.Person;
+import com.positivity.peoplecontact.internal.dto.ResolvePersonRequest;
+import com.positivity.peoplecontact.internal.dto.ResolvePersonResponse;
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.repository.PersonContactPointRepository;
+import com.positivity.peoplecontact.internal.repository.PersonRepository;
+import com.positivity.peoplecontact.internal.repository.PersonSpecifications;
+import com.positivity.peoplecontact.service.PersonService;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PersonServiceImpl implements PersonService {
+
+    private static final int EMAIL_WEIGHT = 60;
+
+    private static final int PHONE_WEIGHT = 25;
+
+    private static final int LAST_NAME_WEIGHT = 10;
+
+    private static final int FIRST_NAME_WEIGHT = 5;
+
+    private final PersonRepository personRepository;
+
+    private final PersonContactPointRepository personContactPointRepository;
+
+    private final PeopleContactEventPublisher eventPublisher;
+
+    private final PersonWorkPhoneService workPhoneService;
+
+    private final PersonEmailService emailService;
+
+    private final PersonUsernameService usernameService;
+
+    @Value("${pos.people-contact.matching.threshold:30}")
+    private int defaultMatchingThreshold;
+
+    @Override
+    @NonNull
+    public List<Person> getAllPeople(@Nullable String q) {
+        List<Person> people = personRepository.findAll(PersonSpecifications.directoryFilter(q)).stream()
+                .map(this::toDto)
+                .toList();
+        List<UUID> ids = people.stream().map(Person::getId).toList();
+        Map<UUID, String> usernames = usernameService.usernamesByPersonId(ids);
+        people.forEach(p -> p.setUsername(usernames.get(p.getId())));
+        return people;
+    }
+
+    @Override
+    @NonNull
+    public Optional<Person> getPersonById(@NonNull UUID id) {
+        return personRepository.findById(id).map(this::toDto).map(dto -> {
+            dto.setUsername(usernameService.usernameForPerson(id));
+            return dto;
+        });
+    }
+
+    @Override
+    @NonNull
+    public List<Person> getPeopleByIds(@NonNull Collection<UUID> ids) {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        List<Person> people =
+                personRepository.findAllById(ids).stream().map(this::toDto).toList();
+
+        // Attach typed contact points (pos-people-contact is SoT for contacts, ADR-0015 I2), batched.
+        Map<UUID, List<Person.ContactPointDto>> contactsByPerson =
+                personContactPointRepository.findByPersonIdIn(ids).stream()
+                        .collect(Collectors.groupingBy(
+                                PersonContactPoint::getPersonId,
+                                Collectors.mapping(
+                                        cp -> new Person.ContactPointDto(
+                                                cp.getContactType(), cp.getValue(), cp.isPrimary()),
+                                        Collectors.toList())));
+        people.forEach(p -> p.setContactPoints(contactsByPerson.getOrDefault(p.getId(), List.of())));
+
+        Map<UUID, String> usernames = usernameService.usernamesByPersonId(ids);
+        people.forEach(p -> p.setUsername(usernames.get(p.getId())));
+        return people;
+    }
+
+    @Override
+    @Transactional
+    public void replaceContactPoints(@NonNull UUID personId, @NonNull List<Person.ContactPointDto> contactPoints) {
+        personContactPointRepository.deleteByPersonId(personId);
+        if (contactPoints.isEmpty()) {
+            return;
+        }
+        List<PersonContactPoint> entities = contactPoints.stream()
+                .filter(cp -> cp.getContactType() != null && cp.getValue() != null)
+                .map(cp -> PersonContactPoint.builder()
+                        .personId(personId)
+                        .contactType(cp.getContactType())
+                        .value(cp.getValue())
+                        .isPrimary(cp.isPrimary())
+                        .build())
+                .toList();
+        personContactPointRepository.saveAll(entities);
+        publishPersonUpdated(personId);
+    }
+
+    @Override
+    @Transactional
+    @NonNull
+    public Person savePerson(@NonNull Person person) {
+        // Username is owned by pos-security and linked via user_person_link; it is not a
+        // Person attribute and is not persisted here.
+        com.positivity.peoplecontact.internal.entity.Person saved = personRepository.save(toEntity(person));
+        workPhoneService.replaceWorkPhones(
+                saved.getId(), person.getPhoneNumbers() == null ? List.of() : person.getPhoneNumbers());
+        emailService.replaceEmails(saved.getId(), person.getPrimaryEmail(), person.getSecondaryEmail());
+        publishPersonUpdated(saved.getId());
+        Person dto = toDto(saved);
+        dto.setUsername(usernameService.usernameForPerson(saved.getId()));
+        return dto;
+    }
+
+    @Override
+    @Transactional
+    @NonNull
+    public ResolvePersonResponse resolvePerson(@NonNull ResolvePersonRequest request) {
+        String email = normalizeEmail(request.getEmail());
+        String phone = normalizePhone(request.getPhone());
+        String lastName = normalizeText(request.getLastName());
+        String firstName = normalizeText(request.getFirstName());
+
+        if (email == null && phone == null && lastName == null && firstName == null) {
+            throw new IllegalArgumentException("At least one of email, phone, lastName, or firstName is required");
+        }
+
+        int threshold = resolveThreshold(request.getThreshold());
+        Map<UUID, ScoredCandidate> candidates = new HashMap<>();
+
+        if (email != null) {
+            List<UUID> emailMatchIds = emailService.findPersonIdsByEmail(email);
+            if (!emailMatchIds.isEmpty()) {
+                personRepository
+                        .findAllById(emailMatchIds)
+                        .forEach(person -> addScore(candidates, person, EMAIL_WEIGHT, "EMAIL"));
+            }
+        }
+
+        if (phone != null) {
+            List<UUID> phoneMatchIds = workPhoneService.findPersonIdsByWorkPhone(phone);
+            if (!phoneMatchIds.isEmpty()) {
+                personRepository
+                        .findAllById(phoneMatchIds)
+                        .forEach(person -> addScore(candidates, person, PHONE_WEIGHT, "PHONE"));
+            }
+        }
+
+        if (lastName != null) {
+            personRepository
+                    .findByLastNameIgnoreCase(lastName)
+                    .forEach(person -> addScore(candidates, person, LAST_NAME_WEIGHT, "LAST_NAME"));
+        }
+
+        if (firstName != null) {
+            personRepository
+                    .findByFirstNameIgnoreCase(firstName)
+                    .forEach(person -> addScore(candidates, person, FIRST_NAME_WEIGHT, "FIRST_NAME"));
+        }
+
+        Optional<ScoredCandidate> best = candidates.values().stream()
+                .max(Comparator.comparingInt(ScoredCandidate::getScore)
+                        .thenComparing(
+                                candidate -> candidate.getPerson().getUpdatedAt(),
+                                Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(candidate -> candidate.getPerson().getId()));
+
+        if (best.isPresent() && best.get().getScore() >= threshold) {
+            ScoredCandidate matched = best.get();
+            return ResolvePersonResponse.builder()
+                    .personId(matched.getPerson().getId())
+                    .matchedExisting(true)
+                    .score(matched.getScore())
+                    .thresholdApplied(threshold)
+                    .matchedBy(new ArrayList<>(matched.getMatchedBy()))
+                    .firstName(matched.getPerson().getFirstName())
+                    .lastName(matched.getPerson().getLastName())
+                    .primaryEmail(
+                            emailService.getEmails(matched.getPerson().getId()).primary())
+                    .phoneNumbers(
+                            workPhoneService.getWorkPhones(matched.getPerson().getId()))
+                    .build();
+        }
+
+        com.positivity.peoplecontact.internal.entity.Person entity =
+                new com.positivity.peoplecontact.internal.entity.Person();
+        entity.setFirstName(firstName);
+        entity.setLastName(lastName);
+
+        com.positivity.peoplecontact.internal.entity.Person created = personRepository.save(entity);
+        List<String> createdPhones = phone != null ? List.of(phone) : List.of();
+        workPhoneService.replaceWorkPhones(created.getId(), createdPhones);
+        emailService.replaceEmails(created.getId(), email, null);
+        publishPersonUpdated(created.getId());
+        return ResolvePersonResponse.builder()
+                .personId(created.getId())
+                .matchedExisting(false)
+                .score(0)
+                .thresholdApplied(threshold)
+                .matchedBy(List.of("CREATED"))
+                .firstName(created.getFirstName())
+                .lastName(created.getLastName())
+                .primaryEmail(email)
+                .phoneNumbers(createdPhones)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void deletePerson(@NonNull UUID id) {
+        personRepository.deleteById(id);
+        eventPublisher.publishPersonDeleted(id);
+    }
+
+    /** Re-read the committed identity snapshot and queue a person.updated fact (ADR-0044 §6). */
+    private void publishPersonUpdated(@NonNull UUID personId) {
+        personRepository
+                .findById(personId)
+                .ifPresent(entity -> eventPublisher.publishPersonUpdated(
+                        entity, personContactPointRepository.findByPersonId(personId)));
+    }
+
+    private int resolveThreshold(Integer thresholdOverride) {
+        int threshold = thresholdOverride != null ? thresholdOverride : defaultMatchingThreshold;
+        return Math.max(0, threshold);
+    }
+
+    private void addScore(
+            Map<UUID, ScoredCandidate> candidates,
+            com.positivity.peoplecontact.internal.entity.Person person,
+            int score,
+            String reason) {
+        ScoredCandidate candidate = candidates.computeIfAbsent(person.getId(), ignored -> new ScoredCandidate(person));
+        candidate.add(score, reason);
+    }
+
+    private String normalizeText(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private String normalizeEmail(String email) {
+        String normalized = normalizeText(email);
+        return normalized == null ? null : normalized.toLowerCase();
+    }
+
+    private String normalizePhone(String phone) {
+        String normalized = normalizeText(phone);
+        if (normalized == null) {
+            return null;
+        }
+        String digits = normalized.replaceAll("[^0-9]", "");
+        if (digits.isEmpty()) {
+            return null;
+        }
+        if (normalized.startsWith("+")) {
+            return "+" + digits;
+        }
+        return digits;
+    }
+
+    private Person toDto(com.positivity.peoplecontact.internal.entity.Person entity) {
+        Person dto = new Person();
+        dto.setId(entity.getId());
+        dto.setFirstName(entity.getFirstName());
+        dto.setLastName(entity.getLastName());
+        PersonEmailService.EmailPair emails = emailService.getEmails(entity.getId());
+        dto.setPrimaryEmail(emails.primary());
+        dto.setSecondaryEmail(emails.secondary());
+        dto.setPhoneNumbers(workPhoneService.getWorkPhones(entity.getId()));
+        // username resolved by the caller (single or batched) from user_person_link;
+        // not stored on the Person entity. Employment data lives in pos-people (ADR-0044 §6).
+        return dto;
+    }
+
+    private com.positivity.peoplecontact.internal.entity.Person toEntity(Person dto) {
+        com.positivity.peoplecontact.internal.entity.Person entity =
+                new com.positivity.peoplecontact.internal.entity.Person();
+        entity.setId(dto.getId());
+        entity.setFirstName(dto.getFirstName());
+        entity.setLastName(dto.getLastName());
+        // email + phoneNumbers persisted separately as contact points; username owned by pos-security.
+        return entity;
+    }
+
+    private static final class ScoredCandidate {
+
+        private final com.positivity.peoplecontact.internal.entity.Person person;
+
+        private final Set<String> matchedBy = new LinkedHashSet<>();
+
+        private int score;
+
+        private ScoredCandidate(com.positivity.peoplecontact.internal.entity.Person person) {
+            this.person = person;
+        }
+
+        private void add(int delta, String reason) {
+            this.score += delta;
+            this.matchedBy.add(reason);
+        }
+
+        private com.positivity.peoplecontact.internal.entity.Person getPerson() {
+            return person;
+        }
+
+        private int getScore() {
+            return score;
+        }
+
+        private Set<String> getMatchedBy() {
+            return matchedBy;
+        }
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonUsernameService.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonUsernameService.java
@@ -1,0 +1,49 @@
+package com.positivity.peoplecontact.internal.service;
+
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves a person's username from the user_person_link mapping. The username (the credential
+ * identifier owned by pos-security) is stored directly on the link, so resolution is a local
+ * read — no pos-security round-trip. Username is not a Person attribute.
+ */
+@Service
+@RequiredArgsConstructor
+public class PersonUsernameService {
+
+    private final UserPersonLinkRepository linkRepository;
+
+    /** Username for a single person, or null if unlinked. */
+    public @Nullable String usernameForPerson(@NonNull UUID personId) {
+        Optional<String> username = linkRepository.findByPerson_Id(personId).stream()
+                .map(UserPersonLink::getUsername)
+                .filter(Objects::nonNull)
+                .findFirst();
+        return username.isPresent() ? username.get() : null;
+    }
+
+    /** Batch personId → username for directory/list paths. */
+    public @NonNull Map<UUID, String> usernamesByPersonId(@NonNull Collection<UUID> personIds) {
+        if (personIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<UUID, String> result = new HashMap<>();
+        for (UserPersonLink link : linkRepository.findByPerson_IdIn(personIds)) {
+            if (link.getPerson() != null && link.getUsername() != null) {
+                result.putIfAbsent(link.getPerson().getId(), link.getUsername());
+            }
+        }
+        return result;
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonWorkPhoneService.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonWorkPhoneService.java
@@ -1,0 +1,81 @@
+package com.positivity.peoplecontact.internal.service;
+
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import com.positivity.peoplecontact.internal.repository.PersonContactPointRepository;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Reads and writes a person's work phone numbers through
+ * {@link PersonContactPoint} rows of type {@link ContactPointType#PHONE_WORK},
+ * consolidating the former {@code person_phone_numbers} element collection into the
+ * single contact-point store.
+ */
+@Service
+@RequiredArgsConstructor
+public class PersonWorkPhoneService {
+
+    private final PersonContactPointRepository contactPointRepository;
+
+    /** Work phone values for a person, primary first. */
+    public @NonNull List<String> getWorkPhones(@NonNull UUID personId) {
+        return contactPointRepository.findByPersonIdAndContactType(personId, ContactPointType.PHONE_WORK).stream()
+                .sorted(Comparator.comparing(PersonContactPoint::isPrimary)
+                        .reversed()
+                        .thenComparing(p -> p.getCreatedAt() == null ? Instant.EPOCH : p.getCreatedAt()))
+                .map(PersonContactPoint::getValue)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /** Batch variant: personId → work phone values. */
+    public @NonNull Map<UUID, List<String>> getWorkPhones(@NonNull Collection<UUID> personIds) {
+        if (personIds.isEmpty()) {
+            return Map.of();
+        }
+        return contactPointRepository.findByPersonIdIn(personIds).stream()
+                .filter(p -> p.getContactType() == ContactPointType.PHONE_WORK && p.getValue() != null)
+                .collect(Collectors.groupingBy(
+                        PersonContactPoint::getPersonId,
+                        Collectors.mapping(PersonContactPoint::getValue, Collectors.toList())));
+    }
+
+    /** Replace all of a person's work phones with the given list (first becomes primary). */
+    @Transactional
+    public void replaceWorkPhones(@NonNull UUID personId, @NonNull List<String> phones) {
+        contactPointRepository.deleteByPersonIdAndContactType(personId, ContactPointType.PHONE_WORK);
+        boolean primary = true;
+        for (String phone : phones) {
+            if (phone == null || phone.isBlank()) {
+                continue;
+            }
+            contactPointRepository.save(PersonContactPoint.builder()
+                    .personId(personId)
+                    .contactType(ContactPointType.PHONE_WORK)
+                    .value(phone.trim())
+                    .isPrimary(primary)
+                    .build());
+            primary = false;
+        }
+    }
+
+    /** Person ids that have the given value as a work phone (duplicate detection). */
+    public @NonNull List<UUID> findPersonIdsByWorkPhone(@NonNull String phone) {
+        return contactPointRepository.findByContactTypeAndValue(ContactPointType.PHONE_WORK, phone).stream()
+                .map(PersonContactPoint::getPersonId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/UserPersonLinkServiceImpl.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/UserPersonLinkServiceImpl.java
@@ -1,0 +1,205 @@
+package com.positivity.peoplecontact.internal.service;
+
+import com.positivity.peoplecontact.internal.config.PeopleContactEventPublisher;
+import com.positivity.peoplecontact.internal.dto.LinkUserToPersonRequest;
+import com.positivity.peoplecontact.internal.dto.PersonResponse;
+import com.positivity.peoplecontact.internal.dto.UserPersonLinkResponse;
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import com.positivity.peoplecontact.internal.exception.PersonNotFoundException;
+import com.positivity.peoplecontact.internal.exception.UserAlreadyLinkedException;
+import com.positivity.peoplecontact.internal.exception.UserPersonLinkNotFoundException;
+import com.positivity.peoplecontact.internal.repository.PersonRepository;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
+import com.positivity.peoplecontact.service.UserPersonLinkService;
+import com.positivity.security.common.SecurityContextHelper;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class UserPersonLinkServiceImpl implements UserPersonLinkService {
+
+    private static final String SYSTEM_USER = "system";
+
+    private final UserPersonLinkRepository linkRepository;
+
+    private final PeopleContactEventPublisher eventPublisher;
+
+    private final PersonRepository personRepository;
+
+    private final PersonWorkPhoneService workPhoneService;
+
+    private final PersonEmailService emailService;
+
+    private final PersonUsernameService usernameService;
+
+    public UserPersonLinkServiceImpl(
+            @NonNull UserPersonLinkRepository linkRepository,
+            @NonNull PersonRepository personRepository,
+            @NonNull PersonWorkPhoneService workPhoneService,
+            @NonNull PersonEmailService emailService,
+            @NonNull PersonUsernameService usernameService,
+            @NonNull PeopleContactEventPublisher eventPublisher) {
+        this.linkRepository = linkRepository;
+        this.personRepository = personRepository;
+        this.workPhoneService = workPhoneService;
+        this.emailService = emailService;
+        this.usernameService = usernameService;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override
+    public boolean linkExistsByUsername(@NonNull String username) {
+        return linkRepository.existsByUsername(username);
+    }
+
+    @Override
+    public boolean linkExistsByUsernameAndPersonId(@NonNull String username, @NonNull UUID personId) {
+        return linkRepository.existsByUsernameAndPerson_Id(username, personId);
+    }
+
+    @Override
+    @NonNull
+    public UserPersonLinkResponse createUserLink(@NonNull String username, @NonNull UUID personId) {
+        Person person = personRepository.findById(personId).orElseThrow(() -> new PersonNotFoundException(personId));
+
+        if (linkRepository.existsByUsername(username)) {
+            UserPersonLink existingLink =
+                    linkRepository.findByUsername(username).orElseThrow(() -> new UserAlreadyLinkedException(username));
+            if (existingLink.getPersonId().equals(personId)) {
+                return toResponse(existingLink);
+            }
+            throw new UserAlreadyLinkedException(username, existingLink.getPersonId(), personId);
+        }
+
+        UserPersonLink link = new UserPersonLink();
+        link.setUsername(username);
+        link.setPerson(person);
+        link.setLinkType("PRIMARY");
+        link.setCreatedBy(SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_USER));
+        try {
+            UserPersonLink saved = linkRepository.save(link);
+            eventPublisher.publishLinkUpdated(saved);
+            return toResponse(saved);
+        } catch (DataIntegrityViolationException e) {
+            UserPersonLink existingLink =
+                    linkRepository.findByUsername(username).orElseThrow(() -> e);
+            if (existingLink.getPersonId().equals(personId)) {
+                return toResponse(existingLink);
+            }
+            throw new UserAlreadyLinkedException(username, existingLink.getPersonId(), personId);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @NonNull
+    public List<UserPersonLinkResponse> getUserLinks(@NonNull UUID personId) {
+        personRepository.findById(personId).orElseThrow(() -> new PersonNotFoundException(personId));
+
+        return linkRepository.findByPerson_Id(personId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Override
+    @NonNull
+    public UserPersonLinkResponse linkUserToPerson(@NonNull LinkUserToPersonRequest request) {
+        UserPersonLinkResponse response = createUserLink(request.getUsername(), request.getPersonId());
+        if (request.getNotes() != null || request.getLinkType() != null) {
+            var existingLink = linkRepository.findByUsername(request.getUsername());
+            if (existingLink.isPresent()) {
+                UserPersonLink link = existingLink.get();
+                if (request.getLinkType() != null && !request.getLinkType().isBlank()) {
+                    link.setLinkType(request.getLinkType());
+                }
+                if (request.getNotes() != null) {
+                    link.setNotes(request.getNotes());
+                }
+                UserPersonLink saved = linkRepository.save(link);
+                eventPublisher.publishLinkUpdated(saved);
+                response = toResponse(saved);
+            }
+        }
+        return response;
+    }
+
+    @Override
+    public void unlinkUserFromPerson(@NonNull String username) {
+        UserPersonLink link = linkRepository
+                .findByUsername(username)
+                .orElseThrow(() -> new UserPersonLinkNotFoundException(username));
+        linkRepository.delete(link);
+        eventPublisher.publishLinkRemoved(link);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @NonNull
+    public PersonResponse findPersonByUsername(@NonNull String username) {
+        UserPersonLink link = linkRepository
+                .findByUsername(username)
+                .orElseThrow(() -> new UserPersonLinkNotFoundException(username));
+
+        Person person = personRepository
+                .findById(link.getPersonId())
+                .orElseThrow(() -> new PersonNotFoundException(link.getPersonId()));
+
+        return toPersonResponse(person);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @NonNull
+    public List<String> findUsernamesByPersonId(@NonNull UUID personId) {
+        personRepository.findById(personId).orElseThrow(() -> new PersonNotFoundException(personId));
+
+        return linkRepository.findByPerson_Id(personId).stream()
+                .map(UserPersonLink::getUsername)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @NonNull
+    public UserPersonLinkResponse findLinkByPersonId(@NonNull UUID personId) {
+        personRepository.findById(personId).orElseThrow(() -> new PersonNotFoundException(personId));
+
+        UserPersonLink link = linkRepository
+                .findFirstByPerson_IdAndStatusOrderByCreatedAtDesc(
+                        personId, com.positivity.peoplecontact.internal.enums.UserLinkStatus.ACTIVE)
+                .orElseThrow(() -> new UserPersonLinkNotFoundException(personId));
+
+        return toResponse(link);
+    }
+
+    private UserPersonLinkResponse toResponse(UserPersonLink link) {
+        return UserPersonLinkResponse.builder()
+                .linkId(link.getId())
+                .username(link.getUsername())
+                .personId(link.getPersonId())
+                .linkType(link.getLinkType())
+                .createdAt(link.getCreatedAt())
+                .createdBy(link.getCreatedBy())
+                .notes(link.getNotes())
+                .build();
+    }
+
+    private PersonResponse toPersonResponse(Person person) {
+        PersonEmailService.EmailPair emails = emailService.getEmails(person.getId());
+        return PersonResponse.builder()
+                .id(person.getId())
+                .firstName(person.getFirstName())
+                .lastName(person.getLastName())
+                .primaryEmail(emails.primary())
+                .secondaryEmail(emails.secondary())
+                .phoneNumbers(workPhoneService.getWorkPhones(person.getId()))
+                .username(usernameService.usernameForPerson(person.getId()))
+                .build();
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/UserPersonTranslationServiceImpl.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/UserPersonTranslationServiceImpl.java
@@ -1,0 +1,65 @@
+package com.positivity.peoplecontact.internal.service;
+
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import com.positivity.peoplecontact.internal.enums.UserLinkStatus;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
+import com.positivity.peoplecontact.service.UserPersonTranslationService;
+import com.positivity.security.common.SecurityContextHelper;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Transactional(readOnly = true)
+public class UserPersonTranslationServiceImpl implements UserPersonTranslationService {
+
+    private final UserPersonLinkRepository userPersonLinkRepository;
+
+    public UserPersonTranslationServiceImpl(@NonNull UserPersonLinkRepository userPersonLinkRepository) {
+        this.userPersonLinkRepository = userPersonLinkRepository;
+    }
+
+    @Override
+    @NonNull
+    public UUID getPersonUuidForUser(@NonNull String username) {
+        return userPersonLinkRepository
+                .findByUsername(username)
+                .map(UserPersonLink::getPersonId)
+                .orElseThrow(() -> new EntityNotFoundException("No person link found for username: " + username));
+    }
+
+    @Override
+    @NonNull
+    public UUID getPersonUuidForCurrentUser() {
+        String username;
+        try {
+            // Throws IllegalStateException (never returns empty) when the security
+            // context is missing or carries no username.
+            username = SecurityContextHelper.getCurrentUsername().orElse(null);
+        } catch (IllegalStateException ex) {
+            username = null;
+        }
+        if (username == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authenticated user context is missing");
+        }
+        return getPersonUuidForUser(username);
+    }
+
+    @Override
+    @NonNull
+    public Optional<String> getUsernameForPerson(@NonNull UUID personUuid) {
+        return userPersonLinkRepository
+                .findByPerson_IdAndStatus(personUuid, UserLinkStatus.ACTIVE)
+                .map(UserPersonLink::getUsername);
+    }
+
+    @Override
+    public boolean isUserLinkedToPerson(@NonNull String username, @NonNull UUID personUuid) {
+        return userPersonLinkRepository.existsByUsernameAndPerson_Id(username, personUuid);
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/OutboxReplayService.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/OutboxReplayService.java
@@ -1,0 +1,17 @@
+package com.positivity.peoplecontact.service;
+
+import java.time.Instant;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Re-queues already-published outbox events for re-publication (ADR-0044 §4 backfill/drift
+ * repair). Consumers dedupe by eventId, so replay is idempotent.
+ */
+public interface OutboxReplayService {
+
+    /** Re-queue published events created at or after {@code since}. Returns the count queued. */
+    int replaySince(@NonNull Instant since);
+
+    /** Re-queue published events created in {@code [since, until)}. Returns the count queued. */
+    int replayBetween(@NonNull Instant since, @NonNull Instant until);
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/PeopleAccessControlService.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/PeopleAccessControlService.java
@@ -1,0 +1,27 @@
+package com.positivity.peoplecontact.service;
+
+import com.positivity.peoplecontact.internal.client.dto.RoleDto;
+import com.positivity.peoplecontact.internal.client.dto.UserRoleDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+public interface PeopleAccessControlService {
+
+    @NonNull
+    List<RoleDto> getAvailableRolesForPerson(@NonNull UUID personUuid);
+
+    @NonNull
+    List<UserRoleDto> getPersonRoleAssignments(@NonNull UUID personUuid, boolean includeHistory, LocalDateTime endDate);
+
+    @NonNull
+    UserRoleDto assignRoleToPerson(
+            @NonNull UUID personUuid,
+            @NonNull String roleCode,
+            UUID locationId,
+            LocalDateTime startDate,
+            LocalDateTime endDate);
+
+    void revokeRoleFromPerson(@NonNull UUID personUuid, @NonNull String roleCode, LocalDateTime endDate);
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/PersonService.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/PersonService.java
@@ -1,0 +1,54 @@
+package com.positivity.peoplecontact.service;
+
+import com.positivity.peoplecontact.internal.dto.Person;
+import com.positivity.peoplecontact.internal.dto.ResolvePersonRequest;
+import com.positivity.peoplecontact.internal.dto.ResolvePersonResponse;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public interface PersonService {
+
+    @NonNull
+    default List<Person> getAllPeople() {
+        return getAllPeople(null);
+    }
+
+    @NonNull
+    List<Person> getAllPeople(@Nullable String q);
+
+    @NonNull
+    Optional<Person> getPersonById(@NonNull UUID id);
+
+    /**
+     * Resolve many persons by id in one round trip. Unknown ids are omitted from
+     * the result (no error). Supports cross-service identity reads where
+     * pos-people-contact is the source of truth for person attributes (ADR-0015 I2).
+     *
+     * @param ids the person ids to fetch
+     * @return persons that exist, in no guaranteed order
+     */
+    @NonNull
+    List<Person> getPeopleByIds(@NonNull Collection<UUID> ids);
+
+    /**
+     * Replace all typed contact points for a person (pos-people-contact is the source of
+     * truth for contacts, ADR-0015 I2). Existing points are removed and replaced
+     * with the supplied set.
+     *
+     * @param personId the canonical person id
+     * @param contactPoints the contact points to persist (may be empty)
+     */
+    void replaceContactPoints(@NonNull UUID personId, @NonNull List<Person.ContactPointDto> contactPoints);
+
+    @NonNull
+    Person savePerson(@NonNull Person person);
+
+    @NonNull
+    ResolvePersonResponse resolvePerson(@NonNull ResolvePersonRequest request);
+
+    void deletePerson(@NonNull UUID id);
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/UserPersonLinkService.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/UserPersonLinkService.java
@@ -1,0 +1,35 @@
+package com.positivity.peoplecontact.service;
+
+import com.positivity.peoplecontact.internal.dto.LinkUserToPersonRequest;
+import com.positivity.peoplecontact.internal.dto.PersonResponse;
+import com.positivity.peoplecontact.internal.dto.UserPersonLinkResponse;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+public interface UserPersonLinkService {
+
+    boolean linkExistsByUsername(@NonNull String username);
+
+    boolean linkExistsByUsernameAndPersonId(@NonNull String username, @NonNull UUID personId);
+
+    @NonNull
+    UserPersonLinkResponse createUserLink(@NonNull String username, @NonNull UUID personId);
+
+    @NonNull
+    List<UserPersonLinkResponse> getUserLinks(@NonNull UUID personId);
+
+    @NonNull
+    UserPersonLinkResponse linkUserToPerson(@NonNull LinkUserToPersonRequest request);
+
+    void unlinkUserFromPerson(@NonNull String username);
+
+    @NonNull
+    PersonResponse findPersonByUsername(@NonNull String username);
+
+    @NonNull
+    List<String> findUsernamesByPersonId(@NonNull UUID personId);
+
+    @NonNull
+    UserPersonLinkResponse findLinkByPersonId(@NonNull UUID personId);
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/UserPersonTranslationService.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/service/UserPersonTranslationService.java
@@ -1,0 +1,26 @@
+package com.positivity.peoplecontact.service;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+public interface UserPersonTranslationService {
+
+    @NonNull
+    UUID getPersonUuidForUser(@NonNull String username);
+
+    /**
+     * Resolve the current authenticated user's person id from the security context.
+     * @return person UUID linked to the current user
+     * @throws org.springframework.web.server.ResponseStatusException 401 when no
+     * authenticated user context is present
+     * @throws jakarta.persistence.EntityNotFoundException when the user has no person link
+     */
+    @NonNull
+    UUID getPersonUuidForCurrentUser();
+
+    @NonNull
+    Optional<String> getUsernameForPerson(@NonNull UUID personUuid);
+
+    boolean isUserLinkedToPerson(@NonNull String username, @NonNull UUID personUuid);
+}

--- a/pos-people-contact/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/pos-people-contact/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,76 @@
+{
+  "properties": [
+    {
+      "name": "pos.people-contact.matching.threshold",
+      "type": "java.lang.Integer",
+      "description": "Minimum matching score threshold for person resolution.",
+      "defaultValue": 30
+    },
+    {
+      "name": "pos.security-service.service-id",
+      "type": "java.lang.String",
+      "description": "Eureka service-id for the pos-security-service.",
+      "defaultValue": "security-service"
+    },
+    {
+      "name": "pos.people-contact.kafka.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the ADR-0044 domain-event flow (outbox drain, command listener, manifests).",
+      "defaultValue": false
+    },
+    {
+      "name": "pos.people-contact.kafka.events-topic",
+      "type": "java.lang.String",
+      "description": "Fact topic for people-contact identity events.",
+      "defaultValue": "people-contact.events.v1"
+    },
+    {
+      "name": "pos.people-contact.kafka.commands-topic",
+      "type": "java.lang.String",
+      "description": "Command topic consumed by this module (outbox replay).",
+      "defaultValue": "people-contact.commands.v1"
+    },
+    {
+      "name": "pos.people-contact.kafka.commands-consumer-group",
+      "type": "java.lang.String",
+      "description": "Consumer group for the command listener.",
+      "defaultValue": "pos-people-contact-commands"
+    },
+    {
+      "name": "pos.people-contact.manifest.topic",
+      "type": "java.lang.String",
+      "description": "Reconciliation manifest topic.",
+      "defaultValue": "people-contact.manifest.v1"
+    },
+    {
+      "name": "pos.people-contact.manifest.window",
+      "type": "java.lang.String",
+      "description": "Reconciliation window length (ISO-8601 duration).",
+      "defaultValue": "PT1H"
+    },
+    {
+      "name": "pos.people-contact.manifest.grace",
+      "type": "java.lang.String",
+      "description": "Delay after window close before the manifest is published.",
+      "defaultValue": "PT5M"
+    },
+    {
+      "name": "pos.people-contact.outbox.poll-interval-ms",
+      "type": "java.lang.Long",
+      "description": "Outbox drain poll interval in milliseconds.",
+      "defaultValue": 1000
+    },
+    {
+      "name": "pos.people-contact.outbox.send-timeout-ms",
+      "type": "java.lang.Long",
+      "description": "Kafka send timeout for outbox publishes in milliseconds.",
+      "defaultValue": 10000
+    },
+    {
+      "name": "pos.people-contact.outbox.replay.max-lookback",
+      "type": "java.lang.String",
+      "description": "Maximum lookback for outbox replay commands (ISO-8601 duration).",
+      "defaultValue": "P30D"
+    }
+  ]
+}

--- a/pos-people-contact/src/main/resources/application-alpha.yml
+++ b/pos-people-contact/src/main/resources/application-alpha.yml
@@ -1,0 +1,13 @@
+# Environment-specific runtime intentionally inherits env-driven base settings.
+
+logging:
+  level:
+    # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-people-contact/src/main/resources/application-dev.yml
+++ b/pos-people-contact/src/main/resources/application-dev.yml
@@ -1,0 +1,34 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:pos_people_contact;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ''
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+server:
+  port: 0
+
+management:
+  server:
+    port: 0
+  endpoint:
+    health:
+      show-details: always
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    fetch-registry: true
+    register-with-eureka: true
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}

--- a/pos-people-contact/src/main/resources/application-indus.yml
+++ b/pos-people-contact/src/main/resources/application-indus.yml
@@ -1,0 +1,13 @@
+# Industrialization runtime inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-people-contact/src/main/resources/application-prod.yml
+++ b/pos-people-contact/src/main/resources/application-prod.yml
@@ -1,0 +1,13 @@
+# Environment-specific runtime intentionally inherits env-driven base settings.
+
+# ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
+logging:
+  level:
+    root: INFO
+    com:
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN

--- a/pos-people-contact/src/main/resources/application.yml
+++ b/pos-people-contact/src/main/resources/application.yml
@@ -1,0 +1,80 @@
+spring:
+  application:
+    name: people-contact
+  kafka:
+    bootstrap-servers:
+      - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:}
+    username: ${SPRING_DATASOURCE_USERNAME:}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.postgresql.Driver}
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: validate
+  flyway:
+    out-of-order: ${SPRING_FLYWAY_OUT_OF_ORDER:false}
+
+server:
+  port: 0
+  tomcat:
+    max-http-header-size: 65536
+
+management:
+  server:
+    port: 0
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: when-authorized
+
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL:}
+    fetch-registry: true
+    register-with-eureka: true
+  instance:
+    prefer-ip-address: true
+
+logging:
+  level:
+    root: INFO
+    org:
+      springframework: INFO
+    com:
+      positivity:
+        peoplecontact: INFO
+      netflix:
+        discovery:
+          shared:
+            resolver:
+              aws:
+                ConfigClusterResolver: WARN
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+
+  default-produces-media-type: application/json
+pos:
+  security-service:
+    service-id: ${POS_SECURITY_SERVICE_SERVICE_ID:security-service}
+  people-contact:
+    kafka:
+      # ADR-0044 domain-event flow (people-contact.events.v1 facts via the transactional outbox,
+      # people-contact.commands.v1 replay/bootstrap commands, people-contact.manifest.v1
+      # reconciliation).
+      enabled: ${POS_PEOPLE_CONTACT_KAFKA_ENABLED:false}
+      events-topic: ${POS_PEOPLE_CONTACT_EVENTS_TOPIC:people-contact.events.v1}
+      commands-topic: ${POS_PEOPLE_CONTACT_COMMANDS_TOPIC:people-contact.commands.v1}
+      commands-consumer-group: ${POS_PEOPLE_CONTACT_COMMANDS_CONSUMER_GROUP:pos-people-contact-commands}
+    manifest:
+      topic: ${POS_PEOPLE_CONTACT_MANIFEST_TOPIC:people-contact.manifest.v1}

--- a/pos-people-contact/src/main/resources/db/migration/R__seed_reference_people_contact.sql
+++ b/pos-people-contact/src/main/resources/db/migration/R__seed_reference_people_contact.sql
@@ -1,0 +1,34 @@
+-- Repeatable seed migration for people-contact reference/bootstrap data.
+-- Identity only: employment (employee, location assignments) lives in pos-people.
+SET TIME ZONE 'UTC';
+
+-- person (System Administrator) — admin.alpha's person record (identity only).
+INSERT INTO person (id, first_name, last_name, created_at, updated_at)
+VALUES (
+    '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid,
+    'System', 'Administrator',
+    NOW(), NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Email lives in person_contact_point (EMAIL); username is resolved via user_person_links.
+INSERT INTO person_contact_point (id, person_id, contact_type, value, is_primary, created_at, updated_at)
+SELECT gen_random_uuid(), '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid, 'EMAIL', 'admin.alpha@durionpos.org', TRUE, NOW(), NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM person_contact_point
+    WHERE person_id = '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid
+      AND contact_type = 'EMAIL'
+      AND value = 'admin.alpha@durionpos.org');
+
+-- user_person_links (keyed by username).
+INSERT INTO user_person_links (id, username, person_id, link_type, status, created_at, created_by)
+VALUES (
+    '4790360f-65ab-20e9-88e3-7bf9277bf2b9'::uuid,
+    'admin.alpha',
+    '583fa3b3-d1bf-a40d-8e21-8cd54424d5d0'::uuid,
+    'PRIMARY',
+    'ACTIVE',
+    NOW(),
+    'seed-generator'
+)
+ON CONFLICT (username) DO NOTHING;

--- a/pos-people-contact/src/main/resources/db/migration/V1__baseline_people_contact_schema.sql
+++ b/pos-people-contact/src/main/resources/db/migration/V1__baseline_people_contact_schema.sql
@@ -1,0 +1,44 @@
+-- pos-people-contact baseline schema (ADR-0044 Phase 3, issue #874).
+-- Identity/contact/link authority split out of pos-people: person is identity only
+-- (employment stays in pos-people); user_person_links is keyed by username;
+-- contact_info_json on the entity is a derived @Formula (not stored).
+-- person.legal_name was retired in pos-people (issue #726) and is not carried over.
+
+create table person (
+    id UUID not null,
+    first_name varchar(255),
+    last_name varchar(255),
+    preferred_name varchar(255),
+    created_at timestamp(6) with time zone,
+    updated_at timestamp(6) with time zone,
+    primary key (id)
+);
+
+create table person_contact_point (
+    id UUID not null,
+    person_id uuid not null,
+    contact_type varchar(20) not null check ((contact_type in ('EMAIL','PHONE_MOBILE','PHONE_HOME','PHONE_WORK'))),
+    "value" varchar(255) not null,
+    is_primary boolean not null,
+    created_at timestamp(6) with time zone,
+    updated_at timestamp(6) with time zone,
+    primary key (id)
+);
+
+create table user_person_links (
+    id UUID not null,
+    person_id UUID not null,
+    username varchar(255) not null unique,
+    status varchar(20) not null check ((status in ('ACTIVE','INACTIVE'))),
+    link_type varchar(50),
+    notes varchar(1000),
+    created_by varchar(255),
+    created_at timestamp(6) with time zone not null,
+    updated_at timestamp(6) with time zone,
+    primary key (id),
+    constraint fk_user_person_links_person foreign key (person_id) references person
+);
+
+create index idx_person_contact_point_person on person_contact_point (person_id);
+create index idx_person_contact_point_type on person_contact_point (contact_type);
+create index idx_user_person_links_person_id on user_person_links (person_id);

--- a/pos-people-contact/src/main/resources/db/migration/V2__create_event_outbox.sql
+++ b/pos-people-contact/src/main/resources/db/migration/V2__create_event_outbox.sql
@@ -1,0 +1,21 @@
+-- ADR-0044 §4: transactional outbox for domain events (people-contact.events.v1, issue #874).
+-- Rows are written in the same transaction as the business state change and
+-- drained to Kafka by a background publisher (at-least-once delivery).
+CREATE TABLE event_outbox (
+    id uuid NOT NULL,
+    topic character varying(255) NOT NULL,
+    record_key character varying(255) NOT NULL,
+    payload text NOT NULL,
+    created_at timestamp(6) with time zone NOT NULL,
+    published_at timestamp(6) with time zone,
+    attempts integer NOT NULL DEFAULT 0,
+    last_error text,
+    CONSTRAINT event_outbox_pkey PRIMARY KEY (id)
+);
+
+-- Drain scans: unpublished rows in id order (UUIDv7 ids are time-ordered).
+CREATE INDEX idx_event_outbox_unpublished ON event_outbox (id) WHERE published_at IS NULL;
+
+-- Manifest computation scans published rows of a topic by created_at window (ADR-0044 §4).
+CREATE INDEX idx_event_outbox_published_window ON event_outbox (topic, created_at)
+    WHERE published_at IS NOT NULL;

--- a/pos-people-contact/src/main/resources/permissions.yaml
+++ b/pos-people-contact/src/main/resources/permissions.yaml
@@ -1,0 +1,22 @@
+domain: people-contact
+serviceName: pos-people-contact
+version: "1.0"
+permissions:
+  - name: "people-contact:person:create"
+    description: "Create person"
+  - name: "people-contact:person:delete"
+    description: "Delete person"
+  - name: "people-contact:person:edit"
+    description: "Edit person"
+  - name: "people-contact:person:view"
+    description: "View person"
+  - name: "people-contact:role:assign"
+    description: "Assign roles to people"
+  - name: "people-contact:role:revoke"
+    description: "Revoke roles from people"
+  - name: "people-contact:role:view"
+    description: "View role assignments"
+  - name: "people-contact:userLink:view"
+    description: "View user-person links"
+  - name: "people-contact:userLink:write"
+    description: "Write user-person links"

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/ArchitectureTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/ArchitectureTest.java
@@ -1,0 +1,184 @@
+package com.positivity.peoplecontact;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaCall;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import java.util.UUID;
+
+/**
+ * ArchUnit tests enforcing architecture rules for pos-people module.
+ *
+ * Enforces: - Internal package encapsulation - Service layer as only public API
+ * -
+ * Controller -> Service -> Repository layering - No circular dependencies
+ */
+@AnalyzeClasses(packages = "com.positivity.peoplecontact", importOptions = ImportOption.DoNotIncludeTests.class)
+public class ArchitectureTest {
+
+    private static final DescribedPredicate<JavaCall<?>> UUID_RANDOM_UUID_CALL =
+            new DescribedPredicate<>("call UUID.randomUUID()") {
+
+                public boolean test(JavaCall<?> input) {
+                    return input.getTargetOwner().isEquivalentTo(UUID.class) && "randomUUID".equals(input.getName());
+                }
+            };
+
+    @ArchTest
+    static final ArchRule controllers_should_not_access_repositories_directly = noClasses()
+            .that()
+            .resideInAPackage("..internal.controller..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("..internal.repository..")
+            .allowEmptyShould(true)
+            .because("controllers must go through service layer");
+
+    @ArchTest
+    static final ArchRule controllers_should_not_access_entities_directly = noClasses()
+            .that()
+            .resideInAPackage("..internal.controller..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("..internal.entity..")
+            .allowEmptyShould(true)
+            .because("controllers should work with DTOs, not entities");
+
+    @ArchTest
+    static final ArchRule services_should_not_depend_on_controllers = noClasses()
+            .that()
+            .resideInAnyPackage(
+                    "com.positivity.peoplecontact.service..", "com.positivity.peoplecontact.internal.service..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("..internal.controller..")
+            .allowEmptyShould(true)
+            .because("services should not depend on web layer");
+
+    @ArchTest
+    static final ArchRule entities_should_not_depend_on_services = noClasses()
+            .that()
+            .resideInAPackage("..internal.entity..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("..service..")
+            .allowEmptyShould(true)
+            .because("entities should be independent of business logic");
+
+    @ArchTest
+    static final ArchRule repositories_should_only_be_accessed_from_services_or_config = noClasses()
+            .that()
+            .resideOutsideOfPackages(
+                    "com.positivity.peoplecontact.service..",
+                    "com.positivity.peoplecontact.internal.service..",
+                    "..internal.repository..",
+                    "..internal.config..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("..internal.repository..")
+            .allowEmptyShould(true)
+            .because("repositories should only be accessed from service layer");
+
+    @ArchTest
+    static final ArchRule spring_boot_application_should_be_in_root_package = classes()
+            .that()
+            .areAnnotatedWith("org.springframework.boot.autoconfigure.SpringBootApplication")
+            .should()
+            .resideInAPackage("com.positivity.peoplecontact")
+            .andShould()
+            .resideOutsideOfPackages("..internal..", "..service..")
+            .allowEmptyShould(true)
+            .because("@SpringBootApplication must be at root for component scanning");
+
+    @ArchTest
+    static final ArchRule only_service_layer_should_be_public_api = classes()
+            .that()
+            .resideInAPackage("com.positivity.peoplecontact.service..")
+            .and()
+            .areNotAnonymousClasses()
+            .and()
+            .areNotInnerClasses()
+            .should()
+            .bePublic()
+            .allowEmptyShould(true)
+            .because("service layer is the public API of this module");
+
+    @ArchTest
+    static final ArchRule classes_outside_internal_should_use_service_naming = classes()
+            .that()
+            .resideInAPackage("com.positivity.peoplecontact..")
+            .and()
+            .resideOutsideOfPackages("..internal..", "com.positivity.peoplecontact")
+            .and()
+            .areNotAnonymousClasses()
+            .and()
+            .areNotInnerClasses()
+            .and()
+            .haveSimpleNameNotContaining("Dto")
+            .and()
+            .haveSimpleNameNotContaining("Exception")
+            .should()
+            .haveSimpleNameEndingWith("Service")
+            .allowEmptyShould(true)
+            .because("outside internal packages, exposed module types should be service contracts");
+
+    @ArchTest
+    static final ArchRule mapped_controller_methods_should_require_authorization = methods()
+            .that()
+            .areAnnotatedWith("org.springframework.web.bind.annotation.RequestMapping")
+            .or()
+            .areAnnotatedWith("org.springframework.web.bind.annotation.GetMapping")
+            .or()
+            .areAnnotatedWith("org.springframework.web.bind.annotation.PostMapping")
+            .or()
+            .areAnnotatedWith("org.springframework.web.bind.annotation.PutMapping")
+            .or()
+            .areAnnotatedWith("org.springframework.web.bind.annotation.DeleteMapping")
+            .or()
+            .areAnnotatedWith("org.springframework.web.bind.annotation.PatchMapping")
+            .should()
+            .beAnnotatedWith("org.springframework.security.access.prepost.PreAuthorize")
+            .orShould()
+            .beDeclaredInClassesThat()
+            .areAnnotatedWith("org.springframework.security.access.prepost.PreAuthorize")
+            .allowEmptyShould(true)
+            .because("all HTTP endpoints must declare authorization guards");
+
+    @ArchTest
+    static final ArchRule packages_should_be_free_of_cycles = slices().matching(
+                    "com.positivity.peoplecontact.internal.(*)..")
+            .should()
+            .beFreeOfCycles()
+            .allowEmptyShould(true)
+            .because("cyclic dependencies make modules harder to maintain and evolve");
+
+    @ArchTest
+    static final ArchRule entities_should_depend_on_uuidv7_generator = classes()
+            .that()
+            .resideInAnyPackage("..internal.entity..", "..internal.model..")
+            .and()
+            .areAnnotatedWith("jakarta.persistence.Entity")
+            .should()
+            .dependOnClassesThat()
+            .haveFullyQualifiedName("com.positivity.shared.id.UUIDv7Id")
+            .allowEmptyShould(true)
+            .because("ADR-0013 mandates UUID v7 generation for all entity identifiers");
+
+    @ArchTest
+    static final ArchRule entities_should_not_call_uuid_randomUUID = noClasses()
+            .that()
+            .resideInAnyPackage("..internal.entity..", "..internal.model..")
+            .and()
+            .areAnnotatedWith("jakarta.persistence.Entity")
+            .should()
+            .callMethodWhere(UUID_RANDOM_UUID_CALL)
+            .allowEmptyShould(true)
+            .because("UUIDv7Generator centralizes ID creation; direct randomUUID calls are not allowed");
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/ArchitectureTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/ArchitectureTest.java
@@ -14,7 +14,7 @@ import com.tngtech.archunit.lang.ArchRule;
 import java.util.UUID;
 
 /**
- * ArchUnit tests enforcing architecture rules for pos-people module.
+ * ArchUnit tests enforcing architecture rules for pos-people-contact module.
  *
  * Enforces: - Internal package encapsulation - Service layer as only public API
  * -

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/BaseContractIntegrationTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/BaseContractIntegrationTest.java
@@ -1,0 +1,3 @@
+package com.positivity.peoplecontact;
+
+public abstract class BaseContractIntegrationTest extends BaseIntegrationTest {}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/BaseIntegrationTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/BaseIntegrationTest.java
@@ -1,0 +1,106 @@
+package com.positivity.peoplecontact;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:people-access;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "spring.flyway.enabled=false",
+            "eureka.client.enabled=false",
+            "pos.security.permission-registration.enabled=false"
+        })
+@ActiveProfiles("test")
+public abstract class BaseIntegrationTest {
+
+    @Autowired
+    protected WebApplicationContext webApplicationContext;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected JdbcTemplate jdbcTemplate;
+
+    protected MockMvc mockMvc;
+
+    protected static final String TEST_USER = "integration-test-user";
+
+    protected static final String TEST_AUTHORITIES = String.join(
+            ",",
+            "people-contact:role:view",
+            "people-contact:role:assign",
+            "people-contact:role:revoke",
+            "people-contact:person:view",
+            "people-contact:person:create",
+            "people-contact:person:edit",
+            "people-contact:person:delete",
+            "people:employee:create",
+            "people:employee:edit",
+            "people:employee:view",
+            "people:employee:deactivate",
+            "people-contact:userLink:write",
+            "people-contact:userLink:view",
+            "people:availability:view",
+            "people:timeAdjustment:create",
+            "people:timeAdjustment:view",
+            "people:timeAdjustment:approve",
+            "people:timeEntry:approve",
+            "people:timeEntry:reject",
+            "people:timeException:create",
+            "people:timeException:view",
+            "people:timeException:acknowledge",
+            "people:timeException:resolve",
+            "people:time:export:read");
+
+    protected static final String TEST_CORRELATION_ID = "people-test-correlation-id";
+
+    @BeforeEach
+    void setUpMockMvc() {
+        resetDatabaseState();
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .build();
+    }
+
+    private void resetDatabaseState() {
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY FALSE");
+        try {
+            jdbcTemplate
+                    .queryForList(
+                            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PUBLIC' AND TABLE_TYPE = 'BASE TABLE'",
+                            String.class)
+                    .forEach(table -> jdbcTemplate.execute("TRUNCATE TABLE \"" + table + "\""));
+        } finally {
+            jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY TRUE");
+        }
+    }
+
+    protected MockHttpServletRequestBuilder withAuth(MockHttpServletRequestBuilder builder) {
+        return builder.header("X-User", TEST_USER)
+                .header("X-Authorities", TEST_AUTHORITIES)
+                .header("X-Correlation-Id", TEST_CORRELATION_ID);
+    }
+
+    protected MockHttpServletRequestBuilder withAuth(MockHttpServletRequestBuilder builder, String authorities) {
+        return builder.header("X-User", TEST_USER)
+                .header("X-Authorities", authorities)
+                .header("X-Correlation-Id", TEST_CORRELATION_ID);
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/config/TestSecurityConfig.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/config/TestSecurityConfig.java
@@ -1,0 +1,79 @@
+package com.positivity.peoplecontact.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@TestConfiguration(proxyBeanMethods = false)
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+@Profile("test")
+public class TestSecurityConfig {
+
+    private static final List<SimpleGrantedAuthority> TEST_AUTHORITIES = List.of(
+            new SimpleGrantedAuthority("ROLE_ADMIN"),
+            new SimpleGrantedAuthority("ROLE_PEOPLE_VIEW"),
+            new SimpleGrantedAuthority("ROLE_PEOPLE_EDIT"),
+            new SimpleGrantedAuthority("people:employee:create"));
+
+    @Bean(name = "gatewaySecurityFilterChain")
+    @Primary
+    public SecurityFilterChain gatewaySecurityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new TestAutoAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    @Primary
+    @SuppressWarnings("java:S1874")
+    public UserDetailsService testUserDetailsService() {
+        var user = User.withUsername("testuser")
+                .password("{noop}test")
+                .authorities(TEST_AUTHORITIES)
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    private static class TestAutoAuthFilter extends OncePerRequestFilter {
+        @Override
+        protected void doFilterInternal(
+                HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+                throws ServletException, IOException {
+            String headerAuthorities = request.getHeader("X-Authorities");
+            List<SimpleGrantedAuthority> authorities = headerAuthorities == null || headerAuthorities.isBlank()
+                    ? TEST_AUTHORITIES
+                    : Arrays.stream(headerAuthorities.split(","))
+                            .map(String::trim)
+                            .filter(value -> !value.isBlank())
+                            .map(SimpleGrantedAuthority::new)
+                            .toList();
+
+            var authentication = new UsernamePasswordAuthenticationToken("testuser", null, authorities);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/contract/UserPersonLinkContractBehaviorIT.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/contract/UserPersonLinkContractBehaviorIT.java
@@ -1,0 +1,130 @@
+package com.positivity.peoplecontact.contract;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.peoplecontact.BaseContractIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+@DisplayName("User Person Link ContractBehaviorIT")
+class UserPersonLinkContractBehaviorIT extends BaseContractIntegrationTest {
+
+    @Test
+    @DisplayName("CP-117-020: Create user-person link -> 201")
+    void cp117020_createUserPersonLink_returns201() throws Exception {
+        UUID personId = createPerson();
+        String userId = "user.one";
+
+        mockMvc.perform(withAuth(post("/v1/people/user-links")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(linkPayload(userId, personId))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.username").value(userId))
+                .andExpect(jsonPath("$.personId").value(personId.toString()));
+    }
+
+    @Test
+    @DisplayName("ID-117-020: Duplicate create is idempotent -> 200")
+    void id117020_duplicateCreateIdempotent_returns200() throws Exception {
+        UUID personId = createPerson();
+        String userId = "user.one";
+
+        String payload = linkPayload(userId, personId);
+
+        mockMvc.perform(withAuth(post("/v1/people/user-links")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(withAuth(post("/v1/people/user-links")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value(userId));
+    }
+
+    @Test
+    @DisplayName("VE-117-020: userId linked to different personId -> 409")
+    void ve117020_conflictingPersonLink_returns409() throws Exception {
+        UUID personA = createPerson();
+        UUID personB = createPerson();
+        String userId = "user.one";
+
+        mockMvc.perform(withAuth(post("/v1/people/user-links")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(linkPayload(userId, personA))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(withAuth(post("/v1/people/user-links")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(linkPayload(userId, personB))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("CP-117-021: Get links by person -> 200")
+    void cp117021_getLinksByPerson_returns200() throws Exception {
+        UUID personId = createPerson();
+        String userIdOne = "user.one";
+        String userIdTwo = "user.two";
+
+        mockMvc.perform(withAuth(post("/v1/people/user-links")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(linkPayload(userIdOne, personId))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(withAuth(post("/v1/people/user-links")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(linkPayload(userIdTwo, personId))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(withAuth(get("/v1/people/user-links/{personId}", personId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[*].personId", everyItem(is(personId.toString()))))
+                .andExpect(jsonPath("$[*].username", containsInAnyOrder(userIdOne, userIdTwo)));
+    }
+
+    private UUID createPerson() throws Exception {
+        String email = "link.person." + UUID.fromString("00000000-0000-0000-0000-000000000001") + "@example.com";
+        String payload = """
+				{
+				  "firstName": "Link",
+				  "lastName": "Person",
+				                                                        "primaryEmail": "%s",
+				  "secondaryEmail": "link.person.secondary@example.com",
+				  "phoneNumbers": ["555-117-0200"]
+				}
+				                                                """.formatted(email);
+
+        String response = mockMvc.perform(withAuth(post("/v1/people")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload)))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        return UUID.fromString(objectMapper.readTree(response).get("id").asText());
+    }
+
+    private String linkPayload(String username, UUID personId) {
+        return """
+				{
+				  "username": "%s",
+				  "personId": "%s",
+				  "linkType": "PRIMARY",
+				  "notes": "created by contract test"
+				}
+				""".formatted(username, personId);
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/controller/PersonAccessControllerIT.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/controller/PersonAccessControllerIT.java
@@ -1,0 +1,130 @@
+package com.positivity.peoplecontact.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.peoplecontact.BaseIntegrationTest;
+import com.positivity.peoplecontact.internal.client.dto.RoleDto;
+import com.positivity.peoplecontact.internal.client.dto.UserRoleDto;
+import com.positivity.peoplecontact.internal.exception.PersonNotFoundException;
+import com.positivity.peoplecontact.service.PeopleAccessControlService;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class PersonAccessControllerIT extends BaseIntegrationTest {
+
+    @MockitoBean
+    private PeopleAccessControlService peopleAccessControlService;
+
+    @Test
+    void getRoles_returns200() throws Exception {
+        UUID personUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        when(peopleAccessControlService.getAvailableRolesForPerson(personUuid))
+                .thenReturn(List.of(
+                        RoleDto.builder().code("MANAGER").name("Manager role").build()));
+
+        mockMvc.perform(withAuth(get("/v1/people/{personUuid}/access/roles", personUuid)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].code").value("MANAGER"));
+    }
+
+    @Test
+    void getRoles_returns404WhenPersonNotFound() throws Exception {
+        UUID personUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        when(peopleAccessControlService.getAvailableRolesForPerson(personUuid))
+                .thenThrow(new PersonNotFoundException(personUuid));
+
+        mockMvc.perform(withAuth(get("/v1/people/{personUuid}/access/roles", personUuid)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.detail").value("Person not found with id: " + personUuid))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    void getAssignments_returns200() throws Exception {
+        UUID personUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UserRoleDto assignment =
+                UserRoleDto.builder().userId("user-1").roleCode("MANAGER").build();
+
+        when(peopleAccessControlService.getPersonRoleAssignments(personUuid, false, null))
+                .thenReturn(List.of(assignment));
+
+        mockMvc.perform(withAuth(get("/v1/people/{personUuid}/access/assignments", personUuid)
+                        .param("includeHistory", "false")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].roleCode").value("MANAGER"));
+    }
+
+    @Test
+    void getAssignments_defaultsToFalseWhenIncludeHistoryOmitted() throws Exception {
+        UUID personUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UserRoleDto assignment =
+                UserRoleDto.builder().userId("user-1").roleCode("MANAGER").build();
+
+        // Should default to false when includeHistory is not provided
+        when(peopleAccessControlService.getPersonRoleAssignments(personUuid, false, null))
+                .thenReturn(List.of(assignment));
+
+        mockMvc.perform(withAuth(get("/v1/people/{personUuid}/access/assignments", personUuid)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].roleCode").value("MANAGER"));
+    }
+
+    @Test
+    void getAssignments_returns404WhenPersonLinkMissing() throws Exception {
+        UUID personUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        when(peopleAccessControlService.getPersonRoleAssignments(personUuid, true, null))
+                .thenThrow(new EntityNotFoundException("No user link found"));
+
+        mockMvc.perform(withAuth(get("/v1/people/{personUuid}/access/assignments", personUuid)
+                        .param("includeHistory", "true")))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createAssignment_returns201() throws Exception {
+        UUID personUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UserRoleDto created = UserRoleDto.builder().roleCode("MANAGER").build();
+
+        when(peopleAccessControlService.assignRoleToPerson(eq(personUuid), eq("MANAGER"), any(), any(), any()))
+                .thenReturn(created);
+
+        String payload = """
+				{
+				  "roleCode": "MANAGER"
+				}
+				""";
+
+        mockMvc.perform(withAuth(post("/v1/people/{personUuid}/access/assignments", personUuid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.roleCode").value("MANAGER"));
+    }
+
+    @Test
+    void revokeAssignment_returns204() throws Exception {
+        UUID personUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        String roleCode = "MANAGER";
+        doNothing()
+                .when(peopleAccessControlService)
+                .revokeRoleFromPerson(personUuid, roleCode, LocalDateTime.parse("2026-02-16T00:00:00"));
+
+        mockMvc.perform(withAuth(delete("/v1/people/{personUuid}/access/assignments/{roleCode}", personUuid, roleCode)
+                        .param("endDate", "2026-02-16T00:00:00")))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/controller/UserPersonLinkControllerIT.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/controller/UserPersonLinkControllerIT.java
@@ -1,0 +1,252 @@
+package com.positivity.peoplecontact.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.peoplecontact.internal.repository.PersonRepository;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:userpersonlink;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "spring.flyway.enabled=false",
+            "eureka.client.enabled=false"
+        })
+@AutoConfigureTestRestTemplate
+@ActiveProfiles("test")
+class UserPersonLinkControllerIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private PersonRepository personRepository;
+
+    @Autowired
+    private UserPersonLinkRepository userPersonLinkRepository;
+
+    // The link is stored directly with the username, so no cross-service username
+    // resolution is needed. The mocked client is harmless and left in place.
+    @org.springframework.test.context.bean.override.mockito.MockitoBean
+    private com.positivity.peoplecontact.internal.client.SecurityServiceClient securityServiceClient;
+
+    @BeforeEach
+    void resetData() {
+        userPersonLinkRepository.deleteAll();
+        personRepository.deleteAll();
+    }
+
+    private HttpHeaders authenticatedHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("X-User", "test-user");
+        headers.add(
+                "X-Authorities",
+                "people-contact:person:create,people-contact:userLink:write,people-contact:userLink:view");
+        return headers;
+    }
+
+    @Test
+    void linkUserToPerson_success_returns201() {
+        UUID personId = createPerson("Casey", "Lane", "casey@example.com");
+        String username = "caseylane";
+
+        HttpEntity<String> entity = new HttpEntity<>(
+                createLinkRequestJson(username, personId, "PRIMARY", "integration test"), authenticatedHeaders());
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/v1/people/users/link", HttpMethod.POST, entity, new ParameterizedTypeReference<>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).containsEntry("username", username);
+        assertThat(response.getBody()).containsEntry("personId", personId.toString());
+    }
+
+    @Test
+    void linkUserToPerson_personNotFound_returns404() {
+        String username = "caseylane";
+        HttpEntity<String> entity = new HttpEntity<>(
+                createLinkRequestJson(
+                        username, UUID.fromString("00000000-0000-0000-0000-000000000001"), "PRIMARY", null),
+                authenticatedHeaders());
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/v1/people/users/link", HttpMethod.POST, entity, new ParameterizedTypeReference<>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().get("detail").toString()).contains("Person not found");
+    }
+
+    @Test
+    void linkUserToPerson_alreadyLinked_returns200() {
+        UUID personId = createPerson("Taylor", "Ray", "taylor@example.com");
+        String username = "taylorray";
+        HttpEntity<String> entity =
+                new HttpEntity<>(createLinkRequestJson(username, personId, "PRIMARY", null), authenticatedHeaders());
+
+        ResponseEntity<Map<String, Object>> firstResponse = restTemplate.exchange(
+                "/v1/people/users/link", HttpMethod.POST, entity, new ParameterizedTypeReference<>() {});
+        assertThat(firstResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        ResponseEntity<Map<String, Object>> secondResponse = restTemplate.exchange(
+                "/v1/people/users/link", HttpMethod.POST, entity, new ParameterizedTypeReference<>() {});
+
+        assertThat(secondResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(secondResponse.getBody()).isNotNull();
+        assertThat(secondResponse.getBody()).containsEntry("username", username);
+    }
+
+    @Test
+    void linkUserToPerson_invalidRequest_returns400() {
+        String invalidPayload = "{\"username\":\"\",\"personId\":\"not-a-uuid\"}";
+
+        HttpEntity<String> entity = new HttpEntity<>(invalidPayload, authenticatedHeaders());
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/v1/people/users/link", HttpMethod.POST, entity, new ParameterizedTypeReference<>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).containsEntry("status", 400);
+        assertThat(response.getBody()).containsEntry("error", "Bad Request");
+        assertThat(response.getBody()).containsEntry("path", "/v1/people/users/link");
+    }
+
+    @Test
+    void unlinkUserFromPerson_success_returns204() {
+        UUID personId = createPerson("Chris", "Doe", "chris@example.com");
+        String username = "chrisdoe";
+        linkUser(username, personId);
+
+        HttpEntity<Void> entity = new HttpEntity<>(authenticatedHeaders());
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "/v1/people/users/{username}/link", HttpMethod.DELETE, entity, Void.class, username);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+
+    @Test
+    void unlinkUserFromPerson_notFound_returns404() {
+        HttpEntity<Void> entity = new HttpEntity<>(authenticatedHeaders());
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/v1/people/users/{username}/link",
+                HttpMethod.DELETE,
+                entity,
+                new ParameterizedTypeReference<>() {},
+                "unknownuser");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().get("detail").toString()).contains("No person link found");
+    }
+
+    @Test
+    void findPersonByUserId_success_returns200() {
+        UUID personId = createPerson("Jordan", "Case", "jordan@example.com");
+        String username = "jordancase";
+        linkUser(username, personId);
+
+        HttpEntity<Void> entity = new HttpEntity<>(authenticatedHeaders());
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/v1/people/users/{username}/person",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<>() {},
+                username);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).containsEntry("id", personId.toString());
+        assertThat(response.getBody()).containsEntry("firstName", "Jordan");
+    }
+
+    @Test
+    void findPersonByUserId_notFound_returns404() {
+        HttpEntity<Void> entity = new HttpEntity<>(authenticatedHeaders());
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/v1/people/users/{username}/person",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<>() {},
+                "unknownuser");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().get("detail").toString()).contains("No person link found");
+    }
+
+    @Test
+    void findUserIdsByPersonId_success_returns200() {
+        UUID personId = createPerson("Dana", "Stone", "dana@example.com");
+        String userA = "danastone";
+        String userB = "danastone2";
+        linkUser(userA, personId);
+        linkUser(userB, personId);
+
+        HttpEntity<Void> entity = new HttpEntity<>(authenticatedHeaders());
+        ResponseEntity<List<String>> response = restTemplate.exchange(
+                "/v1/people/{personId}/users", HttpMethod.GET, entity, new ParameterizedTypeReference<>() {}, personId);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsExactlyInAnyOrder(userA, userB);
+    }
+
+    @Test
+    void findUserIdsByPersonId_empty_returns200() {
+        UUID personId = createPerson("Robin", "Mills", "robin@example.com");
+
+        HttpEntity<Void> entity = new HttpEntity<>(authenticatedHeaders());
+        ResponseEntity<List<String>> response = restTemplate.exchange(
+                "/v1/people/{personId}/users", HttpMethod.GET, entity, new ParameterizedTypeReference<>() {}, personId);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    private UUID createPerson(String firstName, String lastName, String email) {
+        String payload = "{" + "\"firstName\":\"" + firstName + "\"," + "\"lastName\":\"" + lastName + "\","
+                + "\"primaryEmail\":\"" + email + "\"," + "\"phoneNumbers\":[\"555-1212\"]" + "}";
+        HttpEntity<String> entity = new HttpEntity<>(payload, authenticatedHeaders());
+        ResponseEntity<Map<String, Object>> response =
+                restTemplate.exchange("/v1/people", HttpMethod.POST, entity, new ParameterizedTypeReference<>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        return UUID.fromString(response.getBody().get("id").toString());
+    }
+
+    private void linkUser(String username, UUID personId) {
+        HttpEntity<String> entity =
+                new HttpEntity<>(createLinkRequestJson(username, personId, "PRIMARY", null), authenticatedHeaders());
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/v1/people/users/link", HttpMethod.POST, entity, new ParameterizedTypeReference<>() {});
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    private String createLinkRequestJson(String username, UUID personId, String linkType, String notes) {
+        String notesPart = notes == null ? "null" : "\"" + notes + "\"";
+        return "{" + "\"username\":\"" + username + "\"," + "\"personId\":\"" + personId + "\"," + "\"linkType\":\""
+                + linkType + "\"," + "\"notes\":" + notesPart + "}";
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/PeopleContactCommandListenerTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/PeopleContactCommandListenerTest.java
@@ -1,0 +1,87 @@
+package com.positivity.peoplecontact.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.service.OutboxReplayService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link PeopleContactCommandListener} (ADR-0044 §4, #874).
+ */
+class PeopleContactCommandListenerTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-12T12:00:00Z"), ZoneOffset.UTC);
+
+    private final OutboxReplayService replayService = mock(OutboxReplayService.class);
+
+    private PeopleContactCommandListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new PeopleContactCommandListener(TEST_CLOCK, new ObjectMapper(), replayService);
+        ReflectionTestUtils.setField(listener, "replayMaxLookback", Duration.ofDays(30));
+    }
+
+    private String replayCommand(String since, String until) {
+        return """
+                {"commandType":"people-contact.outbox.replay-requested",
+                 "payload":{"since":"%s","until":"%s"}}
+                """.formatted(since, until);
+    }
+
+    @Test
+    @DisplayName("Bounded replay command re-queues the window with slack")
+    void boundedReplay() {
+        listener.onCommand(replayCommand("2026-07-12T10:00:00Z", "2026-07-12T11:00:00Z"));
+
+        ArgumentCaptor<Instant> since = ArgumentCaptor.forClass(Instant.class);
+        ArgumentCaptor<Instant> until = ArgumentCaptor.forClass(Instant.class);
+        verify(replayService).replayBetween(since.capture(), until.capture());
+        assertThat(since.getValue()).isEqualTo(Instant.parse("2026-07-12T09:59:59Z"));
+        assertThat(until.getValue()).isEqualTo(Instant.parse("2026-07-12T11:00:01Z"));
+    }
+
+    @Test
+    @DisplayName("Replay commands beyond the max lookback are rejected")
+    void rejectsAncientReplay() {
+        listener.onCommand(replayCommand("2026-05-01T00:00:00Z", "2026-05-01T01:00:00Z"));
+
+        verify(replayService, never()).replayBetween(any(), any());
+        verify(replayService, never()).replaySince(any());
+    }
+
+    @Test
+    @DisplayName("Malformed commands are logged and dropped, not rethrown")
+    void dropsMalformedCommands() {
+        assertThatCode(() -> listener.onCommand("{ not json ")).doesNotThrowAnyException();
+        assertThatCode(() -> listener.onCommand("{\"commandType\":\"something.else\"}"))
+                .doesNotThrowAnyException();
+        verify(replayService, never()).replayBetween(any(), any());
+    }
+
+    @Test
+    @DisplayName("Transient DB errors rethrow for container retry/DLQ (ADR-0044 §4, PR #865 review)")
+    void rethrowsTransientErrors() {
+        when(replayService.replayBetween(any(), any())).thenThrow(new QueryTimeoutException("db timeout"));
+
+        assertThatExceptionOfType(QueryTimeoutException.class)
+                .isThrownBy(() -> listener.onCommand(replayCommand("2026-07-12T10:00:00Z", "2026-07-12T11:00:00Z")));
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/PeopleContactEventPublisherTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/PeopleContactEventPublisherTest.java
@@ -1,0 +1,160 @@
+package com.positivity.peoplecontact.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.peoplecontact.PersonDeletedV1;
+import com.positivity.domainevents.peoplecontact.PersonUpdatedV1;
+import com.positivity.domainevents.peoplecontact.UserPersonLinkRemovedV1;
+import com.positivity.domainevents.peoplecontact.UserPersonLinkUpdatedV1;
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import com.positivity.peoplecontact.internal.enums.UserLinkStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Unit tests for {@link PeopleContactEventPublisher} (ADR-0044 §6, #874).
+ */
+class PeopleContactEventPublisherTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-12T12:00:00Z"), ZoneOffset.UTC);
+    private static final UUID PERSON_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID LINK_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+    private final OutboxEventWriter writer = mock(OutboxEventWriter.class);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<OutboxEventWriter> writerProvider = mock(ObjectProvider.class);
+
+    private PeopleContactEventPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new PeopleContactEventPublisher(TEST_CLOCK, writerProvider, "people-contact.events.v1");
+    }
+
+    private Person person() {
+        return Person.builder()
+                .id(PERSON_ID)
+                .firstName("Jane")
+                .lastName("Smith")
+                .build();
+    }
+
+    private UserPersonLink link() {
+        UserPersonLink link = new UserPersonLink();
+        link.setId(LINK_ID);
+        link.setUsername("jane.smith");
+        link.setPerson(person());
+        link.setStatus(UserLinkStatus.ACTIVE);
+        link.setLinkType("PRIMARY");
+        return link;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private DomainEventEnvelope capturePublished(String expectedTopic) {
+        ArgumentCaptor<String> topic = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<DomainEventEnvelope> envelope = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(topic.capture(), envelope.capture());
+        assertThat(topic.getValue()).isEqualTo(expectedTopic);
+        return envelope.getValue();
+    }
+
+    @Test
+    @DisplayName("Queues a person.updated envelope carrying the contact-point snapshot")
+    void queuesPersonUpdated() {
+        when(writerProvider.getIfAvailable()).thenReturn(writer);
+        PersonContactPoint email = PersonContactPoint.builder()
+                .personId(PERSON_ID)
+                .contactType(ContactPointType.EMAIL)
+                .value("jane@example.com")
+                .isPrimary(true)
+                .build();
+
+        publisher.publishPersonUpdated(person(), List.of(email));
+
+        DomainEventEnvelope<?> envelope = capturePublished("people-contact.events.v1");
+        assertThat(envelope.eventType()).isEqualTo(PersonUpdatedV1.EVENT_TYPE);
+        assertThat(envelope.aggregateId()).isEqualTo(PERSON_ID);
+        assertThat(envelope.aggregateVersion()).isEqualTo(TEST_CLOCK.instant().toEpochMilli());
+        assertThat(envelope.sourceService()).isEqualTo("pos-people-contact");
+        PersonUpdatedV1 payload = (PersonUpdatedV1) envelope.payload();
+        assertThat(payload.personId()).isEqualTo(PERSON_ID);
+        assertThat(payload.firstName()).isEqualTo("Jane");
+        assertThat(payload.contactPoints())
+                .containsExactly(new PersonUpdatedV1.ContactPointV1("EMAIL", "jane@example.com", true));
+    }
+
+    @Test
+    @DisplayName("Queues a person.deleted envelope keyed by the person id")
+    void queuesPersonDeleted() {
+        when(writerProvider.getIfAvailable()).thenReturn(writer);
+
+        publisher.publishPersonDeleted(PERSON_ID);
+
+        DomainEventEnvelope<?> envelope = capturePublished("people-contact.events.v1");
+        assertThat(envelope.eventType()).isEqualTo(PersonDeletedV1.EVENT_TYPE);
+        assertThat(envelope.aggregateId()).isEqualTo(PERSON_ID);
+        assertThat(((PersonDeletedV1) envelope.payload()).personId()).isEqualTo(PERSON_ID);
+    }
+
+    @Test
+    @DisplayName("Queues a user-person-link.updated envelope keyed by the link id")
+    void queuesLinkUpdated() {
+        when(writerProvider.getIfAvailable()).thenReturn(writer);
+
+        publisher.publishLinkUpdated(link());
+
+        DomainEventEnvelope<?> envelope = capturePublished("people-contact.events.v1");
+        assertThat(envelope.eventType()).isEqualTo(UserPersonLinkUpdatedV1.EVENT_TYPE);
+        assertThat(envelope.aggregateId()).isEqualTo(LINK_ID);
+        UserPersonLinkUpdatedV1 payload = (UserPersonLinkUpdatedV1) envelope.payload();
+        assertThat(payload.personId()).isEqualTo(PERSON_ID);
+        assertThat(payload.username()).isEqualTo("jane.smith");
+        assertThat(payload.status()).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("Queues a user-person-link.removed envelope keyed by the link id")
+    void queuesLinkRemoved() {
+        when(writerProvider.getIfAvailable()).thenReturn(writer);
+
+        publisher.publishLinkRemoved(link());
+
+        DomainEventEnvelope<?> envelope = capturePublished("people-contact.events.v1");
+        assertThat(envelope.eventType()).isEqualTo(UserPersonLinkRemovedV1.EVENT_TYPE);
+        assertThat(envelope.aggregateId()).isEqualTo(LINK_ID);
+        UserPersonLinkRemovedV1 payload = (UserPersonLinkRemovedV1) envelope.payload();
+        assertThat(payload.username()).isEqualTo("jane.smith");
+        assertThat(payload.personId()).isEqualTo(PERSON_ID);
+    }
+
+    @Test
+    @DisplayName("No-op when the Kafka feature flag is off (writer bean absent)")
+    void noopWithoutWriter() {
+        when(writerProvider.getIfAvailable()).thenReturn(null);
+
+        publisher.publishPersonUpdated(person(), List.of());
+        publisher.publishPersonDeleted(PERSON_ID);
+        publisher.publishLinkUpdated(link());
+        publisher.publishLinkRemoved(link());
+
+        verify(writer, never()).publish(any(), any());
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/dto/PersonContactPointDtoTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/dto/PersonContactPointDtoTest.java
@@ -1,0 +1,47 @@
+package com.positivity.peoplecontact.internal.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Locks the JSON wire name of the contact-point primary flag to "primary" in BOTH
+ * directions. The getter serialized as "primary" while the field deserialized from
+ * "isPrimary" — an asymmetry that 400'd PUT /v1/people/{id}/contact-points and broke
+ * the pos-customer dual-write.
+ */
+class PersonContactPointDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serializesPrimaryFlagAsPrimary() {
+        String json =
+                mapper.writeValueAsString(new Person.ContactPointDto(ContactPointType.EMAIL, "g@example.com", true));
+
+        assertThat(json).contains("\"primary\":true");
+        assertThat(json).doesNotContain("isPrimary");
+    }
+
+    @Test
+    void deserializesFromPrimaryField() {
+        Person.ContactPointDto dto = mapper.readValue(
+                "{\"contactType\":\"EMAIL\",\"value\":\"g@example.com\",\"primary\":true}",
+                Person.ContactPointDto.class);
+
+        assertThat(dto.getContactType()).isEqualTo(ContactPointType.EMAIL);
+        assertThat(dto.getValue()).isEqualTo("g@example.com");
+        assertThat(dto.isPrimary()).isTrue();
+    }
+
+    @Test
+    void deserializesPrimaryFalse() {
+        Person.ContactPointDto dto = mapper.readValue(
+                "{\"contactType\":\"PHONE_WORK\",\"value\":\"704-555-1\",\"primary\":false}",
+                Person.ContactPointDto.class);
+
+        assertThat(dto.isPrimary()).isFalse();
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/repository/PersonSpecificationsQueryIT.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/repository/PersonSpecificationsQueryIT.java
@@ -1,0 +1,87 @@
+package com.positivity.peoplecontact.internal.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Executes {@link PersonSpecifications#directoryFilter} against a real JPA metamodel so
+ * the query's attribute references are resolved (the mock-based unit test cannot catch a
+ * predicate that references a non-existent attribute). Guards the people directory/search
+ * paths against regressions like a filter referencing a dropped Person column.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:specquery;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "spring.flyway.enabled=false",
+            "eureka.client.enabled=false"
+        })
+@ActiveProfiles("test")
+class PersonSpecificationsQueryIT {
+
+    @Autowired
+    private PersonRepository personRepository;
+
+    @Autowired
+    private PersonContactPointRepository contactPointRepository;
+
+    @MockitoBean
+    private com.positivity.peoplecontact.internal.client.SecurityServiceClient securityServiceClient;
+
+    private UUID alice;
+    private UUID bob;
+
+    @BeforeEach
+    void seed() {
+        contactPointRepository.deleteAll();
+        personRepository.deleteAll();
+
+        Person a = personRepository.saveAndFlush(
+                Person.builder().firstName("Alice").lastName("Anderson").build());
+        Person b = personRepository.saveAndFlush(
+                Person.builder().firstName("Bob").lastName("Brown").build());
+        alice = a.getId();
+        bob = b.getId();
+
+        contactPointRepository.saveAndFlush(PersonContactPoint.builder()
+                .personId(bob)
+                .contactType(ContactPointType.EMAIL)
+                .value("bob@example.com")
+                .isPrimary(true)
+                .build());
+    }
+
+    @Test
+    void search_matchesByName() {
+        List<Person> result = personRepository.findAll(PersonSpecifications.directoryFilter("ali"));
+        assertThat(result).extracting(Person::getId).containsExactly(alice);
+    }
+
+    @Test
+    void search_matchesByEmailContactPoint() {
+        List<Person> result = personRepository.findAll(PersonSpecifications.directoryFilter("bob@example"));
+        assertThat(result).extracting(Person::getId).containsExactly(bob);
+    }
+
+    @Test
+    void search_blankReturnsAll() {
+        List<Person> result = personRepository.findAll(PersonSpecifications.directoryFilter("  "));
+        assertThat(result).extracting(Person::getId).containsExactlyInAnyOrder(alice, bob);
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/repository/PersonSpecificationsTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/repository/PersonSpecificationsTest.java
@@ -1,0 +1,102 @@
+package com.positivity.peoplecontact.internal.repository;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the people-contact directory search matches name columns and EMAIL contact-point
+ * values via a correlated subquery over {@link PersonContactPoint}. Employment filters moved to
+ * pos-people with the ADR-0044 §6 split — identity search here is name/email only.
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+class PersonSpecificationsTest {
+
+    private Root<Person> mockRoot() {
+        Root<Person> root = mock(Root.class);
+        Path path = mock(Path.class);
+        when(root.get(any(String.class))).thenReturn(path);
+        when(path.in(any(Subquery.class))).thenReturn(mock(Predicate.class));
+        return root;
+    }
+
+    private CriteriaBuilder mockCb() {
+        CriteriaBuilder cb = mock(CriteriaBuilder.class);
+        when(cb.and(any(Predicate[].class))).thenReturn(mock(Predicate.class));
+        when(cb.and(any(Expression.class), any(Expression.class))).thenReturn(mock(Predicate.class));
+        when(cb.or(any(Predicate[].class))).thenReturn(mock(Predicate.class));
+        when(cb.conjunction()).thenReturn(mock(Predicate.class));
+        when(cb.lower(any())).thenReturn(mock(Expression.class));
+        when(cb.like(any(Expression.class), any(String.class))).thenReturn(mock(Predicate.class));
+        when(cb.equal(any(Expression.class), any(Object.class))).thenReturn(mock(Predicate.class));
+        return cb;
+    }
+
+    private Subquery<UUID> mockSubquery(CriteriaQuery<?> query) {
+        Subquery<UUID> sub = mock(Subquery.class);
+        Root<PersonContactPoint> cpRoot = mock(Root.class);
+        Path cpPath = mock(Path.class);
+        when(cpRoot.get(any(String.class))).thenReturn(cpPath);
+        when(sub.from(any(Class.class))).thenReturn((Root) cpRoot);
+        when(sub.select(any())).thenReturn((Subquery) sub);
+        when(query.subquery(any(Class.class))).thenReturn((Subquery) sub);
+        return sub;
+    }
+
+    @Test
+    void queryFilter_matchesNamesAndEmailContactPoints() {
+        Root<Person> root = mockRoot();
+        CriteriaBuilder cb = mockCb();
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+        Subquery<UUID> sub = mockSubquery(query);
+
+        PersonSpecifications.directoryFilter("smith").toPredicate(root, query, cb);
+
+        // A correlated subquery over PersonContactPoint is built for the email match…
+        verify(query).subquery(UUID.class);
+        verify(sub).from(PersonContactPoint.class);
+        verify(sub).select(any());
+        verify(sub).where(any(Predicate.class));
+        // …and the name columns are matched on the person root.
+        verify(root).get("firstName");
+        verify(root).get("lastName");
+    }
+
+    @Test
+    void blankQuery_addsNoPredicateOrSubquery() {
+        Root<Person> root = mockRoot();
+        CriteriaBuilder cb = mockCb();
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+
+        PersonSpecifications.directoryFilter("  ").toPredicate(root, query, cb);
+
+        verify(query, never()).subquery(any(Class.class));
+        verify(root, never()).get(any(String.class));
+    }
+
+    @Test
+    void nullQuery_addsNoPredicateOrSubquery() {
+        Root<Person> root = mockRoot();
+        CriteriaBuilder cb = mockCb();
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+
+        PersonSpecifications.directoryFilter(null).toPredicate(root, query, cb);
+
+        verify(query, never()).subquery(any(Class.class));
+        verify(root, never()).get(any(String.class));
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/service/PersonEmailServiceTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/service/PersonEmailServiceTest.java
@@ -1,0 +1,69 @@
+package com.positivity.peoplecontact.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import com.positivity.peoplecontact.internal.repository.PersonContactPointRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PersonEmailServiceTest {
+
+    private static final UUID PERSON = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    @Mock
+    private PersonContactPointRepository repository;
+
+    @InjectMocks
+    private PersonEmailService service;
+
+    private PersonContactPoint cp(String value, boolean primary) {
+        return PersonContactPoint.builder()
+                .personId(PERSON)
+                .contactType(ContactPointType.EMAIL)
+                .value(value)
+                .isPrimary(primary)
+                .build();
+    }
+
+    @Test
+    void getEmails_returnsPrimaryAndSecondary() {
+        when(repository.findByPersonIdAndContactType(PERSON, ContactPointType.EMAIL))
+                .thenReturn(List.of(cp("second@x.com", false), cp("primary@x.com", true)));
+
+        PersonEmailService.EmailPair pair = service.getEmails(PERSON);
+
+        assertThat(pair.primary()).isEqualTo("primary@x.com");
+        assertThat(pair.secondary()).isEqualTo("second@x.com");
+    }
+
+    @Test
+    void replaceEmails_deletesThenSavesPrimaryAndSecondary_skippingBlanks() {
+        service.replaceEmails(PERSON, "primary@x.com", "  ");
+
+        verify(repository).deleteByPersonIdAndContactType(PERSON, ContactPointType.EMAIL);
+        ArgumentCaptor<PersonContactPoint> captor = ArgumentCaptor.forClass(PersonContactPoint.class);
+        verify(repository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getValue()).isEqualTo("primary@x.com");
+        assertThat(captor.getValue().isPrimary()).isTrue();
+    }
+
+    @Test
+    void findPersonIdsByPrimaryEmail_mapsIds() {
+        when(repository.findByContactTypeAndIsPrimaryAndValueIgnoreCase(ContactPointType.EMAIL, true, "primary@x.com"))
+                .thenReturn(List.of(cp("primary@x.com", true)));
+
+        assertThat(service.findPersonIdsByPrimaryEmail("primary@x.com")).containsExactly(PERSON);
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/service/PersonUsernameServiceTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/service/PersonUsernameServiceTest.java
@@ -1,0 +1,58 @@
+package com.positivity.peoplecontact.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PersonUsernameServiceTest {
+
+    private static final UUID PERSON = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    @Mock
+    private UserPersonLinkRepository linkRepository;
+
+    @InjectMocks
+    private PersonUsernameService service;
+
+    private UserPersonLink link() {
+        UserPersonLink l = new UserPersonLink();
+        l.setUsername("jordan");
+        l.setPerson(Person.builder().id(PERSON).build());
+        return l;
+    }
+
+    @Test
+    void usernameForPerson_resolvesViaLink() {
+        when(linkRepository.findByPerson_Id(PERSON)).thenReturn(List.of(link()));
+
+        assertThat(service.usernameForPerson(PERSON)).isEqualTo("jordan");
+    }
+
+    @Test
+    void usernameForPerson_nullWhenUnlinked() {
+        when(linkRepository.findByPerson_Id(PERSON)).thenReturn(List.of());
+
+        assertThat(service.usernameForPerson(PERSON)).isNull();
+    }
+
+    @Test
+    void usernamesByPersonId_batchResolves() {
+        when(linkRepository.findByPerson_IdIn(List.of(PERSON))).thenReturn(List.of(link()));
+
+        Map<UUID, String> result = service.usernamesByPersonId(List.of(PERSON));
+
+        assertThat(result).containsEntry(PERSON, "jordan");
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/service/PersonWorkPhoneServiceTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/service/PersonWorkPhoneServiceTest.java
@@ -1,0 +1,68 @@
+package com.positivity.peoplecontact.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import com.positivity.peoplecontact.internal.repository.PersonContactPointRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PersonWorkPhoneServiceTest {
+
+    private static final UUID PERSON = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    @Mock
+    private PersonContactPointRepository repository;
+
+    @InjectMocks
+    private PersonWorkPhoneService service;
+
+    private PersonContactPoint cp(String value, boolean primary) {
+        return PersonContactPoint.builder()
+                .personId(PERSON)
+                .contactType(ContactPointType.PHONE_WORK)
+                .value(value)
+                .isPrimary(primary)
+                .build();
+    }
+
+    @Test
+    void getWorkPhones_returnsValuesPrimaryFirst() {
+        when(repository.findByPersonIdAndContactType(PERSON, ContactPointType.PHONE_WORK))
+                .thenReturn(List.of(cp("555-0002", false), cp("555-0001", true)));
+
+        assertThat(service.getWorkPhones(PERSON)).containsExactly("555-0001", "555-0002");
+    }
+
+    @Test
+    void replaceWorkPhones_deletesThenInsertsFirstPrimary_skippingBlanks() {
+        service.replaceWorkPhones(PERSON, List.of("555-0001", "  ", "555-0002"));
+
+        verify(repository).deleteByPersonIdAndContactType(PERSON, ContactPointType.PHONE_WORK);
+        ArgumentCaptor<PersonContactPoint> captor = ArgumentCaptor.forClass(PersonContactPoint.class);
+        verify(repository, times(2)).save(captor.capture());
+        List<PersonContactPoint> saved = captor.getAllValues();
+        assertThat(saved).extracting(PersonContactPoint::getValue).containsExactly("555-0001", "555-0002");
+        assertThat(saved.get(0).isPrimary()).isTrue();
+        assertThat(saved.get(1).isPrimary()).isFalse();
+    }
+
+    @Test
+    void findPersonIdsByWorkPhone_mapsToPersonIds() {
+        when(repository.findByContactTypeAndValue(ContactPointType.PHONE_WORK, "555-0001"))
+                .thenReturn(List.of(cp("555-0001", true)));
+
+        assertThat(service.findPersonIdsByWorkPhone("555-0001")).containsExactly(PERSON);
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/migration/FlywayMigrationIT.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/migration/FlywayMigrationIT.java
@@ -1,0 +1,81 @@
+package com.positivity.peoplecontact.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Boots the full application context against a real Postgres (Testcontainers) so the collapsed
+ * Flyway baseline (V1) and the repeatable seeds run, then Hibernate validates the entity mappings
+ * (ddl-auto=validate). Context startup succeeding proves the migration, the seed SQL, and the JPA
+ * entities all agree.
+ *
+ * <p>This is the durable guard for the class of breakages that bricked deploys before — untested
+ * SQL, because the default tests use H2 with Flyway disabled (e.g. a migration writing to a table
+ * in another service's DB, or a seed referencing persons it never inserts). Requires Docker.
+ */
+@SpringBootTest
+@ActiveProfiles("pg")
+@Testcontainers
+class FlywayMigrationIT {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @org.springframework.test.context.bean.override.mockito.MockitoBean
+    private com.positivity.peoplecontact.internal.client.SecurityServiceClient securityServiceClient;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void baselineAndSeedsApply_andStructuralChangesTookEffect() {
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+
+        // Identity-only schema: person carries no employment columns (HR stays in pos-people,
+        // ADR-0044 §6) and no legal_name (#726).
+        assertThat(droppedColumn(jdbc, "person", "employee_number")).isTrue();
+        assertThat(droppedColumn(jdbc, "person", "status")).isTrue();
+        assertThat(droppedColumn(jdbc, "person", "contact_info_json")).isTrue();
+        assertThat(droppedColumn(jdbc, "person", "legal_name")).isTrue();
+
+        // user_person_links is keyed by username; contact points are typed rows.
+        assertThat(hasColumn(jdbc, "user_person_links", "username")).isTrue();
+        assertThat(droppedColumn(jdbc, "user_person_links", "user_id")).isTrue();
+        assertThat(hasColumn(jdbc, "person_contact_point", "contact_type")).isTrue();
+
+        // Transactional outbox for people-contact.events.v1 (ADR-0044 §4).
+        assertThat(hasColumn(jdbc, "event_outbox", "record_key")).isTrue();
+        assertThat(hasColumn(jdbc, "event_outbox", "published_at")).isTrue();
+
+        // Seeds loaded: bootstrap person + link.
+        assertThat(jdbc.queryForObject("SELECT count(*) FROM person", Integer.class))
+                .isGreaterThanOrEqualTo(1);
+        assertThat(jdbc.queryForObject("SELECT count(*) FROM user_person_links", Integer.class))
+                .isGreaterThanOrEqualTo(1);
+    }
+
+    private boolean hasColumn(JdbcTemplate jdbc, String table, String column) {
+        Integer n = jdbc.queryForObject(
+                "SELECT count(*) FROM information_schema.columns WHERE table_schema='public'"
+                        + " AND table_name=? AND column_name=?",
+                Integer.class,
+                table,
+                column);
+        return n != null && n > 0;
+    }
+
+    private boolean droppedColumn(JdbcTemplate jdbc, String table, String column) {
+        return !hasColumn(jdbc, table, column);
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/service/PeopleAccessControlServiceTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/service/PeopleAccessControlServiceTest.java
@@ -1,0 +1,154 @@
+package com.positivity.peoplecontact.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.internal.client.SecurityServiceClient;
+import com.positivity.peoplecontact.internal.client.dto.RoleDto;
+import com.positivity.peoplecontact.internal.client.dto.User;
+import com.positivity.peoplecontact.internal.client.dto.UserRoleDto;
+import com.positivity.peoplecontact.internal.exception.PersonNotFoundException;
+import com.positivity.peoplecontact.internal.repository.PersonRepository;
+import com.positivity.peoplecontact.internal.service.PeopleAccessControlServiceImpl;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PeopleAccessControlServiceTest {
+
+    private SecurityServiceClient securityServiceClient;
+
+    private UserPersonTranslationService userPersonTranslationService;
+
+    private PersonRepository personRepository;
+
+    private PeopleAccessControlService peopleAccessControlService;
+
+    // Fixed test values for deterministic tests
+    private UUID testPersonId;
+
+    private UUID testUserId;
+
+    private String testUsername;
+
+    private UUID testLocationId;
+
+    @BeforeEach
+    void setUp() {
+        securityServiceClient = mock(SecurityServiceClient.class);
+        userPersonTranslationService = mock(UserPersonTranslationService.class);
+        personRepository = mock(PersonRepository.class);
+        peopleAccessControlService = new PeopleAccessControlServiceImpl(
+                userPersonTranslationService, securityServiceClient, personRepository);
+
+        // Initialize fixed test values
+        testPersonId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        testUserId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        testUsername = "some.user";
+        testLocationId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    }
+
+    private User userWithId() {
+        User user = new User();
+        user.setId(testUserId);
+        user.setUsername(testUsername);
+        return user;
+    }
+
+    @Test
+    void getAvailableRolesForPerson_combinesLocationAndGlobalRoles() {
+        RoleDto locationRole =
+                RoleDto.builder().code("MANAGER").scopeType("LOCATION").build();
+        RoleDto globalRole = RoleDto.builder().code("ADMIN").scopeType("GLOBAL").build();
+
+        when(personRepository.existsById(testPersonId)).thenReturn(true);
+        when(securityServiceClient.getAvailableRoles("LOCATION")).thenReturn(List.of(locationRole));
+        when(securityServiceClient.getAvailableRoles("GLOBAL")).thenReturn(List.of(globalRole));
+
+        List<RoleDto> result = peopleAccessControlService.getAvailableRolesForPerson(testPersonId);
+
+        assertEquals(2, result.size());
+        verify(personRepository).existsById(testPersonId);
+    }
+
+    @Test
+    void getAvailableRolesForPerson_throwsWhenPersonNotFound() {
+        when(personRepository.existsById(testPersonId)).thenReturn(false);
+
+        assertThrows(
+                PersonNotFoundException.class,
+                () -> peopleAccessControlService.getAvailableRolesForPerson(testPersonId));
+    }
+
+    @Test
+    void getPersonRoleAssignments_translatesPersonAndFetchesAssignments() {
+        UserRoleDto assignment = UserRoleDto.builder().roleCode("MANAGER").build();
+        when(userPersonTranslationService.getUsernameForPerson(testPersonId)).thenReturn(Optional.of(testUsername));
+        when(securityServiceClient.getUserByUsername(testUsername)).thenReturn(Optional.of(userWithId()));
+        when(securityServiceClient.getUserRoleAssignments(testUserId, true, null))
+                .thenReturn(List.of(assignment));
+
+        List<UserRoleDto> result = peopleAccessControlService.getPersonRoleAssignments(testPersonId, true, null);
+
+        assertEquals(1, result.size());
+        verify(userPersonTranslationService).getUsernameForPerson(testPersonId);
+        verify(securityServiceClient).getUserRoleAssignments(testUserId, true, null);
+    }
+
+    @Test
+    void assignRoleToPerson_translatesPersonAndCreatesAssignment() {
+        UserRoleDto created = UserRoleDto.builder().roleCode("MANAGER").build();
+
+        when(userPersonTranslationService.getUsernameForPerson(testPersonId)).thenReturn(Optional.of(testUsername));
+        when(securityServiceClient.getUserByUsername(testUsername)).thenReturn(Optional.of(userWithId()));
+        when(securityServiceClient.assignRole(any())).thenReturn(created);
+
+        UserRoleDto result = peopleAccessControlService.assignRoleToPerson(
+                testPersonId, "MANAGER", testLocationId, LocalDateTime.parse("2026-02-16T10:00:00"), null);
+
+        assertEquals("MANAGER", result.getRoleCode());
+        verify(securityServiceClient).assignRole(any());
+    }
+
+    @Test
+    void revokeRoleFromPerson_callsSecurityClient() {
+        LocalDateTime endDate = LocalDateTime.parse("2026-02-16T11:00:00");
+        when(userPersonTranslationService.getUsernameForPerson(testPersonId)).thenReturn(Optional.of(testUsername));
+        when(securityServiceClient.getUserByUsername(testUsername)).thenReturn(Optional.of(userWithId()));
+
+        peopleAccessControlService.revokeRoleFromPerson(testPersonId, "MANAGER", endDate);
+
+        verify(securityServiceClient).revokeRole(testUserId, "MANAGER", endDate);
+    }
+
+    @Test
+    void personMethods_throwWhenNoUserLinkExists() {
+        when(userPersonTranslationService.getUsernameForPerson(testPersonId)).thenReturn(Optional.empty());
+
+        assertThrows(
+                EntityNotFoundException.class,
+                () -> peopleAccessControlService.getPersonRoleAssignments(testPersonId, false, null));
+    }
+
+    @Test
+    void assignRoleToPerson_throwsWhenEndDateBeforeStartDate() {
+        LocalDateTime startDate = LocalDateTime.parse("2026-02-20T10:00:00");
+        LocalDateTime endDate = LocalDateTime.parse("2026-02-15T10:00:00"); // before
+        // startDate
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> peopleAccessControlService.assignRoleToPerson(
+                        testPersonId, "MANAGER", testLocationId, startDate, endDate));
+
+        assertEquals("endDate must be greater than or equal to startDate", exception.getMessage());
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/service/UserPersonLinkServiceTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/service/UserPersonLinkServiceTest.java
@@ -1,0 +1,236 @@
+package com.positivity.peoplecontact.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.internal.dto.LinkUserToPersonRequest;
+import com.positivity.peoplecontact.internal.dto.PersonResponse;
+import com.positivity.peoplecontact.internal.dto.UserPersonLinkResponse;
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import com.positivity.peoplecontact.internal.exception.PersonNotFoundException;
+import com.positivity.peoplecontact.internal.exception.UserAlreadyLinkedException;
+import com.positivity.peoplecontact.internal.exception.UserPersonLinkNotFoundException;
+import com.positivity.peoplecontact.internal.repository.PersonRepository;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
+import com.positivity.peoplecontact.internal.service.UserPersonLinkServiceImpl;
+import com.positivity.security.common.SecurityContextHelper;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserPersonLinkServiceTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private UserPersonLinkRepository linkRepository;
+
+    @Mock
+    private PersonRepository personRepository;
+
+    @Mock
+    private com.positivity.peoplecontact.internal.service.PersonWorkPhoneService workPhoneService;
+
+    @Mock
+    private com.positivity.peoplecontact.internal.service.PersonEmailService emailService;
+
+    @Mock
+    private com.positivity.peoplecontact.internal.service.PersonUsernameService usernameService;
+
+    @Mock
+    private com.positivity.peoplecontact.internal.config.PeopleContactEventPublisher eventPublisher;
+
+    private UserPersonLinkServiceImpl service;
+
+    // Fixed test values for deterministic tests
+    private UUID testPersonId;
+
+    private String testUsername;
+
+    private String testUsername2;
+
+    private UUID testPersonId2;
+
+    @BeforeEach
+    void setUp() {
+        service = new UserPersonLinkServiceImpl(
+                linkRepository, personRepository, workPhoneService, emailService, usernameService, eventPublisher);
+
+        // Initialize fixed test values
+        testPersonId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        testUsername = "marcus.webb";
+        testUsername2 = "dana.cole";
+        testPersonId2 = UUID.fromString("00000000-0000-0000-0000-000000000004");
+    }
+
+    @Test
+    void linkUserToPerson_success() {
+        LinkUserToPersonRequest request = new LinkUserToPersonRequest(testUsername, testPersonId);
+        request.setLinkType("PRIMARY");
+        request.setNotes("notes");
+
+        Person person = Person.builder()
+                .id(testPersonId)
+                .firstName("Alex")
+                .lastName("Smith")
+                .build();
+        when(personRepository.findById(testPersonId)).thenReturn(Optional.of(person));
+        when(linkRepository.existsByUsername(testUsername)).thenReturn(false);
+        when(linkRepository.save(any(UserPersonLink.class))).thenAnswer(invocation -> {
+            UserPersonLink link = invocation.getArgument(0);
+            link.setId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+            link.setCreatedAt(Instant.now(TEST_CLOCK));
+            return link;
+        });
+
+        try (MockedStatic<SecurityContextHelper> helperMock = Mockito.mockStatic(SecurityContextHelper.class)) {
+            helperMock
+                    .when(() -> SecurityContextHelper.getCurrentUsernameOrDefault("system"))
+                    .thenReturn("tester");
+
+            UserPersonLinkResponse response = service.linkUserToPerson(request);
+
+            assertThat(response).isNotNull();
+            assertThat(response.getUsername()).isEqualTo(testUsername);
+            assertThat(response.getPersonId()).isEqualTo(testPersonId);
+            assertThat(response.getCreatedBy()).isEqualTo("tester");
+            assertThat(response.getLinkId()).isNotNull();
+        }
+    }
+
+    @Test
+    void linkUserToPerson_personNotFound() {
+        LinkUserToPersonRequest request = new LinkUserToPersonRequest(testUsername, testPersonId2);
+
+        when(personRepository.findById(testPersonId2)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.linkUserToPerson(request))
+                .isInstanceOf(PersonNotFoundException.class)
+                .hasMessageContaining("Person not found");
+
+        verify(linkRepository, never()).save(any(UserPersonLink.class));
+    }
+
+    @Test
+    void linkUserToPerson_alreadyLinked() {
+        LinkUserToPersonRequest request = new LinkUserToPersonRequest(testUsername, testPersonId);
+
+        when(personRepository.findById(testPersonId))
+                .thenReturn(Optional.of(Person.builder().id(testPersonId).build()));
+        when(linkRepository.existsByUsername(testUsername)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.linkUserToPerson(request))
+                .isInstanceOf(UserAlreadyLinkedException.class)
+                .hasMessageContaining("already linked");
+
+        verify(linkRepository, never()).save(any(UserPersonLink.class));
+    }
+
+    @Test
+    void unlinkUserFromPerson_success() {
+        UserPersonLink link = new UserPersonLink();
+        link.setId(UUID.fromString("00000000-0000-0000-0000-0000000000aa"));
+        link.setUsername(testUsername);
+        link.setPerson(Person.builder().id(testPersonId).build());
+        when(linkRepository.findByUsername(testUsername)).thenReturn(Optional.of(link));
+
+        service.unlinkUserFromPerson(testUsername);
+
+        verify(linkRepository).delete(link);
+        verify(eventPublisher).publishLinkRemoved(link);
+    }
+
+    @Test
+    void unlinkUserFromPerson_notFound() {
+        when(linkRepository.findByUsername(testUsername2)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.unlinkUserFromPerson(testUsername2))
+                .isInstanceOf(UserPersonLinkNotFoundException.class)
+                .hasMessageContaining("No person link found");
+
+        verify(linkRepository, never()).delete(any(UserPersonLink.class));
+    }
+
+    @Test
+    void findPersonByUsername_success() {
+        UserPersonLink link = new UserPersonLink();
+        link.setUsername(testUsername);
+        link.setPerson(Person.builder().id(testPersonId).build());
+
+        Person person = Person.builder()
+                .id(testPersonId)
+                .firstName("Jordan")
+                .lastName("Case")
+                .build();
+
+        when(linkRepository.findByUsername(testUsername)).thenReturn(Optional.of(link));
+        when(personRepository.findById(testPersonId)).thenReturn(Optional.of(person));
+        when(workPhoneService.getWorkPhones(testPersonId)).thenReturn(java.util.List.of());
+        when(emailService.getEmails(testPersonId))
+                .thenReturn(new com.positivity.peoplecontact.internal.service.PersonEmailService.EmailPair(
+                        "jordan@example.com", null));
+
+        PersonResponse response = service.findPersonByUsername(testUsername);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(testPersonId);
+        assertThat(response.getFirstName()).isEqualTo("Jordan");
+        assertThat(response.getPrimaryEmail()).isEqualTo("jordan@example.com");
+    }
+
+    @Test
+    void findPersonByUsername_notFound() {
+        when(linkRepository.findByUsername(testUsername2)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.findPersonByUsername(testUsername2))
+                .isInstanceOf(UserPersonLinkNotFoundException.class)
+                .hasMessageContaining("No person link found");
+    }
+
+    @Test
+    void findUsernamesByPersonId_success() {
+        when(personRepository.findById(testPersonId))
+                .thenReturn(Optional.of(Person.builder().id(testPersonId).build()));
+
+        UserPersonLink firstLink = new UserPersonLink();
+        firstLink.setUsername(testUsername);
+        firstLink.setPerson(Person.builder().id(testPersonId).build());
+
+        UserPersonLink secondLink = new UserPersonLink();
+        secondLink.setUsername(testUsername2);
+        secondLink.setPerson(Person.builder().id(testPersonId).build());
+
+        when(linkRepository.findByPerson_Id(testPersonId)).thenReturn(List.of(firstLink, secondLink));
+
+        List<String> usernames = service.findUsernamesByPersonId(testPersonId);
+
+        assertThat(usernames).containsExactly(testUsername, testUsername2);
+    }
+
+    @Test
+    void findUsernamesByPersonId_empty() {
+        when(personRepository.findById(testPersonId2))
+                .thenReturn(Optional.of(Person.builder().id(testPersonId2).build()));
+        when(linkRepository.findByPerson_Id(testPersonId2)).thenReturn(List.of());
+
+        List<String> usernames = service.findUsernamesByPersonId(testPersonId2);
+
+        assertThat(usernames).isEmpty();
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/service/UserPersonTranslationServiceTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/service/UserPersonTranslationServiceTest.java
@@ -1,0 +1,97 @@
+package com.positivity.peoplecontact.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import com.positivity.peoplecontact.internal.enums.UserLinkStatus;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
+import com.positivity.peoplecontact.internal.service.UserPersonTranslationServiceImpl;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UserPersonTranslationServiceTest {
+
+    private UserPersonLinkRepository userPersonLinkRepository;
+
+    private UserPersonTranslationService userPersonTranslationService;
+
+    private UUID testPersonId;
+
+    private UUID missingPersonId;
+
+    private String testUsername;
+
+    private String missingUsername;
+
+    @BeforeEach
+    void setUp() {
+        userPersonLinkRepository = mock(UserPersonLinkRepository.class);
+        userPersonTranslationService = new UserPersonTranslationServiceImpl(userPersonLinkRepository);
+        testPersonId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        missingPersonId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        testUsername = "jordan";
+        missingUsername = "nobody";
+    }
+
+    @Test
+    void getPersonUuidForUser_returnsMappedPersonUuid() {
+        UserPersonLink link = new UserPersonLink();
+        link.setPerson(Person.builder().id(testPersonId).build());
+        link.setUsername(testUsername);
+        when(userPersonLinkRepository.findByUsername(testUsername)).thenReturn(Optional.of(link));
+
+        UUID result = userPersonTranslationService.getPersonUuidForUser(testUsername);
+
+        assertEquals(testPersonId, result);
+    }
+
+    @Test
+    void getPersonUuidForUser_throwsWhenNoLinkExists() {
+        when(userPersonLinkRepository.findByUsername(missingUsername)).thenReturn(Optional.empty());
+
+        assertThrows(
+                EntityNotFoundException.class,
+                () -> userPersonTranslationService.getPersonUuidForUser(missingUsername));
+    }
+
+    @Test
+    void getUsernameForPerson_returnsOptionalUsername() {
+        UserPersonLink link = new UserPersonLink();
+        link.setPerson(Person.builder().id(testPersonId).build());
+        link.setUsername(testUsername);
+        link.setStatus(UserLinkStatus.ACTIVE);
+        when(userPersonLinkRepository.findByPerson_IdAndStatus(testPersonId, UserLinkStatus.ACTIVE))
+                .thenReturn(Optional.of(link));
+
+        Optional<String> result = userPersonTranslationService.getUsernameForPerson(testPersonId);
+
+        assertEquals(Optional.of(testUsername), result);
+    }
+
+    @Test
+    void getUsernameForPerson_returnsEmptyWhenNoLinkExists() {
+        when(userPersonLinkRepository.findByPerson_IdAndStatus(missingPersonId, UserLinkStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        Optional<String> result = userPersonTranslationService.getUsernameForPerson(missingPersonId);
+
+        assertEquals(Optional.empty(), result);
+    }
+
+    @Test
+    void isUserLinkedToPerson_returnsTrueWhenLinkExists() {
+        when(userPersonLinkRepository.existsByUsernameAndPerson_Id(testUsername, testPersonId))
+                .thenReturn(true);
+
+        boolean result = userPersonTranslationService.isUserLinkedToPerson(testUsername, testPersonId);
+
+        assertEquals(true, result);
+    }
+}

--- a/pos-people-contact/src/test/resources/application-pg.yml
+++ b/pos-people-contact/src/test/resources/application-pg.yml
@@ -1,0 +1,27 @@
+# Test profile that runs the real Flyway baseline + repeatable seeds against a Testcontainers
+# Postgres, with Hibernate ddl-auto=validate. This executes the migrations and seed SQL in CI,
+# catching the class of breakages that H2 + flyway-disabled tests miss (column drift, cross-DB
+# refs, seed FK gaps). The datasource is supplied at runtime by @ServiceConnection.
+spring:
+  application:
+    name: pos-people-contact-pg-test
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+  flyway:
+    enabled: true
+
+security:
+  enabled: false
+
+eureka:
+  client:
+    enabled: false
+
+logging:
+  level:
+    com.positivity: INFO

--- a/pos-security-service/.flattened-pom.xml
+++ b/pos-security-service/.flattened-pom.xml
@@ -71,6 +71,11 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       <version>${springdoc-openapi.version}</version>

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -456,13 +456,23 @@ public enum PermissionCode {
     // ── Inventory (new) ────────────────────────────────────────────────────────
     INVENTORY__LOCATION__SYNC(349, "inventory:location:sync"),
     // ── Workorder (new) ────────────────────────────────────────────────────────
-    WORKORDER__EVENTS__REPLAY(350, "workorder:events:replay");
+    WORKORDER__EVENTS__REPLAY(350, "workorder:events:replay"),
+    // ── People Contact (new, ADR-0044 Phase 3 split — #874) ───────────────────
+    PEOPLE_CONTACT__PERSON__VIEW(351, "people-contact:person:view"),
+    PEOPLE_CONTACT__PERSON__CREATE(352, "people-contact:person:create"),
+    PEOPLE_CONTACT__PERSON__EDIT(353, "people-contact:person:edit"),
+    PEOPLE_CONTACT__PERSON__DELETE(354, "people-contact:person:delete"),
+    PEOPLE_CONTACT__ROLE__VIEW(355, "people-contact:role:view"),
+    PEOPLE_CONTACT__ROLE__ASSIGN(356, "people-contact:role:assign"),
+    PEOPLE_CONTACT__ROLE__REVOKE(357, "people-contact:role:revoke"),
+    PEOPLE_CONTACT__USER_LINK__VIEW(358, "people-contact:userLink:view"),
+    PEOPLE_CONTACT__USER_LINK__WRITE(359, "people-contact:userLink:write");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 18;
+    public static final int CATALOG_VERSION = 19;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 351;
-    private static final int EXPECTED_CATALOG_VERSION = 18;
+    private static final int EXPECTED_PERMISSION_COUNT = 360;
+    private static final int EXPECTED_CATALOG_VERSION = 19;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — 350 entries
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("catalog contains exactly 351 permissions")
+    @DisplayName("catalog contains exactly 360 permissions")
     void catalogContainsExpectedPermissions() {
         assertThat(PermissionCode.values()).hasSize(EXPECTED_PERMISSION_COUNT);
     }

--- a/postgres/init-databases.sql
+++ b/postgres/init-databases.sql
@@ -14,6 +14,7 @@ CREATE DATABASE pos_location_db;
 CREATE DATABASE pos_mcp;
 CREATE DATABASE pos_order_db;
 CREATE DATABASE pos_people_db;
+CREATE DATABASE pos_people_contact_db;
 CREATE DATABASE pos_price_db;
 CREATE DATABASE pos_security_db;
 CREATE DATABASE pos_shop_manager_db;


### PR DESCRIPTION
Implements #874 (Phase 3.1 of #844 / #823, [ADR-0044](https://github.com/louisburroughs/durion/blob/master/docs/adr/0044-platform-event-only-domain-walls.adr.md) §6).

**Contract guide:** changes follow the people domain contract guide — [`durion/domains/people/.business-rules/BACKEND_CONTRACT_GUIDE.md`](https://github.com/louisburroughs/durion/blob/master/domains/people/.business-rules/BACKEND_CONTRACT_GUIDE.md). Person/link REST contracts are moved verbatim from pos-people (same paths under the new `/people-contact/**` route); the only surface changes are the removal of the employment-coupled pieces listed below, which stay live in pos-people until #875.

## What

Splits the identity domain out of pos-people into a new **`pos-people-contact`** module that owns `Person`, `PersonContactPoint`, and `UserPersonLink` (ADR-0015), publishes identity facts on `people-contact.events.v1`, and becomes the authority the security projection (#876) and consumer replicas (#877) will feed from.

### Module surface (moved from pos-people, package `com.positivity.peoplecontact`)
- `PersonController` (directory search, CRUD, resolve, contact-point replacement), `UserPersonLinkController`, `PersonAccessController` (person→role proxy to pos-security-service — utility whitelist sync call).
- Services: `PersonService`, `UserPersonLinkService`, `UserPersonTranslationService`, `PeopleAccessControlService` + impls, email/phone/username helpers.
- Own schema + Flyway baseline (`person`, `person_contact_point`, `user_person_links`, `event_outbox`) + bootstrap seed (admin.alpha person/link).

### Deliberately NOT moved (needs Employee data; stays in pos-people until #875)
- Directory employment filters (`?type=EMPLOYEE|ACTIVE|INACTIVE`) — people-contact search is name/email only.
- `PersonBulkIngestController` (it creates employees, not just persons).
- The inactive-person/active-user compliance report (joins `employee`).
- Person DTO's `employeeStatus` field.

### Eventing (ADR-0044 §4, mirrors the Phase 2 vehicle producer from #865)
- Transactional outbox → `people-contact.events.v1`: `person.updated` (full snapshot incl. contact points), `person.deleted`, `user-person-link.updated`, `user-person-link.removed`. Payload DTOs added to pos-domain-events under `com.positivity.domainevents.peoplecontact`.
- `people-contact.commands.v1` listener (`people-contact.outbox.replay-requested`) with exponential-backoff retry + `.dlq` routing; `people-contact.manifest.v1` reconciliation manifests.
- Envelope `aggregateVersion` is the emission timestamp in epoch millis (person/link rows carry no JPA `@Version`; documented on the payloads).
- Feature flag `pos.people-contact.kafka.enabled` (`POS_PEOPLE_CONTACT_KAFKA_ENABLED`, default off), same rollout shape as vehicle-inventory.

### Platform registration
- Permissions `people-contact:person:*`, `people-contact:role:*`, `people-contact:userLink:*` registered at startup **and added to the PermissionCode catalog (bits 351–359, catalog v19) with the mirrored GatewayPermissionCatalog entries**; `PEOPLE_CONTACT_*` audit event types registered with pos-event-receiver.
- Gateway route `/people-contact/**` → `lb://PEOPLE-CONTACT` + swagger group entry.
- docker-compose service (host port 8095) + `pos_people_contact_db`; reactor module; pos-archunit dependency + entity-standards package.

## Compatibility

pos-people is untouched: its person/link endpoints keep working during the migration window, so nothing breaks before the #875 cutover (HR slimdown + table drop + backfill verification) and the #878 frontend switch.

## Review follow-ups

Copilot's four comments are fixed in 7e533a7. Inherited findings from the self-review are filed as #880 (revoke authority missing from the security-service client's X-Authorities) and #881 (person hard-delete orphans contact points; link FK violation surfaces as 500).

## Verification

- `pos-people-contact`: 57 unit tests + failsafe ITs (incl. Testcontainers Flyway migration IT) green under full quality gates (checkstyle, spotbugs, spotless).
- `pos-security-service`: 433 tests green with the catalog v19 additions; `pos-api-gateway`: 71 tests green with the new route + mirrored catalog.
- `pos-archunit`: ArchitectureTests, EntityStandardsArchitectureTest, DomainWallsTest all green — no new domain-wall violations (only sync client targets pos-security-service, whitelisted).

Closes #874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)