### PR TITLE
fix(ci): stop pos-archunit integration-test job at the test phase (#909)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,16 +295,18 @@ jobs:
           ./mvnw -pl pos-events test -DskipITs -T 1C -B -q
 
       - name: Run integration tests
-        # verify re-runs surefire, so pos-archunit needs the same reactor treatment as in
-        # the unit-tests job (#909); scope surefire and failsafe to its own tests.
+        # pos-archunit has no failsafe ITs, and running `verify` on the -am reactor
+        # takes the upstream modules through package, where spring-boot:repackage
+        # swaps their jars for fat jars whose classes hide under BOOT-INF/classes —
+        # ArchUnit then sees nothing and ClasspathVisibilityGuardTest fails (#909).
+        # Stop at the test phase so siblings resolve to target/classes, exactly as
+        # in the unit-tests job.
         run: |
           if [[ "${{ matrix.module }}" == "pos-archunit" ]]; then
-            ./mvnw -pl pos-archunit -am -DskipTests=false verify \
+            ./mvnw -pl pos-archunit -am -DskipTests=false test \
               -Dtest='com/positivity/archunit/*' \
               -Dsurefire.failIfNoSpecifiedTests=false \
-              -Dit.test='com/positivity/archunit/*' \
-              -Dfailsafe.failIfNoSpecifiedTests=false \
-              -T 1C -B -q -o
+              -DskipITs -T 1C -B -q -o
           else
             ./mvnw -pl ${{ matrix.module }} -DskipTests=false verify -T 1C -B -q -o
           fi


### PR DESCRIPTION
Since #915, the Integration Tests (pos-archunit) job fails on every main push: it runs `./mvnw -pl pos-archunit -am verify`, and `verify` takes the -am sibling modules through package, where spring-boot:repackage swaps their thin jars for fat jars. ArchUnit cannot see application classes under BOOT-INF/classes, so ClasspathVisibilityGuardTest fails for all 21 app modules.

pos-archunit has no failsafe ITs, so verify only re-ran the surefire suite that the unit-tests job already covers. Run the job at the test phase instead, where sibling modules still resolve to target/classes — the same treatment the unit-tests job uses.


Claude-Session: https://claude.ai/code/session_01Q7jZZK4V8oZ3N2Pw9hz5DD