### PR TITLE
feat(invoice): standalone refunds not anchored to a captured PaymentIntent (#926)

### DIFF
--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/config/EventTypes.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/config/EventTypes.java
@@ -112,6 +112,20 @@ public final class EventTypes {
             .apiVersion("1")
             .build();
 
+    // ==================== ISSUE #926 — STANDALONE REFUND EVENTS ====================
+
+    public static final EventTypeRegistration INVOICE_STANDALONE_REFUND = EventTypeRegistration.write(
+                    "INVOICE_STANDALONE_REFUND",
+                    "Record a standalone refund for an invoice whose original payment is not in the system")
+            .apiVersion("1")
+            .build();
+
+    public static final EventTypeRegistration INVOICE_PARTY_STANDALONE_REFUND = EventTypeRegistration.write(
+                    "INVOICE_PARTY_STANDALONE_REFUND",
+                    "Record a standalone refund anchored to a customer party with no invoice in the system")
+            .apiVersion("1")
+            .build();
+
     // ==================== STORY #7 — RECEIPT EVENTS ====================
 
     public static final EventTypeRegistration INVOICE_RECEIPT_GENERATE = EventTypeRegistration.write(
@@ -155,6 +169,8 @@ public final class EventTypes {
                 INVOICE_PAYMENT_CAPTURE,
                 INVOICE_PAYMENT_VOID,
                 INVOICE_PAYMENT_REFUND,
+                INVOICE_STANDALONE_REFUND,
+                INVOICE_PARTY_STANDALONE_REFUND,
                 INVOICE_RECEIPT_GENERATE,
                 INVOICE_RECEIPT_REPRINT,
                 INVOICE_RECEIPT_PRINT_DELIVERY,

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentReversalExceptionHandler.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentReversalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.positivity.invoice.internal.controller;
 
 import com.positivity.invoice.internal.exception.InsufficientRefundableAmountException;
 import com.positivity.invoice.internal.exception.InvalidPaymentStateException;
+import com.positivity.invoice.internal.exception.InvoiceNotFoundException;
 import com.positivity.invoice.internal.exception.PaymentGatewayException;
 import com.positivity.invoice.internal.exception.PaymentIntentNotFoundException;
 import com.positivity.invoice.internal.exception.PaymentWindowExpiredException;
@@ -16,7 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(assignableTypes = PaymentReversalController.class)
+@RestControllerAdvice(assignableTypes = {PaymentReversalController.class, StandaloneRefundController.class})
 @RequiredArgsConstructor
 public class PaymentReversalExceptionHandler {
 
@@ -25,6 +26,19 @@ public class PaymentReversalExceptionHandler {
 
     @ExceptionHandler(PaymentIntentNotFoundException.class)
     public ResponseEntity<ApiError> handleNotFound(PaymentIntentNotFoundException ex, HttpServletRequest request) {
+        String correlationId = correlationId(request);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .header(X_CORRELATION_ID, correlationId)
+                .body(ApiError.of(
+                        "NOT_FOUND",
+                        ex.getMessage(),
+                        HttpStatus.NOT_FOUND.value(),
+                        Instant.now(clock).toString(),
+                        correlationId));
+    }
+
+    @ExceptionHandler(InvoiceNotFoundException.class)
+    public ResponseEntity<ApiError> handleInvoiceNotFound(InvoiceNotFoundException ex, HttpServletRequest request) {
         String correlationId = correlationId(request);
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .header(X_CORRELATION_ID, correlationId)

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/StandaloneRefundController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/StandaloneRefundController.java
@@ -1,0 +1,159 @@
+package com.positivity.invoice.internal.controller;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.invoice.internal.dto.RefundPaymentResponse;
+import com.positivity.invoice.internal.enums.RefundReason;
+import com.positivity.invoice.service.PaymentReversalService;
+import com.positivity.invoice.service.RefundPaymentResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Standalone refunds — refunds not anchored to a captured PaymentIntent (#926).
+ *
+ * <p>Covers cases where the original payment is not in the system: walk-in warranty claims on
+ * sales from a predecessor system, pre-deploy invoices, vendor-paid scenarios. The refund is
+ * anchored to the invoice when one exists, or directly to the customer party otherwise, and is
+ * disbursed out of band (till, check, vendor payment). The service layer gates both endpoints
+ * with the finance-only {@code ISSUE_MANUAL_REFUND} authority.
+ */
+@RestController
+@io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
+@RequestMapping("/v1")
+@PreAuthorize("isAuthenticated()")
+@Tag(name = "StandaloneRefund")
+public class StandaloneRefundController {
+
+    private final PaymentReversalService paymentReversalService;
+
+    public StandaloneRefundController(@NonNull PaymentReversalService paymentReversalService) {
+        this.paymentReversalService = paymentReversalService;
+    }
+
+    @PostMapping("/invoices/{invoiceId}/refunds")
+    @EmitEvent(id = "INVOICE_STANDALONE_REFUND", apiVersion = "1")
+    @Operation(
+            summary = "Record standalone refund for an invoice",
+            description = "Record a refund against an invoice whose original payment is not in the system;"
+                    + " the disbursement itself happens out of band")
+    @ApiResponse(responseCode = "201", description = "Refund recorded")
+    @ApiResponse(responseCode = "404", description = "Invoice not found")
+    @ApiResponse(responseCode = "422", description = "Insufficient refundable amount")
+    public ResponseEntity<RefundPaymentResponse> refundInvoiceStandalone(
+            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull StandaloneRefundRequest request) {
+        RefundPaymentResult saved = paymentReversalService.refundInvoiceStandalone(
+                invoiceId, request.amount(), request.reason(), request.notes(), request.externalReference());
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(saved));
+    }
+
+    @PostMapping("/refunds")
+    @EmitEvent(id = "INVOICE_PARTY_STANDALONE_REFUND", apiVersion = "1")
+    @Operation(
+            summary = "Record standalone refund for a customer party",
+            description = "Record a refund anchored to a customer party when no invoice exists in the system;"
+                    + " the disbursement itself happens out of band")
+    @ApiResponse(responseCode = "201", description = "Refund recorded")
+    @ApiResponse(responseCode = "400", description = "Missing party anchor")
+    public ResponseEntity<RefundPaymentResponse> refundPartyStandalone(
+            @Valid @RequestBody @NonNull PartyStandaloneRefundRequest request) {
+        RefundPaymentResult saved = paymentReversalService.refundPartyStandalone(
+                request.partyId(), request.amount(), request.reason(), request.notes(), request.externalReference());
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(saved));
+    }
+
+    @NonNull
+    private static RefundPaymentResponse toResponse(@NonNull RefundPaymentResult saved) {
+        RefundPaymentResponse response = new RefundPaymentResponse();
+        response.setRefundId(saved.getRefundId());
+        response.setInvoiceId(saved.getInvoiceId());
+        response.setPaymentIntentId(saved.getPaymentIntentId());
+        response.setPartyId(saved.getPartyId());
+        response.setAmount(saved.getAmount());
+        response.setReason(saved.getReason());
+        response.setNotes(saved.getNotes());
+        response.setStatus(saved.getStatus());
+        response.setGatewayReference(saved.getGatewayReference());
+        response.setExternalReference(saved.getExternalReference());
+        response.setCompletedAt(saved.getCompletedAt());
+        return response;
+    }
+
+    @Schema(description = "Request to record a standalone refund against an invoice")
+    private record StandaloneRefundRequest(
+            @NotNull @Positive @Schema(description = "Amount to refund", example = "25.00", requiredMode = REQUIRED)
+            BigDecimal amount,
+
+            @NotNull
+            @Schema(
+                    description = "Reason the refund is being issued",
+                    example = "CUSTOMER_RETURN",
+                    requiredMode = REQUIRED)
+            RefundReason reason,
+
+            @Schema(
+                    description = "Optional free-text notes explaining the refund",
+                    example = "Walk-in warranty claim on a predecessor-system cash sale",
+                    requiredMode = NOT_REQUIRED)
+            String notes,
+
+            @Size(max = 64)
+            @Schema(
+                    description = "Optional correlation id to an external record (e.g. a warranty claim settlement)",
+                    example = "WC-2026-000042",
+                    requiredMode = NOT_REQUIRED)
+            String externalReference) {}
+
+    @Schema(description = "Request to record a standalone refund anchored to a customer party")
+    private record PartyStandaloneRefundRequest(
+            @NotBlank
+            @Size(max = 64)
+            @Schema(
+                    description = "Customer party the refund is anchored to",
+                    example = "party-000123",
+                    requiredMode = REQUIRED)
+            String partyId,
+
+            @NotNull @Positive @Schema(description = "Amount to refund", example = "25.00", requiredMode = REQUIRED)
+            BigDecimal amount,
+
+            @NotNull
+            @Schema(
+                    description = "Reason the refund is being issued",
+                    example = "CUSTOMER_RETURN",
+                    requiredMode = REQUIRED)
+            RefundReason reason,
+
+            @Schema(
+                    description = "Optional free-text notes explaining the refund",
+                    example = "Vendor-paid warranty settlement, no invoice on file",
+                    requiredMode = NOT_REQUIRED)
+            String notes,
+
+            @Size(max = 64)
+            @Schema(
+                    description = "Optional correlation id to an external record (e.g. a warranty claim settlement)",
+                    example = "WC-2026-000042",
+                    requiredMode = NOT_REQUIRED)
+            String externalReference) {}
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/RefundPaymentResponse.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/RefundPaymentResponse.java
@@ -23,18 +23,23 @@ public class RefundPaymentResponse {
             requiredMode = REQUIRED)
     private UUID refundId;
 
-    @NotNull
     @Schema(
-            description = "Identifier of the invoice being refunded",
+            description = "Identifier of the invoice being refunded; absent for party-anchored standalone refunds",
             example = "01960003-0000-7000-8000-000000000040",
-            requiredMode = REQUIRED)
+            requiredMode = NOT_REQUIRED)
     private UUID invoiceId;
 
     @Schema(
-            description = "Identifier of the originating payment intent",
+            description = "Identifier of the originating payment intent; absent for standalone refunds",
             example = "01960003-0000-7000-8000-000000000020",
             requiredMode = NOT_REQUIRED)
     private UUID paymentIntentId;
+
+    @Schema(
+            description = "Customer party the refund is anchored to (standalone refunds)",
+            example = "party-000123",
+            requiredMode = NOT_REQUIRED)
+    private String partyId;
 
     @Schema(description = "Refunded amount", example = "50.00", requiredMode = NOT_REQUIRED)
     private BigDecimal amount;

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/RefundPaymentResponse.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/dto/RefundPaymentResponse.java
@@ -36,7 +36,8 @@ public class RefundPaymentResponse {
     private UUID paymentIntentId;
 
     @Schema(
-            description = "Customer party the refund is anchored to (standalone refunds)",
+            description = "Customer party associated with the refund — the anchor for standalone refunds,"
+                    + " derived from the invoice for invoice- and payment-anchored refunds",
             example = "party-000123",
             requiredMode = NOT_REQUIRED)
     private String partyId;

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/RefundRecord.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/RefundRecord.java
@@ -44,9 +44,10 @@ public class RefundRecord {
     private Invoice invoice;
 
     /**
-     * Customer party anchor for standalone refunds. Set from the invoice for invoice-anchored
-     * standalone refunds, or supplied directly when no invoice exists. At least one of
-     * paymentIntent, invoice, or partyId is always present (DB check constraint).
+     * Customer party associated with the refund. Set from the invoice when one is present
+     * (payment-anchored and invoice-anchored refunds), or supplied directly for party-anchored
+     * standalone refunds where it is the sole anchor. At least one of paymentIntent, invoice,
+     * or partyId is always present (DB check constraint).
      */
     @Column(name = "party_id", length = 64)
     private String partyId;

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/RefundRecord.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/RefundRecord.java
@@ -33,13 +33,23 @@ public class RefundRecord {
     @Column(name = "id", columnDefinition = "UUID", nullable = false, updatable = false)
     private UUID id;
 
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "payment_intent_id", nullable = false)
+    /** Null for standalone refunds — the original payment is not in the system (#926). */
+    @ManyToOne
+    @JoinColumn(name = "payment_intent_id")
     private PaymentIntent paymentIntent;
 
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "invoice_id", nullable = false)
+    /** Null for party-anchored standalone refunds with no invoice in the system (#926). */
+    @ManyToOne
+    @JoinColumn(name = "invoice_id")
     private Invoice invoice;
+
+    /**
+     * Customer party anchor for standalone refunds. Set from the invoice for invoice-anchored
+     * standalone refunds, or supplied directly when no invoice exists. At least one of
+     * paymentIntent, invoice, or partyId is always present (DB check constraint).
+     */
+    @Column(name = "party_id", length = 64)
+    private String partyId;
 
     @Column(name = "amount", nullable = false, precision = 19, scale = 4)
     private BigDecimal amount;

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/RefundRecordRepository.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/RefundRecordRepository.java
@@ -9,4 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefundRecordRepository extends JpaRepository<RefundRecord, UUID> {
 
     List<RefundRecord> findByPaymentIntent_Id(@NonNull UUID paymentIntentId);
+
+    List<RefundRecord> findByInvoice_Id(@NonNull UUID invoiceId);
+
+    List<RefundRecord> findByPartyIdAndPaymentIntentIsNull(@NonNull String partyId);
 }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/PaymentReversalServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/PaymentReversalServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.invoice.internal.service;
 
+import com.positivity.invoice.internal.entity.Invoice;
 import com.positivity.invoice.internal.entity.PaymentIntent;
 import com.positivity.invoice.internal.entity.RefundRecord;
 import com.positivity.invoice.internal.enums.PaymentIntentStatus;
@@ -8,6 +9,7 @@ import com.positivity.invoice.internal.enums.RefundStatus;
 import com.positivity.invoice.internal.enums.VoidReason;
 import com.positivity.invoice.internal.exception.InsufficientRefundableAmountException;
 import com.positivity.invoice.internal.exception.InvalidPaymentStateException;
+import com.positivity.invoice.internal.exception.InvoiceNotFoundException;
 import com.positivity.invoice.internal.exception.PaymentGatewayException;
 import com.positivity.invoice.internal.exception.PaymentIntentNotFoundException;
 import com.positivity.invoice.internal.exception.PaymentWindowExpiredException;
@@ -15,6 +17,7 @@ import com.positivity.invoice.internal.payment.GatewayPaymentResult;
 import com.positivity.invoice.internal.payment.GatewayRefundRequest;
 import com.positivity.invoice.internal.payment.GatewayVoidRequest;
 import com.positivity.invoice.internal.payment.PaymentGatewayPort;
+import com.positivity.invoice.internal.repository.InvoiceRepository;
 import com.positivity.invoice.internal.repository.PaymentIntentRepository;
 import com.positivity.invoice.internal.repository.RefundRecordRepository;
 import com.positivity.invoice.service.PaymentReversalService;
@@ -38,22 +41,26 @@ public class PaymentReversalServiceImpl implements PaymentReversalService {
 
     private static final String VOID_PAYMENT = "VOID_PAYMENT";
     private static final String REFUND_PAYMENT = "REFUND_PAYMENT";
+    private static final String ISSUE_MANUAL_REFUND = "ISSUE_MANUAL_REFUND";
     private static final String SUPERVISOR_OVERRIDE = "SUPERVISOR_OVERRIDE";
     private static final long VOID_WINDOW_HOURS = 24L;
     private static final long REFUND_WINDOW_DAYS = 180L;
 
     private final PaymentIntentRepository paymentIntentRepository;
     private final RefundRecordRepository refundRecordRepository;
+    private final InvoiceRepository invoiceRepository;
     private final PaymentGatewayPort paymentGatewayPort;
     private final Clock clock;
 
     public PaymentReversalServiceImpl(
             @NonNull PaymentIntentRepository paymentIntentRepository,
             @NonNull RefundRecordRepository refundRecordRepository,
+            @NonNull InvoiceRepository invoiceRepository,
             @NonNull PaymentGatewayPort paymentGatewayPort,
             @NonNull Clock clock) {
         this.paymentIntentRepository = paymentIntentRepository;
         this.refundRecordRepository = refundRecordRepository;
+        this.invoiceRepository = invoiceRepository;
         this.paymentGatewayPort = paymentGatewayPort;
         this.clock = clock;
     }
@@ -171,6 +178,7 @@ public class PaymentReversalServiceImpl implements PaymentReversalService {
         RefundRecord refundRecord = new RefundRecord();
         refundRecord.setPaymentIntent(paymentIntent);
         refundRecord.setInvoice(paymentIntent.getInvoice());
+        refundRecord.setPartyId(paymentIntent.getInvoice().getPartyId());
         refundRecord.setAmount(amount);
         refundRecord.setReason(reason);
         refundRecord.setNotes(notes);
@@ -187,6 +195,110 @@ public class PaymentReversalServiceImpl implements PaymentReversalService {
         return toResult(saved);
     }
 
+    @Override
+    @NonNull
+    public RefundPaymentResult refundInvoiceStandalone(
+            @NonNull UUID invoiceId,
+            @NonNull BigDecimal amount,
+            @NonNull RefundReason reason,
+            @Nullable String notes,
+            @Nullable String externalReference) {
+        requireAuthority(ISSUE_MANUAL_REFUND);
+        Invoice invoice =
+                invoiceRepository.findById(invoiceId).orElseThrow(() -> new InvoiceNotFoundException(invoiceId));
+
+        List<RefundRecord> existingRefunds = refundRecordRepository.findByInvoice_Id(invoiceId);
+        String normalizedReference = normalizeExternalReference(externalReference);
+        RefundRecord replayed = findStandaloneReplay(existingRefunds, normalizedReference);
+        if (replayed != null) {
+            return toResult(replayed);
+        }
+
+        // Without a captured amount to bound against, cap cumulative refunds (payment-anchored
+        // and standalone alike) at the invoice total so an invoice can never over-refund.
+        BigDecimal alreadyRefunded = existingRefunds.stream()
+                .filter(refund -> refund.getStatus() != RefundStatus.FAILED)
+                .map(RefundRecord::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal refundable = invoice.getTotal().subtract(alreadyRefunded);
+        if (amount.compareTo(refundable) > 0) {
+            throw new InsufficientRefundableAmountException(
+                    "Insufficient refundable amount: " + refundable + " < " + amount);
+        }
+
+        return saveStandaloneRefund(invoice, invoice.getPartyId(), amount, reason, notes, normalizedReference);
+    }
+
+    @Override
+    @NonNull
+    public RefundPaymentResult refundPartyStandalone(
+            @NonNull String partyId,
+            @NonNull BigDecimal amount,
+            @NonNull RefundReason reason,
+            @Nullable String notes,
+            @Nullable String externalReference) {
+        requireAuthority(ISSUE_MANUAL_REFUND);
+        if (partyId.isBlank()) {
+            throw new IllegalArgumentException("partyId must not be blank");
+        }
+
+        String normalizedReference = normalizeExternalReference(externalReference);
+        RefundRecord replayed = findStandaloneReplay(
+                refundRecordRepository.findByPartyIdAndPaymentIntentIsNull(partyId.trim()), normalizedReference);
+        if (replayed != null) {
+            return toResult(replayed);
+        }
+
+        return saveStandaloneRefund(null, partyId.trim(), amount, reason, notes, normalizedReference);
+    }
+
+    /**
+     * Idempotent replay guard for standalone refunds, mirroring {@link #refundPayment}: a retry
+     * carrying the same externalReference returns the existing non-FAILED standalone record
+     * instead of paying the customer twice.
+     */
+    @Nullable
+    private static RefundRecord findStandaloneReplay(
+            @NonNull List<RefundRecord> candidates, @Nullable String normalizedReference) {
+        if (normalizedReference == null) {
+            return null;
+        }
+        return candidates.stream()
+                .filter(existing -> existing.getPaymentIntent() == null)
+                .filter(existing -> existing.getStatus() != RefundStatus.FAILED)
+                .filter(existing -> normalizedReference.equals(existing.getExternalReference()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Persists a standalone refund. There is no PaymentIntent and therefore no gateway leg —
+     * the disbursement itself happens out of band (till, check, vendor payment) — so the record
+     * completes immediately and exists to carry the refund liability.
+     */
+    @NonNull
+    private RefundPaymentResult saveStandaloneRefund(
+            @Nullable Invoice invoice,
+            @Nullable String partyId,
+            @NonNull BigDecimal amount,
+            @NonNull RefundReason reason,
+            @Nullable String notes,
+            @Nullable String normalizedReference) {
+        Instant now = Instant.now(clock);
+        RefundRecord refundRecord = new RefundRecord();
+        refundRecord.setInvoice(invoice);
+        refundRecord.setPartyId(partyId);
+        refundRecord.setAmount(amount);
+        refundRecord.setReason(reason);
+        refundRecord.setNotes(notes);
+        refundRecord.setExternalReference(normalizedReference);
+        refundRecord.setRequestedBy(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
+        refundRecord.setRequestedAt(now);
+        refundRecord.setStatus(RefundStatus.COMPLETED);
+        refundRecord.setCompletedAt(now);
+        return toResult(refundRecordRepository.save(refundRecord));
+    }
+
     @NonNull
     private static RefundPaymentResult toResult(@NonNull RefundRecord saved) {
         RefundPaymentResult resultDto = new RefundPaymentResult();
@@ -197,6 +309,7 @@ public class PaymentReversalServiceImpl implements PaymentReversalService {
                 saved.getPaymentIntent() == null
                         ? null
                         : saved.getPaymentIntent().getId());
+        resultDto.setPartyId(saved.getPartyId());
         resultDto.setAmount(saved.getAmount());
         resultDto.setReason(saved.getReason());
         resultDto.setNotes(saved.getNotes());

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/PaymentReversalServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/PaymentReversalServiceImpl.java
@@ -242,9 +242,15 @@ public class PaymentReversalServiceImpl implements PaymentReversalService {
             throw new IllegalArgumentException("partyId must not be blank");
         }
 
+        // Restrict replay candidates to purely party-anchored records: the lookup also returns
+        // invoice-anchored standalone refunds (partyId is stamped from the invoice), and a
+        // party-endpoint retry must not replay a record carrying a different anchor shape.
         String normalizedReference = normalizeExternalReference(externalReference);
-        RefundRecord replayed = findStandaloneReplay(
-                refundRecordRepository.findByPartyIdAndPaymentIntentIsNull(partyId.trim()), normalizedReference);
+        List<RefundRecord> candidates =
+                refundRecordRepository.findByPartyIdAndPaymentIntentIsNull(partyId.trim()).stream()
+                        .filter(existing -> existing.getInvoice() == null)
+                        .toList();
+        RefundRecord replayed = findStandaloneReplay(candidates, normalizedReference);
         if (replayed != null) {
             return toResult(replayed);
         }

--- a/pos-invoice/src/main/java/com/positivity/invoice/service/PaymentReversalService.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/service/PaymentReversalService.java
@@ -20,4 +20,29 @@ public interface PaymentReversalService {
             @NonNull RefundReason reason,
             @Nullable String notes,
             @Nullable String externalReference);
+
+    /**
+     * Records a standalone refund anchored to an invoice whose original payment is not in the
+     * system (predecessor-system sale, pre-deploy invoice, vendor-paid). Disbursement happens
+     * out of band; the record carries the refund liability (#926).
+     */
+    @NonNull
+    RefundPaymentResult refundInvoiceStandalone(
+            @NonNull UUID invoiceId,
+            @NonNull BigDecimal amount,
+            @NonNull RefundReason reason,
+            @Nullable String notes,
+            @Nullable String externalReference);
+
+    /**
+     * Records a standalone refund anchored to a customer party when no invoice exists in the
+     * system. Disbursement happens out of band; the record carries the refund liability (#926).
+     */
+    @NonNull
+    RefundPaymentResult refundPartyStandalone(
+            @NonNull String partyId,
+            @NonNull BigDecimal amount,
+            @NonNull RefundReason reason,
+            @Nullable String notes,
+            @Nullable String externalReference);
 }

--- a/pos-invoice/src/main/java/com/positivity/invoice/service/RefundPaymentResult.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/service/RefundPaymentResult.java
@@ -12,6 +12,7 @@ public class RefundPaymentResult {
     private UUID refundId;
     private UUID invoiceId;
     private UUID paymentIntentId;
+    private String partyId;
     private BigDecimal amount;
     private RefundReason reason;
     private String notes;

--- a/pos-invoice/src/main/resources/db/migration/V10__standalone_refunds.sql
+++ b/pos-invoice/src/main/resources/db/migration/V10__standalone_refunds.sql
@@ -1,0 +1,17 @@
+-- Standalone refunds (#926):
+--   * refund_records no longer requires a captured PaymentIntent — walk-in warranty claims on
+--     cash sales from predecessor systems, pre-deploy invoices, and vendor-paid scenarios have
+--     no PaymentIntent to anchor to;
+--   * payment_intent_id and invoice_id become nullable, a party_id anchor is added for
+--     no-invoice cases, and a check constraint guarantees every refund keeps at least one
+--     anchor (payment intent, invoice, or party).
+-- H2-compatible: plain ADD COLUMN, ALTER COLUMN ... DROP NOT NULL, and named-constraint ADD only.
+
+ALTER TABLE refund_records ALTER COLUMN payment_intent_id DROP NOT NULL;
+
+ALTER TABLE refund_records ALTER COLUMN invoice_id DROP NOT NULL;
+
+ALTER TABLE refund_records ADD COLUMN party_id character varying(64);
+
+ALTER TABLE refund_records ADD CONSTRAINT refund_records_anchor_check
+    CHECK (payment_intent_id IS NOT NULL OR invoice_id IS NOT NULL OR party_id IS NOT NULL);

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/controller/StandaloneRefundControllerTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/controller/StandaloneRefundControllerTest.java
@@ -1,0 +1,154 @@
+package com.positivity.invoice.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.invoice.internal.enums.RefundReason;
+import com.positivity.invoice.internal.enums.RefundStatus;
+import com.positivity.invoice.internal.exception.InsufficientRefundableAmountException;
+import com.positivity.invoice.internal.exception.InvoiceNotFoundException;
+import com.positivity.invoice.service.PaymentReversalService;
+import com.positivity.invoice.service.RefundPaymentResult;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Controller-layer unit tests for {@link StandaloneRefundController} covering issue #926:
+ * standalone refunds not anchored to a captured PaymentIntent.
+ *
+ * <p>Uses standalone MockMvc (no Spring context) with Mockito for the service layer. Authority
+ * enforcement (ISSUE_MANUAL_REFUND) is validated at the service layer in
+ * {@link com.positivity.invoice.internal.service.PaymentReversalServiceImplTest}; this layer
+ * asserts HTTP response codes.
+ */
+@ExtendWith(MockitoExtension.class)
+class StandaloneRefundControllerTest {
+
+    private static final UUID INVOICE_ID = UUID.fromString("00000000-0000-7000-8000-000000000001");
+    private static final UUID REFUND_ID = UUID.fromString("00000000-0000-7000-8000-000000000005");
+
+    @Mock
+    private PaymentReversalService paymentReversalService;
+
+    @InjectMocks
+    private StandaloneRefundController standaloneRefundController;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-01-15T14:30:22Z"), ZoneOffset.UTC);
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(standaloneRefundController)
+                .setControllerAdvice(new PaymentReversalExceptionHandler(clock))
+                .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /v1/invoices/{invoiceId}/refunds — invoice-anchored standalone refund
+    // -------------------------------------------------------------------------
+
+    @Test
+    void refundInvoiceStandalone_returns201() throws Exception {
+        RefundPaymentResult saved = new RefundPaymentResult();
+        saved.setRefundId(REFUND_ID);
+        saved.setInvoiceId(INVOICE_ID);
+        saved.setPartyId("party-0001");
+        saved.setAmount(BigDecimal.valueOf(120.00));
+        saved.setReason(RefundReason.OTHER);
+        saved.setStatus(RefundStatus.COMPLETED);
+        saved.setExternalReference("WC-2026-000042");
+        saved.setCompletedAt(Instant.parse("2026-01-15T14:30:22Z"));
+
+        when(paymentReversalService.refundInvoiceStandalone(eq(INVOICE_ID), any(), any(), any(), any()))
+                .thenReturn(saved);
+
+        mockMvc.perform(post("/v1/invoices/{invoiceId}/refunds", INVOICE_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"amount\":120.00,\"reason\":\"OTHER\","
+                                + "\"externalReference\":\"WC-2026-000042\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.refundId").value(REFUND_ID.toString()))
+                .andExpect(jsonPath("$.partyId").value("party-0001"))
+                .andExpect(jsonPath("$.paymentIntentId").doesNotExist())
+                .andExpect(jsonPath("$.status").value("COMPLETED"));
+    }
+
+    @Test
+    void refundInvoiceStandalone_invoiceNotFound_returns404() throws Exception {
+        doThrow(new InvoiceNotFoundException(INVOICE_ID))
+                .when(paymentReversalService)
+                .refundInvoiceStandalone(any(), any(), any(), any(), any());
+
+        mockMvc.perform(post("/v1/invoices/{invoiceId}/refunds", INVOICE_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"amount\":50.00,\"reason\":\"OTHER\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void refundInvoiceStandalone_exceedsRefundable_returns422() throws Exception {
+        doThrow(new InsufficientRefundableAmountException("Insufficient refundable amount: 50.00 < 100.00"))
+                .when(paymentReversalService)
+                .refundInvoiceStandalone(any(), any(), any(), any(), any());
+
+        mockMvc.perform(post("/v1/invoices/{invoiceId}/refunds", INVOICE_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"amount\":100.00,\"reason\":\"OTHER\"}"))
+                .andExpect(status().is(422));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /v1/refunds — party-anchored standalone refund
+    // -------------------------------------------------------------------------
+
+    @Test
+    void refundPartyStandalone_returns201() throws Exception {
+        RefundPaymentResult saved = new RefundPaymentResult();
+        saved.setRefundId(REFUND_ID);
+        saved.setPartyId("party-0009");
+        saved.setAmount(BigDecimal.valueOf(75.00));
+        saved.setReason(RefundReason.OTHER);
+        saved.setStatus(RefundStatus.COMPLETED);
+        saved.setExternalReference("WC-2026-000043");
+
+        when(paymentReversalService.refundPartyStandalone(eq("party-0009"), any(), any(), any(), any()))
+                .thenReturn(saved);
+
+        mockMvc.perform(post("/v1/refunds")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"partyId\":\"party-0009\",\"amount\":75.00,\"reason\":\"OTHER\","
+                                + "\"externalReference\":\"WC-2026-000043\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.refundId").value(REFUND_ID.toString()))
+                .andExpect(jsonPath("$.partyId").value("party-0009"))
+                .andExpect(jsonPath("$.invoiceId").doesNotExist());
+    }
+
+    @Test
+    void refundPartyStandalone_missingPartyId_returns400() throws Exception {
+        mockMvc.perform(post("/v1/refunds")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"amount\":75.00,\"reason\":\"OTHER\"}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/PaymentReversalServiceImplTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/PaymentReversalServiceImplTest.java
@@ -667,6 +667,34 @@ class PaymentReversalServiceImplTest {
         verifyNoInteractions(refundRecordRepository, paymentGatewayPort);
     }
 
+    /**
+     * The party-anchored replay guard must ignore invoice-anchored standalone refunds even
+     * though they carry the same partyId (stamped from the invoice) — a party-endpoint retry
+     * must never replay a record with a different anchor shape.
+     */
+    @Test
+    void refundPartyStandalone_invoiceAnchoredRecordSameReference_isNotReplayed() {
+        withAuthorities("ISSUE_MANUAL_REFUND");
+
+        RefundRecord invoiceAnchored = new RefundRecord();
+        invoiceAnchored.setId(UUID.fromString("00000000-0000-7000-8000-000000000044"));
+        invoiceAnchored.setInvoice(invoice(INVOICE_ID));
+        invoiceAnchored.setPartyId("party-0009");
+        invoiceAnchored.setAmount(BigDecimal.valueOf(75_00, 2));
+        invoiceAnchored.setStatus(RefundStatus.COMPLETED);
+        invoiceAnchored.setExternalReference("WC-2026-000043");
+        when(refundRecordRepository.findByPartyIdAndPaymentIntentIsNull("party-0009"))
+                .thenReturn(List.of(invoiceAnchored));
+        when(refundRecordRepository.save(any(RefundRecord.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        RefundPaymentResult result = paymentReversalServiceImpl.refundPartyStandalone(
+                "party-0009", BigDecimal.valueOf(75_00, 2), RefundReason.OTHER, null, "WC-2026-000043");
+
+        assertThat(result.getRefundId()).isNotEqualTo(invoiceAnchored.getId());
+        assertThat(result.getInvoiceId()).isNull();
+        verify(refundRecordRepository).save(any(RefundRecord.class));
+    }
+
     @Test
     void refundPartyStandalone_replaySameExternalReference_returnsExistingRecord() {
         withAuthorities("ISSUE_MANUAL_REFUND");

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/PaymentReversalServiceImplTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/PaymentReversalServiceImplTest.java
@@ -18,6 +18,7 @@ import com.positivity.invoice.internal.enums.RefundStatus;
 import com.positivity.invoice.internal.enums.VoidReason;
 import com.positivity.invoice.internal.exception.InsufficientRefundableAmountException;
 import com.positivity.invoice.internal.exception.InvalidPaymentStateException;
+import com.positivity.invoice.internal.exception.InvoiceNotFoundException;
 import com.positivity.invoice.internal.exception.PaymentGatewayException;
 import com.positivity.invoice.internal.exception.PaymentIntentNotFoundException;
 import com.positivity.invoice.internal.exception.PaymentWindowExpiredException;
@@ -25,8 +26,10 @@ import com.positivity.invoice.internal.payment.GatewayPaymentResult;
 import com.positivity.invoice.internal.payment.GatewayRefundRequest;
 import com.positivity.invoice.internal.payment.GatewayVoidRequest;
 import com.positivity.invoice.internal.payment.PaymentGatewayPort;
+import com.positivity.invoice.internal.repository.InvoiceRepository;
 import com.positivity.invoice.internal.repository.PaymentIntentRepository;
 import com.positivity.invoice.internal.repository.RefundRecordRepository;
+import com.positivity.invoice.service.RefundPaymentResult;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
@@ -98,6 +101,9 @@ class PaymentReversalServiceImplTest {
 
     @Mock
     private RefundRecordRepository refundRecordRepository;
+
+    @Mock
+    private InvoiceRepository invoiceRepository;
 
     @Mock
     private PaymentGatewayPort paymentGatewayPort;
@@ -527,6 +533,161 @@ class PaymentReversalServiceImplTest {
     }
 
     // -------------------------------------------------------------------------
+    // Issue #926 — standalone refunds (no captured PaymentIntent)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Invoice-anchored standalone refund: no gateway leg, record saved COMPLETED with the
+     * invoice's party id, no PaymentIntent, and completedAt stamped from the clock.
+     */
+    @Test
+    void refundInvoiceStandalone_success_savesCompletedRecordWithoutGateway() {
+        withAuthorities("ISSUE_MANUAL_REFUND");
+        Invoice invoice = invoiceWithTotal(BigDecimal.valueOf(500_00, 2));
+        when(invoiceRepository.findById(INVOICE_ID)).thenReturn(Optional.of(invoice));
+        when(refundRecordRepository.findByInvoice_Id(INVOICE_ID)).thenReturn(List.of());
+        when(refundRecordRepository.save(any(RefundRecord.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        paymentReversalServiceImpl.refundInvoiceStandalone(
+                INVOICE_ID, BigDecimal.valueOf(120_00, 2), RefundReason.OTHER, "walk-in claim", " WC-2026-000042 ");
+
+        ArgumentCaptor<RefundRecord> captor = ArgumentCaptor.forClass(RefundRecord.class);
+        verify(refundRecordRepository).save(captor.capture());
+        RefundRecord saved = captor.getValue();
+        assertThat(saved.getPaymentIntent()).isNull();
+        assertThat(saved.getInvoice()).isSameAs(invoice);
+        assertThat(saved.getPartyId()).isEqualTo("party-0001");
+        assertThat(saved.getStatus()).isEqualTo(RefundStatus.COMPLETED);
+        assertThat(saved.getGatewayReference()).isNull();
+        assertThat(saved.getExternalReference()).isEqualTo("WC-2026-000042");
+        assertThat(saved.getCompletedAt()).isEqualTo(CLOCK_INSTANT);
+        verifyNoInteractions(paymentGatewayPort);
+    }
+
+    /** Standalone refunds require the finance-only ISSUE_MANUAL_REFUND authority. */
+    @Test
+    void refundInvoiceStandalone_missingPermission_throwsAccessDeniedException() {
+        withAuthorities("REFUND_PAYMENT"); // captured-payment authority is not enough
+
+        assertThatThrownBy(() -> paymentReversalServiceImpl.refundInvoiceStandalone(
+                        INVOICE_ID, BigDecimal.valueOf(50), RefundReason.OTHER, null, null))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(invoiceRepository, refundRecordRepository, paymentGatewayPort);
+    }
+
+    @Test
+    void refundInvoiceStandalone_invoiceNotFound_throwsInvoiceNotFoundException() {
+        withAuthorities("ISSUE_MANUAL_REFUND");
+        when(invoiceRepository.findById(INVOICE_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> paymentReversalServiceImpl.refundInvoiceStandalone(
+                        INVOICE_ID, BigDecimal.valueOf(50), RefundReason.OTHER, null, null))
+                .isInstanceOf(InvoiceNotFoundException.class);
+
+        verifyNoInteractions(refundRecordRepository, paymentGatewayPort);
+    }
+
+    /**
+     * Cumulative refunds on the invoice (payment-anchored and standalone alike) are capped at
+     * the invoice total: total=500, prior refund 450 → requesting 100 exceeds the remaining 50.
+     */
+    @Test
+    void refundInvoiceStandalone_exceedsInvoiceTotal_throwsInsufficientRefundableAmountException() {
+        withAuthorities("ISSUE_MANUAL_REFUND");
+        Invoice invoice = invoiceWithTotal(BigDecimal.valueOf(500_00, 2));
+        when(invoiceRepository.findById(INVOICE_ID)).thenReturn(Optional.of(invoice));
+
+        RefundRecord prior = new RefundRecord();
+        prior.setAmount(BigDecimal.valueOf(450_00, 2));
+        prior.setStatus(RefundStatus.COMPLETED);
+        when(refundRecordRepository.findByInvoice_Id(INVOICE_ID)).thenReturn(List.of(prior));
+
+        assertThatThrownBy(() -> paymentReversalServiceImpl.refundInvoiceStandalone(
+                        INVOICE_ID, BigDecimal.valueOf(100_00, 2), RefundReason.OTHER, null, null))
+                .isInstanceOf(InsufficientRefundableAmountException.class);
+
+        verify(refundRecordRepository, never()).save(any());
+    }
+
+    /**
+     * Idempotent replay guard: retrying with the same externalReference returns the existing
+     * non-FAILED standalone record instead of recording a second refund.
+     */
+    @Test
+    void refundInvoiceStandalone_replaySameExternalReference_returnsExistingRecord() {
+        withAuthorities("ISSUE_MANUAL_REFUND");
+        Invoice invoice = invoiceWithTotal(BigDecimal.valueOf(500_00, 2));
+        when(invoiceRepository.findById(INVOICE_ID)).thenReturn(Optional.of(invoice));
+
+        RefundRecord existing = new RefundRecord();
+        existing.setId(UUID.fromString("00000000-0000-7000-8000-000000000042"));
+        existing.setInvoice(invoice);
+        existing.setAmount(BigDecimal.valueOf(120_00, 2));
+        existing.setStatus(RefundStatus.COMPLETED);
+        existing.setExternalReference("WC-2026-000042");
+        when(refundRecordRepository.findByInvoice_Id(INVOICE_ID)).thenReturn(List.of(existing));
+
+        RefundPaymentResult result = paymentReversalServiceImpl.refundInvoiceStandalone(
+                INVOICE_ID, BigDecimal.valueOf(120_00, 2), RefundReason.OTHER, null, "WC-2026-000042");
+
+        assertThat(result.getRefundId()).isEqualTo(existing.getId());
+        verify(refundRecordRepository, never()).save(any());
+    }
+
+    /** Party-anchored standalone refund: no invoice in the system, anchored to the party id. */
+    @Test
+    void refundPartyStandalone_success_savesCompletedRecordAnchoredToParty() {
+        withAuthorities("ISSUE_MANUAL_REFUND");
+        when(refundRecordRepository.findByPartyIdAndPaymentIntentIsNull("party-0009"))
+                .thenReturn(List.of());
+        when(refundRecordRepository.save(any(RefundRecord.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        paymentReversalServiceImpl.refundPartyStandalone(
+                " party-0009 ", BigDecimal.valueOf(75_00, 2), RefundReason.OTHER, null, "WC-2026-000043");
+
+        ArgumentCaptor<RefundRecord> captor = ArgumentCaptor.forClass(RefundRecord.class);
+        verify(refundRecordRepository).save(captor.capture());
+        RefundRecord saved = captor.getValue();
+        assertThat(saved.getPaymentIntent()).isNull();
+        assertThat(saved.getInvoice()).isNull();
+        assertThat(saved.getPartyId()).isEqualTo("party-0009");
+        assertThat(saved.getStatus()).isEqualTo(RefundStatus.COMPLETED);
+        verifyNoInteractions(paymentGatewayPort);
+    }
+
+    @Test
+    void refundPartyStandalone_blankPartyId_throwsIllegalArgumentException() {
+        withAuthorities("ISSUE_MANUAL_REFUND");
+
+        assertThatThrownBy(() -> paymentReversalServiceImpl.refundPartyStandalone(
+                        "   ", BigDecimal.valueOf(50), RefundReason.OTHER, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verifyNoInteractions(refundRecordRepository, paymentGatewayPort);
+    }
+
+    @Test
+    void refundPartyStandalone_replaySameExternalReference_returnsExistingRecord() {
+        withAuthorities("ISSUE_MANUAL_REFUND");
+
+        RefundRecord existing = new RefundRecord();
+        existing.setId(UUID.fromString("00000000-0000-7000-8000-000000000043"));
+        existing.setPartyId("party-0009");
+        existing.setAmount(BigDecimal.valueOf(75_00, 2));
+        existing.setStatus(RefundStatus.COMPLETED);
+        existing.setExternalReference("WC-2026-000043");
+        when(refundRecordRepository.findByPartyIdAndPaymentIntentIsNull("party-0009"))
+                .thenReturn(List.of(existing));
+
+        RefundPaymentResult result = paymentReversalServiceImpl.refundPartyStandalone(
+                "party-0009", BigDecimal.valueOf(75_00, 2), RefundReason.OTHER, null, "WC-2026-000043");
+
+        assertThat(result.getRefundId()).isEqualTo(existing.getId());
+        verify(refundRecordRepository, never()).save(any());
+    }
+
+    // -------------------------------------------------------------------------
     // PaymentGatewayException — direct constructor coverage
     // -------------------------------------------------------------------------
 
@@ -592,6 +753,14 @@ class PaymentReversalServiceImplTest {
     private Invoice invoice(UUID id) {
         Invoice invoice = new Invoice();
         invoice.setId(id);
+        return invoice;
+    }
+
+    /** Builds an invoice fixture for standalone-refund tests (total + party anchor). */
+    private Invoice invoiceWithTotal(BigDecimal total) {
+        Invoice invoice = invoice(INVOICE_ID);
+        invoice.setTotal(total);
+        invoice.setPartyId("party-0001");
         return invoice;
     }
 


### PR DESCRIPTION
Closes #926

## Problem

`POST /v1/invoices/{invoiceId}/payments/{paymentId}/refunds` requires an existing captured `PaymentIntent`, so warranty REFUND settlements were impossible when the original payment isn't in the system (walk-in claim on a predecessor-system cash sale, pre-deploy invoices, vendor-paid scenarios). Those cases were settled as `GOODWILL`/`NO_ACTION` with manual till handling, under-reporting refund liability.

## Changes

### New endpoints (pos-invoice)

- **`POST /v1/invoices/{invoiceId}/refunds`** — invoice-anchored standalone refund, for invoices whose original payment is not in the system. Without a captured amount to bound against, cumulative refunds on the invoice (payment-anchored and standalone alike) are capped at the invoice total (`422 INSUFFICIENT_REFUNDABLE_AMOUNT` beyond that).
- **`POST /v1/refunds`** — party-anchored standalone refund for no-invoice cases (`partyId` required in the body).

Both paths:
- are gated by the existing finance-only **`ISSUE_MANUAL_REFUND`** authority (`.github/permissions/permissions_v1.yml`), enforced in the service layer like `REFUND_PAYMENT`;
- reuse the `RefundRecord` lifecycle and the **`externalReference` idempotent-replay guard** from the captured-payment refund path — a retry carrying the same reference returns the existing non-FAILED standalone record instead of paying the customer twice;
- have **no gateway leg** — disbursement happens out of band (till, check, vendor payment) — so records save as `COMPLETED` immediately and exist to carry the refund liability;
- match the existing refund path's tax handling (the recorded amount only; no tax computation, same as `refundPayment`).

### Schema (`V10__standalone_refunds.sql`)

- `refund_records.payment_intent_id` and `invoice_id` become nullable;
- new `party_id varchar(64)` anchor column;
- check constraint guarantees every refund keeps at least one anchor (payment intent, invoice, or party).

Verified H2-compatible against the repo's exact H2 version (2.4.240), including constraint enforcement.

### Supporting changes

- `PaymentReversalService` gains `refundInvoiceStandalone` / `refundPartyStandalone`; `RefundPaymentResult`/`RefundPaymentResponse` expose `partyId`.
- New `INVOICE_STANDALONE_REFUND` / `INVOICE_PARTY_STANDALONE_REFUND` event registrations (`write` preset).
- `PaymentReversalExceptionHandler` extended to the new controller, with `InvoiceNotFoundException → 404`.
- Payment-anchored refunds now also stamp `party_id`, so all refund records are uniformly queryable by party.

## API contract

Per BACKEND_CONTRACT_GUIDE.md: this PR adds two endpoints to the invoice domain contract surface — `POST /v1/invoices/{invoiceId}/refunds` and `POST /v1/refunds` — both returning the existing `RefundPaymentResponse` shape extended with an optional `partyId` field (`invoiceId`/`paymentIntentId` become optional in the response since standalone refunds may carry neither). No existing request/response fields changed; the aggregated OpenAPI spec picks the new operations up from the controller annotations. The invoice domain contract guide entry should gain these two operations when the durion-side contract is synced.

## Testing

- 8 new service-layer tests (authority gate, invoice-not-found, invoice-total cap, replay guard, party anchoring, blank-party rejection) and 5 new controller tests (201/404/422/400 mappings).
- Full pos-invoice suite: 211/211 green; `package` passes Checkstyle/Spotless/SpotBugs.

## Out of scope / follow-up

pos-warranty's settlement flow still calls the payment-anchored endpoint; wiring its `InvoiceClient` to the new endpoints when no `paymentId` exists is a #920-side follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119v99RUnK46SXiJC2U3dzw