### PR TITLE
Add StatementLineMappingRepository cleanup to integration tests

### DIFF
--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/ContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/ContractBehaviorIT.java
@@ -15,6 +15,7 @@ import com.positivity.accounting.internal.repository.DefaultGLMappingRepository;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.JournalEntryLineRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
@@ -65,6 +66,9 @@ class ContractBehaviorIT extends BaseContractIntegrationTest {
     @Autowired
     private DefaultGLMappingRepository defaultGLMappingRepository;
 
+    @Autowired
+    private StatementLineMappingRepository statementLineMappingRepository;
+
     private static final String API_V1 = "/v1/accounting";
 
     // Gateway header values — mirrors what pos-api-gateway injects after JWT
@@ -106,6 +110,7 @@ class ContractBehaviorIT extends BaseContractIntegrationTest {
         journalEntryLineRepository.deleteAll();
         journalEntryRepository.deleteAll();
         defaultGLMappingRepository.deleteAll();
+        statementLineMappingRepository.deleteAll();
         glAccountRepository.deleteAll();
     }
 

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/CreditMemoContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/CreditMemoContractBehaviorIT.java
@@ -20,6 +20,7 @@ import com.positivity.accounting.internal.repository.CreditMemoRepository;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.JournalEntryLineRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
 import com.positivity.accounting.internal.service.InvoiceBalanceCalculator;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -67,6 +68,9 @@ public class CreditMemoContractBehaviorIT extends BaseContractIntegrationTest {
     @Autowired
     private JournalEntryLineRepository journalEntryLineRepository;
 
+    @Autowired
+    private StatementLineMappingRepository statementLineMappingRepository;
+
     @MockitoBean
     private InvoiceBalanceCalculator invoiceBalanceCalculator;
 
@@ -81,6 +85,7 @@ public class CreditMemoContractBehaviorIT extends BaseContractIntegrationTest {
         journalEntryLineRepository.deleteAll();
         journalEntryRepository.deleteAll();
         creditMemoRepository.deleteAll();
+        statementLineMappingRepository.deleteAll();
         glAccountRepository.deleteAll();
 
         // Default replica state (ADR-0044 #842): a FINALIZED $110 invoice with a $110
@@ -110,6 +115,7 @@ public class CreditMemoContractBehaviorIT extends BaseContractIntegrationTest {
         journalEntryLineRepository.deleteAll();
         journalEntryRepository.deleteAll();
         creditMemoRepository.deleteAll();
+        statementLineMappingRepository.deleteAll();
         glAccountRepository.deleteAll();
     }
 

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/JournalEntryContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/JournalEntryContractBehaviorIT.java
@@ -16,6 +16,7 @@ import com.positivity.accounting.internal.enums.AccountType;
 import com.positivity.accounting.internal.repository.DefaultGLMappingRepository;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
@@ -61,6 +62,9 @@ class JournalEntryContractBehaviorIT extends BaseContractIntegrationTest {
     @Autowired
     private DefaultGLMappingRepository defaultGLMappingRepository;
 
+    @Autowired
+    private StatementLineMappingRepository statementLineMappingRepository;
+
     private static final String API_V1_JOURNAL_ENTRIES = "/v1/accounting/journal-entries";
     private static final String API_V1_GL_ACCOUNTS = "/v1/accounting/gl-accounts";
 
@@ -73,6 +77,7 @@ class JournalEntryContractBehaviorIT extends BaseContractIntegrationTest {
         // Clean up before each test
         journalEntryRepository.deleteAll();
         defaultGLMappingRepository.deleteAll();
+        statementLineMappingRepository.deleteAll();
         glAccountRepository.deleteAll();
 
         // Create test GL accounts
@@ -88,6 +93,7 @@ class JournalEntryContractBehaviorIT extends BaseContractIntegrationTest {
     void tearDown() {
         journalEntryRepository.deleteAll();
         defaultGLMappingRepository.deleteAll();
+        statementLineMappingRepository.deleteAll();
         glAccountRepository.deleteAll();
     }
 

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/LaborOverheadReportContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/LaborOverheadReportContractBehaviorIT.java
@@ -25,11 +25,13 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Provider behavioral contract test (CAP-316): proves the Labor &amp; Overhead report amounts trace to
  * posted GL data for a seeded location/period, and that subtotals roll up from the contributing leaf.
  */
+@Transactional
 @DisplayName("Labor & Overhead Report ContractBehaviorIT")
 class LaborOverheadReportContractBehaviorIT extends BaseContractIntegrationTest {
 
@@ -86,8 +88,8 @@ class LaborOverheadReportContractBehaviorIT extends BaseContractIntegrationTest 
     @Test
     @DisplayName("Only POSTED entries contribute: DRAFT and REVERSED on the same account/period are excluded")
     void excludesNonPostedEntries() throws Exception {
-        // Distinct location: the contract IT shares one H2 instance across tests with no per-test
-        // reset, and line-code mappings are global, so each test scopes its postings by location.
+        // Distinct location: line-code mappings are global, so each test scopes its postings by
+        // location to stay independent of seeded or sibling-test data.
         String location = "LOC-IT-316-NONPOSTED";
         GLAccount account = seedAccount("6010-IT2", "Retread Plant Hourly Wages (IT2)");
         seedMapping("1.1.1", account);

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/SuspenseQueueContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/SuspenseQueueContractBehaviorIT.java
@@ -20,6 +20,7 @@ import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.JournalEntryLineRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
 import com.positivity.accounting.internal.repository.ReprocessingAttemptHistoryRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -71,6 +72,9 @@ class SuspenseQueueContractBehaviorIT extends BaseContractIntegrationTest {
     @Autowired
     private JournalEntryLineRepository journalEntryLineRepository;
 
+    @Autowired
+    private StatementLineMappingRepository statementLineMappingRepository;
+
     private static final String API_V1 = "/v1/accounting/events";
 
     @BeforeEach
@@ -80,6 +84,7 @@ class SuspenseQueueContractBehaviorIT extends BaseContractIntegrationTest {
         journalEntryLineRepository.deleteAll();
         journalEntryRepository.deleteAll();
         defaultGLMappingRepository.deleteAll();
+        statementLineMappingRepository.deleteAll();
         glAccountRepository.deleteAll();
 
         createDefaultMappingForSuccessfulReprocessing();

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/integration/AccountingServiceIntegrationTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/integration/AccountingServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import com.positivity.accounting.BaseIntegrationTest;
 import com.positivity.accounting.internal.entity.GLAccount;
 import com.positivity.accounting.internal.enums.AccountType;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -43,6 +44,9 @@ class AccountingServiceIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private GLAccountRepository glAccountRepository;
 
+    @Autowired
+    private StatementLineMappingRepository statementLineMappingRepository;
+
     private static final UUID ORG_ID = UUID.fromString("00000000-0000-4000-a000-000000000010");
     private static final String BASE_URL = "/v1/accounting";
 
@@ -54,6 +58,7 @@ class AccountingServiceIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        statementLineMappingRepository.deleteAll();
         glAccountRepository.deleteAll();
     }
 


### PR DESCRIPTION
Ensures `StatementLineMappingRepository` is cleared in setUp/tearDown lifecycle methods across all integration test classes to prevent test pollution and data leakage between test runs.

**Key changes:**
- Injected `StatementLineMappingRepository` as `@Autowired` dependency in five integration test classes
- Added `statementLineMappingRepository.deleteAll()` calls in setUp/tearDown methods:
  - `CreditMemoContractBehaviorIT`
  - `JournalEntryContractBehaviorIT`
  - `ContractBehaviorIT`
  - `SuspenseQueueContractBehaviorIT`
  - `AccountingServiceIntegrationTest`
- Added `@Transactional` annotation to `LaborOverheadReportContractBehaviorIT` for transaction management
- Updated test comment in `LaborOverheadReportContractBehaviorIT` to clarify test isolation strategy (location-scoped postings for independence from seeded/sibling data)

**Rationale:**
Statement line mappings are global state that can persist across tests. Explicit cleanup ensures each test starts with a clean slate, preventing flaky tests caused by leftover data from previous test runs.

https://claude.ai/code/session_01Q7jZZK4V8oZ3N2Pw9hz5DD