### PR TITLE
feat(workorder): accept optional part scope on suggestSubstitutes (#914)

### DIFF
--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -667,6 +667,8 @@ paths:
     $ref: ../../pos-people/openapi.yaml#/paths/~1v1~1people~1availability
   /v1/people/bulk-ingest:
     $ref: ../../pos-people/openapi.yaml#/paths/~1v1~1people~1bulk-ingest
+  /v1/people/compliance/inactive-person-active-user:
+    $ref: ../../pos-people/openapi.yaml#/paths/~1v1~1people~1compliance~1inactive-person-active-user
   /v1/people/employees:
     $ref: ../../pos-people/openapi.yaml#/paths/~1v1~1people~1employees
   /v1/people/employees/by-number/{employeeNumber}:
@@ -929,6 +931,8 @@ paths:
     $ref: ../../pos-shop-manager/openapi.yaml#/paths/~1v1~1appointments~1{appointmentId}~1reschedule
   /v1/schedules/view:
     $ref: ../../pos-shop-manager/openapi.yaml#/paths/~1v1~1schedules~1view
+  /v1/shop-manager/{locationId}/technicians/{personId}/person:
+    $ref: ../../pos-shop-manager/openapi.yaml#/paths/~1v1~1shop-manager~1{locationId}~1technicians~1{personId}~1person
   /v1/shop/audit:
     $ref: ../../pos-shop-manager/openapi.yaml#/paths/~1v1~1shop~1audit
   /v1/shop/audit/{id}:

--- a/pos-workorder/openapi.json
+++ b/pos-workorder/openapi.json
@@ -737,7 +737,7 @@
           "Substitute Link API"
         ],
         "summary": "Suggest workorder substitutes",
-        "description": "Suggest substitute parts for a workorder based on the parts currently required",
+        "description": "Suggest substitute parts for a workorder based on the parts currently required. An optional request body scopes the suggestions to a single part.",
         "operationId": "suggestSubstitutes",
         "parameters": [
           {
@@ -750,6 +750,15 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SuggestSubstitutesRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Substitute suggestions returned",
@@ -1142,7 +1151,7 @@
           "Workorder Picked Items"
         ],
         "summary": "Consume picked items into workorder",
-        "description": "Consume the picked items for a workorder so parts usage is recorded against the job",
+        "description": "Queues asynchronous consumption of picked items (ADR-0044 #901): the response is 202 with per-item status PENDING; the inventory.consumption.recorded fact updates the pick replicas and subsequent picked-items reads observe the consumed quantities.",
         "operationId": "consumePickedItems",
         "parameters": [
           {
@@ -1167,8 +1176,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Picked items consumed successfully",
+          "202": {
+            "description": "Consumption queued; poll the picked items for consumed quantities (status PENDING).",
             "content": {
               "application/json": {
                 "schema": {
@@ -1320,7 +1329,7 @@
           "Workorder Pick Facade"
         ],
         "summary": "Complete pick task",
-        "description": "Complete a workorder pick task after all of its pick lines are confirmed",
+        "description": "Queues asynchronous completion of a workorder pick task (ADR-0044 #901). Returns 202 with status PENDING while the command is in flight; an already-complete task is returned as-is with 200.",
         "operationId": "completePickTask",
         "parameters": [
           {
@@ -1355,8 +1364,18 @@
           }
         },
         "responses": {
+          "202": {
+            "description": "Completion queued; poll the pick tasks for the applied state (status PENDING).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkorderPickTaskResponse"
+                }
+              }
+            }
+          },
           "200": {
-            "description": "Pick task completed successfully",
+            "description": "Task already complete; current state returned.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1404,7 +1423,7 @@
           "Workorder Pick Facade"
         ],
         "summary": "Confirm pick line quantity",
-        "description": "Confirm the picked quantity for a workorder pick line after scan resolution",
+        "description": "Queues asynchronous pick confirmation (ADR-0044 #901): the response is 202 with status PENDING; the inventory.pick-task.updated fact updates the pick replica and subsequent reads observe the confirmed quantity.",
         "operationId": "confirmPickLine",
         "parameters": [
           {
@@ -1449,8 +1468,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Pick line confirmed successfully",
+          "202": {
+            "description": "Confirmation queued; poll the pick tasks for the applied quantity (status PENDING).",
             "content": {
               "application/json": {
                 "schema": {
@@ -2328,8 +2347,8 @@
         "tags": [
           "Work Order API"
         ],
-        "summary": "Generate invoice draft from completed workorder",
-        "description": "Generate an invoice draft from a completed workorder with optional idempotency key.",
+        "summary": "Request invoice generation from a completed workorder",
+        "description": "Queues asynchronous invoice generation (ADR-0044 #900): the response is 202 with status PENDING and the invoiceId appears on the workorder once the invoice.events.v1 fact links it. Re-sending the same Idempotency-Key collapses to one generation. When the workorder is already invoiced, the linked invoice is returned with 200.",
         "operationId": "generateInvoice",
         "parameters": [
           {
@@ -2354,8 +2373,18 @@
           }
         ],
         "responses": {
+          "202": {
+            "description": "Generation queued; poll the workorder for the linked invoiceId (status PENDING).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceGenerationResponse"
+                }
+              }
+            }
+          },
           "200": {
-            "description": "Invoice generated successfully or existing invoice returned for idempotent replay.",
+            "description": "Existing linked invoice returned for idempotent replay.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5291,12 +5320,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "additionalProperties": {},
-                  "contains": {},
                   "items": {
                     "$ref": "#/components/schemas/WorkorderPickedItemResponse"
-                  },
-                  "unevaluatedItems": {}
+                  }
                 }
               }
             }
@@ -5415,12 +5441,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "additionalProperties": {},
-                  "contains": {},
                   "items": {
                     "$ref": "#/components/schemas/WorkorderPickTaskResponse"
-                  },
-                  "unevaluatedItems": {}
+                  }
                 }
               }
             }
@@ -5981,8 +6004,7 @@
               "application/pdf": {
                 "schema": {
                   "type": "string",
-                  "format": "binary",
-                  "additionalProperties": {}
+                  "format": "binary"
                 }
               }
             }
