### PR TITLE
[CAP:odoo-parity-accounting] Wave 3 — dry-run resolution, trial balance, AR GL posting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+<!-- .github/pull_request_template.md -->
+## Capability & Traceability
+- Capability: `cap:<cap-id>`
+- Parent STORY (durion): louisburroughs/durion#<parent-id>
+- Child issue: louisburroughs/durion-positivity-backend#<child-id>
+- Domain: `domain:<domain>`
+
+## Contract References (REQUIRED for backend PRs touching API/event behavior)
+<!--
+  The "Contract Sync Enforcement" check FAILS unless the text BACKEND_CONTRACT_GUIDE.md
+  appears somewhere in this PR body whenever contract-relevant files change
+  (controllers, DTOs, *Request/*Response, events, openapi.yaml, validation/error models).
+  Keep the reference below and link it to the relevant domain anchor.
+-->
+- Contract guide entry (durion): `domains/<domain>/.business-rules/BACKEND_CONTRACT_GUIDE.md` → <link-to-anchor>
+- Durion contract PR (if applicable): <link-to-durion-pr>
+
+## Contract Chain (when a Controller changed)
+- [ ] OpenAPI annotations updated on the controller
+- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
+- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)
+
+## Scope
+- What changed:
+- Why:
+
+## Tests
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Provider behavioral contract tests added/updated
+- How to run:
+
+## Risk & Rollback
+- Risk level: Low / Medium / High
+- Rollback plan:
+
+## Checklist
+- [ ] Branch name matches `cap/<cap-id>`
+- [ ] PR title starts with `[CAP:<cap-id>]`
+- [ ] Links to parent + child issues are present
+- [ ] Contract guide updated (when contract semantics changed)
+- [ ] Required CI checks passing

--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -1457,13 +1457,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MappingResolutionTestResponse'
-        '403':
-          description: Forbidden
+                $ref: '#/components/schemas/ApiError'
+        '401':
+          description: Missing or invalid authentication
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MappingResolutionTestResponse'
+                $ref: '#/components/schemas/ApiError'
+        '403':
+          description: Caller lacks the accounting:posting_rules:view permission
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - accounting:posting_rules:view
@@ -2872,19 +2878,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TrialBalanceReport'
+                $ref: '#/components/schemas/ApiError'
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TrialBalanceReport'
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - missing reporting:view:financial-statements
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TrialBalanceReport'
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - reporting:view:financial-statements

--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -1284,7 +1284,7 @@ paths:
       tags:
       - Payment Applications
       summary: Apply payment
-      description: Apply a payment to an invoice and update its status.
+      description: 'Apply a payment to one or more invoices and update their status. The optional allocationStrategy field controls allocation order: CALLER_ORDER (default when omitted) honors the caller-supplied order; OLDEST_FIRST allocates by ascending invoice date.'
       operationId: applyPayment
       parameters:
       - name: paymentId
@@ -1431,6 +1431,44 @@ paths:
         - accounting:gl-mapping:resolve
       x-required-permissions:
       - accounting:gl-mapping:resolve
+  /v1/accounting/mappings/resolve-test:
+    post:
+      tags:
+      - GL Mapping API
+      summary: Dry-run mapping/rule resolution
+      description: 'Resolves a hypothetical accounting event against the published posting rules and GL mappings, returning the matched rule (id/name/version), mapping details, the exact journal entry lines the evaluator would post (including E1 proportional split-line shares and residual distribution), and per-predicate evaluation outcomes (E2 condition grammar). This is a read-only inspection tool: NOTHING is persisted — no accounting event, journal entry, or outbox record is created. A no-match outcome is a normal 200 response with matched=false (not a 404).'
+      operationId: resolveTestMapping
+      requestBody:
+        description: Dry-run mapping/rule resolution request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MappingResolutionTestRequest'
+        required: true
+      responses:
+        '200':
+          description: Dry-run resolution completed (matched=false when no published rule matched)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MappingResolutionTestResponse'
+        '400':
+          description: Invalid request payload, or the sample payload could not be interpreted by the rules
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MappingResolutionTestResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MappingResolutionTestResponse'
+      security:
+      - bearerAuth:
+        - accounting:posting_rules:view
+      x-required-permissions:
+      - accounting:posting_rules:view
   /v1/accounting/mapping-keys:
     post:
       tags:
@@ -2801,6 +2839,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LaborOverheadCostReport'
+      security:
+      - bearerAuth:
+        - reporting:view:financial-statements
+      x-required-permissions:
+      - reporting:view:financial-statements
+  /v1/accounting/reports/financial/trial-balance:
+    get:
+      tags:
+      - Financial Reporting
+      summary: Generate Trial Balance
+      description: 'Generate Trial Balance as of a specific date: per-account debit/credit/balance rows from POSTED journal lines, grand totals proving sum(debit) == sum(credit), and an entry-number gap-check footnote per monthly sequence scope'
+      operationId: generateTrialBalance
+      parameters:
+      - name: asOf
+        in: query
+        description: As-of date (YYYY-MM-DD)
+        required: true
+        schema:
+          type: string
+          format: date
+        example: 2026-06-30
+      responses:
+        '200':
+          description: Trial balance generated successfully (rows empty when no POSTED data exists as of the date)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrialBalanceReport'
+        '400':
+          description: Invalid or missing asOf date
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrialBalanceReport'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrialBalanceReport'
+        '403':
+          description: Forbidden - missing reporting:view:financial-statements
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrialBalanceReport'
       security:
       - bearerAuth:
         - reporting:view:financial-statements
@@ -5524,6 +5608,16 @@ components:
           items:
             $ref: '#/components/schemas/InvoiceApplication'
           minItems: 1
+        allocationStrategy:
+          type:
+          - string
+          - 'null'
+          default: CALLER_ORDER
+          description: Optional allocation strategy. CALLER_ORDER (default when absent) applies amounts in the order supplied by the caller; OLDEST_FIRST allocates by ascending invoice date. Omitting this field is equivalent to CALLER_ORDER.
+          enum:
+          - CALLER_ORDER
+          - OLDEST_FIRST
+          example: OLDEST_FIRST
       required:
       - applicationRequestId
       - applications
@@ -5775,6 +5869,166 @@ components:
           description: Resolved GL account UUID for the requested external code
           example: 01960003-0000-7000-8000-000000000001
       required:
+      - glAccountId
+    MappingResolutionTestRequest:
+      type: object
+      description: Dry-run mapping/rule resolution request describing a hypothetical accounting event. Nothing is persisted by this operation.
+      properties:
+        eventType:
+          type: string
+          description: Accounting event type to resolve posting rules for
+          example: INVOICE_FINALIZED
+          minLength: 1
+        samplePayload:
+          type: object
+          description: Sample event payload (arbitrary JSON object) evaluated against rule predicates and amount fields. Optional; when omitted the rules are evaluated against an empty payload.
+          example:
+            totalAmount: 125.0
+            channel: POS
+        transactionDate:
+          type: string
+          format: date
+          description: Transaction date used for effective-dated rule version and GL mapping selection
+          example: 2026-01-15
+      required:
+      - eventType
+      - transactionDate
+    MappingResolutionTestResponse:
+      type: object
+      description: Dry-run mapping/rule resolution result. A no-match outcome is represented as matched=false with a reason, not as an error. Nothing is persisted.
+      properties:
+        matched:
+          type: boolean
+          description: Whether a published posting rule matched the supplied event. false means no rule matched; inspect noMatchReason/noMatchDetail.
+          example: true
+        matchedRule:
+          $ref: '#/components/schemas/MatchedRule'
+        matchedMapping:
+          $ref: '#/components/schemas/MatchedMapping'
+        resolvedLines:
+          type: array
+          description: Journal entry lines the evaluator would post for this event, including E1 proportional split-line shares and residual distribution. Present when matched=true.
+          items:
+            $ref: '#/components/schemas/ResolvedLine'
+        predicateEvaluations:
+          type: array
+          description: Per-predicate evaluation outcomes against the sample payload (E2 condition grammar). Populated for every candidate rule condition that was evaluated.
+          items:
+            $ref: '#/components/schemas/PredicateEvaluation'
+        noMatchReason:
+          type: string
+          description: Machine-readable no-match reason, present when matched=false
+          example: UNMAPPED_EVENT_TYPE
+        noMatchDetail:
+          type: string
+          description: Human-readable no-match detail, present when matched=false
+          example: No published rule version maps event type INVOICE_FINALIZED on 2026-01-15
+      required:
+      - matched
+    MatchedMapping:
+      type: object
+      description: Mapping evaluation details for the matched rule
+      properties:
+        mappingType:
+          type: string
+          description: Type of mapping that was matched (exact, fallback, category_default)
+          example: exact
+        mappingKey:
+          type: string
+          description: Mapping key that was matched
+          example: INVENTORY:SKU-1234
+        keysEvaluated:
+          type: array
+          description: All mapping keys evaluated during the search, in evaluation order
+          items:
+            type: string
+    MatchedRule:
+      type: object
+      description: Identity of the posting rule that matched the dry-run event
+      properties:
+        postingRuleSetId:
+          type: string
+          format: uuid
+          description: Posting rule set identifier
+          example: 01960003-0000-7000-8000-000000000001
+        ruleSetName:
+          type: string
+          description: Posting rule set name
+          example: Invoice finalization postings
+        ruleVersionId:
+          type: string
+          format: uuid
+          description: Posting rule version identifier that was evaluated
+          example: 01960003-0000-7000-8000-000000000002
+        versionNumber:
+          type: integer
+          format: int32
+          description: Posting rule version number that was evaluated
+          example: 3
+      required:
+      - postingRuleSetId
+      - ruleSetName
+      - ruleVersionId
+      - versionNumber
+    PredicateEvaluation:
+      type: object
+      description: Evaluation outcome of one rule condition predicate (E2 grammar)
+      properties:
+        predicate:
+          type: string
+          description: Predicate expression as configured on the rule condition
+          example: payload.channel == 'POS' && payload.totalAmount > 100
+        matched:
+          type: boolean
+          description: Whether the predicate matched the supplied event type and sample payload
+          example: true
+        detail:
+          type: string
+          description: Optional evaluation detail (e.g. which clause failed)
+          example: 'clause payload.totalAmount > 100 evaluated false (actual: 42.00)'
+      required:
+      - matched
+      - predicate
+    ResolvedLine:
+      type: object
+      description: One journal entry line the dry-run evaluator would post
+      properties:
+        glAccountId:
+          type: string
+          format: uuid
+          description: Resolved GL account identifier
+          example: 01960003-0000-7000-8000-000000000003
+        accountCode:
+          type: string
+          description: Resolved GL account code
+          example: '4000'
+        accountName:
+          type: string
+          description: Resolved GL account name
+          example: Sales Revenue
+        debitAmount:
+          type: number
+          description: Debit amount for this line
+          example: 75.0
+        creditAmount:
+          type: number
+          description: Credit amount for this line
+          example: 0.0
+        description:
+          type: string
+          description: Line description
+          example: Recognize revenue (60% share)
+        splitGroup:
+          type: string
+          description: E1 split group this line belongs to; null for non-split lines
+          example: revenue-split
+        factorPercent:
+          type: number
+          description: E1 split factor percentage applied to this line; null for non-split lines
+          example: 60.0
+      required:
+      - creditAmount
+      - debitAmount
       - glAccountId
     MappingKeyCreateRequest:
       type: object
@@ -7064,6 +7318,105 @@ components:
       - monthly
       - usdOnly
       - ytd
+    EntryNumberGapCheck:
+      type: object
+      description: Entry-number gap-check result for one monthly sequence scope; absent gaps mean a clean ledger
+      properties:
+        scopeKey:
+          type: string
+          description: Monthly sequence scope key
+          example: JE-202607
+        missingNumbers:
+          type: array
+          description: Ascending sequence numbers handed out but missing from the ledger for this scope
+          example:
+          - 7
+          - 12
+          items:
+            type: integer
+            format: int64
+      required:
+      - missingNumbers
+      - scopeKey
+    TrialBalanceReport:
+      type: object
+      description: Trial Balance report with per-account debit/credit/balance rows from POSTED journal lines, grand totals proving sum(debit) == sum(credit), and an entry-number gap-check footnote
+      properties:
+        asOfDate:
+          type: string
+          format: date
+          description: Date the trial balance is reported as of (inclusive)
+          example: 2026-06-30
+        generatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the report was generated (ISO 8601)
+          example: 2026-06-30 08:00:00+00:00
+        rows:
+          type: array
+          description: Per-account trial balance rows ordered by account number; empty when no POSTED data exists
+          items:
+            $ref: '#/components/schemas/TrialBalanceRow'
+        totalDebit:
+          type: number
+          description: Grand total of all POSTED debit amounts across rows
+          example: 1250000.0
+        totalCredit:
+          type: number
+          description: Grand total of all POSTED credit amounts across rows
+          example: 1250000.0
+        balanced:
+          type: boolean
+          description: Whether sum of debits equals sum of credits; false surfaces a balance-constraint violation
+          example: true
+        entryNumberGaps:
+          type: array
+          description: 'Entry-number gap-check footnote: per-month sequence scopes with missing entry numbers; empty on a clean ledger'
+          items:
+            $ref: '#/components/schemas/EntryNumberGapCheck'
+      required:
+      - asOfDate
+      - balanced
+      - entryNumberGaps
+      - generatedAt
+      - rows
+      - totalCredit
+      - totalDebit
+    TrialBalanceRow:
+      type: object
+      description: Per-account trial balance row aggregated from POSTED journal lines
+      properties:
+        accountId:
+          type: string
+          description: GL account ID (UUID)
+          example: 123e4567-e89b-12d3-a456-426614174000
+        accountNumber:
+          type: string
+          description: GL account number (chart-of-accounts code)
+          example: '1000'
+        accountName:
+          type: string
+          description: GL account display name
+          example: Cash - Operating
+        totalDebit:
+          type: number
+          description: Sum of POSTED debit amounts for the account up to the as-of date
+          example: 125000.0
+        totalCredit:
+          type: number
+          description: Sum of POSTED credit amounts for the account up to the as-of date
+          example: 45000.0
+        balance:
+          type: number
+          description: Net account balance (totalDebit - totalCredit, signed)
+          example: 80000.0
+      required:
+      - accountId
+      - accountName
+      - accountNumber
+      - balance
+      - totalCredit
+      - totalDebit
     IncomeStatementReport:
       type: object
       description: Income statement (Profit & Loss) report built from POSTED journal entries

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
@@ -16,7 +16,7 @@ public final class EventTypes {
 
     /**
      * All event type registrations for the accounting module.
-     * Total: 62 event types (includes +2 from CAP-251 #5:
+     * Total: 63 event types (includes +2 from CAP-251 #5:
      * ACCOUNTING_STATUS_SYNC_PROCESS and ACCOUNTING_STATUS_VIEW, in addition to
      * CAP-053 Vendor Bill workflow + GL Mapping, +3 from PRD missing endpoints:
      * ACCOUNTING_REPORT_EXPORT_REQUEST, ACCOUNTING_REPORT_EXPORT_STATUS,
@@ -30,7 +30,8 @@ public final class EventTypes {
      * +2 from the org-level hard-lock date (Story B2, Issue #944):
      * ACCOUNTING_PERIOD_HARD_LOCK_VIEW, ACCOUNTING_PERIOD_HARD_LOCK_SET, and
      * +1 from AR cash-receipt GL posting (Story C1, Issue #954):
-     * PAYMENT_APPLICATION_GL_POSTING).
+     * PAYMENT_APPLICATION_GL_POSTING, and +1 from the trial balance report
+     * (Story G1, Issue #956): REPORT_TRIAL_BALANCE_GENERATE).
      */
     public static List<EventTypeRegistration> all() {
         return List.of(
@@ -121,12 +122,16 @@ public final class EventTypes {
                 EventTypeRegistration.fastRead("ACCOUNTING_CREDIT_MEMO_GET", "Get credit memo details by ID")
                         .build(),
 
-                // FinancialReportingController - 4 events (CAP-054)
+                // FinancialReportingController - 5 events (CAP-054, parity-G1)
                 EventTypeRegistration.search(
                                 "REPORT_INCOME_STATEMENT_GENERATE", "Generate income statement report for a date range")
                         .build(),
                 EventTypeRegistration.search(
                                 "REPORT_BALANCE_SHEET_GENERATE", "Generate balance sheet report as of a specific date")
+                        .build(),
+                EventTypeRegistration.search(
+                                "REPORT_TRIAL_BALANCE_GENERATE",
+                                "Generate trial balance report as of a specific date with entry-number gap footnote")
                         .build(),
                 EventTypeRegistration.fastRead(
                                 "REPORT_DRILLDOWN_ACCOUNTS",

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
@@ -16,7 +16,7 @@ public final class EventTypes {
 
     /**
      * All event type registrations for the accounting module.
-     * Total: 61 event types (includes +2 from CAP-251 #5:
+     * Total: 62 event types (includes +2 from CAP-251 #5:
      * ACCOUNTING_STATUS_SYNC_PROCESS and ACCOUNTING_STATUS_VIEW, in addition to
      * CAP-053 Vendor Bill workflow + GL Mapping, +3 from PRD missing endpoints:
      * ACCOUNTING_REPORT_EXPORT_REQUEST, ACCOUNTING_REPORT_EXPORT_STATUS,
@@ -28,7 +28,9 @@ public final class EventTypes {
      * journal-entry lifecycle events (Story A3, Issue #943):
      * ACCOUNTING_JOURNAL_ENTRY_POST, ACCOUNTING_JOURNAL_ENTRY_REVERSE, and
      * +2 from the org-level hard-lock date (Story B2, Issue #944):
-     * ACCOUNTING_PERIOD_HARD_LOCK_VIEW, ACCOUNTING_PERIOD_HARD_LOCK_SET).
+     * ACCOUNTING_PERIOD_HARD_LOCK_VIEW, ACCOUNTING_PERIOD_HARD_LOCK_SET, and
+     * +1 from AR cash-receipt GL posting (Story C1, Issue #954):
+     * PAYMENT_APPLICATION_GL_POSTING).
      */
     public static List<EventTypeRegistration> all() {
         return List.of(
@@ -182,6 +184,12 @@ public final class EventTypes {
 
                 // AP Payment GL Posting - 1 event (Issue #128)
                 EventTypeRegistration.write("AP_PAYMENT_GL_POSTING", "Post AP payment to GL (Dr AP, Cr Cash/Bank)")
+                        .build(),
+
+                // AR Payment Application GL Posting - 1 event (story C1, Issue #954)
+                EventTypeRegistration.write(
+                                "PAYMENT_APPLICATION_GL_POSTING",
+                                "Post AR payment application to GL (Dr Undeposited Funds, Cr AR)")
                         .build(),
 
                 // AccountingStatusSyncService — 2 events (CAP-251 #5)

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
@@ -16,7 +16,8 @@ public final class EventTypes {
 
     /**
      * All event type registrations for the accounting module.
-     * Total: 63 event types (includes +2 from CAP-251 #5:
+     * Total: 64 event types (includes +1 from the mapping resolution dry-run
+     * (Story E3, Issue #957): ACCOUNTING_MAPPING_RESOLVE_TEST, and +2 from CAP-251 #5:
      * ACCOUNTING_STATUS_SYNC_PROCESS and ACCOUNTING_STATUS_VIEW, in addition to
      * CAP-053 Vendor Bill workflow + GL Mapping, +3 from PRD missing endpoints:
      * ACCOUNTING_REPORT_EXPORT_REQUEST, ACCOUNTING_REPORT_EXPORT_STATUS,
@@ -148,13 +149,17 @@ public final class EventTypes {
                                 "Generate Labor & Overhead cost report for a location and fiscal year")
                         .build(),
 
-                // GLMappingController - 2 events (GL Mapping)
+                // GLMappingController - 3 events (GL Mapping + parity-E3 dry-run)
                 EventTypeRegistration.write(
                                 "ACCOUNTING_GL_MAPPING_CREATE", "Create GL mapping from external code to GL account")
                         .build(),
                 EventTypeRegistration.fastRead(
                                 "ACCOUNTING_GL_MAPPING_RESOLVE",
                                 "Resolve external code to GL account using effective-dated mapping")
+                        .build(),
+                EventTypeRegistration.search(
+                                "ACCOUNTING_MAPPING_RESOLVE_TEST",
+                                "Dry-run mapping/rule resolution for a hypothetical event (no persistence)")
                         .build(),
 
                 // VendorBillService - 6 events (CAP-053 Issue #130)

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/FinancialReportingController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/FinancialReportingController.java
@@ -7,6 +7,7 @@ import com.positivity.accounting.internal.dto.JournalLineDrilldownResponse;
 import com.positivity.accounting.internal.dto.TrialBalanceReport;
 import com.positivity.accounting.service.FinancialReportingService;
 import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -142,9 +143,18 @@ public class FinancialReportingController {
             responseCode = "200",
             description = "Trial balance generated successfully (rows empty when no POSTED data exists as of the date)",
             content = @Content(schema = @Schema(implementation = TrialBalanceReport.class)))
-    @ApiResponse(responseCode = "400", description = "Invalid or missing asOf date")
-    @ApiResponse(responseCode = "401", description = "Unauthorized")
-    @ApiResponse(responseCode = "403", description = "Forbidden - missing reporting:view:financial-statements")
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid or missing asOf date",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Forbidden - missing reporting:view:financial-statements",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<TrialBalanceReport> generateTrialBalance(
             @Parameter(description = "As-of date (YYYY-MM-DD)", required = true, example = "2026-06-30")
                     @RequestParam

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/FinancialReportingController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/FinancialReportingController.java
@@ -4,6 +4,7 @@ import com.positivity.accounting.internal.dto.AccountDrilldownResponse;
 import com.positivity.accounting.internal.dto.BalanceSheetReport;
 import com.positivity.accounting.internal.dto.IncomeStatementReport;
 import com.positivity.accounting.internal.dto.JournalLineDrilldownResponse;
+import com.positivity.accounting.internal.dto.TrialBalanceReport;
 import com.positivity.accounting.service.FinancialReportingService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
@@ -123,6 +124,38 @@ public class FinancialReportingController {
                     LocalDate asOfDate) {
 
         BalanceSheetReport report = financialReportingService.generateBalanceSheet(asOfDate);
+        return ResponseEntity.ok(report);
+    }
+
+    /**
+     * Generate Trial Balance as of a specific date.
+     */
+    @GetMapping(value = "/trial-balance", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
+    @EmitEvent(id = "REPORT_TRIAL_BALANCE_GENERATE", apiVersion = "1")
+    @Operation(
+            summary = "Generate Trial Balance",
+            description =
+                    "Generate Trial Balance as of a specific date: per-account debit/credit/balance rows from POSTED journal lines, grand totals proving sum(debit) == sum(credit), and an entry-number gap-check footnote per monthly sequence scope",
+            tags = {"Financial Reporting"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Trial balance generated successfully (rows empty when no POSTED data exists as of the date)",
+            content = @Content(schema = @Schema(implementation = TrialBalanceReport.class)))
+    @ApiResponse(responseCode = "400", description = "Invalid or missing asOf date")
+    @ApiResponse(responseCode = "401", description = "Unauthorized")
+    @ApiResponse(responseCode = "403", description = "Forbidden - missing reporting:view:financial-statements")
+    public ResponseEntity<TrialBalanceReport> generateTrialBalance(
+            @Parameter(description = "As-of date (YYYY-MM-DD)", required = true, example = "2026-06-30")
+                    @RequestParam
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    @NonNull
+                    LocalDate asOf) {
+
+        // Malformed/missing asOf is rejected by Spring binding before reaching here;
+        // the module's @RestControllerAdvice maps it to 400 Bad Request with the
+        // accounting domain's standard ApiError format (ADR-0017).
+        TrialBalanceReport report = financialReportingService.generateTrialBalance(asOf);
         return ResponseEntity.ok(report);
     }
 

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/GLMappingController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/GLMappingController.java
@@ -9,6 +9,7 @@ import com.positivity.accounting.internal.dto.MappingResolutionTestResponse;
 import com.positivity.accounting.service.GLMappingService;
 import com.positivity.accounting.service.MappingResolutionTestService;
 import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -147,8 +148,16 @@ public class GLMappingController {
             content = @Content(schema = @Schema(implementation = MappingResolutionTestResponse.class)))
     @ApiResponse(
             responseCode = "400",
-            description = "Invalid request payload, or the sample payload could not be interpreted by the rules")
-    @ApiResponse(responseCode = "403", description = "Forbidden")
+            description = "Invalid request payload, or the sample payload could not be interpreted by the rules",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "401",
+            description = "Missing or invalid authentication",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:posting_rules:view permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<MappingResolutionTestResponse> resolveTestMapping(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                             description = "Dry-run mapping/rule resolution request",

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/GLMappingController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/GLMappingController.java
@@ -4,7 +4,10 @@ import com.positivity.accounting.internal.dto.GLMappingCreateRequest;
 import com.positivity.accounting.internal.dto.GLMappingCreateResponse;
 import com.positivity.accounting.internal.dto.GLMappingResolveRequest;
 import com.positivity.accounting.internal.dto.GLMappingResolveResponse;
+import com.positivity.accounting.internal.dto.MappingResolutionTestRequest;
+import com.positivity.accounting.internal.dto.MappingResolutionTestResponse;
 import com.positivity.accounting.service.GLMappingService;
+import com.positivity.accounting.service.MappingResolutionTestService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -34,6 +37,7 @@ import org.springframework.web.bind.annotation.*;
 public class GLMappingController {
 
     private final GLMappingService glMappingService;
+    private final MappingResolutionTestService mappingResolutionTestService;
 
     /**
      * Create a new GL mapping.
@@ -110,6 +114,55 @@ public class GLMappingController {
                 request.getTransactionDate());
 
         GLMappingResolveResponse response = glMappingService.resolveMapping(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Dry-run posting rule / mapping resolution (story E3, issue #957).
+     *
+     * @param request dry-run request with event type, optional sample payload, and
+     *                transaction date
+     * @return dry-run resolution result; matched=false when no rule matched
+     */
+    @PostMapping("/resolve-test")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:posting_rules:view"})
+    @PreAuthorize("hasAuthority('accounting:posting_rules:view')")
+    @EmitEvent(id = "ACCOUNTING_MAPPING_RESOLVE_TEST", apiVersion = "1")
+    @Operation(
+            summary = "Dry-run mapping/rule resolution",
+            description = "Resolves a hypothetical accounting event against the published posting rules and GL "
+                    + "mappings, returning the matched rule (id/name/version), mapping details, the exact journal "
+                    + "entry lines the evaluator would post (including E1 proportional split-line shares and "
+                    + "residual distribution), and per-predicate evaluation outcomes (E2 condition grammar). "
+                    + "This is a read-only inspection tool: NOTHING is persisted — no accounting event, journal "
+                    + "entry, or outbox record is created. A no-match outcome is a normal 200 response with "
+                    + "matched=false (not a 404).",
+            tags = {"GL Mapping API"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Dry-run resolution completed (matched=false when no published rule matched)",
+            content = @Content(schema = @Schema(implementation = MappingResolutionTestResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid request payload, or the sample payload could not be interpreted by the rules")
+    @ApiResponse(responseCode = "403", description = "Forbidden")
+    public ResponseEntity<MappingResolutionTestResponse> resolveTestMapping(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Dry-run mapping/rule resolution request",
+                            required = true,
+                            content = @Content(schema = @Schema(implementation = MappingResolutionTestRequest.class)))
+                    @Valid
+                    @RequestBody
+                    MappingResolutionTestRequest request) {
+        log.info(
+                "Dry-run mapping resolution request: eventType={}, transactionDate={}",
+                request.getEventType(),
+                request.getTransactionDate());
+
+        MappingResolutionTestResponse response = mappingResolutionTestService.resolveTest(request);
 
         return ResponseEntity.ok(response);
     }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/PaymentApplicationController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/PaymentApplicationController.java
@@ -99,9 +99,11 @@ public class PaymentApplicationController {
      * - Applications are atomic across all target invoices
      * - Idempotent via applicationRequestId
      * - Overpayments create CustomerCredit
+     * - Optional allocationStrategy: CALLER_ORDER (default when absent) or
+     *   OLDEST_FIRST (allocate by ascending invoice date) — Issue #955
      *
      * @param paymentId payment to apply
-     * @param request   application request with invoices and amounts
+     * @param request   application request with invoices, amounts, and optional allocation strategy
      * @return application response with details
      */
     @PostMapping("/payments/{paymentId}/applications")
@@ -111,7 +113,10 @@ public class PaymentApplicationController {
     @PreAuthorize("hasAuthority('accounting:payment:apply')")
     @Operation(
             summary = "Apply payment",
-            description = "Apply a payment to an invoice and update its status.",
+            description = "Apply a payment to one or more invoices and update their status. "
+                    + "The optional allocationStrategy field controls allocation order: "
+                    + "CALLER_ORDER (default when omitted) honors the caller-supplied order; "
+                    + "OLDEST_FIRST allocates by ascending invoice date.",
             tags = {"Payment Applications"})
     @ApiResponse(responseCode = "201", description = "Payment applied successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request or insufficient funds")

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/EntryNumberGapCheck.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/EntryNumberGapCheck.java
@@ -1,0 +1,41 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.*;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Entry-number gap-check footnote entry for one monthly sequence scope.
+ *
+ * Reports sequence numbers that were handed out by the accounting sequence
+ * for the scope but have no matching {@code journal_entry.entry_number} row
+ * (see {@code AccountingSequenceRepository#findMissingEntryNumbers}).
+ * A clean ledger produces no entries at all.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Entry-number gap-check result for one monthly sequence scope; absent gaps mean a clean ledger")
+public class EntryNumberGapCheck {
+
+    /**
+     * Monthly sequence scope key, e.g. {@code JE-202607}.
+     */
+    @Schema(description = "Monthly sequence scope key", example = "JE-202607", requiredMode = REQUIRED)
+    @NonNull
+    private String scopeKey;
+
+    /**
+     * Ascending list of sequence numbers missing from the ledger for this scope.
+     */
+    @Schema(
+            description = "Ascending sequence numbers handed out but missing from the ledger for this scope",
+            example = "[7, 12]",
+            requiredMode = REQUIRED)
+    @NonNull
+    private List<Long> missingNumbers;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/MappingResolutionTestRequest.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/MappingResolutionTestRequest.java
@@ -1,0 +1,55 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Request for a dry-run posting rule / mapping resolution (story E3, issue
+ * #957).
+ *
+ * Describes a hypothetical accounting event: the event type, an optional
+ * sample payload, and the transaction date used for effective-dated rule
+ * version and mapping selection. Nothing about this request is persisted.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(
+        description = "Dry-run mapping/rule resolution request describing a hypothetical accounting event. "
+                + "Nothing is persisted by this operation.")
+public class MappingResolutionTestRequest {
+
+    @NotBlank(message = "Event type is required")
+    @Schema(
+            description = "Accounting event type to resolve posting rules for",
+            example = "INVOICE_FINALIZED",
+            requiredMode = REQUIRED)
+    private String eventType;
+
+    @Nullable
+    @Schema(
+            description = "Sample event payload (arbitrary JSON object) evaluated against rule predicates "
+                    + "and amount fields. Optional; when omitted the rules are evaluated against an empty payload.",
+            example = "{\"totalAmount\": 125.00, \"channel\": \"POS\"}",
+            requiredMode = NOT_REQUIRED)
+    private Map<String, Object> samplePayload;
+
+    @NotNull(message = "Transaction date is required")
+    @Schema(
+            description = "Transaction date used for effective-dated rule version and GL mapping selection",
+            example = "2026-01-15",
+            requiredMode = REQUIRED)
+    private LocalDate transactionDate;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/MappingResolutionTestResponse.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/MappingResolutionTestResponse.java
@@ -1,0 +1,217 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Result of a dry-run posting rule / mapping resolution (story E3, issue
+ * #957).
+ *
+ * Mirrors exactly what the posting rule evaluator would produce for the
+ * supplied hypothetical event — matched rule identity, mapping details,
+ * resolved journal entry lines (including E1 proportional split shares), and
+ * per-predicate evaluation outcomes (E2 grammar) — without persisting
+ * anything.
+ *
+ * A no-match outcome is a normal 200 response with {@code matched=false} and a
+ * populated {@code noMatchReason}/{@code noMatchDetail}; it is not an error.
+ */
+@Value
+@Builder
+@Schema(
+        description = "Dry-run mapping/rule resolution result. A no-match outcome is represented as "
+                + "matched=false with a reason, not as an error. Nothing is persisted.")
+public class MappingResolutionTestResponse {
+
+    /** Whether a published posting rule matched the supplied event. */
+    @Schema(
+            description = "Whether a published posting rule matched the supplied event. "
+                    + "false means no rule matched; inspect noMatchReason/noMatchDetail.",
+            example = "true",
+            requiredMode = REQUIRED)
+    boolean matched;
+
+    /** Identity of the rule that matched (present when matched=true). */
+    @Nullable
+    @Schema(
+            description = "Identity of the posting rule that matched, present when matched=true",
+            requiredMode = NOT_REQUIRED)
+    MatchedRule matchedRule;
+
+    /** Mapping evaluation details (present when matched=true). */
+    @Nullable
+    @Schema(description = "Mapping evaluation details, present when matched=true", requiredMode = NOT_REQUIRED)
+    MatchedMapping matchedMapping;
+
+    /**
+     * Journal entry lines the evaluator would post, including E1
+     * split-line shares (present when matched=true).
+     */
+    @Nullable
+    @Schema(
+            description = "Journal entry lines the evaluator would post for this event, including "
+                    + "E1 proportional split-line shares and residual distribution. Present when matched=true.",
+            requiredMode = NOT_REQUIRED)
+    List<ResolvedLine> resolvedLines;
+
+    /** Per-predicate evaluation outcomes (E2 grammar). */
+    @Nullable
+    @Schema(
+            description = "Per-predicate evaluation outcomes against the sample payload (E2 condition grammar). "
+                    + "Populated for every candidate rule condition that was evaluated.",
+            requiredMode = NOT_REQUIRED)
+    List<PredicateEvaluation> predicateEvaluations;
+
+    /** Machine-readable no-match reason (present when matched=false). */
+    @Nullable
+    @Schema(
+            description = "Machine-readable no-match reason, present when matched=false",
+            example = "UNMAPPED_EVENT_TYPE",
+            requiredMode = NOT_REQUIRED)
+    String noMatchReason;
+
+    /** Human-readable no-match detail (present when matched=false). */
+    @Nullable
+    @Schema(
+            description = "Human-readable no-match detail, present when matched=false",
+            example = "No published rule version maps event type INVOICE_FINALIZED on 2026-01-15",
+            requiredMode = NOT_REQUIRED)
+    String noMatchDetail;
+
+    /** Identity of the posting rule that matched the dry-run event. */
+    @Value
+    @Builder
+    @Schema(description = "Identity of the posting rule that matched the dry-run event")
+    public static class MatchedRule {
+
+        @Schema(
+                description = "Posting rule set identifier",
+                example = "01960003-0000-7000-8000-000000000001",
+                requiredMode = REQUIRED)
+        UUID postingRuleSetId;
+
+        @Schema(
+                description = "Posting rule set name",
+                example = "Invoice finalization postings",
+                requiredMode = REQUIRED)
+        String ruleSetName;
+
+        @Schema(
+                description = "Posting rule version identifier that was evaluated",
+                example = "01960003-0000-7000-8000-000000000002",
+                requiredMode = REQUIRED)
+        UUID ruleVersionId;
+
+        @Schema(description = "Posting rule version number that was evaluated", example = "3", requiredMode = REQUIRED)
+        Integer versionNumber;
+    }
+
+    /** Mapping evaluation details for the matched rule. */
+    @Value
+    @Builder
+    @Schema(description = "Mapping evaluation details for the matched rule")
+    public static class MatchedMapping {
+
+        @Schema(
+                description = "Type of mapping that was matched (exact, fallback, category_default)",
+                example = "exact",
+                requiredMode = NOT_REQUIRED)
+        @Nullable
+        String mappingType;
+
+        @Schema(
+                description = "Mapping key that was matched",
+                example = "INVENTORY:SKU-1234",
+                requiredMode = NOT_REQUIRED)
+        @Nullable
+        String mappingKey;
+
+        @Schema(
+                description = "All mapping keys evaluated during the search, in evaluation order",
+                requiredMode = NOT_REQUIRED)
+        @Nullable
+        List<String> keysEvaluated;
+    }
+
+    /** One journal entry line the evaluator would post. */
+    @Value
+    @Builder
+    @Schema(description = "One journal entry line the dry-run evaluator would post")
+    public static class ResolvedLine {
+
+        @Schema(
+                description = "Resolved GL account identifier",
+                example = "01960003-0000-7000-8000-000000000003",
+                requiredMode = REQUIRED)
+        UUID glAccountId;
+
+        @Schema(description = "Resolved GL account code", example = "4000", requiredMode = NOT_REQUIRED)
+        @Nullable
+        String accountCode;
+
+        @Schema(description = "Resolved GL account name", example = "Sales Revenue", requiredMode = NOT_REQUIRED)
+        @Nullable
+        String accountName;
+
+        @Schema(description = "Debit amount for this line", example = "75.00", requiredMode = REQUIRED)
+        BigDecimal debitAmount;
+
+        @Schema(description = "Credit amount for this line", example = "0.00", requiredMode = REQUIRED)
+        BigDecimal creditAmount;
+
+        @Schema(
+                description = "Line description",
+                example = "Recognize revenue (60% share)",
+                requiredMode = NOT_REQUIRED)
+        @Nullable
+        String description;
+
+        @Schema(
+                description = "E1 split group this line belongs to; null for non-split lines",
+                example = "revenue-split",
+                requiredMode = NOT_REQUIRED)
+        @Nullable
+        String splitGroup;
+
+        @Schema(
+                description = "E1 split factor percentage applied to this line; null for non-split lines",
+                example = "60.0",
+                requiredMode = NOT_REQUIRED)
+        @Nullable
+        BigDecimal factorPercent;
+    }
+
+    /** Evaluation outcome of one rule condition predicate (E2 grammar). */
+    @Value
+    @Builder
+    @Schema(description = "Evaluation outcome of one rule condition predicate (E2 grammar)")
+    public static class PredicateEvaluation {
+
+        @Schema(
+                description = "Predicate expression as configured on the rule condition",
+                example = "payload.channel == 'POS' && payload.totalAmount > 100",
+                requiredMode = REQUIRED)
+        String predicate;
+
+        @Schema(
+                description = "Whether the predicate matched the supplied event type and sample payload",
+                example = "true",
+                requiredMode = REQUIRED)
+        boolean matched;
+
+        @Schema(
+                description = "Optional evaluation detail (e.g. which clause failed)",
+                example = "clause payload.totalAmount > 100 evaluated false (actual: 42.00)",
+                requiredMode = NOT_REQUIRED)
+        @Nullable
+        String detail;
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/PaymentApplicationGLPostingEvent.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/PaymentApplicationGLPostingEvent.java
@@ -1,0 +1,80 @@
+package com.positivity.accounting.internal.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Outbox work item enqueued when a payment application to invoices succeeds
+ * (AR cash receipt), triggering asynchronous GL posting of:
+ * <ul>
+ * <li>Dr Undeposited Funds (cash receipt held until settlement deposit)</li>
+ * <li>Cr Accounts Receivable (invoice balance reduction)</li>
+ * </ul>
+ *
+ * <p>
+ * Per parity decision D-3 the debit side is always Undeposited Funds — cash
+ * receipts are never posted straight to Cash; settlement reconciliation
+ * clears Undeposited Funds to Cash later.
+ *
+ * <p>
+ * Enqueued in the same transaction as the payment application (transactional
+ * outbox) by
+ * {@link com.positivity.accounting.internal.service.PaymentApplicationServiceImpl}
+ * and consumed by
+ * {@link com.positivity.accounting.internal.handler.PaymentApplicationGLPostingEventHandler}.
+ *
+ * @see <a href=
+ *      "https://github.com/louisburroughs/durion-positivity-backend/issues/954">Issue
+ *      #954 (story C1)</a>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentApplicationGLPostingEvent {
+
+    /** Outbox event UUID (delivery identity, not the posting idempotency key). */
+    @NonNull
+    @JsonProperty("eventId")
+    private UUID eventId;
+
+    /**
+     * Caller-supplied application request id — the posting idempotency key and
+     * the journal entry {@code sourceEventId} basis.
+     */
+    @NonNull
+    @JsonProperty("applicationRequestId")
+    private String applicationRequestId;
+
+    /** Receivable payment UUID the application drew from. */
+    @NonNull
+    @JsonProperty("paymentId")
+    private UUID paymentId;
+
+    /** Customer UUID. */
+    @NonNull
+    @JsonProperty("customerId")
+    private UUID customerId;
+
+    /** Payment currency (ISO 4217). */
+    @NonNull
+    @JsonProperty("currency")
+    private String currency;
+
+    /** Total amount actually applied across all invoices in the request. */
+    @NonNull
+    @JsonProperty("appliedAmount")
+    private BigDecimal appliedAmount;
+
+    /** Timestamp the application was recorded. */
+    @NonNull
+    @JsonProperty("applicationTimestamp")
+    private Instant applicationTimestamp;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/PaymentApplicationRequest.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/PaymentApplicationRequest.java
@@ -1,7 +1,9 @@
 package com.positivity.accounting.internal.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import com.positivity.accounting.internal.enums.AllocationStrategy;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
@@ -9,6 +11,8 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import lombok.*;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Request DTO for applying a payment to one or more invoices.
@@ -45,6 +49,29 @@ public class PaymentApplicationRequest {
     @NotEmpty(message = "At least one invoice application is required")
     @Valid
     private List<InvoiceApplication> applications;
+
+    /**
+     * Optional allocation strategy. When absent, {@link AllocationStrategy#CALLER_ORDER}
+     * is used and behavior is identical to requests that predate this field.
+     */
+    @Schema(
+            description = "Optional allocation strategy. CALLER_ORDER (default when absent) applies amounts in "
+                    + "the order supplied by the caller; OLDEST_FIRST allocates by ascending invoice date. "
+                    + "Omitting this field is equivalent to CALLER_ORDER.",
+            example = "OLDEST_FIRST",
+            requiredMode = NOT_REQUIRED,
+            nullable = true,
+            defaultValue = "CALLER_ORDER")
+    @Nullable private AllocationStrategy allocationStrategy;
+
+    /**
+     * Resolves the effective allocation strategy, applying the documented default.
+     *
+     * @return the caller-supplied strategy, or {@link AllocationStrategy#CALLER_ORDER} when absent
+     */
+    @NonNull public AllocationStrategy resolveAllocationStrategy() {
+        return allocationStrategy != null ? allocationStrategy : AllocationStrategy.CALLER_ORDER;
+    }
 
     /**
      * Individual invoice application within a payment application request.

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TrialBalanceAccountTotal.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TrialBalanceAccountTotal.java
@@ -1,0 +1,20 @@
+package com.positivity.accounting.internal.dto;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Internal aggregation projection for the Trial Balance report (story G1,
+ * issue #956): per-GL-account debit/credit totals summed from POSTED journal
+ * lines up to the as-of date. Produced by a JPQL constructor expression in
+ * {@code JournalEntryRepository#sumPostedDebitsCreditsByAccountAsOf}; not part
+ * of the API surface (the response row is {@link TrialBalanceRow}).
+ *
+ * @param glAccountId GL account ID
+ * @param accountCode chart-of-accounts code (account number)
+ * @param accountName GL account display name
+ * @param totalDebit  sum of POSTED debit amounts, never null (COALESCE 0)
+ * @param totalCredit sum of POSTED credit amounts, never null (COALESCE 0)
+ */
+public record TrialBalanceAccountTotal(
+        UUID glAccountId, String accountCode, String accountName, BigDecimal totalDebit, BigDecimal totalCredit) {}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TrialBalanceReport.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TrialBalanceReport.java
@@ -1,0 +1,107 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.*;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Trial Balance report response.
+ *
+ * Per-account debit/credit/balance rows from POSTED journal lines up to and
+ * including the as-of date, with grand totals proving the balance constraint
+ * (sum of debits == sum of credits), plus an entry-number gap-check footnote
+ * block per monthly sequence scope.
+ *
+ * Rows are empty (with zero totals) when no POSTED data exists as of the
+ * requested date. The gap footnote is empty on a clean ledger.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(
+        description =
+                "Trial Balance report with per-account debit/credit/balance rows from POSTED journal lines, grand totals proving sum(debit) == sum(credit), and an entry-number gap-check footnote")
+public class TrialBalanceReport {
+
+    /**
+     * Report as-of date (inclusive).
+     */
+    @Schema(
+            description = "Date the trial balance is reported as of (inclusive)",
+            example = "2026-06-30",
+            requiredMode = REQUIRED)
+    @NonNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate asOfDate;
+
+    /**
+     * Timestamp when report was generated.
+     */
+    @Schema(
+            description = "Timestamp when the report was generated (ISO 8601)",
+            example = "2026-06-30T08:00:00Z",
+            requiredMode = REQUIRED)
+    @NonNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    private Instant generatedAt;
+
+    /**
+     * Per-account rows ordered by account number. Empty when no POSTED data
+     * exists as of the requested date.
+     */
+    @Schema(
+            description = "Per-account trial balance rows ordered by account number; empty when no POSTED data exists",
+            requiredMode = REQUIRED)
+    @NonNull
+    private List<TrialBalanceRow> rows;
+
+    /**
+     * Grand total of all debit amounts across rows.
+     */
+    @Schema(
+            description = "Grand total of all POSTED debit amounts across rows",
+            example = "1250000.00",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal totalDebit;
+
+    /**
+     * Grand total of all credit amounts across rows.
+     */
+    @Schema(
+            description = "Grand total of all POSTED credit amounts across rows",
+            example = "1250000.00",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal totalCredit;
+
+    /**
+     * Whether the trial balance balances: totalDebit == totalCredit.
+     * FALSE surfaces a balance-constraint violation operationally.
+     */
+    @Schema(
+            description = "Whether sum of debits equals sum of credits; false surfaces a balance-constraint violation",
+            example = "true",
+            requiredMode = REQUIRED)
+    @NonNull
+    private Boolean balanced;
+
+    /**
+     * Entry-number gap-check footnote block: one entry per monthly sequence
+     * scope with missing numbers. Empty on a clean ledger.
+     */
+    @Schema(
+            description =
+                    "Entry-number gap-check footnote: per-month sequence scopes with missing entry numbers; empty on a clean ledger",
+            requiredMode = REQUIRED)
+    @NonNull
+    private List<EntryNumberGapCheck> entryNumberGaps;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TrialBalanceRow.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TrialBalanceRow.java
@@ -1,0 +1,76 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import lombok.*;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * One per-account row of the Trial Balance report.
+ *
+ * Debit and credit totals are aggregated from POSTED journal lines only.
+ * Balance is the signed net of the account (totalDebit - totalCredit).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Per-account trial balance row aggregated from POSTED journal lines")
+public class TrialBalanceRow {
+
+    /**
+     * GL account ID (UUID).
+     */
+    @Schema(
+            description = "GL account ID (UUID)",
+            example = "123e4567-e89b-12d3-a456-426614174000",
+            requiredMode = REQUIRED)
+    @NonNull
+    private String accountId;
+
+    /**
+     * GL account number (chart-of-accounts code).
+     */
+    @Schema(description = "GL account number (chart-of-accounts code)", example = "1000", requiredMode = REQUIRED)
+    @NonNull
+    private String accountNumber;
+
+    /**
+     * GL account display name.
+     */
+    @Schema(description = "GL account display name", example = "Cash - Operating", requiredMode = REQUIRED)
+    @NonNull
+    private String accountName;
+
+    /**
+     * Sum of POSTED debit amounts for the account up to the as-of date.
+     */
+    @Schema(
+            description = "Sum of POSTED debit amounts for the account up to the as-of date",
+            example = "125000.00",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal totalDebit;
+
+    /**
+     * Sum of POSTED credit amounts for the account up to the as-of date.
+     */
+    @Schema(
+            description = "Sum of POSTED credit amounts for the account up to the as-of date",
+            example = "45000.00",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal totalCredit;
+
+    /**
+     * Net balance for the account: totalDebit - totalCredit (signed).
+     */
+    @Schema(
+            description = "Net account balance (totalDebit - totalCredit, signed)",
+            example = "80000.00",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal balance;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/enums/AllocationStrategy.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/enums/AllocationStrategy.java
@@ -1,0 +1,32 @@
+package com.positivity.accounting.internal.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Strategy controlling the order in which a payment is allocated across target invoices.
+ *
+ * <p>Crosses the payment-application service boundary as an optional field on
+ * {@link com.positivity.accounting.internal.dto.PaymentApplicationRequest}; when absent the
+ * behavior is {@link #CALLER_ORDER}, which is byte-identical to the pre-strategy contract.
+ *
+ * @see <a href=
+ *      "https://github.com/louisburroughs/durion-positivity-backend/issues/955">Issue
+ *      #955</a>
+ */
+@Schema(
+        description = "Order in which the payment is allocated across the requested invoices. "
+                + "CALLER_ORDER (default when absent) applies amounts in the order supplied by the caller; "
+                + "OLDEST_FIRST allocates by ascending invoice date.")
+public enum AllocationStrategy {
+
+    /**
+     * Apply amounts to invoices in the exact order supplied by the caller.
+     * Default when no strategy is provided; preserves pre-existing behavior.
+     */
+    CALLER_ORDER,
+
+    /**
+     * Apply amounts to invoices ordered by ascending invoice date (oldest invoice first).
+     */
+    OLDEST_FIRST
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandler.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandler.java
@@ -1,0 +1,158 @@
+package com.positivity.accounting.internal.handler;
+
+import com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.exception.AccountingPeriodClosedException;
+import com.positivity.accounting.internal.exception.AccountingPeriodHardLockedException;
+import com.positivity.accounting.service.GLMappingResolver;
+import com.positivity.accounting.service.GLPostingService;
+import com.positivity.accounting.service.IdempotencyService;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Event handler for AR payment application GL posting work items (story C1,
+ * issue #954).
+ *
+ * <p>
+ * Consumes {@link PaymentApplicationGLPostingEvent} work items delivered from
+ * the transactional outbox (mirroring the {@link APPaymentGLPostingEventHandler}
+ * async pattern) and posts the cash receipt to the ledger via
+ * {@link GLPostingService#postPaymentApplication}:
+ * <ul>
+ * <li>Dr Undeposited Funds (parity decision D-3 — never straight to Cash)</li>
+ * <li>Cr Accounts Receivable</li>
+ * </ul>
+ *
+ * <p>
+ * Accounts are never hardcoded: both sides resolve through the
+ * {@code PAYMENT_APPLICATION} posting category and its
+ * {@code UNDEPOSITED_FUNDS} / {@code ACCOUNTS_RECEIVABLE} mapping keys
+ * (seeded by {@code R__seed_reference_accounting.sql}).
+ *
+ * <p>
+ * Idempotency: the posting key is the caller-supplied application request id
+ * (namespaced with {@code PAYMENT_APPLICATION_GL_POSTING:}); a replayed or
+ * duplicate work item is a no-op, so an application never double-posts. The
+ * key is registered in the same transaction as the posted journal entry.
+ *
+ * <p>
+ * Failure semantics mirror the AP payment flow: any exception propagates to
+ * {@link com.positivity.accounting.internal.service.OutboxProcessor}, which
+ * marks the work item failed and retries with backoff (FAILED after max
+ * retries). Posting into a CLOSED or hard-locked period surfaces the Wave 2
+ * period-gate exceptions unwrapped so the failure reason stays visible.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentApplicationGLPostingEventHandler {
+
+    static final String POSTING_CATEGORY_NAME = "PAYMENT_APPLICATION";
+    static final String DEBIT_MAPPING_KEY = "UNDEPOSITED_FUNDS";
+    static final String CREDIT_MAPPING_KEY = "ACCOUNTS_RECEIVABLE";
+    static final String IDEMPOTENCY_KEY_PREFIX = "PAYMENT_APPLICATION_GL_POSTING:";
+
+    private final Clock clock;
+    private final IdempotencyService idempotencyService;
+    private final GLMappingResolver glMappingResolver;
+    private final GLPostingService glPostingService;
+
+    /**
+     * Handle payment application GL posting work item → post balanced journal
+     * entry (Dr Undeposited Funds, Cr AR).
+     *
+     * @param event payment application GL posting work item
+     */
+    @EventListener
+    @Transactional
+    public void onPaymentApplicationGLPosting(@NonNull PaymentApplicationGLPostingEvent event) {
+        String applicationRequestId = event.getApplicationRequestId();
+        String idempotencyKey = IDEMPOTENCY_KEY_PREFIX + applicationRequestId;
+
+        if (idempotencyService.isKeyProcessed(idempotencyKey)) {
+            log.info(
+                    "Payment application GL posting already processed, skipping | applicationRequestId={} "
+                            + "| eventId={}",
+                    applicationRequestId,
+                    event.getEventId());
+            return;
+        }
+
+        log.info(
+                "Received PaymentApplicationGLPostingEvent | eventId={} | applicationRequestId={} | paymentId={} "
+                        + "| appliedAmount={}",
+                event.getEventId(),
+                applicationRequestId,
+                event.getPaymentId(),
+                event.getAppliedAmount());
+
+        try {
+            // Transaction date matches the journal entry date set inside
+            // postPaymentApplication (both derive from the injected clock).
+            LocalDateTime transactionDate = LocalDateTime.now(clock);
+
+            // Account resolution via posting category / mapping key
+            // configuration — no hardcoded account ids (story C1 requirement).
+            UUID undepositedFundsAccountId =
+                    glMappingResolver.resolveGLAccount(POSTING_CATEGORY_NAME, DEBIT_MAPPING_KEY, transactionDate);
+            UUID arAccountId =
+                    glMappingResolver.resolveGLAccount(POSTING_CATEGORY_NAME, CREDIT_MAPPING_KEY, transactionDate);
+
+            UUID sourceEventId = toSourceEventId(applicationRequestId);
+            String description = "AR cash receipt for payment application request " + applicationRequestId;
+
+            JournalEntry posted = glPostingService.postPaymentApplication(
+                    sourceEventId, undepositedFundsAccountId, arAccountId, event.getAppliedAmount(), description);
+
+            idempotencyService.registerKey(idempotencyKey, posted.getJournalEntryId());
+
+            log.info(
+                    "Payment application GL posting completed | applicationRequestId={} | journalEntryId={}",
+                    applicationRequestId,
+                    posted.getJournalEntryId());
+
+        } catch (AccountingPeriodClosedException | AccountingPeriodHardLockedException e) {
+            // Wave 2 period gate: propagate unwrapped so the failure reason
+            // stays visible in the outbox retry record; retry succeeds once the
+            // period is reopened (or the hard lock moved).
+            log.warn(
+                    "Payment application GL posting blocked by period gate | applicationRequestId={} | error={}",
+                    applicationRequestId,
+                    e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "Failed to process PaymentApplicationGLPostingEvent | applicationRequestId={} | eventId={} "
+                            + "| error={}",
+                    applicationRequestId,
+                    event.getEventId(),
+                    e.getMessage(),
+                    e);
+            throw new IllegalStateException(
+                    "GL posting failed for payment application request: " + applicationRequestId, e);
+        }
+    }
+
+    /**
+     * Derive the journal entry {@code sourceEventId} from the caller-supplied
+     * application request id. UUID-shaped request ids are used verbatim;
+     * anything else maps deterministically via a name-based UUID so replays of
+     * the same request id always produce the same source event id.
+     */
+    static @NonNull UUID toSourceEventId(@NonNull String applicationRequestId) {
+        try {
+            return UUID.fromString(applicationRequestId);
+        } catch (IllegalArgumentException e) {
+            return UUID.nameUUIDFromBytes(applicationRequestId.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandler.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandler.java
@@ -96,9 +96,16 @@ public class PaymentApplicationGLPostingEventHandler {
                 event.getAppliedAmount());
 
         try {
-            // Transaction date matches the journal entry date set inside
-            // postPaymentApplication (both derive from the injected clock).
-            LocalDateTime transactionDate = LocalDateTime.now(clock);
+            // Transaction date is the event's business timestamp (when the
+            // payment application actually occurred), NOT the processing/clock
+            // time. On outbox retries or backlog the clock time drifts into the
+            // wrong accounting period and selects the wrong effective-dated GL
+            // mapping; deriving from applicationTimestamp keeps both the entry
+            // date and the mapping resolution stable across replays. The Instant
+            // is converted to LocalDateTime using the injected clock's zone,
+            // matching the module's Instant→LocalDateTime convention.
+            LocalDateTime transactionDate =
+                    LocalDateTime.ofInstant(event.getApplicationTimestamp(), clock.getZone());
 
             // Account resolution via posting category / mapping key
             // configuration — no hardcoded account ids (story C1 requirement).
@@ -111,7 +118,12 @@ public class PaymentApplicationGLPostingEventHandler {
             String description = "AR cash receipt for payment application request " + applicationRequestId;
 
             JournalEntry posted = glPostingService.postPaymentApplication(
-                    sourceEventId, undepositedFundsAccountId, arAccountId, event.getAppliedAmount(), description);
+                    sourceEventId,
+                    undepositedFundsAccountId,
+                    arAccountId,
+                    event.getAppliedAmount(),
+                    transactionDate,
+                    description);
 
             idempotencyService.registerKey(idempotencyKey, posted.getJournalEntryId());
 

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/AccountingSequenceRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/AccountingSequenceRepository.java
@@ -28,6 +28,13 @@ public interface AccountingSequenceRepository extends JpaRepository<AccountingSe
     Optional<AccountingSequence> findByScopeKey(String scopeKey);
 
     /**
+     * All sequence rows in deterministic scope-key order (no lock). Used by
+     * Trial Balance gap-check reporting (story G1, issue #956) to enumerate
+     * the monthly {@code JE-&#123;YYYYMM&#125;} scopes to audit.
+     */
+    List<AccountingSequence> findAllByOrderByScopeKeyAsc();
+
+    /**
      * Gap-detection: expected-vs-stored comparison for one month scope,
      * returning the sequence numbers that were handed out (per
      * {@code next_value}) but have no matching {@code journal_entry.entry_number}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/CreditMemoRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/CreditMemoRepository.java
@@ -68,4 +68,32 @@ public interface CreditMemoRepository extends JpaRepository<CreditMemo, UUID> {
             "SELECT COALESCE(SUM(cm.creditAmount + cm.taxAmountReversed), 0) FROM CreditMemo cm"
                     + " WHERE cm.originalInvoiceId = :originalInvoiceId AND cm.status = :status")
     java.math.BigDecimal sumCreditedAmountByInvoiceIdAndStatus(UUID originalInvoiceId, CreditMemoStatus status);
+
+    /**
+     * Sum of credit amounts (revenue portion only, excluding reversed tax) for an invoice in a
+     * given status. Used to determine how much of the invoice's net (pre-tax) amount has already
+     * been credited (issue #953).
+     *
+     * @param originalInvoiceId invoice identifier
+     * @param status            credit memo status to include (normally POSTED)
+     * @return total credited revenue amount
+     */
+    @org.springframework.data.jpa.repository.Query(
+            "SELECT COALESCE(SUM(cm.creditAmount), 0) FROM CreditMemo cm"
+                    + " WHERE cm.originalInvoiceId = :originalInvoiceId AND cm.status = :status")
+    java.math.BigDecimal sumCreditAmountByInvoiceIdAndStatus(UUID originalInvoiceId, CreditMemoStatus status);
+
+    /**
+     * Sum of reversed tax amounts for an invoice in a given status. Used for the final-credit
+     * residual correction so cumulative tax reversals sum exactly to the invoice's stored tax
+     * (issue #953).
+     *
+     * @param originalInvoiceId invoice identifier
+     * @param status            credit memo status to include (normally POSTED)
+     * @return total reversed tax amount
+     */
+    @org.springframework.data.jpa.repository.Query(
+            "SELECT COALESCE(SUM(cm.taxAmountReversed), 0) FROM CreditMemo cm"
+                    + " WHERE cm.originalInvoiceId = :originalInvoiceId AND cm.status = :status")
+    java.math.BigDecimal sumTaxReversedAmountByInvoiceIdAndStatus(UUID originalInvoiceId, CreditMemoStatus status);
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/JournalEntryRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/JournalEntryRepository.java
@@ -155,6 +155,33 @@ public interface JournalEntryRepository extends JpaRepository<JournalEntry, UUID
     java.math.BigDecimal sumPostedBalanceAsOf(UUID glAccountId, LocalDateTime asOfDate);
 
     /**
+     * Aggregate POSTED journal lines up to and including the as-of instant into
+     * per-account debit/credit totals, ordered by chart-of-accounts code.
+     * Used for Trial Balance generation (story G1, issue #956); aggregation is
+     * done in the database so the full line set is never loaded into memory.
+     *
+     * @param asOfDate reporting cutoff (inclusive; pass end-of-day for a date)
+     * @return one aggregate per account with POSTED activity, ordered by
+     *         account code; empty when no POSTED data exists as of the cutoff
+     */
+    @Query("""
+                SELECT new com.positivity.accounting.internal.dto.TrialBalanceAccountTotal(
+                    jel.glAccount.glAccountId,
+                    jel.glAccount.accountCode,
+                    jel.glAccount.accountName,
+                    COALESCE(SUM(CASE WHEN jel.debitAmount IS NOT NULL THEN jel.debitAmount ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN jel.creditAmount IS NOT NULL THEN jel.creditAmount ELSE 0 END), 0))
+                FROM JournalEntry je
+                JOIN je.lines jel
+                WHERE je.status = 'POSTED'
+                  AND je.transactionDate <= :asOfDate
+                GROUP BY jel.glAccount.glAccountId, jel.glAccount.accountCode, jel.glAccount.accountName
+                ORDER BY jel.glAccount.accountCode
+            """)
+    List<com.positivity.accounting.internal.dto.TrialBalanceAccountTotal> sumPostedDebitsCreditsByAccountAsOf(
+            LocalDateTime asOfDate);
+
+    /**
      * Find all POSTED journal lines for a GL account within date range.
      * Used for drilldown reporting.
      *

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
@@ -55,6 +55,14 @@ public class CreditMemoServiceImpl implements CreditMemoService {
 
     private static final String DEFAULT_CURRENCY = "USD";
 
+    /** Currency scale (2dp) applied to reversed tax amounts. */
+    private static final int CURRENCY_SCALE = 2;
+
+    /** Precision of the intermediate credit ratio; only the final tax amount is currency-rounded. */
+    private static final int RATIO_SCALE = 10;
+
+    private static final BigDecimal ZERO_TAX = new BigDecimal("0.00");
+
     private final CreditMemoRepository creditMemoRepository;
     private final InvoiceBalanceCalculator invoiceBalanceCalculator;
     private final GLPostingService glPostingService;
@@ -91,7 +99,7 @@ public class CreditMemoServiceImpl implements CreditMemoService {
         BigDecimal balanceDue = invoiceBalanceCalculator.balanceDue(invoice);
         validateBalanceDue(invoice, balanceDue);
 
-        CreditAmountCalculation creditCalculation = calculateCreditAmounts(request, balanceDue);
+        CreditAmountCalculation creditCalculation = calculateCreditAmounts(request, invoice);
         validateCreditDoesNotExceedBalance(request, balanceDue, creditCalculation);
 
         PriorPeriodInfo priorPeriodInfo = determinePriorPeriodInfo(invoice);
@@ -145,12 +153,52 @@ public class CreditMemoServiceImpl implements CreditMemoService {
                         + invoice.getTotal());
     }
 
-    private CreditAmountCalculation calculateCreditAmounts(CreateCreditMemoRequest request, BigDecimal balanceDue) {
-        BigDecimal taxAmount = balanceDue.multiply(new BigDecimal("0.10"));
-        BigDecimal creditRatio = request.getCreditAmount().divide(balanceDue, 4, RoundingMode.HALF_UP);
-        BigDecimal taxReversed = taxAmount.multiply(creditRatio).setScale(2, RoundingMode.HALF_UP);
+    private CreditAmountCalculation calculateCreditAmounts(CreateCreditMemoRequest request, ExtInvoice invoice) {
+        BigDecimal taxReversed = calculateTaxReversed(request.getCreditAmount(), invoice);
         BigDecimal totalCreditAmount = request.getCreditAmount().add(taxReversed);
         return new CreditAmountCalculation(taxReversed, totalCreditAmount);
+    }
+
+    /**
+     * Derive the tax to reverse from the invoice's STORED tax scalar (issue #953, Odoo parity
+     * decision D-4). Tax is frozen at invoice finalization and is never recomputed from rates at
+     * credit time (rate-drift protection).
+     *
+     * <p>The credit amount is the revenue (pre-tax) portion being reversed, so the pro-rating
+     * ratio is {@code creditAmount / net} where {@code net = total − tax}, and
+     * {@code taxReversed = round(tax × ratio)} HALF_UP at currency scale.
+     *
+     * <p>Final-credit residual correction (Odoo last-partial pattern): when this credit consumes
+     * the invoice's remaining net amount, the reversal is {@code tax − previouslyReversed} so the
+     * cumulative reversals across all POSTED memos sum exactly to the stored tax (e.g. 35.59
+     * split 50/50 posts 17.80 then 17.79).
+     */
+    @NonNull
+    private BigDecimal calculateTaxReversed(@NonNull BigDecimal creditAmount, @NonNull ExtInvoice invoice) {
+        BigDecimal storedTax = invoice.getTax();
+        if (storedTax == null || storedTax.signum() <= 0) {
+            return ZERO_TAX;
+        }
+        BigDecimal totalTax = storedTax.setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
+        BigDecimal total = invoice.getTotal() == null ? BigDecimal.ZERO : invoice.getTotal();
+        BigDecimal netAmount = total.subtract(storedTax);
+
+        BigDecimal previouslyCreditedNet =
+                creditMemoRepository.sumCreditAmountByInvoiceIdAndStatus(invoice.getInvoiceId(), CreditMemoStatus.POSTED);
+        BigDecimal remainingNet = netAmount.subtract(previouslyCreditedNet);
+
+        if (creditAmount.compareTo(remainingNet) >= 0) {
+            // Final line: reverse the residual so cumulative reversals sum exactly to the
+            // stored tax. A non-positive residual means the tax is already fully reversed.
+            BigDecimal previouslyReversed = creditMemoRepository.sumTaxReversedAmountByInvoiceIdAndStatus(
+                    invoice.getInvoiceId(), CreditMemoStatus.POSTED);
+            BigDecimal residual = totalTax.subtract(previouslyReversed);
+            return residual.signum() > 0 ? residual : ZERO_TAX;
+        }
+
+        // remainingNet > creditAmount > 0 implies netAmount > 0: division is safe.
+        BigDecimal creditRatio = creditAmount.divide(netAmount, RATIO_SCALE, RoundingMode.HALF_UP);
+        return totalTax.multiply(creditRatio).setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
     }
 
     private void validateCreditDoesNotExceedBalance(

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
@@ -2,12 +2,18 @@ package com.positivity.accounting.internal.service;
 
 import com.positivity.accounting.internal.dto.AccountDrilldownResponse;
 import com.positivity.accounting.internal.dto.BalanceSheetReport;
+import com.positivity.accounting.internal.dto.EntryNumberGapCheck;
 import com.positivity.accounting.internal.dto.IncomeStatementReport;
 import com.positivity.accounting.internal.dto.JournalLineDrilldownResponse;
+import com.positivity.accounting.internal.dto.TrialBalanceAccountTotal;
+import com.positivity.accounting.internal.dto.TrialBalanceReport;
+import com.positivity.accounting.internal.dto.TrialBalanceRow;
+import com.positivity.accounting.internal.entity.AccountingSequence;
 import com.positivity.accounting.internal.entity.JournalEntry;
 import com.positivity.accounting.internal.entity.StatementLineMapping;
 import com.positivity.accounting.internal.enums.OperationType;
 import com.positivity.accounting.internal.enums.StatementType;
+import com.positivity.accounting.internal.repository.AccountingSequenceRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
 import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
 import com.positivity.accounting.service.FinancialReportingService;
@@ -46,16 +52,25 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
     private static final BigDecimal BALANCE_TOLERANCE = new BigDecimal("0.01"); // 1 cent tolerance for rounding
 
+    /**
+     * Prefix of journal-entry monthly sequence scopes ({@code JE-{YYYYMM}}),
+     * matching {@code JournalEntryServiceImpl#entryNumberScopeKey}.
+     */
+    private static final String ENTRY_NUMBER_SCOPE_PREFIX = "JE-";
+
     private final JournalEntryRepository journalEntryRepository;
     private final StatementLineMappingRepository statementLineMappingRepository;
+    private final AccountingSequenceRepository accountingSequenceRepository;
     private final Clock clock;
 
     public FinancialReportingServiceImpl(
             JournalEntryRepository journalEntryRepository,
             StatementLineMappingRepository statementLineMappingRepository,
+            AccountingSequenceRepository accountingSequenceRepository,
             Clock clock) {
         this.journalEntryRepository = journalEntryRepository;
         this.statementLineMappingRepository = statementLineMappingRepository;
+        this.accountingSequenceRepository = accountingSequenceRepository;
         this.clock = clock;
     }
 
@@ -238,6 +253,98 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                 .balanced(balanced)
                 .generatedAt(Instant.now(clock))
                 .build();
+    }
+
+    @Override
+    public @NonNull TrialBalanceReport generateTrialBalance(@NonNull LocalDate asOf) {
+
+        log.info("Generating trial balance as of {}", asOf);
+
+        LocalDateTime asOfDateTime = asOf.atTime(LocalTime.MAX);
+
+        // Per-account aggregation happens in the database (grouped JPQL over
+        // POSTED lines, ordered by account code) — the line set is never
+        // materialized in memory.
+        List<TrialBalanceAccountTotal> accountTotals =
+                journalEntryRepository.sumPostedDebitsCreditsByAccountAsOf(asOfDateTime);
+
+        List<TrialBalanceRow> rows = accountTotals.stream()
+                .map(total -> TrialBalanceRow.builder()
+                        .accountId(total.glAccountId().toString())
+                        .accountNumber(total.accountCode())
+                        .accountName(total.accountName())
+                        .totalDebit(total.totalDebit())
+                        .totalCredit(total.totalCredit())
+                        .balance(total.totalDebit().subtract(total.totalCredit()))
+                        .build())
+                .toList();
+
+        BigDecimal totalDebit = rows.stream()
+                .map(TrialBalanceRow::getTotalDebit)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalCredit = rows.stream()
+                .map(TrialBalanceRow::getTotalCredit)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Computed, never assumed: an unbalanced ledger (A1 constraint
+        // violation) must surface operationally as balanced = false.
+        boolean balanced = totalDebit.compareTo(totalCredit) == 0;
+        if (!balanced) {
+            log.warn(
+                    "Trial balance NOT balanced as of {}: totalDebit={}, totalCredit={}, diff={}",
+                    asOf,
+                    totalDebit,
+                    totalCredit,
+                    totalDebit.subtract(totalCredit));
+        }
+
+        // Per contract: an empty ledger reports an empty gap footnote (and the
+        // gap query is PostgreSQL-only, so it is not touched needlessly).
+        List<EntryNumberGapCheck> entryNumberGaps = rows.isEmpty() ? List.of() : checkEntryNumberGaps(asOf);
+
+        log.info(
+                "Trial balance generated as of {}: accounts={}, totalDebit={}, totalCredit={}, balanced={}, gapScopes={}",
+                asOf,
+                rows.size(),
+                totalDebit,
+                totalCredit,
+                balanced,
+                entryNumberGaps.size());
+
+        return TrialBalanceReport.builder()
+                .asOfDate(asOf)
+                .generatedAt(Instant.now(clock))
+                .rows(rows)
+                .totalDebit(totalDebit)
+                .totalCredit(totalCredit)
+                .balanced(balanced)
+                .entryNumberGaps(entryNumberGaps)
+                .build();
+    }
+
+    /**
+     * Run the entry-number gap-check (story A2's
+     * {@code AccountingSequenceRepository#findMissingEntryNumbers}) for every
+     * monthly journal-entry sequence scope up to and including the as-of
+     * month, keeping only scopes that actually have missing numbers. Scope
+     * keys are {@code JE-{YYYYMM}} on the entry's transaction month, so the
+     * lexicographic comparison against the as-of month boundary is a correct
+     * chronological cut. A clean ledger yields an empty footnote.
+     */
+    private List<EntryNumberGapCheck> checkEntryNumberGaps(LocalDate asOf) {
+        String asOfScopeBoundary =
+                String.format("%s%04d%02d", ENTRY_NUMBER_SCOPE_PREFIX, asOf.getYear(), asOf.getMonthValue());
+
+        return accountingSequenceRepository.findAllByOrderByScopeKeyAsc().stream()
+                .map(AccountingSequence::getScopeKey)
+                .filter(scopeKey -> scopeKey.startsWith(ENTRY_NUMBER_SCOPE_PREFIX)
+                        && scopeKey.compareTo(asOfScopeBoundary) <= 0)
+                .map(scopeKey -> EntryNumberGapCheck.builder()
+                        .scopeKey(scopeKey)
+                        .missingNumbers(accountingSequenceRepository.findMissingEntryNumbers(scopeKey))
+                        .build())
+                .filter(gapCheck -> !gapCheck.getMissingNumbers().isEmpty())
+                .toList();
     }
 
     @Override

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLMappingResolverImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLMappingResolverImpl.java
@@ -1,7 +1,11 @@
 package com.positivity.accounting.internal.service;
 
 import com.positivity.accounting.internal.entity.GLMapping;
+import com.positivity.accounting.internal.entity.MappingKey;
+import com.positivity.accounting.internal.entity.PostingCategory;
 import com.positivity.accounting.internal.repository.GLMappingRepository;
+import com.positivity.accounting.internal.repository.MappingKeyRepository;
+import com.positivity.accounting.internal.repository.PostingCategoryRepository;
 import com.positivity.accounting.service.GLMappingResolver;
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -46,6 +50,8 @@ public class GLMappingResolverImpl implements GLMappingResolver {
             List.of("businessUnitId", "locationId", "departmentId", "costCenterId");
 
     private final GLMappingRepository mappingRepository;
+    private final PostingCategoryRepository postingCategoryRepository;
+    private final MappingKeyRepository mappingKeyRepository;
 
     /**
      * Resolves a posting category and mapping key to a GL account.
@@ -116,6 +122,34 @@ public class GLMappingResolverImpl implements GLMappingResolver {
                 String.format("No GL mapping found for %s:%s on %s", postingCategoryId, mappingKeyId, transactionDate);
         log.warn(msg);
         throw new IllegalArgumentException(msg);
+    }
+
+    /**
+     * Resolves a posting category and mapping key to a GL account by their
+     * configured names (story C1, issue #954). No dimensional context —
+     * resolution falls through to the category default mapping.
+     *
+     * @param postingCategoryName posting category name
+     * @param mappingKeyName      mapping key name within the category
+     * @param transactionDate     effective date for resolution
+     * @return GL account ID for posting
+     * @throws IllegalArgumentException if the category, key, or an effective
+     *                                  mapping is not configured
+     */
+    @Override
+    public UUID resolveGLAccount(String postingCategoryName, String mappingKeyName, LocalDateTime transactionDate) {
+        PostingCategory category = postingCategoryRepository
+                .findByCategoryName(postingCategoryName)
+                .orElseThrow(() ->
+                        new IllegalArgumentException("Posting category not configured: " + postingCategoryName));
+
+        MappingKey mappingKey = mappingKeyRepository
+                .findByPostingCategory_PostingCategoryIdAndKeyName(category.getPostingCategoryId(), mappingKeyName)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Mapping key not configured: " + postingCategoryName + "/" + mappingKeyName));
+
+        return resolveGLAccount(
+                category.getPostingCategoryId(), mappingKey.getMappingKeyId(), transactionDate, Map.of());
     }
 
     /**

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
@@ -177,9 +177,10 @@ public class GLPostingServiceImpl implements GLPostingService {
             @NonNull UUID undepositedFundsAccountId,
             @NonNull UUID arAccountId,
             @NonNull BigDecimal amount,
+            @NonNull LocalDateTime transactionDate,
             @NonNull String description) {
         return postPaymentApplication(
-                paymentApplicationId, undepositedFundsAccountId, arAccountId, amount, description, null);
+                paymentApplicationId, undepositedFundsAccountId, arAccountId, amount, transactionDate, description, null);
     }
 
     @Override
@@ -188,6 +189,7 @@ public class GLPostingServiceImpl implements GLPostingService {
             @NonNull UUID undepositedFundsAccountId,
             @NonNull UUID arAccountId,
             @NonNull BigDecimal amount,
+            @NonNull LocalDateTime transactionDate,
             @NonNull String description,
             @Nullable String overrideJustification) {
 
@@ -198,7 +200,7 @@ public class GLPostingServiceImpl implements GLPostingService {
                 amount);
 
         JournalEntry entry = new JournalEntry();
-        entry.setTransactionDate(LocalDateTime.now(clock));
+        entry.setTransactionDate(transactionDate);
         entry.setDescription(description);
         entry.setSourceEventId(paymentApplicationId);
 

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
@@ -156,40 +156,43 @@ public class GLPostingServiceImpl implements GLPostingService {
     }
 
     /**
-     * Post a payment application to GL.
+     * Post a payment application (AR cash receipt) to GL.
      *
      * Creates journal entry with:
-     * - Debit: Cash/Bank
+     * - Debit: Undeposited Funds (decision D-3 — never straight to Cash)
      * - Credit: Accounts Receivable
      *
-     * @param paymentApplicationId Payment application ID (source event)
-     * @param cashAccountId        GL account for cash/bank
-     * @param arAccountId          GL account for AR
-     * @param amount               Payment amount
-     * @param description          Entry description
+     * @param paymentApplicationId      Payment application request ID (source
+     *                                  event)
+     * @param undepositedFundsAccountId GL account for Undeposited Funds (debit
+     *                                  side)
+     * @param arAccountId               GL account for AR
+     * @param amount                    Payment amount
+     * @param description               Entry description
      * @return Posted journal entry
      */
     @Override
     public JournalEntry postPaymentApplication(
             @NonNull UUID paymentApplicationId,
-            @NonNull UUID cashAccountId,
+            @NonNull UUID undepositedFundsAccountId,
             @NonNull UUID arAccountId,
             @NonNull BigDecimal amount,
             @NonNull String description) {
-        return postPaymentApplication(paymentApplicationId, cashAccountId, arAccountId, amount, description, null);
+        return postPaymentApplication(
+                paymentApplicationId, undepositedFundsAccountId, arAccountId, amount, description, null);
     }
 
     @Override
     public JournalEntry postPaymentApplication(
             @NonNull UUID paymentApplicationId,
-            @NonNull UUID cashAccountId,
+            @NonNull UUID undepositedFundsAccountId,
             @NonNull UUID arAccountId,
             @NonNull BigDecimal amount,
             @NonNull String description,
             @Nullable String overrideJustification) {
 
         log.info(
-                "Posting payment application GL entry {}: debit cash {}, credit AR {}",
+                "Posting payment application GL entry {}: debit undeposited funds {}, credit AR {}",
                 paymentApplicationId,
                 amount,
                 amount);
@@ -201,9 +204,9 @@ public class GLPostingServiceImpl implements GLPostingService {
 
         List<JournalEntryLine> lines = new ArrayList<>();
 
-        // Debit: Cash
+        // Debit: Undeposited Funds (D-3)
         JournalEntryLine cashLine = new JournalEntryLine();
-        cashLine.setGlAccountId(cashAccountId);
+        cashLine.setGlAccountId(undepositedFundsAccountId);
         cashLine.setDebitAmount(amount);
         cashLine.setCreditAmount(BigDecimal.ZERO);
         cashLine.setDescription("Cash Receipt - PA#" + paymentApplicationId);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/MappingResolutionTestServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/MappingResolutionTestServiceImpl.java
@@ -1,0 +1,482 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.dto.MappingResolutionTestRequest;
+import com.positivity.accounting.internal.dto.MappingResolutionTestResponse;
+import com.positivity.accounting.internal.dto.MappingResolutionTestResponse.MatchedMapping;
+import com.positivity.accounting.internal.dto.MappingResolutionTestResponse.MatchedRule;
+import com.positivity.accounting.internal.dto.MappingResolutionTestResponse.PredicateEvaluation;
+import com.positivity.accounting.internal.dto.MappingResolutionTestResponse.ResolvedLine;
+import com.positivity.accounting.internal.dto.PostingResult;
+import com.positivity.accounting.internal.entity.AccountingEvent;
+import com.positivity.accounting.internal.entity.GLAccount;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.entity.PostingRuleVersion;
+import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.PostingRuleVersionRepository;
+import com.positivity.accounting.service.MappingResolutionTestService;
+import com.positivity.accounting.service.PostingRuleEvaluator;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Dry-run posting rule / mapping resolution (story E3, issue #957).
+ *
+ * <p>Reuses the production Wave-2 machinery — {@link PostingRuleEvaluator}
+ * (E1 split lines, E2 predicates) via a transient, never-saved
+ * {@link AccountingEvent} — so the dry-run result is byte-identical to what a
+ * real event would post. This service performs <strong>zero persistence</strong>:
+ * it builds no accounting event, journal entry, outbox record, or idempotency
+ * key; all repository access is read-only lookup (rule version + GL account
+ * enrichment). The whole flow runs in a {@code readOnly} transaction.
+ *
+ * <p>The evaluator produces the authoritative matched rule, resolved line
+ * amounts, and mapping metadata. This service additionally re-reads the
+ * matched rule version's {@code rulesDefinition} to enrich each line with its
+ * E1 {@code splitGroup}/{@code factorPercent} and to surface per-predicate
+ * (E2) evaluation outcomes — none of which the evaluator's
+ * {@link PostingResult} carries.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MappingResolutionTestServiceImpl implements MappingResolutionTestService {
+
+    /**
+     * Placeholder organization used only to satisfy the evaluator's
+     * non-null guard. Rule-version selection is by event type, so the value
+     * does not influence resolution.
+     */
+    private static final UUID DRY_RUN_ORGANIZATION_ID = new UUID(0L, 0L);
+
+    private final PostingRuleEvaluator postingRuleEvaluator;
+    private final PostingRuleVersionRepository versionRepository;
+    private final GLAccountRepository glAccountRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public MappingResolutionTestResponse resolveTest(@NonNull MappingResolutionTestRequest request) {
+        if (request.getEventType() == null || request.getEventType().isBlank()) {
+            throw new IllegalArgumentException("Event type is required");
+        }
+        if (request.getTransactionDate() == null) {
+            throw new IllegalArgumentException("Transaction date is required");
+        }
+
+        AccountingEvent event = buildTransientEvent(request);
+
+        // Authoritative evaluation via the production engine (no persistence).
+        PostingResult result = postingRuleEvaluator.evaluateEvent(event, null);
+
+        if (result.isSuccess()) {
+            return buildMatchedResponse(request, event, result);
+        }
+        return buildNoMatchResponse(request, event, result);
+    }
+
+    /**
+     * Builds a transient (never-saved) accounting event from the request.
+     * The sample payload's {@code organizationId}, when present, must be a
+     * valid UUID; a malformed value is a caller error.
+     */
+    private AccountingEvent buildTransientEvent(MappingResolutionTestRequest request) {
+        Map<String, Object> payload =
+                request.getSamplePayload() != null ? request.getSamplePayload() : Collections.emptyMap();
+
+        AccountingEvent event = new AccountingEvent();
+        event.setEventType(request.getEventType());
+        event.setOrganizationId(resolveOrganizationId(payload));
+        event.setTransactionDate(request.getTransactionDate().atStartOfDay());
+        event.setPayload(payload);
+        event.setSourceSystem("DRY_RUN");
+        return event;
+    }
+
+    private UUID resolveOrganizationId(Map<String, Object> payload) {
+        Object raw = payload.get("organizationId");
+        if (raw == null) {
+            return DRY_RUN_ORGANIZATION_ID;
+        }
+        if (raw instanceof UUID uuid) {
+            return uuid;
+        }
+        try {
+            return UUID.fromString(raw.toString());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Sample payload field 'organizationId' value '" + raw + "' is not a valid UUID", e);
+        }
+    }
+
+    // ── Matched path ──────────────────────────────────────────────────────────
+
+    private MappingResolutionTestResponse buildMatchedResponse(
+            MappingResolutionTestRequest request, AccountingEvent event, PostingResult result) {
+        JournalEntry draft = result.getJournalEntryDraft();
+        if (draft == null) {
+            // Defensive: success without a draft should not happen.
+            return MappingResolutionTestResponse.builder()
+                    .matched(false)
+                    .noMatchReason("INTERNAL_ERROR")
+                    .noMatchDetail("Evaluation succeeded but produced no journal entry draft")
+                    .build();
+        }
+
+        UUID versionId = result.getMappingVersionUsed();
+        PostingRuleVersion version = versionId != null
+                ? versionRepository.findById(versionId).orElse(null)
+                : null;
+
+        // Re-read the matched rule condition for E1 split metadata and E2
+        // predicate outcomes; the evaluator's result does not carry these.
+        ConditionScan scan = scanConditions(version, event);
+
+        // A referenced amount field that is present but non-numeric is a
+        // caller error (the engine silently coerces it to zero); surface it
+        // as a 400 rather than returning a misleading zero-amount result.
+        if (scan.matchedLineSpecs != null) {
+            assertAmountFieldsInterpretable(scan.matchedLineSpecs, event.getPayload());
+        }
+
+        List<ResolvedLine> resolvedLines = buildResolvedLines(draft.getLines(), scan.matchedLineSpecs);
+
+        MatchedRule matchedRule = null;
+        if (version != null) {
+            matchedRule = MatchedRule.builder()
+                    .postingRuleSetId(draft.getPostingRuleSetId())
+                    .ruleSetName(version.getPostingRuleSet() != null
+                            ? version.getPostingRuleSet().getName()
+                            : null)
+                    .ruleVersionId(version.getVersionId())
+                    .versionNumber(version.getVersionNumber())
+                    .build();
+        }
+
+        MatchedMapping matchedMapping = MatchedMapping.builder()
+                .mappingType(asString(result.getEvaluationDetails(), "mappingType"))
+                .mappingKey(asString(result.getEvaluationDetails(), "mappingKey"))
+                .keysEvaluated(scan.keysEvaluated.isEmpty() ? null : List.copyOf(scan.keysEvaluated))
+                .build();
+
+        return MappingResolutionTestResponse.builder()
+                .matched(true)
+                .matchedRule(matchedRule)
+                .matchedMapping(matchedMapping)
+                .resolvedLines(resolvedLines)
+                .predicateEvaluations(scan.predicateEvaluations.isEmpty() ? null : scan.predicateEvaluations)
+                .build();
+    }
+
+    private List<ResolvedLine> buildResolvedLines(
+            List<JournalEntryLine> draftLines, @Nullable List<LineSpec> matchedLineSpecs) {
+        Map<UUID, GLAccount> accounts = loadAccounts(draftLines);
+        List<ResolvedLine> resolvedLines = new ArrayList<>();
+
+        for (int i = 0; i < draftLines.size(); i++) {
+            JournalEntryLine line = draftLines.get(i);
+            UUID accountId = line.getGlAccountId();
+            GLAccount account = accountId != null ? accounts.get(accountId) : null;
+            LineSpec spec = matchedLineSpecs != null && i < matchedLineSpecs.size() ? matchedLineSpecs.get(i) : null;
+
+            resolvedLines.add(ResolvedLine.builder()
+                    .glAccountId(accountId)
+                    .accountCode(account != null ? account.getAccountCode() : null)
+                    .accountName(account != null ? account.getAccountName() : null)
+                    .debitAmount(line.getDebitAmount())
+                    .creditAmount(line.getCreditAmount())
+                    .description(line.getDescription())
+                    .splitGroup(spec != null ? spec.splitGroup() : null)
+                    .factorPercent(spec != null ? spec.factorPercent() : null)
+                    .build());
+        }
+        return resolvedLines;
+    }
+
+    private Map<UUID, GLAccount> loadAccounts(List<JournalEntryLine> draftLines) {
+        Set<UUID> ids = new LinkedHashSet<>();
+        for (JournalEntryLine line : draftLines) {
+            UUID id = line.getGlAccountId();
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        if (ids.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<UUID, GLAccount> byId = new LinkedHashMap<>();
+        for (GLAccount account : glAccountRepository.findAllById(ids)) {
+            byId.put(account.getGlAccountId(), account);
+        }
+        return byId;
+    }
+
+    // ── No-match path ─────────────────────────────────────────────────────────
+
+    private MappingResolutionTestResponse buildNoMatchResponse(
+            MappingResolutionTestRequest request, AccountingEvent event, PostingResult result) {
+        String reason = result.getFailureReason() != null
+                ? result.getFailureReason().name()
+                : "NO_RULE_VERSION";
+
+        // A rule version was selected but no condition matched: surface the
+        // per-predicate outcomes so the caller can see why.
+        PostingRuleVersion version = null;
+        UUID versionId = asUuid(result.getEvaluationDetails(), "ruleVersionUsed");
+        if (versionId != null) {
+            version = versionRepository.findById(versionId).orElse(null);
+        }
+        ConditionScan scan = scanConditions(version, event);
+
+        return MappingResolutionTestResponse.builder()
+                .matched(false)
+                .noMatchReason(reason)
+                .noMatchDetail(result.getFailureDetails())
+                .predicateEvaluations(scan.predicateEvaluations.isEmpty() ? null : scan.predicateEvaluations)
+                .build();
+    }
+
+    // ── Rule-definition rescan (metadata enrichment) ───────────────────────────
+
+    /**
+     * Parses the matched rule version's {@code rulesDefinition} and replays
+     * the evaluator's first-match condition loop to recover per-predicate
+     * (E2) outcomes and, for the matched condition, its line specs (E1
+     * {@code splitGroup}/{@code factorPercent}). Kept read-only and free of
+     * side effects.
+     */
+    private ConditionScan scanConditions(@Nullable PostingRuleVersion version, AccountingEvent event) {
+        ConditionScan scan = new ConditionScan();
+        if (version == null) {
+            return scan;
+        }
+        String rulesJson = version.getRulesDefinition();
+        if (rulesJson == null || rulesJson.isBlank() || "{}".equals(rulesJson.trim())) {
+            return scan;
+        }
+
+        JsonNode conditions;
+        try {
+            JsonNode root = objectMapper.readTree(rulesJson);
+            conditions = root.get("conditions");
+        } catch (Exception e) {
+            log.warn("Dry-run could not parse rulesDefinition for version {}: {}", version.getVersionId(), e.getMessage());
+            return scan;
+        }
+        if (conditions == null || !conditions.isArray()) {
+            return scan;
+        }
+
+        for (JsonNode conditionBlock : conditions) {
+            String conditionExpr = conditionBlock.has("condition")
+                    ? conditionBlock.get("condition").asString()
+                    : null;
+            String predicateLabel = conditionExpr != null ? conditionExpr : "*";
+            scan.keysEvaluated.add(predicateLabel);
+
+            PredicateOutcome outcome = evaluatePredicate(conditionExpr, event);
+            scan.predicateEvaluations.add(PredicateEvaluation.builder()
+                    .predicate(predicateLabel)
+                    .matched(outcome.matched())
+                    .detail(outcome.detail())
+                    .build());
+
+            if (!outcome.matched()) {
+                continue;
+            }
+
+            JsonNode linesNode = conditionBlock.get("lines");
+            if (linesNode == null || !linesNode.isArray() || linesNode.isEmpty()) {
+                // Mirror the evaluator: a matched-but-empty condition is skipped.
+                continue;
+            }
+
+            // First condition that matches and has lines is the one the
+            // evaluator resolved; capture its line specs and stop.
+            scan.matchedLineSpecs = parseLineSpecs(linesNode);
+            break;
+        }
+        return scan;
+    }
+
+    private List<LineSpec> parseLineSpecs(JsonNode linesNode) {
+        List<LineSpec> specs = new ArrayList<>();
+        for (JsonNode lineNode : linesNode) {
+            String amountField =
+                    lineNode.has("amountField") ? lineNode.get("amountField").asString() : null;
+            BigDecimal factorPercent = null;
+            if (lineNode.has("factorPercent")) {
+                try {
+                    factorPercent = new BigDecimal(lineNode.get("factorPercent").asString());
+                } catch (NumberFormatException e) {
+                    factorPercent = null;
+                }
+            }
+            String splitGroup = lineNode.has("splitGroup")
+                    ? lineNode.get("splitGroup").asString()
+                    : null;
+            specs.add(new LineSpec(amountField, factorPercent, splitGroup));
+        }
+        return specs;
+    }
+
+    // ── Predicate evaluation (E2 grammar reuse) ────────────────────────────────
+
+    private PredicateOutcome evaluatePredicate(@Nullable String conditionExpr, AccountingEvent event) {
+        if (conditionExpr == null || conditionExpr.isBlank() || "*".equals(conditionExpr.trim())) {
+            return new PredicateOutcome(true, null);
+        }
+        PredicateParser.Predicate predicate;
+        try {
+            predicate = PredicateParser.parse(conditionExpr);
+        } catch (PredicateParser.ParseException e) {
+            return new PredicateOutcome(false, "Predicate could not be parsed: " + e.getMessage());
+        }
+
+        boolean matched = predicate.matches(event.getEventType(), event.getPayload());
+        if (matched) {
+            return new PredicateOutcome(true, null);
+        }
+        String failingClause = firstFailingClause(predicate, event);
+        String detail = failingClause != null
+                ? "clause " + failingClause + " evaluated false"
+                : "Predicate '" + conditionExpr + "' did not match the sample event";
+        return new PredicateOutcome(false, detail);
+    }
+
+    @Nullable
+    private String firstFailingClause(PredicateParser.Predicate predicate, AccountingEvent event) {
+        for (PredicateParser.Clause clause : predicate.clauses()) {
+            boolean clauseMatched = new PredicateParser.Predicate(List.of(clause))
+                    .matches(event.getEventType(), event.getPayload());
+            if (!clauseMatched) {
+                return renderClause(clause);
+            }
+        }
+        return null;
+    }
+
+    private String renderClause(PredicateParser.Clause clause) {
+        String lhs;
+        if (clause.lhs() instanceof PredicateParser.EventTypeRef) {
+            lhs = "eventType";
+        } else if (clause.lhs() instanceof PredicateParser.PayloadPath path) {
+            lhs = "payload." + String.join(".", path.segments());
+        } else {
+            lhs = "?";
+        }
+        String rhs = switch (clause.literal()) {
+            case PredicateParser.StringLiteral s -> "'" + s.value() + "'";
+            case PredicateParser.NumberLiteral n -> n.value().toPlainString();
+        };
+        return lhs + " " + clause.op().symbol() + " " + rhs;
+    }
+
+    // ── Amount interpretability guard ──────────────────────────────────────────
+
+    /**
+     * Ensures every {@code amountField} referenced by the matched condition
+     * that is present in the payload is numeric-coercible. An absent field
+     * mirrors the real engine (resolves to zero) and is allowed; a
+     * present-but-non-numeric value is a caller error mapped to HTTP 400.
+     */
+    private void assertAmountFieldsInterpretable(List<LineSpec> specs, @Nullable Map<String, Object> payload) {
+        Set<String> checked = new LinkedHashSet<>();
+        for (LineSpec spec : specs) {
+            String field = spec.amountField();
+            if (field == null || field.isBlank() || !checked.add(field)) {
+                continue;
+            }
+            Object value = navigatePayload(field, payload);
+            if (value == null) {
+                continue; // absent → engine uses zero, mirror it
+            }
+            if (!isNumeric(value)) {
+                throw new IllegalArgumentException("Sample payload field '" + field + "' value '" + value
+                        + "' cannot be interpreted as a numeric amount");
+            }
+        }
+    }
+
+    @Nullable
+    private Object navigatePayload(String amountField, @Nullable Map<String, Object> payload) {
+        String fieldPath = amountField.startsWith("payload.") ? amountField.substring("payload.".length()) : amountField;
+        Object current = payload;
+        for (String part : fieldPath.split("\\.")) {
+            if (current instanceof Map<?, ?> map) {
+                current = map.get(part);
+            } else {
+                return null;
+            }
+        }
+        return current;
+    }
+
+    private boolean isNumeric(Object value) {
+        if (value instanceof Number) {
+            return true;
+        }
+        if (value instanceof String str) {
+            try {
+                new BigDecimal(str.trim());
+                return true;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    // ── Small helpers ──────────────────────────────────────────────────────────
+
+    @Nullable
+    private String asString(@Nullable Map<String, Object> details, String key) {
+        if (details == null) {
+            return null;
+        }
+        Object value = details.get(key);
+        return value != null ? value.toString() : null;
+    }
+
+    @Nullable
+    private UUID asUuid(@Nullable Map<String, Object> details, String key) {
+        if (details == null) {
+            return null;
+        }
+        Object value = details.get(key);
+        if (value instanceof UUID uuid) {
+            return uuid;
+        }
+        return null;
+    }
+
+    // ── Value carriers ─────────────────────────────────────────────────────────
+
+    private record LineSpec(@Nullable String amountField, @Nullable BigDecimal factorPercent, @Nullable String splitGroup) {}
+
+    private record PredicateOutcome(boolean matched, @Nullable String detail) {}
+
+    private static final class ConditionScan {
+        private final List<String> keysEvaluated = new ArrayList<>();
+        private final List<PredicateEvaluation> predicateEvaluations = new ArrayList<>();
+
+        @Nullable
+        private List<LineSpec> matchedLineSpecs;
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/OutboxProcessor.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/OutboxProcessor.java
@@ -3,6 +3,7 @@ package com.positivity.accounting.internal.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.positivity.accounting.internal.dto.APPaymentGLPostingEvent;
+import com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent;
 import com.positivity.accounting.internal.entity.EventOutbox;
 import com.positivity.accounting.internal.entity.EventOutbox.OutboxStatus;
 import com.positivity.accounting.internal.repository.EventOutboxRepository;
@@ -54,8 +55,11 @@ public class OutboxProcessor {
     private static final int BATCH_SIZE = 10;
     private static final int MAX_RETRIES = 5;
     private static final Duration RETRY_DELAY = Duration.ofSeconds(30);
-    private static final Map<String, Class<?>> EVENT_TYPE_REGISTRY =
-            Map.of(APPaymentGLPostingEvent.class.getName(), APPaymentGLPostingEvent.class);
+    private static final Map<String, Class<?>> EVENT_TYPE_REGISTRY = Map.of(
+            APPaymentGLPostingEvent.class.getName(),
+            APPaymentGLPostingEvent.class,
+            PaymentApplicationGLPostingEvent.class.getName(),
+            PaymentApplicationGLPostingEvent.class);
 
     /**
      * Scheduled task to process pending outbox events.

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PaymentApplicationServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PaymentApplicationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.accounting.internal.service;
 
+import com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent;
 import com.positivity.accounting.internal.dto.PaymentApplicationRequest;
 import com.positivity.accounting.internal.dto.PaymentApplicationResponse;
 import com.positivity.accounting.internal.entity.CustomerCredit;
@@ -14,6 +15,7 @@ import com.positivity.accounting.internal.repository.CustomerCreditRepository;
 import com.positivity.accounting.internal.repository.PaymentApplicationRepository;
 import com.positivity.accounting.internal.repository.PaymentApplicationReversalRepository;
 import com.positivity.accounting.internal.repository.ReceivablePaymentRepository;
+import com.positivity.accounting.service.OutboxService;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.shared.id.UUIDv7Generator;
 import java.math.BigDecimal;
@@ -61,6 +63,7 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
     private final CustomerCreditRepository customerCreditRepository;
     private final PaymentApplicationReversalRepository reversalRepository;
     private final InvoiceBalanceCalculator invoiceBalanceCalculator;
+    private final OutboxService outboxService;
 
     /**
      * Handle PaymentCleared event from Payment domain.
@@ -231,7 +234,14 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
 
         receivablePaymentRepository.save(payment);
 
-        // 9. Build response
+        // 9. Enqueue GL posting work item in the SAME transaction (transactional
+        // outbox, story C1 issue #954). The async consumer posts
+        // Dr Undeposited Funds / Cr AR (decision D-3); if this transaction rolls
+        // back, the work item rolls back with it, so only committed applications
+        // ever reach the ledger.
+        enqueueGLPostingWorkItem(paymentId, request.getApplicationRequestId(), payment, validation, applicationTimestamp);
+
+        // 10. Build response
         return PaymentApplicationResponse.builder()
                 .paymentId(paymentId)
                 .customerId(payment.getCustomerId())
@@ -436,6 +446,45 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
     }
 
     // ===== PRIVATE HELPER METHODS =====
+
+    /**
+     * Persist a {@link PaymentApplicationGLPostingEvent} work item to the
+     * transactional outbox (story C1, issue #954). Runs inside the surrounding
+     * application transaction ({@code saveToOutbox} uses MANDATORY
+     * propagation), guaranteeing the ledger work item exists iff the
+     * application committed. The application request id travels on the event
+     * as both the posting idempotency key and the journal entry
+     * {@code sourceEventId} basis.
+     */
+    private void enqueueGLPostingWorkItem(
+            @NonNull UUID paymentId,
+            @NonNull String applicationRequestId,
+            @NonNull ReceivablePayment payment,
+            @NonNull InvoiceApplicationValidation validation,
+            @NonNull Instant applicationTimestamp) {
+        PaymentApplicationGLPostingEvent glPostingEvent = PaymentApplicationGLPostingEvent.builder()
+                .eventId(UUIDv7Generator.generate())
+                .applicationRequestId(applicationRequestId)
+                .paymentId(paymentId)
+                .customerId(payment.getCustomerId())
+                .currency(payment.getCurrency())
+                .appliedAmount(validation.actualTotalApplicationAmount())
+                .applicationTimestamp(applicationTimestamp)
+                .build();
+
+        outboxService.saveToOutbox(
+                glPostingEvent.getEventId(),
+                "PaymentApplication",
+                paymentId,
+                glPostingEvent.getClass().getName(),
+                glPostingEvent);
+
+        log.info(
+                "GL posting work item persisted to outbox | applicationRequestId={} | eventId={} | appliedAmount={}",
+                applicationRequestId,
+                glPostingEvent.getEventId(),
+                validation.actualTotalApplicationAmount());
+    }
 
     /**
      * Validate an invoice application against the {@code ext_invoice} replica and accounting's

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PaymentApplicationServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PaymentApplicationServiceImpl.java
@@ -8,6 +8,7 @@ import com.positivity.accounting.internal.entity.PaymentApplication;
 import com.positivity.accounting.internal.entity.PaymentApplicationReversal;
 import com.positivity.accounting.internal.entity.ReceivablePayment;
 import com.positivity.accounting.internal.entity.ReceivablePayment.ReceivablePaymentStatus;
+import com.positivity.accounting.internal.enums.AllocationStrategy;
 import com.positivity.accounting.internal.enums.InvoiceStatus;
 import com.positivity.accounting.internal.repository.CustomerCreditRepository;
 import com.positivity.accounting.internal.repository.PaymentApplicationRepository;
@@ -19,6 +20,7 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -155,7 +157,9 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
      * 8. Emit events for downstream consumers
      *
      * @param paymentId payment to apply
-     * @param request   application request with invoices and amounts
+     * @param request   application request with invoices, amounts, and optional
+     *                  allocation strategy (see
+     *                  {@link #orderApplicationsForAllocation(PaymentApplicationRequest)})
      * @return application response with details
      * @throws ResponseStatusException with NOT_FOUND if payment not found
      * @throws ResponseStatusException with BAD_REQUEST if validation fails or
@@ -547,7 +551,7 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
 
         // All mutations are accounting-local (ADR-0044, #842): a failure rolls back the whole
         // transaction, so no cross-service compensating reversals are needed anymore.
-        for (PaymentApplicationRequest.InvoiceApplication invoiceApp : request.getApplications()) {
+        for (PaymentApplicationRequest.InvoiceApplication invoiceApp : orderApplicationsForAllocation(request)) {
             applySingleInvoiceApplication(
                     new InvoiceApplicationExecutionContext(
                             paymentId,
@@ -561,6 +565,47 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
                             invoiceApp.getInvoiceId(), cappedAmounts.get(invoiceApp.getInvoiceId())));
         }
         return applicationDetails;
+    }
+
+    /**
+     * Resolve the allocation iteration order per the request's effective strategy (Issue #955).
+     *
+     * <p>{@code CALLER_ORDER} (including an absent strategy) returns the caller-supplied list
+     * untouched, keeping behavior byte-identical to requests predating the field.
+     * {@code OLDEST_FIRST} returns a sorted copy ordered by ascending replica invoice date
+     * ({@link ExtInvoice#getInvoiceCreatedAt()}); invoices with no replica date sort last, and
+     * equal dates tie-break deterministically by ascending invoice id. Reordering affects
+     * allocation order only — validation, capping, and idempotency semantics are unchanged.
+     *
+     * @param request the application request (strategy resolved via
+     *                {@link PaymentApplicationRequest#resolveAllocationStrategy()})
+     * @return the invoice applications in allocation order
+     */
+    @NonNull private List<PaymentApplicationRequest.InvoiceApplication> orderApplicationsForAllocation(
+            @NonNull PaymentApplicationRequest request) {
+        List<PaymentApplicationRequest.InvoiceApplication> applications = request.getApplications();
+        if (request.resolveAllocationStrategy() != AllocationStrategy.OLDEST_FIRST) {
+            return applications;
+        }
+
+        Map<UUID, Instant> invoiceDates = new HashMap<>();
+        for (PaymentApplicationRequest.InvoiceApplication invoiceApp : applications) {
+            UUID invoiceId = invoiceApp.getInvoiceId();
+            if (!invoiceDates.containsKey(invoiceId)) {
+                invoiceDates.put(
+                        invoiceId,
+                        invoiceBalanceCalculator
+                                .findInvoice(invoiceId)
+                                .map(ExtInvoice::getInvoiceCreatedAt)
+                                .orElse(null));
+            }
+        }
+
+        Comparator<PaymentApplicationRequest.InvoiceApplication> byInvoiceDateThenId = Comparator.comparing(
+                        (PaymentApplicationRequest.InvoiceApplication app) -> invoiceDates.get(app.getInvoiceId()),
+                        Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(PaymentApplicationRequest.InvoiceApplication::getInvoiceId);
+        return applications.stream().sorted(byInvoiceDateThenId).toList();
     }
 
     private void applySingleInvoiceApplication(

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/FinancialReportingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/FinancialReportingService.java
@@ -53,6 +53,30 @@ public interface FinancialReportingService {
     BalanceSheetReport generateBalanceSheet(@NonNull LocalDate asOfDate);
 
     /**
+     * Generate Trial Balance as of specified date.
+     *
+     * Aggregates all POSTED journal lines up to and including the as-of date
+     * into per-account debit/credit/balance rows (ordered by account number),
+     * with grand totals proving the balance constraint (sum of debits equals
+     * sum of credits; the {@code balanced} flag is false when the constraint
+     * is violated).
+     *
+     * Also runs the entry-number gap-check (per monthly sequence scope, see
+     * {@code AccountingSequenceRepository#findMissingEntryNumbers}) and
+     * attaches the results as a footnote block; the footnote is empty on a
+     * clean ledger.
+     *
+     * Returns empty rows with zero totals (balanced = true) and an empty gap
+     * footnote when no POSTED data exists as of the requested date.
+     *
+     * @param asOf reporting date (inclusive)
+     * @return trial balance report with per-account rows, grand totals, and
+     *         entry-number gap footnote
+     */
+    @NonNull
+    TrialBalanceReport generateTrialBalance(@NonNull LocalDate asOf);
+
+    /**
      * Drill down from a statement line to see contributing GL accounts.
      *
      * Returns all accounts mapped to the specified statement line code,

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/GLMappingResolver.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/GLMappingResolver.java
@@ -34,6 +34,24 @@ public interface GLMappingResolver {
             Map<String, String> dimensionContext);
 
     /**
+     * Resolves a posting category and mapping key to a GL account by their
+     * configured names (story C1, issue #954). Looks up the category and key
+     * configuration, then delegates to
+     * {@link #resolveGLAccount(UUID, UUID, LocalDateTime, Map)} with no
+     * dimensional context (category default resolution).
+     *
+     * @param postingCategoryName posting category name (e.g.
+     *                            {@code PAYMENT_APPLICATION})
+     * @param mappingKeyName      mapping key name within the category (e.g.
+     *                            {@code UNDEPOSITED_FUNDS})
+     * @param transactionDate     effective date for resolution
+     * @return GL account ID for posting
+     * @throws IllegalArgumentException if the category, key, or an effective
+     *                                  mapping is not configured
+     */
+    UUID resolveGLAccount(String postingCategoryName, String mappingKeyName, LocalDateTime transactionDate);
+
+    /**
      * Validates a GL mapping for consistency and non-overlapping effective dates.
      *
      * Checks:

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
@@ -63,21 +63,29 @@ public interface GLPostingService {
             @Nullable String overrideJustification);
 
     /**
-     * Post a payment application to GL.
+     * Post a payment application (AR cash receipt) to GL.
      *
      * Creates journal entry with:
-     * - Debit: Cash/Bank
+     * - Debit: Undeposited Funds (decision D-3 — cash receipts are never
+     * posted straight to Cash; settlement reconciliation clears Undeposited
+     * Funds to Cash later)
      * - Credit: Accounts Receivable
      *
-     * @param paymentApplicationId Payment application ID (source event)
-     * @param cashAccountId        GL account for cash/bank
-     * @param arAccountId          GL account for AR
-     * @param amount               Payment amount
-     * @param description          Entry description
+     * @param paymentApplicationId       Payment application request ID (source
+     *                                   event)
+     * @param undepositedFundsAccountId  GL account for Undeposited Funds
+     *                                   (debit side)
+     * @param arAccountId                GL account for AR
+     * @param amount                     Payment amount
+     * @param description                Entry description
      * @return Posted journal entry
      */
     JournalEntry postPaymentApplication(
-            UUID paymentApplicationId, UUID cashAccountId, UUID arAccountId, BigDecimal amount, String description);
+            UUID paymentApplicationId,
+            UUID undepositedFundsAccountId,
+            UUID arAccountId,
+            BigDecimal amount,
+            String description);
 
     /**
      * Post a payment application to GL with an optional accounting-period
@@ -93,7 +101,7 @@ public interface GLPostingService {
      */
     JournalEntry postPaymentApplication(
             @NonNull UUID paymentApplicationId,
-            @NonNull UUID cashAccountId,
+            @NonNull UUID undepositedFundsAccountId,
             @NonNull UUID arAccountId,
             @NonNull BigDecimal amount,
             @NonNull String description,

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
@@ -2,6 +2,7 @@ package com.positivity.accounting.service;
 
 import com.positivity.accounting.internal.entity.JournalEntry;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -77,6 +78,11 @@ public interface GLPostingService {
      *                                   (debit side)
      * @param arAccountId                GL account for AR
      * @param amount                     Payment amount
+     * @param transactionDate            Business transaction date (the payment
+     *                                   application timestamp) used as the
+     *                                   journal entry date; must not be derived
+     *                                   from processing/clock time so outbox
+     *                                   retries post into the correct period
      * @param description                Entry description
      * @return Posted journal entry
      */
@@ -85,6 +91,7 @@ public interface GLPostingService {
             UUID undepositedFundsAccountId,
             UUID arAccountId,
             BigDecimal amount,
+            LocalDateTime transactionDate,
             String description);
 
     /**
@@ -104,6 +111,7 @@ public interface GLPostingService {
             @NonNull UUID undepositedFundsAccountId,
             @NonNull UUID arAccountId,
             @NonNull BigDecimal amount,
+            @NonNull LocalDateTime transactionDate,
             @NonNull String description,
             @Nullable String overrideJustification);
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/MappingResolutionTestService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/MappingResolutionTestService.java
@@ -1,0 +1,53 @@
+package com.positivity.accounting.service;
+
+import com.positivity.accounting.internal.dto.MappingResolutionTestRequest;
+import com.positivity.accounting.internal.dto.MappingResolutionTestResponse;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Dry-run posting rule / mapping resolution service (story E3, issue #957).
+ *
+ * Resolves a hypothetical accounting event against the published posting
+ * rules and GL mappings, returning exactly what the posting engine would
+ * post — matched rule identity, mapping details, resolved lines (including
+ * E1 proportional split shares and residual distribution), and per-predicate
+ * evaluation outcomes (E2 grammar) — <strong>without persisting
+ * anything</strong>.
+ *
+ * Contract:
+ * <ul>
+ * <li>The implementation MUST reuse the production evaluation machinery
+ * ({@link PostingRuleEvaluator}, {@code PredicateParser},
+ * {@link GLMappingResolver}) so dry-run output is identical to what a real
+ * event would produce. The recommended approach is to build a transient
+ * (never-saved) {@code AccountingEvent} from the request and pass it to the
+ * evaluator; no accounting event, journal entry, outbox record, or any other
+ * row may be written as a side effect.</li>
+ * <li>No matching published rule for the event type / transaction date is a
+ * normal outcome: return {@code matched=false} with a populated
+ * {@code noMatchReason}/{@code noMatchDetail}. Do NOT throw.</li>
+ * <li>A sample payload that cannot be interpreted by the rules (for example
+ * a non-numeric amount field) is a caller error: throw
+ * {@link IllegalArgumentException} with a descriptive message; the module
+ * exception handler maps it to HTTP 400 {@code VALIDATION_ERROR}.</li>
+ * </ul>
+ *
+ * @see PostingRuleEvaluator
+ * @see GLMappingResolver
+ */
+public interface MappingResolutionTestService {
+
+    /**
+     * Performs a dry-run resolution of the supplied hypothetical event.
+     *
+     * @param request the dry-run request (validated: non-blank event type,
+     *                non-null transaction date; sample payload optional)
+     * @return the dry-run resolution result; {@code matched=false} when no
+     *         published rule matched (never null)
+     * @throws IllegalArgumentException if the sample payload cannot be
+     *                                  interpreted by the matched rules
+     *                                  (mapped to HTTP 400)
+     */
+    @NonNull
+    MappingResolutionTestResponse resolveTest(@NonNull MappingResolutionTestRequest request);
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/PaymentApplicationService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/PaymentApplicationService.java
@@ -20,6 +20,19 @@ public interface PaymentApplicationService {
             @NonNull Instant clearedAt,
             @NonNull UUID sourceEventId);
 
+    /**
+     * Apply a payment across the requested invoices.
+     *
+     * <p>Allocation ordering is governed by the request's optional
+     * {@code allocationStrategy}; implementations must resolve the effective strategy via
+     * {@link PaymentApplicationRequest#resolveAllocationStrategy()} so an absent value
+     * defaults to {@code CALLER_ORDER} (behavior identical to requests predating the field),
+     * while {@code OLDEST_FIRST} allocates by ascending invoice date (Issue #955).
+     *
+     * @param paymentId payment to apply
+     * @param request   invoices, amounts, idempotency key, and optional allocation strategy
+     * @return application response with per-invoice application details
+     */
     @NonNull
     PaymentApplicationResponse applyPaymentToInvoices(
             @NonNull UUID paymentId, @NonNull PaymentApplicationRequest request);

--- a/pos-accounting/src/main/resources/db/migration/R__seed_reference_accounting.sql
+++ b/pos-accounting/src/main/resources/db/migration/R__seed_reference_accounting.sql
@@ -99,6 +99,18 @@ ON CONFLICT (posting_category_id) DO UPDATE SET
     modified_at = NOW(),
     modified_by = 'seed-generator';
 
+-- Story C1 (Issue #954, decision D-3): AR cash-receipt GL posting category.
+-- Payment applications post Dr Undeposited Funds (1090) / Cr AR (1200);
+-- accounts resolve through this category's mapping keys — never hardcoded.
+INSERT INTO posting_category (posting_category_id, category_name, description, is_active, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000ca01'::uuid, 'PAYMENT_APPLICATION', 'AR cash receipt GL posting (Dr Undeposited Funds / Cr AR, decision D-3)', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (posting_category_id) DO UPDATE SET
+    category_name = EXCLUDED.category_name,
+    description = EXCLUDED.description,
+    is_active = EXCLUDED.is_active,
+    modified_at = NOW(),
+    modified_by = 'seed-generator';
+
 -- Mapping keys
 INSERT INTO mapping_key (mapping_key_id, posting_category_id, key_name, description, is_active, created_at, created_by, modified_at, modified_by)
 VALUES ('05b9e38b-003d-5a02-ec1b-db48542ccc12'::uuid, '70eb38c4-cf6a-992a-81c3-2a4c958a458a'::uuid, 'DEFAULT', 'DEFAULT', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
@@ -110,9 +122,58 @@ ON CONFLICT (mapping_key_id) DO UPDATE SET
     modified_at = NOW(),
     modified_by = 'seed-generator';
 
+-- Story C1 (Issue #954): mapping keys for the PAYMENT_APPLICATION category.
+INSERT INTO mapping_key (mapping_key_id, posting_category_id, key_name, description, is_active, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000ca02'::uuid, '5eed0acc-0000-4000-8000-00000000ca01'::uuid, 'UNDEPOSITED_FUNDS', 'Debit side of AR cash receipt (decision D-3)', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (mapping_key_id) DO UPDATE SET
+    posting_category_id = EXCLUDED.posting_category_id,
+    key_name = EXCLUDED.key_name,
+    description = EXCLUDED.description,
+    is_active = EXCLUDED.is_active,
+    modified_at = NOW(),
+    modified_by = 'seed-generator';
+INSERT INTO mapping_key (mapping_key_id, posting_category_id, key_name, description, is_active, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000ca03'::uuid, '5eed0acc-0000-4000-8000-00000000ca01'::uuid, 'ACCOUNTS_RECEIVABLE', 'Credit side of AR cash receipt', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (mapping_key_id) DO UPDATE SET
+    posting_category_id = EXCLUDED.posting_category_id,
+    key_name = EXCLUDED.key_name,
+    description = EXCLUDED.description,
+    is_active = EXCLUDED.is_active,
+    modified_at = NOW(),
+    modified_by = 'seed-generator';
+
 -- GL mappings
 INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
 VALUES ('c3d2b7cf-a895-077a-2a37-48115a2b7c22'::uuid, 'ORDER', 'ORDER_COMPLETED', '70eb38c4-cf6a-992a-81c3-2a4c958a458a'::uuid, '05b9e38b-003d-5a02-ec1b-db48542ccc12'::uuid, 'b8798348-d3be-9582-7a6d-883ae3e64e66'::uuid, NOW(), NOW(), 'seed-generator')
+ON CONFLICT (gl_mapping_id) DO UPDATE SET
+    source_system = EXCLUDED.source_system,
+    external_code = EXCLUDED.external_code,
+    posting_category_id = EXCLUDED.posting_category_id,
+    mapping_key_id = EXCLUDED.mapping_key_id,
+    gl_account_id = EXCLUDED.gl_account_id,
+    effective_start_date = EXCLUDED.effective_start_date,
+    effective_end_date = EXCLUDED.effective_end_date,
+    dimensions = EXCLUDED.dimensions,
+    created_by = 'seed-generator';
+
+-- Story C1 (Issue #954): PAYMENT_APPLICATION account mappings. Fixed
+-- effective_start_date (not NOW()) so re-runs stay idempotent and the
+-- mapping always covers every posting date. 1090 = Undeposited Funds,
+-- 1200 = Accounts Receivable (both seeded above by story H1).
+INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000ca04'::uuid, 'ACCOUNTING', 'PAYMENT_APPLICATION_UNDEPOSITED_FUNDS', '5eed0acc-0000-4000-8000-00000000ca01'::uuid, '5eed0acc-0000-4000-8000-00000000ca02'::uuid, '5eed0acc-0000-4000-8000-000000001090'::uuid, TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
+ON CONFLICT (gl_mapping_id) DO UPDATE SET
+    source_system = EXCLUDED.source_system,
+    external_code = EXCLUDED.external_code,
+    posting_category_id = EXCLUDED.posting_category_id,
+    mapping_key_id = EXCLUDED.mapping_key_id,
+    gl_account_id = EXCLUDED.gl_account_id,
+    effective_start_date = EXCLUDED.effective_start_date,
+    effective_end_date = EXCLUDED.effective_end_date,
+    dimensions = EXCLUDED.dimensions,
+    created_by = 'seed-generator';
+INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000ca05'::uuid, 'ACCOUNTING', 'PAYMENT_APPLICATION_ACCOUNTS_RECEIVABLE', '5eed0acc-0000-4000-8000-00000000ca01'::uuid, '5eed0acc-0000-4000-8000-00000000ca03'::uuid, '0f12890f-383d-b449-b555-bd4b37bf1f44'::uuid, TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
 ON CONFLICT (gl_mapping_id) DO UPDATE SET
     source_system = EXCLUDED.source_system,
     external_code = EXCLUDED.external_code,

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/CreditMemoContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/CreditMemoContractBehaviorIT.java
@@ -89,7 +89,8 @@ public class CreditMemoContractBehaviorIT extends BaseContractIntegrationTest {
         glAccountRepository.deleteAll();
 
         // Default replica state (ADR-0044 #842): a FINALIZED $110 invoice with a $110
-        // derived balance, matching the previous invoice-service stubs.
+        // derived balance, matching the previous invoice-service stubs. Stored scalar
+        // tax of $10 (issue #953): tax reversal derives from this frozen value.
         UUID invoiceId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID customerId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         ExtInvoice defaultInvoice = ExtInvoice.builder()
@@ -98,6 +99,7 @@ public class CreditMemoContractBehaviorIT extends BaseContractIntegrationTest {
                 .partyId(customerId.toString())
                 .status("FINALIZED")
                 .total(new BigDecimal("110.00"))
+                .tax(new BigDecimal("10.00"))
                 .finalizedAt(Instant.now(Clock.systemUTC()))
                 .aggregateVersion(1L)
                 .updatedAt(Instant.now(Clock.systemUTC()))
@@ -162,8 +164,9 @@ public class CreditMemoContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(jsonPath("$.creditMemoId").exists())
                 .andExpect(jsonPath("$.originalInvoiceId").value(testInvoiceId.toString()))
                 .andExpect(jsonPath("$.creditAmount").value(100.00))
-                .andExpect(jsonPath("$.taxAmountReversed").exists()) // Calculated proportionally
-                .andExpect(jsonPath("$.totalAmount").exists()) // Credit + tax
+                // Full-net credit reverses the entire stored tax (issue #953)
+                .andExpect(jsonPath("$.taxAmountReversed").value(10.00))
+                .andExpect(jsonPath("$.totalAmount").value(110.00)) // Credit + tax
                 .andExpect(jsonPath("$.reasonCode").value("RETURNED_GOODS"))
                 .andExpect(jsonPath("$.status").value("POSTED"))
                 .andExpect(jsonPath("$.priorPeriodAdjustment").value(false))
@@ -201,6 +204,9 @@ public class CreditMemoContractBehaviorIT extends BaseContractIntegrationTest {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.creditAmount").value(25.00))
+                // Stored tax 10.00 pro-rated by 25.00/100.00 of the net (issue #953)
+                .andExpect(jsonPath("$.taxAmountReversed").value(2.50))
+                .andExpect(jsonPath("$.totalAmount").value(27.50))
                 .andExpect(jsonPath("$.reasonCode").value("PRICING_ERROR"))
                 .andExpect(jsonPath("$.status").value("POSTED"));
     }

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/controller/FinancialReportingControllerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/controller/FinancialReportingControllerTest.java
@@ -11,7 +11,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.positivity.accounting.BaseIntegrationTest;
+import com.positivity.accounting.internal.dto.TrialBalanceReport;
 import com.positivity.accounting.service.FinancialReportingService;
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Collections;
 import org.junit.jupiter.api.DisplayName;
@@ -217,6 +220,69 @@ class FinancialReportingControllerTest extends BaseIntegrationTest {
                     .andExpect(jsonPath("$.message", containsString("End date cannot be before")));
 
             verify(financialReportingService, never()).drilldownToAccounts(any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Trial Balance - asOf Validation (G1, #956)")
+    class TrialBalanceValidation {
+
+        @Test
+        @DisplayName("Should generate trial balance for a valid asOf date")
+        void shouldGenerateTrialBalanceForValidAsOf() throws Exception {
+            // Given: Service returns an empty balanced report
+            LocalDate asOf = LocalDate.of(2026, 6, 30);
+            when(financialReportingService.generateTrialBalance(eq(asOf)))
+                    .thenReturn(TrialBalanceReport.builder()
+                            .asOfDate(asOf)
+                            .generatedAt(Instant.parse("2026-07-01T00:00:00Z"))
+                            .rows(Collections.emptyList())
+                            .totalDebit(BigDecimal.ZERO)
+                            .totalCredit(BigDecimal.ZERO)
+                            .balanced(true)
+                            .entryNumberGaps(Collections.emptyList())
+                            .build());
+
+            // When: Request with valid asOf date
+            mockMvc.perform(get("/v1/accounting/reports/financial/trial-balance")
+                            .header("X-Authorities", "reporting:view:financial-statements")
+                            .header("X-User", "test-user")
+                            .param("asOf", asOf.toString()))
+                    // Then: Should succeed with the report body
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.asOfDate").value("2026-06-30"))
+                    .andExpect(jsonPath("$.balanced").value(true))
+                    .andExpect(jsonPath("$.rows").isEmpty())
+                    .andExpect(jsonPath("$.entryNumberGaps").isEmpty());
+
+            verify(financialReportingService).generateTrialBalance(eq(asOf));
+        }
+
+        @Test
+        @DisplayName("Should reject malformed asOf date")
+        void shouldRejectMalformedAsOf() throws Exception {
+            // When: Request with a non-ISO date
+            mockMvc.perform(get("/v1/accounting/reports/financial/trial-balance")
+                            .header("X-Authorities", "reporting:view:financial-statements")
+                            .header("X-User", "test-user")
+                            .param("asOf", "06/30/2026"))
+                    // Then: Spring binding rejects it before the service is reached
+                    .andExpect(status().isBadRequest());
+
+            verify(financialReportingService, never()).generateTrialBalance(any());
+        }
+
+        @Test
+        @DisplayName("Should reject missing asOf date")
+        void shouldRejectMissingAsOf() throws Exception {
+            // When: Request without the required asOf parameter
+            mockMvc.perform(get("/v1/accounting/reports/financial/trial-balance")
+                            .header("X-Authorities", "reporting:view:financial-statements")
+                            .header("X-User", "test-user"))
+                    // Then: Should return 400 Bad Request
+                    .andExpect(status().isBadRequest());
+
+            verify(financialReportingService, never()).generateTrialBalance(any());
         }
     }
 }

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/controller/MappingResolutionTestControllerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/controller/MappingResolutionTestControllerTest.java
@@ -1,0 +1,141 @@
+package com.positivity.accounting.internal.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.accounting.BaseIntegrationTest;
+import com.positivity.accounting.internal.dto.MappingResolutionTestRequest;
+import com.positivity.accounting.internal.dto.MappingResolutionTestResponse;
+import com.positivity.accounting.service.MappingResolutionTestService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Integration tests for the dry-run mapping resolution endpoint (story E3,
+ * issue #957) on {@link GLMappingController}.
+ */
+@DisplayName("GLMappingController dry-run resolution endpoint (E3)")
+class MappingResolutionTestControllerTest extends BaseIntegrationTest {
+
+    private static final String RESOLVE_TEST_URL = "/v1/accounting/mappings/resolve-test";
+    private static final String VIEW_AUTHORITY = "accounting:posting_rules:view";
+
+    private static final UUID RULE_SET_ID = UUID.fromString("01960003-0000-7000-8000-000000000001");
+    private static final UUID VERSION_ID = UUID.fromString("01960003-0000-7000-8000-000000000002");
+    private static final UUID ACCOUNT_ID = UUID.fromString("01960003-0000-7000-8000-000000000003");
+
+    @MockitoBean
+    private MappingResolutionTestService mappingResolutionTestService;
+
+    private static MappingResolutionTestRequest validRequest() {
+        return MappingResolutionTestRequest.builder()
+                .eventType("billing.invoicePosted")
+                .samplePayload(Map.of("totalAmount", "125.00", "channel", "POS"))
+                .transactionDate(LocalDate.of(2026, 1, 15))
+                .build();
+    }
+
+    private static MappingResolutionTestResponse matchedResponse() {
+        return MappingResolutionTestResponse.builder()
+                .matched(true)
+                .matchedRule(MappingResolutionTestResponse.MatchedRule.builder()
+                        .postingRuleSetId(RULE_SET_ID)
+                        .ruleSetName("Invoice finalization postings")
+                        .ruleVersionId(VERSION_ID)
+                        .versionNumber(3)
+                        .build())
+                .matchedMapping(MappingResolutionTestResponse.MatchedMapping.builder()
+                        .mappingType("exact")
+                        .mappingKey("payload.channel == 'POS'")
+                        .keysEvaluated(List.of("payload.channel == 'POS'"))
+                        .build())
+                .resolvedLines(List.of(MappingResolutionTestResponse.ResolvedLine.builder()
+                        .glAccountId(ACCOUNT_ID)
+                        .accountCode("4000")
+                        .accountName("Sales Revenue")
+                        .debitAmount(new BigDecimal("125.00"))
+                        .creditAmount(BigDecimal.ZERO)
+                        .splitGroup("revenue-split")
+                        .factorPercent(new BigDecimal("60.0"))
+                        .build()))
+                .predicateEvaluations(List.of(MappingResolutionTestResponse.PredicateEvaluation.builder()
+                        .predicate("payload.channel == 'POS'")
+                        .matched(true)
+                        .build()))
+                .build();
+    }
+
+    @Test
+    @DisplayName("returns 200 with the dry-run resolution result")
+    void returnsResolutionResult() throws Exception {
+        when(mappingResolutionTestService.resolveTest(any(MappingResolutionTestRequest.class)))
+                .thenReturn(matchedResponse());
+
+        mockMvc.perform(post(RESOLVE_TEST_URL)
+                        .header("X-Authorities", VIEW_AUTHORITY)
+                        .header("X-User", "test-user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.matched", is(true)))
+                .andExpect(jsonPath("$.matchedRule.postingRuleSetId", is(RULE_SET_ID.toString())))
+                .andExpect(jsonPath("$.matchedRule.versionNumber", is(3)))
+                .andExpect(jsonPath("$.matchedMapping.mappingType", is("exact")))
+                .andExpect(jsonPath("$.resolvedLines[0].accountCode", is("4000")))
+                .andExpect(jsonPath("$.resolvedLines[0].splitGroup", is("revenue-split")))
+                .andExpect(jsonPath("$.predicateEvaluations[0].matched", is(true)));
+    }
+
+    @Test
+    @DisplayName("returns 400 when the sample payload cannot be interpreted")
+    void returns400ForUninterpretablePayload() throws Exception {
+        when(mappingResolutionTestService.resolveTest(any(MappingResolutionTestRequest.class)))
+                .thenThrow(new IllegalArgumentException(
+                        "Sample payload field 'payload.totalAmount' value 'abc' cannot be interpreted as an amount"));
+
+        mockMvc.perform(post(RESOLVE_TEST_URL)
+                        .header("X-Authorities", VIEW_AUTHORITY)
+                        .header("X-User", "test-user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("returns 400 when the event type is blank")
+    void returns400ForBlankEventType() throws Exception {
+        MappingResolutionTestRequest invalid = MappingResolutionTestRequest.builder()
+                .eventType(" ")
+                .transactionDate(LocalDate.of(2026, 1, 15))
+                .build();
+
+        mockMvc.perform(post(RESOLVE_TEST_URL)
+                        .header("X-Authorities", VIEW_AUTHORITY)
+                        .header("X-User", "test-user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("returns 403 without the posting_rules view authority")
+    void returns403WithoutAuthority() throws Exception {
+        mockMvc.perform(post(RESOLVE_TEST_URL)
+                        .header("X-Authorities", "accounting:gl-mapping:create")
+                        .header("X-User", "test-user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandlerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandlerTest.java
@@ -217,6 +217,67 @@ class PaymentApplicationGLPostingEventHandlerTest {
     }
 
     @Test
+    @DisplayName("F4: transaction date and mapping resolution derive from applicationTimestamp, not clock-now (outbox backlog)")
+    void backlogRetry_usesApplicationTimestampNotClockNow() {
+        // Simulate an outbox retry / backlog: the payment application actually
+        // happened weeks BEFORE the clock's "now". The JE transaction date and
+        // the effective-dated GL mapping resolution must both anchor to the
+        // business (application) date, never the later processing clock time —
+        // otherwise the entry lands in the wrong accounting period and selects
+        // the wrong effective-dated mapping (F4, PR #974).
+        Instant applicationInstant = Instant.parse("2026-02-01T08:30:00Z");
+        LocalDateTime expectedTransactionDate = LocalDateTime.ofInstant(applicationInstant, clock.getZone());
+        LocalDateTime clockNow = LocalDateTime.now(clock);
+
+        // Guard: the two dates must genuinely differ so the assertions below
+        // distinguish application-date provenance from clock-now provenance.
+        assertThat(expectedTransactionDate).isNotEqualTo(clockNow);
+
+        PaymentApplicationGLPostingEvent backlogEvent = PaymentApplicationGLPostingEvent.builder()
+                .eventId(testEvent.getEventId())
+                .applicationRequestId(APPLICATION_REQUEST_ID)
+                .paymentId(testEvent.getPaymentId())
+                .customerId(testEvent.getCustomerId())
+                .currency("USD")
+                .appliedAmount(new BigDecimal("500.00"))
+                .applicationTimestamp(applicationInstant)
+                .build();
+
+        stubAccountResolution();
+        when(glPostingService.postPaymentApplication(
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(BigDecimal.class),
+                        any(LocalDateTime.class),
+                        any(String.class)))
+                .thenReturn(postedEntry);
+
+        handler.onPaymentApplicationGLPosting(backlogEvent);
+
+        // Mapping resolution effective date == application-derived date (both legs).
+        ArgumentCaptor<LocalDateTime> mappingDateCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(glMappingResolver)
+                .resolveGLAccount(eq("PAYMENT_APPLICATION"), eq("UNDEPOSITED_FUNDS"), mappingDateCaptor.capture());
+        assertThat(mappingDateCaptor.getValue()).isEqualTo(expectedTransactionDate).isNotEqualTo(clockNow);
+
+        verify(glMappingResolver)
+                .resolveGLAccount(eq("PAYMENT_APPLICATION"), eq("ACCOUNTS_RECEIVABLE"), eq(expectedTransactionDate));
+
+        // Journal entry transaction date == application-derived date, NOT clock-now.
+        ArgumentCaptor<LocalDateTime> postDateCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(glPostingService)
+                .postPaymentApplication(
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(BigDecimal.class),
+                        postDateCaptor.capture(),
+                        any(String.class));
+        assertThat(postDateCaptor.getValue()).isEqualTo(expectedTransactionDate).isNotEqualTo(clockNow);
+    }
+
+    @Test
     @DisplayName("non-UUID application request id derives a deterministic name-based sourceEventId")
     void nonUuidRequestId_derivesDeterministicSourceEventId() {
         stubAccountResolution();

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandlerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandlerTest.java
@@ -1,0 +1,228 @@
+package com.positivity.accounting.internal.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.exception.AccountingPeriodClosedException;
+import com.positivity.accounting.service.GLMappingResolver;
+import com.positivity.accounting.service.GLPostingService;
+import com.positivity.accounting.service.IdempotencyService;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link PaymentApplicationGLPostingEventHandler} (story C1,
+ * issue #954): AR cash receipt GL posting — Dr Undeposited Funds, Cr AR.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentApplicationGLPostingEventHandler")
+class PaymentApplicationGLPostingEventHandlerTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-03-15T10:00:00Z"), ZoneOffset.UTC);
+    private static final String APPLICATION_REQUEST_ID = "0195f1a2-0000-7000-8000-000000000042";
+    private static final String IDEMPOTENCY_KEY = "PAYMENT_APPLICATION_GL_POSTING:" + APPLICATION_REQUEST_ID;
+
+    @Spy
+    private Clock clock = TEST_CLOCK;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private GLMappingResolver glMappingResolver;
+
+    @Mock
+    private GLPostingService glPostingService;
+
+    @InjectMocks
+    private PaymentApplicationGLPostingEventHandler handler;
+
+    private PaymentApplicationGLPostingEvent testEvent;
+    private UUID undepositedFundsAccountId;
+    private UUID arAccountId;
+    private UUID journalEntryId;
+    private JournalEntry postedEntry;
+
+    @BeforeEach
+    void setUp() {
+        undepositedFundsAccountId = UUID.fromString("00000000-0000-0000-0000-000000001090");
+        arAccountId = UUID.fromString("00000000-0000-0000-0000-000000001200");
+        journalEntryId = UUID.fromString("00000000-0000-0000-0000-00000000e001");
+
+        testEvent = PaymentApplicationGLPostingEvent.builder()
+                .eventId(UUID.fromString("00000000-0000-0000-0000-00000000a001"))
+                .applicationRequestId(APPLICATION_REQUEST_ID)
+                .paymentId(UUID.fromString("00000000-0000-0000-0000-00000000b001"))
+                .customerId(UUID.fromString("00000000-0000-0000-0000-00000000b002"))
+                .currency("USD")
+                .appliedAmount(new BigDecimal("500.00"))
+                .applicationTimestamp(Instant.parse("2026-03-15T09:59:00Z"))
+                .build();
+
+        postedEntry = new JournalEntry();
+        postedEntry.setJournalEntryId(journalEntryId);
+    }
+
+    private void stubAccountResolution() {
+        when(glMappingResolver.resolveGLAccount(
+                        eq("PAYMENT_APPLICATION"), eq("UNDEPOSITED_FUNDS"), any(LocalDateTime.class)))
+                .thenReturn(undepositedFundsAccountId);
+        when(glMappingResolver.resolveGLAccount(
+                        eq("PAYMENT_APPLICATION"), eq("ACCOUNTS_RECEIVABLE"), any(LocalDateTime.class)))
+                .thenReturn(arAccountId);
+    }
+
+    @Test
+    @DisplayName("happy path posts Dr Undeposited Funds / Cr AR with sourceEventId = application request id")
+    void happyPath_postsBalancedEntryWithResolvedAccounts() {
+        stubAccountResolution();
+        when(glPostingService.postPaymentApplication(
+                        any(UUID.class), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class)))
+                .thenReturn(postedEntry);
+
+        handler.onPaymentApplicationGLPosting(testEvent);
+
+        ArgumentCaptor<UUID> sourceEventIdCaptor = ArgumentCaptor.forClass(UUID.class);
+        ArgumentCaptor<UUID> debitAccountCaptor = ArgumentCaptor.forClass(UUID.class);
+        ArgumentCaptor<UUID> creditAccountCaptor = ArgumentCaptor.forClass(UUID.class);
+        ArgumentCaptor<BigDecimal> amountCaptor = ArgumentCaptor.forClass(BigDecimal.class);
+        ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(glPostingService)
+                .postPaymentApplication(
+                        sourceEventIdCaptor.capture(),
+                        debitAccountCaptor.capture(),
+                        creditAccountCaptor.capture(),
+                        amountCaptor.capture(),
+                        descriptionCaptor.capture());
+
+        assertThat(sourceEventIdCaptor.getValue()).isEqualTo(UUID.fromString(APPLICATION_REQUEST_ID));
+        assertThat(debitAccountCaptor.getValue()).isEqualTo(undepositedFundsAccountId);
+        assertThat(creditAccountCaptor.getValue()).isEqualTo(arAccountId);
+        assertThat(amountCaptor.getValue()).isEqualByComparingTo("500.00");
+        assertThat(descriptionCaptor.getValue()).contains(APPLICATION_REQUEST_ID);
+    }
+
+    @Test
+    @DisplayName("happy path registers idempotency key after successful post")
+    void happyPath_registersIdempotencyKey() {
+        stubAccountResolution();
+        when(glPostingService.postPaymentApplication(
+                        any(UUID.class), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class)))
+                .thenReturn(postedEntry);
+
+        handler.onPaymentApplicationGLPosting(testEvent);
+
+        verify(idempotencyService).registerKey(IDEMPOTENCY_KEY, journalEntryId);
+    }
+
+    @Test
+    @DisplayName("duplicate work item no-ops when idempotency key already processed")
+    void duplicateWorkItem_noOps() {
+        when(idempotencyService.isKeyProcessed(IDEMPOTENCY_KEY)).thenReturn(true);
+
+        handler.onPaymentApplicationGLPosting(testEvent);
+
+        verifyNoInteractions(glPostingService, glMappingResolver);
+        verify(idempotencyService, never()).registerKey(any(String.class), any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("missing PAYMENT_APPLICATION posting configuration fails without registering idempotency key")
+    void missingPostingConfiguration_failsRetryable() {
+        when(glMappingResolver.resolveGLAccount(
+                        eq("PAYMENT_APPLICATION"), eq("UNDEPOSITED_FUNDS"), any(LocalDateTime.class)))
+                .thenThrow(new IllegalArgumentException("Posting category not configured: PAYMENT_APPLICATION"));
+
+        assertThatThrownBy(() -> handler.onPaymentApplicationGLPosting(testEvent))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(APPLICATION_REQUEST_ID)
+                .cause()
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verifyNoInteractions(glPostingService);
+        verify(idempotencyService, never()).registerKey(any(String.class), any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("unresolvable GL mapping fails without posting or registering idempotency key")
+    void unresolvableMapping_failsRetryable() {
+        when(glMappingResolver.resolveGLAccount(
+                        eq("PAYMENT_APPLICATION"), eq("UNDEPOSITED_FUNDS"), any(LocalDateTime.class)))
+                .thenReturn(undepositedFundsAccountId);
+        when(glMappingResolver.resolveGLAccount(
+                        eq("PAYMENT_APPLICATION"), eq("ACCOUNTS_RECEIVABLE"), any(LocalDateTime.class)))
+                .thenThrow(new IllegalArgumentException("No GL mapping found"));
+
+        assertThatThrownBy(() -> handler.onPaymentApplicationGLPosting(testEvent))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(APPLICATION_REQUEST_ID)
+                .cause()
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verifyNoInteractions(glPostingService);
+        verify(idempotencyService, never()).registerKey(any(String.class), any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("period-closed posting failure propagates unwrapped and does not register idempotency key")
+    void periodClosed_propagatesForRetry() {
+        stubAccountResolution();
+        when(glPostingService.postPaymentApplication(
+                        any(UUID.class), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class)))
+                .thenThrow(new AccountingPeriodClosedException("2026-03", "Period 2026-03 is CLOSED"));
+
+        assertThatThrownBy(() -> handler.onPaymentApplicationGLPosting(testEvent))
+                .isInstanceOf(AccountingPeriodClosedException.class);
+
+        verify(idempotencyService, never()).registerKey(any(String.class), any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("non-UUID application request id derives a deterministic name-based sourceEventId")
+    void nonUuidRequestId_derivesDeterministicSourceEventId() {
+        stubAccountResolution();
+        when(glPostingService.postPaymentApplication(
+                        any(UUID.class), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class)))
+                .thenReturn(postedEntry);
+
+        PaymentApplicationGLPostingEvent nonUuidEvent = PaymentApplicationGLPostingEvent.builder()
+                .eventId(testEvent.getEventId())
+                .applicationRequestId("REQ-2026-000123")
+                .paymentId(testEvent.getPaymentId())
+                .customerId(testEvent.getCustomerId())
+                .currency("USD")
+                .appliedAmount(new BigDecimal("500.00"))
+                .applicationTimestamp(testEvent.getApplicationTimestamp())
+                .build();
+
+        handler.onPaymentApplicationGLPosting(nonUuidEvent);
+
+        UUID expected = UUID.nameUUIDFromBytes("REQ-2026-000123".getBytes(StandardCharsets.UTF_8));
+        verify(glPostingService)
+                .postPaymentApplication(
+                        eq(expected), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class));
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandlerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/handler/PaymentApplicationGLPostingEventHandlerTest.java
@@ -99,7 +99,12 @@ class PaymentApplicationGLPostingEventHandlerTest {
     void happyPath_postsBalancedEntryWithResolvedAccounts() {
         stubAccountResolution();
         when(glPostingService.postPaymentApplication(
-                        any(UUID.class), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class)))
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(BigDecimal.class),
+                        any(LocalDateTime.class),
+                        any(String.class)))
                 .thenReturn(postedEntry);
 
         handler.onPaymentApplicationGLPosting(testEvent);
@@ -116,6 +121,7 @@ class PaymentApplicationGLPostingEventHandlerTest {
                         debitAccountCaptor.capture(),
                         creditAccountCaptor.capture(),
                         amountCaptor.capture(),
+                        any(LocalDateTime.class),
                         descriptionCaptor.capture());
 
         assertThat(sourceEventIdCaptor.getValue()).isEqualTo(UUID.fromString(APPLICATION_REQUEST_ID));
@@ -130,7 +136,12 @@ class PaymentApplicationGLPostingEventHandlerTest {
     void happyPath_registersIdempotencyKey() {
         stubAccountResolution();
         when(glPostingService.postPaymentApplication(
-                        any(UUID.class), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class)))
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(BigDecimal.class),
+                        any(LocalDateTime.class),
+                        any(String.class)))
                 .thenReturn(postedEntry);
 
         handler.onPaymentApplicationGLPosting(testEvent);
@@ -191,7 +202,12 @@ class PaymentApplicationGLPostingEventHandlerTest {
     void periodClosed_propagatesForRetry() {
         stubAccountResolution();
         when(glPostingService.postPaymentApplication(
-                        any(UUID.class), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class)))
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(BigDecimal.class),
+                        any(LocalDateTime.class),
+                        any(String.class)))
                 .thenThrow(new AccountingPeriodClosedException("2026-03", "Period 2026-03 is CLOSED"));
 
         assertThatThrownBy(() -> handler.onPaymentApplicationGLPosting(testEvent))
@@ -205,7 +221,12 @@ class PaymentApplicationGLPostingEventHandlerTest {
     void nonUuidRequestId_derivesDeterministicSourceEventId() {
         stubAccountResolution();
         when(glPostingService.postPaymentApplication(
-                        any(UUID.class), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class)))
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(BigDecimal.class),
+                        any(LocalDateTime.class),
+                        any(String.class)))
                 .thenReturn(postedEntry);
 
         PaymentApplicationGLPostingEvent nonUuidEvent = PaymentApplicationGLPostingEvent.builder()
@@ -223,6 +244,11 @@ class PaymentApplicationGLPostingEventHandlerTest {
         UUID expected = UUID.nameUUIDFromBytes("REQ-2026-000123".getBytes(StandardCharsets.UTF_8));
         verify(glPostingService)
                 .postPaymentApplication(
-                        eq(expected), any(UUID.class), any(UUID.class), any(BigDecimal.class), any(String.class));
+                        eq(expected),
+                        any(UUID.class),
+                        any(UUID.class),
+                        any(BigDecimal.class),
+                        any(LocalDateTime.class),
+                        any(String.class));
     }
 }

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingServiceImplTest.java
@@ -1,0 +1,200 @@
+package com.positivity.accounting.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.accounting.internal.dto.EntryNumberGapCheck;
+import com.positivity.accounting.internal.dto.TrialBalanceAccountTotal;
+import com.positivity.accounting.internal.dto.TrialBalanceReport;
+import com.positivity.accounting.internal.dto.TrialBalanceRow;
+import com.positivity.accounting.internal.entity.AccountingSequence;
+import com.positivity.accounting.internal.repository.AccountingSequenceRepository;
+import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link FinancialReportingServiceImpl#generateTrialBalance}
+ * (story G1, issue #956): per-account aggregation mapping, balanced-flag
+ * computation, entry-number gap footnote scoping, empty-ledger shape, and
+ * inclusive as-of date boundary.
+ */
+@ExtendWith(MockitoExtension.class)
+class FinancialReportingServiceImplTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-07-01T12:00:00Z");
+    private static final LocalDate AS_OF = LocalDate.of(2026, 6, 30);
+
+    private static final UUID ACCT_CASH = UUID.fromString("a1000000-0000-7000-8000-000000000001");
+    private static final UUID ACCT_REVENUE = UUID.fromString("a1000000-0000-7000-8000-000000000002");
+
+    @Mock
+    private JournalEntryRepository journalEntryRepository;
+
+    @Mock
+    private StatementLineMappingRepository statementLineMappingRepository;
+
+    @Mock
+    private AccountingSequenceRepository accountingSequenceRepository;
+
+    private FinancialReportingServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FinancialReportingServiceImpl(
+                journalEntryRepository,
+                statementLineMappingRepository,
+                accountingSequenceRepository,
+                Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
+    }
+
+    private void aggregatedTotals(TrialBalanceAccountTotal... totals) {
+        when(journalEntryRepository.sumPostedDebitsCreditsByAccountAsOf(AS_OF.atTime(LocalTime.MAX)))
+                .thenReturn(List.of(totals));
+    }
+
+    private static AccountingSequence sequence(String scopeKey) {
+        AccountingSequence sequence = new AccountingSequence();
+        sequence.setScopeKey(scopeKey);
+        sequence.setNextValue(10L);
+        return sequence;
+    }
+
+    @Test
+    @DisplayName("Maps per-account aggregates to rows with signed balance, preserving account-number order")
+    void mapsAggregatesToRowsWithSignedBalances() {
+        aggregatedTotals(
+                new TrialBalanceAccountTotal(ACCT_CASH, "1000", "Cash", new BigDecimal("150.00"), new BigDecimal("40.00")),
+                new TrialBalanceAccountTotal(
+                        ACCT_REVENUE, "4000", "Revenue", new BigDecimal("40.00"), new BigDecimal("150.00")));
+        when(accountingSequenceRepository.findAllByOrderByScopeKeyAsc()).thenReturn(List.of());
+
+        TrialBalanceReport report = service.generateTrialBalance(AS_OF);
+
+        assertThat(report.getAsOfDate()).isEqualTo(AS_OF);
+        assertThat(report.getGeneratedAt()).isEqualTo(FIXED_NOW);
+        assertThat(report.getRows())
+                .extracting(
+                        TrialBalanceRow::getAccountId,
+                        TrialBalanceRow::getAccountNumber,
+                        TrialBalanceRow::getAccountName,
+                        TrialBalanceRow::getTotalDebit,
+                        TrialBalanceRow::getTotalCredit,
+                        TrialBalanceRow::getBalance)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(
+                                ACCT_CASH.toString(),
+                                "1000",
+                                "Cash",
+                                new BigDecimal("150.00"),
+                                new BigDecimal("40.00"),
+                                new BigDecimal("110.00")),
+                        org.assertj.core.groups.Tuple.tuple(
+                                ACCT_REVENUE.toString(),
+                                "4000",
+                                "Revenue",
+                                new BigDecimal("40.00"),
+                                new BigDecimal("150.00"),
+                                new BigDecimal("-110.00")));
+        assertThat(report.getTotalDebit()).isEqualByComparingTo("190.00");
+        assertThat(report.getTotalCredit()).isEqualByComparingTo("190.00");
+        assertThat(report.getBalanced()).isTrue();
+        assertThat(report.getEntryNumberGaps()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Computes balanced=false when sum of debits does not equal sum of credits")
+    void computesBalancedFalseForUnbalancedLedger() {
+        aggregatedTotals(
+                new TrialBalanceAccountTotal(ACCT_CASH, "1000", "Cash", new BigDecimal("100.00"), BigDecimal.ZERO),
+                new TrialBalanceAccountTotal(ACCT_REVENUE, "4000", "Revenue", BigDecimal.ZERO, new BigDecimal("90.00")));
+        when(accountingSequenceRepository.findAllByOrderByScopeKeyAsc()).thenReturn(List.of());
+
+        TrialBalanceReport report = service.generateTrialBalance(AS_OF);
+
+        assertThat(report.getTotalDebit()).isEqualByComparingTo("100.00");
+        assertThat(report.getTotalCredit()).isEqualByComparingTo("90.00");
+        assertThat(report.getBalanced()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Balanced compares numeric value, not BigDecimal scale")
+    void balancedIgnoresBigDecimalScaleDifferences() {
+        aggregatedTotals(
+                new TrialBalanceAccountTotal(ACCT_CASH, "1000", "Cash", new BigDecimal("100.0"), new BigDecimal("100.00")));
+        when(accountingSequenceRepository.findAllByOrderByScopeKeyAsc()).thenReturn(List.of());
+
+        TrialBalanceReport report = service.generateTrialBalance(AS_OF);
+
+        assertThat(report.getBalanced()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Populates gap footnote only for JE scopes up to the as-of month that actually have gaps")
+    void populatesGapFootnoteForJeScopesUpToAsOfMonth() {
+        aggregatedTotals(
+                new TrialBalanceAccountTotal(ACCT_CASH, "1000", "Cash", new BigDecimal("10.00"), new BigDecimal("10.00")));
+        when(accountingSequenceRepository.findAllByOrderByScopeKeyAsc())
+                .thenReturn(List.of(
+                        sequence("INV-202605"),
+                        sequence("JE-202605"),
+                        sequence("JE-202606"),
+                        sequence("JE-202607")));
+        when(accountingSequenceRepository.findMissingEntryNumbers("JE-202605")).thenReturn(List.of(3L, 7L));
+        when(accountingSequenceRepository.findMissingEntryNumbers("JE-202606")).thenReturn(List.of());
+
+        TrialBalanceReport report = service.generateTrialBalance(AS_OF);
+
+        assertThat(report.getEntryNumberGaps())
+                .extracting(EntryNumberGapCheck::getScopeKey, EntryNumberGapCheck::getMissingNumbers)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple("JE-202605", List.of(3L, 7L)));
+        // Scopes after the as-of month and non-JE scopes are never gap-checked
+        verify(accountingSequenceRepository, never()).findMissingEntryNumbers("JE-202607");
+        verify(accountingSequenceRepository, never()).findMissingEntryNumbers("INV-202605");
+    }
+
+    @Test
+    @DisplayName("Returns empty rows, zero totals, balanced=true, and empty gap footnote when no POSTED data exists")
+    void returnsEmptyBalancedReportForEmptyLedger() {
+        aggregatedTotals();
+
+        TrialBalanceReport report = service.generateTrialBalance(AS_OF);
+
+        assertThat(report.getRows()).isEmpty();
+        assertThat(report.getTotalDebit()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(report.getTotalCredit()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(report.getBalanced()).isTrue();
+        assertThat(report.getEntryNumberGaps()).isEmpty();
+        verifyNoInteractions(accountingSequenceRepository);
+    }
+
+    @Test
+    @DisplayName("Queries the aggregate with an inclusive end-of-day as-of boundary")
+    void passesInclusiveEndOfDayBoundaryToRepository() {
+        aggregatedTotals();
+
+        service.generateTrialBalance(AS_OF);
+
+        ArgumentCaptor<LocalDateTime> asOfCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(journalEntryRepository).sumPostedDebitsCreditsByAccountAsOf(asOfCaptor.capture());
+        assertThat(asOfCaptor.getValue()).isEqualTo(AS_OF.atTime(LocalTime.MAX));
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/CreditMemoServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/CreditMemoServiceTest.java
@@ -118,9 +118,9 @@ class CreditMemoServiceTest {
         testCreditMemo.setPriorPeriodAdjustment(false);
         testCreditMemo.setCurrency("USD");
 
-        // Replica row for the invoice (owned by pos-invoice, fed via invoice.events.v1)
-        testInvoice =
-                replicaInvoice("FINALIZED", "110.00", Instant.now(TEST_CLOCK).minusSeconds(86400));
+        // Replica row for the invoice (owned by pos-invoice, fed via invoice.events.v1).
+        // Stored scalar tax of 10.00 on a 110.00 total => net (pre-tax) amount of 100.00.
+        testInvoice = replicaInvoice("FINALIZED", "110.00", "10.00", Instant.now(TEST_CLOCK) .minusSeconds(86400));
 
         // Mock GL config (lenient - not all tests reach GL posting)
         lenient().when(glConfig.getRevenueAccountId()).thenReturn(testRevenueAccountId);
@@ -160,6 +160,8 @@ class CreditMemoServiceTest {
 
         CreditMemo saved = captor.getValue();
         assertThat(saved.getCreditAmount()).isEqualByComparingTo("50.00");
+        // Stored tax 10.00 pro-rated by credit ratio 50.00/100.00 (net) = 5.00
+        assertThat(saved.getTaxAmountReversed()).isEqualByComparingTo("5.00");
         assertThat(saved.getReasonCode()).isEqualTo("RETURNED_GOODS");
         assertThat(saved.getStatus()).isEqualTo(CreditMemoStatus.POSTED);
         assertThat(saved.getCustomerId()).isEqualTo(testCustomerId);
@@ -229,13 +231,12 @@ class CreditMemoServiceTest {
     @Test
     @DisplayName("Should throw exception when total credit (including tax) exceeds invoice balance")
     void testCreateCreditMemo_TotalAmountWithTaxExceedsBalance() {
-        // Given - invoice balance is $110.00
-        // With a 10% tax reversal, we need a creditAmount such that:
-        // creditAmount + (creditAmount * 0.10) > balanceDue
-        // Setting creditAmount to $105.00 gives us:
+        // Given - invoice balance is $110.00, stored tax 10.00, net 100.00.
+        // A creditAmount of $105.00 exceeds the remaining net (100.00), so the
+        // final-credit residual path reverses the full stored tax:
         // - creditAmount: $105.00
-        // - taxReversed: $10.50 (10% of 105)
-        // - total: $115.50, which exceeds the $110.00 balance
+        // - taxReversed: $10.00 (full stored tax residual)
+        // - total: $115.00, which exceeds the $110.00 balance
         testRequest.setCreditAmount(new BigDecimal("105.00"));
         stubReplica(testInvoice, "110.00");
 
@@ -266,7 +267,7 @@ class CreditMemoServiceTest {
     @DisplayName("Should throw exception when invoice is not AR-eligible (DRAFT)")
     void testCreateCreditMemo_DraftInvoice() {
         // Given - a DRAFT invoice never entered AR
-        testInvoice = replicaInvoice("DRAFT", "110.00", null);
+        testInvoice = replicaInvoice("DRAFT", "110.00", "10.00", null);
         when(invoiceBalanceCalculator.findInvoice(testInvoiceId)).thenReturn(Optional.of(testInvoice));
         when(invoiceBalanceCalculator.isArEligible(testInvoice)).thenReturn(false);
 
@@ -297,7 +298,7 @@ class CreditMemoServiceTest {
     void testCreateCreditMemo_PriorPeriodAdjustment() {
         // Given - invoice finalized in a prior period
         Instant priorPeriodDate = Instant.now(TEST_CLOCK).minusSeconds(2592000); // 30 days ago
-        testInvoice = replicaInvoice("FINALIZED", "110.00", priorPeriodDate);
+        testInvoice = replicaInvoice("FINALIZED", "110.00", "10.00", priorPeriodDate);
 
         testCreditMemo.setPriorPeriodAdjustment(true);
         testCreditMemo.setOriginalPeriodId("2026-01");
@@ -484,16 +485,179 @@ class CreditMemoServiceTest {
     }
 
     // ========================================
+    // Stored-tax reversal semantics (issue #953, Odoo parity D-4)
+    // ========================================
+
+    @Test
+    @DisplayName("Regression: tax reversal derives from stored invoice tax, not a fictional 10% of balance")
+    void testStoredTax_NoFictionalTenPercent() {
+        // Given - invoice with NO stored tax; the legacy code would have invented
+        // 10% of the balance (110.00 * 0.10 * 50/110 = 5.00)
+        testInvoice = replicaInvoice("FINALIZED", "110.00", null, Instant.now(TEST_CLOCK));
+        stubReplica(testInvoice, "110.00");
+        stubSaveEcho();
+
+        // When
+        CreditMemoResponse response = service.createCreditMemo(testRequest, "test-user");
+
+        // Then - no stored tax means nothing to reverse
+        assertThat(response.getTaxAmountReversed()).isEqualByComparingTo("0.00");
+        assertThat(response.getTotalAmount()).isEqualByComparingTo("50.00");
+        verify(glPostingService)
+                .postCreditMemoReversal(
+                        any(UUID.class),
+                        eq(testRevenueAccountId),
+                        eq(testTaxAccountId),
+                        eq(testArAccountId),
+                        eq(new BigDecimal("50.00")),
+                        eq(new BigDecimal("0.00")),
+                        anyString(),
+                        eq(false),
+                        eq(null));
+    }
+
+    @Test
+    @DisplayName("Partial credit rounds pro-rated stored tax HALF_UP at currency scale (35.59 * 0.5 -> 17.80)")
+    void testStoredTax_RatioRoundingHalfUp() {
+        // Given - tax 35.59 on net 200.00 (total 235.59); credit half the net
+        testInvoice = replicaInvoice("FINALIZED", "235.59", "35.59", Instant.now(TEST_CLOCK));
+        stubReplica(testInvoice, "235.59");
+        stubSaveEcho();
+        testRequest.setCreditAmount(new BigDecimal("100.00"));
+
+        // When
+        CreditMemoResponse response = service.createCreditMemo(testRequest, "test-user");
+
+        // Then - 35.59 * 0.5 = 17.795 -> HALF_UP -> 17.80
+        assertThat(response.getTaxAmountReversed()).isEqualByComparingTo("17.80");
+        assertThat(response.getTotalAmount()).isEqualByComparingTo("117.80");
+    }
+
+    @Test
+    @DisplayName("Final credit posts the tax residual so cumulative reversals sum exactly to stored tax (17.79)")
+    void testStoredTax_FinalCreditResidual() {
+        // Given - same 35.59-tax invoice; a prior POSTED memo credited 100.00 net
+        // and reversed 17.80 tax; this credit consumes the remaining net
+        testInvoice = replicaInvoice("FINALIZED", "235.59", "35.59", Instant.now(TEST_CLOCK));
+        stubReplica(testInvoice, "117.79");
+        stubPriorCredits("100.00", "17.80");
+        stubSaveEcho();
+        testRequest.setCreditAmount(new BigDecimal("100.00"));
+
+        // When
+        CreditMemoResponse response = service.createCreditMemo(testRequest, "test-user");
+
+        // Then - residual = 35.59 - 17.80 = 17.79 (not round(35.59 * 0.5) = 17.80)
+        assertThat(response.getTaxAmountReversed()).isEqualByComparingTo("17.79");
+        assertThat(response.getTotalAmount()).isEqualByComparingTo("117.79");
+        assertThat(response.getInvoiceBalanceAfter()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    @DisplayName("Single full credit reverses the stored tax exactly")
+    void testStoredTax_SingleFullCreditExactness() {
+        // Given - full-net credit in one memo
+        testInvoice = replicaInvoice("FINALIZED", "235.59", "35.59", Instant.now(TEST_CLOCK));
+        stubReplica(testInvoice, "235.59");
+        stubSaveEcho();
+        testRequest.setCreditAmount(new BigDecimal("200.00"));
+
+        // When
+        CreditMemoResponse response = service.createCreditMemo(testRequest, "test-user");
+
+        // Then - cumulative reversal equals the stored tax with a single credit
+        assertThat(response.getTaxAmountReversed()).isEqualByComparingTo("35.59");
+        assertThat(response.getTotalAmount()).isEqualByComparingTo("235.59");
+        assertThat(response.getInvoiceBalanceAfter()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    @DisplayName("Adversarial: penny tax (0.01) is not lost across partial credits")
+    void testStoredTax_PennyTaxResidual() {
+        // Given - tax 0.01 on net 100.00 (total 100.01); a third-part credit
+        testInvoice = replicaInvoice("FINALIZED", "100.01", "0.01", Instant.now(TEST_CLOCK));
+        stubReplica(testInvoice, "100.01");
+        stubSaveEcho();
+        testRequest.setCreditAmount(new BigDecimal("33.33"));
+
+        // When - partial credit: 0.01 * 0.3333 rounds to 0.00
+        CreditMemoResponse partial = service.createCreditMemo(testRequest, "test-user");
+        assertThat(partial.getTaxAmountReversed()).isEqualByComparingTo("0.00");
+
+        // Given - two prior partials credited 66.66 net with 0.00 tax reversed
+        stubReplica(testInvoice, "33.35");
+        stubPriorCredits("66.66", "0.00");
+        testRequest.setCreditAmount(new BigDecimal("33.34"));
+
+        // When - final credit consumes the remaining net
+        CreditMemoResponse finalCredit = service.createCreditMemo(testRequest, "test-user");
+
+        // Then - the whole 0.01 tax surfaces on the final line
+        assertThat(finalCredit.getTaxAmountReversed()).isEqualByComparingTo("0.01");
+    }
+
+    @Test
+    @DisplayName("Adversarial: 99.99 tax over three equal credits sums exactly (33.33 + 33.33 + 33.33)")
+    void testStoredTax_HighTaxThreeWayResidual() {
+        // Given - tax 99.99 on net 300.00 (total 399.99); first third
+        testInvoice = replicaInvoice("FINALIZED", "399.99", "99.99", Instant.now(TEST_CLOCK));
+        stubReplica(testInvoice, "399.99");
+        stubSaveEcho();
+        testRequest.setCreditAmount(new BigDecimal("100.00"));
+
+        // When - 99.99 * (100/300) = 33.33
+        CreditMemoResponse first = service.createCreditMemo(testRequest, "test-user");
+        assertThat(first.getTaxAmountReversed()).isEqualByComparingTo("33.33");
+
+        // Given - two thirds already credited; final third
+        stubReplica(testInvoice, "133.33");
+        stubPriorCredits("200.00", "66.66");
+
+        // When - residual = 99.99 - 66.66 = 33.33
+        CreditMemoResponse last = service.createCreditMemo(testRequest, "test-user");
+
+        // Then - cumulative 66.66 + 33.33 = 99.99 = stored tax
+        assertThat(last.getTaxAmountReversed()).isEqualByComparingTo("33.33");
+    }
+
+    @Test
+    @DisplayName("Sequence: single partial then final credit reverses 17.80 then 17.79")
+    void testStoredTax_PartialThenFinalSequence() {
+        // Given - Odoo residual vector: tax 35.59 split 50/50 across two credits
+        testInvoice = replicaInvoice("FINALIZED", "235.59", "35.59", Instant.now(TEST_CLOCK));
+        stubReplica(testInvoice, "235.59");
+        stubSaveEcho();
+        testRequest.setCreditAmount(new BigDecimal("100.00"));
+
+        // When - first half
+        CreditMemoResponse first = service.createCreditMemo(testRequest, "test-user");
+        assertThat(first.getTaxAmountReversed()).isEqualByComparingTo("17.80");
+
+        // Given - the first memo is now POSTED history
+        stubReplica(testInvoice, "117.79");
+        stubPriorCredits("100.00", "17.80");
+
+        // When - second half (final)
+        CreditMemoResponse second = service.createCreditMemo(testRequest, "test-user");
+
+        // Then - 17.80 + 17.79 = 35.59 exactly
+        assertThat(second.getTaxAmountReversed()).isEqualByComparingTo("17.79");
+        assertThat(first.getTaxAmountReversed().add(second.getTaxAmountReversed()))
+                .isEqualByComparingTo("35.59");
+    }
+
+    // ========================================
     // Helper Methods
     // ========================================
 
-    private ExtInvoice replicaInvoice(String status, String total, Instant finalizedAt) {
+    private ExtInvoice replicaInvoice(String status, String total, String tax, Instant finalizedAt) {
         return ExtInvoice.builder()
                 .invoiceId(testInvoiceId)
                 .workorderId(UUID.fromString("00000000-0000-0000-0000-0000000000ff"))
                 .partyId(testCustomerId.toString())
                 .status(status)
                 .total(new BigDecimal(total))
+                .tax(tax != null ? new BigDecimal(tax) : null)
                 .finalizedAt(finalizedAt)
                 .aggregateVersion(1L)
                 .updatedAt(Instant.now(TEST_CLOCK))
@@ -506,5 +670,27 @@ class CreditMemoServiceTest {
                 .thenReturn(Optional.of(invoice));
         lenient().when(invoiceBalanceCalculator.isArEligible(invoice)).thenReturn(true);
         lenient().when(invoiceBalanceCalculator.balanceDue(invoice)).thenReturn(new BigDecimal(balanceDue));
+        stubPriorCredits("0.00", "0.00");
+    }
+
+    /** Stub the sums of previously POSTED credit memos (revenue portion / reversed tax). */
+    private void stubPriorCredits(String creditedRevenue, String reversedTax) {
+        lenient()
+                .when(creditMemoRepository.sumCreditAmountByInvoiceIdAndStatus(
+                        testInvoiceId, CreditMemoStatus.POSTED))
+                .thenReturn(new BigDecimal(creditedRevenue));
+        lenient()
+                .when(creditMemoRepository.sumTaxReversedAmountByInvoiceIdAndStatus(
+                        testInvoiceId, CreditMemoStatus.POSTED))
+                .thenReturn(new BigDecimal(reversedTax));
+    }
+
+    /** Echo the saved entity back (with an id) so responses reflect the computed amounts. */
+    private void stubSaveEcho() {
+        when(creditMemoRepository.save(any(CreditMemo.class))).thenAnswer(invocation -> {
+            CreditMemo memo = invocation.getArgument(0);
+            memo.setCreditMemoId(testCreditMemoId);
+            return memo;
+        });
     }
 }

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/GLMappingResolverTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/GLMappingResolverTest.java
@@ -7,7 +7,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.positivity.accounting.internal.entity.GLMapping;
+import com.positivity.accounting.internal.entity.MappingKey;
+import com.positivity.accounting.internal.entity.PostingCategory;
 import com.positivity.accounting.internal.repository.GLMappingRepository;
+import com.positivity.accounting.internal.repository.MappingKeyRepository;
+import com.positivity.accounting.internal.repository.PostingCategoryRepository;
 import com.positivity.accounting.internal.service.GLMappingResolverImpl;
 import java.time.Clock;
 import java.time.Instant;
@@ -48,6 +52,12 @@ class GLMappingResolverTest {
 
     @Mock
     private GLMappingRepository mappingRepository;
+
+    @Mock
+    private PostingCategoryRepository postingCategoryRepository;
+
+    @Mock
+    private MappingKeyRepository mappingKeyRepository;
 
     @InjectMocks
     private GLMappingResolverImpl resolver;
@@ -421,6 +431,69 @@ class GLMappingResolverTest {
 
             // Assert — exact match wins
             assertThat(result).isEqualTo(exactAccountId);
+        }
+    }
+
+    // ========================================
+    // Name-based resolution (story C1, issue #954)
+    // ========================================
+
+    @Nested
+    @DisplayName("resolveGLAccount by category/key name")
+    class ResolveByName {
+
+        @Test
+        @DisplayName("resolves through category and key configuration to the mapped account")
+        void resolvesThroughConfiguration() {
+            UUID glAccountId = UUID.fromString("00000000-0000-0000-0000-000000001090");
+
+            PostingCategory category = new PostingCategory();
+            category.setPostingCategoryId(postingCategoryId);
+            category.setCategoryName("PAYMENT_APPLICATION");
+            when(postingCategoryRepository.findByCategoryName("PAYMENT_APPLICATION"))
+                    .thenReturn(Optional.of(category));
+
+            MappingKey key = new MappingKey();
+            key.setMappingKeyId(mappingKeyId);
+            when(mappingKeyRepository.findByPostingCategory_PostingCategoryIdAndKeyName(
+                            postingCategoryId, "UNDEPOSITED_FUNDS"))
+                    .thenReturn(Optional.of(key));
+
+            when(mappingRepository.findEffectiveMapping(postingCategoryId, mappingKeyId, transactionDate))
+                    .thenReturn(Optional.of(createMapping(glAccountId, null)));
+
+            UUID resolved = resolver.resolveGLAccount("PAYMENT_APPLICATION", "UNDEPOSITED_FUNDS", transactionDate);
+
+            assertThat(resolved).isEqualTo(glAccountId);
+        }
+
+        @Test
+        @DisplayName("throws when the posting category is not configured")
+        void throwsWhenCategoryMissing() {
+            when(postingCategoryRepository.findByCategoryName("PAYMENT_APPLICATION"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                            resolver.resolveGLAccount("PAYMENT_APPLICATION", "UNDEPOSITED_FUNDS", transactionDate))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Posting category not configured");
+        }
+
+        @Test
+        @DisplayName("throws when the mapping key is not configured")
+        void throwsWhenMappingKeyMissing() {
+            PostingCategory category = new PostingCategory();
+            category.setPostingCategoryId(postingCategoryId);
+            when(postingCategoryRepository.findByCategoryName("PAYMENT_APPLICATION"))
+                    .thenReturn(Optional.of(category));
+            when(mappingKeyRepository.findByPostingCategory_PostingCategoryIdAndKeyName(
+                            postingCategoryId, "UNDEPOSITED_FUNDS"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                            resolver.resolveGLAccount("PAYMENT_APPLICATION", "UNDEPOSITED_FUNDS", transactionDate))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Mapping key not configured");
         }
     }
 

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/GLPostingServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/GLPostingServiceTest.java
@@ -40,6 +40,13 @@ class GLPostingServiceTest {
 
     private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
+    /**
+     * Deterministic transaction date threaded into {@code postPaymentApplication}.
+     * The exact value is arbitrary but fixed so the posted entry's transaction
+     * date is stable and assertable (never wall-clock {@code now()}).
+     */
+    private static final LocalDateTime TXN_DATE = LocalDateTime.of(2024, 2, 15, 9, 30, 0);
+
     @Spy
     private Clock clock = TEST_CLOCK;
 
@@ -323,7 +330,7 @@ class GLPostingServiceTest {
 
         // Act
         JournalEntry result = service.postPaymentApplication(
-                testPaymentApplicationId, testCashAccountId, testArAccountId, amount, LocalDateTime.now(), description);
+                testPaymentApplicationId, testCashAccountId, testArAccountId, amount, TXN_DATE, description);
 
         // Assert
         assertThat(result.getStatus()).isEqualTo(JournalEntryStatus.POSTED);
@@ -331,6 +338,9 @@ class GLPostingServiceTest {
         JournalEntry createdEntry = entryCaptor.getValue();
         assertThat(createdEntry.getLines()).hasSize(2);
         assertThat(createdEntry.getSourceEventId()).isEqualTo(testPaymentApplicationId);
+        // The caller-supplied transaction date is threaded onto the entry
+        // verbatim (no wall-clock substitution) — F4 date-provenance guard.
+        assertThat(createdEntry.getTransactionDate()).isEqualTo(TXN_DATE);
 
         // Verify balance
         BigDecimal totalDebits = createdEntry.getLines().stream()
@@ -361,7 +371,7 @@ class GLPostingServiceTest {
         when(journalEntryService.postJournalEntry(any(), isNull())).thenReturn(new JournalEntry());
 
         // Act
-        service.postPaymentApplication(testPaymentApplicationId, testCashAccountId, testArAccountId, amount, LocalDateTime.now(), "Test");
+        service.postPaymentApplication(testPaymentApplicationId, testCashAccountId, testArAccountId, amount, TXN_DATE, "Test");
 
         // Assert
         JournalEntry entry = entryCaptor.getValue();
@@ -389,7 +399,7 @@ class GLPostingServiceTest {
         when(journalEntryService.postJournalEntry(any(), isNull())).thenReturn(new JournalEntry());
 
         // Act
-        service.postPaymentApplication(testPaymentApplicationId, testCashAccountId, testArAccountId, amount, LocalDateTime.now(), "Test");
+        service.postPaymentApplication(testPaymentApplicationId, testCashAccountId, testArAccountId, amount, TXN_DATE, "Test");
 
         // Assert
         JournalEntry entry = entryCaptor.getValue();
@@ -418,7 +428,7 @@ class GLPostingServiceTest {
 
         // Act
         service.postPaymentApplication(
-                testPaymentApplicationId, testCashAccountId, testArAccountId, new BigDecimal("100.00"), LocalDateTime.now(), description);
+                testPaymentApplicationId, testCashAccountId, testArAccountId, new BigDecimal("100.00"), TXN_DATE, description);
 
         // Assert
         JournalEntry entry = entryCaptor.getValue();

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/GLPostingServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/GLPostingServiceTest.java
@@ -15,6 +15,7 @@ import com.positivity.accounting.internal.service.JournalEntryServiceImpl;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -322,7 +323,7 @@ class GLPostingServiceTest {
 
         // Act
         JournalEntry result = service.postPaymentApplication(
-                testPaymentApplicationId, testCashAccountId, testArAccountId, amount, description);
+                testPaymentApplicationId, testCashAccountId, testArAccountId, amount, LocalDateTime.now(), description);
 
         // Assert
         assertThat(result.getStatus()).isEqualTo(JournalEntryStatus.POSTED);
@@ -360,7 +361,7 @@ class GLPostingServiceTest {
         when(journalEntryService.postJournalEntry(any(), isNull())).thenReturn(new JournalEntry());
 
         // Act
-        service.postPaymentApplication(testPaymentApplicationId, testCashAccountId, testArAccountId, amount, "Test");
+        service.postPaymentApplication(testPaymentApplicationId, testCashAccountId, testArAccountId, amount, LocalDateTime.now(), "Test");
 
         // Assert
         JournalEntry entry = entryCaptor.getValue();
@@ -388,7 +389,7 @@ class GLPostingServiceTest {
         when(journalEntryService.postJournalEntry(any(), isNull())).thenReturn(new JournalEntry());
 
         // Act
-        service.postPaymentApplication(testPaymentApplicationId, testCashAccountId, testArAccountId, amount, "Test");
+        service.postPaymentApplication(testPaymentApplicationId, testCashAccountId, testArAccountId, amount, LocalDateTime.now(), "Test");
 
         // Assert
         JournalEntry entry = entryCaptor.getValue();
@@ -417,7 +418,7 @@ class GLPostingServiceTest {
 
         // Act
         service.postPaymentApplication(
-                testPaymentApplicationId, testCashAccountId, testArAccountId, new BigDecimal("100.00"), description);
+                testPaymentApplicationId, testCashAccountId, testArAccountId, new BigDecimal("100.00"), LocalDateTime.now(), description);
 
         // Assert
         JournalEntry entry = entryCaptor.getValue();

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/MappingResolutionTestServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/MappingResolutionTestServiceTest.java
@@ -1,0 +1,407 @@
+package com.positivity.accounting.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.accounting.internal.config.DefaultGLMappingProperties;
+import com.positivity.accounting.internal.dto.MappingResolutionTestRequest;
+import com.positivity.accounting.internal.dto.MappingResolutionTestResponse;
+import com.positivity.accounting.internal.entity.GLAccount;
+import com.positivity.accounting.internal.entity.PostingRuleSet;
+import com.positivity.accounting.internal.entity.PostingRuleVersion;
+import com.positivity.accounting.internal.enums.PostingRuleSetState;
+import com.positivity.accounting.internal.repository.DefaultGLMappingRepository;
+import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.PostingRuleSetRepository;
+import com.positivity.accounting.internal.repository.PostingRuleVersionRepository;
+import com.positivity.accounting.internal.service.MappingResolutionTestServiceImpl;
+import com.positivity.accounting.internal.service.PostingRuleEvaluatorImpl;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the dry-run mapping resolution service (story E3, issue
+ * #957).
+ *
+ * <p>The service under test is wired against the REAL
+ * {@link PostingRuleEvaluatorImpl} (with mocked repositories) so the dry-run
+ * output is produced by exactly the same machinery as real posting — E1
+ * proportional split shares with residual distribution and E2 predicate
+ * evaluation included — while proving that no persistence interaction of any
+ * kind takes place.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MappingResolutionTestService dry-run resolution (E3)")
+class MappingResolutionTestServiceTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC);
+    private static final String EVENT_TYPE = "billing.invoicePosted";
+    private static final LocalDate TX_DATE = LocalDate.of(2026, 1, 15);
+
+    private static final UUID RULE_SET_ID = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
+    private static final UUID VERSION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000ab");
+
+    private static final UUID ACCOUNT_A = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID ACCOUNT_B = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+    private static final UUID ACCOUNT_C = UUID.fromString("00000000-0000-0000-0000-0000000000a3");
+    private static final UUID ACCOUNT_D = UUID.fromString("00000000-0000-0000-0000-0000000000a4");
+
+    @Mock
+    private PostingRuleVersionRepository versionRepository;
+
+    @Mock
+    private PostingRuleSetRepository ruleSetRepository;
+
+    @Mock
+    private GLMappingResolver glMappingResolver;
+
+    @Mock
+    private DefaultGLMappingRepository defaultGLMappingRepository;
+
+    @Mock
+    private GLAccountRepository glAccountRepository;
+
+    private MappingResolutionTestServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        DefaultGLMappingProperties properties = new DefaultGLMappingProperties();
+        properties.setEnabled(false);
+
+        PostingRuleEvaluatorImpl evaluator = new PostingRuleEvaluatorImpl(
+                TEST_CLOCK,
+                versionRepository,
+                ruleSetRepository,
+                glMappingResolver,
+                defaultGLMappingRepository,
+                properties,
+                new ObjectMapper());
+
+        service = new MappingResolutionTestServiceImpl(
+                evaluator, versionRepository, glAccountRepository, new ObjectMapper());
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private void stubPublishedRules(String rulesDefinition) {
+        PostingRuleSet ruleSet = new PostingRuleSet();
+        ruleSet.setPostingRuleSetId(RULE_SET_ID);
+        ruleSet.setName("Invoice finalization postings");
+        ruleSet.setEventType(EVENT_TYPE);
+
+        PostingRuleVersion version = new PostingRuleVersion();
+        version.setVersionId(VERSION_ID);
+        version.setVersionNumber(3);
+        version.setState(PostingRuleSetState.PUBLISHED);
+        version.setRulesDefinition(rulesDefinition);
+        version.setPostingRuleSet(ruleSet);
+
+        when(ruleSetRepository.findByEventType(EVENT_TYPE)).thenReturn(List.of(ruleSet));
+        when(versionRepository.findByPostingRuleSet_PostingRuleSetIdAndState(
+                        RULE_SET_ID, PostingRuleSetState.PUBLISHED))
+                .thenReturn(List.of(version));
+        when(versionRepository.findById(VERSION_ID)).thenReturn(Optional.of(version));
+    }
+
+    private static GLAccount glAccount(UUID id, String code, String name) {
+        GLAccount account = new GLAccount();
+        account.setGlAccountId(id);
+        account.setAccountCode(code);
+        account.setAccountName(name);
+        return account;
+    }
+
+    private static String line(UUID account, String side, String extraJson) {
+        return "{\"glAccountId\":\"" + account + "\",\"side\":\"" + side
+                + "\",\"amountField\":\"payload.totalAmount\""
+                + (extraJson.isEmpty() ? "" : "," + extraJson) + "}";
+    }
+
+    private static String splitLine(UUID account, String side, String factor, String group) {
+        return line(account, side, "\"factorPercent\":" + factor + ",\"splitGroup\":\"" + group + "\"");
+    }
+
+    private static String rules(String condition, String... lines) {
+        return "{\"conditions\":[{\"condition\":\"" + condition + "\",\"lines\":[" + String.join(",", lines) + "]}]}";
+    }
+
+    private static MappingResolutionTestRequest request(String eventType, Map<String, Object> payload) {
+        return MappingResolutionTestRequest.builder()
+                .eventType(eventType)
+                .samplePayload(payload)
+                .transactionDate(TX_DATE)
+                .build();
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Happy path: matched rule with E1 split lines")
+    class HappyPath {
+
+        private static final String CONDITION = "payload.channel == 'POS' && payload.totalAmount > 100";
+
+        private MappingResolutionTestResponse resolveHappyPath() {
+            stubPublishedRules(rules(
+                    CONDITION,
+                    splitLine(ACCOUNT_A, "DEBIT", "33.3333", "revenue-split"),
+                    splitLine(ACCOUNT_B, "DEBIT", "33.3333", "revenue-split"),
+                    splitLine(ACCOUNT_C, "DEBIT", "33.3334", "revenue-split"),
+                    line(ACCOUNT_D, "CREDIT", "")));
+            when(glAccountRepository.findAllById(any())).thenReturn(List.of(
+                    glAccount(ACCOUNT_A, "4000", "Sales Revenue A"),
+                    glAccount(ACCOUNT_B, "4001", "Sales Revenue B"),
+                    glAccount(ACCOUNT_C, "4002", "Sales Revenue C"),
+                    glAccount(ACCOUNT_D, "1200", "Accounts Receivable")));
+
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("channel", "POS");
+            payload.put("totalAmount", "125.00");
+            return service.resolveTest(request(EVENT_TYPE, payload));
+        }
+
+        @Test
+        @DisplayName("matches the published rule and reports its identity")
+        void matchesPublishedRule() {
+            MappingResolutionTestResponse response = resolveHappyPath();
+
+            assertThat(response.isMatched()).isTrue();
+            assertThat(response.getNoMatchReason()).isNull();
+            assertThat(response.getMatchedRule()).isNotNull();
+            assertThat(response.getMatchedRule().getPostingRuleSetId()).isEqualTo(RULE_SET_ID);
+            assertThat(response.getMatchedRule().getRuleSetName()).isEqualTo("Invoice finalization postings");
+            assertThat(response.getMatchedRule().getRuleVersionId()).isEqualTo(VERSION_ID);
+            assertThat(response.getMatchedRule().getVersionNumber()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("reports mapping type, key, and keys evaluated")
+        void reportsMappingDetails() {
+            MappingResolutionTestResponse response = resolveHappyPath();
+
+            assertThat(response.getMatchedMapping()).isNotNull();
+            assertThat(response.getMatchedMapping().getMappingType()).isEqualTo("exact");
+            assertThat(response.getMatchedMapping().getMappingKey()).isEqualTo(CONDITION);
+            assertThat(response.getMatchedMapping().getKeysEvaluated()).containsExactly(CONDITION);
+        }
+
+        @Test
+        @DisplayName("resolves E1 split shares that sum exactly to the source amount")
+        void resolvesSplitSharesExactly() {
+            MappingResolutionTestResponse response = resolveHappyPath();
+
+            List<MappingResolutionTestResponse.ResolvedLine> lines = response.getResolvedLines();
+            assertThat(lines).hasSize(4);
+
+            // 125.00 x 33.3333% = 41.666625 → 41.67 (HALF_UP); x3 rounded sum
+            // = 41.67+41.67+41.67 = 125.01 → residual -0.01 goes to the line
+            // with the largest raw share (the 33.3334 line, index 2)
+            assertThat(lines.get(0).getDebitAmount()).isEqualByComparingTo("41.67");
+            assertThat(lines.get(1).getDebitAmount()).isEqualByComparingTo("41.67");
+            assertThat(lines.get(2).getDebitAmount()).isEqualByComparingTo("41.66");
+            assertThat(lines.get(3).getCreditAmount()).isEqualByComparingTo("125.00");
+
+            BigDecimal debitSum = lines.subList(0, 3).stream()
+                    .map(MappingResolutionTestResponse.ResolvedLine::getDebitAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            assertThat(debitSum).isEqualByComparingTo("125.00");
+        }
+
+        @Test
+        @DisplayName("annotates split lines with splitGroup and factorPercent")
+        void annotatesSplitMetadata() {
+            MappingResolutionTestResponse response = resolveHappyPath();
+
+            List<MappingResolutionTestResponse.ResolvedLine> lines = response.getResolvedLines();
+            assertThat(lines.get(0).getSplitGroup()).isEqualTo("revenue-split");
+            assertThat(lines.get(0).getFactorPercent()).isEqualByComparingTo("33.3333");
+            assertThat(lines.get(2).getSplitGroup()).isEqualTo("revenue-split");
+            assertThat(lines.get(2).getFactorPercent()).isEqualByComparingTo("33.3334");
+            assertThat(lines.get(3).getSplitGroup()).isNull();
+            assertThat(lines.get(3).getFactorPercent()).isNull();
+        }
+
+        @Test
+        @DisplayName("enriches lines with GL account code and name")
+        void enrichesAccountCodeAndName() {
+            MappingResolutionTestResponse response = resolveHappyPath();
+
+            List<MappingResolutionTestResponse.ResolvedLine> lines = response.getResolvedLines();
+            assertThat(lines.get(0).getGlAccountId()).isEqualTo(ACCOUNT_A);
+            assertThat(lines.get(0).getAccountCode()).isEqualTo("4000");
+            assertThat(lines.get(0).getAccountName()).isEqualTo("Sales Revenue A");
+            assertThat(lines.get(3).getAccountCode()).isEqualTo("1200");
+            assertThat(lines.get(3).getAccountName()).isEqualTo("Accounts Receivable");
+        }
+
+        @Test
+        @DisplayName("reports the matched predicate evaluation")
+        void reportsPredicateEvaluations() {
+            MappingResolutionTestResponse response = resolveHappyPath();
+
+            assertThat(response.getPredicateEvaluations()).hasSize(1);
+            MappingResolutionTestResponse.PredicateEvaluation eval =
+                    response.getPredicateEvaluations().get(0);
+            assertThat(eval.getPredicate()).isEqualTo(CONDITION);
+            assertThat(eval.isMatched()).isTrue();
+        }
+
+        @Test
+        @DisplayName("performs zero persistence interactions")
+        void performsZeroPersistence() {
+            resolveHappyPath();
+
+            verify(versionRepository, never()).save(any());
+            verify(versionRepository, never()).saveAll(any());
+            verify(versionRepository, never()).delete(any());
+            verify(ruleSetRepository, never()).save(any());
+            verify(ruleSetRepository, never()).saveAll(any());
+            verify(defaultGLMappingRepository, never()).save(any());
+            verify(defaultGLMappingRepository, never()).saveAll(any());
+            verify(glAccountRepository, never()).save(any());
+            verify(glAccountRepository, never()).saveAll(any());
+            // Direct glAccountId rules never touch the mapping resolver
+            verifyNoInteractions(glMappingResolver);
+        }
+    }
+
+    @Nested
+    @DisplayName("No-match outcomes")
+    class NoMatch {
+
+        @Test
+        @DisplayName("predicate non-match returns matched=false with failing clause detail")
+        void predicateNonMatch() {
+            stubPublishedRules(rules(
+                    "payload.channel == 'POS' && payload.totalAmount > 100",
+                    line(ACCOUNT_A, "DEBIT", ""),
+                    line(ACCOUNT_D, "CREDIT", "")));
+
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("channel", "WEB");
+            payload.put("totalAmount", "125.00");
+
+            MappingResolutionTestResponse response = service.resolveTest(request(EVENT_TYPE, payload));
+
+            assertThat(response.isMatched()).isFalse();
+            assertThat(response.getNoMatchReason()).isEqualTo("UNMAPPED_EVENT_TYPE");
+            assertThat(response.getNoMatchDetail()).isNotBlank();
+            assertThat(response.getMatchedRule()).isNull();
+            assertThat(response.getResolvedLines()).isNull();
+
+            assertThat(response.getPredicateEvaluations()).hasSize(1);
+            MappingResolutionTestResponse.PredicateEvaluation eval =
+                    response.getPredicateEvaluations().get(0);
+            assertThat(eval.isMatched()).isFalse();
+            assertThat(eval.getDetail()).contains("payload.channel == 'POS'");
+        }
+
+        @Test
+        @DisplayName("unknown event type returns matched=false with NO_RULE_VERSION reason")
+        void unknownEventType() {
+            when(ruleSetRepository.findByEventType("unknown.event")).thenReturn(List.of());
+
+            MappingResolutionTestResponse response =
+                    service.resolveTest(request("unknown.event", Map.of("totalAmount", "10.00")));
+
+            assertThat(response.isMatched()).isFalse();
+            assertThat(response.getNoMatchReason()).isEqualTo("NO_RULE_VERSION");
+            assertThat(response.getNoMatchDetail()).contains("unknown.event");
+            assertThat(response.getMatchedRule()).isNull();
+            assertThat(response.getMatchedMapping()).isNull();
+            assertThat(response.getResolvedLines()).isNull();
+        }
+
+        @Test
+        @DisplayName("no-match performs zero persistence interactions")
+        void noMatchPerformsZeroPersistence() {
+            when(ruleSetRepository.findByEventType("unknown.event")).thenReturn(List.of());
+
+            service.resolveTest(request("unknown.event", Map.of()));
+
+            verify(versionRepository, never()).save(any());
+            verify(ruleSetRepository, never()).save(any());
+            verify(defaultGLMappingRepository, never()).save(any());
+            verify(glAccountRepository, never()).save(any());
+            verifyNoInteractions(glMappingResolver);
+        }
+    }
+
+    @Nested
+    @DisplayName("Caller errors")
+    class CallerErrors {
+
+        @Test
+        @DisplayName("non-numeric amount field in sample payload throws IllegalArgumentException")
+        void nonNumericAmountThrows() {
+            stubPublishedRules(rules(
+                    "eventType == '" + EVENT_TYPE + "'",
+                    line(ACCOUNT_A, "DEBIT", ""),
+                    line(ACCOUNT_D, "CREDIT", "")));
+
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("totalAmount", "not-a-number");
+
+            assertThatThrownBy(() -> service.resolveTest(request(EVENT_TYPE, payload)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("totalAmount");
+        }
+
+        @Test
+        @DisplayName("non-UUID organizationId in sample payload throws IllegalArgumentException")
+        void badOrganizationIdThrows() {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("organizationId", "not-a-uuid");
+
+            assertThatThrownBy(() -> service.resolveTest(request(EVENT_TYPE, payload)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("organizationId");
+        }
+    }
+
+    @Nested
+    @DisplayName("Missing amount field mirrors the real engine")
+    class MissingAmount {
+
+        @Test
+        @DisplayName("absent amount field resolves to zero amounts, matching real posting")
+        void absentAmountFieldMatchesWithZeroAmounts() {
+            stubPublishedRules(rules(
+                    "eventType == '" + EVENT_TYPE + "'",
+                    line(ACCOUNT_A, "DEBIT", ""),
+                    line(ACCOUNT_D, "CREDIT", "")));
+            when(glAccountRepository.findAllById(any())).thenReturn(List.of(
+                    glAccount(ACCOUNT_A, "4000", "Sales Revenue A"),
+                    glAccount(ACCOUNT_D, "1200", "Accounts Receivable")));
+
+            MappingResolutionTestResponse response =
+                    service.resolveTest(request(EVENT_TYPE, Map.of("channel", "POS")));
+
+            assertThat(response.isMatched()).isTrue();
+            assertThat(response.getResolvedLines()).hasSize(2);
+            assertThat(response.getResolvedLines().get(0).getDebitAmount()).isEqualByComparingTo("0");
+            assertThat(response.getResolvedLines().get(1).getCreditAmount()).isEqualByComparingTo("0");
+        }
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/OutboxProcessorTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/OutboxProcessorTest.java
@@ -120,6 +120,40 @@ class OutboxProcessorTest {
     }
 
     @Test
+    @DisplayName("processPendingEvents - publishes PaymentApplicationGLPostingEvent (story C1)")
+    void processPendingEvents_publishesPaymentApplicationGLPostingEvent() throws Exception {
+        com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent event =
+                com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent.builder()
+                        .eventId(eventId)
+                        .applicationRequestId("00000000-0000-0000-0000-000000000042")
+                        .paymentId(UUID.fromString("00000000-0000-0000-0000-000000000020"))
+                        .customerId(UUID.fromString("00000000-0000-0000-0000-000000000021"))
+                        .currency("USD")
+                        .appliedAmount(new java.math.BigDecimal("500.00"))
+                        .applicationTimestamp(Instant.parse("2024-01-01T00:00:00Z"))
+                        .build();
+
+        ObjectMapper timeAwareMapper =
+                new ObjectMapper().registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        OutboxProcessor timeAwareProcessor =
+                new OutboxProcessor(clock, outboxRepository, outboxService, eventPublisher, timeAwareMapper);
+
+        testOutbox.setAggregateType("PaymentApplication");
+        testOutbox.setEventType(
+                com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent.class.getName());
+        testOutbox.setPayload(timeAwareMapper.writeValueAsString(event));
+
+        when(outboxRepository.findPendingForRetry(eq(OutboxStatus.PENDING), any(Instant.class), any(Pageable.class)))
+                .thenReturn(List.of(testOutbox));
+
+        timeAwareProcessor.processPendingEvents();
+
+        verify(eventPublisher)
+                .publishEvent(any(com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent.class));
+        verify(outboxService).markAsPublished(outboxId);
+    }
+
+    @Test
     @DisplayName("processPendingEvents - marks as failed when event type is unsupported")
     void processPendingEvents_unsupportedEventType() {
         testOutbox.setEventType("com.example.UnknownEvent");

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/PaymentApplicationServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/PaymentApplicationServiceTest.java
@@ -18,6 +18,7 @@ import com.positivity.accounting.internal.entity.PaymentApplication;
 import com.positivity.accounting.internal.entity.PaymentApplicationReversal;
 import com.positivity.accounting.internal.entity.ReceivablePayment;
 import com.positivity.accounting.internal.entity.ReceivablePayment.ReceivablePaymentStatus;
+import com.positivity.accounting.internal.enums.AllocationStrategy;
 import com.positivity.accounting.internal.enums.InvoiceStatus;
 import com.positivity.accounting.internal.repository.CustomerCreditRepository;
 import com.positivity.accounting.internal.repository.PaymentApplicationRepository;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -858,8 +860,188 @@ class PaymentApplicationServiceTest {
     }
 
     // ========================================
+    // Allocation Strategy Tests (Issue #955)
+    // ========================================
+
+    @Test
+    @DisplayName("Should allocate in caller order when allocationStrategy is absent (regression)")
+    void testApplyPaymentToInvoices_AbsentStrategy_PreservesCallerOrder() {
+        // Arrange: caller order [newer, older] — oldest-first would reverse it
+        UUID newerInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+        UUID olderInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId,
+                List.of(
+                        createInvoiceApplication(newerInvoice, "300.00"),
+                        createInvoiceApplication(olderInvoice, "400.00")));
+
+        stubAppliableRequest();
+        stubInvoice(newerInvoice, "1000.00", Instant.parse("2023-06-01T00:00:00Z"));
+        stubInvoice(olderInvoice, "1000.00", Instant.parse("2023-01-01T00:00:00Z"));
+
+        // Act
+        PaymentApplicationResponse response = service.applyPaymentToInvoices(testPaymentId, request);
+
+        // Assert: caller-supplied order preserved
+        verify(paymentApplicationRepository, times(2)).save(paymentApplicationCaptor.capture());
+        assertThat(paymentApplicationCaptor.getAllValues())
+                .extracting(PaymentApplication::getInvoiceId)
+                .containsExactly(newerInvoice, olderInvoice);
+        assertThat(response.getApplications())
+                .extracting(PaymentApplicationResponse.ApplicationDetail::getInvoiceId)
+                .containsExactly(newerInvoice, olderInvoice);
+        assertThat(response.getAppliedAmount()).isEqualByComparingTo("700.00");
+        assertThat(response.getRemainingAmount()).isEqualByComparingTo("300.00");
+    }
+
+    @Test
+    @DisplayName("Should allocate in caller order when CALLER_ORDER is explicit (identical to default)")
+    void testApplyPaymentToInvoices_ExplicitCallerOrder_PreservesCallerOrder() {
+        // Arrange
+        UUID newerInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+        UUID olderInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId,
+                List.of(
+                        createInvoiceApplication(newerInvoice, "300.00"),
+                        createInvoiceApplication(olderInvoice, "400.00")));
+        request.setAllocationStrategy(AllocationStrategy.CALLER_ORDER);
+
+        stubAppliableRequest();
+        stubInvoice(newerInvoice, "1000.00", Instant.parse("2023-06-01T00:00:00Z"));
+        stubInvoice(olderInvoice, "1000.00", Instant.parse("2023-01-01T00:00:00Z"));
+
+        // Act
+        PaymentApplicationResponse response = service.applyPaymentToInvoices(testPaymentId, request);
+
+        // Assert: identical to the absent-strategy path
+        verify(paymentApplicationRepository, times(2)).save(paymentApplicationCaptor.capture());
+        assertThat(paymentApplicationCaptor.getAllValues())
+                .extracting(PaymentApplication::getInvoiceId)
+                .containsExactly(newerInvoice, olderInvoice);
+        assertThat(response.getApplications())
+                .extracting(PaymentApplicationResponse.ApplicationDetail::getInvoiceId)
+                .containsExactly(newerInvoice, olderInvoice);
+    }
+
+    @Test
+    @DisplayName("Should allocate oldest invoice first when OLDEST_FIRST is requested")
+    void testApplyPaymentToInvoices_OldestFirst_ReordersByInvoiceDate() {
+        // Arrange: caller order [newest, oldest, middle]
+        UUID newestInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+        UUID oldestInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+        UUID middleInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000c");
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId,
+                List.of(
+                        createInvoiceApplication(newestInvoice, "100.00"),
+                        createInvoiceApplication(oldestInvoice, "200.00"),
+                        createInvoiceApplication(middleInvoice, "300.00")));
+        request.setAllocationStrategy(AllocationStrategy.OLDEST_FIRST);
+
+        stubAppliableRequest();
+        stubInvoice(newestInvoice, "1000.00", Instant.parse("2023-09-01T00:00:00Z"));
+        stubInvoice(oldestInvoice, "1000.00", Instant.parse("2023-01-01T00:00:00Z"));
+        stubInvoice(middleInvoice, "1000.00", Instant.parse("2023-05-01T00:00:00Z"));
+
+        // Act
+        PaymentApplicationResponse response = service.applyPaymentToInvoices(testPaymentId, request);
+
+        // Assert: allocation (and response detail) order is ascending invoice date
+        verify(paymentApplicationRepository, times(3)).save(paymentApplicationCaptor.capture());
+        assertThat(paymentApplicationCaptor.getAllValues())
+                .extracting(PaymentApplication::getInvoiceId)
+                .containsExactly(oldestInvoice, middleInvoice, newestInvoice);
+        assertThat(response.getApplications())
+                .extracting(PaymentApplicationResponse.ApplicationDetail::getInvoiceId)
+                .containsExactly(oldestInvoice, middleInvoice, newestInvoice);
+
+        // Per-invoice amounts still follow the caller's requested amounts
+        assertThat(response.getApplications())
+                .extracting(PaymentApplicationResponse.ApplicationDetail::getAppliedAmount)
+                .usingElementComparator(BigDecimal::compareTo)
+                .containsExactly(new BigDecimal("200.00"), new BigDecimal("300.00"), new BigDecimal("100.00"));
+    }
+
+    @Test
+    @DisplayName("Should tie-break equal invoice dates by invoice id for OLDEST_FIRST")
+    void testApplyPaymentToInvoices_OldestFirst_TieBreaksByInvoiceId() {
+        // Arrange: equal dates, caller order [higher id, lower id]
+        UUID lowerIdInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+        UUID higherIdInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+        Instant sharedDate = Instant.parse("2023-03-01T00:00:00Z");
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId,
+                List.of(
+                        createInvoiceApplication(higherIdInvoice, "300.00"),
+                        createInvoiceApplication(lowerIdInvoice, "400.00")));
+        request.setAllocationStrategy(AllocationStrategy.OLDEST_FIRST);
+
+        stubAppliableRequest();
+        stubInvoice(lowerIdInvoice, "1000.00", sharedDate);
+        stubInvoice(higherIdInvoice, "1000.00", sharedDate);
+
+        // Act
+        service.applyPaymentToInvoices(testPaymentId, request);
+
+        // Assert: deterministic ascending invoice-id order on equal dates
+        verify(paymentApplicationRepository, times(2)).save(paymentApplicationCaptor.capture());
+        assertThat(paymentApplicationCaptor.getAllValues())
+                .extracting(PaymentApplication::getInvoiceId)
+                .containsExactly(lowerIdInvoice, higherIdInvoice);
+    }
+
+    @Test
+    @DisplayName("Should keep unappliedAmount math unchanged for OLDEST_FIRST partial allocation")
+    void testApplyPaymentToInvoices_OldestFirst_PartialAllocation_UnappliedMathUnchanged() {
+        // Arrange: 700.00 requested of 1000.00 available, caller order [newer, older]
+        UUID newerInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+        UUID olderInvoice = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId,
+                List.of(
+                        createInvoiceApplication(newerInvoice, "400.00"),
+                        createInvoiceApplication(olderInvoice, "300.00")));
+        request.setAllocationStrategy(AllocationStrategy.OLDEST_FIRST);
+
+        stubAppliableRequest();
+        stubInvoice(newerInvoice, "800.00", Instant.parse("2023-08-01T00:00:00Z"));
+        stubInvoice(olderInvoice, "600.00", Instant.parse("2023-02-01T00:00:00Z"));
+
+        // Act
+        PaymentApplicationResponse response = service.applyPaymentToInvoices(testPaymentId, request);
+
+        // Assert: same totals as caller-order would produce — only the order differs
+        assertThat(response.getAppliedAmount()).isEqualByComparingTo("700.00");
+        assertThat(response.getRemainingAmount()).isEqualByComparingTo("300.00");
+        assertThat(testPayment.getUnappliedAmount()).isEqualByComparingTo("300.00");
+        assertThat(response.getCustomerCredit()).isNull();
+
+        verify(paymentApplicationRepository, times(2)).save(paymentApplicationCaptor.capture());
+        List<PaymentApplication> savedApps = paymentApplicationCaptor.getAllValues();
+        assertThat(savedApps)
+                .extracting(PaymentApplication::getInvoiceId)
+                .containsExactly(olderInvoice, newerInvoice);
+        assertThat(savedApps)
+                .extracting(PaymentApplication::getAppliedAmount)
+                .usingElementComparator(BigDecimal::compareTo)
+                .containsExactly(new BigDecimal("300.00"), new BigDecimal("400.00"));
+    }
+
+    // ========================================
     // Helper Methods
     // ========================================
+
+    /** Common happy-path stubbing for applyPaymentToInvoices tests. */
+    private void stubAppliableRequest() {
+        when(paymentApplicationRepository.existsByApplicationRequestId(testApplicationRequestId))
+                .thenReturn(false);
+        when(receivablePaymentRepository.findById(testPaymentId)).thenReturn(Optional.of(testPayment));
+        when(paymentApplicationRepository.save(any(PaymentApplication.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(receivablePaymentRepository.save(any(ReceivablePayment.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
 
     private PaymentApplicationRequest createApplicationRequest(
             @NonNull String requestId, @NonNull List<PaymentApplicationRequest.InvoiceApplication> applications) {
@@ -882,8 +1064,18 @@ class PaymentApplicationServiceTest {
      * validation-failure tests never reach the status derivation.
      */
     private void stubInvoice(@NonNull UUID invoiceId, @NonNull String balanceDue) {
+        stubInvoice(invoiceId, balanceDue, null);
+    }
+
+    /**
+     * Stub variant that also sets the replica invoice date, used by allocation-strategy tests
+     * (Issue #955).
+     */
+    private void stubInvoice(
+            @NonNull UUID invoiceId, @NonNull String balanceDue, @Nullable Instant invoiceCreatedAt) {
         ExtInvoice invoice = ExtInvoice.builder()
                 .invoiceId(invoiceId)
+                .invoiceCreatedAt(invoiceCreatedAt)
                 .workorderId(UUID.fromString("00000000-0000-0000-0000-0000000000ff"))
                 .partyId(testCustomerId.toString())
                 .status("FINALIZED")

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/PaymentApplicationServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/PaymentApplicationServiceTest.java
@@ -8,8 +8,10 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent;
 import com.positivity.accounting.internal.dto.PaymentApplicationRequest;
 import com.positivity.accounting.internal.dto.PaymentApplicationResponse;
 import com.positivity.accounting.internal.entity.CustomerCredit;
@@ -81,6 +83,9 @@ class PaymentApplicationServiceTest {
 
     @Mock
     private InvoiceBalanceCalculator invoiceBalanceCalculator;
+
+    @Mock
+    private OutboxService outboxService;
 
     @InjectMocks
     private PaymentApplicationServiceImpl service;
@@ -499,6 +504,97 @@ class PaymentApplicationServiceTest {
                 .hasMessageContaining("Insufficient funds")
                 .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
                 .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    // ========================================
+    // GL posting outbox enqueue tests (story C1, issue #954)
+    // ========================================
+
+    @Test
+    @DisplayName("Should enqueue PAYMENT_APPLICATION_GL_POSTING outbox work item on successful application")
+    void testApplyPaymentToInvoices_Success_EnqueuesGLPostingOutboxWorkItem() {
+        // Arrange
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId, List.of(createInvoiceApplication(testInvoiceId, "500.00")));
+
+        when(paymentApplicationRepository.existsByApplicationRequestId(testApplicationRequestId))
+                .thenReturn(false);
+        when(receivablePaymentRepository.findById(testPaymentId)).thenReturn(Optional.of(testPayment));
+        when(paymentApplicationRepository.save(any(PaymentApplication.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(receivablePaymentRepository.save(any(ReceivablePayment.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        stubInvoice(testInvoiceId, "1000.00");
+
+        // Act
+        service.applyPaymentToInvoices(testPaymentId, request);
+
+        // Assert: work item saved to the outbox in the same transaction
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(outboxService)
+                .saveToOutbox(
+                        any(UUID.class),
+                        eq("PaymentApplication"),
+                        eq(testPaymentId),
+                        eq(PaymentApplicationGLPostingEvent.class.getName()),
+                        eventCaptor.capture());
+
+        PaymentApplicationGLPostingEvent event = (PaymentApplicationGLPostingEvent) eventCaptor.getValue();
+        assertThat(event.getEventId()).isNotNull();
+        assertThat(event.getApplicationRequestId()).isEqualTo(testApplicationRequestId);
+        assertThat(event.getPaymentId()).isEqualTo(testPaymentId);
+        assertThat(event.getCustomerId()).isEqualTo(testCustomerId);
+        assertThat(event.getCurrency()).isEqualTo("USD");
+        assertThat(event.getAppliedAmount()).isEqualByComparingTo("500.00");
+        assertThat(event.getApplicationTimestamp()).isEqualTo(Instant.now(TEST_CLOCK));
+    }
+
+    @Test
+    @DisplayName("Should not enqueue GL posting work item when validation fails")
+    void testApplyPaymentToInvoices_ValidationFailure_DoesNotEnqueueGLPosting() {
+        // Arrange: insufficient funds fails before any mutation
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId, List.of(createInvoiceApplication(testInvoiceId, "1500.00")));
+
+        when(paymentApplicationRepository.existsByApplicationRequestId(testApplicationRequestId))
+                .thenReturn(false);
+        when(receivablePaymentRepository.findById(testPaymentId)).thenReturn(Optional.of(testPayment));
+
+        // Act & Assert
+        assertThatThrownBy(() -> service.applyPaymentToInvoices(testPaymentId, request))
+                .isInstanceOf(ResponseStatusException.class);
+
+        verifyNoInteractions(outboxService);
+    }
+
+    @Test
+    @DisplayName("Should not enqueue GL posting work item on idempotent replay")
+    void testApplyPaymentToInvoices_IdempotentReplay_DoesNotEnqueueGLPosting() {
+        // Arrange: request id already processed
+        PaymentApplication existingApplication = new PaymentApplication();
+        existingApplication.setPaymentApplicationId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+        existingApplication.setPayment(testPayment);
+        existingApplication.setCustomerId(testCustomerId);
+        existingApplication.setInvoiceId(testInvoiceId);
+        existingApplication.setAppliedAmount(new BigDecimal("500.00"));
+        existingApplication.setCurrency("USD");
+        existingApplication.setApplicationRequestId(testApplicationRequestId);
+        existingApplication.setApplicationTimestamp(Instant.now(TEST_CLOCK));
+
+        when(paymentApplicationRepository.existsByApplicationRequestId(testApplicationRequestId))
+                .thenReturn(true);
+        when(paymentApplicationRepository.findAllByApplicationRequestId(testApplicationRequestId))
+                .thenReturn(List.of(existingApplication));
+        when(receivablePaymentRepository.findById(testPaymentId)).thenReturn(Optional.of(testPayment));
+
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId, List.of(createInvoiceApplication(testInvoiceId, "500.00")));
+
+        // Act
+        service.applyPaymentToInvoices(testPaymentId, request);
+
+        // Assert: replay must not double-enqueue (double-post guard, story C1)
+        verifyNoInteractions(outboxService);
     }
 
     // ========================================

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/PeriodEnforcementGateTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/PeriodEnforcementGateTest.java
@@ -412,7 +412,10 @@ class PeriodEnforcementGateTest {
         @Test
         @DisplayName("hard-locked: rejected regardless of override")
         void hardLocked_rejectedRegardlessOfOverride() {
-            configurationService.setHardLockDate(LocalDate.now().plusDays(1), "Lock everything to date");
+            // plusDays(2), not plusDays(1): near local midnight the posting date (resolved in a
+            // different zone) can already be "tomorrow", which would land ON a +1 lock date where
+            // the boundary rule still posts. +2 keeps today strictly before the lock in any zone.
+            configurationService.setHardLockDate(LocalDate.now().plusDays(2), "Lock everything to date");
 
             authenticate(OVERRIDE_AUTHORITY);
             assertThatThrownBy(() -> postCreditMemo(JUSTIFICATION))
@@ -468,7 +471,10 @@ class PeriodEnforcementGateTest {
         @Test
         @DisplayName("hard-locked: rejected regardless of override")
         void hardLocked_rejectedRegardlessOfOverride() {
-            configurationService.setHardLockDate(LocalDate.now().plusDays(1), "Lock everything to date");
+            // plusDays(2), not plusDays(1): near local midnight the posting date (resolved in a
+            // different zone) can already be "tomorrow", which would land ON a +1 lock date where
+            // the boundary rule still posts. +2 keeps today strictly before the lock in any zone.
+            configurationService.setHardLockDate(LocalDate.now().plusDays(2), "Lock everything to date");
 
             authenticate(OVERRIDE_AUTHORITY);
             assertThatThrownBy(() -> postPaymentApplication(JUSTIFICATION))

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/PeriodEnforcementGateTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/PeriodEnforcementGateTest.java
@@ -435,6 +435,7 @@ class PeriodEnforcementGateTest {
                     glAccountId,
                     glAccountId,
                     new BigDecimal("55.0000"),
+                    LocalDateTime.now(),
                     "B2 payment application test",
                     overrideJustification);
         }

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -103,6 +103,8 @@ paths:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1mappings
   /v1/accounting/mappings/resolve:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1mappings~1resolve
+  /v1/accounting/mappings/resolve-test:
+    $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1mappings~1resolve-test
   /v1/accounting/payment-applications/{applicationId}/reverse:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1payment-applications~1{applicationId}~1reverse
   /v1/accounting/payments/{paymentId}/applications:
@@ -111,6 +113,14 @@ paths:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1payments~1{paymentId}~1reverse
   /v1/accounting/payments/{paymentId}/void:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1payments~1{paymentId}~1void
+  /v1/accounting/periods:
+    $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1periods
+  /v1/accounting/periods/hard-lock:
+    $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1periods~1hard-lock
+  /v1/accounting/periods/{periodCode}/close:
+    $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1periods~1{periodCode}~1close
+  /v1/accounting/periods/{periodCode}/reopen:
+    $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1periods~1{periodCode}~1reopen
   /v1/accounting/posting-categories:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1posting-categories
   /v1/accounting/posting-categories/{postingCategoryId}:
@@ -141,6 +151,8 @@ paths:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1reports~1financial~1drilldown~1journal-lines~1{accountId}
   /v1/accounting/reports/financial/income-statement:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1reports~1financial~1income-statement
+  /v1/accounting/reports/financial/trial-balance:
+    $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1reports~1financial~1trial-balance
   /v1/accounting/reports/location/labor-overhead:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1reports~1location~1labor-overhead
   /v1/accounting/vendor-bills:
@@ -157,6 +169,10 @@ paths:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1vendor-bills~1{billId}
   /v1/accounting/vendor-bills/{billId}/resolve-exception:
     $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1vendor-bills~1{billId}~1resolve-exception
+  /v1/accounting/vendors:
+    $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1vendors
+  /v1/accounting/vendors/{vendorId}:
+    $ref: ../../pos-accounting/openapi.yaml#/paths/~1v1~1accounting~1vendors~1{vendorId}
   /v1/bulk-jobs:
     $ref: ../../pos-bulk-loader/openapi.yaml#/paths/~1v1~1bulk-jobs
   /v1/bulk-jobs/{jobId}:


### PR DESCRIPTION
## Odoo-parity accounting — Wave 3

Closes the accounting parity wave. Verified locally: `mvnw -pl pos-accounting -am verify` → BUILD SUCCESS, 177 ITs + all module unit tests green.

## Contract References
- Contract guide entry (durion): `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` (GL Mapping API → dry-run resolution).
- Contract chain complete: controller OpenAPI annotations → regenerated `pos-accounting/openapi.yaml` + `pos-api-gateway/docs/openapi-aggregate.yaml` → Angular SDK regenerated (`durion-positivity-sdk-angular` main `6343f50`).

### Stories
- **#957 (E3)** — dry-run mapping/rule resolution. `POST /v1/accounting/mappings/resolve-test`: read-only inspection resolving a hypothetical event against published posting rules and GL mappings; returns matched rule/mapping, the journal-entry lines the evaluator would post (E1 proportional splits + residual), and per-predicate outcomes (E2 grammar). Nothing persisted; no-match is a normal 200 with `matched=false`. New event `ACCOUNTING_MAPPING_RESOLVE_TEST`.
- **#956 (G1)** — trial balance report with numbering-gap footnote.
- **#954** — wire AR cash-receipt GL posting on payment application.
- **#955** — optional `OLDEST_FIRST` payment allocation strategy.
- **#953** — derive credit-memo tax reversal from stored invoice tax.

### SDK
Regenerated and pushed to `durion-positivity-sdk-angular` main (`6343f50`): `GLMappingAPIService.resolveTestMapping` + `MappingResolutionTest{Request,Response}` and nested models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)