### PR TITLE
Fix 403 on people-contact endpoints: add missing bits 351–359 to DownstreamPermissionCatalog

### DIFF
--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -407,6 +407,17 @@ public final class DownstreamPermissionCatalog {
         // ── New batch (bits 350–350) ──────────────────────────────────────────
         "PERM_workorder:events:replay", // 350
 
+        // ── People Contact (bits 351–359, ADR-0044 Phase 3 split #874) ────────
+        "PERM_people-contact:person:view", // 351
+        "PERM_people-contact:person:create", // 352
+        "PERM_people-contact:person:edit", // 353
+        "PERM_people-contact:person:delete", // 354
+        "PERM_people-contact:role:view", // 355
+        "PERM_people-contact:role:assign", // 356
+        "PERM_people-contact:role:revoke", // 357
+        "PERM_people-contact:userLink:view", // 358
+        "PERM_people-contact:userLink:write", // 359
+
         // ── New batch (bits 360–361) ──────────────────────────────────────────
         "PERM_people:compliance:view", // 360
         "PERM_shop:technician:view" // 361

--- a/pos-security-common/src/test/java/com/positivity/security/common/DownstreamPermissionCatalogTest.java
+++ b/pos-security-common/src/test/java/com/positivity/security/common/DownstreamPermissionCatalogTest.java
@@ -50,6 +50,24 @@ class DownstreamPermissionCatalogTest {
     }
 
     @Test
+    void authorityForBit_peopleContactBlock_matchesGatewayCatalogAssignments() {
+        // Bits 351-359 were assigned to pos-people-contact in the gateway catalog
+        // (ADR-0044 Phase 3 split #874) but were missing here, shifting every
+        // later bit and causing 403s for people-contact endpoints.
+        assertThat(DownstreamPermissionCatalog.authorityForBit(351)).isEqualTo("PERM_people-contact:person:view");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(352)).isEqualTo("PERM_people-contact:person:create");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(353)).isEqualTo("PERM_people-contact:person:edit");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(354)).isEqualTo("PERM_people-contact:person:delete");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(355)).isEqualTo("PERM_people-contact:role:view");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(356)).isEqualTo("PERM_people-contact:role:assign");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(357)).isEqualTo("PERM_people-contact:role:revoke");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(358)).isEqualTo("PERM_people-contact:userLink:view");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(359)).isEqualTo("PERM_people-contact:userLink:write");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(360)).isEqualTo("PERM_people:compliance:view");
+        assertThat(DownstreamPermissionCatalog.authorityForBit(361)).isEqualTo("PERM_shop:technician:view");
+    }
+
+    @Test
     void catalogVersion_isPositive() {
         assertThat(DownstreamPermissionCatalog.CATALOG_VERSION).isGreaterThan(0);
     }


### PR DESCRIPTION
## Problem

`admin.alpha` (and every other user) got `403 Forbidden` on `GET /people-contact/v1/people` on alpha, despite the ADMIN role granting all people-contact permissions.

## Root cause

The gateway catalog (`GatewayPermissionCatalog`) and the token encoder (`PermissionCode`) both assign bits **351–359** to the pos-people-contact permissions (ADR-0044 Phase 3 split #874). The downstream mirror — `DownstreamPermissionCatalog` in `pos-security-common`, which every service uses to decode the `X-Perm-Bits` header into authorities — never received those nine entries: its array jumped from bit 350 (`workorder:events:replay`) straight to the entries commented `// 360` and `// 361`.

Because `AUTHORITY_BY_BIT` is positional (array index = bit), downstream services decoded bit 351 (`people-contact:person:view`) as `people:compliance:view`, none of the `people-contact:*` authorities ever materialized, and bits 360–361 fell off the end of the array. The `@PreAuthorize("hasAuthority('people-contact:person:view')")` check in `PersonController` therefore denied every request with 403.

Two guards missed the drift:
- The `X-Perm-Ver` check passed because both catalogs declared `CATALOG_VERSION = 20` despite differing content.
- `scripts/generate-permissions.py --check` compares by permission name only, not position, and its `--sync` mode only appends to the end of the array.

## Fix

- Insert the nine `people-contact:*` entries at bits 351–359 in `DownstreamPermissionCatalog`, restoring positional parity with `GatewayPermissionCatalog` (verified programmatically: both arrays now identical, 362 entries).
- Add a regression test pinning bits 351–361 in `DownstreamPermissionCatalogTest` so this block can't silently shift again.

## Testing

- `./mvnw -pl pos-security-common -am test` — 22 tests, all green (includes the new regression test).
- `python3 scripts/generate-permissions.py . --check` — up-to-date.
- Spotless applied.

## Deployment note

The bug is decode-side, so redeploying pos-people-contact (and any service running the stale pos-security-common) with this change clears the 403. Existing tokens are fine — no re-login needed.

## Follow-up suggestion

Add a CI check (or extend `generate-permissions.py --check`) to assert positional equality between `GatewayPermissionCatalog` and `DownstreamPermissionCatalog`, so version-matches-but-content-drifts can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178XGA9kFvqmxnT5fts83X6

---
_Generated by [Claude Code](https://claude.ai/code/session_0178XGA9kFvqmxnT5fts83X6)_