@@ -7177,6 +7199,18 @@
           "technicianId"
         ]
       },
+      "SuggestSubstitutesRequest": {
+        "type": "object",
+        "description": "Request to scope workorder substitute suggestions to a specific part",
+        "properties": {
+          "partId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the part (product) on the workorder to suggest substitutes for; omit for workorder-wide suggestions",
+            "example": "01960003-0000-7000-8000-000000000001"
+          }
+        }
+      },
       "SubstituteLinkResponse": {
         "type": "object",
         "description": "A substitute-part link associating a product with an approved substitute",
@@ -7542,6 +7576,7 @@
             "type": "string",
             "description": "Outcome status for the item",
             "enum": [
+              "PENDING",
               "SUCCESS",
               "PARTIAL",
               "FAILED"

--- a/pos-workorder/openapi.json
+++ b/pos-workorder/openapi.json
@@ -737,7 +737,7 @@
           "Substitute Link API"
         ],
         "summary": "Suggest workorder substitutes",
-        "description": "Suggest substitute parts for a workorder based on the parts currently required. An optional request body scopes the suggestions to a single part.",
+        "description": "Suggest substitute parts for a workorder. Provide a request body with partId to scope suggestions to that part's active substitute links. Without a part scope this currently returns an empty list; workorder-wide suggestions are not yet implemented.",
         "operationId": "suggestSubstitutes",
         "parameters": [
           {

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -451,7 +451,7 @@ paths:
       tags:
       - Substitute Link API
       summary: Suggest workorder substitutes
-      description: Suggest substitute parts for a workorder based on the parts currently required. An optional request body scopes the suggestions to a single part.
+      description: Suggest substitute parts for a workorder. Provide a request body with partId to scope suggestions to that part's active substitute links. Without a part scope this currently returns an empty list; workorder-wide suggestions are not yet implemented.
       operationId: suggestSubstitutes
       parameters:
       - name: workorderId

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -451,7 +451,7 @@ paths:
       tags:
       - Substitute Link API
       summary: Suggest workorder substitutes
-      description: Suggest substitute parts for a workorder based on the parts currently required
+      description: Suggest substitute parts for a workorder based on the parts currently required. An optional request body scopes the suggestions to a single part.
       operationId: suggestSubstitutes
       parameters:
       - name: workorderId
@@ -460,6 +460,11 @@ paths:
         schema:
           type: string
           format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SuggestSubstitutesRequest'
       responses:
         '200':
           description: Substitute suggestions returned
@@ -4516,6 +4521,15 @@ components:
           example: Assigned to senior tech for brake system work
       required:
       - technicianId
+    SuggestSubstitutesRequest:
+      type: object
+      description: Request to scope workorder substitute suggestions to a specific part
+      properties:
+        partId:
+          type: string
+          format: uuid
+          description: Identifier of the part (product) on the workorder to suggest substitutes for; omit for workorder-wide suggestions
+          example: 01960003-0000-7000-8000-000000000001
     SubstituteLinkResponse:
       type: object
       description: A substitute-part link associating a product with an approved substitute

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/SubstituteLinkController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/SubstituteLinkController.java
@@ -3,6 +3,7 @@ package com.positivity.workorder.internal.controller;
 import com.positivity.events.EmitEvent;
 import com.positivity.workorder.internal.dto.pick.CreateSubstituteLinkRequest;
 import com.positivity.workorder.internal.dto.pick.SubstituteLinkResponse;
+import com.positivity.workorder.internal.dto.pick.SuggestSubstitutesRequest;
 import com.positivity.workorder.internal.dto.pick.UpdateSubstituteLinkRequest;
 import com.positivity.workorder.service.SubstituteLinkService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -84,11 +85,14 @@ public class SubstituteLinkController {
     @EmitEvent(id = "WORKORDER_SUBSTITUTE_SUGGEST", apiVersion = "1")
     @Operation(
             summary = "Suggest workorder substitutes",
-            description = "Suggest substitute parts for a workorder based on the parts currently required")
+            description = "Suggest substitute parts for a workorder based on the parts currently required. "
+                    + "An optional request body scopes the suggestions to a single part.")
     @ApiResponse(responseCode = "200", description = "Substitute suggestions returned")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<List<SubstituteLinkResponse>> suggestSubstitutes(@PathVariable UUID workorderId) {
-        return ResponseEntity.ok(substituteLinkService.suggestSubstitutes(workorderId));
+    public ResponseEntity<List<SubstituteLinkResponse>> suggestSubstitutes(
+            @PathVariable UUID workorderId, @RequestBody(required = false) @Valid SuggestSubstitutesRequest request) {
+        UUID partId = request != null ? request.getPartId() : null;
+        return ResponseEntity.ok(substituteLinkService.suggestSubstitutes(workorderId, partId));
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/SubstituteLinkController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/SubstituteLinkController.java
@@ -85,8 +85,9 @@ public class SubstituteLinkController {
     @EmitEvent(id = "WORKORDER_SUBSTITUTE_SUGGEST", apiVersion = "1")
     @Operation(
             summary = "Suggest workorder substitutes",
-            description = "Suggest substitute parts for a workorder based on the parts currently required. "
-                    + "An optional request body scopes the suggestions to a single part.")
+            description = "Suggest substitute parts for a workorder. Provide a request body with partId to scope "
+                    + "suggestions to that part's active substitute links. Without a part scope this currently "
+                    + "returns an empty list; workorder-wide suggestions are not yet implemented.")
     @ApiResponse(responseCode = "200", description = "Substitute suggestions returned")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("isAuthenticated()")

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/pick/SuggestSubstitutesRequest.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/pick/SuggestSubstitutesRequest.java
@@ -1,0 +1,25 @@
+package com.positivity.workorder.internal.dto.pick;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to scope workorder substitute suggestions to a specific part")
+public class SuggestSubstitutesRequest {
+
+    @Schema(
+            description = "Identifier of the part (product) on the workorder to suggest substitutes for; "
+                    + "omit for workorder-wide suggestions",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = NOT_REQUIRED)
+    private UUID partId;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/SubstituteLinkServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/SubstituteLinkServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -163,10 +164,15 @@ public class SubstituteLinkServiceImpl implements SubstituteLinkService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<SubstituteLinkResponse> suggestSubstitutes(@NonNull UUID workorderId) {
-        // Stub: full implementation requires WorkorderService to look up workorder
-        // line items. Returns empty list until WorkorderService integration is added
-        // in a future story.
+    public List<SubstituteLinkResponse> suggestSubstitutes(@NonNull UUID workorderId, @Nullable UUID partId) {
+        if (partId != null) {
+            return substituteLinkRepository.findByProductIdAndIsActiveTrueOrderByPriorityAsc(partId).stream()
+                    .map(this::toResponse)
+                    .toList();
+        }
+        // Workorder-wide stub: full implementation requires WorkorderService to look
+        // up workorder line items. Returns empty list until WorkorderService
+        // integration is added in a future story.
         return List.of();
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/SubstituteLinkService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/SubstituteLinkService.java
@@ -6,6 +6,7 @@ import com.positivity.workorder.internal.dto.pick.UpdateSubstituteLinkRequest;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public interface SubstituteLinkService {
     SubstituteLinkResponse createLink(@NonNull CreateSubstituteLinkRequest request);
@@ -16,5 +17,10 @@ public interface SubstituteLinkService {
 
     List<SubstituteLinkResponse> listLinks(@NonNull UUID productId);
 
-    List<SubstituteLinkResponse> suggestSubstitutes(@NonNull UUID workorderId);
+    /**
+     * Suggest substitute parts for a workorder. When {@code partId} is provided, suggestions are
+     * scoped to active substitute links for that part; when null, suggestions cover the whole
+     * workorder.
+     */
+    List<SubstituteLinkResponse> suggestSubstitutes(@NonNull UUID workorderId, @Nullable UUID partId);
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/SubstituteLinkService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/SubstituteLinkService.java
@@ -19,8 +19,9 @@ public interface SubstituteLinkService {
 
     /**
      * Suggest substitute parts for a workorder. When {@code partId} is provided, suggestions are
-     * scoped to active substitute links for that part; when null, suggestions cover the whole
-     * workorder.
+     * scoped to active substitute links for that part. When null, this currently returns an empty
+     * list — workorder-wide suggestions require line-item lookup via WorkorderService and are not
+     * yet implemented (see issue #45).
      */
     List<SubstituteLinkResponse> suggestSubstitutes(@NonNull UUID workorderId, @Nullable UUID partId);
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/controller/SubstituteLinkControllerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/controller/SubstituteLinkControllerTest.java
@@ -2,6 +2,7 @@ package com.positivity.workorder.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -16,6 +17,7 @@ import com.positivity.workorder.config.TestSecurityConfig;
 import com.positivity.workorder.internal.controller.SubstituteLinkController;
 import com.positivity.workorder.internal.dto.pick.CreateSubstituteLinkRequest;
 import com.positivity.workorder.internal.dto.pick.SubstituteLinkResponse;
+import com.positivity.workorder.internal.dto.pick.SuggestSubstitutesRequest;
 import com.positivity.workorder.internal.dto.pick.UpdateSubstituteLinkRequest;
 import com.positivity.workorder.internal.enums.SubstituteType;
 import com.positivity.workorder.internal.exception.DuplicateSubstituteLinkException;
@@ -298,12 +300,42 @@ class SubstituteLinkControllerTest {
     @DisplayName("AC8: POST /v1/workorders/{workorderId}/suggestSubstitutes returns 200")
     void whenSuggestSubstitutes_thenReturns200() throws Exception {
         // Arrange
-        when(substituteLinkService.suggestSubstitutes(eq(WORKORDER_ID))).thenReturn(List.of());
+        when(substituteLinkService.suggestSubstitutes(eq(WORKORDER_ID), isNull()))
+                .thenReturn(List.of());
 
         // Act & Assert
         mockMvc.perform(post(SUGGEST_URL, WORKORDER_ID).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$").isEmpty());
+    }
+
+    // Issue #914: suggestSubstitutes accepts an optional part identifier
+    @Test
+    @DisplayName("Issue #914: POST suggestSubstitutes with partId body forwards part scope to service")
+    void whenSuggestSubstitutesWithPartId_thenScopesToPart() throws Exception {
+        // Arrange
+        var response = SubstituteLinkResponse.builder()
+                .id(LINK_ID)
+                .productId(PRODUCT_ID)
+                .substitutePartId(SUBSTITUTE_PART_ID)
+                .substituteType(SubstituteType.EQUIVALENT)
+                .priority(100)
+                .isActive(true)
+                .version(0)
+                .build();
+        when(substituteLinkService.suggestSubstitutes(eq(WORKORDER_ID), eq(PRODUCT_ID)))
+                .thenReturn(List.of(response));
+
+        var request = SuggestSubstitutesRequest.builder().partId(PRODUCT_ID).build();
+
+        // Act & Assert
+        mockMvc.perform(post(SUGGEST_URL, WORKORDER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].productId").value(PRODUCT_ID.toString()))
+                .andExpect(jsonPath("$[0].substitutePartId").value(SUBSTITUTE_PART_ID.toString()));
     }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/SubstituteLinkServiceTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/SubstituteLinkServiceTest.java
@@ -277,6 +277,35 @@ class SubstituteLinkServiceTest {
                 .isLessThanOrEqualTo(results.get(2).getPriority());
     }
 
+    // Issue #914: part-scoped suggestions return the part's active links
+    @Test
+    @DisplayName("Issue #914: suggestSubstitutes with partId returns active links for that part")
+    void suggestSubstitutes_withPartId_returnsLinksForPart() {
+        // Arrange
+        var link = buildLink(LINK_ID, 100, true);
+        when(substituteLinkRepository.findByProductIdAndIsActiveTrueOrderByPriorityAsc(PRODUCT_ID))
+                .thenReturn(List.of(link));
+
+        // Act
+        List<SubstituteLinkResponse> results = substituteLinkService.suggestSubstitutes(UUID.randomUUID(), PRODUCT_ID);
+
+        // Assert
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getProductId()).isEqualTo(PRODUCT_ID);
+        assertThat(results.getFirst().getSubstitutePartId()).isEqualTo(SUBSTITUTE_PART_ID);
+    }
+
+    // Issue #914: workorder-wide suggestions remain a stub until line-item lookup lands
+    @Test
+    @DisplayName("Issue #914: suggestSubstitutes without partId returns empty list")
+    void suggestSubstitutes_withoutPartId_returnsEmpty() {
+        // Act
+        List<SubstituteLinkResponse> results = substituteLinkService.suggestSubstitutes(UUID.randomUUID(), null);
+
+        // Assert
+        assertThat(results).isEmpty();
+    }
+
     // --- Helpers ---
 
     private void setAuthenticatedUserInSecurityContext(String username) {


### PR DESCRIPTION
POST /v1/workorders/{workorderId}/suggestSubstitutes now takes an optional SuggestSubstitutesRequest body carrying a partId. When present, suggestions are scoped to that part's active substitute links (ordered by priority); when absent, behavior is unchanged (workorder-wide stub pending WorkorderService line-item lookup).

Regenerated pos-workorder openapi.yaml via scripts/generate-openapi.sh and re-derived openapi.json (also syncs stale ADR-0044 descriptions that were already in the committed yaml). Aggregate spec picked up two previously-uncommitted refs from pos-people/pos-shop-manager.

Unblocks the Angular SDK regeneration and frontend issue durion-positivity-frontend#141.

**Contract chain**: follows `BACKEND_CONTRACT_GUIDE.md` (workexec domain) — controller annotations → regenerated `pos-workorder/openapi.yaml`/`openapi.json` + gateway aggregate → Angular SDK (`@durion-sdk/workorder`, regenerated in durion-positivity-sdk-angular#29) → frontend consumption (durion-positivity-frontend#141).

Closes #914.

Claude-Session: https://claude.ai/code/session_01HV6GZjEnAgg7jrHxGTJdKJ