### PR TITLE
fix(gateway,deploy): trusted-proxies for X-Forwarded headers (#911) + wire pos-people-contact into alpha deploy

### DIFF
--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          ALL_SERVICES_JSON='["pos-accounting","pos-api-gateway","pos-bulk-loader","pos-catalog","pos-customer","pos-documents","pos-event-receiver","pos-image","pos-inventory","pos-invoice","pos-location","pos-mcp-server","pos-people","pos-price","pos-security-service","pos-service-discovery","pos-shop-manager","pos-tax","pos-vehicle-inventory","pos-workorder"]'
+          ALL_SERVICES_JSON='["pos-accounting","pos-api-gateway","pos-bulk-loader","pos-catalog","pos-customer","pos-documents","pos-event-receiver","pos-image","pos-inventory","pos-invoice","pos-location","pos-mcp-server","pos-people","pos-people-contact","pos-price","pos-security-service","pos-service-discovery","pos-shop-manager","pos-tax","pos-vehicle-inventory","pos-workorder"]'
           FORCE_FULL_REBUILD=false
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then

--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -57,6 +57,46 @@ run_periodic_docker_prune() {
   return 0
 }
 
+# postgres/init-databases.sql only runs on fresh volume initialization, so databases
+# added after the alpha volume was first created never come into existence. Reconcile:
+# parse the CREATE DATABASE lines and create any database that is missing. Names are
+# constrained to [A-Za-z0-9_]+ by the sed pattern, so interpolation into SQL is safe.
+reconcile_databases() {
+  local init_sql="${BACKEND_DIR}/postgres/init-databases.sql"
+  if [[ ! -f "${init_sql}" ]]; then
+    echo "Warning: ${init_sql} not found; skipping database reconciliation." >&2
+    return 0
+  fi
+
+  echo "Ensuring postgres is up for database reconciliation"
+  docker compose "${COMPOSE_ARGS[@]}" up -d postgres
+
+  local attempt
+  for attempt in $(seq 1 60); do
+    if docker compose "${COMPOSE_ARGS[@]}" exec -T postgres \
+        sh -c 'pg_isready -q -U "${POSTGRES_USER}"'; then
+      break
+    fi
+    if [[ "${attempt}" -eq 60 ]]; then
+      echo "postgres did not become ready within 60s; aborting before database reconciliation." >&2
+      return 1
+    fi
+    sleep 1
+  done
+
+  local db exists
+  while read -r db; do
+    [[ -n "${db}" ]] || continue
+    exists="$(docker compose "${COMPOSE_ARGS[@]}" exec -T postgres \
+      sh -c 'psql -U "${POSTGRES_USER}" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '"'"''"${db}"''"'"'"')"
+    if [[ "${exists}" != "1" ]]; then
+      echo "Creating missing database: ${db}"
+      docker compose "${COMPOSE_ARGS[@]}" exec -T postgres \
+        sh -c 'psql -U "${POSTGRES_USER}" -d postgres -c "CREATE DATABASE '"${db}"';"'
+    fi
+  done < <(sed -nE 's/^CREATE DATABASE ([A-Za-z0-9_]+);$/\1/p' "${init_sql}")
+}
+
 OBSERVABILITY_SERVICES=(
   jaeger
   prometheus
@@ -203,6 +243,8 @@ docker compose "${COMPOSE_ARGS[@]}" run --rm --no-deps kafka-topic-init
 
 echo "Starting Kafka exporter"
 docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate kafka-exporter
+
+reconcile_databases
 
 echo "Pulling backend services: ${BACKEND_SERVICES[*]}"
 docker compose "${COMPOSE_ARGS[@]}" pull --quiet "${BACKEND_SERVICES[@]}"

--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -89,6 +89,7 @@ BACKEND_SERVICES=(
   pos-location
   pos-mcp-server
   pos-people
+  pos-people-contact
   pos-price
   pos-security-service
   pos-shop-manager

--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -151,6 +151,14 @@ services:
     restart: unless-stopped
     logging: *logging
 
+  pos-people-contact:
+    image: ${ECR_REGISTRY}/durion/pos-people-contact:${BACKEND_TAG}
+    restart: unless-stopped
+    logging: *logging
+    # #838 flag flip — uncomment in the second deploy, after the broker is verified healthy:
+    # environment:
+    #   POS_PEOPLE_CONTACT_KAFKA_ENABLED: "true"
+
   pos-price:
     image: ${ECR_REGISTRY}/durion/pos-price:${BACKEND_TAG}
     restart: unless-stopped

--- a/pos-api-gateway/src/main/resources/application.yml
+++ b/pos-api-gateway/src/main/resources/application.yml
@@ -8,6 +8,15 @@ spring:
     gateway:
       server:
         webflux:
+          # CVE-2025-41235 hardening (SCG 2025.x): X-Forwarded-*/Forwarded headers are stripped
+          # and never appended unless the peer's remote address matches this regex — leaving it
+          # unset makes downstream absolute-URL reconstruction (bulk-loader TUS Location,
+          # #833/#834) fall back to internal container addresses. Trust loopback (dev/local) and
+          # RFC1918 ranges (compose networks, host nginx, frontend SSR proxy on alpha). Spoofed
+          # X-Forwarded-* from these ranges affects only URL reconstruction and client-IP
+          # logging: identity always comes from the JWT, and inbound identity headers are
+          # stripped independently (auth.strip-inbound-identity-headers).
+          trusted-proxies: '127\.0\.0\.1|::1|0:0:0:0:0:0:0:1|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}'
           discovery:
             locator:
               # Discovery locator disabled - only explicitly configured routes are exposed

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/TrustedProxiesConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/TrustedProxiesConfigTest.java
@@ -1,0 +1,82 @@
+package com.positivity.gateway.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Pins the {@code spring.cloud.gateway.server.webflux.trusted-proxies} regex.
+ *
+ * <p>Since the CVE-2025-41235 hardening, Spring Cloud Gateway strips inbound
+ * {@code X-Forwarded-*}/{@code Forwarded} headers and appends none of its own unless the peer's
+ * remote address matches this pattern. If the property disappears or stops matching the compose
+ * network / host proxy addresses, downstream absolute-URL reconstruction silently regresses to
+ * internal container URLs (bulk-loader TUS {@code Location}, #833/#834) — so the expected matching
+ * behavior is asserted here against the real application.yml value.
+ *
+ * <p>The gateway evaluates the pattern as a full match against the peer's host address string,
+ * which is mirrored here via {@link java.util.regex.Matcher#matches()}.
+ */
+class TrustedProxiesConfigTest {
+
+    private static Pattern trustedProxies;
+
+    @BeforeAll
+    static void loadPattern() throws IOException {
+        List<PropertySource<?>> sources =
+                new YamlPropertySourceLoader().load("application", new ClassPathResource("application.yml"));
+        Object value = sources.stream()
+                .map(s -> s.getProperty("spring.cloud.gateway.server.webflux.trusted-proxies"))
+                .filter(v -> v != null)
+                .findFirst()
+                .orElse(null);
+        assertThat(value)
+                .as("trusted-proxies must be configured, otherwise the gateway forwards no X-Forwarded-* headers")
+                .isNotNull();
+        trustedProxies = Pattern.compile(value.toString());
+    }
+
+    @Test
+    @DisplayName("trusts loopback and RFC1918 peers (compose networks, host nginx, frontend SSR proxy)")
+    void trustsInternalPeers() {
+        assertThat(List.of(
+                        "127.0.0.1",
+                        "0:0:0:0:0:0:0:1",
+                        "::1",
+                        "10.0.3.7",
+                        "172.16.0.1",
+                        "172.22.0.11",
+                        "172.31.255.254",
+                        "192.168.1.10"))
+                .allSatisfy(
+                        address -> assertThat(trustedProxies.matcher(address).matches())
+                                .as("expected trusted peer: %s", address)
+                                .isTrue());
+    }
+
+    @Test
+    @DisplayName("does not trust public or out-of-range addresses")
+    void rejectsExternalPeers() {
+        assertThat(List.of(
+                        "203.0.113.9",
+                        "8.8.8.8",
+                        // 172.x outside the 172.16.0.0/12 private block
+                        "172.15.0.1",
+                        "172.32.0.1",
+                        // prefix/suffix junk must not full-match
+                        "1172.22.0.11",
+                        "192.168.1.10.evil.example"))
+                .allSatisfy(
+                        address -> assertThat(trustedProxies.matcher(address).matches())
+                                .as("expected untrusted peer: %s", address)
+                                .isFalse());
+    }
+}


### PR DESCRIPTION
Three deployment-blocking fixes, verified against alpha:

## 1. Gateway: `trusted-proxies` so X-Forwarded headers survive (#911, unblocks #833/#834)

Since the CVE-2025-41235 hardening (Spring Cloud Gateway 2025.x), the gateway strips inbound `X-Forwarded-*`/`Forwarded` headers and appends none of its own unless `spring.cloud.gateway.server.webflux.trusted-proxies` matches the peer. The property was unset, so the #834 TUS `Location` fix was inert on alpha — bulk-loader reconstructed `Location` from its own container address (`http://172.22.0.11:8080/...`), verified live via bulk-loader's springdoc `servers` URL.

- `pos-api-gateway/application.yml`: trust loopback + RFC1918 ranges (compose networks, host nginx, frontend SSR proxy). Spoofed `X-Forwarded-*` from those ranges affects only URL reconstruction and client-IP logging — identity always comes from the JWT, and inbound identity headers are stripped independently.
- `TrustedProxiesConfigTest` pins the regex against the real `application.yml` (presence, full-match semantics, accept/reject sets) so removing or narrowing it fails the build.

## 2. Deploy: wire `pos-people-contact` into the alpha chain

The service existed only in the base `docker-compose.yml`, so it was never built for the stack tag nor started on alpha — despite the #875 cutover making it the authority for the contact surface.

- `build-push-ecr.yml`: added to `ALL_SERVICES_JSON` (full-stack builds publish `durion/pos-people-contact`)
- `deployment/alpha/docker-compose.prod.yml`: ECR image + restart/logging override, commented `POS_PEOPLE_CONTACT_KAFKA_ENABLED` flag flip per the #838 two-deploy pattern
- `deployment/alpha/deploy-backend.sh`: added to `BACKEND_SERVICES`

Prerequisites already done manually: `durion/pos-people-contact` ECR repository and `pos_people_contact_db` on the alpha postgres.

## 3. Deploy: reconcile missing per-service databases

`postgres/init-databases.sql` only runs on fresh volume initialization, so databases added later never exist on alpha. `deploy-backend.sh` now parses the `CREATE DATABASE` lines and creates any missing database before starting backend services (idempotent; names constrained to `[A-Za-z0-9_]+` before SQL interpolation; bounded `pg_isready` wait). Removes the manual psql step for all future services.

## Verification

- Full `pos-api-gateway` suite green (incl. new pinning test)
- `reconcile_databases` dry-run with stubbed docker: creates exactly the missing databases, skips existing, well-formed psql commands
- YAML/shell syntax validated
- Post-deploy checklist tracked in #911 (re-probe api-docs `servers` URL, end-to-end TUS upload, `pos-people-contact` in `compose ps`)

Closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QTHafhvxoU5GDF4RAb5WR

---
_Generated by [Claude Code](https://claude.ai/code/session_014QTHafhvxoU5GDF4RAb5WR)_