### PR TITLE
feat(accounting): add AP vendor directory endpoints for vendor-payment typeahead (#816)

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
@@ -16,11 +16,12 @@ public final class EventTypes {
 
     /**
      * All event type registrations for the accounting module.
-     * Total: 50 event types (includes +2 from CAP-251 #5:
+     * Total: 54 event types (includes +2 from CAP-251 #5:
      * ACCOUNTING_STATUS_SYNC_PROCESS and ACCOUNTING_STATUS_VIEW, in addition to
-     * CAP-053 Vendor Bill workflow + GL Mapping, and +3 from PRD missing endpoints:
+     * CAP-053 Vendor Bill workflow + GL Mapping, +3 from PRD missing endpoints:
      * ACCOUNTING_REPORT_EXPORT_REQUEST, ACCOUNTING_REPORT_EXPORT_STATUS,
-     * ACCOUNTING_REPORT_EXPORT_LIST).
+     * ACCOUNTING_REPORT_EXPORT_LIST, and +2 from the vendor directory
+     * (Issue #816): ACCOUNTING_VENDOR_SEARCH, ACCOUNTING_VENDOR_GET).
      */
     public static List<EventTypeRegistration> all() {
         return List.of(
@@ -189,6 +190,13 @@ public final class EventTypes {
 
                 // TimekeepingExportController — 1 event (Wave 4 SDK migration)
                 EventTypeRegistration.write("ACCOUNTING_EXPORT_REQUEST", "Request timekeeping export job")
+                        .build(),
+
+                // VendorDirectoryController — 2 events (Issue #816)
+                EventTypeRegistration.search(
+                                "ACCOUNTING_VENDOR_SEARCH", "Search AP vendor directory by name (typeahead)")
+                        .build(),
+                EventTypeRegistration.fastRead("ACCOUNTING_VENDOR_GET", "Get AP vendor directory entry by ID")
                         .build());
     }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/VendorDirectoryController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/VendorDirectoryController.java
@@ -1,0 +1,123 @@
+package com.positivity.accounting.internal.controller;
+
+import com.positivity.accounting.internal.dto.VendorResponse;
+import com.positivity.accounting.service.VendorDirectoryService;
+import com.positivity.events.EmitEvent;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for the AP vendor directory (Issue #816).
+ *
+ * <p>
+ * Provides vendor name → vendorId resolution for the frontend vendor-payment
+ * typeahead, mirroring the CRM party search pattern used by customer-lookup:
+ * a debounce-friendly name search plus a single-vendor fetch to label
+ * deep-linked ids.
+ *
+ * @see VendorDirectoryService
+ */
+@Slf4j
+@RestController
+@RequestMapping("/v1/accounting/vendors")
+@RequiredArgsConstructor
+@Tag(
+        name = "Vendor Directory API",
+        description = "Vendor search and lookup endpoints for name-to-vendorId resolution (typeahead support)")
+@Validated
+public class VendorDirectoryController {
+
+    private final VendorDirectoryService vendorDirectoryService;
+
+    /**
+     * Search vendors by name (typeahead).
+     *
+     * GET /v1/accounting/vendors?name={term}
+     *
+     * @param name  optional name search term; blank/absent lists all vendors
+     * @param limit maximum results to return (server caps at 100)
+     * @return name-matched vendors ordered by name
+     */
+    @GetMapping
+    @EmitEvent(id = "ACCOUNTING_VENDOR_SEARCH", apiVersion = "1")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:ap:view"})
+    @PreAuthorize("hasAuthority('accounting:ap:view')")
+    @Operation(
+            summary = "Search vendors by name",
+            description = "Case-insensitive name-contains search over the AP vendor directory, ordered by name."
+                    + " Omit the name parameter to list all vendors (up to the limit).",
+            tags = {"Vendor Directory API"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Matching vendors returned",
+            content = @Content(schema = @Schema(implementation = VendorResponse.class)))
+    public ResponseEntity<List<VendorResponse>> searchVendors(
+            @Parameter(description = "Name search term (case-insensitive contains)", example = "acme")
+                    @Nullable
+                    @RequestParam(required = false)
+                    String name,
+            @Parameter(description = "Maximum results to return (server caps at 100)", example = "20")
+                    @RequestParam(required = false, defaultValue = "20")
+                    int limit) {
+        log.info("Received vendor search request | termLength={} | limit={}", name == null ? 0 : name.length(), limit);
+
+        return ResponseEntity.ok(vendorDirectoryService.searchVendors(name, limit));
+    }
+
+    /**
+     * Get a single vendor by id (label resolution for preset ids).
+     *
+     * GET /v1/accounting/vendors/{vendorId}
+     *
+     * @param vendorId the vendor UUID
+     * @return vendor with 200 status, or 404 if not found
+     */
+    @GetMapping("/{vendorId}")
+    @EmitEvent(id = "ACCOUNTING_VENDOR_GET", apiVersion = "1")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:ap:view"})
+    @PreAuthorize("hasAuthority('accounting:ap:view')")
+    @Operation(
+            summary = "Get vendor by id",
+            description = "Resolves a single vendor by its identifier, e.g. to display a name for a deep-linked id",
+            tags = {"Vendor Directory API"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Vendor found",
+            content = @Content(schema = @Schema(implementation = VendorResponse.class)))
+    @ApiResponse(responseCode = "404", description = "Vendor not found")
+    public ResponseEntity<VendorResponse> getVendorById(
+            @Parameter(description = "Vendor identifier", example = "550e8400-e29b-41d4-a716-446655440001")
+                    @NonNull
+                    @PathVariable
+                    UUID vendorId) {
+        log.info("Received vendor lookup request | vendorId={}", vendorId);
+
+        return vendorDirectoryService
+                .getVendorById(vendorId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/VendorDirectoryController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/VendorDirectoryController.java
@@ -5,6 +5,7 @@ import com.positivity.accounting.service.VendorDirectoryService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -71,7 +72,7 @@ public class VendorDirectoryController {
     @ApiResponse(
             responseCode = "200",
             description = "Matching vendors returned",
-            content = @Content(schema = @Schema(implementation = VendorResponse.class)))
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = VendorResponse.class))))
     public ResponseEntity<List<VendorResponse>> searchVendors(
             @Parameter(description = "Name search term (case-insensitive contains)", example = "acme")
                     @Nullable

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/VendorResponse.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/VendorResponse.java
@@ -1,0 +1,46 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Response DTO for an AP vendor directory entry (Issue #816).
+ * Used by the frontend vendor typeahead to resolve a vendor name to its
+ * stable vendorId (and back, for deep-linked ids).
+ */
+@Value
+@Builder
+@Schema(description = "AP vendor directory entry (name to vendorId resolution)")
+public class VendorResponse {
+
+    /** Stable vendor identifier. */
+    @Schema(
+            description = "Stable vendor identifier",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    UUID vendorId;
+
+    /** Vendor display name. */
+    @Schema(description = "Vendor display name", example = "Acme Auto Parts", requiredMode = REQUIRED)
+    String name;
+
+    /** Optional human-readable vendor number. */
+    @Schema(
+            description = "Human-readable vendor number, when assigned",
+            example = "V-1042",
+            requiredMode = NOT_REQUIRED)
+    String vendorNumber;
+
+    /** Vendor status. */
+    @Schema(
+            description = "Vendor status",
+            example = "ACTIVE",
+            allowableValues = {"ACTIVE", "INACTIVE"},
+            requiredMode = NOT_REQUIRED)
+    String status;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/Vendor.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/Vendor.java
@@ -1,0 +1,106 @@
+package com.positivity.accounting.internal.entity;
+
+import com.positivity.accounting.internal.enums.VendorStatus;
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * AP vendor directory entry (Issue #816).
+ *
+ * <p>
+ * Backs the vendor name typeahead used by the frontend vendor-payment page
+ * (name → vendorId resolution). The vendorId is assigned by the upstream
+ * system that owns the vendor relationship (purchasing / goods-received
+ * events); the UUIDv7 generator honors assigned identifiers, and the
+ * {@link Persistable} contract keeps {@code save()} on the {@code persist()}
+ * path for new rows with pre-set ids.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "ap_vendor",
+        indexes = {@Index(name = "idx_ap_vendor_name", columnList = "name")})
+public class Vendor implements Persistable<UUID> {
+
+    /**
+     * Transient flag used by Spring Data JPA to distinguish new entities from
+     * existing ones. Required because the entity uses an externally assigned
+     * ID, which would otherwise cause {@code save()} to call {@code merge()}
+     * instead of {@code persist()}.
+     */
+    @Transient
+    private boolean isNew = true;
+
+    @EqualsAndHashCode.Include
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "vendor_id", nullable = false, columnDefinition = "UUID")
+    private UUID vendorId;
+
+    @Column(name = "name", length = 200, nullable = false)
+    private String name;
+
+    @Column(name = "vendor_number", length = 50)
+    private String vendorNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private VendorStatus status = VendorStatus.ACTIVE;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public Vendor(UUID vendorId, String name) {
+        this.vendorId = vendorId;
+        this.name = name;
+    }
+
+    @Override
+    public UUID getId() {
+        return vendorId;
+    }
+
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+    @PostLoad
+    @PostPersist
+    void markNotNew() {
+        this.isNew = false;
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/enums/VendorStatus.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/enums/VendorStatus.java
@@ -1,0 +1,9 @@
+package com.positivity.accounting.internal.enums;
+
+/**
+ * Lifecycle status of an AP vendor directory entry.
+ */
+public enum VendorStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/VendorRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/VendorRepository.java
@@ -1,0 +1,24 @@
+package com.positivity.accounting.internal.repository;
+
+import com.positivity.accounting.internal.entity.Vendor;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for the AP vendor directory (Issue #816).
+ */
+public interface VendorRepository extends JpaRepository<Vendor, UUID> {
+
+    /**
+     * Case-insensitive name-contains search, ordered by name, for typeahead
+     * queries. Pass an unsorted {@link Pageable} to cap the result size.
+     */
+    List<Vendor> findByNameContainingIgnoreCaseOrderByNameAsc(String name, Pageable pageable);
+
+    /**
+     * List all vendors ordered by name (used when no search term is given).
+     */
+    List<Vendor> findAllByOrderByNameAsc(Pageable pageable);
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/VendorBillServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/VendorBillServiceImpl.java
@@ -120,8 +120,17 @@ public class VendorBillServiceImpl implements VendorBillService {
         // Step 4: Save bill
         VendorBill savedBill = billRepository.save(bill);
 
-        // Keep the AP vendor directory (name typeahead) in sync (Issue #816)
-        vendorDirectoryService.recordVendor(event.getVendorId(), event.getVendorName());
+        // Keep the AP vendor directory (name typeahead) in sync (Issue #816).
+        // Best-effort: runs in its own transaction, and a failure (e.g. a
+        // concurrent insert of the same vendor) must never fail bill creation.
+        try {
+            vendorDirectoryService.recordVendor(event.getVendorId(), event.getVendorName());
+        } catch (RuntimeException e) {
+            log.warn(
+                    "Vendor directory sync failed, continuing bill creation | vendorId={} | error={}",
+                    event.getVendorId(),
+                    e.getMessage());
+        }
 
         // Step 5: Save line items for three-way matching
         int lineNumber = 1;

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/VendorBillServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/VendorBillServiceImpl.java
@@ -15,6 +15,7 @@ import com.positivity.accounting.internal.repository.VendorBillLineRepository;
 import com.positivity.accounting.internal.repository.VendorBillMatchCandidateRepository;
 import com.positivity.accounting.internal.repository.VendorBillRepository;
 import com.positivity.accounting.service.VendorBillService;
+import com.positivity.accounting.service.VendorDirectoryService;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.shared.id.UUIDv7Generator;
 import java.math.BigDecimal;
@@ -62,6 +63,7 @@ public class VendorBillServiceImpl implements VendorBillService {
     private final VendorBillLineRepository billLineRepository;
     private final VendorBillMatchCandidateRepository matchCandidateRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final VendorDirectoryService vendorDirectoryService;
 
     private String getCurrentUser() {
         return SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_USER);
@@ -117,6 +119,9 @@ public class VendorBillServiceImpl implements VendorBillService {
 
         // Step 4: Save bill
         VendorBill savedBill = billRepository.save(bill);
+
+        // Keep the AP vendor directory (name typeahead) in sync (Issue #816)
+        vendorDirectoryService.recordVendor(event.getVendorId(), event.getVendorName());
 
         // Step 5: Save line items for three-way matching
         int lineNumber = 1;

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/VendorDirectoryServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/VendorDirectoryServiceImpl.java
@@ -14,6 +14,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -50,8 +51,13 @@ public class VendorDirectoryServiceImpl implements VendorDirectoryService {
         return vendorRepository.findById(vendorId).map(VendorDirectoryServiceImpl::toResponse);
     }
 
+    // REQUIRES_NEW isolates the upsert from the caller's transaction: a
+    // concurrent insert of the same vendorId can still fail this write with a
+    // duplicate-key violation, but only this transaction rolls back — the
+    // upstream bill/payment flow is unaffected (callers treat directory sync
+    // as best-effort and the concurrent writer already stored the same data).
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void recordVendor(@NonNull UUID vendorId, @Nullable String vendorName) {
         if (vendorName == null || vendorName.isBlank()) {
             return;

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/VendorDirectoryServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/VendorDirectoryServiceImpl.java
@@ -1,0 +1,84 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.dto.VendorResponse;
+import com.positivity.accounting.internal.entity.Vendor;
+import com.positivity.accounting.internal.repository.VendorRepository;
+import com.positivity.accounting.service.VendorDirectoryService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Implementation of the AP vendor directory (Issue #816).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VendorDirectoryServiceImpl implements VendorDirectoryService {
+
+    /** Server-side cap on typeahead result size. */
+    public static final int MAX_RESULTS = 100;
+
+    private static final int DEFAULT_LIMIT = 20;
+
+    private final VendorRepository vendorRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public @NonNull List<VendorResponse> searchVendors(@Nullable String name, int limit) {
+        int capped = limit > 0 ? Math.min(limit, MAX_RESULTS) : DEFAULT_LIMIT;
+        Pageable page = PageRequest.of(0, capped);
+
+        List<Vendor> vendors = (name == null || name.isBlank())
+                ? vendorRepository.findAllByOrderByNameAsc(page)
+                : vendorRepository.findByNameContainingIgnoreCaseOrderByNameAsc(name.trim(), page);
+
+        return vendors.stream().map(VendorDirectoryServiceImpl::toResponse).toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public @NonNull Optional<VendorResponse> getVendorById(@NonNull UUID vendorId) {
+        return vendorRepository.findById(vendorId).map(VendorDirectoryServiceImpl::toResponse);
+    }
+
+    @Override
+    @Transactional
+    public void recordVendor(@NonNull UUID vendorId, @Nullable String vendorName) {
+        if (vendorName == null || vendorName.isBlank()) {
+            return;
+        }
+        String name = vendorName.trim();
+
+        Optional<Vendor> existing = vendorRepository.findById(vendorId);
+        if (existing.isPresent()) {
+            Vendor vendor = existing.get();
+            if (!name.equals(vendor.getName())) {
+                log.info("Refreshing vendor directory name | vendorId={}", vendorId);
+                vendor.setName(name);
+                vendorRepository.save(vendor);
+            }
+            return;
+        }
+
+        log.info("Adding vendor to directory | vendorId={}", vendorId);
+        vendorRepository.save(new Vendor(vendorId, name));
+    }
+
+    private static VendorResponse toResponse(Vendor vendor) {
+        return VendorResponse.builder()
+                .vendorId(vendor.getVendorId())
+                .name(vendor.getName())
+                .vendorNumber(vendor.getVendorNumber())
+                .status(vendor.getStatus() != null ? vendor.getStatus().name() : null)
+                .build();
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/VendorDirectoryService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/VendorDirectoryService.java
@@ -54,6 +54,8 @@ public interface VendorDirectoryService {
      * <p>
      * Inserts a new directory entry, or refreshes the stored name when it has
      * changed. A null/blank name is ignored so call sites don't need to guard.
+     * Runs in its own transaction; callers should treat it as best-effort and
+     * not let a failure abort the surrounding business flow.
      *
      * @param vendorId   vendor UUID from the upstream event
      * @param vendorName vendor display name from the upstream event (may be

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/VendorDirectoryService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/VendorDirectoryService.java
@@ -1,0 +1,63 @@
+package com.positivity.accounting.service;
+
+import com.positivity.accounting.internal.dto.VendorResponse;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * AP vendor directory: vendor name → vendorId resolution (Issue #816).
+ *
+ * <p>
+ * Backs the frontend vendor-payment typeahead so operators search vendors by
+ * name instead of typing raw UUIDs. The directory is populated from AP flows
+ * that carry both vendorId and vendorName (goods-received events) via
+ * {@link #recordVendor(UUID, String)}, plus a one-time backfill from existing
+ * vendor bills and payments.
+ *
+ * @see <a href=
+ *      "https://github.com/louisburroughs/durion-positivity-backend/issues/816">Issue
+ *      #816</a>
+ */
+public interface VendorDirectoryService {
+
+    /**
+     * Search vendors by name for typeahead use.
+     *
+     * <p>
+     * Matching is case-insensitive contains on the vendor name; results are
+     * ordered by name. A blank or null term lists all vendors (up to
+     * {@code limit}).
+     *
+     * @param name  optional name search term (null/blank lists all vendors)
+     * @param limit maximum results to return (clamped to a server-side cap)
+     * @return name-matched vendors ordered by name
+     */
+    @NonNull
+    List<VendorResponse> searchVendors(@Nullable String name, int limit);
+
+    /**
+     * Resolve a single vendor by id (e.g. to label a deep-linked
+     * {@code ?vendorId=}).
+     *
+     * @param vendorId vendor UUID
+     * @return the vendor, if present in the directory
+     */
+    @NonNull
+    Optional<VendorResponse> getVendorById(@NonNull UUID vendorId);
+
+    /**
+     * Record (upsert) a vendor observed on an AP flow.
+     *
+     * <p>
+     * Inserts a new directory entry, or refreshes the stored name when it has
+     * changed. A null/blank name is ignored so call sites don't need to guard.
+     *
+     * @param vendorId   vendor UUID from the upstream event
+     * @param vendorName vendor display name from the upstream event (may be
+     *                   null/blank, in which case the call is a no-op)
+     */
+    void recordVendor(@NonNull UUID vendorId, @Nullable String vendorName);
+}

--- a/pos-accounting/src/main/resources/db/migration/V6__create_ap_vendor.sql
+++ b/pos-accounting/src/main/resources/db/migration/V6__create_ap_vendor.sql
@@ -1,0 +1,33 @@
+-- AP vendor directory (Issue #816).
+-- Provides a searchable vendor name -> vendorId directory for the frontend
+-- vendor-payment typeahead. Rows are upserted from AP flows that carry
+-- vendorId + vendorName (goods-received events) and backfilled below from
+-- existing vendor bills / payments.
+
+CREATE TABLE ap_vendor (
+    vendor_id uuid NOT NULL,
+    name character varying(200) NOT NULL,
+    vendor_number character varying(50),
+    status character varying(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT ap_vendor_pkey PRIMARY KEY (vendor_id),
+    CONSTRAINT ap_vendor_status_check CHECK (((status)::text = ANY ((ARRAY['ACTIVE'::character varying, 'INACTIVE'::character varying])::text[])))
+);
+
+CREATE INDEX idx_ap_vendor_name ON ap_vendor USING btree (lower(name));
+
+-- Backfill from existing vendor bills (most recent name per vendor wins).
+INSERT INTO ap_vendor (vendor_id, name, status, created_at, updated_at)
+SELECT DISTINCT ON (vendor_id) vendor_id, vendor_name, 'ACTIVE', now(), now()
+FROM vendor_bill
+WHERE vendor_name IS NOT NULL AND vendor_name <> ''
+ORDER BY vendor_id, created_at DESC;
+
+-- Backfill vendors that only appear on AP payments.
+INSERT INTO ap_vendor (vendor_id, name, status, created_at, updated_at)
+SELECT DISTINCT ON (vendor_id) vendor_id, vendor_name, 'ACTIVE', now(), now()
+FROM ap_payment
+WHERE vendor_name IS NOT NULL AND vendor_name <> ''
+ORDER BY vendor_id, created_at DESC
+ON CONFLICT (vendor_id) DO NOTHING;

--- a/pos-accounting/src/main/resources/db/migration/V6__create_ap_vendor.sql
+++ b/pos-accounting/src/main/resources/db/migration/V6__create_ap_vendor.sql
@@ -15,7 +15,10 @@ CREATE TABLE ap_vendor (
     CONSTRAINT ap_vendor_status_check CHECK (((status)::text = ANY ((ARRAY['ACTIVE'::character varying, 'INACTIVE'::character varying])::text[])))
 );
 
-CREATE INDEX idx_ap_vendor_name ON ap_vendor USING btree (lower(name));
+-- Plain btree on name: supports ORDER BY name and matches the JPA entity's
+-- declared index (contains-style typeahead matching can't use a btree either
+-- way; a trigram index can be added later if search volume warrants it).
+CREATE INDEX idx_ap_vendor_name ON ap_vendor USING btree (name);
 
 -- Backfill from existing vendor bills (most recent name per vendor wins).
 INSERT INTO ap_vendor (vendor_id, name, status, created_at, updated_at)

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/controller/VendorDirectoryControllerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/controller/VendorDirectoryControllerTest.java
@@ -1,0 +1,107 @@
+package com.positivity.accounting.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.accounting.BaseIntegrationTest;
+import com.positivity.accounting.internal.dto.VendorResponse;
+import com.positivity.accounting.service.VendorDirectoryService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Tests for VendorDirectoryController (Issue #816): vendor name typeahead
+ * search and single-vendor lookup, including permission enforcement.
+ */
+@DisplayName("VendorDirectoryController Tests")
+class VendorDirectoryControllerTest extends BaseIntegrationTest {
+
+    private static final UUID VENDOR_ID = UUID.fromString("01960003-0000-7000-8000-000000000001");
+
+    @MockitoBean
+    private VendorDirectoryService vendorDirectoryService;
+
+    private static VendorResponse acme() {
+        return VendorResponse.builder()
+                .vendorId(VENDOR_ID)
+                .name("Acme Auto Parts")
+                .status("ACTIVE")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("GET /v1/accounting/vendors")
+    class SearchVendors {
+
+        @Test
+        @DisplayName("Should return name-matched vendors")
+        void shouldReturnMatchedVendors() throws Exception {
+            when(vendorDirectoryService.searchVendors(eq("acme"), anyInt())).thenReturn(List.of(acme()));
+
+            mockMvc.perform(withAuth(get("/v1/accounting/vendors").param("name", "acme")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].vendorId").value(VENDOR_ID.toString()))
+                    .andExpect(jsonPath("$[0].name").value("Acme Auto Parts"))
+                    .andExpect(jsonPath("$[0].status").value("ACTIVE"));
+        }
+
+        @Test
+        @DisplayName("Should list vendors when no name term is given")
+        void shouldListWithoutTerm() throws Exception {
+            when(vendorDirectoryService.searchVendors(any(), anyInt())).thenReturn(List.of(acme()));
+
+            mockMvc.perform(withAuth(get("/v1/accounting/vendors")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].vendorId").value(VENDOR_ID.toString()));
+        }
+
+        @Test
+        @DisplayName("Should reject search without accounting:ap:view authority")
+        void shouldRejectWithoutPermission() throws Exception {
+            mockMvc.perform(withAuth(get("/v1/accounting/vendors").param("name", "acme"), "accounting:je:view"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /v1/accounting/vendors/{vendorId}")
+    class GetVendorById {
+
+        @Test
+        @DisplayName("Should resolve a single vendor by id")
+        void shouldResolveVendorById() throws Exception {
+            when(vendorDirectoryService.getVendorById(VENDOR_ID)).thenReturn(Optional.of(acme()));
+
+            mockMvc.perform(withAuth(get("/v1/accounting/vendors/{vendorId}", VENDOR_ID)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.vendorId").value(VENDOR_ID.toString()))
+                    .andExpect(jsonPath("$.name").value("Acme Auto Parts"));
+        }
+
+        @Test
+        @DisplayName("Should return 404 for unknown vendor")
+        void shouldReturn404ForUnknownVendor() throws Exception {
+            when(vendorDirectoryService.getVendorById(VENDOR_ID)).thenReturn(Optional.empty());
+
+            mockMvc.perform(withAuth(get("/v1/accounting/vendors/{vendorId}", VENDOR_ID)))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("Should reject lookup without accounting:ap:view authority")
+        void shouldRejectWithoutPermission() throws Exception {
+            mockMvc.perform(withAuth(get("/v1/accounting/vendors/{vendorId}", VENDOR_ID), "accounting:je:view"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/VendorBillServiceGLPostingTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/VendorBillServiceGLPostingTest.java
@@ -1,7 +1,9 @@
 package com.positivity.accounting.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +96,30 @@ class VendorBillServiceGLPostingTest {
                                 .isInventoryItem(false)
                                 .build()))
                 .build();
+    }
+
+    @Test
+    @DisplayName("Should record vendor in directory when bill is created")
+    void shouldRecordVendorInDirectory() {
+        when(billRepository.findByOriginEventId(testEvent.getEventId())).thenReturn(Optional.empty());
+        when(billRepository.save(any(VendorBill.class))).thenReturn(createSavedBill());
+
+        vendorBillService.handleGoodsReceivedEvent(testEvent);
+
+        verify(vendorDirectoryService).recordVendor(testVendorId, "Test Vendor Inc");
+    }
+
+    @Test
+    @DisplayName("Should not fail bill creation when vendor directory sync fails")
+    void shouldNotFailBillCreationWhenDirectorySyncFails() {
+        when(billRepository.findByOriginEventId(testEvent.getEventId())).thenReturn(Optional.empty());
+        when(billRepository.save(any(VendorBill.class))).thenReturn(createSavedBill());
+        doThrow(new RuntimeException("duplicate key"))
+                .when(vendorDirectoryService)
+                .recordVendor(any(), any());
+
+        assertThatCode(() -> vendorBillService.handleGoodsReceivedEvent(testEvent))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/VendorBillServiceGLPostingTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/VendorBillServiceGLPostingTest.java
@@ -52,6 +52,9 @@ class VendorBillServiceGLPostingTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private VendorDirectoryService vendorDirectoryService;
+
     @InjectMocks
     private VendorBillServiceImpl vendorBillService;
 

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/VendorBillServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/VendorBillServiceTest.java
@@ -65,6 +65,9 @@ class VendorBillServiceTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private VendorDirectoryService vendorDirectoryService;
+
     @InjectMocks
     private VendorBillServiceImpl vendorBillService;
 

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/VendorDirectoryServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/VendorDirectoryServiceImplTest.java
@@ -1,0 +1,187 @@
+package com.positivity.accounting.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.accounting.internal.dto.VendorResponse;
+import com.positivity.accounting.internal.entity.Vendor;
+import com.positivity.accounting.internal.enums.VendorStatus;
+import com.positivity.accounting.internal.repository.VendorRepository;
+import com.positivity.accounting.internal.service.VendorDirectoryServiceImpl;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Unit tests for VendorDirectoryServiceImpl (Issue #816).
+ * Covers typeahead search, single-vendor lookup, and upsert behavior.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VendorDirectoryService Unit Tests")
+class VendorDirectoryServiceImplTest {
+
+    private static final UUID VENDOR_ID = UUID.fromString("00000000-0000-0000-0000-000000000042");
+
+    @Mock
+    private VendorRepository vendorRepository;
+
+    @InjectMocks
+    private VendorDirectoryServiceImpl service;
+
+    private static Vendor vendor(UUID id, String name) {
+        Vendor vendor = new Vendor(id, name);
+        vendor.setStatus(VendorStatus.ACTIVE);
+        return vendor;
+    }
+
+    @Nested
+    @DisplayName("searchVendors")
+    class SearchVendors {
+
+        @Test
+        @DisplayName("Should perform case-insensitive contains search ordered by name")
+        void shouldSearchByName() {
+            when(vendorRepository.findByNameContainingIgnoreCaseOrderByNameAsc(eq("acme"), any(Pageable.class)))
+                    .thenReturn(List.of(vendor(VENDOR_ID, "Acme Auto Parts")));
+
+            List<VendorResponse> results = service.searchVendors("acme", 20);
+
+            assertThat(results).hasSize(1);
+            assertThat(results.getFirst().getVendorId()).isEqualTo(VENDOR_ID);
+            assertThat(results.getFirst().getName()).isEqualTo("Acme Auto Parts");
+            assertThat(results.getFirst().getStatus()).isEqualTo("ACTIVE");
+        }
+
+        @Test
+        @DisplayName("Should trim the search term before matching")
+        void shouldTrimSearchTerm() {
+            when(vendorRepository.findByNameContainingIgnoreCaseOrderByNameAsc(eq("acme"), any(Pageable.class)))
+                    .thenReturn(List.of());
+
+            service.searchVendors("  acme  ", 20);
+
+            verify(vendorRepository).findByNameContainingIgnoreCaseOrderByNameAsc(eq("acme"), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("Should list all vendors when no term is given")
+        void shouldListAllWhenTermBlank() {
+            when(vendorRepository.findAllByOrderByNameAsc(any(Pageable.class))).thenReturn(List.of());
+
+            service.searchVendors("  ", 20);
+            service.searchVendors(null, 20);
+
+            verify(vendorRepository, never())
+                    .findByNameContainingIgnoreCaseOrderByNameAsc(any(String.class), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("Should cap requested limit at the server-side maximum")
+        void shouldCapLimit() {
+            when(vendorRepository.findAllByOrderByNameAsc(any(Pageable.class))).thenReturn(List.of());
+
+            service.searchVendors(null, 5000);
+
+            verify(vendorRepository).findAllByOrderByNameAsc(PageRequest.of(0, VendorDirectoryServiceImpl.MAX_RESULTS));
+        }
+
+        @Test
+        @DisplayName("Should fall back to the default limit for non-positive limits")
+        void shouldDefaultNonPositiveLimit() {
+            when(vendorRepository.findAllByOrderByNameAsc(any(Pageable.class))).thenReturn(List.of());
+
+            service.searchVendors(null, 0);
+
+            verify(vendorRepository).findAllByOrderByNameAsc(PageRequest.of(0, 20));
+        }
+    }
+
+    @Nested
+    @DisplayName("getVendorById")
+    class GetVendorById {
+
+        @Test
+        @DisplayName("Should resolve a vendor by id")
+        void shouldResolveVendor() {
+            when(vendorRepository.findById(VENDOR_ID)).thenReturn(Optional.of(vendor(VENDOR_ID, "Acme Auto Parts")));
+
+            Optional<VendorResponse> result = service.getVendorById(VENDOR_ID);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getName()).isEqualTo("Acme Auto Parts");
+        }
+
+        @Test
+        @DisplayName("Should return empty for unknown vendor")
+        void shouldReturnEmptyForUnknown() {
+            when(vendorRepository.findById(VENDOR_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.getVendorById(VENDOR_ID)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("recordVendor")
+    class RecordVendor {
+
+        @Test
+        @DisplayName("Should insert a new vendor when not present")
+        void shouldInsertNewVendor() {
+            when(vendorRepository.findById(VENDOR_ID)).thenReturn(Optional.empty());
+
+            service.recordVendor(VENDOR_ID, "Acme Auto Parts");
+
+            ArgumentCaptor<Vendor> captor = ArgumentCaptor.forClass(Vendor.class);
+            verify(vendorRepository).save(captor.capture());
+            assertThat(captor.getValue().getVendorId()).isEqualTo(VENDOR_ID);
+            assertThat(captor.getValue().getName()).isEqualTo("Acme Auto Parts");
+            assertThat(captor.getValue().getStatus()).isEqualTo(VendorStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("Should refresh the stored name when it changed")
+        void shouldRefreshChangedName() {
+            when(vendorRepository.findById(VENDOR_ID)).thenReturn(Optional.of(vendor(VENDOR_ID, "Old Name")));
+
+            service.recordVendor(VENDOR_ID, "New Name");
+
+            ArgumentCaptor<Vendor> captor = ArgumentCaptor.forClass(Vendor.class);
+            verify(vendorRepository).save(captor.capture());
+            assertThat(captor.getValue().getName()).isEqualTo("New Name");
+        }
+
+        @Test
+        @DisplayName("Should not save when the name is unchanged")
+        void shouldSkipUnchangedName() {
+            when(vendorRepository.findById(VENDOR_ID)).thenReturn(Optional.of(vendor(VENDOR_ID, "Acme Auto Parts")));
+
+            service.recordVendor(VENDOR_ID, "Acme Auto Parts");
+
+            verify(vendorRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should ignore null or blank names")
+        void shouldIgnoreBlankNames() {
+            service.recordVendor(VENDOR_ID, null);
+            service.recordVendor(VENDOR_ID, "   ");
+
+            verify(vendorRepository, never()).findById(any());
+            verify(vendorRepository, never()).save(any());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #816.

Adds a vendor search/directory API to `pos-accounting` so the frontend can replace the raw "Vendor ID" UUID field on `/app/accounting/vendor-payments/new` with a name typeahead (clearing the `uuid-on-screen` audit finding):

- `GET /v1/accounting/vendors?name={term}&limit=` — case-insensitive name-contains search over the AP vendor directory, ordered by name, server-capped at 100 rows (default 20). Blank/absent term lists all vendors. Debounce-friendly server-side matching, mirroring the CRM party search pattern used by customer-lookup.
- `GET /v1/accounting/vendors/{vendorId}` — single-vendor lookup (200/404) so a deep-linked `?vendorId=` can be resolved back to a readable name.
- Response shape: `{ vendorId, name, vendorNumber?, status }`.

## Contract

- Accounting domain contract guide: `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` (same guide referenced by the existing `VendorBill` / `GLAccount` entities). This PR adds a new read-only vendor directory resource (`/v1/accounting/vendors`) alongside the existing Vendor Bill contract; it does not change any existing endpoint's contract.

## Design

No vendor master existed anywhere in the platform — vendors only appeared as denormalized `vendorId`/`vendorName` on `vendor_bill`, `ap_payment`, and purchase orders. This PR introduces an `ap_vendor` directory table:

- **Migration `V6__create_ap_vendor.sql`** creates the table (with a name index for ordering) and backfills it from the distinct vendor pairs already on `vendor_bill` and `ap_payment` (most recent name wins).
- **Organic sync**: `VendorBillServiceImpl` upserts a directory entry whenever a goods-received event (the only AP flow carrying both `vendorId` and `vendorName`) creates a bill, via the new `VendorDirectoryService.recordVendor(...)`. Sync is best-effort in its own transaction so a duplicate-key race can never fail bill creation.
- The `Vendor` entity uses the externally assigned UUID with the `Persistable` pattern (mirroring `GLAccount`) so `save()` stays on the `persist()` path; the shared UUIDv7 generator honors pre-set ids.

## Conventions

- Both endpoints require the existing `accounting:ap:view` permission (no new permission needed).
- `@EmitEvent` ids `ACCOUNTING_VENDOR_SEARCH` (search preset) and `ACCOUNTING_VENDOR_GET` (fastRead) registered in `EventTypes`.
- Public API surface in `service/` (`VendorDirectoryService`), everything else in `internal/`.

## Testing

- 17 new tests: `VendorDirectoryServiceImplTest` (search term trimming, limit capping, upsert insert/refresh/no-op/blank-name cases), `VendorDirectoryControllerTest` (MockMvc: search, list-without-term, 404, permission denial on both endpoints), plus bill-flow tests covering directory sync and its failure isolation.
- Full `pos-accounting` suite green: 677 tests, 0 failures.
- Module-level `ArchitectureTest` and cross-module `pos-archunit` `ArchitectureTests` pass.
- Spotless, Checkstyle, and SpotBugs gates pass.

## Frontend follow-up (out of scope here)

- Swap the free-text "Vendor ID" input for a shared typeahead bound to `vendorId` (mirroring `app-customer-lookup`).
- Regenerate `@durion-sdk/accounting` from the updated OpenAPI spec — the new controller carries full springdoc annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLrmfcf8UCLb9zJqqYfNT1