### PR TITLE
Fix Kafka startup failure: use spring-boot-starter-kafka for Boot 4 auto-configuration

### DIFF
--- a/pos-accounting/pom.xml
+++ b/pos-accounting/pom.xml
@@ -78,10 +78,12 @@
             <version>${opentelemetry.version}</version>
         </dependency>
 
-        <!-- Kafka producer/consumer support -->
+        <!-- Kafka producer/consumer support. Spring Boot 4 moved KafkaAutoConfiguration out of
+             spring-boot-autoconfigure into spring-boot-kafka, so the bare spring-kafka dependency
+             no longer yields an auto-configured KafkaTemplate/listener container factory. -->
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
 
         <!-- Spring Retry -->

--- a/pos-catalog/pom.xml
+++ b/pos-catalog/pom.xml
@@ -85,8 +85,8 @@
         </dependency>
         <!-- ADR-0044 §6 (#899): inventory availability/lead-time replica feed -->
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>com.positivity</groupId>

--- a/pos-customer/pom.xml
+++ b/pos-customer/pom.xml
@@ -58,8 +58,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
 
         <!-- Caching -->

--- a/pos-inventory/pom.xml
+++ b/pos-inventory/pom.xml
@@ -121,8 +121,8 @@
         </dependency>
         <!-- ADR-0044 §6 (#892): location replica feed from location.events.v1 -->
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>com.positivity</groupId>

--- a/pos-invoice/pom.xml
+++ b/pos-invoice/pom.xml
@@ -59,8 +59,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>com.positivity</groupId>

--- a/pos-location/pom.xml
+++ b/pos-location/pom.xml
@@ -177,8 +177,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
     </dependencies>
 

--- a/pos-warranty/pom.xml
+++ b/pos-warranty/pom.xml
@@ -122,8 +122,8 @@
         </dependency>
         <!-- Kafka producer for the transactional outbox drain (ADR-0044 §4, PRD §9.3) -->
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
         <!-- Domain-event envelope + topic naming (DomainEventEnvelope, DomainTopics) -->
         <dependency>

--- a/pos-workorder/pom.xml
+++ b/pos-workorder/pom.xml
@@ -119,8 +119,8 @@
         </dependency>
         <!-- Kafka producer/consumer support -->
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
         <!-- PostgreSQL Driver -->
         <dependency>


### PR DESCRIPTION
## Problem

pos-accounting failed to start in Docker:

```
Parameter 0 of constructor in com.positivity.accounting.internal.config.WorkorderCommandPublisher
required a bean of type 'org.springframework.kafka.core.KafkaTemplate' that could not be found.
```

## Root cause

Spring Boot 4 moved `KafkaAutoConfiguration` out of `spring-boot-autoconfigure` into the new `spring-boot-kafka` module (the 4.1.0 autoconfigure jar contains zero Kafka classes). Modules depending on bare `org.springframework.kafka:spring-kafka` therefore get no auto-configured `KafkaTemplate` or listener container factory.

pos-accounting was the first to hit it because compose defaults `POS_ACCOUNTING_KAFKA_ENABLED=true` (since the warranty rollout) and its image was freshly rebuilt. The same failure was reproduced from current source with pos-warranty (`POS_WARRANTY_KAFKA_ENABLED=true` by default) — its running container only survives on a stale pre-Boot-4 image. All other bare-`spring-kafka` modules carry the same latent bug behind their `@ConditionalOnProperty` kafka flags.

The five modules using `spring-cloud-starter-stream-kafka` (people, people-contact, security-service, shop-manager, vehicle-inventory) are unaffected — the binder brings `spring-boot-kafka:4.1.0` transitively.

## Change

Replace `org.springframework.kafka:spring-kafka` with `org.springframework.boot:spring-boot-starter-kafka` (version managed by the Boot parent; brings `spring-kafka` plus the `spring-boot-kafka` auto-configuration module) in:

- pos-accounting (with a comment documenting the Boot 4 move)
- pos-catalog, pos-customer, pos-inventory, pos-invoice, pos-location, pos-warranty, pos-workorder

## Verification

- Booted the packaged pos-accounting jar with `pos.accounting.kafka.enabled=true`: context starts, `WorkorderCommandPublisher` bean created, all four listener containers running. Module tests: 685 passed.
- Reproduced the failure on pos-warranty before the fix, then booted the rebuilt jar with `pos.warranty.kafka.enabled=true`: starts cleanly.
- Full reactor build with tests for all changed modules: BUILD SUCCESS.

## Rollout note

pos-warranty and pos-inventory containers currently run stale pre-Boot-4 images; rebuild them (`docker-compose up -d --build`) after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQrUgXBnM5KDPFNb5kWTFH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQrUgXBnM5KDPFNb5kWTFH)_