### PR TITLE
feat(location): publish location/storage-location facts on location.events.v1 (ADR-0044 Phase 4.2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -732,6 +732,9 @@ services:
     ports:
       - "8084:8080"
     environment:
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
+      # ADR-0044 §6 (#890): location fact producer (outbox drain, manifests, replay commands)
+      POS_LOCATION_KAFKA_ENABLED: ${POS_LOCATION_KAFKA_ENABLED:-false}
       EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
       GATEWAY_URL: http://pos-api-gateway:8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_location_db

--- a/pos-customer/src/main/resources/db/migration/V16__event_outbox_published_window_index.sql
+++ b/pos-customer/src/main/resources/db/migration/V16__event_outbox_published_window_index.sql
@@ -1,0 +1,5 @@
+-- ADR-0044 §4 (#889/#894 review): the reconciliation ManifestPublisher scans published
+-- rows of a topic by created_at window; without this index the scan degrades to a full
+-- table walk as outbox history grows. Matches the pos-people-contact/pos-people outbox DDL.
+CREATE INDEX idx_event_outbox_published_window ON event_outbox (topic, created_at)
+    WHERE published_at IS NOT NULL;

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/location/LocationDeletedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/location/LocationDeletedV1.java
@@ -1,0 +1,24 @@
+package com.positivity.domainevents.location;
+
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Fact: a location was hard-deleted by its owner (ADR-0044 §6, issue #890 Phase 4.2).
+ *
+ * <p>Published by pos-location on {@code location.events.v1} with
+ * {@code eventType = "location.location.deleted"}. Consumers remove the location from their
+ * {@code ext_location} replicas.
+ *
+ * @param locationId deleted location identifier (also the envelope aggregateId)
+ */
+public record LocationDeletedV1(@NonNull UUID locationId) {
+
+    public static final String EVENT_TYPE = "location.location.deleted";
+
+    public LocationDeletedV1 {
+        if (locationId == null) {
+            throw new IllegalArgumentException("locationId must not be null");
+        }
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/location/LocationUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/location/LocationUpdatedV1.java
@@ -1,0 +1,67 @@
+package com.positivity.domainevents.location;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: a location (site/shop) was created or changed (ADR-0044 §6, issue #890 Phase 4.2).
+ *
+ * <p>Published by pos-location on {@code location.events.v1} with
+ * {@code eventType = "location.location.updated"}. Consumers maintain read-only
+ * {@code ext_location} replicas serving rosters (pos-inventory, pos-people), site defaults
+ * (pos-inventory) and the tax destination address (pos-invoice, pos-workorder).
+ *
+ * <p>The address fields are the tax-jurisdiction inputs previously served by
+ * {@code GET /v1/locations/{id}} — ADR-0044 explicitly reversed the older "never replicate
+ * address data" rule for this feed; consumers must still run ADR-0021 address validation on
+ * replica data before tax calculation.
+ *
+ * @param locationId location identifier (also the envelope aggregateId)
+ * @param name display name
+ * @param code unique short code
+ * @param status owner status string, e.g. {@code ACTIVE}
+ * @param active convenience flag mirroring the owner's {@code is_active} column
+ * @param locationType location type name (null when untyped)
+ * @param hrLocationId external HR system location reference
+ * @param timezone IANA timezone id
+ * @param addressLine1 street address line 1
+ * @param addressLine2 street address line 2
+ * @param city city
+ * @param region state/province code
+ * @param postalCode postal code (required for tax jurisdiction determination)
+ * @param country country code (required for tax jurisdiction determination)
+ * @param defaultStagingLocationId site default staging storage location
+ * @param defaultQuarantineLocationId site default quarantine storage location
+ * @param createdAt owner row creation timestamp
+ * @param updatedAt owner row last-update timestamp
+ */
+public record LocationUpdatedV1(
+        @NonNull UUID locationId,
+        @Nullable String name,
+        @Nullable String code,
+        @Nullable String status,
+        boolean active,
+        @Nullable String locationType,
+        @Nullable String hrLocationId,
+        @Nullable String timezone,
+        @Nullable String addressLine1,
+        @Nullable String addressLine2,
+        @Nullable String city,
+        @Nullable String region,
+        @Nullable String postalCode,
+        @Nullable String country,
+        @Nullable UUID defaultStagingLocationId,
+        @Nullable UUID defaultQuarantineLocationId,
+        @Nullable Instant createdAt,
+        @Nullable Instant updatedAt) {
+
+    public static final String EVENT_TYPE = "location.location.updated";
+
+    public LocationUpdatedV1 {
+        if (locationId == null) {
+            throw new IllegalArgumentException("locationId must not be null");
+        }
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/location/StorageLocationUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/location/StorageLocationUpdatedV1.java
@@ -1,0 +1,49 @@
+package com.positivity.domainevents.location;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: a storage location was created or changed (ADR-0044 §6, issue #890 Phase 4.2).
+ *
+ * <p>Published by pos-location on {@code location.events.v1} with
+ * {@code eventType = "location.storage-location.updated"}. Consumers (pos-inventory) rebuild
+ * site topology/descendant queries and validation over their {@code ext_storage_location}
+ * replica. Storage locations are never hard-deleted by the owner — decommissioning arrives as
+ * a status change on this same event, so there is no companion deleted event.
+ *
+ * @param storageLocationId storage location identifier (also the envelope aggregateId)
+ * @param siteId owning site (location) id
+ * @param name display name
+ * @param barcode scan barcode
+ * @param storageLocationType owner type name, e.g. {@code SHELF}, {@code BIN}
+ * @param status owner status name, e.g. {@code ACTIVE}, {@code DECOMMISSIONED}
+ * @param parentStorageLocationId parent node in the site's storage tree (null for roots)
+ * @param capacity free-form capacity descriptor
+ * @param temperature free-form temperature/climate descriptor
+ * @param createdAt owner row creation timestamp
+ * @param updatedAt owner row last-update timestamp
+ */
+public record StorageLocationUpdatedV1(
+        @NonNull UUID storageLocationId,
+        @Nullable UUID siteId,
+        @Nullable String name,
+        @Nullable String barcode,
+        @Nullable String storageLocationType,
+        @Nullable String status,
+        @Nullable UUID parentStorageLocationId,
+        @Nullable String capacity,
+        @Nullable String temperature,
+        @Nullable Instant createdAt,
+        @Nullable Instant updatedAt) {
+
+    public static final String EVENT_TYPE = "location.storage-location.updated";
+
+    public StorageLocationUpdatedV1 {
+        if (storageLocationId == null) {
+            throw new IllegalArgumentException("storageLocationId must not be null");
+        }
+    }
+}

--- a/pos-location/pom.xml
+++ b/pos-location/pom.xml
@@ -169,6 +169,17 @@
             <artifactId>pos-events</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Cross-module domain event contracts + transactional outbox (ADR-0044, #890) -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-domain-events</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pos-location/src/main/java/com/positivity/location/PosLocationApplication.java
+++ b/pos-location/src/main/java/com/positivity/location/PosLocationApplication.java
@@ -6,9 +6,11 @@ import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoCon
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestClient;
 
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
+@EnableScheduling
 public class PosLocationApplication {
     public static void main(String[] args) {
         SpringApplication.run(PosLocationApplication.class, args);

--- a/pos-location/src/main/java/com/positivity/location/internal/config/KafkaErrorHandlingConfig.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/config/KafkaErrorHandlingConfig.java
@@ -1,0 +1,53 @@
+package com.positivity.location.internal.config;
+
+import java.util.function.BiFunction;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.ExponentialBackOff;
+
+/**
+ * Retry and dead-letter handling for the module's Kafka listeners (ADR-0044 §4, issue #890).
+ *
+ * <p>Failed records are retried with exponential backoff; when retries are exhausted the record is
+ * published to {@code {topic}.dlq} so poison messages surface for alerting instead of silently
+ * blocking or dropping. Replay commands are idempotent, so retries are harmless.
+ *
+ * <p>Spring Boot wires a single {@code CommonErrorHandler} bean into the auto-configured listener
+ * container factory, so declaring the bean is sufficient.
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(prefix = "pos.location.kafka", name = "enabled", havingValue = "true")
+public class KafkaErrorHandlingConfig {
+
+    /** Route to {@code {topic}.dlq}; partition -1 lets the producer choose. */
+    static final BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> DLQ_DESTINATION =
+            (record, ex) -> new TopicPartition(record.topic() + ".dlq", -1);
+
+    @Bean
+    public DefaultErrorHandler kafkaErrorHandler(@SuppressWarnings("rawtypes") KafkaTemplate kafkaTemplate) {
+        @SuppressWarnings("unchecked")
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate, DLQ_DESTINATION);
+
+        ExponentialBackOff backOff = new ExponentialBackOff(1000L, 2.0);
+        backOff.setMaxInterval(30_000L);
+        backOff.setMaxAttempts(5);
+
+        DefaultErrorHandler handler = new DefaultErrorHandler(recoverer, backOff);
+        handler.setRetryListeners((record, ex, attempt) -> log.warn(
+                "Kafka record processing failed topic={} partition={} offset={} attempt={}",
+                record.topic(),
+                record.partition(),
+                record.offset(),
+                attempt,
+                ex));
+        return handler;
+    }
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/config/LocationCommandListener.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/config/LocationCommandListener.java
@@ -1,0 +1,122 @@
+package com.positivity.location.internal.config;
+
+import com.positivity.location.service.OutboxReplayService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Kafka command listener for {@code location.commands.v1} (ADR-0044 §4, issue #890).
+ *
+ * <p>Supported command types:
+ * <ul>
+ * <li>{@code location.outbox.replay-requested} — consumer-initiated drift repair and replica
+ * bootstrap: re-queues published outbox events created in the requested window for
+ * re-publication; consumers dedupe by eventId so replay is idempotent.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.location.kafka", name = "enabled", havingValue = "true")
+public class LocationCommandListener {
+
+    /** Canonical dotted name normalized to command-type form: LOCATION_OUTBOX_REPLAY_REQUESTED. */
+    private static final String COMMAND_OUTBOX_REPLAY_REQUESTED = "LOCATION_OUTBOX_REPLAY_REQUESTED";
+
+    /** Covers the sub-millisecond skew between outbox createdAt and the eventId timestamp. */
+    private static final Duration REPLAY_WINDOW_SLACK = Duration.ofSeconds(1);
+
+    /** Replay commands older than this are rejected — bounds repair cost. */
+    @Value("${pos.location.outbox.replay.max-lookback:P30D}")
+    private Duration replayMaxLookback;
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final OutboxReplayService outboxReplayService;
+
+    @KafkaListener(
+            topics = "${pos.location.kafka.commands-topic:location.commands.v1}",
+            groupId = "${pos.location.kafka.commands-consumer-group:pos-location-commands}")
+    public void onCommand(@NonNull String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            String rawCommandType = root.path("commandType").stringValue(null);
+            if (rawCommandType == null || rawCommandType.isBlank()) {
+                log.debug("Ignoring command without commandType: {}", message);
+                return;
+            }
+            // Normalize dotted command names (location.outbox.replay-requested) to one form.
+            String commandType =
+                    rawCommandType.toUpperCase(Locale.ROOT).replace('.', '_').replace('-', '_');
+
+            if (COMMAND_OUTBOX_REPLAY_REQUESTED.equals(commandType)) {
+                handleOutboxReplayRequested(root);
+                return;
+            }
+            log.debug("Ignoring unsupported commandType={} message={}", commandType, message);
+        } catch (TransientDataAccessException e) {
+            // Let the container error handler retry with backoff and route to {topic}.dlq
+            // (ADR-0044 §4) — replay is idempotent, so redelivery is harmless.
+            throw e;
+        } catch (Exception e) {
+            // Malformed/unsupported commands are permanent failures: retrying cannot fix them,
+            // so log and drop instead of poisoning the partition.
+            log.error("Failed to process Kafka command message: {}", message, e);
+        }
+    }
+
+    private void handleOutboxReplayRequested(@NonNull JsonNode root) {
+        JsonNode payloadNode = root.get("payload");
+        Instant since = parseInstant(payloadNode, "since");
+        if (since == null) {
+            log.warn("Ignoring outbox replay command with missing/malformed payload.since: {}", root);
+            return;
+        }
+        Instant lookbackLimit = Instant.now(clock).minus(replayMaxLookback);
+        if (since.isBefore(lookbackLimit)) {
+            // A malformed or ancient `since` must not trigger a huge re-emit.
+            log.warn(
+                    "Ignoring outbox replay command: since={} exceeds max lookback {} (limit {})",
+                    since,
+                    replayMaxLookback,
+                    lookbackLimit);
+            return;
+        }
+        Instant until = parseInstant(payloadNode, "until");
+        int queued;
+        if (until != null && until.isAfter(since)) {
+            // Bounded window repair; +/- slack covers createdAt vs eventId-timestamp skew.
+            queued = outboxReplayService.replayBetween(
+                    since.minus(REPLAY_WINDOW_SLACK), until.plus(REPLAY_WINDOW_SLACK));
+        } else {
+            queued = outboxReplayService.replaySince(since.minus(REPLAY_WINDOW_SLACK));
+        }
+        log.info("Outbox replay command processed since={} until={} eventsQueued={}", since, until, queued);
+    }
+
+    private @Nullable Instant parseInstant(@Nullable JsonNode payloadNode, @NonNull String field) {
+        String value = payloadNode == null ? null : payloadNode.path(field).stringValue(null);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(value);
+        } catch (Exception _) {
+            log.warn("Malformed payload.{}={} on outbox replay command", field, value);
+            return null;
+        }
+    }
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/config/ManifestPublisher.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/config/ManifestPublisher.java
@@ -1,0 +1,221 @@
+package com.positivity.location.internal.config;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import com.positivity.location.internal.entity.OutboxEvent;
+import com.positivity.location.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Publishes reconciliation manifests for the location fact topic (ADR-0044 §4, issue #890).
+ *
+ * <p>Each closed window gets one {@link ReconciliationManifestV1} on {@code location.manifest.v1}
+ * summarizing the events published from {@code event_outbox} whose eventId (UUIDv7) timestamp
+ * falls in the window. Consumers recompute the summary from their processed-events log and
+ * request an outbox replay over {@code location.commands.v1} on drift.
+ *
+ * <p>Manifests are sent directly (no outbox): a lost manifest is self-healing — the next run
+ * re-publishes it, and consumers can additionally alert on manifest absence. Publication waits
+ * {@code grace} after window close so in-flight publishes and consumer lag settle before the
+ * comparison, avoiding false drift. Re-publishing the same window (e.g. after a restart) is
+ * harmless because the consumer-side comparison is stateless and idempotent.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "pos.location.kafka", name = "enabled", havingValue = "true")
+public class ManifestPublisher {
+
+    /** Covers the sub-millisecond skew between outbox {@code createdAt} and the eventId timestamp. */
+    private static final Duration CREATED_AT_SLACK = Duration.ofSeconds(1);
+
+    private static final String DOMAIN = "location";
+
+    /** Catch-up bound per run — 24 windows covers a day-long outage at the default 1h window. */
+    private static final int MAX_WINDOWS_PER_RUN = 24;
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+    private final Counter publishedCounter;
+    private final Counter failedCounter;
+
+    @Value("${pos.location.kafka.events-topic:location.events.v1}")
+    private String eventsTopic;
+
+    @Value("${pos.location.manifest.topic:location.manifest.v1}")
+    private String manifestTopic;
+
+    /** Reconciliation window length. */
+    @Value("${pos.location.manifest.window:PT1H}")
+    private Duration window;
+
+    /** How long after a window closes before its manifest is published. */
+    @Value("${pos.location.manifest.grace:PT5M}")
+    private Duration grace;
+
+    @Value("${pos.location.manifest.send-timeout-ms:10000}")
+    private long sendTimeoutMs;
+
+    @Nullable
+    private Instant lastPublishedWindowEnd;
+
+    public ManifestPublisher(
+            OutboxEventRepository outboxEventRepository,
+            KafkaTemplate<String, String> kafkaTemplate,
+            ObjectMapper objectMapper,
+            Clock clock,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.publishedCounter = registry == null
+                ? null
+                : Counter.builder("location.manifest.published")
+                        .description("Reconciliation manifests published")
+                        .register(registry);
+        this.failedCounter = registry == null
+                ? null
+                : Counter.builder("location.manifest.publish.failures")
+                        .description("Reconciliation manifest publish attempts that failed")
+                        .register(registry);
+    }
+
+    @Scheduled(fixedDelayString = "${pos.location.manifest.poll-interval-ms:300000}")
+    public void publishDueManifest() {
+        Instant latestClosed = latestClosedWindowEnd();
+        if (latestClosed == null || (lastPublishedWindowEnd != null && !latestClosed.isAfter(lastPublishedWindowEnd))) {
+            return;
+        }
+        // First run publishes only the latest closed window (no historic backfill on boot);
+        // afterwards every window is published in order so scheduler gaps cannot skip one
+        // permanently.
+        Instant windowEnd = lastPublishedWindowEnd == null ? latestClosed : lastPublishedWindowEnd.plus(window);
+        int published = 0;
+        while (!windowEnd.isAfter(latestClosed) && published < MAX_WINDOWS_PER_RUN) {
+            Instant windowStart = windowEnd.minus(window);
+            try {
+                publishManifest(windowStart, windowEnd);
+                lastPublishedWindowEnd = windowEnd;
+                increment(publishedCounter);
+                published++;
+                windowEnd = windowEnd.plus(window);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                recordFailure(windowStart, windowEnd, e);
+                return;
+            } catch (Exception e) {
+                // Retry this window on the next poll; later windows stay queued behind it.
+                recordFailure(windowStart, windowEnd, e);
+                return;
+            }
+        }
+        if (!windowEnd.isAfter(latestClosed)) {
+            log.info("Manifest catch-up capped at {} windows this run; continuing next poll", MAX_WINDOWS_PER_RUN);
+        }
+    }
+
+    /** End of the most recent window that closed at least {@code grace} ago, aligned to the window length. */
+    private @Nullable Instant latestClosedWindowEnd() {
+        long windowMillis = window.toMillis();
+        long cutoff = Instant.now(clock).minus(grace).toEpochMilli();
+        long aligned = Math.floorDiv(cutoff, windowMillis) * windowMillis;
+        return aligned <= 0 ? null : Instant.ofEpochMilli(aligned);
+    }
+
+    private void publishManifest(Instant windowStart, Instant windowEnd) throws Exception {
+        List<OutboxEvent> candidates = outboxEventRepository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(
+                eventsTopic, windowStart.minus(CREATED_AT_SLACK), windowEnd.plus(CREATED_AT_SLACK));
+
+        List<String> eventIds = new ArrayList<>();
+        TreeMap<String, Long> eventTypeCounts = new TreeMap<>();
+        for (OutboxEvent row : candidates) {
+            // One malformed row must not block the window's manifest forever: skip it with a
+            // warning; the consumer-side mismatch it may cause is visible drift.
+            try {
+                JsonNode envelope = objectMapper.readTree(row.getPayload());
+                String eventId = envelope.path("eventId").stringValue(null);
+                if (eventId == null || eventId.isBlank()) {
+                    log.warn("Outbox row {} has no eventId in its payload; excluded from manifest", row.getId());
+                    continue;
+                }
+                if (!UuidV7Timestamps.isInWindow(UUID.fromString(eventId), windowStart, windowEnd)) {
+                    continue;
+                }
+                eventIds.add(eventId);
+                String eventType = envelope.path("eventType").stringValue(null);
+                eventTypeCounts.merge(eventType == null || eventType.isBlank() ? "unknown" : eventType, 1L, Long::sum);
+            } catch (Exception e) {
+                log.warn("Outbox row {} has an unparsable payload/eventId; excluded from manifest", row.getId(), e);
+            }
+        }
+
+        ReconciliationManifestV1 manifest = new ReconciliationManifestV1(
+                windowStart,
+                windowEnd,
+                eventIds.size(),
+                ReconciliationManifestV1.checksumOf(eventIds),
+                eventTypeCounts.isEmpty() ? null : eventTypeCounts);
+
+        DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
+                ReconciliationManifestV1.eventTypeFor(DOMAIN),
+                1,
+                manifestAggregateId(windowStart),
+                windowStart.getEpochSecond(),
+                "pos-location",
+                null,
+                null,
+                manifest,
+                clock);
+
+        kafkaTemplate
+                .send(manifestTopic, envelope.recordKey(), objectMapper.writeValueAsString(envelope))
+                .get(sendTimeoutMs, TimeUnit.MILLISECONDS);
+        log.info(
+                "Published reconciliation manifest window=[{}, {}) events={} topic={}",
+                windowStart,
+                windowEnd,
+                eventIds.size(),
+                manifestTopic);
+    }
+
+    /** Deterministic per-window aggregate id, so re-published manifests key to the same partition. */
+    private UUID manifestAggregateId(Instant windowStart) {
+        return UUID.nameUUIDFromBytes(
+                (DOMAIN + ".manifest:" + eventsTopic + ":" + windowStart).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void recordFailure(Instant windowStart, Instant windowEnd, Exception e) {
+        increment(failedCounter);
+        log.warn("Reconciliation manifest publish failed window=[{}, {})", windowStart, windowEnd, e);
+    }
+
+    private void increment(@Nullable Counter counter) {
+        if (counter != null) {
+            counter.increment();
+        }
+    }
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/config/OutboxEventWriter.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/config/OutboxEventWriter.java
@@ -1,0 +1,57 @@
+package com.positivity.location.internal.config;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.location.internal.entity.OutboxEvent;
+import com.positivity.location.internal.repository.OutboxEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Transactional-outbox writer for location domain events (ADR-0044 §4, issue #890).
+ *
+ * <p>Serializes a full {@link DomainEventEnvelope} into {@code event_outbox} within the caller's
+ * transaction, so an event exists if and only if the business state change committed.
+ * {@link OutboxPublisher} drains the table to Kafka with at-least-once delivery.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.location.kafka", name = "enabled", havingValue = "true")
+public class OutboxEventWriter {
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final OutboxEventRepository outboxEventRepository;
+
+    /**
+     * Queue an envelope for publication as part of the current transaction. Must be called inside
+     * the business transaction ({@code MANDATORY}) — that is the whole point of the outbox.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void publish(@NonNull String topic, @NonNull DomainEventEnvelope<?> envelope) {
+        OutboxEvent event = OutboxEvent.builder()
+                .topic(topic)
+                .recordKey(envelope.recordKey())
+                .payload(serialize(envelope))
+                .createdAt(Instant.now(clock))
+                .build();
+        outboxEventRepository.save(event);
+        log.debug("Queued outbox event type={} topic={} key={}", envelope.eventType(), topic, envelope.recordKey());
+    }
+
+    private String serialize(DomainEventEnvelope<?> envelope) {
+        try {
+            return objectMapper.writeValueAsString(envelope);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to serialize event envelope for type: " + envelope.eventType(), e);
+        }
+    }
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/config/OutboxPublisher.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/config/OutboxPublisher.java
@@ -1,0 +1,116 @@
+package com.positivity.location.internal.config;
+
+import com.positivity.location.internal.entity.OutboxEvent;
+import com.positivity.location.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Drains {@code event_outbox} to Kafka (ADR-0044 §4, issue #890).
+ *
+ * <p>At-least-once: a row is marked published (in its own short transaction, so no DB connection
+ * is held across the blocking broker send) only after the broker acknowledges, and a crash between
+ * send and mark re-sends on the next poll — consumers must be idempotent by {@code eventId}. Rows
+ * are processed in id order (UUIDv7 = insertion time); the batch stops at the first failure so a
+ * struggling broker cannot reorder events, and failed rows retry on every poll with
+ * {@code attempts}/{@code last_error} recorded for alerting.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "pos.location.kafka", name = "enabled", havingValue = "true")
+public class OutboxPublisher {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final Clock clock;
+    private final Counter publishedCounter;
+    private final Counter failedCounter;
+
+    @Value("${pos.location.outbox.send-timeout-ms:10000}")
+    private long sendTimeoutMs;
+
+    public OutboxPublisher(
+            OutboxEventRepository outboxEventRepository,
+            KafkaTemplate<String, String> kafkaTemplate,
+            Clock clock,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.kafkaTemplate = kafkaTemplate;
+        this.clock = clock;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.publishedCounter = registry == null
+                ? null
+                : Counter.builder("location.outbox.published")
+                        .description("Outbox events successfully published to Kafka")
+                        .register(registry);
+        this.failedCounter = registry == null
+                ? null
+                : Counter.builder("location.outbox.publish.failures")
+                        .description("Outbox publish attempts that failed")
+                        .register(registry);
+    }
+
+    @Scheduled(fixedDelayString = "${pos.location.outbox.poll-interval-ms:1000}")
+    public void publishPending() {
+        List<OutboxEvent> pending = outboxEventRepository.findTop100ByPublishedAtIsNullOrderByIdAsc();
+        for (OutboxEvent event : pending) {
+            if (!publish(event)) {
+                // Stop at the first failure to preserve publish order; retry next poll.
+                break;
+            }
+        }
+    }
+
+    private boolean publish(OutboxEvent event) {
+        try {
+            kafkaTemplate
+                    .send(event.getTopic(), event.getRecordKey(), event.getPayload())
+                    .get(sendTimeoutMs, TimeUnit.MILLISECONDS);
+            event.setPublishedAt(Instant.now(clock));
+            event.setAttempts(0);
+            event.setLastError(null);
+            outboxEventRepository.save(event);
+            increment(publishedCounter);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            recordFailure(event, e);
+            return false;
+        } catch (Exception e) {
+            recordFailure(event, e);
+            return false;
+        }
+    }
+
+    private void recordFailure(OutboxEvent event, Exception e) {
+        event.setAttempts(event.getAttempts() + 1);
+        String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+        event.setLastError(message.length() > 2000 ? message.substring(0, 2000) : message);
+        outboxEventRepository.save(event);
+        increment(failedCounter);
+        log.warn(
+                "Outbox publish failed id={} topic={} key={} attempts={}",
+                event.getId(),
+                event.getTopic(),
+                event.getRecordKey(),
+                event.getAttempts(),
+                e);
+    }
+
+    private void increment(Counter counter) {
+        if (counter != null) {
+            counter.increment();
+        }
+    }
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/entity/OutboxEvent.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/entity/OutboxEvent.java
@@ -1,0 +1,54 @@
+package com.positivity.location.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Transactional-outbox row (ADR-0044 §4, issue #890): a serialized Kafka event written in the
+ * same transaction as the business state change and drained by {@code OutboxPublisher}.
+ */
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "event_outbox")
+public class OutboxEvent {
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(name = "record_key", nullable = false)
+    private String recordKey;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String payload;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "published_at")
+    private Instant publishedAt;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private int attempts = 0;
+
+    @Column(name = "last_error", columnDefinition = "text")
+    private String lastError;
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/repository/OutboxEventRepository.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/repository/OutboxEventRepository.java
@@ -1,0 +1,45 @@
+package com.positivity.location.internal.repository;
+
+import com.positivity.location.internal.entity.OutboxEvent;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+
+    /** Oldest unpublished rows first — UUIDv7 ids are time-ordered, preserving publish order. */
+    @NonNull
+    List<OutboxEvent> findTop100ByPublishedAtIsNullOrderByIdAsc();
+
+    /**
+     * Published events of one topic created in a window, for reconciliation-manifest assembly
+     * (ADR-0044 §4, #890). Callers widen the window slightly: {@code createdAt} and the payload's
+     * eventId are stamped microseconds apart.
+     */
+    @NonNull
+    List<OutboxEvent> findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(
+            @NonNull String topic, @NonNull Instant from, @NonNull Instant to);
+
+    /**
+     * Mark already-published events created at or after {@code since} for re-publication
+     * (ADR-0044 backfill/drift repair). The publisher re-sends them; consumers dedupe by eventId.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update OutboxEvent e set e.publishedAt = null, e.attempts = 0, e.lastError = null"
+            + " where e.publishedAt is not null and e.createdAt >= :since")
+    int markForReplaySince(@Param("since") @NonNull Instant since);
+
+    /**
+     * Bounded variant for manifest-driven drift repair: re-queue only the drifted window instead
+     * of everything since {@code since}.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update OutboxEvent e set e.publishedAt = null, e.attempts = 0, e.lastError = null"
+            + " where e.publishedAt is not null and e.createdAt >= :since and e.createdAt < :until")
+    int markForReplayBetween(@Param("since") @NonNull Instant since, @Param("until") @NonNull Instant until);
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/service/LocationFactPublisher.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/LocationFactPublisher.java
@@ -1,0 +1,128 @@
+package com.positivity.location.internal.service;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.location.LocationDeletedV1;
+import com.positivity.domainevents.location.LocationUpdatedV1;
+import com.positivity.domainevents.location.StorageLocationUpdatedV1;
+import com.positivity.location.internal.config.OutboxEventWriter;
+import com.positivity.location.internal.entity.Location;
+import com.positivity.location.internal.entity.StorageLocationEntity;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publishes location-owned facts to {@code location.events.v1} through the transactional outbox
+ * (ADR-0044 §6, issue #890 Phase 4.2).
+ *
+ * <p>Every location/storage-location mutation site calls {@link #locationChanged},
+ * {@link #locationDeleted} or {@link #storageLocationChanged} inside its business transaction.
+ * When Kafka publishing is disabled ({@code pos.location.kafka.enabled=false}) the outbox writer
+ * bean is absent and every method is a no-op, so callers never need their own guard.
+ *
+ * <p>The envelope's {@code aggregateVersion} is the emission timestamp in epoch millis — the
+ * platform-wide last-writer-wins hint consumers apply their strictly-below stale guard to.
+ */
+@Slf4j
+@Component
+public class LocationFactPublisher {
+
+    private static final String SOURCE = "pos-location";
+
+    private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+    private final Clock clock;
+    private final String eventsTopic;
+
+    public LocationFactPublisher(
+            ObjectProvider<OutboxEventWriter> outboxEventWriter,
+            Clock clock,
+            // Same property ManifestPublisher scans event_outbox by, so an override can never
+            // desync the outbox rows from the manifest computation.
+            @Value("${pos.location.kafka.events-topic:location.events.v1}") String eventsTopic) {
+        this.outboxEventWriter = outboxEventWriter;
+        this.clock = clock;
+        this.eventsTopic = eventsTopic;
+    }
+
+    /** Emit {@code location.location.updated} for a just-saved location. */
+    public void locationChanged(@NonNull Location location) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        LocationUpdatedV1 payload = new LocationUpdatedV1(
+                location.getId(),
+                location.getName(),
+                location.getCode(),
+                location.getStatus(),
+                location.isActive(),
+                location.getType() != null ? location.getType().getName() : null,
+                location.getHrLocationId(),
+                location.getTimezone(),
+                location.getAddressLine1(),
+                location.getAddressLine2(),
+                location.getCity(),
+                location.getState(),
+                location.getPostalCode(),
+                location.getCountry(),
+                location.getDefaultStagingLocation() != null
+                        ? location.getDefaultStagingLocation().getId()
+                        : null,
+                location.getDefaultQuarantineLocation() != null
+                        ? location.getDefaultQuarantineLocation().getId()
+                        : null,
+                location.getCreatedAt(),
+                location.getUpdatedAt());
+        publish(writer, LocationUpdatedV1.EVENT_TYPE, location.getId(), payload);
+    }
+
+    /** Emit {@code location.location.deleted} for a location removed in the current transaction. */
+    public void locationDeleted(@NonNull UUID locationId) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        publish(writer, LocationDeletedV1.EVENT_TYPE, locationId, new LocationDeletedV1(locationId));
+    }
+
+    /**
+     * Emit {@code location.storage-location.updated} for a just-saved storage location. Storage
+     * locations are never hard-deleted — decommissioning is a status change on this same fact.
+     */
+    public void storageLocationChanged(@NonNull StorageLocationEntity storageLocation) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        StorageLocationUpdatedV1 payload = new StorageLocationUpdatedV1(
+                storageLocation.getId(),
+                storageLocation.getSite() != null ? storageLocation.getSite().getId() : null,
+                storageLocation.getName(),
+                storageLocation.getBarcode(),
+                storageLocation.getType() != null ? storageLocation.getType().name() : null,
+                storageLocation.getStatus() != null
+                        ? storageLocation.getStatus().name()
+                        : null,
+                storageLocation.getParentStorageLocation() != null
+                        ? storageLocation.getParentStorageLocation().getId()
+                        : null,
+                storageLocation.getCapacity(),
+                storageLocation.getTemperature(),
+                storageLocation.getCreatedAt(),
+                storageLocation.getUpdatedAt());
+        publish(writer, StorageLocationUpdatedV1.EVENT_TYPE, storageLocation.getId(), payload);
+    }
+
+    private void publish(
+            @NonNull OutboxEventWriter writer, @NonNull String eventType, @NonNull UUID aggregateId, Object payload) {
+        DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
+                eventType, 1, aggregateId, Instant.now(clock).toEpochMilli(), SOURCE, null, null, payload, clock);
+        writer.publish(eventsTopic, envelope);
+        log.debug("Queued {} for aggregate {}", eventType, aggregateId);
+    }
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/service/LocationServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/LocationServiceImpl.java
@@ -64,6 +64,7 @@ public class LocationServiceImpl implements LocationService {
     private final LocationRepository locationRepository;
     private final LocationParentRepository locationParentRepository;
     private final LocationTypeRepository locationTypeRepository;
+    private final LocationFactPublisher locationFactPublisher;
 
     // Issue CAP-136 #78: lightweight process-level guard used with repository
     // checks.
@@ -296,7 +297,9 @@ public class LocationServiceImpl implements LocationService {
 
     private Location saveLocationInternal(Location location) {
         try {
-            return locationRepository.saveAndFlush(location);
+            Location saved = locationRepository.saveAndFlush(location);
+            locationFactPublisher.locationChanged(saved);
+            return saved;
         } catch (OptimisticLockingFailureException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "OPTIMISTIC_LOCK_FAILED", e);
         } catch (DataIntegrityViolationException e) {
@@ -341,8 +344,10 @@ public class LocationServiceImpl implements LocationService {
         return all.toString();
     }
 
+    @Transactional
     public void deleteLocation(UUID id) {
         locationRepository.deleteById(id);
+        locationFactPublisher.locationDeleted(id);
     }
 
     @Transactional

--- a/pos-location/src/main/java/com/positivity/location/internal/service/OutboxReplayServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/OutboxReplayServiceImpl.java
@@ -1,0 +1,34 @@
+package com.positivity.location.internal.service;
+
+import com.positivity.location.internal.repository.OutboxEventRepository;
+import com.positivity.location.service.OutboxReplayService;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxReplayServiceImpl implements OutboxReplayService {
+
+    private final OutboxEventRepository outboxEventRepository;
+
+    @Override
+    @Transactional
+    public int replaySince(@NonNull Instant since) {
+        int count = outboxEventRepository.markForReplaySince(since);
+        log.info("Outbox replay requested since={} eventsQueued={}", since, count);
+        return count;
+    }
+
+    @Override
+    @Transactional
+    public int replayBetween(@NonNull Instant since, @NonNull Instant until) {
+        int count = outboxEventRepository.markForReplayBetween(since, until);
+        log.info("Outbox replay requested window=[{}, {}) eventsQueued={}", since, until, count);
+        return count;
+    }
+}

--- a/pos-location/src/main/java/com/positivity/location/internal/service/SiteDefaultsServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/SiteDefaultsServiceImpl.java
@@ -33,6 +33,7 @@ public class SiteDefaultsServiceImpl implements SiteDefaultsService {
 
     private final LocationRepository locationRepository;
     private final StorageLocationRepository storageLocationRepository;
+    private final LocationFactPublisher locationFactPublisher;
 
     /**
      * Configures default staging and quarantine storage locations for a site.
@@ -64,6 +65,8 @@ public class SiteDefaultsServiceImpl implements SiteDefaultsService {
         location.setDefaultStagingLocation(stagingLocation);
         location.setDefaultQuarantineLocation(quarantineLocation);
         locationRepository.save(location);
+        // Site defaults travel on the location fact (ADR-0044 §6, #890).
+        locationFactPublisher.locationChanged(location);
 
         return SiteDefaultsResponse.builder()
                 .siteId(siteId)

--- a/pos-location/src/main/java/com/positivity/location/internal/service/StorageLocationServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/StorageLocationServiceImpl.java
@@ -54,16 +54,19 @@ public class StorageLocationServiceImpl implements StorageLocationService {
 
     private final StorageLocationRepository storageLocationRepository;
     private final LocationRepository locationRepository;
+    private final LocationFactPublisher locationFactPublisher;
     private final StorageLocationInventoryTransferService storageLocationInventoryTransferService;
     private final LocationInventoryInquiryClient locationInventoryInquiryClient;
 
     public StorageLocationServiceImpl(
             StorageLocationRepository storageLocationRepository,
             LocationRepository locationRepository,
+            LocationFactPublisher locationFactPublisher,
             StorageLocationInventoryTransferService storageLocationInventoryTransferService,
             LocationInventoryInquiryClient locationInventoryInquiryClient) {
         this.storageLocationRepository = storageLocationRepository;
         this.locationRepository = locationRepository;
+        this.locationFactPublisher = locationFactPublisher;
         this.storageLocationInventoryTransferService = storageLocationInventoryTransferService;
         this.locationInventoryInquiryClient = locationInventoryInquiryClient;
     }
@@ -116,6 +119,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
                 .capacity(serializeJson(request.getCapacity(), CAPACITY))
                 .temperature(serializeJson(request.getTemperature(), TEMPERATURE))
                 .build());
+        locationFactPublisher.storageLocationChanged(saved);
 
         return toResponse(saved);
     }
@@ -243,6 +247,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
         applyPatchedStatus(siteId, storageLocationId, patch, existing);
 
         StorageLocationEntity saved = storageLocationRepository.saveAndFlush(existing);
+        locationFactPublisher.storageLocationChanged(saved);
         return toResponse(saved);
     }
 
@@ -267,6 +272,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
 
         existing.setStatus(StorageLocationStatus.INACTIVE);
         StorageLocationEntity saved = storageLocationRepository.saveAndFlush(existing);
+        locationFactPublisher.storageLocationChanged(saved);
         return toResponse(saved);
     }
 

--- a/pos-location/src/main/java/com/positivity/location/service/OutboxReplayService.java
+++ b/pos-location/src/main/java/com/positivity/location/service/OutboxReplayService.java
@@ -1,0 +1,17 @@
+package com.positivity.location.service;
+
+import java.time.Instant;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Re-queues already-published outbox events for re-publication (ADR-0044 §4 backfill/drift
+ * repair, issue #890). Consumers dedupe by eventId, so replay is idempotent.
+ */
+public interface OutboxReplayService {
+
+    /** Re-queue published events created at or after {@code since}. Returns the count queued. */
+    int replaySince(@NonNull Instant since);
+
+    /** Re-queue published events created in {@code [since, until)}. Returns the count queued. */
+    int replayBetween(@NonNull Instant since, @NonNull Instant until);
+}

--- a/pos-location/src/main/resources/application.yml
+++ b/pos-location/src/main/resources/application.yml
@@ -12,6 +12,14 @@ spring:
       ddl-auto: validate
   flyway:
     out-of-order: ${SPRING_FLYWAY_OUT_OF_ORDER:false}
+  kafka:
+    bootstrap-servers:
+      - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: pos-location-commands
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 server:
   port: 0
@@ -66,3 +74,14 @@ pos:
     service-id: ${POS_PEOPLE_SERVICE_ID:people}
   inventory:
     service-id: ${POS_INVENTORY_SERVICE_ID:inventory}
+  location:
+    # Fact producer + reconciliation + inbound replay commands (ADR-0044 §6, #890)
+    kafka:
+      events-topic: ${POS_LOCATION_EVENTS_TOPIC:location.events.v1}
+      commands-topic: ${POS_LOCATION_COMMANDS_TOPIC:location.commands.v1}
+      commands-consumer-group: ${POS_LOCATION_COMMANDS_CONSUMER_GROUP:pos-location-commands}
+      enabled: ${POS_LOCATION_KAFKA_ENABLED:false}
+    manifest:
+      topic: ${POS_LOCATION_MANIFEST_TOPIC:location.manifest.v1}
+      window: ${POS_LOCATION_MANIFEST_WINDOW:PT1H}
+      grace: ${POS_LOCATION_MANIFEST_GRACE:PT5M}

--- a/pos-location/src/main/resources/db/migration/V2__create_event_outbox.sql
+++ b/pos-location/src/main/resources/db/migration/V2__create_event_outbox.sql
@@ -1,0 +1,17 @@
+-- ADR-0044 §4: transactional outbox for domain events (location.events.v1, issue #890).
+-- Rows are written in the same transaction as the business state change and
+-- drained to Kafka by a background publisher (at-least-once delivery).
+CREATE TABLE event_outbox (
+    id uuid NOT NULL,
+    topic character varying(255) NOT NULL,
+    record_key character varying(255) NOT NULL,
+    payload text NOT NULL,
+    created_at timestamp(6) with time zone NOT NULL,
+    published_at timestamp(6) with time zone,
+    attempts integer NOT NULL DEFAULT 0,
+    last_error text,
+    CONSTRAINT event_outbox_pkey PRIMARY KEY (id)
+);
+
+-- Drain scans: unpublished rows in id order (UUIDv7 ids are time-ordered).
+CREATE INDEX idx_event_outbox_unpublished ON event_outbox (id) WHERE published_at IS NULL;

--- a/pos-location/src/main/resources/db/migration/V2__create_event_outbox.sql
+++ b/pos-location/src/main/resources/db/migration/V2__create_event_outbox.sql
@@ -15,3 +15,7 @@ CREATE TABLE event_outbox (
 
 -- Drain scans: unpublished rows in id order (UUIDv7 ids are time-ordered).
 CREATE INDEX idx_event_outbox_unpublished ON event_outbox (id) WHERE published_at IS NULL;
+
+-- Manifest computation scans published rows of a topic by created_at window (ADR-0044 §4).
+CREATE INDEX idx_event_outbox_published_window ON event_outbox (topic, created_at)
+    WHERE published_at IS NOT NULL;

--- a/pos-location/src/test/java/com/positivity/location/internal/config/LocationCommandListenerTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/config/LocationCommandListenerTest.java
@@ -1,0 +1,97 @@
+package com.positivity.location.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.location.service.OutboxReplayService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link LocationCommandListener} (ADR-0044 §4, #890).
+ */
+class LocationCommandListenerTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-13T12:00:00Z"), ZoneOffset.UTC);
+
+    private final OutboxReplayService replayService = mock(OutboxReplayService.class);
+
+    private LocationCommandListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new LocationCommandListener(TEST_CLOCK, new ObjectMapper(), replayService);
+        ReflectionTestUtils.setField(listener, "replayMaxLookback", Duration.ofDays(30));
+    }
+
+    private String replayCommand(String since, String until) {
+        return """
+                {"commandType":"location.outbox.replay-requested",
+                 "payload":{"since":"%s","until":"%s"}}
+                """.formatted(since, until);
+    }
+
+    @Test
+    @DisplayName("Bounded replay command re-queues the window with slack")
+    void boundedReplay() {
+        listener.onCommand(replayCommand("2026-07-13T10:00:00Z", "2026-07-13T11:00:00Z"));
+
+        ArgumentCaptor<Instant> since = ArgumentCaptor.forClass(Instant.class);
+        ArgumentCaptor<Instant> until = ArgumentCaptor.forClass(Instant.class);
+        verify(replayService).replayBetween(since.capture(), until.capture());
+        assertThat(since.getValue()).isEqualTo(Instant.parse("2026-07-13T09:59:59Z"));
+        assertThat(until.getValue()).isEqualTo(Instant.parse("2026-07-13T11:00:01Z"));
+    }
+
+    @Test
+    @DisplayName("Open-ended replay command falls back to replaySince")
+    void openEndedReplay() {
+        listener.onCommand("""
+                {"commandType":"LOCATION_OUTBOX_REPLAY_REQUESTED","payload":{"since":"2026-07-13T10:00:00Z"}}
+                """);
+
+        verify(replayService).replaySince(Instant.parse("2026-07-13T09:59:59Z"));
+    }
+
+    @Test
+    @DisplayName("Replay commands beyond the max lookback are rejected")
+    void rejectsAncientReplay() {
+        listener.onCommand(replayCommand("2026-05-01T00:00:00Z", "2026-05-01T01:00:00Z"));
+
+        verify(replayService, never()).replayBetween(any(), any());
+        verify(replayService, never()).replaySince(any());
+    }
+
+    @Test
+    @DisplayName("Malformed commands are logged and dropped, not rethrown")
+    void dropsMalformedCommands() {
+        assertThatCode(() -> listener.onCommand("{ not json ")).doesNotThrowAnyException();
+        assertThatCode(() -> listener.onCommand("{\"commandType\":\"something.else\"}"))
+                .doesNotThrowAnyException();
+        verify(replayService, never()).replayBetween(any(), any());
+    }
+
+    @Test
+    @DisplayName("Transient DB errors rethrow for container retry/DLQ (ADR-0044 §4)")
+    void rethrowsTransientErrors() {
+        when(replayService.replayBetween(any(), any())).thenThrow(new QueryTimeoutException("db timeout"));
+
+        assertThatExceptionOfType(QueryTimeoutException.class)
+                .isThrownBy(() -> listener.onCommand(replayCommand("2026-07-13T10:00:00Z", "2026-07-13T11:00:00Z")));
+    }
+}

--- a/pos-location/src/test/java/com/positivity/location/internal/service/LocationFactPublisherTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/service/LocationFactPublisherTest.java
@@ -1,0 +1,145 @@
+package com.positivity.location.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.location.LocationDeletedV1;
+import com.positivity.domainevents.location.LocationUpdatedV1;
+import com.positivity.domainevents.location.StorageLocationUpdatedV1;
+import com.positivity.location.internal.config.OutboxEventWriter;
+import com.positivity.location.internal.entity.Location;
+import com.positivity.location.internal.entity.StorageLocationEntity;
+import com.positivity.location.internal.enums.StorageLocationStatus;
+import com.positivity.location.internal.enums.StorageLocationType;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Unit tests for {@link LocationFactPublisher} (ADR-0044 §6, #890).
+ */
+class LocationFactPublisherTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-13T12:00:00Z"), ZoneOffset.UTC);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<OutboxEventWriter> writerProvider = mock(ObjectProvider.class);
+
+    private final OutboxEventWriter writer = mock(OutboxEventWriter.class);
+
+    private LocationFactPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        when(writerProvider.getIfAvailable()).thenReturn(writer);
+        publisher = new LocationFactPublisher(writerProvider, TEST_CLOCK, "location.events.v1");
+    }
+
+    @Test
+    @DisplayName("Location fact carries the tax address and site defaults")
+    void locationFact() {
+        Location location = new Location();
+        location.setId(UUID.randomUUID());
+        location.setName("Main Shop");
+        location.setCode("MAIN");
+        location.setStatus("ACTIVE");
+        location.setActive(true);
+        location.setTimezone("America/New_York");
+        location.setAddressLine1("1 Main St");
+        location.setCity("Springfield");
+        location.setState("VA");
+        location.setPostalCode("22150");
+        location.setCountry("US");
+        StorageLocationEntity staging = StorageLocationEntity.builder()
+                .id(UUID.randomUUID())
+                .name("Staging")
+                .build();
+        location.setDefaultStagingLocation(staging);
+
+        publisher.locationChanged(location);
+
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(eq("location.events.v1"), captor.capture());
+        assertThat(captor.getValue().eventType()).isEqualTo(LocationUpdatedV1.EVENT_TYPE);
+        LocationUpdatedV1 fact = (LocationUpdatedV1) captor.getValue().payload();
+        assertThat(fact.locationId()).isEqualTo(location.getId());
+        assertThat(fact.name()).isEqualTo("Main Shop");
+        assertThat(fact.active()).isTrue();
+        assertThat(fact.addressLine1()).isEqualTo("1 Main St");
+        assertThat(fact.region()).isEqualTo("VA");
+        assertThat(fact.postalCode()).isEqualTo("22150");
+        assertThat(fact.country()).isEqualTo("US");
+        assertThat(fact.defaultStagingLocationId()).isEqualTo(staging.getId());
+        assertThat(fact.defaultQuarantineLocationId()).isNull();
+    }
+
+    @Test
+    @DisplayName("Location delete emits the deleted fact")
+    void locationDeleted() {
+        UUID id = UUID.randomUUID();
+
+        publisher.locationDeleted(id);
+
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(eq("location.events.v1"), captor.capture());
+        assertThat(captor.getValue().eventType()).isEqualTo(LocationDeletedV1.EVENT_TYPE);
+        assertThat(((LocationDeletedV1) captor.getValue().payload()).locationId())
+                .isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("Storage-location fact carries site + parent topology")
+    void storageLocationFact() {
+        Location site = new Location();
+        site.setId(UUID.randomUUID());
+        StorageLocationEntity parent =
+                StorageLocationEntity.builder().id(UUID.randomUUID()).build();
+        StorageLocationEntity storage = StorageLocationEntity.builder()
+                .id(UUID.randomUUID())
+                .name("Bin A1")
+                .barcode("B-A1")
+                .type(StorageLocationType.BIN)
+                .status(StorageLocationStatus.ACTIVE)
+                .site(site)
+                .parentStorageLocation(parent)
+                .build();
+
+        publisher.storageLocationChanged(storage);
+
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(eq("location.events.v1"), captor.capture());
+        assertThat(captor.getValue().eventType()).isEqualTo(StorageLocationUpdatedV1.EVENT_TYPE);
+        StorageLocationUpdatedV1 fact =
+                (StorageLocationUpdatedV1) captor.getValue().payload();
+        assertThat(fact.storageLocationId()).isEqualTo(storage.getId());
+        assertThat(fact.siteId()).isEqualTo(site.getId());
+        assertThat(fact.parentStorageLocationId()).isEqualTo(parent.getId());
+        assertThat(fact.storageLocationType()).isEqualTo("BIN");
+        assertThat(fact.status()).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("All methods no-op when Kafka publishing is disabled")
+    void noopWhenWriterAbsent() {
+        when(writerProvider.getIfAvailable()).thenReturn(null);
+
+        publisher.locationChanged(new Location());
+        publisher.locationDeleted(UUID.randomUUID());
+        publisher.storageLocationChanged(
+                StorageLocationEntity.builder().id(UUID.randomUUID()).build());
+
+        verify(writer, never()).publish(any(), any());
+    }
+}

--- a/pos-location/src/test/java/com/positivity/location/service/LocationServiceTest.java
+++ b/pos-location/src/test/java/com/positivity/location/service/LocationServiceTest.java
@@ -66,6 +66,9 @@ class LocationServiceTest {
     @Mock
     private LocationTypeRepository locationTypeRepository;
 
+    @Mock
+    private com.positivity.location.internal.service.LocationFactPublisher locationFactPublisher;
+
     @InjectMocks
     private LocationServiceImpl locationService;
 

--- a/pos-location/src/test/java/com/positivity/location/service/SiteDefaultsServiceTest.java
+++ b/pos-location/src/test/java/com/positivity/location/service/SiteDefaultsServiceTest.java
@@ -59,6 +59,9 @@ class SiteDefaultsServiceTest {
     @Mock
     private StorageLocationRepository storageLocationRepository;
 
+    @Mock
+    private com.positivity.location.internal.service.LocationFactPublisher locationFactPublisher;
+
     @InjectMocks
     private SiteDefaultsServiceImpl siteDefaultsService;
 

--- a/pos-location/src/test/java/com/positivity/location/service/StorageLocationServiceTest.java
+++ b/pos-location/src/test/java/com/positivity/location/service/StorageLocationServiceTest.java
@@ -70,6 +70,9 @@ class StorageLocationServiceTest {
     @Mock
     private LocationInventoryInquiryClient locationInventoryInquiryClient;
 
+    @Mock
+    private com.positivity.location.internal.service.LocationFactPublisher locationFactPublisher;
+
     @InjectMocks
     private StorageLocationServiceImpl storageLocationService;
 


### PR DESCRIPTION
Closes #890. Part of #845 / #823 ([ADR-0044](https://github.com/louisburroughs/durion/blob/master/docs/adr/0044-platform-event-only-domain-walls.adr.md) §6).

pos-location gets its **first Kafka wiring** — the full ADR-0044 producer stack — so the Phase 4.4 consumers (#892) can retire the four pos-inventory location clients, the invoice/workorder tax-address clients, and pos-people's `LocationReferenceClient`.

## Facts (new payloads in `com.positivity.domainevents.location`)

| Event type | Payload | Consumers |
|---|---|---|
| `location.location.updated` | `LocationUpdatedV1` — name, code, status/active, type, hrLocationId, timezone, **tax-jurisdiction address** (line1/2, city, region, postalCode, country), site defaults (staging + quarantine storage-location ids) | inventory roster/site defaults, people (name + active), invoice/workorder tax address |
| `location.location.deleted` | `LocationDeletedV1` | replica removal |
| `location.storage-location.updated` | `StorageLocationUpdatedV1` — siteId, name, barcode, type, status, parentStorageLocationId, capacity, temperature | inventory topology/descendants/validation |

The address fields are the deliberate ADR-0044 reversal of the old "never replicate address data" rule; consumers must still run ADR-0021 address validation on replica data before tax calculation (#845 acceptance). Storage locations are never hard-deleted by the owner — decommissioning arrives as a status change on the updated fact, so there is no storage-location deleted event.

## Emission points

`LocationFactPublisher` (no-op when `pos.location.kafka.enabled=false`) is called inside the business transaction from:

- `LocationServiceImpl.saveLocationInternal` — the single choke point for every location create/update path (all callers already `@Transactional`)
- `LocationServiceImpl.deleteLocation` — now `@Transactional` so the deleted fact rides the delete transaction
- `SiteDefaultsServiceImpl.configureDefaults` — site defaults travel on the location fact
- `StorageLocationServiceImpl` create / patch / deactivate

## Producer infrastructure (the #874/#889 pattern)

- `event_outbox` table (migration V2) + `OutboxEventWriter` (`Propagation.MANDATORY`) + `OutboxPublisher` drain (stop-at-first-failure ordering, attempts/last_error for alerting)
- `ManifestPublisher` — `ReconciliationManifestV1` windows on `location.manifest.v1` (1h window / 5m grace, ordered catch-up capped at 24 windows/run)
- `LocationCommandListener` — `location.outbox.replay-requested` on `location.commands.v1` with the 30-day lookback guard; `OutboxReplayService` re-queues published rows (consumers dedupe by eventId)
- DLQ error handling (`{topic}.dlq`, exponential backoff), `@EnableScheduling`, pom gains `pos-domain-events` + `spring-kafka`, application.yml/docker-compose topics behind `POS_LOCATION_KAFKA_ENABLED` (default off)

The fact publisher and the manifest computation share the `pos.location.kafka.events-topic` property, so a topic override can never desync them (carries forward the PR #893 review fix).

## Bay ownership (the #890 open question)

Decision recorded on the issue: **pos-location stays the owner of bays**; shop-manager's bay CRUD becomes `location.commands.v1` commands implemented in Phase 4.4 (#892) together with the retirement of shop-manager's `LocationClient`. No bay facts/commands in this PR.

## Testing

- `LocationFactPublisherTest` — location fact carries tax address + site defaults; deleted fact; storage-location topology fields; disabled-flag no-ops.
- `LocationCommandListenerTest` — bounded/open replay with slack, lookback rejection, malformed-drop, transient rethrow.
- Full `pos-location` suite (192 tests incl. ArchitectureTest) and `pos-domain-events` (15) green under complete quality gates (Spotless/Checkstyle/SpotBugs).

Contract reference: `durion/domains/location/.business-rules/BACKEND_CONTRACT_GUIDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TXyBX7Q2nXbPFBdAz8owH