### PR TITLE
Derive FULL_SERVICE_COUNT from the canonical service list

### DIFF
--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -273,6 +273,8 @@ jobs:
     steps:
       - name: Write summary
         run: |
+          set -euo pipefail
+
           SHORT_SHA="${GITHUB_SHA::7}"
           IMAGE_TAG="sha-${SHORT_SHA}"
           SERVICE_COUNT="$(jq 'length' <<< '${{ needs.detect-services.outputs.services }}')"

--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -39,6 +39,7 @@ jobs:
       services: ${{ steps.detect.outputs.services }}
       modules-csv: ${{ steps.detect.outputs.modules-csv }}
       has-changes: ${{ steps.detect.outputs.has-changes }}
+      all-services: ${{ steps.detect.outputs.all-services }}
 
     steps:
       - name: Checkout
@@ -52,6 +53,7 @@ jobs:
           set -euo pipefail
 
           ALL_SERVICES_JSON='["pos-accounting","pos-api-gateway","pos-bulk-loader","pos-catalog","pos-customer","pos-documents","pos-event-receiver","pos-image","pos-inventory","pos-invoice","pos-location","pos-mcp-server","pos-people","pos-people-contact","pos-price","pos-security-service","pos-service-discovery","pos-shop-manager","pos-tax","pos-vehicle-inventory","pos-warranty","pos-workorder"]'
+          echo "all-services=${ALL_SERVICES_JSON}" >> "$GITHUB_OUTPUT"
           FORCE_FULL_REBUILD=false
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
@@ -274,7 +276,9 @@ jobs:
           SHORT_SHA="${GITHUB_SHA::7}"
           IMAGE_TAG="sha-${SHORT_SHA}"
           SERVICE_COUNT="$(jq 'length' <<< '${{ needs.detect-services.outputs.services }}')"
-          FULL_SERVICE_COUNT=22
+          # Derived from the canonical list in detect-services so it can't go stale
+          # when services are added or removed.
+          FULL_SERVICE_COUNT="$(jq 'length' <<< '${{ needs.detect-services.outputs.all-services }}')"
 
           echo "## Backend Images Published" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Follow-up to PR #930 review feedback: the hard-coded count in the deployment summary was already stale once (17 vs 21) and would drift again on the next service addition. Expose ALL_SERVICES_JSON as an all-services job output from detect-services and compute the count with jq in the summary step.


Claude-Session: https://claude.ai/code/session_01NWFDeHGtpwHvmknZKdNqXc