### PR TITLE
Fix reconcile_databases silently stopping after the first database

### DIFF
--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -84,17 +84,23 @@ reconcile_databases() {
     sleep 1
   done
 
-  local db exists
-  while read -r db; do
+  # Read the full list before the loop: `docker compose exec` attaches the container
+  # to the loop's stdin and drains it, so a `while read` fed by process substitution
+  # silently stops after the first database. The execs also get </dev/null so they
+  # can never consume anything meant for the shell.
+  local dbs db exists
+  mapfile -t dbs < <(sed -nE 's/^CREATE DATABASE ([A-Za-z0-9_]+);$/\1/p' "${init_sql}")
+  echo "Reconciling ${#dbs[@]} databases from init-databases.sql"
+  for db in "${dbs[@]}"; do
     [[ -n "${db}" ]] || continue
     exists="$(docker compose "${COMPOSE_ARGS[@]}" exec -T postgres \
-      sh -c 'psql -U "${POSTGRES_USER}" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '"'"''"${db}"''"'"'"')"
+      sh -c 'psql -U "${POSTGRES_USER}" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '"'"''"${db}"''"'"'"' </dev/null)"
     if [[ "${exists}" != "1" ]]; then
       echo "Creating missing database: ${db}"
       docker compose "${COMPOSE_ARGS[@]}" exec -T postgres \
-        sh -c 'psql -U "${POSTGRES_USER}" -d postgres -c "CREATE DATABASE '"${db}"';"'
+        sh -c 'psql -U "${POSTGRES_USER}" -d postgres -c "CREATE DATABASE '"${db}"';"' </dev/null
     fi
-  done < <(sed -nE 's/^CREATE DATABASE ([A-Za-z0-9_]+);$/\1/p' "${init_sql}")
+  done
 }
 
 OBSERVABILITY_SERVICES=(


### PR DESCRIPTION
## Problem

pos-warranty failed to start on alpha:

```
FATAL: database "pos_warranty_db" does not exist
```

`reconcile_databases` in `deployment/alpha/deploy-backend.sh` is supposed to create any database listed in `postgres/init-databases.sql` that is missing (the init SQL only runs on fresh volume initialization). The list contains `pos_warranty_db`, but the loop never reached it: `docker compose exec -T` inside the `while read` loop attaches the container to the loop's stdin and drains the process substitution feeding it, so reconciliation silently stopped after the first name. Nothing returned nonzero, so `set -euo pipefail` had nothing to catch. The bug was invisible until now because every database earlier in the list already existed — `pos_warranty_db` is the first genuinely new database since the reconcile step was added.

## Change

`deployment/alpha/deploy-backend.sh` only:

- Read the database list into an array with `mapfile` before the loop, instead of streaming it into `while read` alongside the execs.
- Redirect `</dev/null` into both `psql` execs so they can never consume input meant for the shell.
- Log `Reconciling N databases from init-databases.sql` so deploy output shows the full list was walked.

## Verification

- `bash -n` passes.
- Simulated the stdin-drain with a `cat >/dev/null` stand-in for `docker compose exec`: the old loop shape processes 1 of 26 names; the fixed shape processes 26 of 26.

## Rollout

On the next deploy, reconcile will walk the full list and create `pos_warranty_db` (and any other stragglers) before the service batches start, so pos-warranty can boot and Flyway can baseline its schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQrUgXBnM5KDPFNb5kWTFH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQrUgXBnM5KDPFNb5kWTFH)_