### PR TITLE
fix(archunit): fail loudly on invisible cross-module classes + reactor CI build, and pay down the entity debt it exposed (#909)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
           if [[ "${{ matrix.module }}" == "pos-archunit" ]]; then
             ./mvnw -pl pos-archunit -am test \
               org.jacoco:jacoco-maven-plugin:0.8.14:report \
-              -Dtest='com.positivity.archunit.*' \
+              -Dtest='com/positivity/archunit/*' \
               -Dsurefire.failIfNoSpecifiedTests=false \
               -DskipITs -T 1C -B -q -o
           else
@@ -300,9 +300,9 @@ jobs:
         run: |
           if [[ "${{ matrix.module }}" == "pos-archunit" ]]; then
             ./mvnw -pl pos-archunit -am -DskipTests=false verify \
-              -Dtest='com.positivity.archunit.*' \
+              -Dtest='com/positivity/archunit/*' \
               -Dsurefire.failIfNoSpecifiedTests=false \
-              -Dit.test='com.positivity.archunit.*' \
+              -Dit.test='com/positivity/archunit/*' \
               -Dfailsafe.failIfNoSpecifiedTests=false \
               -T 1C -B -q -o
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,21 @@ jobs:
         run: ./scripts/check-flyway-hygiene.sh
 
       - name: Run unit tests
-        run: ./mvnw -pl ${{ matrix.module }} test
-          org.jacoco:jacoco-maven-plugin:0.8.14:report -DskipITs -T 1C -B -q -o
+        # pos-archunit's cross-module rules need sibling modules' target/classes on the
+        # classpath: the installed Spring Boot fat jars hide application classes under
+        # BOOT-INF/classes and every rule passes vacuously (#909). Build it as a reactor
+        # (-am) while running only its own tests in the upstream modules' place.
+        run: |
+          if [[ "${{ matrix.module }}" == "pos-archunit" ]]; then
+            ./mvnw -pl pos-archunit -am test \
+              org.jacoco:jacoco-maven-plugin:0.8.14:report \
+              -Dtest='com.positivity.archunit.*' \
+              -Dsurefire.failIfNoSpecifiedTests=false \
+              -DskipITs -T 1C -B -q -o
+          else
+            ./mvnw -pl ${{ matrix.module }} test \
+              org.jacoco:jacoco-maven-plugin:0.8.14:report -DskipITs -T 1C -B -q -o
+          fi
 
       - name: Upload test results
         if: always()
@@ -282,7 +295,19 @@ jobs:
           ./mvnw -pl pos-events test -DskipITs -T 1C -B -q
 
       - name: Run integration tests
-        run: ./mvnw -pl ${{ matrix.module }} -DskipTests=false verify -T 1C -B -q -o
+        # verify re-runs surefire, so pos-archunit needs the same reactor treatment as in
+        # the unit-tests job (#909); scope surefire and failsafe to its own tests.
+        run: |
+          if [[ "${{ matrix.module }}" == "pos-archunit" ]]; then
+            ./mvnw -pl pos-archunit -am -DskipTests=false verify \
+              -Dtest='com.positivity.archunit.*' \
+              -Dsurefire.failIfNoSpecifiedTests=false \
+              -Dit.test='com.positivity.archunit.*' \
+              -Dfailsafe.failIfNoSpecifiedTests=false \
+              -T 1C -B -q -o
+          else
+            ./mvnw -pl ${{ matrix.module }} -DskipTests=false verify -T 1C -B -q -o
+          fi
 
       - name: Upload integration test results
         if: always()

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/ExtCustomerBillingRules.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/ExtCustomerBillingRules.java
@@ -1,9 +1,12 @@
 package com.positivity.accounting.internal.entity;
 
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
@@ -11,12 +14,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only replica of pos-customer billing rules (ADR-0044 R3, issue #842). Written exclusively
  * by the {@code customer.events.v1} consumer; accounting business logic only reads it.
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -62,6 +68,13 @@ public class ExtCustomerBillingRules {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
+
+    /** ArchUnit UUIDv7 rule hook (ADR-0013, generator-owned upstream): the key is the owner's UUIDv7, stored verbatim. */
+    @Transient
+    public Class<?> uuidv7Dependency() {
+        return UUIDv7Generator.class;
+    }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/ExtInvoice.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/ExtInvoice.java
@@ -1,9 +1,12 @@
 package com.positivity.accounting.internal.entity;
 
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
@@ -11,6 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only replica of pos-invoice's invoice documents (ADR-0044 R3, #842), materialized from
@@ -19,6 +24,7 @@ import lombok.NoArgsConstructor;
  * ERROR}); AR state (balance due) is derived in accounting, not stored on the replica.
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -69,6 +75,13 @@ public class ExtInvoice {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
+
+    /** ArchUnit UUIDv7 rule hook (ADR-0013, generator-owned upstream): the key is the owner's UUIDv7, stored verbatim. */
+    @Transient
+    public Class<?> uuidv7Dependency() {
+        return UUIDv7Generator.class;
+    }
 }

--- a/pos-archunit/README.md
+++ b/pos-archunit/README.md
@@ -43,5 +43,5 @@ application classes live under `BOOT-INF/classes/` where ArchUnit cannot see the
 zero classes and pass vacuously. `ClasspathVisibilityGuardTest` turns that silent pass into a loud failure
 by asserting each module dependency contributes at least one imported class (and each enforced entity
 package contains at least one `@Entity`). The CI job therefore runs this module with
-`-am -Dtest='com.positivity.archunit.*' -Dsurefire.failIfNoSpecifiedTests=false` so upstream modules are
+`-am -Dtest='com/positivity/archunit/*' -Dsurefire.failIfNoSpecifiedTests=false` so upstream modules are
 compiled but only this module's tests execute.

--- a/pos-archunit/README.md
+++ b/pos-archunit/README.md
@@ -13,6 +13,8 @@ Architecture testing aggregator that enforces internal package encapsulation and
 
 - `ArchitectureTests` — primary cross-module ArchUnit test suite; validates inter-module boundaries
 - `EntityStandardsArchitectureTest` — validates JPA entity conventions (naming, annotations, ID strategy)
+- `DomainWallsTest` — source-based ADR-0044 check that `internal.client` code only targets utility modules
+- `ClasspathVisibilityGuardTest` — fails the build when module classes are invisible to ArchUnit (see below)
 - `PositivityArchunitApplication` — placeholder Spring Boot application required for classpath scanning
 
 ## Dependencies (test scope)
@@ -24,8 +26,22 @@ Architecture testing aggregator that enforces internal package encapsulation and
 This is a test-only aggregator. It does not expose a runnable service.
 
 ```bash
-# Run all architecture tests
+# Run all architecture tests — the -am (also-make) flag is REQUIRED, see below
 ./mvnw -pl pos-archunit -am test
 ```
 
-Architecture violations fail the build. Add new domain modules to the `pom.xml` dependency list and to the corresponding `ArchitectureTests` rule when they are created.
+Architecture violations fail the build. Add new domain modules to the `pom.xml` dependency list, to the
+corresponding `ArchitectureTests` rule, and to `ClasspathVisibilityGuardTest.MODULE_ROOT_PACKAGES` when
+they are created.
+
+### Why `-am` is required (issue #909)
+
+The class-graph rules import `com.positivity` from the test classpath. In a reactor build (`-am`), sibling
+modules resolve to their `target/classes` directories, which ArchUnit can read. In a solo build
+(`mvn -pl pos-archunit test`), they resolve to the installed Spring Boot repackaged fat jars, whose
+application classes live under `BOOT-INF/classes/` where ArchUnit cannot see them — every rule would match
+zero classes and pass vacuously. `ClasspathVisibilityGuardTest` turns that silent pass into a loud failure
+by asserting each module dependency contributes at least one imported class (and each enforced entity
+package contains at least one `@Entity`). The CI job therefore runs this module with
+`-am -Dtest='com.positivity.archunit.*' -Dsurefire.failIfNoSpecifiedTests=false` so upstream modules are
+compiled but only this module's tests execute.

--- a/pos-archunit/src/test/java/com/positivity/archunit/ClasspathVisibilityGuardTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/ClasspathVisibilityGuardTest.java
@@ -1,0 +1,106 @@
+package com.positivity.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards against vacuous passes of the cross-module ArchUnit rules (#909).
+ *
+ * <p>When pos-archunit is built outside the Maven reactor (e.g. {@code mvn -pl pos-archunit test}),
+ * its module dependencies resolve to the installed Spring Boot repackaged fat jars, whose
+ * application classes live under {@code BOOT-INF/classes/} where ArchUnit's classpath importer
+ * cannot see them. Every rule then matches zero classes and {@code allowEmptyShould(true)} turns
+ * the run into a silent pass. This test fails loudly instead: it asserts that every module
+ * dependency contributes at least one class to the imported class set, and that every package
+ * enforced by {@link EntityStandardsArchitectureTest} contains at least one {@code @Entity}.
+ *
+ * <p>If this test fails, run pos-archunit as a reactor build so sibling modules resolve to their
+ * {@code target/classes} directories: {@code ./mvnw -pl pos-archunit -am test}.
+ */
+class ClasspathVisibilityGuardTest {
+
+    private static final String REMEDY = " — ArchUnit cannot see application classes inside Spring Boot repackaged"
+            + " fat jars (BOOT-INF/classes). Run pos-archunit as a reactor build so module dependencies"
+            + " resolve to target/classes: ./mvnw -pl pos-archunit -am test (see issue #909).";
+
+    private static final String ENTITY_ANNOTATION = "jakarta.persistence.Entity";
+
+    /**
+     * Root package contributed by each com.positivity module dependency declared in
+     * pos-archunit/pom.xml. Keep in sync with the pom when adding or removing module dependencies.
+     */
+    private static final Map<String, String> MODULE_ROOT_PACKAGES = new TreeMap<>(Map.ofEntries(
+            Map.entry("pos-accounting", "com.positivity.accounting"),
+            Map.entry("pos-catalog", "com.positivity.catalog"),
+            Map.entry("pos-customer", "com.positivity.customer"),
+            Map.entry("pos-event-receiver", "com.positivity.poseventreceiver"),
+            Map.entry("pos-events", "com.positivity.events"),
+            Map.entry("pos-image", "com.positivity.image"),
+            Map.entry("pos-inquiry", "com.positivity.inquiry"),
+            Map.entry("pos-inventory", "com.positivity.inventory"),
+            Map.entry("pos-invoice", "com.positivity.invoice"),
+            Map.entry("pos-location", "com.positivity.location"),
+            Map.entry("pos-mcp-server", "com.positivity.mcp"),
+            Map.entry("pos-order", "com.positivity.order"),
+            Map.entry("pos-people", "com.positivity.people"),
+            Map.entry("pos-people-contact", "com.positivity.peoplecontact"),
+            Map.entry("pos-security-service", "com.positivity.securityservice"),
+            Map.entry("pos-shop-manager", "com.positivity.shopmanager"),
+            Map.entry("pos-vehicle-fitment", "com.positivity.vehiclefitment"),
+            Map.entry("pos-vehicle-inventory", "com.positivity.vehicle"),
+            Map.entry("pos-vehicle-reference-carapi", "com.positivity.vehiclereferencecarapi"),
+            Map.entry("pos-vehicle-reference-nhtsa", "com.positivity.nhtsa"),
+            Map.entry("pos-workorder", "com.positivity.workorder")));
+
+    private static JavaClasses allClasses;
+
+    @BeforeAll
+    static void setup() {
+        allClasses = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("com.positivity");
+    }
+
+    @Test
+    void everyModuleDependencyShouldContributeClasses() {
+        List<String> hiddenModules = MODULE_ROOT_PACKAGES.entrySet().stream()
+                .filter(entry -> allClasses.stream().noneMatch(javaClass -> residesIn(javaClass, entry.getValue())))
+                .map(entry -> entry.getKey() + " (" + entry.getValue() + ")")
+                .toList();
+
+        Assertions.assertTrue(
+                hiddenModules.isEmpty(),
+                () -> "No classes imported from module dependencies: " + String.join(", ", hiddenModules) + REMEDY);
+    }
+
+    @Test
+    void everyEnforcedEntityPackageShouldContainEntities() {
+        List<String> emptyPackages = List.of(EntityStandardsArchitectureTest.ENFORCED_ENTITY_PACKAGES).stream()
+                .map(pattern -> pattern.substring(0, pattern.length() - "..".length()))
+                .filter(packagePrefix -> allClasses.stream()
+                        .noneMatch(javaClass ->
+                                residesIn(javaClass, packagePrefix) && javaClass.isAnnotatedWith(ENTITY_ANNOTATION)))
+                .toList();
+
+        Assertions.assertTrue(
+                emptyPackages.isEmpty(),
+                () -> "No @Entity classes imported from enforced entity packages: "
+                        + String.join(", ", emptyPackages)
+                        + ". Either the module's classes are invisible" + REMEDY
+                        + " Or the module no longer has entities — then remove the package from"
+                        + " EntityStandardsArchitectureTest.ENFORCED_ENTITY_PACKAGES.");
+    }
+
+    private static boolean residesIn(JavaClass javaClass, String packagePrefix) {
+        String packageName = javaClass.getPackageName();
+        return packageName.equals(packagePrefix) || packageName.startsWith(packagePrefix + ".");
+    }
+}

--- a/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
@@ -28,9 +28,11 @@ import java.util.UUID;
 @AnalyzeClasses(packages = "com.positivity", importOptions = ImportOption.DoNotIncludeTests.class)
 class EntityStandardsArchitectureTest {
 
-    private static final String[] ENFORCED_ENTITY_PACKAGES = {
+    // Every package listed here must contain at least one @Entity visible to the importer —
+    // ClasspathVisibilityGuardTest enforces this so the rules below can never pass vacuously (#909).
+    // pos-documents has no JPA entities, so it is intentionally absent.
+    static final String[] ENFORCED_ENTITY_PACKAGES = {
         "com.positivity.location.internal.entity..",
-        "com.positivity.documents.internal.entity..",
         "com.positivity.inventory.internal.entity..",
         "com.positivity.accounting.internal.entity..",
         "com.positivity.invoice.internal.entity..",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtLocationParentReplica.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtLocationParentReplica.java
@@ -1,6 +1,6 @@
 package com.positivity.inventory.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -48,7 +48,7 @@ public class ExtLocationParentReplica {
      */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 
     @Data

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtStorageLocationReplica.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtStorageLocationReplica.java
@@ -1,8 +1,9 @@
 package com.positivity.inventory.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -12,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only storage-location replica fed by {@code location.storage-location.updated} facts on
@@ -28,6 +31,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ext_storage_location")
 public class ExtStorageLocationReplica {
 
@@ -59,6 +63,7 @@ public class ExtStorageLocationReplica {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
@@ -68,6 +73,6 @@ public class ExtStorageLocationReplica {
      */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtWorkorderPartReplica.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtWorkorderPartReplica.java
@@ -1,6 +1,6 @@
 package com.positivity.inventory.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -45,6 +45,6 @@ public class ExtWorkorderPartReplica {
      */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtWorkorderReplica.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtWorkorderReplica.java
@@ -1,8 +1,9 @@
 package com.positivity.inventory.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -12,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only workorder replica fed by {@code workorder.events.v1} (ADR-0044 §6, #897).
@@ -25,6 +28,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ext_workorder")
 public class ExtWorkorderReplica {
 
@@ -41,6 +45,7 @@ public class ExtWorkorderReplica {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
@@ -50,6 +55,6 @@ public class ExtWorkorderReplica {
      */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/OutboxEvent.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/OutboxEvent.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.internal.entity;
 import com.positivity.shared.id.UUIDv7Id;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -12,12 +13,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Transactional-outbox row (ADR-0044 §4, issue #899). a serialized Kafka event written in the
  * same transaction as the business state change and drained by {@code OutboxPublisher}.
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,6 +43,7 @@ public class OutboxEvent {
     @Column(nullable = false, columnDefinition = "text")
     private String payload;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLocationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLocationServiceImpl.java
@@ -1,6 +1,5 @@
 package com.positivity.inventory.internal.service;
 
-import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import com.positivity.inventory.internal.dto.DeactivateLocationResponse;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
@@ -56,7 +55,8 @@ public class InventoryLocationServiceImpl implements InventoryLocationService {
             throw new IllegalArgumentException("locationId is required");
         }
 
-        StorageLocationValidationService.StorageLocationValidation sourceValidation = validateSourceLocation(locationId);
+        StorageLocationValidationService.StorageLocationValidation sourceValidation =
+                validateSourceLocation(locationId);
         List<InventoryLedgerEntryRepository.LocationOnHand> onHandRows =
                 inventoryLedgerEntryRepository.findPositiveOnHandByLocation(
                         locationId, InventoryLedgerEventType.onHandAffectingTypes());

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryRollupServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryRollupServiceImpl.java
@@ -1,12 +1,11 @@
 package com.positivity.inventory.internal.service;
 
-import com.positivity.inventory.internal.service.StorageLocationTopologyService;
-import com.positivity.inventory.internal.service.StorageLocationTopologyService.LocationDescendant;
 import com.positivity.inventory.internal.dto.rollup.LocationInventoryRollupResponse;
 import com.positivity.inventory.internal.dto.rollup.RollupQuantities;
 import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
 import com.positivity.inventory.internal.dto.rollup.SiteRollupSummary;
 import com.positivity.inventory.internal.exception.RollupExpansionTooLargeException;
+import com.positivity.inventory.internal.service.StorageLocationTopologyService.LocationDescendant;
 import com.positivity.inventory.service.LocationInventoryRollupService;
 import com.positivity.inventory.service.SiteInventoryRollupService;
 import java.util.ArrayList;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationManifestListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationManifestListener.java
@@ -122,7 +122,8 @@ public class LocationManifestListener {
     }
 
     /** Command envelope for the owner's {@code location.commands.v1} listener. */
-    record ReplayCommand(@NonNull String commandType, @NonNull Payload payload) {
+    record ReplayCommand(
+            @NonNull String commandType, @NonNull Payload payload) {
         record Payload(@Nullable String since, @Nullable String until) {}
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationSyncServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationSyncServiceImpl.java
@@ -1,10 +1,10 @@
 package com.positivity.inventory.internal.service;
 
+import com.positivity.inventory.internal.dto.sync.LocationSyncRunResponse;
+import com.positivity.inventory.internal.dto.sync.SyncLogResponse;
 import com.positivity.inventory.internal.entity.LocationSyncLogEntity;
 import com.positivity.inventory.internal.enums.LocationSyncLogScope;
 import com.positivity.inventory.internal.enums.LocationSyncOutcome;
-import com.positivity.inventory.internal.dto.sync.LocationSyncRunResponse;
-import com.positivity.inventory.internal.dto.sync.SyncLogResponse;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.repository.LocationSyncLogRepository;
 import com.positivity.inventory.service.LocationSyncService;
@@ -193,7 +193,8 @@ public class LocationSyncServiceImpl implements LocationSyncService {
     }
 
     /** Command envelope for the owner's {@code location.commands.v1} listener. */
-    record ReplayCommand(@NonNull String commandType, @NonNull Payload payload) {
+    record ReplayCommand(
+            @NonNull String commandType, @NonNull Payload payload) {
         record Payload(@Nullable String since, @Nullable String until) {}
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayValidationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayValidationServiceImpl.java
@@ -1,7 +1,5 @@
 package com.positivity.inventory.internal.service;
 
-import com.positivity.inventory.internal.service.StorageLocationValidationService;
-import com.positivity.inventory.internal.service.StorageLocationValidationService.StorageLocationValidation;
 import com.positivity.inventory.internal.dto.PutawayExecutionRequest;
 import com.positivity.inventory.internal.dto.ValidationResult;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
@@ -13,6 +11,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.PutawayRuleRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
 import com.positivity.inventory.internal.security.PutawayPermissions;
+import com.positivity.inventory.internal.service.StorageLocationValidationService.StorageLocationValidation;
 import com.positivity.inventory.service.PutawayValidationService;
 import com.positivity.security.common.SecurityContextHelper;
 import java.util.Arrays;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
@@ -1,8 +1,6 @@
 package com.positivity.inventory.internal.service;
 
-import com.positivity.inventory.internal.service.SiteDefaultsService;
 import com.positivity.inventory.internal.client.SourceDocumentStubClient;
-import com.positivity.inventory.internal.service.WorkorderValidationService;
 import com.positivity.inventory.internal.dto.receiving.CreateReceivingSessionRequest;
 import com.positivity.inventory.internal.dto.receiving.CrossDockRequest;
 import com.positivity.inventory.internal.dto.receiving.CrossDockResponse;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
@@ -1,6 +1,5 @@
 package com.positivity.inventory.internal.service;
 
-import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import com.positivity.inventory.internal.dto.reservation.CreateReservationRequest;
 import com.positivity.inventory.internal.dto.reservation.PromoteAllocationRequest;
 import com.positivity.inventory.internal.dto.reservation.ReservationResponse;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteDefaultsService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteDefaultsService.java
@@ -23,8 +23,6 @@ public class SiteDefaultsService {
 
     @NonNull
     public Optional<UUID> getDefaultStagingLocationId(@NonNull UUID siteId) {
-        return locationRefRepository
-                .findByLocationId(siteId)
-                .map(LocationRefEntity::getDefaultStagingLocationId);
+        return locationRefRepository.findByLocationId(siteId).map(LocationRefEntity::getDefaultStagingLocationId);
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryRollupServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryRollupServiceImpl.java
@@ -1,10 +1,9 @@
 package com.positivity.inventory.internal.service;
 
-import com.positivity.inventory.internal.service.StorageLocationTopologyService;
-import com.positivity.inventory.internal.service.StorageLocationTopologyService.StorageLocationNode;
 import com.positivity.inventory.internal.dto.rollup.RollupQuantities;
 import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
 import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
+import com.positivity.inventory.internal.service.StorageLocationTopologyService.StorageLocationNode;
 import com.positivity.inventory.service.SiteInventoryRollupService;
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WorkorderManifestListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WorkorderManifestListener.java
@@ -122,7 +122,8 @@ public class WorkorderManifestListener {
     }
 
     /** Command envelope for the owner's {@code workorder.commands.v1} listener. */
-    record ReplayCommand(@NonNull String commandType, @NonNull Payload payload) {
+    record ReplayCommand(
+            @NonNull String commandType, @NonNull Payload payload) {
         record Payload(@Nullable String since, @Nullable String until) {}
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WorkorderValidationService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WorkorderValidationService.java
@@ -34,9 +34,8 @@ public class WorkorderValidationService {
 
         ExtWorkorderReplica workorder = extWorkorderReplicaRepository
                 .findById(workorderUuid)
-                .orElseThrow(() -> new IllegalStateException(
-                        "No workorder replica row for workorderId " + workorderId
-                                + " — verify the workorder.events.v1 feed is consumed"));
+                .orElseThrow(() -> new IllegalStateException("No workorder replica row for workorderId " + workorderId
+                        + " — verify the workorder.events.v1 feed is consumed"));
         if (workorder.getStatus() == null || workorder.getStatus().isBlank()) {
             throw new IllegalStateException("Workorder replica has no status for workorderId " + workorderId);
         }

--- a/pos-inventory/src/test/java/com/positivity/inventory/ArchitectureTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/ArchitectureTest.java
@@ -154,7 +154,7 @@ public class ArchitectureTest {
             .because("internal package cycles make the implementation harder to maintain and evolve");
 
     @ArchTest
-    static final ArchRule entities_should_depend_on_uuidv7_generator = classes()
+    static final ArchRule entities_should_use_uuidv7_id_or_generator = classes()
             .that()
             .resideInAnyPackage("..internal.entity..", "..internal.model..")
             .and()

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryLocationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryLocationServiceImplTest.java
@@ -2,12 +2,12 @@ package com.positivity.inventory.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import com.positivity.inventory.internal.dto.DeactivateLocationResponse;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.service.InventoryLocationServiceImpl;
+import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import com.positivity.security.common.GatewaySecurityConstants;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Proxy;

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryRollupServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryRollupServiceImplTest.java
@@ -8,8 +8,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.positivity.inventory.internal.service.StorageLocationTopologyService;
-import com.positivity.inventory.internal.service.StorageLocationTopologyService.LocationDescendant;
 import com.positivity.inventory.internal.dto.rollup.LocationInventoryRollupResponse;
 import com.positivity.inventory.internal.dto.rollup.RollupQuantities;
 import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
@@ -17,6 +15,8 @@ import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.RollupExpansionTooLargeException;
 import com.positivity.inventory.internal.service.LocationInventoryRollupServiceImpl;
+import com.positivity.inventory.internal.service.StorageLocationTopologyService;
+import com.positivity.inventory.internal.service.StorageLocationTopologyService.LocationDescendant;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayValidationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayValidationServiceImplTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import com.positivity.inventory.internal.dto.PutawayExecutionRequest;
 import com.positivity.inventory.internal.dto.ValidationResult;
 import com.positivity.inventory.internal.enums.OverrideReasonCode;
@@ -24,6 +23,7 @@ import com.positivity.inventory.internal.repository.PutawayRuleRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
 import com.positivity.inventory.internal.security.PutawayPermissions;
 import com.positivity.inventory.internal.service.PutawayValidationServiceImpl;
+import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import com.positivity.security.common.GatewaySecurityConstants;
 import java.util.Arrays;
 import java.util.Map;

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReceivingServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReceivingServiceImplTest.java
@@ -8,9 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.positivity.inventory.internal.service.SiteDefaultsService;
 import com.positivity.inventory.internal.client.SourceDocumentStubClient;
-import com.positivity.inventory.internal.service.WorkorderValidationService;
 import com.positivity.inventory.internal.dto.receiving.CreateReceivingSessionRequest;
 import com.positivity.inventory.internal.dto.receiving.CrossDockRequest;
 import com.positivity.inventory.internal.dto.receiving.CrossDockResponse;
@@ -32,6 +30,8 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.InventoryVarianceRepository;
 import com.positivity.inventory.internal.repository.ReceivingSessionRepository;
 import com.positivity.inventory.internal.service.ReceivingServiceImpl;
+import com.positivity.inventory.internal.service.SiteDefaultsService;
+import com.positivity.inventory.internal.service.WorkorderValidationService;
 import com.positivity.security.common.GatewaySecurityConstants;
 import java.math.BigDecimal;
 import java.time.Clock;

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import com.positivity.inventory.internal.dto.reservation.CreateReservationRequest;
 import com.positivity.inventory.internal.dto.reservation.PromoteAllocationRequest;
 import com.positivity.inventory.internal.dto.reservation.ReservationResponse;
@@ -27,6 +26,7 @@ import com.positivity.inventory.internal.repository.AllocationRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.internal.service.ReservationServiceImpl;
+import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/SiteInventoryRollupServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/SiteInventoryRollupServiceImplTest.java
@@ -6,8 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import com.positivity.inventory.internal.service.StorageLocationTopologyService;
-import com.positivity.inventory.internal.service.StorageLocationTopologyService.StorageLocationNode;
 import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
 import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
@@ -16,6 +14,8 @@ import com.positivity.inventory.internal.exception.LocationServiceUnavailableExc
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.service.SiteInventoryQuantityLoader;
 import com.positivity.inventory.internal.service.SiteInventoryRollupServiceImpl;
+import com.positivity.inventory.internal.service.StorageLocationTopologyService;
+import com.positivity.inventory.internal.service.StorageLocationTopologyService.StorageLocationNode;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +53,8 @@ class SiteInventoryRollupServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new SiteInventoryRollupServiceImpl(topologyService, new SiteInventoryQuantityLoader(ledgerRepository));
+        service =
+                new SiteInventoryRollupServiceImpl(topologyService, new SiteInventoryQuantityLoader(ledgerRepository));
     }
 
     private static List<StorageLocationNode> threeLevelTopology() {

--- a/pos-invoice/src/test/java/com/positivity/invoice/ArchitectureTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/ArchitectureTest.java
@@ -133,7 +133,7 @@ public class ArchitectureTest {
             .because("cyclic dependencies make modules harder to maintain and evolve");
 
     @ArchTest
-    static final ArchRule entities_should_depend_on_uuidv7_generator = classes()
+    static final ArchRule entities_should_use_uuidv7_id_or_generator = classes()
             .that()
             .resideInAnyPackage("..internal.entity..", "..internal.model..")
             .and()

--- a/pos-location/src/main/java/com/positivity/location/internal/entity/ExtPersonReplica.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/entity/ExtPersonReplica.java
@@ -1,8 +1,9 @@
 package com.positivity.location.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -12,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only person identity replica fed by {@code people-contact.events.v1} (ADR-0044 §6, #885):
@@ -24,6 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ext_people_contact_person")
 public class ExtPersonReplica {
 
@@ -47,12 +51,13 @@ public class ExtPersonReplica {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
     /** ArchUnit UUIDv7 rule hook (ADR-0013): the key is the owner's UUIDv7, stored verbatim. */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/entity/ExtStorageLocationOnHandReplica.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/entity/ExtStorageLocationOnHandReplica.java
@@ -1,8 +1,9 @@
 package com.positivity.location.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -12,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only storage-location on-hand replica fed by {@code inventory.events.v1} (ADR-0044 §6,
@@ -24,6 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ext_storage_location_on_hand")
 public class ExtStorageLocationOnHandReplica {
 
@@ -37,6 +41,7 @@ public class ExtStorageLocationOnHandReplica {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
@@ -46,6 +51,6 @@ public class ExtStorageLocationOnHandReplica {
      */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/entity/OutboxEvent.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/entity/OutboxEvent.java
@@ -3,6 +3,7 @@ package com.positivity.location.internal.entity;
 import com.positivity.shared.id.UUIDv7Id;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -12,12 +13,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Transactional-outbox row (ADR-0044 §4, issue #890): a serialized Kafka event written in the
  * same transaction as the business state change and drained by {@code OutboxPublisher}.
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,6 +43,7 @@ public class OutboxEvent {
     @Column(nullable = false, columnDefinition = "text")
     private String payload;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 

--- a/pos-location/src/test/java/com/positivity/location/ArchitectureTest.java
+++ b/pos-location/src/test/java/com/positivity/location/ArchitectureTest.java
@@ -163,6 +163,9 @@ public class ArchitectureTest {
             .areAnnotatedWith("jakarta.persistence.Entity")
             .should()
             .dependOnClassesThat()
+            .haveFullyQualifiedName("com.positivity.shared.id.UUIDv7Generator")
+            .orShould()
+            .dependOnClassesThat()
             .haveFullyQualifiedName("com.positivity.shared.id.UUIDv7Id")
             .allowEmptyShould(true)
             .because("ADR-0013 addendum mandates UUID v7 identifiers via shared @UUIDv7Id");

--- a/pos-location/src/test/java/com/positivity/location/ArchitectureTest.java
+++ b/pos-location/src/test/java/com/positivity/location/ArchitectureTest.java
@@ -156,7 +156,7 @@ public class ArchitectureTest {
             .because("cyclic dependencies make modules harder to maintain and evolve");
 
     @ArchTest
-    static final ArchRule entities_should_use_uuidv7_id_annotation = classes()
+    static final ArchRule entities_should_use_uuidv7_id_or_generator = classes()
             .that()
             .resideInAnyPackage("..internal.entity..", "..internal.model..")
             .and()
@@ -168,7 +168,7 @@ public class ArchitectureTest {
             .dependOnClassesThat()
             .haveFullyQualifiedName("com.positivity.shared.id.UUIDv7Id")
             .allowEmptyShould(true)
-            .because("ADR-0013 addendum mandates UUID v7 identifiers via shared @UUIDv7Id");
+            .because("ADR-0013 addendum mandates UUID v7 identifiers via @UUIDv7Id or UUIDv7Generator");
 
     @ArchTest
     static final ArchRule entities_should_not_call_uuid_randomUUID = noClasses()

--- a/pos-mcp-server/.flattened-pom.xml
+++ b/pos-mcp-server/.flattened-pom.xml
@@ -38,6 +38,11 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/OutboxEvent.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/entity/OutboxEvent.java
@@ -3,6 +3,7 @@ package com.positivity.peoplecontact.internal.entity;
 import com.positivity.shared.id.UUIDv7Id;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -12,12 +13,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Transactional-outbox row (ADR-0044 §4): a serialized Kafka event written in the same
  * transaction as the business state change and drained by {@code OutboxPublisher}.
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,6 +43,7 @@ public class OutboxEvent {
     @Column(nullable = false, columnDefinition = "text")
     private String payload;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/ExtJobTimeReplica.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/ExtJobTimeReplica.java
@@ -1,8 +1,9 @@
 package com.positivity.people.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -12,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only job-time replica fed by {@code workorder.job_time.recorded.v1} facts
@@ -24,6 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ext_workorder_job_time")
 public class ExtJobTimeReplica {
 
@@ -46,6 +50,7 @@ public class ExtJobTimeReplica {
     @Column(name = "minutes", nullable = false)
     private int minutes;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
@@ -55,6 +60,6 @@ public class ExtJobTimeReplica {
      */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/ExtLocationReplica.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/ExtLocationReplica.java
@@ -1,8 +1,9 @@
 package com.positivity.people.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -12,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only location replica fed by {@code location.events.v1} (ADR-0044 §6, #892).
@@ -25,6 +28,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ext_location")
 public class ExtLocationReplica {
 
@@ -44,6 +48,7 @@ public class ExtLocationReplica {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
@@ -53,6 +58,6 @@ public class ExtLocationReplica {
      */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/ExtPersonReplica.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/ExtPersonReplica.java
@@ -1,8 +1,9 @@
 package com.positivity.people.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -12,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only person identity replica fed by {@code people-contact.events.v1} (ADR-0044 §6, #875).
@@ -25,6 +28,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ext_people_contact_person")
 public class ExtPersonReplica {
 
@@ -62,6 +66,7 @@ public class ExtPersonReplica {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
@@ -71,6 +76,6 @@ public class ExtPersonReplica {
      */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/ExtUserLinkReplica.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/ExtUserLinkReplica.java
@@ -1,8 +1,9 @@
 package com.positivity.people.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -12,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Read-only user-person-link replica fed by {@code people-contact.events.v1} (ADR-0044 §6, #875).
@@ -22,6 +25,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ext_people_contact_user_link")
 public class ExtUserLinkReplica {
 
@@ -41,6 +45,7 @@ public class ExtUserLinkReplica {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
@@ -50,6 +55,6 @@ public class ExtUserLinkReplica {
      */
     @Transient
     public Class<?> uuidv7Dependency() {
-        return UUIDv7Id.class;
+        return UUIDv7Generator.class;
     }
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/OutboxEvent.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/OutboxEvent.java
@@ -3,6 +3,7 @@ package com.positivity.people.internal.entity;
 import com.positivity.shared.id.UUIDv7Id;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -12,12 +13,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Transactional-outbox row (ADR-0044 §4): a serialized Kafka event written in the same
  * transaction as the business state change and drained by {@code OutboxPublisher}.
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,6 +43,7 @@ public class OutboxEvent {
     @Column(nullable = false, columnDefinition = "text")
     private String payload;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 

--- a/pos-people/src/test/java/com/positivity/people/ArchitectureTest.java
+++ b/pos-people/src/test/java/com/positivity/people/ArchitectureTest.java
@@ -165,6 +165,9 @@ public class ArchitectureTest {
             .areAnnotatedWith("jakarta.persistence.Entity")
             .should()
             .dependOnClassesThat()
+            .haveFullyQualifiedName("com.positivity.shared.id.UUIDv7Generator")
+            .orShould()
+            .dependOnClassesThat()
             .haveFullyQualifiedName("com.positivity.shared.id.UUIDv7Id")
             .allowEmptyShould(true)
             .because("ADR-0013 mandates UUID v7 generation for all entity identifiers");

--- a/pos-people/src/test/java/com/positivity/people/ArchitectureTest.java
+++ b/pos-people/src/test/java/com/positivity/people/ArchitectureTest.java
@@ -158,7 +158,7 @@ public class ArchitectureTest {
             .because("cyclic dependencies make modules harder to maintain and evolve");
 
     @ArchTest
-    static final ArchRule entities_should_depend_on_uuidv7_generator = classes()
+    static final ArchRule entities_should_use_uuidv7_id_or_generator = classes()
             .that()
             .resideInAnyPackage("..internal.entity..", "..internal.model..")
             .and()


### PR DESCRIPTION
Closes #909.

## Problem

The pos-archunit class-graph rules (`EntityStandardsArchitectureTest`, and any `@AnalyzeClasses(packages = "com.positivity")` rule) only see sibling modules' classes in reactor builds, where Maven resolves them to `target/classes`. In solo runs — including the per-module CI matrix jobs — dependencies resolve to the installed Spring Boot repackaged fat jars, whose application classes live under `BOOT-INF/classes/` where ArchUnit's importer cannot see them. Every rule matched zero classes and `allowEmptyShould(true)` turned that into a silent pass.

## Fix (issue options 3 + 2, composed)

- **Guard test (option 3)**: new `ClasspathVisibilityGuardTest` asserts every `com.positivity` module dependency of pos-archunit contributes at least one imported class, and every `ENFORCED_ENTITY_PACKAGES` entry contains at least one `@Entity`. A vacuous run now fails with a message pointing at the `-am` remedy. Verified against installed fat jars: the solo run fails listing all 20 hidden modules (pos-events stays visible — thin jar).
- **CI reactor build (option 2)**: the pos-archunit entries of both the unit-test and integration-test matrices now run `-am` with `-Dtest='com/positivity/archunit/*' -Dsurefire.failIfNoSpecifiedTests=false` (failsafe scoped the same way), so upstream modules compile to `target/classes` but only pos-archunit's tests execute. Note: the dotted pattern `com.positivity.archunit.*` silently matches **nothing** in surefire — the first attempt "passed" with zero tests run; the slash form is verified locally to select exactly the archunit suite (20 tests).
- `com.positivity.documents.internal.entity..` removed from `ENFORCED_ENTITY_PACKAGES`: pos-documents has no JPA entities and is not a pos-archunit dependency, so the entry was unenforceable.
- pos-archunit README documents why `-am` is required.

## Latent entity debt the fix exposed

With the rules finally seeing classes, they flagged the same ADR-0013/ADR-0024 debt PR #908 fixed in pos-invoice, in modules that were never really analyzed:

- `ext_*` replicas in pos-accounting, pos-inventory, pos-location, pos-people: `uuidv7Dependency()` hooks returned `UUIDv7Id.class`, which the rule does not count (it accepts `@UUIDv7Id` on the field or a `UUIDv7Generator` dependency) — switched to `UUIDv7Generator.class`, matching #908. The two pos-accounting replicas had no hook at all — added.
- `@EntityListeners(AuditingEntityListener.class)` + `@LastModifiedDate` on replica `updatedAt`, and `@CreatedDate` on `OutboxEvent.createdAt` in pos-inventory, pos-location, pos-people, pos-people-contact. Safe: every module has a Clock-backed `JpaAuditingConfig`, and writers already stamp these fields with `Instant.now(clock)`.
- pos-location/pos-people module-level UUID rules only accepted a `UUIDv7Id` dependency; aligned to the `UUIDv7Generator OR UUIDv7Id` form pos-invoice and pos-inventory already use, and renamed the shared rule constant to `entities_should_use_uuidv7_id_or_generator` (Copilot review).

## Contract impact

None — no API, DTO, or event payload changes (per BACKEND_CONTRACT_GUIDE.md, no contract PR is needed). The contract-relevant filter matched only the internal `OutboxEvent` JPA entities, which gained auditing annotations (`@CreatedDate`, `@EntityListeners`); the serialized event payloads, topics, and REST surface are untouched.

## Verification

- `./mvnw -pl pos-archunit -am test -Dtest='com/positivity/archunit/*' -Dsurefire.failIfNoSpecifiedTests=false` → 20/20 pass (guard included).
- `./mvnw install -DskipTests && ./mvnw -pl pos-archunit test` → **fails loudly** on the guard (the #909 repro, previously a silent pass).
- Unit tests green for pos-accounting, pos-inventory, pos-location, pos-people, pos-people-contact.

Incidental: spotless picked up formatting-only fixes in pos-inventory service/test files that were merged unformatted, and `pos-mcp-server/.flattened-pom.xml` was regenerated to match its current pom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBFZmifa5JEuNvrPezpDNH