### PR TITLE
fix(people-contact): person hard-delete integrity + security-service authority contract pinned (#880, #881)

### DIFF
--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/RestClientConfig.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/RestClientConfig.java
@@ -13,6 +13,26 @@ import org.springframework.web.client.RestClient;
 @Configuration
 public class RestClientConfig {
 
+    /**
+     * Static service-to-service grant for every {@code SecurityServiceClient} operation
+     * (#880). Endpoint → authority, as enforced by pos-security-service:
+     *
+     * <ul>
+     * <li>{@code GET /v1/users} → {@code security:user:view}</li>
+     * <li>{@code GET /v1/roles}, {@code GET /v1/roles/by-name/{name}},
+     * {@code GET /v1/roles/assignments/user/{userId}} → {@code security:role:view}</li>
+     * <li>{@code POST /v1/roles/assignments}, {@code DELETE /v1/roles/assignments/{assignmentId}}
+     * (revoke) → {@code security:role:assign}</li>
+     * </ul>
+     *
+     * <p>pos-security-service defines no separate revoke authority — assignment removal is
+     * guarded by {@code security:role:assign}. {@code SecurityServiceAuthoritiesContractTest}
+     * (here) and {@code PeopleContactClientAuthoritiesTest} (pos-security-service) pin both
+     * sides of this contract.
+     */
+    public static final String SECURITY_SERVICE_AUTHORITIES =
+            "security:user:view,security:role:view,security:role:assign";
+
     @Bean
     @Primary
     public RestClient.Builder restClientBuilder() {
@@ -38,7 +58,7 @@ public class RestClientConfig {
         return builder.requestFactory(factory)
                 .baseUrl("http://" + serviceId)
                 .defaultHeader("X-User", "pos-people-contact")
-                .defaultHeader("X-Authorities", "security:user:view,security:role:view,security:role:assign")
+                .defaultHeader("X-Authorities", SECURITY_SERVICE_AUTHORITIES)
                 .build();
     }
 }

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PeopleExceptionHandler.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PeopleExceptionHandler.java
@@ -2,6 +2,7 @@ package com.positivity.peoplecontact.internal.controller;
 
 import com.positivity.peoplecontact.internal.client.SecurityServiceException;
 import com.positivity.peoplecontact.internal.exception.NotFoundException;
+import com.positivity.peoplecontact.internal.exception.PersonHasLinkedUsersException;
 import com.positivity.peoplecontact.internal.exception.PersonNotFoundException;
 import com.positivity.peoplecontact.internal.exception.SemanticValidationException;
 import com.positivity.peoplecontact.internal.exception.UserAlreadyLinkedException;
@@ -48,6 +49,14 @@ public class PeopleExceptionHandler {
     public ProblemDetail handleLinkNotFound(UserPersonLinkNotFoundException ex) {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
         problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        return problem;
+    }
+
+    @ExceptionHandler(PersonHasLinkedUsersException.class)
+    public ProblemDetail handlePersonHasLinkedUsers(PersonHasLinkedUsersException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
+        problem.setProperty("nextAction", PersonHasLinkedUsersException.NEXT_ACTION);
         return problem;
     }
 

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/PersonHasLinkedUsersException.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/exception/PersonHasLinkedUsersException.java
@@ -1,0 +1,17 @@
+package com.positivity.peoplecontact.internal.exception;
+
+import java.util.UUID;
+
+/**
+ * A person cannot be hard-deleted while {@code user_person_links} rows still reference it
+ * (#881). Surfaced as 409 CONFLICT with a {@code nextAction} instead of letting the FK
+ * violation escape as a 500 (ADR-0017 response-code matrix).
+ */
+public class PersonHasLinkedUsersException extends RuntimeException {
+
+    public static final String NEXT_ACTION = "Unlink the person's user accounts, then retry the delete.";
+
+    public PersonHasLinkedUsersException(UUID personId) {
+        super("Person " + personId + " still has linked user accounts and cannot be deleted");
+    }
+}

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/UserPersonLinkRepository.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/repository/UserPersonLinkRepository.java
@@ -24,6 +24,8 @@ public interface UserPersonLinkRepository extends JpaRepository<UserPersonLink, 
 
     boolean existsByUsername(@NonNull String username);
 
+    boolean existsByPerson_Id(@NonNull UUID personId);
+
     boolean existsByUsernameAndPerson_Id(@NonNull String username, @NonNull UUID personId);
 
     void deleteByUsername(@NonNull String username);

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonServiceImpl.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonServiceImpl.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -245,7 +246,15 @@ public class PersonServiceImpl implements PersonService {
         // #881: contact points have no FK to person — remove them in the same transaction so
         // the person.deleted fact and the authority's own tables cannot drift apart.
         personContactPointRepository.deleteByPersonId(id);
-        personRepository.deleteById(id);
+        try {
+            personRepository.deleteById(id);
+            // Force the DELETE to execute here so a link created concurrently (between the
+            // exists pre-check above and this statement) still surfaces as the 409, not as a
+            // DataIntegrityViolationException-turned-500 at commit time.
+            personRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new PersonHasLinkedUsersException(id);
+        }
         eventPublisher.publishPersonDeleted(id);
     }
 

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonServiceImpl.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/service/PersonServiceImpl.java
@@ -4,9 +4,11 @@ import com.positivity.peoplecontact.internal.dto.Person;
 import com.positivity.peoplecontact.internal.dto.ResolvePersonRequest;
 import com.positivity.peoplecontact.internal.dto.ResolvePersonResponse;
 import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.exception.PersonHasLinkedUsersException;
 import com.positivity.peoplecontact.internal.repository.PersonContactPointRepository;
 import com.positivity.peoplecontact.internal.repository.PersonRepository;
 import com.positivity.peoplecontact.internal.repository.PersonSpecifications;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
 import com.positivity.peoplecontact.service.PersonService;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,6 +45,8 @@ public class PersonServiceImpl implements PersonService {
     private final PersonRepository personRepository;
 
     private final PersonContactPointRepository personContactPointRepository;
+
+    private final UserPersonLinkRepository userPersonLinkRepository;
 
     private final PeopleContactEventPublisher eventPublisher;
 
@@ -233,6 +237,14 @@ public class PersonServiceImpl implements PersonService {
     @Override
     @Transactional
     public void deletePerson(@NonNull UUID id) {
+        // #881: fail fast with 409 instead of letting the user_person_links FK violation
+        // escape as a 500; the caller must unlink users first.
+        if (userPersonLinkRepository.existsByPerson_Id(id)) {
+            throw new PersonHasLinkedUsersException(id);
+        }
+        // #881: contact points have no FK to person — remove them in the same transaction so
+        // the person.deleted fact and the authority's own tables cannot drift apart.
+        personContactPointRepository.deleteByPersonId(id);
         personRepository.deleteById(id);
         eventPublisher.publishPersonDeleted(id);
     }

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/config/SecurityServiceAuthoritiesContractTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/config/SecurityServiceAuthoritiesContractTest.java
@@ -1,0 +1,38 @@
+package com.positivity.peoplecontact.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.peoplecontact.internal.config.RestClientConfig;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract test for the static service-to-service grant sent to pos-security-service (#880).
+ *
+ * <p>The client performs six operations; pos-security-service enforces one authority per
+ * endpoint (see the {@code SECURITY_SERVICE_AUTHORITIES} javadoc for the mapping). This test
+ * pins the header set so a header edit that drops a required authority — or an operation added
+ * without extending the grant — fails here instead of 403ing at runtime. The mirror test in
+ * pos-security-service ({@code PeopleContactClientAuthoritiesTest}) pins the other side: the
+ * endpoints this module calls must not start requiring authorities outside this grant.
+ */
+class SecurityServiceAuthoritiesContractTest {
+
+    /** One authority per operation class the client performs — keep in sync with the javadoc. */
+    private static final Set<String> REQUIRED_AUTHORITIES = Set.of(
+            // GET /v1/users
+            "security:user:view",
+            // GET /v1/roles, GET /v1/roles/by-name/{name}, GET /v1/roles/assignments/user/{userId}
+            "security:role:view",
+            // POST /v1/roles/assignments and DELETE /v1/roles/assignments/{assignmentId} (revoke)
+            "security:role:assign");
+
+    @Test
+    @DisplayName("The static X-Authorities grant covers every operation the client performs, revoke included")
+    void grantCoversAllClientOperations() {
+        Set<String> granted = Set.of(RestClientConfig.SECURITY_SERVICE_AUTHORITIES.split(","));
+
+        assertThat(granted).containsExactlyInAnyOrderElementsOf(REQUIRED_AUTHORITIES);
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/controller/PersonDeleteIT.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/controller/PersonDeleteIT.java
@@ -1,0 +1,155 @@
+package com.positivity.peoplecontact.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.peoplecontact.internal.entity.Person;
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.entity.UserPersonLink;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import com.positivity.peoplecontact.internal.enums.UserLinkStatus;
+import com.positivity.peoplecontact.internal.repository.PersonContactPointRepository;
+import com.positivity.peoplecontact.internal.repository.PersonRepository;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Integration coverage for the person hard-delete flow (#881): contact points are removed in
+ * the same transaction, and a person that still has {@code user_person_links} rows answers 409
+ * CONFLICT with a {@code nextAction} instead of surfacing the FK violation as a 500.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:persondelete;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "spring.flyway.enabled=false",
+            "eureka.client.enabled=false"
+        })
+@AutoConfigureTestRestTemplate
+@ActiveProfiles("test")
+class PersonDeleteIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private PersonRepository personRepository;
+
+    @Autowired
+    private PersonContactPointRepository personContactPointRepository;
+
+    @Autowired
+    private UserPersonLinkRepository userPersonLinkRepository;
+
+    @org.springframework.test.context.bean.override.mockito.MockitoBean
+    private com.positivity.peoplecontact.internal.client.SecurityServiceClient securityServiceClient;
+
+    @BeforeEach
+    void resetData() {
+        userPersonLinkRepository.deleteAll();
+        personContactPointRepository.deleteAll();
+        personRepository.deleteAll();
+    }
+
+    private HttpHeaders authenticatedHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("X-User", "test-user");
+        headers.add("X-Authorities", "people-contact:person:delete");
+        return headers;
+    }
+
+    private Person createPerson() {
+        return personRepository.save(
+                Person.builder().firstName("Del").lastName("Etable").build());
+    }
+
+    private void addContactPoint(UUID personId, ContactPointType type, String value) {
+        personContactPointRepository.save(PersonContactPoint.builder()
+                .personId(personId)
+                .contactType(type)
+                .value(value)
+                .isPrimary(true)
+                .build());
+    }
+
+    @Test
+    @DisplayName("Deleting a person removes its contact points in the same transaction")
+    void deleteRemovesContactPoints() {
+        Person person = createPerson();
+        addContactPoint(person.getId(), ContactPointType.EMAIL, "del@example.com");
+        addContactPoint(person.getId(), ContactPointType.PHONE_MOBILE, "+15550100");
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "/v1/people/{id}",
+                HttpMethod.DELETE,
+                new HttpEntity<>(authenticatedHeaders()),
+                Void.class,
+                person.getId());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(personRepository.findById(person.getId())).isEmpty();
+        assertThat(personContactPointRepository.findByPersonId(person.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Deleting a person with linked users answers 409 with a nextAction, not a 500")
+    void deleteWithLinkedUsersConflicts() {
+        Person person = createPerson();
+        addContactPoint(person.getId(), ContactPointType.EMAIL, "linked@example.com");
+        UserPersonLink link = new UserPersonLink();
+        link.setUsername("linked-user");
+        link.setPerson(person);
+        link.setStatus(UserLinkStatus.ACTIVE);
+        userPersonLinkRepository.save(link);
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/v1/people/{id}",
+                HttpMethod.DELETE,
+                new HttpEntity<>(authenticatedHeaders()),
+                new ParameterizedTypeReference<>() {},
+                person.getId());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody()).isNotNull();
+        assertThat((String) response.getBody().get("detail")).contains("linked user");
+        assertThat((String) response.getBody().get("nextAction")).contains("Unlink");
+        // Nothing was deleted: the person, its link, and its contact points survive.
+        assertThat(personRepository.findById(person.getId())).isPresent();
+        assertThat(userPersonLinkRepository.findByPerson_Id(person.getId())).hasSize(1);
+        assertThat(personContactPointRepository.findByPersonId(person.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Deleting an unknown person answers 404")
+    void deleteUnknownPersonIs404() {
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "/v1/people/{id}",
+                HttpMethod.DELETE,
+                new HttpEntity<>(authenticatedHeaders()),
+                Void.class,
+                UUID.randomUUID());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}

--- a/pos-security-service/src/test/java/com/positivity/securityservice/contract/PeopleContactClientAuthoritiesTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/contract/PeopleContactClientAuthoritiesTest.java
@@ -1,0 +1,65 @@
+package com.positivity.securityservice.contract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.securityservice.internal.controller.RoleController;
+import com.positivity.securityservice.internal.controller.UserController;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * Contract test for pos-people-contact's static service-to-service grant (#880).
+ *
+ * <p>pos-people-contact's {@code SecurityServiceClient} sends a fixed
+ * {@code X-Authorities: security:user:view,security:role:view,security:role:assign} header and
+ * calls the endpoints pinned below — including role revocation, which this service guards with
+ * {@code security:role:assign} (there is no separate revoke authority). If one of these
+ * endpoints starts requiring an authority outside that grant, this test fails at build time
+ * instead of the client 403ing at runtime. The mirror test lives in pos-people-contact
+ * ({@code SecurityServiceAuthoritiesContractTest}).
+ */
+class PeopleContactClientAuthoritiesTest {
+
+    /** The exact grant pos-people-contact sends; keep in sync with its RestClientConfig. */
+    private static final Set<String> PEOPLE_CONTACT_GRANT =
+            Set.of("security:user:view", "security:role:view", "security:role:assign");
+
+    @Test
+    @DisplayName("Every endpoint pos-people-contact calls requires an authority inside its static grant")
+    void endpointsUsedByPeopleContactStayInsideTheGrant() {
+        assertAuthorityInGrant(UserController.class, "getAllUsers");
+        assertAuthorityInGrant(RoleController.class, "getRoleByName");
+        assertAuthorityInGrant(RoleController.class, "getAllRoles");
+        assertAuthorityInGrant(RoleController.class, "getUserRoleAssignments");
+        assertAuthorityInGrant(RoleController.class, "createRoleAssignment");
+        // Revocation path: DELETE /v1/roles/assignments/{assignmentId} — guarded by
+        // security:role:assign, not a distinct revoke authority (#880 finding).
+        assertAuthorityInGrant(RoleController.class, "revokeRoleAssignment");
+    }
+
+    private static void assertAuthorityInGrant(Class<?> controller, String methodName) {
+        Method method = Arrays.stream(controller.getMethods())
+                .filter(m -> m.getName().equals(methodName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(controller.getSimpleName() + "#" + methodName
+                        + " no longer exists — update the" + " pos-people-contact client contract (#880)"));
+        PreAuthorize preAuthorize = method.getAnnotation(PreAuthorize.class);
+        assertThat(preAuthorize)
+                .as("%s#%s must declare @PreAuthorize", controller.getSimpleName(), methodName)
+                .isNotNull();
+        String expression = preAuthorize.value();
+        boolean covered =
+                PEOPLE_CONTACT_GRANT.stream().anyMatch(authority -> expression.contains("'" + authority + "'"));
+        assertThat(covered)
+                .as(
+                        "%s#%s requires %s, which is outside pos-people-contact's static grant %s —"
+                                + " update the client's X-Authorities header (see"
+                                + " pos-people-contact RestClientConfig, #880)",
+                        controller.getSimpleName(), methodName, expression, PEOPLE_CONTACT_GRANT)
+                .isTrue();
+    }
+}

--- a/pos-security-service/src/test/java/com/positivity/securityservice/contract/PeopleContactClientAuthoritiesTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/contract/PeopleContactClientAuthoritiesTest.java
@@ -6,7 +6,10 @@ import com.positivity.securityservice.internal.controller.RoleController;
 import com.positivity.securityservice.internal.controller.UserController;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -52,14 +55,25 @@ class PeopleContactClientAuthoritiesTest {
                 .as("%s#%s must declare @PreAuthorize", controller.getSimpleName(), methodName)
                 .isNotNull();
         String expression = preAuthorize.value();
-        boolean covered =
-                PEOPLE_CONTACT_GRANT.stream().anyMatch(authority -> expression.contains("'" + authority + "'"));
-        assertThat(covered)
+        // Every authority referenced by the expression must be inside the grant: an expression
+        // like hasAuthority('a') and hasAuthority('b') with b outside the grant would 403 the
+        // client at runtime even though a is granted.
+        Set<String> required = new HashSet<>();
+        Matcher matcher = Pattern.compile("'([^']+)'").matcher(expression);
+        while (matcher.find()) {
+            required.add(matcher.group(1));
+        }
+        assertThat(required)
+                .as(
+                        "%s#%s declares no authorities in its @PreAuthorize expression: %s",
+                        controller.getSimpleName(), methodName, expression)
+                .isNotEmpty();
+        assertThat(required)
                 .as(
                         "%s#%s requires %s, which is outside pos-people-contact's static grant %s —"
                                 + " update the client's X-Authorities header (see"
                                 + " pos-people-contact RestClientConfig, #880)",
                         controller.getSimpleName(), methodName, expression, PEOPLE_CONTACT_GRANT)
-                .isTrue();
+                .isSubsetOf(PEOPLE_CONTACT_GRANT);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the two defects found in the #879 review. pos-people's copies of both code paths are gone since the #875 cutover, so pos-people-contact is the only fix site.

### #881 — person hard-delete
- `deletePerson` now removes the person's contact points **in the same transaction**: `person_contact_point` has no FK to `person`, so the previous bare `deleteById` left orphan rows — and in the authority module that meant the emitted `people-contact.person.deleted` fact told replicas to drop a person whose contact rows the owner still kept (permanent internal drift).
- A person that still has `user_person_links` rows now answers **409 CONFLICT** with a `nextAction` ("Unlink the person's user accounts, then retry the delete.") via `PersonHasLinkedUsersException`, instead of the FK violation surfacing as a 500 (ADR-0017 response-code matrix / `docs/ERROR_ENVELOPE.md`).
- The `person.deleted` outbox event still queues in the same transaction, so the conflict path rolls everything back — verified by test.
- `PersonDeleteIT` (3 tests): happy path (204, contact points gone), linked-user conflict (409 + `nextAction`, person/link/contact points all survive), unknown person (404).

### #880 — role revoke authority
**Finding: no gap exists.** pos-security-service guards assignment removal (`DELETE /v1/roles/assignments/{assignmentId}`, the endpoint `SecurityServiceClient.revokeRole` calls) with `security:role:assign` — there is **no distinct revoke authority** — so the static grant already covers all six operations the client performs and no runtime 403 occurs today.

What changed is that the contract is now pinned instead of implicit:
- The grant is a documented constant (`RestClientConfig.SECURITY_SERVICE_AUTHORITIES`) with an endpoint → authority table in its javadoc.
- `SecurityServiceAuthoritiesContractTest` (pos-people-contact) asserts the header set matches the operations performed.
- `PeopleContactClientAuthoritiesTest` (pos-security-service) reflects over the six endpoints the client calls and asserts each `@PreAuthorize` stays inside the grant — if a `security:role:revoke` authority is ever introduced on the revoke endpoint, the build fails there with a message pointing at the client header, instead of the client 403ing at runtime.

Contract guides: checked `domains/people` and `domains/security` `BACKEND_CONTRACT_GUIDE.md` — no controller contract changed (the 409 is a new error outcome on an existing endpoint, documented via OpenAPI-visible ProblemDetail), and BACKEND_CONTRACT_GUIDE.md needs no update.

## Testing
- New: `PersonDeleteIT` (3), `SecurityServiceAuthoritiesContractTest` (1), `PeopleContactClientAuthoritiesTest` (1).
- Full suites green: pos-people-contact, pos-security-service.

Closes #880
Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125Ws3dq5BLCZLrG7hr9mEo