### PR TITLE
feat(customer): publish customer.party/person-identity facts on customer.events.v1 (ADR-0044 Phase 4.1)

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandListener.java
@@ -1,0 +1,122 @@
+package com.positivity.customer.internal.config;
+
+import com.positivity.customer.service.OutboxReplayService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Kafka command listener for {@code customer.commands.v1} (ADR-0044 §4, issue #889).
+ *
+ * <p>Supported command types:
+ * <ul>
+ * <li>{@code customer.outbox.replay-requested} — consumer-initiated drift repair and replica
+ * bootstrap: re-queues published outbox events created in the requested window for
+ * re-publication; consumers dedupe by eventId so replay is idempotent.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
+public class CustomerCommandListener {
+
+    /** Canonical dotted name normalized to command-type form: CUSTOMER_OUTBOX_REPLAY_REQUESTED. */
+    private static final String COMMAND_OUTBOX_REPLAY_REQUESTED = "CUSTOMER_OUTBOX_REPLAY_REQUESTED";
+
+    /** Covers the sub-millisecond skew between outbox createdAt and the eventId timestamp. */
+    private static final Duration REPLAY_WINDOW_SLACK = Duration.ofSeconds(1);
+
+    /** Replay commands older than this are rejected — bounds repair cost. */
+    @Value("${pos.customer.outbox.replay.max-lookback:P30D}")
+    private Duration replayMaxLookback;
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final OutboxReplayService outboxReplayService;
+
+    @KafkaListener(
+            topics = "${pos.customer.kafka.commands-topic:customer.commands.v1}",
+            groupId = "${pos.customer.kafka.commands-consumer-group:pos-customer-commands}")
+    public void onCommand(@NonNull String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            String rawCommandType = root.path("commandType").stringValue(null);
+            if (rawCommandType == null || rawCommandType.isBlank()) {
+                log.debug("Ignoring command without commandType: {}", message);
+                return;
+            }
+            // Normalize dotted command names (customer.outbox.replay-requested) to one form.
+            String commandType =
+                    rawCommandType.toUpperCase(Locale.ROOT).replace('.', '_').replace('-', '_');
+
+            if (COMMAND_OUTBOX_REPLAY_REQUESTED.equals(commandType)) {
+                handleOutboxReplayRequested(root);
+                return;
+            }
+            log.debug("Ignoring unsupported commandType={} message={}", commandType, message);
+        } catch (TransientDataAccessException e) {
+            // Let the container error handler retry with backoff and route to {topic}.dlq
+            // (ADR-0044 §4) — replay is idempotent, so redelivery is harmless.
+            throw e;
+        } catch (Exception e) {
+            // Malformed/unsupported commands are permanent failures: retrying cannot fix them,
+            // so log and drop instead of poisoning the partition.
+            log.error("Failed to process Kafka command message: {}", message, e);
+        }
+    }
+
+    private void handleOutboxReplayRequested(@NonNull JsonNode root) {
+        JsonNode payloadNode = root.get("payload");
+        Instant since = parseInstant(payloadNode, "since");
+        if (since == null) {
+            log.warn("Ignoring outbox replay command with missing/malformed payload.since: {}", root);
+            return;
+        }
+        Instant lookbackLimit = Instant.now(clock).minus(replayMaxLookback);
+        if (since.isBefore(lookbackLimit)) {
+            // A malformed or ancient `since` must not trigger a huge re-emit.
+            log.warn(
+                    "Ignoring outbox replay command: since={} exceeds max lookback {} (limit {})",
+                    since,
+                    replayMaxLookback,
+                    lookbackLimit);
+            return;
+        }
+        Instant until = parseInstant(payloadNode, "until");
+        int queued;
+        if (until != null && until.isAfter(since)) {
+            // Bounded window repair; +/- slack covers createdAt vs eventId-timestamp skew.
+            queued = outboxReplayService.replayBetween(
+                    since.minus(REPLAY_WINDOW_SLACK), until.plus(REPLAY_WINDOW_SLACK));
+        } else {
+            queued = outboxReplayService.replaySince(since.minus(REPLAY_WINDOW_SLACK));
+        }
+        log.info("Outbox replay command processed since={} until={} eventsQueued={}", since, until, queued);
+    }
+
+    private @Nullable Instant parseInstant(@Nullable JsonNode payloadNode, @NonNull String field) {
+        String value = payloadNode == null ? null : payloadNode.path(field).stringValue(null);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(value);
+        } catch (Exception _) {
+            log.warn("Malformed payload.{}={} on outbox replay command", field, value);
+            return null;
+        }
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/ManifestPublisher.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/ManifestPublisher.java
@@ -1,0 +1,221 @@
+package com.positivity.customer.internal.config;
+
+import com.positivity.customer.internal.entity.OutboxEvent;
+import com.positivity.customer.internal.repository.OutboxEventRepository;
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Publishes reconciliation manifests for the customer fact topic (ADR-0044 §4, issue #889).
+ *
+ * <p>Each closed window gets one {@link ReconciliationManifestV1} on {@code customer.manifest.v1}
+ * summarizing the events published from {@code event_outbox} whose eventId (UUIDv7) timestamp
+ * falls in the window. Consumers recompute the summary from their processed-events log and
+ * request an outbox replay over {@code customer.commands.v1} on drift.
+ *
+ * <p>Manifests are sent directly (no outbox): a lost manifest is self-healing — the next run
+ * re-publishes it, and consumers can additionally alert on manifest absence. Publication waits
+ * {@code grace} after window close so in-flight publishes and consumer lag settle before the
+ * comparison, avoiding false drift. Re-publishing the same window (e.g. after a restart) is
+ * harmless because the consumer-side comparison is stateless and idempotent.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
+public class ManifestPublisher {
+
+    /** Covers the sub-millisecond skew between outbox {@code createdAt} and the eventId timestamp. */
+    private static final Duration CREATED_AT_SLACK = Duration.ofSeconds(1);
+
+    private static final String DOMAIN = "customer";
+
+    /** Catch-up bound per run — 24 windows covers a day-long outage at the default 1h window. */
+    private static final int MAX_WINDOWS_PER_RUN = 24;
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+    private final Counter publishedCounter;
+    private final Counter failedCounter;
+
+    @Value("${pos.customer.kafka.events-topic:customer.events.v1}")
+    private String eventsTopic;
+
+    @Value("${pos.customer.manifest.topic:customer.manifest.v1}")
+    private String manifestTopic;
+
+    /** Reconciliation window length. */
+    @Value("${pos.customer.manifest.window:PT1H}")
+    private Duration window;
+
+    /** How long after a window closes before its manifest is published. */
+    @Value("${pos.customer.manifest.grace:PT5M}")
+    private Duration grace;
+
+    @Value("${pos.customer.manifest.send-timeout-ms:10000}")
+    private long sendTimeoutMs;
+
+    @Nullable
+    private Instant lastPublishedWindowEnd;
+
+    public ManifestPublisher(
+            OutboxEventRepository outboxEventRepository,
+            KafkaTemplate<String, String> kafkaTemplate,
+            ObjectMapper objectMapper,
+            Clock clock,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.publishedCounter = registry == null
+                ? null
+                : Counter.builder("customer.manifest.published")
+                        .description("Reconciliation manifests published")
+                        .register(registry);
+        this.failedCounter = registry == null
+                ? null
+                : Counter.builder("customer.manifest.publish.failures")
+                        .description("Reconciliation manifest publish attempts that failed")
+                        .register(registry);
+    }
+
+    @Scheduled(fixedDelayString = "${pos.customer.manifest.poll-interval-ms:300000}")
+    public void publishDueManifest() {
+        Instant latestClosed = latestClosedWindowEnd();
+        if (latestClosed == null || (lastPublishedWindowEnd != null && !latestClosed.isAfter(lastPublishedWindowEnd))) {
+            return;
+        }
+        // First run publishes only the latest closed window (no historic backfill on boot);
+        // afterwards every window is published in order so scheduler gaps cannot skip one
+        // permanently.
+        Instant windowEnd = lastPublishedWindowEnd == null ? latestClosed : lastPublishedWindowEnd.plus(window);
+        int published = 0;
+        while (!windowEnd.isAfter(latestClosed) && published < MAX_WINDOWS_PER_RUN) {
+            Instant windowStart = windowEnd.minus(window);
+            try {
+                publishManifest(windowStart, windowEnd);
+                lastPublishedWindowEnd = windowEnd;
+                increment(publishedCounter);
+                published++;
+                windowEnd = windowEnd.plus(window);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                recordFailure(windowStart, windowEnd, e);
+                return;
+            } catch (Exception e) {
+                // Retry this window on the next poll; later windows stay queued behind it.
+                recordFailure(windowStart, windowEnd, e);
+                return;
+            }
+        }
+        if (!windowEnd.isAfter(latestClosed)) {
+            log.info("Manifest catch-up capped at {} windows this run; continuing next poll", MAX_WINDOWS_PER_RUN);
+        }
+    }
+
+    /** End of the most recent window that closed at least {@code grace} ago, aligned to the window length. */
+    private @Nullable Instant latestClosedWindowEnd() {
+        long windowMillis = window.toMillis();
+        long cutoff = Instant.now(clock).minus(grace).toEpochMilli();
+        long aligned = Math.floorDiv(cutoff, windowMillis) * windowMillis;
+        return aligned <= 0 ? null : Instant.ofEpochMilli(aligned);
+    }
+
+    private void publishManifest(Instant windowStart, Instant windowEnd) throws Exception {
+        List<OutboxEvent> candidates = outboxEventRepository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(
+                eventsTopic, windowStart.minus(CREATED_AT_SLACK), windowEnd.plus(CREATED_AT_SLACK));
+
+        List<String> eventIds = new ArrayList<>();
+        TreeMap<String, Long> eventTypeCounts = new TreeMap<>();
+        for (OutboxEvent row : candidates) {
+            // One malformed row must not block the window's manifest forever: skip it with a
+            // warning; the consumer-side mismatch it may cause is visible drift.
+            try {
+                JsonNode envelope = objectMapper.readTree(row.getPayload());
+                String eventId = envelope.path("eventId").stringValue(null);
+                if (eventId == null || eventId.isBlank()) {
+                    log.warn("Outbox row {} has no eventId in its payload; excluded from manifest", row.getId());
+                    continue;
+                }
+                if (!UuidV7Timestamps.isInWindow(UUID.fromString(eventId), windowStart, windowEnd)) {
+                    continue;
+                }
+                eventIds.add(eventId);
+                String eventType = envelope.path("eventType").stringValue(null);
+                eventTypeCounts.merge(eventType == null || eventType.isBlank() ? "unknown" : eventType, 1L, Long::sum);
+            } catch (Exception e) {
+                log.warn("Outbox row {} has an unparsable payload/eventId; excluded from manifest", row.getId(), e);
+            }
+        }
+
+        ReconciliationManifestV1 manifest = new ReconciliationManifestV1(
+                windowStart,
+                windowEnd,
+                eventIds.size(),
+                ReconciliationManifestV1.checksumOf(eventIds),
+                eventTypeCounts.isEmpty() ? null : eventTypeCounts);
+
+        DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
+                ReconciliationManifestV1.eventTypeFor(DOMAIN),
+                1,
+                manifestAggregateId(windowStart),
+                windowStart.getEpochSecond(),
+                "pos-customer",
+                null,
+                null,
+                manifest,
+                clock);
+
+        kafkaTemplate
+                .send(manifestTopic, envelope.recordKey(), objectMapper.writeValueAsString(envelope))
+                .get(sendTimeoutMs, TimeUnit.MILLISECONDS);
+        log.info(
+                "Published reconciliation manifest window=[{}, {}) events={} topic={}",
+                windowStart,
+                windowEnd,
+                eventIds.size(),
+                manifestTopic);
+    }
+
+    /** Deterministic per-window aggregate id, so re-published manifests key to the same partition. */
+    private UUID manifestAggregateId(Instant windowStart) {
+        return UUID.nameUUIDFromBytes(
+                (DOMAIN + ".manifest:" + eventsTopic + ":" + windowStart).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void recordFailure(Instant windowStart, Instant windowEnd, Exception e) {
+        increment(failedCounter);
+        log.warn("Reconciliation manifest publish failed window=[{}, {})", windowStart, windowEnd, e);
+    }
+
+    private void increment(@Nullable Counter counter) {
+        if (counter != null) {
+            counter.increment();
+        }
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/OutboxEventRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/OutboxEventRepository.java
@@ -1,14 +1,45 @@
 package com.positivity.customer.internal.repository;
 
 import com.positivity.customer.internal.entity.OutboxEvent;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
 
     /** Oldest unpublished rows first — UUIDv7 ids are time-ordered, preserving publish order. */
     @NonNull
     List<OutboxEvent> findTop100ByPublishedAtIsNullOrderByIdAsc();
+
+    /**
+     * Published events of one topic created in a window, for reconciliation-manifest assembly
+     * (ADR-0044 §4, #889). Callers widen the window slightly: {@code createdAt} and the payload's
+     * eventId are stamped microseconds apart.
+     */
+    @NonNull
+    List<OutboxEvent> findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(
+            @NonNull String topic, @NonNull Instant from, @NonNull Instant to);
+
+    /**
+     * Mark already-published events created at or after {@code since} for re-publication
+     * (ADR-0044 backfill/drift repair). The publisher re-sends them; consumers dedupe by eventId.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update OutboxEvent e set e.publishedAt = null, e.attempts = 0, e.lastError = null"
+            + " where e.publishedAt is not null and e.createdAt >= :since")
+    int markForReplaySince(@Param("since") @NonNull Instant since);
+
+    /**
+     * Bounded variant for manifest-driven drift repair: re-queue only the drifted window instead
+     * of everything since {@code since}.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update OutboxEvent e set e.publishedAt = null, e.attempts = 0, e.lastError = null"
+            + " where e.publishedAt is not null and e.createdAt >= :since and e.createdAt < :until")
+    int markForReplayBetween(@Param("since") @NonNull Instant since, @Param("until") @NonNull Instant until);
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/AccountTierServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/AccountTierServiceImpl.java
@@ -41,6 +41,7 @@ public class AccountTierServiceImpl implements AccountTierService {
     private final Clock clock;
 
     private final CommercialPartyRepository commercialPartyRepository;
+    private final CustomerFactPublisher customerFactPublisher;
 
     // Tier calculation thresholds
     private static final BigDecimal BRONZE_THRESHOLD = new BigDecimal("50000");
@@ -110,6 +111,7 @@ public class AccountTierServiceImpl implements AccountTierService {
             if (!manualOverride || request.isForceRecalculation()) {
                 applyTierToParty(party, recommendedTier, calculation.reason, request.isForceRecalculation());
                 commercialPartyRepository.save(party);
+                customerFactPublisher.partyChanged(party);
                 tierApplied = true;
                 log.info("Applied tier {} to account {}", recommendedTier, request.getAccountId());
             } else {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommercialPartyServiceImpl implements CustomerService {
 
     private final CommercialPartyRepository commercialRepository;
+    private final CustomerFactPublisher customerFactPublisher;
 
     /**
      * Retrieves all customers as DTOs.
@@ -131,7 +132,9 @@ public class CommercialPartyServiceImpl implements CustomerService {
         // Determine party type and save to appropriate repository
         PartyType partyType = customer.getPartyType();
         if (partyType == PartyType.COMMERCIAL) {
-            return toDTO(commercialRepository.save(customer));
+            CommercialParty saved = commercialRepository.save(customer);
+            customerFactPublisher.partyChanged(saved);
+            return toDTO(saved);
         }
 
         return null; // This service only handles commercial parties, return null or throw exception
@@ -155,6 +158,7 @@ public class CommercialPartyServiceImpl implements CustomerService {
             CommercialParty existing = commercialOpt.get();
             updateEntityFromDTO(existing, dto);
             CommercialParty saved = commercialRepository.save(existing);
+            customerFactPublisher.partyChanged(saved);
             return Optional.of(toDTO(saved));
         }
 
@@ -172,8 +176,10 @@ public class CommercialPartyServiceImpl implements CustomerService {
         log.debug("Deleting customer with id: {}", id);
 
         // Check commercial repository
-        if (commercialRepository.existsById(id)) {
+        Optional<CommercialParty> existing = commercialRepository.findById(id);
+        if (existing.isPresent()) {
             commercialRepository.deleteById(id);
+            customerFactPublisher.partyDeleted(existing.get());
             return true;
         }
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
@@ -1,0 +1,203 @@
+package com.positivity.customer.internal.service;
+
+import com.positivity.customer.internal.config.OutboxEventWriter;
+import com.positivity.customer.internal.entity.AbstractParty;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.entity.PersonParty;
+import com.positivity.customer.internal.repository.PartyRelationshipRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
+import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
+import com.positivity.domainevents.customer.CustomerPersonIdentityUpdatedV1;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Publishes customer-owned facts to {@code customer.events.v1} through the transactional outbox
+ * (ADR-0044 §6, issue #889 Phase 4.1).
+ *
+ * <p>Every party mutation site calls {@link #partyChanged}/{@link #partyDeleted} inside its
+ * business transaction; commercial-relationship mutations call {@link #personIdentityChanged}.
+ * When Kafka publishing is disabled ({@code pos.customer.kafka.enabled=false}) the outbox writer
+ * bean is absent and every method is a no-op, so callers never need their own guard.
+ *
+ * <p>The envelope's {@code aggregateVersion} is the emission timestamp in epoch millis — parties
+ * carry no optimistic-lock version, and millisecond last-writer-wins ordering matches the
+ * established pattern of this module's billing-rules fact.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomerFactPublisher {
+
+    private static final String SOURCE = "pos-customer";
+
+    private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+    private final Clock clock;
+    private final PersonDirectoryService personDirectoryService;
+    private final PersonPartyRepository personPartyRepository;
+    private final PartyRelationshipRepository partyRelationshipRepository;
+
+    /**
+     * Emit {@code customer.party.updated} for a just-saved party. Person parties additionally
+     * re-emit their {@code customer.person-identity.updated} fact, because creating or updating
+     * the individual-customer record changes the person's CRM standing.
+     */
+    public void partyChanged(@NonNull AbstractParty party) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        publishPartyUpdated(writer, party);
+        if (party instanceof PersonParty person && person.getPersonId() != null) {
+            publishPersonIdentity(writer, person.getPersonId());
+        }
+    }
+
+    /**
+     * Emit {@code customer.party.deleted} for a party removed in the current transaction. Call
+     * with the entity loaded <em>before</em> the delete so the person linkage is still available;
+     * for person parties the person-identity fact is re-emitted with the individual-customer flag
+     * cleared.
+     */
+    public void partyDeleted(@NonNull AbstractParty party) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        UUID personId = party instanceof PersonParty person ? person.getPersonId() : null;
+        CustomerPartyDeletedV1 payload = new CustomerPartyDeletedV1(party.getPartyId(), personId);
+        publish(writer, CustomerPartyDeletedV1.EVENT_TYPE, party.getPartyId(), payload);
+        if (personId != null) {
+            publishPersonIdentity(writer, personId);
+        }
+    }
+
+    /**
+     * Emit {@code customer.person-identity.updated} for a person whose commercial relationships
+     * changed (relationship created, deactivated, or reassigned by an account merge).
+     */
+    public void personIdentityChanged(@NonNull UUID personId) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        publishPersonIdentity(writer, personId);
+    }
+
+    /**
+     * Re-emit the party fact of the person's individual-customer record after the local
+     * people-contact replica changed — the fact's {@code displayName} is materialized from that
+     * replica, so name changes must propagate to {@code ext_customer_party} consumers.
+     */
+    public void personReplicaChanged(@NonNull UUID personId) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        personPartyRepository.findByPersonId(personId).ifPresent(person -> publishPartyUpdated(writer, person));
+    }
+
+    private void publishPartyUpdated(@NonNull OutboxEventWriter writer, @NonNull AbstractParty party) {
+        String displayName = null;
+        String legalName = null;
+        UUID personId = null;
+        UUID parentPartyId = null;
+        Boolean creditHold = null;
+        String partyType;
+
+        if (party instanceof CommercialParty commercial) {
+            partyType = commercial.getPartyType() != null
+                    ? commercial.getPartyType().name()
+                    : "COMMERCIAL";
+            legalName = commercial.getLegalName();
+            displayName = StringUtils.hasText(commercial.getDisplayName()) ? commercial.getDisplayName() : legalName;
+            parentPartyId = commercial.getParentParty() != null
+                    ? commercial.getParentParty().getPartyId()
+                    : null;
+            creditHold = commercial.getBillingRules() != null
+                    ? commercial.getBillingRules().getCreditHold()
+                    : null;
+        } else if (party instanceof PersonParty person) {
+            partyType = "PERSON";
+            personId = person.getPersonId();
+            displayName = resolvePersonDisplayName(personId);
+        } else {
+            partyType = party.getClass().getSimpleName().toUpperCase(java.util.Locale.ROOT);
+        }
+
+        CustomerPartyUpdatedV1 payload = new CustomerPartyUpdatedV1(
+                party.getPartyId(),
+                partyType,
+                party.getCustomerNumber(),
+                displayName,
+                legalName,
+                personId,
+                party.getStatus() != null ? party.getStatus().name() : "ACTIVE",
+                party.getTier() != null ? party.getTier().name() : null,
+                CustomerRequirementsService.requirementsMet(party),
+                creditHold,
+                parentPartyId);
+        publish(writer, CustomerPartyUpdatedV1.EVENT_TYPE, party.getPartyId(), payload);
+    }
+
+    private void publishPersonIdentity(@NonNull OutboxEventWriter writer, @NonNull UUID personId) {
+        Optional<PersonParty> person = personPartyRepository.findByPersonId(personId);
+        UUID personPartyId = person.map(PersonParty::getPersonPartyId).orElse(null);
+        long commercialAccountCount = personPartyId == null
+                ? 0
+                : partyRelationshipRepository.findActiveByToPersonPartyId(personPartyId, LocalDate.now(clock)).stream()
+                        .map(rel -> rel.getFromParty().getPartyId())
+                        .distinct()
+                        .count();
+        CustomerPersonIdentityUpdatedV1 payload = new CustomerPersonIdentityUpdatedV1(
+                personId, personPartyId, person.isPresent(), commercialAccountCount > 0, (int) commercialAccountCount);
+        publish(writer, CustomerPersonIdentityUpdatedV1.EVENT_TYPE, personId, payload);
+    }
+
+    private @Nullable String resolvePersonDisplayName(@Nullable UUID personId) {
+        if (personId == null) {
+            return null;
+        }
+        PersonDirectoryService.PersonIdentity identity = personDirectoryService
+                .fetchPersonIdentitiesQuietly(Set.of(personId))
+                .get(personId);
+        if (identity == null) {
+            return null;
+        }
+        String displayName = identity.displayName();
+        return displayName.isBlank() ? null : displayName;
+    }
+
+    private void publish(
+            @NonNull OutboxEventWriter writer, @NonNull String eventType, @NonNull UUID aggregateId, Object payload) {
+        DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
+                eventType, 1, aggregateId, Instant.now(clock).toEpochMilli(), SOURCE, null, null, payload, clock);
+        writer.publish(DomainTopics.events("customer"), envelope);
+        log.debug("Queued {} for aggregate {}", eventType, aggregateId);
+    }
+
+    /** Distinct person ids on a batch of relationships — merge helper for bulk reassignment. */
+    public static @NonNull List<UUID> affectedPersonIds(
+            @NonNull List<com.positivity.customer.internal.entity.PartyRelationship> relationships) {
+        return relationships.stream()
+                .map(rel -> rel.getToPerson().getPersonId())
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
@@ -7,7 +7,6 @@ import com.positivity.customer.internal.entity.PersonParty;
 import com.positivity.customer.internal.repository.PartyRelationshipRepository;
 import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.domainevents.DomainEventEnvelope;
-import com.positivity.domainevents.DomainTopics;
 import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
 import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
 import com.positivity.domainevents.customer.CustomerPersonIdentityUpdatedV1;
@@ -18,11 +17,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -41,7 +40,6 @@ import org.springframework.util.StringUtils;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class CustomerFactPublisher {
 
     private static final String SOURCE = "pos-customer";
@@ -51,6 +49,32 @@ public class CustomerFactPublisher {
     private final PersonDirectoryService personDirectoryService;
     private final PersonPartyRepository personPartyRepository;
     private final PartyRelationshipRepository partyRelationshipRepository;
+    private final String eventsTopic;
+
+    public CustomerFactPublisher(
+            ObjectProvider<OutboxEventWriter> outboxEventWriter,
+            Clock clock,
+            PersonDirectoryService personDirectoryService,
+            PersonPartyRepository personPartyRepository,
+            PartyRelationshipRepository partyRelationshipRepository,
+            // Same property ManifestPublisher scans event_outbox by, so an override can never
+            // desync the outbox rows from the manifest computation.
+            @Value("${pos.customer.kafka.events-topic:customer.events.v1}") String eventsTopic) {
+        this.outboxEventWriter = outboxEventWriter;
+        this.clock = clock;
+        this.personDirectoryService = personDirectoryService;
+        this.personPartyRepository = personPartyRepository;
+        this.partyRelationshipRepository = partyRelationshipRepository;
+        this.eventsTopic = eventsTopic;
+    }
+
+    /**
+     * The configured fact topic — exposed so other in-module producers (the billing-rules fact in
+     * {@code PartyServiceImpl}) publish to the same topic the manifest computation scans.
+     */
+    public @NonNull String eventsTopic() {
+        return eventsTopic;
+    }
 
     /**
      * Emit {@code customer.party.updated} for a just-saved party. Person parties additionally
@@ -187,7 +211,7 @@ public class CustomerFactPublisher {
             @NonNull OutboxEventWriter writer, @NonNull String eventType, @NonNull UUID aggregateId, Object payload) {
         DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
                 eventType, 1, aggregateId, Instant.now(clock).toEpochMilli(), SOURCE, null, null, payload, clock);
-        writer.publish(DomainTopics.events("customer"), envelope);
+        writer.publish(eventsTopic, envelope);
         log.debug("Queued {} for aggregate {}", eventType, aggregateId);
     }
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerRequirementsService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerRequirementsService.java
@@ -24,10 +24,16 @@ public class CustomerRequirementsService {
                 .findPartyById(customerId)
                 .<AbstractParty>map(party -> party)
                 .or(() -> personPartyService.findPartyById(customerId).map(party -> party))
-                .map(this::requirementsMet);
+                .map(CustomerRequirementsService::requirementsMet);
     }
 
-    private boolean requirementsMet(@NonNull AbstractParty party) {
+    /**
+     * Owner-computed verdict for an already-loaded party — also the source of the
+     * {@code requirementsMet} field on the {@code customer.party.updated} fact (#889). Static
+     * (pure function of the entity) so {@code CustomerFactPublisher} can use it without a bean
+     * dependency back into the party services.
+     */
+    public static boolean requirementsMet(@NonNull AbstractParty party) {
         if (party.getStatus() != AccountStatus.ACTIVE) {
             return false;
         }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/OutboxReplayServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/OutboxReplayServiceImpl.java
@@ -1,0 +1,34 @@
+package com.positivity.customer.internal.service;
+
+import com.positivity.customer.internal.repository.OutboxEventRepository;
+import com.positivity.customer.service.OutboxReplayService;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxReplayServiceImpl implements OutboxReplayService {
+
+    private final OutboxEventRepository outboxEventRepository;
+
+    @Override
+    @Transactional
+    public int replaySince(@NonNull Instant since) {
+        int count = outboxEventRepository.markForReplaySince(since);
+        log.info("Outbox replay requested since={} eventsQueued={}", since, count);
+        return count;
+    }
+
+    @Override
+    @Transactional
+    public int replayBetween(@NonNull Instant since, @NonNull Instant until) {
+        int count = outboxEventRepository.markForReplayBetween(since, until);
+        log.info("Outbox replay requested window=[{}, {}) eventsQueued={}", since, until, count);
+        return count;
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyRelationshipServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyRelationshipServiceImpl.java
@@ -56,6 +56,7 @@ public class PartyRelationshipServiceImpl implements PartyRelationshipService {
     private final PersonPartyRepository personRepository;
     private final PersonDirectoryService personDirectoryService;
     private final Clock clock;
+    private final CustomerFactPublisher customerFactPublisher;
 
     /**
      * Creates a new party relationship between a commercial account and an
@@ -141,6 +142,9 @@ public class PartyRelationshipServiceImpl implements PartyRelationshipService {
         } else {
             relationship = partyRelationshipRepository.save(relationship);
         }
+
+        // The person's commercial-account linkage changed — re-emit their identity fact (#889).
+        customerFactPublisher.personIdentityChanged(relationship.getToPerson().getPersonId());
 
         log.info(
                 "Created party relationship {} for party {} and person {}",
@@ -265,6 +269,7 @@ public class PartyRelationshipServiceImpl implements PartyRelationshipService {
         relationship.deactivate(today);
         relationship.setUpdatedBy(userId);
         partyRelationshipRepository.save(relationship);
+        customerFactPublisher.personIdentityChanged(relationship.getToPerson().getPersonId());
 
         log.info(
                 "Deactivated relationship {} for party {} and person {}",

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -88,6 +88,8 @@ public class PartyServiceImpl implements PartyService {
     /** Present only when pos.customer.kafka.enabled=true (ADR-0044 producer, issue #842). */
     private final org.springframework.beans.factory.ObjectProvider<OutboxEventWriter> outboxEventWriter;
 
+    private final CustomerFactPublisher customerFactPublisher;
+
     private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_INSTANT.withLocale(Locale.US);
 
     @Override
@@ -115,6 +117,7 @@ public class PartyServiceImpl implements PartyService {
         }
 
         CommercialParty saved = partyRepository.save(party);
+        customerFactPublisher.partyChanged(saved);
         log.info(
                 "Created commercial account with partyId: {}, customerNumber: {}",
                 saved.getPartyId(),
@@ -485,6 +488,11 @@ public class PartyServiceImpl implements PartyService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot merge party with itself");
         }
 
+        // Capture contacts whose commercial-account linkage the reassignment below changes, so
+        // their person-identity facts can be re-emitted after the merge (#889).
+        java.util.List<UUID> affectedPersonIds = CustomerFactPublisher.affectedPersonIds(
+                partyRelationshipRepository.findByFromPartyPartyId(loser.getPartyId()));
+
         // Transfer party relationships from loser to survivor
         partyRelationshipRepository.reassignFromParty(loser.getPartyId(), survivor.getPartyId());
 
@@ -499,6 +507,9 @@ public class PartyServiceImpl implements PartyService {
 
         partyRepository.save(survivor);
         partyRepository.save(loser);
+        customerFactPublisher.partyChanged(survivor);
+        customerFactPublisher.partyChanged(loser);
+        affectedPersonIds.forEach(customerFactPublisher::personIdentityChanged);
         log.info("Successfully merged parties - survivor: {}, loser: {}", survivor.getPartyId(), loser.getPartyId());
 
         return MergePartiesResponse.builder()
@@ -563,6 +574,7 @@ public class PartyServiceImpl implements PartyService {
 
         party.getVehicleVins().add(request.getVinNumber());
         partyRepository.save(party);
+        customerFactPublisher.partyChanged(party);
         log.info("Associated vehicle VIN {} with party {}", request.getVinNumber(), partyId);
 
         return CreateVehicleForPartyResponse.builder()
@@ -838,6 +850,8 @@ public class PartyServiceImpl implements PartyService {
         party.setBillingRules(embedded);
         partyRepository.save(party);
         publishBillingRulesUpdated(partyId, embedded);
+        // Credit hold feeds the party fact's requirementsMet verdict — re-emit it (#889).
+        customerFactPublisher.partyChanged(party);
         return mapToBillingRuleRef(embedded);
     }
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -36,7 +36,6 @@ import com.positivity.customer.internal.repository.PartyRelationshipRepository;
 import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.customer.service.PartyService;
 import com.positivity.domainevents.DomainEventEnvelope;
-import com.positivity.domainevents.DomainTopics;
 import com.positivity.domainevents.customer.BillingRulesUpdatedV1;
 import com.positivity.shared.id.UUIDv7Generator;
 import java.time.Clock;
@@ -891,7 +890,9 @@ public class PartyServiceImpl implements PartyService {
                 null,
                 payload,
                 clock);
-        writer.publish(DomainTopics.events("customer"), envelope);
+        // Publish to the configured topic so the manifest computation (which scans by the same
+        // property) can never desync from the outbox rows (PR #893 review).
+        writer.publish(customerFactPublisher.eventsTopic(), envelope);
     }
 
     private BillingRuleRef mapToBillingRuleRef(BillingRulesEmbeddable embedded) {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PeopleContactEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PeopleContactEventsListener.java
@@ -38,6 +38,7 @@ public class PeopleContactEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
+    private final CustomerFactPublisher customerFactPublisher;
 
     @KafkaListener(
             topics = "${pos.customer.kafka.people-contact-events-topic:people-contact.events.v1}",
@@ -113,6 +114,10 @@ public class PeopleContactEventsListener {
                 .aggregateVersion(aggregateVersion)
                 .updatedAt(Instant.now(clock))
                 .build());
+        // The person-party fact's displayName is materialized from this replica — re-emit it so
+        // ext_customer_party consumers pick up the name change (#889). No-op when the person has
+        // no individual-customer record.
+        customerFactPublisher.personReplicaChanged(payload.personId());
         log.info("Updated ext_people_contact_person personId={} version={}", payload.personId(), aggregateVersion);
     }
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
@@ -32,6 +32,7 @@ public class PersonPartyServiceImpl implements CustomerService {
 
     private final PersonPartyRepository customerRepository;
     private final PersonDirectoryService personDirectoryService;
+    private final CustomerFactPublisher customerFactPublisher;
 
     /**
      * Retrieves all customers as DTOs.
@@ -135,6 +136,7 @@ public class PersonPartyServiceImpl implements CustomerService {
 
         // Determine party type and save to appropriate repository
         PersonParty saved = customerRepository.save(customer);
+        customerFactPublisher.partyChanged(saved);
 
         return toDTO(saved);
     }
@@ -157,6 +159,7 @@ public class PersonPartyServiceImpl implements CustomerService {
             PersonParty existing = personOpt.get();
             updateEntityFromDTO(existing, dto);
             PersonParty saved = customerRepository.save(existing);
+            customerFactPublisher.partyChanged(saved);
             return Optional.of(toDTO(saved));
         }
 
@@ -175,8 +178,10 @@ public class PersonPartyServiceImpl implements CustomerService {
         log.debug("Deleting customer with id: {}", id);
 
         // Check person repository first
-        if (customerRepository.existsById(id)) {
+        Optional<PersonParty> existing = customerRepository.findById(id);
+        if (existing.isPresent()) {
             customerRepository.deleteById(id);
+            customerFactPublisher.partyDeleted(existing.get());
             return true;
         }
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonServiceImpl.java
@@ -47,6 +47,7 @@ public class PersonServiceImpl implements PersonService {
     private final PartyRelationshipRepository partyRelationshipRepository;
     private final PersonDirectoryService personDirectoryService;
     private final Clock clock;
+    private final CustomerFactPublisher customerFactPublisher;
 
     /**
      * Creates a new individual person record with optional contact points.
@@ -123,6 +124,7 @@ public class PersonServiceImpl implements PersonService {
         person.setCustomerNumber("CUST-PER-" + UUIDv7Generator.generate());
         person.setPreferredContactMethod(request.getPreferredContactMethod());
         PersonParty savedPerson = personRepository.save(person);
+        customerFactPublisher.partyChanged(savedPerson);
         log.debug(
                 "PersonParty created with partyId={} mapped to personId={}",
                 savedPerson.getPersonPartyId(),

--- a/pos-customer/src/main/java/com/positivity/customer/service/OutboxReplayService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/service/OutboxReplayService.java
@@ -1,0 +1,17 @@
+package com.positivity.customer.service;
+
+import java.time.Instant;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Re-queues already-published outbox events for re-publication (ADR-0044 §4 backfill/drift
+ * repair, issue #889). Consumers dedupe by eventId, so replay is idempotent.
+ */
+public interface OutboxReplayService {
+
+    /** Re-queue published events created at or after {@code since}. Returns the count queued. */
+    int replaySince(@NonNull Instant since);
+
+    /** Re-queue published events created in {@code [since, until)}. Returns the count queued. */
+    int replayBetween(@NonNull Instant since, @NonNull Instant until);
+}

--- a/pos-customer/src/main/resources/application.yml
+++ b/pos-customer/src/main/resources/application.yml
@@ -92,4 +92,12 @@ pos:
       people-contact-manifest-topic: ${POS_CUSTOMER_PC_MANIFEST_TOPIC:people-contact.manifest.v1}
       people-contact-manifest-consumer-group: ${POS_CUSTOMER_PC_MANIFEST_CONSUMER_GROUP:pos-customer-people-contact-manifests}
       people-contact-commands-topic: ${POS_CUSTOMER_PC_COMMANDS_TOPIC:people-contact.commands.v1}
+      # Own fact topic + reconciliation + inbound replay commands (ADR-0044 §6, #889)
+      events-topic: ${POS_CUSTOMER_EVENTS_TOPIC:customer.events.v1}
+      commands-topic: ${POS_CUSTOMER_COMMANDS_TOPIC:customer.commands.v1}
+      commands-consumer-group: ${POS_CUSTOMER_COMMANDS_CONSUMER_GROUP:pos-customer-commands}
       enabled: ${POS_CUSTOMER_KAFKA_ENABLED:false}
+    manifest:
+      topic: ${POS_CUSTOMER_MANIFEST_TOPIC:customer.manifest.v1}
+      window: ${POS_CUSTOMER_MANIFEST_WINDOW:PT1H}
+      grace: ${POS_CUSTOMER_MANIFEST_GRACE:PT5M}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/CustomerCommandListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/CustomerCommandListenerTest.java
@@ -1,0 +1,97 @@
+package com.positivity.customer.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.service.OutboxReplayService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link CustomerCommandListener} (ADR-0044 §4, #889).
+ */
+class CustomerCommandListenerTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-13T12:00:00Z"), ZoneOffset.UTC);
+
+    private final OutboxReplayService replayService = mock(OutboxReplayService.class);
+
+    private CustomerCommandListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new CustomerCommandListener(TEST_CLOCK, new ObjectMapper(), replayService);
+        ReflectionTestUtils.setField(listener, "replayMaxLookback", Duration.ofDays(30));
+    }
+
+    private String replayCommand(String since, String until) {
+        return """
+                {"commandType":"customer.outbox.replay-requested",
+                 "payload":{"since":"%s","until":"%s"}}
+                """.formatted(since, until);
+    }
+
+    @Test
+    @DisplayName("Bounded replay command re-queues the window with slack")
+    void boundedReplay() {
+        listener.onCommand(replayCommand("2026-07-13T10:00:00Z", "2026-07-13T11:00:00Z"));
+
+        ArgumentCaptor<Instant> since = ArgumentCaptor.forClass(Instant.class);
+        ArgumentCaptor<Instant> until = ArgumentCaptor.forClass(Instant.class);
+        verify(replayService).replayBetween(since.capture(), until.capture());
+        assertThat(since.getValue()).isEqualTo(Instant.parse("2026-07-13T09:59:59Z"));
+        assertThat(until.getValue()).isEqualTo(Instant.parse("2026-07-13T11:00:01Z"));
+    }
+
+    @Test
+    @DisplayName("Open-ended replay command falls back to replaySince")
+    void openEndedReplay() {
+        listener.onCommand("""
+                {"commandType":"CUSTOMER_OUTBOX_REPLAY_REQUESTED","payload":{"since":"2026-07-13T10:00:00Z"}}
+                """);
+
+        verify(replayService).replaySince(Instant.parse("2026-07-13T09:59:59Z"));
+    }
+
+    @Test
+    @DisplayName("Replay commands beyond the max lookback are rejected")
+    void rejectsAncientReplay() {
+        listener.onCommand(replayCommand("2026-05-01T00:00:00Z", "2026-05-01T01:00:00Z"));
+
+        verify(replayService, never()).replayBetween(any(), any());
+        verify(replayService, never()).replaySince(any());
+    }
+
+    @Test
+    @DisplayName("Malformed commands are logged and dropped, not rethrown")
+    void dropsMalformedCommands() {
+        assertThatCode(() -> listener.onCommand("{ not json ")).doesNotThrowAnyException();
+        assertThatCode(() -> listener.onCommand("{\"commandType\":\"something.else\"}"))
+                .doesNotThrowAnyException();
+        verify(replayService, never()).replayBetween(any(), any());
+    }
+
+    @Test
+    @DisplayName("Transient DB errors rethrow for container retry/DLQ (ADR-0044 §4)")
+    void rethrowsTransientErrors() {
+        when(replayService.replayBetween(any(), any())).thenThrow(new QueryTimeoutException("db timeout"));
+
+        assertThatExceptionOfType(QueryTimeoutException.class)
+                .isThrownBy(() -> listener.onCommand(replayCommand("2026-07-13T10:00:00Z", "2026-07-13T11:00:00Z")));
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerFactPublisherTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerFactPublisherTest.java
@@ -55,7 +55,12 @@ class CustomerFactPublisherTest {
     void setUp() {
         when(writerProvider.getIfAvailable()).thenReturn(writer);
         publisher = new CustomerFactPublisher(
-                writerProvider, TEST_CLOCK, personDirectoryService, personPartyRepository, partyRelationshipRepository);
+                writerProvider,
+                TEST_CLOCK,
+                personDirectoryService,
+                personPartyRepository,
+                partyRelationshipRepository,
+                "customer.events.v1");
     }
 
     private CommercialParty commercialParty(AccountStatus status, Boolean creditHold) {

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerFactPublisherTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerFactPublisherTest.java
@@ -1,0 +1,190 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.config.OutboxEventWriter;
+import com.positivity.customer.internal.entity.BillingRulesEmbeddable;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.entity.PersonParty;
+import com.positivity.customer.internal.enums.AccountStatus;
+import com.positivity.customer.internal.repository.PartyRelationshipRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
+import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
+import com.positivity.domainevents.customer.CustomerPersonIdentityUpdatedV1;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Unit tests for {@link CustomerFactPublisher} (ADR-0044 §6, #889).
+ */
+class CustomerFactPublisherTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-13T12:00:00Z"), ZoneOffset.UTC);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<OutboxEventWriter> writerProvider = mock(ObjectProvider.class);
+
+    private final OutboxEventWriter writer = mock(OutboxEventWriter.class);
+    private final PersonDirectoryService personDirectoryService = mock(PersonDirectoryService.class);
+    private final PersonPartyRepository personPartyRepository = mock(PersonPartyRepository.class);
+    private final PartyRelationshipRepository partyRelationshipRepository = mock(PartyRelationshipRepository.class);
+
+    private CustomerFactPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        when(writerProvider.getIfAvailable()).thenReturn(writer);
+        publisher = new CustomerFactPublisher(
+                writerProvider, TEST_CLOCK, personDirectoryService, personPartyRepository, partyRelationshipRepository);
+    }
+
+    private CommercialParty commercialParty(AccountStatus status, Boolean creditHold) {
+        CommercialParty party = new CommercialParty();
+        party.setPartyId(UUID.randomUUID());
+        party.setCustomerNumber("CUST-001");
+        party.setLegalName("Acme Corp");
+        party.setStatus(status);
+        if (creditHold != null) {
+            BillingRulesEmbeddable rules = new BillingRulesEmbeddable();
+            rules.setCreditHold(creditHold);
+            party.setBillingRules(rules);
+        }
+        return party;
+    }
+
+    @Test
+    @DisplayName("Commercial party fact carries the requirements-met verdict (credit hold blocks)")
+    void commercialPartyFact() {
+        CommercialParty party = commercialParty(AccountStatus.ACTIVE, true);
+
+        publisher.partyChanged(party);
+
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(eq("customer.events.v1"), captor.capture());
+        CustomerPartyUpdatedV1 fact = (CustomerPartyUpdatedV1) captor.getValue().payload();
+        assertThat(captor.getValue().eventType()).isEqualTo(CustomerPartyUpdatedV1.EVENT_TYPE);
+        assertThat(fact.partyId()).isEqualTo(party.getPartyId());
+        assertThat(fact.partyType()).isEqualTo("COMMERCIAL");
+        assertThat(fact.displayName()).isEqualTo("Acme Corp");
+        assertThat(fact.legalName()).isEqualTo("Acme Corp");
+        assertThat(fact.requirementsMet()).isFalse();
+        assertThat(fact.creditHold()).isTrue();
+        assertThat(fact.personId()).isNull();
+    }
+
+    @Test
+    @DisplayName("Active commercial party without credit hold meets requirements")
+    void requirementsMetWhenNoHold() {
+        publisher.partyChanged(commercialParty(AccountStatus.ACTIVE, false));
+
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(eq("customer.events.v1"), captor.capture());
+        assertThat(((CustomerPartyUpdatedV1) captor.getValue().payload()).requirementsMet())
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("Person party emits the party fact plus its person-identity fact")
+    void personPartyEmitsBothFacts() {
+        UUID personId = UUID.randomUUID();
+        PersonParty person = new PersonParty();
+        person.setPersonPartyId(UUID.randomUUID());
+        person.setPersonId(personId);
+        person.setCustomerNumber("CUST-PER-1");
+        person.setStatus(AccountStatus.ACTIVE);
+        when(personDirectoryService.fetchPersonIdentitiesQuietly(Set.of(personId)))
+                .thenReturn(Map.of(
+                        personId,
+                        new PersonDirectoryService.PersonIdentity(personId, "Jane", "Smith", null, List.of())));
+        when(personPartyRepository.findByPersonId(personId)).thenReturn(Optional.of(person));
+        when(partyRelationshipRepository.findActiveByToPersonPartyId(eq(person.getPersonPartyId()), any()))
+                .thenReturn(List.of());
+
+        publisher.partyChanged(person);
+
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer, times(2)).publish(eq("customer.events.v1"), captor.capture());
+        CustomerPartyUpdatedV1 partyFact =
+                (CustomerPartyUpdatedV1) captor.getAllValues().get(0).payload();
+        assertThat(partyFact.partyType()).isEqualTo("PERSON");
+        assertThat(partyFact.personId()).isEqualTo(personId);
+        assertThat(partyFact.displayName()).isEqualTo("Jane Smith");
+        assertThat(partyFact.requirementsMet()).isTrue();
+
+        CustomerPersonIdentityUpdatedV1 identityFact =
+                (CustomerPersonIdentityUpdatedV1) captor.getAllValues().get(1).payload();
+        assertThat(identityFact.personId()).isEqualTo(personId);
+        assertThat(identityFact.individualCustomer()).isTrue();
+        assertThat(identityFact.commercialContact()).isFalse();
+        assertThat(identityFact.commercialAccountCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("Person party delete emits the deleted fact and clears the identity flags")
+    void personPartyDelete() {
+        UUID personId = UUID.randomUUID();
+        PersonParty person = new PersonParty();
+        person.setPersonPartyId(UUID.randomUUID());
+        person.setPersonId(personId);
+        person.setStatus(AccountStatus.ACTIVE);
+        when(personPartyRepository.findByPersonId(personId)).thenReturn(Optional.empty());
+
+        publisher.partyDeleted(person);
+
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer, times(2)).publish(eq("customer.events.v1"), captor.capture());
+        CustomerPartyDeletedV1 deleted =
+                (CustomerPartyDeletedV1) captor.getAllValues().get(0).payload();
+        assertThat(deleted.partyId()).isEqualTo(person.getPersonPartyId());
+        assertThat(deleted.personId()).isEqualTo(personId);
+
+        CustomerPersonIdentityUpdatedV1 identityFact =
+                (CustomerPersonIdentityUpdatedV1) captor.getAllValues().get(1).payload();
+        assertThat(identityFact.individualCustomer()).isFalse();
+        assertThat(identityFact.personPartyId()).isNull();
+        assertThat(identityFact.commercialAccountCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("All methods no-op when Kafka publishing is disabled")
+    void noopWhenWriterAbsent() {
+        when(writerProvider.getIfAvailable()).thenReturn(null);
+
+        publisher.partyChanged(commercialParty(AccountStatus.ACTIVE, null));
+        publisher.personIdentityChanged(UUID.randomUUID());
+        publisher.personReplicaChanged(UUID.randomUUID());
+
+        verify(writer, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("personReplicaChanged re-emits the party fact only for persons with a customer record")
+    void personReplicaChanged() {
+        UUID personId = UUID.randomUUID();
+        when(personPartyRepository.findByPersonId(personId)).thenReturn(Optional.empty());
+
+        publisher.personReplicaChanged(personId);
+
+        verify(writer, never()).publish(any(), any());
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/service/CommercialPartyServiceImplSearchTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/CommercialPartyServiceImplSearchTest.java
@@ -25,7 +25,9 @@ class CommercialPartyServiceImplSearchTest {
     private CommercialPartyRepository commercialRepository;
 
     private CommercialPartyServiceImpl service() {
-        return new CommercialPartyServiceImpl(commercialRepository);
+        return new CommercialPartyServiceImpl(
+                commercialRepository,
+                org.mockito.Mockito.mock(com.positivity.customer.internal.service.CustomerFactPublisher.class));
     }
 
     private CommercialParty party(UUID id, String legalName) {

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -104,7 +104,8 @@ class PartyServiceImplTest {
                 cacheManager,
                 personDirectoryService,
                 extVehicleRepository,
-                emptyOutboxWriterProvider());
+                emptyOutboxWriterProvider(),
+                org.mockito.Mockito.mock(com.positivity.customer.internal.service.CustomerFactPublisher.class));
     }
 
     private CommercialParty party(UUID id) {

--- a/pos-customer/src/test/java/com/positivity/customer/service/PersonPartyServiceImplSearchTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PersonPartyServiceImplSearchTest.java
@@ -29,7 +29,10 @@ class PersonPartyServiceImplSearchTest {
     private PersonDirectoryService personDirectoryService;
 
     private PersonPartyServiceImpl service() {
-        return new PersonPartyServiceImpl(personPartyRepository, personDirectoryService);
+        return new PersonPartyServiceImpl(
+                personPartyRepository,
+                personDirectoryService,
+                org.mockito.Mockito.mock(com.positivity.customer.internal.service.CustomerFactPublisher.class));
     }
 
     private PersonParty person(UUID partyId, UUID personId) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyDeletedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyDeletedV1.java
@@ -1,0 +1,27 @@
+package com.positivity.domainevents.customer;
+
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: a customer party was hard-deleted by its owner (ADR-0044 §6, issue #889 Phase 4.1).
+ *
+ * <p>Published by pos-customer on {@code customer.events.v1} with
+ * {@code eventType = "customer.party.deleted"}. Consumers remove the party from their
+ * {@code ext_customer_party} replicas.
+ *
+ * @param partyId deleted party identifier (also the envelope aggregateId)
+ * @param personId canonical person id the party referenced (person parties only)
+ */
+public record CustomerPartyDeletedV1(
+        @NonNull UUID partyId, @Nullable UUID personId) {
+
+    public static final String EVENT_TYPE = "customer.party.deleted";
+
+    public CustomerPartyDeletedV1 {
+        if (partyId == null) {
+            throw new IllegalArgumentException("partyId must not be null");
+        }
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyUpdatedV1.java
@@ -1,0 +1,61 @@
+package com.positivity.domainevents.customer;
+
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: a customer party (person or commercial account) was created or changed
+ * (ADR-0044 §6, issue #889 Phase 4.1).
+ *
+ * <p>Published by pos-customer on {@code customer.events.v1} with
+ * {@code eventType = "customer.party.updated"}. Consumers maintain read-only
+ * {@code ext_customer_party} replicas serving name search/resolution (pos-invoice),
+ * requirements-met checks (pos-workorder) and customer lookups (pos-shop-manager).
+ * Additions must be additive-only within schema version 1.
+ *
+ * <p>{@code displayName} is the CRM-resolved display name: for commercial parties the
+ * account display/legal name, for person parties the identity display name materialized
+ * from the owner's people-contact replica. {@code requirementsMet} is the owner-computed
+ * work-authorization verdict (status is ACTIVE and, for commercial parties, no credit
+ * hold) — re-emitted whenever its inputs change so consumers never recompute it.
+ *
+ * @param partyId party identifier (also the envelope aggregateId)
+ * @param partyType owner's party type name, e.g. {@code PERSON}, {@code COMMERCIAL}
+ * @param customerNumber unique human-facing customer number
+ * @param displayName CRM-resolved display name (may be null when no identity is known yet)
+ * @param legalName legal name (commercial parties only)
+ * @param personId canonical people-contact person id (person parties only)
+ * @param status account status name, e.g. {@code ACTIVE}, {@code INACTIVE}, {@code MERGED}
+ * @param tier account tier name, e.g. {@code STANDARD}
+ * @param requirementsMet owner-computed verdict: party currently meets work requirements
+ * @param creditHold commercial billing-rules credit hold flag (null when not applicable)
+ * @param parentPartyId parent commercial account (null for roots and person parties)
+ */
+public record CustomerPartyUpdatedV1(
+        @NonNull UUID partyId,
+        @NonNull String partyType,
+        @Nullable String customerNumber,
+        @Nullable String displayName,
+        @Nullable String legalName,
+        @Nullable UUID personId,
+        @NonNull String status,
+        @Nullable String tier,
+        boolean requirementsMet,
+        @Nullable Boolean creditHold,
+        @Nullable UUID parentPartyId) {
+
+    public static final String EVENT_TYPE = "customer.party.updated";
+
+    public CustomerPartyUpdatedV1 {
+        if (partyId == null) {
+            throw new IllegalArgumentException("partyId must not be null");
+        }
+        if (partyType == null || partyType.isBlank()) {
+            throw new IllegalArgumentException("partyType must not be blank");
+        }
+        if (status == null || status.isBlank()) {
+            throw new IllegalArgumentException("status must not be blank");
+        }
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPersonIdentityUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPersonIdentityUpdatedV1.java
@@ -1,0 +1,46 @@
+package com.positivity.domainevents.customer;
+
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: a person's CRM customer standing changed (ADR-0044 §6, issue #889 Phase 4.1).
+ *
+ * <p>Published by pos-customer on {@code customer.events.v1} with
+ * {@code eventType = "customer.person-identity.updated"} whenever the person's individual
+ * customer record or commercial relationships change. Consumed by pos-security-service into
+ * its {@code ext_customer_person_identity} replica for self-registration conflict checks.
+ *
+ * <p>Deliberately carries only customer-owned linkage: names and contact points belong to
+ * pos-people-contact and reach consumers on {@code people-contact.events.v1} — consumers
+ * join the two replicas by {@code personId} instead of this module re-broadcasting
+ * identity data it does not own.
+ *
+ * <p>There is no companion deleted event: when the person stops being a customer the fact
+ * is re-emitted with both flags false and a zero count, which consumers upsert as-is.
+ *
+ * @param personId canonical people-contact person id (also the envelope aggregateId)
+ * @param personPartyId the person's individual-customer party id (null when none)
+ * @param individualCustomer true when the person is an individual customer
+ * @param commercialContact true when the person is an active contact of a commercial account
+ * @param commercialAccountCount number of distinct commercial accounts the person is linked to
+ */
+public record CustomerPersonIdentityUpdatedV1(
+        @NonNull UUID personId,
+        @Nullable UUID personPartyId,
+        boolean individualCustomer,
+        boolean commercialContact,
+        int commercialAccountCount) {
+
+    public static final String EVENT_TYPE = "customer.person-identity.updated";
+
+    public CustomerPersonIdentityUpdatedV1 {
+        if (personId == null) {
+            throw new IllegalArgumentException("personId must not be null");
+        }
+        if (commercialAccountCount < 0) {
+            throw new IllegalArgumentException("commercialAccountCount must not be negative");
+        }
+    }
+}


### PR DESCRIPTION
Closes #889. Part of #845 / #823 ([ADR-0044](https://github.com/louisburroughs/durion/blob/master/docs/adr/0044-platform-event-only-domain-walls.adr.md) §6).

pos-customer becomes a full fact producer so the Phase 4.3 consumers (#891) can retire their synchronous customer clients.

## Facts (new payloads in `com.positivity.domainevents.customer`)

| Event type | Payload | Consumers |
|---|---|---|
| `customer.party.updated` | `CustomerPartyUpdatedV1` — partyId, partyType, customerNumber, resolved displayName, legalName, personId, status, tier, **owner-computed `requirementsMet` verdict**, creditHold, parentPartyId | invoice name search/resolution, workorder requirements check, shop-manager lookup |
| `customer.party.deleted` | `CustomerPartyDeletedV1` — partyId, personId | replica removal |
| `customer.person-identity.updated` | `CustomerPersonIdentityUpdatedV1` — personId, personPartyId, individualCustomer, commercialContact, commercialAccountCount | security self-registration conflict checks |

The person-identity fact deliberately carries only customer-owned linkage: names/contact points belong to pos-people-contact and consumers join the two replicas by `personId` instead of this module re-broadcasting identity data it does not own.

## Emission points

`CustomerFactPublisher` (no-op when `pos.customer.kafka.enabled=false`) is called inside the business transaction from every party mutation site:

- create/update/delete in `CommercialPartyServiceImpl`, `PersonPartyServiceImpl`, `PersonServiceImpl`, `PartyServiceImpl` (commercial account create, merge incl. re-emitting identity facts for contacts whose relationships were reassigned, VIN association)
- `AccountTierServiceImpl` tier application
- billing-rules updates re-emit the party fact because credit hold feeds `requirementsMet`
- `PartyRelationshipServiceImpl` create/deactivate re-emit the affected person's identity fact
- people-contact replica updates re-emit the person-party fact so consumer display names never go stale

`CustomerRequirementsService.requirementsMet(AbstractParty)` becomes a public static pure function shared by the REST endpoint and the fact — consumers never recompute the verdict.

## Reconciliation + replay (the #874 producer pattern)

- `ManifestPublisher` publishes `ReconciliationManifestV1` windows on `customer.manifest.v1` (1h window / 5m grace, ordered catch-up, capped at 24 windows/run).
- `CustomerCommandListener` handles `customer.outbox.replay-requested` on `customer.commands.v1` with the 30-day lookback guard; `OutboxReplayService` re-queues published outbox rows (consumers dedupe by eventId).
- `OutboxEventRepository` gains the manifest window query and `markForReplaySince/Between`.

Everything stays behind the existing `pos.customer.kafka.enabled` flag (default off); no schema migration needed (`event_outbox` exists since #842).

## Testing

- `CustomerFactPublisherTest` — verdict computation (credit hold blocks, active+no-hold passes), person-party dual emission with directory-resolved display name, delete clearing identity flags, disabled-flag no-ops.
- `CustomerCommandListenerTest` — bounded/open replay with slack, lookback rejection, malformed-drop, transient rethrow.
- Full `pos-customer` suite (177 tests incl. ArchitectureTest) and `pos-domain-events` green; Spotless/Checkstyle/SpotBugs clean.

Contract reference: `durion/domains/customer/.business-rules/BACKEND_CONTRACT_GUIDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TXyBX7Q2nXbPFBdAz8owH