### PR TITLE
[tax][parity-W1] Rounding reconciliation (T1), effective-dated rates (T2), TaxClient auth (T9a)

### DIFF
--- a/pos-tax-common/README.md
+++ b/pos-tax-common/README.md
@@ -13,6 +13,7 @@ Shared DTO and validation library for consuming the `pos-tax` tax calculation AP
 
 - `TaxCalculationRequest` — input: line items, postal code, state, city, country
 - `TaxCalculationResponse` — output: subtotal, total tax, effective rate, per-jurisdiction breakdown, per-line breakdown
+- `TaxCalculationResponse.LineItemTax.jurisdictions[]` — additive per-line jurisdiction rows, each a `JurisdictionTax {jurisdictionType (TaxJurisdictionType), code, rate, amount}`; the rows sum to the line's `taxAmount`. Never `null` (defaults to an empty list); existing `LineItemTax` fields are unchanged
 - `TaxLineItem` — individual line item within a tax calculation request
 - `IsoCountryCode` / `IsoCountryCodeValidator` — validates ISO 3166-1 alpha-2 country codes
 - `IsoCurrencyCode` / `IsoCurrencyCodeValidator` — validates ISO 4217 currency codes

--- a/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationResponse.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationResponse.java
@@ -1,5 +1,6 @@
 package com.positivity.tax.common.dto;
 
+import com.positivity.tax.common.enums.TaxJurisdictionType;
 import com.positivity.tax.common.enums.TaxReferenceType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -8,6 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -60,7 +62,10 @@ public class TaxCalculationResponse {
     @NotNull(message = "effectiveTaxRate is required")
     @PositiveOrZero(message = "effectiveTaxRate must be >= 0")
     @Schema(
-            description = "Effective tax rate as percentage",
+            description =
+                    "Effective tax rate: total tax divided by the exempt-filtered taxable base (the taxable"
+                            + " amount remaining after tax-exempt lines are excluded), expressed as percentage"
+                            + " points. This is NOT total tax divided by the raw subtotal (ADR-0042).",
             example = "10.00",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private BigDecimal effectiveTaxRate;
@@ -167,5 +172,62 @@ public class TaxCalculationResponse {
                 example = "false",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         private boolean taxExempt;
+
+        /**
+         * Additive per-jurisdiction tax breakdown for this line item.
+         * <p>
+         * Never {@code null}; defaults to an empty list. Provides the individual
+         * jurisdiction rows (type, code, rate, amount) that sum to
+         * {@link #taxAmount}.
+         */
+        @Valid
+        @Builder.Default
+        @Schema(
+                description = "Per-jurisdiction tax breakdown for this line item; rows sum to taxAmount",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        private List<JurisdictionTax> jurisdictions = new ArrayList<>();
+    }
+
+    /**
+     * Nested class for the per-jurisdiction tax breakdown within a single line item.
+     * <p>
+     * Compact companion to {@link TaxJurisdiction}: {@code jurisdictionType} mirrors
+     * the naming of the top-level jurisdiction rows, while {@code rate}/{@code amount}
+     * are the per-line analogues of {@code taxRate}/{@code taxAmount}.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "JurisdictionTax", description = "Per-jurisdiction tax breakdown for a single line item")
+    public static class JurisdictionTax {
+
+        @Schema(
+                description = "Jurisdiction type (e.g. STATE, COUNTY, CITY, DISTRICT)",
+                example = "STATE",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private TaxJurisdictionType jurisdictionType;
+
+        @Schema(
+                description = "Jurisdiction code; in test mode this is the jurisdiction type code"
+                        + " (e.g. STATE, COUNTY, CITY). With an external tax provider it carries the"
+                        + " provider's taxing-authority code.",
+                example = "STATE",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private String code;
+
+        @Schema(
+                description = "Tax rate applied for this jurisdiction, expressed as a decimal fraction"
+                        + " (e.g. 0.0725 for 7.25%)",
+                example = "0.0725",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private BigDecimal rate;
+
+        @PositiveOrZero(message = "amount must be >= 0")
+        @Schema(
+                description = "Tax amount calculated for this jurisdiction on this line item",
+                example = "6.53",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private BigDecimal amount;
     }
 }

--- a/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationResponse.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationResponse.java
@@ -62,10 +62,9 @@ public class TaxCalculationResponse {
     @NotNull(message = "effectiveTaxRate is required")
     @PositiveOrZero(message = "effectiveTaxRate must be >= 0")
     @Schema(
-            description =
-                    "Effective tax rate: total tax divided by the exempt-filtered taxable base (the taxable"
-                            + " amount remaining after tax-exempt lines are excluded), expressed as percentage"
-                            + " points. This is NOT total tax divided by the raw subtotal (ADR-0042).",
+            description = "Effective tax rate: total tax divided by the exempt-filtered taxable base (the taxable"
+                    + " amount remaining after tax-exempt lines are excluded), expressed as percentage"
+                    + " points. This is NOT total tax divided by the raw subtotal (ADR-0042).",
             example = "10.00",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private BigDecimal effectiveTaxRate;
@@ -202,12 +201,14 @@ public class TaxCalculationResponse {
     @Schema(name = "JurisdictionTax", description = "Per-jurisdiction tax breakdown for a single line item")
     public static class JurisdictionTax {
 
+        @NotNull(message = "jurisdictionType is required")
         @Schema(
                 description = "Jurisdiction type (e.g. STATE, COUNTY, CITY, DISTRICT)",
                 example = "STATE",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         private TaxJurisdictionType jurisdictionType;
 
+        @NotBlank(message = "code is required")
         @Schema(
                 description = "Jurisdiction code; in test mode this is the jurisdiction type code"
                         + " (e.g. STATE, COUNTY, CITY). With an external tax provider it carries the"
@@ -216,6 +217,8 @@ public class TaxCalculationResponse {
                 requiredMode = Schema.RequiredMode.REQUIRED)
         private String code;
 
+        @NotNull(message = "rate is required")
+        @PositiveOrZero(message = "rate must be >= 0")
         @Schema(
                 description = "Tax rate applied for this jurisdiction, expressed as a decimal fraction"
                         + " (e.g. 0.0725 for 7.25%)",
@@ -223,6 +226,7 @@ public class TaxCalculationResponse {
                 requiredMode = Schema.RequiredMode.REQUIRED)
         private BigDecimal rate;
 
+        @NotNull(message = "amount is required")
         @PositiveOrZero(message = "amount must be >= 0")
         @Schema(
                 description = "Tax amount calculated for this jurisdiction on this line item",

--- a/pos-tax/README.md
+++ b/pos-tax/README.md
@@ -14,7 +14,8 @@ Tax calculation service for the Durion Positivity ETSMS platform. Supports two o
 
 - `TaxCalculationService` — public service interface; the entry point for all tax calculations
 - `TaxCalculationServiceImpl` — delegates to `TestModeTaxCalculator` or `ExternalTaxServiceClient` based on configuration
-- `TestModeTaxCalculator` — applies configured flat rates per jurisdiction type for dev/test
+- `TestModeTaxCalculator` — applies configured flat rates per jurisdiction type for dev/test, selecting the effective-dated rate set for the transaction date
+- `TaxTotalsReconciler` — package-private helper that enforces the rounding invariant across line, jurisdiction, and total amounts
 - `ExternalTaxServiceClient` — `RestClient`-based client for the external tax provider with retry
 - `TaxController` — REST controller at `/v1/tax`
 
@@ -31,9 +32,49 @@ Tax calculation service for the Durion Positivity ETSMS platform. Supports two o
 | `pos.tax.test-mode.default-rates.STATE`  | `0.0725`         | State rate in test mode                  |
 | `pos.tax.test-mode.default-rates.COUNTY` | `0.01`           | County rate in test mode                 |
 | `pos.tax.test-mode.default-rates.CITY`   | `0.0025`         | City rate in test mode                   |
+| `pos.tax.test-mode.rate-schedule`        | empty            | Ordered effective-dated rate overrides (see below) |
 | `pos.tax.external-service.base-url`      | required in prod | External tax provider URL                |
 | `pos.tax.external-service.api-key`       | required in prod | External tax provider API key            |
 | `pos.tax.retry.max-attempts`             | `3`              | Retry attempts for external API failures |
+
+### Effective-dated test-mode rates
+
+`pos.tax.test-mode.rate-schedule` is an ordered list of `{effective-from, rates{…}}` entries.
+For a given transaction the calculator selects the entry with the greatest `effective-from`
+that is not after the transaction date. When the schedule is empty (the default), or when no
+entry is effective on or before the transaction date, `default-rates` is used, preserving prior
+behavior. The transaction date defaults to today (injected `Clock`) when the request omits it;
+an unparseable `transactionDate` fails fast with a deterministic error (ADR-0021).
+
+```yaml
+pos:
+  tax:
+    test-mode:
+      rate-schedule:
+        - effective-from: 2025-01-01
+          rates:
+            STATE: 0.0700
+            COUNTY: 0.0100
+            CITY: 0.0025
+        - effective-from: 2026-01-01
+          rates:
+            STATE: 0.0725
+            COUNTY: 0.0125
+            CITY: 0.0025
+```
+
+### Rounding reconciliation
+
+Tax is computed on a per-line × per-jurisdiction raw (unrounded) matrix with a single rounding
+stage, after which `TaxTotalsReconciler` enforces the invariant
+`Σ lineItemTaxes.taxAmount == totalTax == Σ jurisdictions.taxAmount` (and per line,
+`Σ jurisdiction-cell amounts == line.taxAmount`). Residual cents are distributed
+deterministically, largest-raw-amount-first (mirrors Odoo `_distribute_delta_amount_smoothly`).
+
+### Effective tax rate
+
+`effectiveTaxRate` is `totalTax` divided by the exempt-filtered taxable base (exempt lines are
+excluded from the denominator). An all-exempt or zero-base cart yields `0.00`.
 
 ## Dependencies
 

--- a/pos-tax/openapi.yaml
+++ b/pos-tax/openapi.yaml
@@ -238,6 +238,39 @@ components:
       - lineItemId
       - quantity
       - unitPrice
+    JurisdictionTax:
+      type: object
+      description: Per-jurisdiction tax breakdown for a single line item
+      properties:
+        jurisdictionType:
+          type: string
+          description: Jurisdiction type (e.g. STATE, COUNTY, CITY, DISTRICT)
+          enum:
+          - COUNTRY
+          - STATE
+          - PROVINCE
+          - COUNTY
+          - CITY
+          - DISTRICT
+          - SPECIAL
+          example: STATE
+        code:
+          type: string
+          description: Jurisdiction code; in test mode this is the jurisdiction type code (e.g. STATE, COUNTY, CITY). With an external tax provider it carries the provider's taxing-authority code.
+          example: STATE
+        rate:
+          type: number
+          description: Tax rate applied for this jurisdiction, expressed as a decimal fraction (e.g. 0.0725 for 7.25%)
+          example: 0.0725
+        amount:
+          type: number
+          description: Tax amount calculated for this jurisdiction on this line item
+          example: 6.53
+      required:
+      - amount
+      - code
+      - jurisdictionType
+      - rate
     LineItemTax:
       type: object
       description: Tax breakdown for a single line item
@@ -263,6 +296,11 @@ components:
           type: boolean
           description: Whether this line item is tax exempt
           example: false
+        jurisdictions:
+          type: array
+          description: Per-jurisdiction tax breakdown for this line item; rows sum to taxAmount
+          items:
+            $ref: '#/components/schemas/JurisdictionTax'
       required:
       - lineItemId
       - subtotal
@@ -287,7 +325,7 @@ components:
           example: 165.0
         effectiveTaxRate:
           type: number
-          description: Effective tax rate as percentage
+          description: 'Effective tax rate: total tax divided by the exempt-filtered taxable base (the taxable amount remaining after tax-exempt lines are excluded), expressed as percentage points. This is NOT total tax divided by the raw subtotal (ADR-0042).'
           example: 10.0
         jurisdictions:
           type: array

--- a/pos-tax/openapi.yaml
+++ b/pos-tax/openapi.yaml
@@ -258,6 +258,7 @@ components:
           type: string
           description: Jurisdiction code; in test mode this is the jurisdiction type code (e.g. STATE, COUNTY, CITY). With an external tax provider it carries the provider's taxing-authority code.
           example: STATE
+          minLength: 1
         rate:
           type: number
           description: Tax rate applied for this jurisdiction, expressed as a decimal fraction (e.g. 0.0725 for 7.25%)

--- a/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxProperties.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxProperties.java
@@ -1,7 +1,10 @@
 package com.positivity.tax.internal.config;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -52,6 +55,41 @@ public class TaxProperties {
          * Example: 90001={state=CA, county=LA}
          */
         private Map<String, Map<String, String>> postalCodeMapping = new HashMap<>();
+
+        /**
+         * Effective-dated override schedule for test-mode rates.
+         * <p>
+         * Ordered list of {@link RateScheduleEntry}. When resolving rates for a
+         * transaction, the entry with the greatest {@code effectiveFrom} that is not
+         * after the transaction date is selected. When empty (the default) or when no
+         * entry is effective on or before the transaction date, {@link #defaultRates}
+         * is used, preserving prior behavior.
+         * <p>
+         * Never {@code null}; defaults to an empty list.
+         */
+        private List<RateScheduleEntry> rateSchedule = new ArrayList<>();
+    }
+
+    /**
+     * A single effective-dated set of test-mode tax rates.
+     * <p>
+     * {@code effectiveFrom} is the inclusive start date on which {@code rates}
+     * become applicable; an entry applies to any transaction date on or after it,
+     * until a later entry supersedes it.
+     */
+    @Data
+    public static class RateScheduleEntry {
+        /**
+         * Inclusive date on which this rate set becomes effective.
+         */
+        private LocalDate effectiveFrom;
+
+        /**
+         * Tax rates by jurisdiction type code for this effective period.
+         * <p>
+         * Example: STATE=0.0725, COUNTY=0.01, CITY=0.0025
+         */
+        private Map<String, BigDecimal> rates = new HashMap<>();
     }
 
     @Data

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxTotalsReconciler.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxTotalsReconciler.java
@@ -1,0 +1,238 @@
+package com.positivity.tax.internal.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Single-stage rounding reconciler over a per-line x per-jurisdiction RAW
+ * (unrounded, full-precision) tax matrix.
+ * <p>
+ * Enforces the money invariant
+ * {@code Sum(lineAmounts) == totalTax == Sum(jurisdictionAmounts)} and, within
+ * each line, {@code Sum(cellAmounts[line]) == lineAmounts[line]}.
+ * <p>
+ * All money math uses {@link BigDecimal}, {@link RoundingMode#HALF_UP} and
+ * currency scale 2 (see ADR-0044 money policy). Residual cents left over after
+ * independent per-item rounding are distributed one cent at a time using a
+ * deterministic largest-raw-first rule (ties broken by larger fractional
+ * remainder, then by ascending stable index), so identical input yields
+ * byte-identical output on every run.
+ * <p>
+ * This is a pure helper: it holds no Spring state and no mutable fields. The
+ * {@link #distributeResidual(List, BigDecimal)} and
+ * {@link #reconcileAmountsToTarget(List, BigDecimal)} entry points are intended
+ * for reuse by later slices (T4/T6) that validate and correct an external
+ * provider's response against the same invariants.
+ */
+@Slf4j
+class TaxTotalsReconciler {
+
+    /** Currency scale for all monetary amounts. */
+    private static final int MONEY_SCALE = 2;
+
+    /** A single cent expressed at {@link #MONEY_SCALE}. */
+    private static final BigDecimal ONE_CENT = BigDecimal.valueOf(1, MONEY_SCALE);
+
+    /**
+     * Result of reconciling a raw tax matrix.
+     *
+     * @param totalTax            the single source-of-truth grand total (rounded)
+     * @param jurisdictionAmounts rounded per-jurisdiction column totals; sum == totalTax
+     * @param lineAmounts         rounded per-line row totals; sum == totalTax
+     * @param cellAmounts         rounded per-line x per-jurisdiction amounts; each row sums to
+     *                            the matching {@code lineAmounts} entry
+     */
+    record ReconciledTax(
+            @NonNull BigDecimal totalTax,
+            @NonNull List<BigDecimal> jurisdictionAmounts,
+            @NonNull List<BigDecimal> lineAmounts,
+            @NonNull List<List<BigDecimal>> cellAmounts) {}
+
+    /**
+     * Reconcile a raw (line x jurisdiction) tax matrix into rounded, internally
+     * consistent totals.
+     *
+     * @param lineTaxableAmounts full-precision taxable base per non-exempt line (row order preserved)
+     * @param jurisdictionRates  decimal-fraction rate per jurisdiction (column order preserved)
+     * @return the reconciled totals satisfying all money invariants
+     */
+    @NonNull
+    ReconciledTax reconcile(
+            @NonNull List<BigDecimal> lineTaxableAmounts, @NonNull List<BigDecimal> jurisdictionRates) {
+        int rowCount = lineTaxableAmounts.size();
+        int colCount = jurisdictionRates.size();
+
+        // Raw cells: rawCell[line][jur] = lineTaxable * rate (full precision, no rounding).
+        BigDecimal[][] rawCells = new BigDecimal[rowCount][colCount];
+        BigDecimal rawTotal = BigDecimal.ZERO;
+        for (int i = 0; i < rowCount; i++) {
+            for (int j = 0; j < colCount; j++) {
+                BigDecimal cell = lineTaxableAmounts.get(i).multiply(jurisdictionRates.get(j));
+                rawCells[i][j] = cell;
+                rawTotal = rawTotal.add(cell);
+            }
+        }
+
+        // Single source of truth for the grand total.
+        BigDecimal totalTax = round(rawTotal);
+
+        // Jurisdiction (column) totals reconciled to totalTax.
+        List<BigDecimal> jurisdictionRaw = new ArrayList<>(colCount);
+        for (int j = 0; j < colCount; j++) {
+            BigDecimal columnRaw = BigDecimal.ZERO;
+            for (int i = 0; i < rowCount; i++) {
+                columnRaw = columnRaw.add(rawCells[i][j]);
+            }
+            jurisdictionRaw.add(columnRaw);
+        }
+        List<BigDecimal> jurisdictionAmounts = distributeResidual(jurisdictionRaw, totalTax);
+
+        // Line (row) totals reconciled to totalTax.
+        List<BigDecimal> lineRaw = new ArrayList<>(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            BigDecimal rowRaw = BigDecimal.ZERO;
+            for (int j = 0; j < colCount; j++) {
+                rowRaw = rowRaw.add(rawCells[i][j]);
+            }
+            lineRaw.add(rowRaw);
+        }
+        List<BigDecimal> lineAmounts = distributeResidual(lineRaw, totalTax);
+
+        // Per-line cell amounts reconciled to that line's rounded total.
+        List<List<BigDecimal>> cellAmounts = new ArrayList<>(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            List<BigDecimal> rowCellsRaw = new ArrayList<>(colCount);
+            for (int j = 0; j < colCount; j++) {
+                rowCellsRaw.add(rawCells[i][j]);
+            }
+            cellAmounts.add(distributeResidual(rowCellsRaw, lineAmounts.get(i)));
+        }
+
+        return new ReconciledTax(totalTax, jurisdictionAmounts, lineAmounts, cellAmounts);
+    }
+
+    /**
+     * Round each raw value to currency scale then distribute the residual cents
+     * (relative to {@code target}) one cent at a time so the returned amounts sum
+     * exactly to {@code target}.
+     * <p>
+     * Distribution order (deterministic): largest raw value first; ties broken by
+     * larger fractional remainder (the sub-cent part discarded by rounding), then
+     * by ascending original index. A positive residual adds cents; a negative
+     * residual subtracts cents. This is the reusable core of the reconciler.
+     *
+     * @param rawValues the per-item raw (full-precision) values
+     * @param target    the exact scale-2 total the rounded amounts must sum to
+     * @return rounded amounts (scale 2) summing exactly to {@code target}
+     */
+    @NonNull
+    List<BigDecimal> distributeResidual(@NonNull List<BigDecimal> rawValues, @NonNull BigDecimal target) {
+        int n = rawValues.size();
+        if (n == 0) {
+            return new ArrayList<>();
+        }
+
+        List<BigDecimal> rounded = new ArrayList<>(n);
+        BigDecimal roundedSum = BigDecimal.ZERO;
+        for (BigDecimal raw : rawValues) {
+            BigDecimal r = round(raw);
+            rounded.add(r);
+            roundedSum = roundedSum.add(r);
+        }
+
+        // Residual in whole cents (exact: target and roundedSum are both scale 2).
+        int residualCents = target.subtract(roundedSum)
+                .movePointRight(MONEY_SCALE)
+                .setScale(0, RoundingMode.HALF_UP)
+                .intValueExact();
+        if (residualCents == 0) {
+            return rounded;
+        }
+
+        List<Integer> order = distributionOrder(rawValues);
+        BigDecimal step = residualCents > 0 ? ONE_CENT : ONE_CENT.negate();
+        int steps = Math.abs(residualCents);
+        for (int k = 0; k < steps; k++) {
+            int idx = order.get(k % n);
+            rounded.set(idx, rounded.get(idx).add(step));
+        }
+        return rounded;
+    }
+
+    /**
+     * Validate and, if drifted, correct an already-computed set of amounts so it
+     * sums exactly to {@code target}, using the same deterministic delta rule.
+     * <p>
+     * Intended for later slices (T4/T6) that reconcile an external provider's
+     * response. Any drift is logged and corrected a cent at a time.
+     *
+     * @param amounts the amounts to validate (e.g. a provider's per-jurisdiction figures)
+     * @param target  the authoritative scale-2 total they must sum to
+     * @return amounts (scale 2) summing exactly to {@code target}
+     */
+    @NonNull
+    List<BigDecimal> reconcileAmountsToTarget(@NonNull List<BigDecimal> amounts, @NonNull BigDecimal target) {
+        BigDecimal sum = BigDecimal.ZERO;
+        for (BigDecimal amount : amounts) {
+            sum = sum.add(round(amount));
+        }
+        BigDecimal drift = target.subtract(sum);
+        if (drift.signum() != 0) {
+            log.warn("Correcting tax reconciliation drift of {} against target {}", drift, target);
+        }
+        return distributeResidual(amounts, target);
+    }
+
+    /**
+     * Whether {@code amounts} already sum exactly to {@code target} at currency scale.
+     *
+     * @param amounts the amounts to check
+     * @param target  the expected total
+     * @return {@code true} when the rounded sum equals {@code target}
+     */
+    boolean sumsTo(@NonNull List<BigDecimal> amounts, @NonNull BigDecimal target) {
+        BigDecimal sum = BigDecimal.ZERO;
+        for (BigDecimal amount : amounts) {
+            sum = sum.add(round(amount));
+        }
+        return sum.compareTo(target) == 0;
+    }
+
+    /**
+     * Deterministic index order for residual distribution: largest raw value
+     * first, ties broken by larger fractional remainder, then ascending index.
+     */
+    @NonNull
+    private List<Integer> distributionOrder(@NonNull List<BigDecimal> rawValues) {
+        List<Integer> order = new ArrayList<>(rawValues.size());
+        for (int i = 0; i < rawValues.size(); i++) {
+            order.add(i);
+        }
+        order.sort(Comparator.<Integer, BigDecimal>comparing(rawValues::get, Comparator.reverseOrder())
+                .thenComparing(i -> fractionalRemainder(rawValues.get(i)), Comparator.reverseOrder())
+                .thenComparingInt(i -> i));
+        return order;
+    }
+
+    /**
+     * Sub-cent fractional remainder of a raw value in {@code [0, 1)}: the part of
+     * the amount below currency resolution that rounding discards.
+     */
+    @NonNull
+    private BigDecimal fractionalRemainder(@NonNull BigDecimal rawValue) {
+        return rawValue.abs().movePointRight(MONEY_SCALE).remainder(BigDecimal.ONE);
+    }
+
+    /**
+     * Round a value to currency scale (scale 2, HALF_UP).
+     */
+    @NonNull
+    private BigDecimal round(@NonNull BigDecimal value) {
+        return value.setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+    }
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxTotalsReconciler.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxTotalsReconciler.java
@@ -17,7 +17,7 @@ import org.jspecify.annotations.NonNull;
  * each line, {@code Sum(cellAmounts[line]) == lineAmounts[line]}.
  * <p>
  * All money math uses {@link BigDecimal}, {@link RoundingMode#HALF_UP} and
- * currency scale 2 (see ADR-0044 money policy). Residual cents left over after
+ * currency scale 2. Residual cents left over after
  * independent per-item rounding are distributed one cent at a time using a
  * deterministic largest-raw-first rule (ties broken by larger fractional
  * remainder, then by ascending stable index), so identical input yields
@@ -62,8 +62,7 @@ class TaxTotalsReconciler {
      * @return the reconciled totals satisfying all money invariants
      */
     @NonNull
-    ReconciledTax reconcile(
-            @NonNull List<BigDecimal> lineTaxableAmounts, @NonNull List<BigDecimal> jurisdictionRates) {
+    ReconciledTax reconcile(@NonNull List<BigDecimal> lineTaxableAmounts, @NonNull List<BigDecimal> jurisdictionRates) {
         int rowCount = lineTaxableAmounts.size();
         int colCount = jurisdictionRates.size();
 

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
@@ -66,8 +66,7 @@ public class TestModeTaxCalculator {
         List<TaxLineItem> lineItems = request.getLineItems();
 
         // Subtotal includes ALL line items (exempt and non-exempt).
-        BigDecimal subtotal =
-                lineItems.stream().map(TaxLineItem::getSubtotal).reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal subtotal = lineItems.stream().map(TaxLineItem::getSubtotal).reduce(BigDecimal.ZERO, BigDecimal::add);
 
         // Resolve the effective transaction date (defaulting to today via the shared
         // Clock) and the rates map effective on that date.
@@ -78,25 +77,22 @@ public class TestModeTaxCalculator {
         List<JurisdictionSpec> specs = determineJurisdictionSpecs(effectiveRates);
 
         // Non-exempt lines form the taxable rows of the matrix (row order preserved).
-        List<TaxLineItem> taxableLines = lineItems.stream()
-                .filter(item -> !item.isTaxExempt())
-                .toList();
+        List<TaxLineItem> taxableLines =
+                lineItems.stream().filter(item -> !item.isTaxExempt()).toList();
         List<BigDecimal> lineTaxableAmounts =
                 taxableLines.stream().map(TaxLineItem::getSubtotal).toList();
         List<BigDecimal> jurisdictionRates =
                 specs.stream().map(JurisdictionSpec::rate).toList();
 
         // Exempt-filtered taxable base: the denominator for the effective rate.
-        BigDecimal taxBase =
-                lineTaxableAmounts.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal taxBase = lineTaxableAmounts.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
 
         // Single rounding stage: all totals reconciled to the same grand total.
         TaxTotalsReconciler.ReconciledTax reconciled = reconciler.reconcile(lineTaxableAmounts, jurisdictionRates);
 
         BigDecimal totalTax = reconciled.totalTax();
         List<TaxJurisdiction> jurisdictions = buildJurisdictions(request, specs, reconciled.jurisdictionAmounts());
-        List<TaxCalculationResponse.LineItemTax> lineItemTaxes =
-                buildLineItemTaxes(lineItems, taxableLines, specs, reconciled);
+        List<TaxCalculationResponse.LineItemTax> lineItemTaxes = buildLineItemTaxes(lineItems, specs, reconciled);
 
         // Effective tax rate = totalTax / exempt-filtered taxable base (ADR-0042),
         // NOT totalTax / raw subtotal. Guard an all-exempt / zero base.
@@ -238,9 +234,8 @@ public class TestModeTaxCalculator {
     @NonNull
     private List<TaxCalculationResponse.LineItemTax> buildLineItemTaxes(
             @NonNull List<TaxLineItem> lineItems,
-            @NonNull List<TaxLineItem> taxableLines,
             @NonNull List<JurisdictionSpec> specs,
-            TaxTotalsReconciler.ReconciledTax reconciled) {
+            TaxTotalsReconciler.@NonNull ReconciledTax reconciled) {
         List<TaxCalculationResponse.LineItemTax> result = new ArrayList<>(lineItems.size());
         int taxableIndex = 0;
         for (TaxLineItem item : lineItems) {
@@ -290,5 +285,6 @@ public class TestModeTaxCalculator {
      * @param type the jurisdiction type
      * @param rate the tax rate as a decimal fraction
      */
-    private record JurisdictionSpec(@NonNull TaxJurisdictionType type, @NonNull BigDecimal rate) {}
+    private record JurisdictionSpec(
+            @NonNull TaxJurisdictionType type, @NonNull BigDecimal rate) {}
 }

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
@@ -10,8 +10,12 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Component;
@@ -26,9 +30,19 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class TestModeTaxCalculator {
+
+    /** Currency scale for all monetary amounts. */
+    private static final int MONEY_SCALE = 2;
+
+    /** Percentage-point conversion factor for decimal-fraction rates. */
+    private static final BigDecimal PERCENT_FACTOR = BigDecimal.valueOf(100);
+
     private final Clock clock;
 
     private final TaxProperties properties;
+
+    /** Stateless, deterministic single-stage rounding reconciler. */
+    private final TaxTotalsReconciler reconciler = new TaxTotalsReconciler();
 
     public TestModeTaxCalculator(TaxProperties properties, Clock clock) {
         this.clock = clock;
@@ -37,6 +51,10 @@ public class TestModeTaxCalculator {
 
     /**
      * Calculate tax in test mode using configured default rates.
+     * <p>
+     * A single rounding stage is applied over the raw (line x jurisdiction)
+     * matrix by {@link TaxTotalsReconciler}, guaranteeing
+     * {@code Sum(lineItemTaxes.taxAmount) == totalTax == Sum(jurisdictions.taxAmount)}.
      *
      * @param request the tax calculation request
      * @return calculated tax response
@@ -45,25 +63,48 @@ public class TestModeTaxCalculator {
     public TaxCalculationResponse calculate(@NonNull TaxCalculationRequest request) {
         log.info("Calculating tax in TEST MODE for postal code: {}", request.getPostalCode());
 
-        // Calculate subtotal from all line items
+        List<TaxLineItem> lineItems = request.getLineItems();
+
+        // Subtotal includes ALL line items (exempt and non-exempt).
         BigDecimal subtotal =
-                request.getLineItems().stream().map(TaxLineItem::getSubtotal).reduce(BigDecimal.ZERO, BigDecimal::add);
+                lineItems.stream().map(TaxLineItem::getSubtotal).reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        // Get applicable jurisdictions based on location
-        List<TaxJurisdiction> jurisdictions = determineJurisdictions(request);
+        // Resolve the effective transaction date (defaulting to today via the shared
+        // Clock) and the rates map effective on that date.
+        LocalDate transactionDate = resolveTransactionDate(request.getTransactionDate());
+        Map<String, BigDecimal> effectiveRates = resolveEffectiveRates(transactionDate);
 
-        // Calculate total tax across all jurisdictions
-        BigDecimal totalTax =
-                jurisdictions.stream().map(TaxJurisdiction::getTaxAmount).reduce(BigDecimal.ZERO, BigDecimal::add);
+        // Applicable jurisdictions (type + decimal-fraction rate); rate order is stable.
+        List<JurisdictionSpec> specs = determineJurisdictionSpecs(effectiveRates);
 
-        // Calculate per-line-item tax breakdown
+        // Non-exempt lines form the taxable rows of the matrix (row order preserved).
+        List<TaxLineItem> taxableLines = lineItems.stream()
+                .filter(item -> !item.isTaxExempt())
+                .toList();
+        List<BigDecimal> lineTaxableAmounts =
+                taxableLines.stream().map(TaxLineItem::getSubtotal).toList();
+        List<BigDecimal> jurisdictionRates =
+                specs.stream().map(JurisdictionSpec::rate).toList();
+
+        // Exempt-filtered taxable base: the denominator for the effective rate.
+        BigDecimal taxBase =
+                lineTaxableAmounts.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Single rounding stage: all totals reconciled to the same grand total.
+        TaxTotalsReconciler.ReconciledTax reconciled = reconciler.reconcile(lineTaxableAmounts, jurisdictionRates);
+
+        BigDecimal totalTax = reconciled.totalTax();
+        List<TaxJurisdiction> jurisdictions = buildJurisdictions(request, specs, reconciled.jurisdictionAmounts());
         List<TaxCalculationResponse.LineItemTax> lineItemTaxes =
-                calculateLineItemTaxes(request.getLineItems(), jurisdictions);
+                buildLineItemTaxes(lineItems, taxableLines, specs, reconciled);
 
-        // Calculate effective tax rate
-        BigDecimal effectiveTaxRate = subtotal.compareTo(BigDecimal.ZERO) > 0
-                ? totalTax.divide(subtotal, 4, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100))
-                : BigDecimal.ZERO;
+        // Effective tax rate = totalTax / exempt-filtered taxable base (ADR-0042),
+        // NOT totalTax / raw subtotal. Guard an all-exempt / zero base.
+        BigDecimal effectiveTaxRate = taxBase.signum() > 0
+                ? totalTax.divide(taxBase, 4, RoundingMode.HALF_UP)
+                        .multiply(PERCENT_FACTOR)
+                        .setScale(MONEY_SCALE, RoundingMode.HALF_UP)
+                : BigDecimal.ZERO.setScale(MONEY_SCALE, RoundingMode.HALF_UP);
 
         return TaxCalculationResponse.builder()
                 .subtotal(subtotal)
@@ -74,113 +115,180 @@ public class TestModeTaxCalculator {
                 .lineItemTaxes(lineItemTaxes)
                 .testMode(true)
                 .calculatedAt(Instant.now(clock))
-                .referenceId(request.getReferenceId() != null ? request.getReferenceId() : null)
-                .referenceType(request.getReferenceType() != null ? request.getReferenceType() : null)
+                .referenceId(request.getReferenceId())
+                .referenceType(request.getReferenceType())
                 .build();
     }
 
     /**
-     * Determine applicable tax jurisdictions based on location.
+     * Determine applicable tax jurisdictions (type and decimal-fraction rate)
+     * from the supplied effective rates. Emits STATE, then COUNTY, then CITY for
+     * any rate configured greater than zero; the order is stable so the
+     * reconciler's tie-breaking is deterministic.
      *
-     * @param request the tax calculation request
-     * @return list of applicable jurisdictions with calculated tax amounts
+     * @param rates the effective rates map by jurisdiction type code
+     * @return ordered list of jurisdiction specs
      */
     @NonNull
-    private List<TaxJurisdiction> determineJurisdictions(@NonNull TaxCalculationRequest request) {
-        List<TaxJurisdiction> jurisdictions = new ArrayList<>();
+    private List<JurisdictionSpec> determineJurisdictionSpecs(@NonNull Map<String, BigDecimal> rates) {
+        List<JurisdictionSpec> specs = new ArrayList<>();
+        for (TaxJurisdictionType type :
+                List.of(TaxJurisdictionType.STATE, TaxJurisdictionType.COUNTY, TaxJurisdictionType.CITY)) {
+            BigDecimal rate = rates.getOrDefault(type.code(), BigDecimal.ZERO);
+            if (rate.compareTo(BigDecimal.ZERO) > 0) {
+                specs.add(new JurisdictionSpec(type, rate));
+            }
+        }
+        return specs;
+    }
 
-        // Get configured default rates
-        var defaultRates = properties.getTestMode().getDefaultRates();
+    /**
+     * Resolve the transaction date used for effective-dated rate selection.
+     * <p>
+     * When {@code raw} is {@code null} or blank, the current date is used, derived
+     * from the shared {@link Clock} so behavior stays deterministic and consistent
+     * with {@code calculatedAt}. Otherwise the value is parsed as an ISO-8601 date
+     * ({@code 2026-02-21}) or date-time ({@code 2026-02-21T09:30:00Z}); the calendar
+     * date component is used as written, without timezone conversion.
+     *
+     * @param raw the optional ISO-8601 transaction date string from the request
+     * @return the resolved transaction date
+     * @throws IllegalArgumentException if {@code raw} is present but not valid ISO-8601
+     */
+    @NonNull
+    private LocalDate resolveTransactionDate(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return LocalDate.now(clock);
+        }
+        String value = raw.trim();
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException dateOnly) {
+            try {
+                return LocalDate.from(DateTimeFormatter.ISO_DATE_TIME.parse(value));
+            } catch (DateTimeParseException dateTime) {
+                throw new IllegalArgumentException(
+                        "transactionDate must be a valid ISO-8601 date or date-time: " + value);
+            }
+        }
+    }
 
-        // Calculate subtotal (tax base)
-        BigDecimal taxBase = request.getLineItems().stream()
-                .filter(item -> !item.isTaxExempt())
-                .map(TaxLineItem::getSubtotal)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    /**
+     * Select the rates map effective on the given transaction date.
+     * <p>
+     * The chosen entry is the one whose {@code effectiveFrom} is the greatest value
+     * not after {@code transactionDate}. On ties (equal {@code effectiveFrom}) the
+     * first such entry in configured order wins, keeping selection deterministic.
+     * When the schedule is empty, or no entry is effective on or before the
+     * transaction date, the flat {@code defaultRates} map is returned, preserving
+     * prior behavior.
+     *
+     * @param transactionDate the date to resolve rates for
+     * @return the effective rates map by jurisdiction type code
+     */
+    @NonNull
+    private Map<String, BigDecimal> resolveEffectiveRates(@NonNull LocalDate transactionDate) {
+        var testMode = properties.getTestMode();
+        Map<String, BigDecimal> selected = null;
+        LocalDate selectedFrom = null;
+        for (TaxProperties.RateScheduleEntry entry : testMode.getRateSchedule()) {
+            LocalDate from = entry.getEffectiveFrom();
+            if (from == null || entry.getRates() == null) {
+                continue;
+            }
+            // from <= transactionDate
+            if (!from.isAfter(transactionDate) && (selectedFrom == null || from.isAfter(selectedFrom))) {
+                selectedFrom = from;
+                selected = entry.getRates();
+            }
+        }
+        return selected != null ? selected : testMode.getDefaultRates();
+    }
 
-        // Apply state tax if configured
-        BigDecimal stateRate = defaultRates.getOrDefault(TaxJurisdictionType.STATE.code(), BigDecimal.ZERO);
-        if (stateRate.compareTo(BigDecimal.ZERO) > 0) {
-            BigDecimal stateTax = taxBase.multiply(stateRate).setScale(2, RoundingMode.HALF_UP);
+    /**
+     * Build the top-level jurisdiction rows from the reconciler's column totals.
+     */
+    @NonNull
+    private List<TaxJurisdiction> buildJurisdictions(
+            @NonNull TaxCalculationRequest request,
+            @NonNull List<JurisdictionSpec> specs,
+            @NonNull List<BigDecimal> jurisdictionAmounts) {
+        List<TaxJurisdiction> jurisdictions = new ArrayList<>(specs.size());
+        for (int j = 0; j < specs.size(); j++) {
+            JurisdictionSpec spec = specs.get(j);
             jurisdictions.add(TaxJurisdiction.builder()
                     .countryCode(request.getCountryCode())
                     .regionCode(request.getStateCode())
                     .city(request.getCity())
                     .postalCode(request.getPostalCode())
                     .line1(request.getAddress())
-                    .jurisdictionType(TaxJurisdictionType.STATE)
-                    .taxRate(stateRate.multiply(BigDecimal.valueOf(100)))
-                    .taxAmount(stateTax)
+                    .jurisdictionType(spec.type())
+                    .taxRate(spec.rate().multiply(PERCENT_FACTOR))
+                    .taxAmount(jurisdictionAmounts.get(j))
                     .build());
         }
-
-        // Apply county tax if configured
-        BigDecimal countyRate = defaultRates.getOrDefault(TaxJurisdictionType.COUNTY.code(), BigDecimal.ZERO);
-        if (countyRate.compareTo(BigDecimal.ZERO) > 0) {
-            BigDecimal countyTax = taxBase.multiply(countyRate).setScale(2, RoundingMode.HALF_UP);
-            jurisdictions.add(TaxJurisdiction.builder()
-                    .countryCode(request.getCountryCode())
-                    .regionCode(request.getStateCode())
-                    .city(request.getCity())
-                    .postalCode(request.getPostalCode())
-                    .line1(request.getAddress())
-                    .jurisdictionType(TaxJurisdictionType.COUNTY)
-                    .taxRate(countyRate.multiply(BigDecimal.valueOf(100)))
-                    .taxAmount(countyTax)
-                    .build());
-        }
-
-        // Apply city tax if configured
-        BigDecimal cityRate = defaultRates.getOrDefault(TaxJurisdictionType.CITY.code(), BigDecimal.ZERO);
-        if (cityRate.compareTo(BigDecimal.ZERO) > 0) {
-            BigDecimal cityTax = taxBase.multiply(cityRate).setScale(2, RoundingMode.HALF_UP);
-            jurisdictions.add(TaxJurisdiction.builder()
-                    .countryCode(request.getCountryCode())
-                    .regionCode(request.getStateCode())
-                    .city(request.getCity())
-                    .postalCode(request.getPostalCode())
-                    .line1(request.getAddress())
-                    .jurisdictionType(TaxJurisdictionType.CITY)
-                    .taxRate(cityRate.multiply(BigDecimal.valueOf(100)))
-                    .taxAmount(cityTax)
-                    .build());
-        }
-
         return jurisdictions;
     }
 
     /**
-     * Calculate per-line-item tax breakdown.
-     *
-     * @param lineItems     the line items
-     * @param jurisdictions the applicable jurisdictions
-     * @return list of line item tax details
+     * Build the per-line tax breakdown, pulling reconciled line totals and
+     * per-jurisdiction cell amounts for non-exempt lines. Exempt lines carry zero
+     * tax and an empty jurisdiction breakdown (zero-rate rows are deferred to T3).
      */
     @NonNull
-    private List<TaxCalculationResponse.LineItemTax> calculateLineItemTaxes(
-            @NonNull List<TaxLineItem> lineItems, @NonNull List<TaxJurisdiction> jurisdictions) {
-        // Calculate combined tax rate from all jurisdictions
-        BigDecimal combinedRate = jurisdictions.stream()
-                .map(j -> j.getTaxRate().divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP))
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-        List<TaxCalculationResponse.LineItemTax> result = new ArrayList<>();
-
+    private List<TaxCalculationResponse.LineItemTax> buildLineItemTaxes(
+            @NonNull List<TaxLineItem> lineItems,
+            @NonNull List<TaxLineItem> taxableLines,
+            @NonNull List<JurisdictionSpec> specs,
+            TaxTotalsReconciler.ReconciledTax reconciled) {
+        List<TaxCalculationResponse.LineItemTax> result = new ArrayList<>(lineItems.size());
+        int taxableIndex = 0;
         for (TaxLineItem item : lineItems) {
             BigDecimal itemSubtotal = item.getSubtotal();
-            BigDecimal itemTax = item.isTaxExempt()
-                    ? BigDecimal.ZERO
-                    : itemSubtotal.multiply(combinedRate).setScale(2, RoundingMode.HALF_UP);
+            if (item.isTaxExempt()) {
+                result.add(TaxCalculationResponse.LineItemTax.builder()
+                        .lineItemId(item.getLineItemId())
+                        .subtotal(itemSubtotal)
+                        .taxAmount(BigDecimal.ZERO.setScale(MONEY_SCALE, RoundingMode.HALF_UP))
+                        .total(itemSubtotal)
+                        .taxExempt(true)
+                        .jurisdictions(new ArrayList<>())
+                        .build());
+                continue;
+            }
+
+            int i = taxableIndex++;
+            BigDecimal lineTax = reconciled.lineAmounts().get(i);
+            List<BigDecimal> cellAmounts = reconciled.cellAmounts().get(i);
+            List<TaxCalculationResponse.JurisdictionTax> cells = new ArrayList<>(specs.size());
+            for (int j = 0; j < specs.size(); j++) {
+                JurisdictionSpec spec = specs.get(j);
+                cells.add(TaxCalculationResponse.JurisdictionTax.builder()
+                        .jurisdictionType(spec.type())
+                        .code(spec.type().code())
+                        .rate(spec.rate())
+                        .amount(cellAmounts.get(j))
+                        .build());
+            }
 
             result.add(TaxCalculationResponse.LineItemTax.builder()
                     .lineItemId(item.getLineItemId())
                     .subtotal(itemSubtotal)
-                    .taxAmount(itemTax)
-                    .total(itemSubtotal.add(itemTax))
-                    .taxExempt(item.isTaxExempt())
+                    .taxAmount(lineTax)
+                    .total(itemSubtotal.add(lineTax))
+                    .taxExempt(false)
+                    .jurisdictions(cells)
                     .build());
         }
-
         return result;
     }
+
+    /**
+     * An applicable jurisdiction with its decimal-fraction rate (e.g. 0.0725 for
+     * 7.25%). Location fields are sourced from the request at build time.
+     *
+     * @param type the jurisdiction type
+     * @param rate the tax rate as a decimal fraction
+     */
+    private record JurisdictionSpec(@NonNull TaxJurisdictionType type, @NonNull BigDecimal rate) {}
 }

--- a/pos-tax/src/test/java/com/positivity/tax/service/ExternalTaxServiceClientTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/service/ExternalTaxServiceClientTest.java
@@ -1,0 +1,69 @@
+package com.positivity.tax.service;
+
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.tax.common.dto.TaxCalculationRequest;
+import com.positivity.tax.common.dto.TaxLineItem;
+import com.positivity.tax.internal.service.ExternalTaxServiceClient;
+import io.github.resilience4j.retry.Retry;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Provider-path serialization contract tests for {@link ExternalTaxServiceClient}.
+ * <p>
+ * Binds a {@link MockRestServiceServer} to the outbound {@link RestClient} and
+ * asserts that {@code transactionDate} is serialized onto the request body sent
+ * to the external tax provider (the {@code .body(request)} path), mirroring the
+ * MockRestServiceServer client-test pattern used elsewhere in the workspace.
+ */
+@DisplayName("ExternalTaxServiceClient provider-serialization Tests")
+class ExternalTaxServiceClientTest {
+
+    private static final String TAX_BASE_URL = "http://tax.test";
+
+    @Test
+    @DisplayName("Serializes transactionDate onto the outbound provider request body")
+    void shouldSerializeTransactionDateOnOutboundRequest() {
+        RestClient.Builder builder = RestClient.builder().baseUrl(TAX_BASE_URL);
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        RestClient restClient = builder.build();
+        ExternalTaxServiceClient client = new ExternalTaxServiceClient(restClient, Retry.ofDefaults("tax-test"));
+
+        server.expect(once(), requestTo(TAX_BASE_URL + "/v1/calculate"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.transactionDate").value("2026-02-21T09:30:00Z"))
+                .andRespond(withSuccess("{\"testMode\":false}", MediaType.APPLICATION_JSON));
+
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(TaxLineItem.builder()
+                        .lineItemId("1")
+                        .description("Part")
+                        .quantity(BigDecimal.ONE)
+                        .unitPrice(new BigDecimal("100"))
+                        .build()))
+                .destinationAddress(TaxCalculationRequest.TaxAddress.builder()
+                        .postalCode("12345")
+                        .regionCode("CA")
+                        .city("Los Angeles")
+                        .countryCode("US")
+                        .build())
+                .transactionDate("2026-02-21T09:30:00Z")
+                .build();
+
+        client.calculateTax(request);
+
+        // Fails if transactionDate was absent/wrong on the outbound body.
+        server.verify();
+    }
+}

--- a/pos-tax/src/test/java/com/positivity/tax/service/TestModeTaxCalculatorTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/service/TestModeTaxCalculatorTest.java
@@ -1,6 +1,7 @@
 package com.positivity.tax.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.positivity.tax.common.dto.TaxCalculationRequest;
 import com.positivity.tax.common.dto.TaxCalculationResponse;
@@ -12,10 +13,13 @@ import com.positivity.tax.internal.service.TestModeTaxCalculator;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -233,7 +237,516 @@ class TestModeTaxCalculatorTest {
         assertThat(response.getEffectiveTaxRate()).isEqualByComparingTo("0.00");
     }
 
+    // ------------------------------------------------------------------
+    // T1: Odoo rounding vectors (single-stage residual distribution)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Odoo vector: 17.79/17.80 split reconciles to 2.49 (naive per-line rounding would drift to 2.50)")
+    void shouldReconcile_17_79_and_17_80_split() {
+        // Given - single STATE jurisdiction at 7%. Independent per-line rounding
+        // gives 1.25 + 1.25 = 2.50, but the true total rounds to 2.49, so the
+        // reconciler must remove one cent from the line dimension.
+        properties.getTestMode().setDefaultRates(Map.of("STATE", new BigDecimal("0.07")));
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(createLineItem("1", "Line A", "1", "17.79"), createLineItem("2", "Line B", "1", "17.80")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "TX", "Austin", "US"))
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then - exact known-answer totals
+        assertThat(response.getTotalTax()).isEqualByComparingTo("2.49");
+        assertThat(response.getJurisdictions()).hasSize(1);
+        assertThat(response.getJurisdictions().get(0).getTaxAmount()).isEqualByComparingTo("2.49");
+        // Per-line: largest raw (17.80) absorbs the -1c so line 1 stays 1.25, line 2 -> 1.24.
+        assertLineTax(response, "1", "1.25");
+        assertLineTax(response, "2", "1.24");
+        assertLineCellAmounts(response, "1", TaxJurisdictionType.STATE, "1.25");
+        assertLineCellAmounts(response, "2", TaxJurisdictionType.STATE, "1.24");
+        // Three-way sigma invariant.
+        assertSigmaInvariant(response);
+    }
+
+    @Test
+    @DisplayName("Odoo vector: three-way 33.33/33.33/33.34 reconciles to 7.00 (naive rounding would drift to 6.99)")
+    void shouldReconcile_threeWay_33_33_33_34() {
+        // Given - single STATE jurisdiction at 7%. Each line raw ~2.333 rounds to
+        // 2.33 (sum 6.99); true total rounds to 7.00 so +1c is distributed to the
+        // largest raw line (33.34).
+        properties.getTestMode().setDefaultRates(Map.of("STATE", new BigDecimal("0.07")));
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(
+                        createLineItem("1", "A", "1", "33.33"),
+                        createLineItem("2", "B", "1", "33.33"),
+                        createLineItem("3", "C", "1", "33.34")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "TX", "Austin", "US"))
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then
+        assertThat(response.getTotalTax()).isEqualByComparingTo("7.00");
+        assertThat(response.getJurisdictions()).hasSize(1);
+        assertThat(response.getJurisdictions().get(0).getTaxAmount()).isEqualByComparingTo("7.00");
+        assertLineTax(response, "1", "2.33");
+        assertLineTax(response, "2", "2.33");
+        assertLineTax(response, "3", "2.34");
+        assertLineCellAmounts(response, "1", TaxJurisdictionType.STATE, "2.33");
+        assertLineCellAmounts(response, "2", TaxJurisdictionType.STATE, "2.33");
+        assertLineCellAmounts(response, "3", TaxJurisdictionType.STATE, "2.34");
+        assertSigmaInvariant(response);
+    }
+
+    @Test
+    @DisplayName("Odoo vector: odd-priced 4-line cart across STATE/COUNTY/CITY reconciles to 3.74 (naive per-dim rounding drifts to 3.75)")
+    void shouldReconcile_multiLine_threeJurisdictions() {
+        // Given - STATE 6.25% / COUNTY 1.25% / CITY 0.75% over four odd prices.
+        // Both the per-line row sum and the per-jurisdiction column sum of the
+        // naively rounded cells drift to 3.75; the reconciler pulls both back to 3.74.
+        Map<String, BigDecimal> rates = new HashMap<>();
+        rates.put("STATE", new BigDecimal("0.0625"));
+        rates.put("COUNTY", new BigDecimal("0.0125"));
+        rates.put("CITY", new BigDecimal("0.0075"));
+        properties.getTestMode().setDefaultRates(rates);
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(
+                        createLineItem("1", "A", "1", "12.37"),
+                        createLineItem("2", "B", "1", "5.19"),
+                        createLineItem("3", "C", "1", "7.83"),
+                        createLineItem("4", "D", "1", "19.99")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then - grand total
+        assertThat(response.getTotalTax()).isEqualByComparingTo("3.74");
+        // Per-jurisdiction column totals (STATE, COUNTY, CITY).
+        assertThat(response.getJurisdictions()).hasSize(3);
+        assertJurisdictionAmount(response, TaxJurisdictionType.STATE, "2.83");
+        assertJurisdictionAmount(response, TaxJurisdictionType.COUNTY, "0.57");
+        assertJurisdictionAmount(response, TaxJurisdictionType.CITY, "0.34");
+        // Per-line totals.
+        assertLineTax(response, "1", "1.02");
+        assertLineTax(response, "2", "0.43");
+        assertLineTax(response, "3", "0.65");
+        assertLineTax(response, "4", "1.64");
+        // Per-line jurisdiction cell amounts (STATE, COUNTY, CITY order).
+        assertLineCellAmounts(response, "1", TaxJurisdictionType.STATE, "0.78");
+        assertLineCellAmounts(response, "1", TaxJurisdictionType.COUNTY, "0.15");
+        assertLineCellAmounts(response, "1", TaxJurisdictionType.CITY, "0.09");
+        assertLineCellAmounts(response, "2", TaxJurisdictionType.STATE, "0.33");
+        assertLineCellAmounts(response, "2", TaxJurisdictionType.COUNTY, "0.06");
+        assertLineCellAmounts(response, "2", TaxJurisdictionType.CITY, "0.04");
+        assertLineCellAmounts(response, "3", TaxJurisdictionType.STATE, "0.49");
+        assertLineCellAmounts(response, "3", TaxJurisdictionType.COUNTY, "0.10");
+        assertLineCellAmounts(response, "3", TaxJurisdictionType.CITY, "0.06");
+        assertLineCellAmounts(response, "4", TaxJurisdictionType.STATE, "1.24");
+        assertLineCellAmounts(response, "4", TaxJurisdictionType.COUNTY, "0.25");
+        assertLineCellAmounts(response, "4", TaxJurisdictionType.CITY, "0.15");
+        assertSigmaInvariant(response);
+    }
+
+    // ------------------------------------------------------------------
+    // T1: Property-based sigma-invariant (keystone). JUnit5 loop over many
+    // randomized carts with a FIXED seed (module has no jqwik on the classpath,
+    // so the property is expressed as a deterministic seeded loop).
+    // ------------------------------------------------------------------
+
+    /** Fixed seed for reproducibility of the property-based cart generation. */
+    private static final long PROPERTY_SEED = 424242L;
+
+    /** Number of randomized carts exercised by the sigma-invariant property. */
+    private static final int PROPERTY_ITERATIONS = 2000;
+
+    @Test
+    @DisplayName("Property: for every randomized cart, sigma(line taxAmount) == totalTax == sigma(jurisdiction taxAmount), "
+            + "and each line's jurisdiction cells sum to its taxAmount")
+    void sigmaInvariantHoldsForRandomizedCarts() {
+        Random random = new Random(PROPERTY_SEED);
+        String[] typeCodes = {"STATE", "COUNTY", "CITY"};
+
+        for (int iteration = 0; iteration < PROPERTY_ITERATIONS; iteration++) {
+            // Random 1..3 jurisdictions, each with a positive decimal-fraction rate.
+            int jurisdictionCount = 1 + random.nextInt(3);
+            Map<String, BigDecimal> rates = new HashMap<>();
+            for (int j = 0; j < jurisdictionCount; j++) {
+                // rate in (0, 0.1000], 4-decimal scale.
+                BigDecimal rate = BigDecimal.valueOf(1 + random.nextInt(1000), 4);
+                rates.put(typeCodes[j], rate);
+            }
+            properties.getTestMode().setDefaultRates(rates);
+
+            // Random 1..8 lines, cent-scale prices in [0.01, 500.00], ~20% exempt.
+            int lineCount = 1 + random.nextInt(8);
+            List<TaxLineItem> lines = new ArrayList<>(lineCount);
+            for (int l = 0; l < lineCount; l++) {
+                BigDecimal price = BigDecimal.valueOf(1 + random.nextInt(50000), 2);
+                TaxLineItem item = TaxLineItem.builder()
+                        .lineItemId(Integer.toString(l))
+                        .description("L" + l)
+                        .quantity(BigDecimal.ONE)
+                        .unitPrice(price)
+                        .subtotal(price)
+                        .taxExempt(random.nextInt(5) == 0)
+                        .build();
+                lines.add(item);
+            }
+
+            TaxCalculationRequest request = TaxCalculationRequest.builder()
+                    .lineItems(lines)
+                    .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                    .build();
+
+            TaxCalculationResponse response = calculator.calculate(request);
+
+            String ctx = "iteration=" + iteration + " seed=" + PROPERTY_SEED;
+            BigDecimal totalTax = response.getTotalTax();
+            BigDecimal lineSum = sumLineTaxes(response);
+            BigDecimal jurisdictionSum = sumJurisdictionAmounts(response);
+
+            assertThat(lineSum)
+                    .as("sum(lineItemTaxes.taxAmount) == totalTax [" + ctx + "]")
+                    .isEqualByComparingTo(totalTax);
+            assertThat(jurisdictionSum)
+                    .as("sum(jurisdictions.taxAmount) == totalTax [" + ctx + "]")
+                    .isEqualByComparingTo(totalTax);
+
+            for (TaxCalculationResponse.LineItemTax line : response.getLineItemTaxes()) {
+                BigDecimal cellSum = line.getJurisdictions().stream()
+                        .map(TaxCalculationResponse.JurisdictionTax::getAmount)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add);
+                assertThat(cellSum)
+                        .as("sum(line " + line.getLineItemId() + " jurisdictions[].amount) == line.taxAmount [" + ctx + "]")
+                        .isEqualByComparingTo(line.getTaxAmount());
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // T1: effectiveTaxRate over the exempt-filtered taxable base
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("effectiveTaxRate divides by the exempt-filtered taxable base, not the raw subtotal")
+    void shouldComputeEffectiveTaxRateOnExemptFilteredBase() {
+        // Given - combined rate 10% (STATE 8 + COUNTY 1 + CITY 1). One $100 taxable
+        // line and one $100 exempt line. Exempt-filtered base = 100 -> rate 10.00%.
+        // A (buggy) subtotal-based rate would be 10/200 = 5.00%.
+        TaxLineItem taxable = createLineItem("1", "Taxable", "1", "100");
+        TaxLineItem exempt = createLineItem("2", "Exempt", "1", "100");
+        exempt.setTaxExempt(true);
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(taxable, exempt))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then
+        assertThat(response.getSubtotal()).isEqualByComparingTo("200.00");
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.00");
+        assertThat(response.getEffectiveTaxRate())
+                .as("effectiveTaxRate uses exempt-filtered base (10/100), not subtotal (10/200)")
+                .isEqualByComparingTo("10.00");
+    }
+
+    @Test
+    @DisplayName("effectiveTaxRate is 0.00 for an all-exempt cart (zero-base guard)")
+    void shouldReturnZeroEffectiveTaxRateForAllExemptCart() {
+        // Given - every line exempt: taxable base is zero.
+        TaxLineItem exemptA = createLineItem("1", "Exempt A", "1", "100");
+        exemptA.setTaxExempt(true);
+        TaxLineItem exemptB = createLineItem("2", "Exempt B", "1", "50");
+        exemptB.setTaxExempt(true);
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(exemptA, exemptB))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then
+        assertThat(response.getSubtotal()).isEqualByComparingTo("150.00");
+        assertThat(response.getTotalTax()).isEqualByComparingTo("0.00");
+        assertThat(response.getEffectiveTaxRate()).isEqualByComparingTo("0.00");
+    }
+
+    // ------------------------------------------------------------------
+    // T1: Determinism - identical input yields identical output
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Calculating the same cart twice yields identical per-line and per-jurisdiction amounts")
+    void shouldBeDeterministicAcrossRepeatedCalculations() {
+        // Given - the drift-prone V3 cart, which exercises residual distribution
+        // in both the line and jurisdiction dimensions.
+        Map<String, BigDecimal> rates = new HashMap<>();
+        rates.put("STATE", new BigDecimal("0.0625"));
+        rates.put("COUNTY", new BigDecimal("0.0125"));
+        rates.put("CITY", new BigDecimal("0.0075"));
+        properties.getTestMode().setDefaultRates(rates);
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(
+                        createLineItem("1", "A", "1", "12.37"),
+                        createLineItem("2", "B", "1", "5.19"),
+                        createLineItem("3", "C", "1", "7.83"),
+                        createLineItem("4", "D", "1", "19.99")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .build();
+
+        // When
+        TaxCalculationResponse first = calculator.calculate(request);
+        TaxCalculationResponse second = calculator.calculate(request);
+
+        // Then - grand total identical.
+        assertThat(second.getTotalTax()).isEqualByComparingTo(first.getTotalTax());
+        // Jurisdiction column amounts identical (same order, same values, same scale).
+        assertThat(second.getJurisdictions()).hasSameSizeAs(first.getJurisdictions());
+        for (int j = 0; j < first.getJurisdictions().size(); j++) {
+            assertThat(second.getJurisdictions().get(j).getTaxAmount())
+                    .isEqualTo(first.getJurisdictions().get(j).getTaxAmount());
+        }
+        // Per-line and per-cell amounts identical.
+        assertThat(second.getLineItemTaxes()).hasSameSizeAs(first.getLineItemTaxes());
+        for (int i = 0; i < first.getLineItemTaxes().size(); i++) {
+            TaxCalculationResponse.LineItemTax a = first.getLineItemTaxes().get(i);
+            TaxCalculationResponse.LineItemTax b = second.getLineItemTaxes().get(i);
+            assertThat(b.getTaxAmount()).isEqualTo(a.getTaxAmount());
+            assertThat(b.getJurisdictions()).hasSameSizeAs(a.getJurisdictions());
+            for (int j = 0; j < a.getJurisdictions().size(); j++) {
+                assertThat(b.getJurisdictions().get(j).getAmount())
+                        .isEqualTo(a.getJurisdictions().get(j).getAmount());
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // T2: Effective-dated rate-schedule selection
+    // ------------------------------------------------------------------
+
+    /**
+     * Two-window schedule: STATE 5% from 2024-01-01, STATE 10% from 2024-06-01.
+     * A request whose transactionDate falls in each window resolves to that
+     * window's rate (different totalTax and jurisdiction breakdown), and the
+     * boundary date (transactionDate == effectiveFrom) selects that entry.
+     */
+    @Test
+    @DisplayName("Effective-date selection: transactionDate resolves to the window's rates, boundary date included")
+    void shouldSelectRatesByEffectiveDateWindow() {
+        configureSchedule(
+                scheduleEntry("2024-01-01", Map.of("STATE", new BigDecimal("0.05"))),
+                scheduleEntry("2024-06-01", Map.of("STATE", new BigDecimal("0.10"))));
+
+        // Mid window A -> 5%.
+        TaxCalculationResponse windowA = calculator.calculate(requestOn("2024-03-15", oneHundredDollarLine()));
+        assertThat(windowA.getTotalTax()).isEqualByComparingTo("5.00");
+        assertThat(windowA.getJurisdictions()).hasSize(1);
+        assertThat(windowA.getJurisdictions().get(0).getTaxRate()).isEqualByComparingTo("5.00");
+
+        // Boundary: transactionDate == effectiveFrom of window B -> that entry applies (10%).
+        TaxCalculationResponse boundaryB = calculator.calculate(requestOn("2024-06-01", oneHundredDollarLine()));
+        assertThat(boundaryB.getTotalTax()).isEqualByComparingTo("10.00");
+        assertThat(boundaryB.getJurisdictions().get(0).getTaxRate()).isEqualByComparingTo("10.00");
+
+        // Mid window B (date-time form also parses to the calendar date) -> 10%.
+        TaxCalculationResponse windowB =
+                calculator.calculate(requestOn("2024-08-01T09:30:00Z", oneHundredDollarLine()));
+        assertThat(windowB.getTotalTax()).isEqualByComparingTo("10.00");
+
+        // Boundary: transactionDate == effectiveFrom of window A -> that entry applies (5%).
+        TaxCalculationResponse boundaryA = calculator.calculate(requestOn("2024-01-01", oneHundredDollarLine()));
+        assertThat(boundaryA.getTotalTax()).isEqualByComparingTo("5.00");
+    }
+
+    /**
+     * With a fixed clock (today = 2024-01-01) and a schedule whose first entry is
+     * effective on that date, an absent/blank transactionDate selects the entry
+     * effective as of the clock's today rather than the flat defaultRates (which
+     * would give 10.00 for this cart).
+     */
+    @Test
+    @DisplayName("Absent/blank transactionDate defaults to the clock's today for schedule selection")
+    void shouldDefaultAbsentTransactionDateToClockToday() {
+        configureSchedule(
+                scheduleEntry("2024-01-01", Map.of("STATE", new BigDecimal("0.05"))),
+                scheduleEntry("2024-06-01", Map.of("STATE", new BigDecimal("0.10"))));
+
+        // FIXED_CLOCK today == 2024-01-01 -> window A (5%), not defaultRates (10%).
+        assertThat(calculator.calculate(requestOn(null, oneHundredDollarLine())).getTotalTax())
+                .as("absent transactionDate -> clock today (2024-01-01) -> window A")
+                .isEqualByComparingTo("5.00");
+        assertThat(calculator.calculate(requestOn("", oneHundredDollarLine())).getTotalTax())
+                .as("empty transactionDate -> clock today")
+                .isEqualByComparingTo("5.00");
+        assertThat(calculator.calculate(requestOn("   ", oneHundredDollarLine())).getTotalTax())
+                .as("blank transactionDate -> clock today")
+                .isEqualByComparingTo("5.00");
+    }
+
+    @Test
+    @DisplayName("Empty rateSchedule falls back to defaultRates (pre-T2 behavior preserved)")
+    void shouldFallBackToDefaultRatesWhenScheduleEmpty() {
+        // setUp leaves rateSchedule empty; defaultRates combined = 10%.
+        TaxCalculationResponse response = calculator.calculate(requestOn("2024-03-15", oneHundredDollarLine()));
+
+        // Identical to the pre-T2 default-rates behavior: 100 * 0.10 = 10.00 across 3 jurisdictions.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.00");
+        assertThat(response.getJurisdictions()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Schedule present but no entry effective on/before the date falls back to defaultRates")
+    void shouldFallBackToDefaultRatesWhenNoEntryQualifies() {
+        // Only a future-dated entry; transaction predates it.
+        configureSchedule(scheduleEntry("2024-06-01", Map.of("STATE", new BigDecimal("0.05"))));
+
+        TaxCalculationResponse response = calculator.calculate(requestOn("2024-01-01", oneHundredDollarLine()));
+
+        // No effectiveFrom <= 2024-01-01 -> defaultRates (10%) across 3 jurisdictions.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.00");
+        assertThat(response.getJurisdictions()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Unparseable non-blank transactionDate fails fast with IllegalArgumentException (ADR-0021)")
+    void shouldFailFastOnUnparseableTransactionDate() {
+        assertThatThrownBy(() -> calculator.calculate(requestOn("not-a-date", oneHundredDollarLine())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("transactionDate");
+
+        assertThatThrownBy(() -> calculator.calculate(requestOn("2024-13-99", oneHundredDollarLine())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("transactionDate");
+    }
+
+    @Test
+    @DisplayName("Sigma-invariant holds for schedule-selected rates over an odd-priced multi-jurisdiction cart")
+    void shouldPreserveSigmaInvariantUnderEffectiveDating() {
+        Map<String, BigDecimal> scheduledRates = new HashMap<>();
+        scheduledRates.put("STATE", new BigDecimal("0.0625"));
+        scheduledRates.put("COUNTY", new BigDecimal("0.0125"));
+        scheduledRates.put("CITY", new BigDecimal("0.0075"));
+        configureSchedule(scheduleEntry("2024-01-01", scheduledRates));
+
+        TaxCalculationRequest request = requestOn(
+                "2024-03-01",
+                List.of(
+                        createLineItem("1", "A", "1", "12.37"),
+                        createLineItem("2", "B", "1", "5.19"),
+                        createLineItem("3", "C", "1", "7.83"),
+                        createLineItem("4", "D", "1", "19.99")));
+
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Schedule-selected rates feed the same single-stage matrix/reconciler as T1:
+        // the known-answer grand total is 3.74 and all three sigma dimensions reconcile.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("3.74");
+        assertThat(response.getJurisdictions()).hasSize(3);
+        assertSigmaInvariant(response);
+    }
+
     // Helper methods
+
+    /** Assert the three-way keystone invariant on a single response. */
+    private void assertSigmaInvariant(TaxCalculationResponse response) {
+        BigDecimal totalTax = response.getTotalTax();
+        assertThat(sumLineTaxes(response))
+                .as("sum(lineItemTaxes.taxAmount) == totalTax")
+                .isEqualByComparingTo(totalTax);
+        assertThat(sumJurisdictionAmounts(response))
+                .as("sum(jurisdictions.taxAmount) == totalTax")
+                .isEqualByComparingTo(totalTax);
+        for (TaxCalculationResponse.LineItemTax line : response.getLineItemTaxes()) {
+            BigDecimal cellSum = line.getJurisdictions().stream()
+                    .map(TaxCalculationResponse.JurisdictionTax::getAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            assertThat(cellSum)
+                    .as("sum(line " + line.getLineItemId() + " jurisdictions[].amount) == line.taxAmount")
+                    .isEqualByComparingTo(line.getTaxAmount());
+        }
+    }
+
+    private BigDecimal sumLineTaxes(TaxCalculationResponse response) {
+        return response.getLineItemTaxes().stream()
+                .map(TaxCalculationResponse.LineItemTax::getTaxAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal sumJurisdictionAmounts(TaxCalculationResponse response) {
+        return response.getJurisdictions().stream()
+                .map(jur -> jur.getTaxAmount())
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private void assertLineTax(TaxCalculationResponse response, String lineItemId, String expected) {
+        TaxCalculationResponse.LineItemTax line = findLine(response, lineItemId);
+        assertThat(line.getTaxAmount())
+                .as("line " + lineItemId + " taxAmount")
+                .isEqualByComparingTo(expected);
+    }
+
+    private void assertLineCellAmounts(
+            TaxCalculationResponse response, String lineItemId, TaxJurisdictionType type, String expected) {
+        TaxCalculationResponse.LineItemTax line = findLine(response, lineItemId);
+        BigDecimal amount = line.getJurisdictions().stream()
+                .filter(cell -> cell.getJurisdictionType() == type)
+                .map(TaxCalculationResponse.JurisdictionTax::getAmount)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "line " + lineItemId + " has no " + type + " jurisdiction cell"));
+        assertThat(amount)
+                .as("line " + lineItemId + " " + type + " cell amount")
+                .isEqualByComparingTo(expected);
+    }
+
+    private void assertJurisdictionAmount(
+            TaxCalculationResponse response, TaxJurisdictionType type, String expected) {
+        BigDecimal amount = response.getJurisdictions().stream()
+                .filter(jur -> jur.getJurisdictionType() == type)
+                .map(jur -> jur.getTaxAmount())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no " + type + " jurisdiction row"));
+        assertThat(amount).as(type + " jurisdiction amount").isEqualByComparingTo(expected);
+    }
+
+    private TaxCalculationResponse.LineItemTax findLine(TaxCalculationResponse response, String lineItemId) {
+        return response.getLineItemTaxes().stream()
+                .filter(line -> lineItemId.equals(line.getLineItemId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no line item with id " + lineItemId));
+    }
+
+    /** Replace the test-mode rate schedule with the given ordered entries. */
+    private void configureSchedule(TaxProperties.RateScheduleEntry... entries) {
+        properties.getTestMode().setRateSchedule(new ArrayList<>(List.of(entries)));
+    }
+
+    private TaxProperties.RateScheduleEntry scheduleEntry(String effectiveFrom, Map<String, BigDecimal> rates) {
+        TaxProperties.RateScheduleEntry entry = new TaxProperties.RateScheduleEntry();
+        entry.setEffectiveFrom(LocalDate.parse(effectiveFrom));
+        entry.setRates(new HashMap<>(rates));
+        return entry;
+    }
+
+    /** A single $100 taxable line (subtotal 100.00) for effective-dating window checks. */
+    private List<TaxLineItem> oneHundredDollarLine() {
+        return List.of(createLineItem("1", "Part", "1", "100"));
+    }
+
+    private TaxCalculationRequest requestOn(String transactionDate, List<TaxLineItem> items) {
+        return TaxCalculationRequest.builder()
+                .lineItems(items)
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .transactionDate(transactionDate)
+                .build();
+    }
 
     private TaxCalculationRequest.TaxAddress createAddress(
             String postalCode, String regionCode, String city, String countryCode) {

--- a/pos-tax/src/test/java/com/positivity/tax/service/TestModeTaxCalculatorTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/service/TestModeTaxCalculatorTest.java
@@ -249,7 +249,8 @@ class TestModeTaxCalculatorTest {
         // reconciler must remove one cent from the line dimension.
         properties.getTestMode().setDefaultRates(Map.of("STATE", new BigDecimal("0.07")));
         TaxCalculationRequest request = TaxCalculationRequest.builder()
-                .lineItems(List.of(createLineItem("1", "Line A", "1", "17.79"), createLineItem("2", "Line B", "1", "17.80")))
+                .lineItems(List.of(
+                        createLineItem("1", "Line A", "1", "17.79"), createLineItem("2", "Line B", "1", "17.80")))
                 .destinationAddress(createAddress(TEST_POSTAL_CODE, "TX", "Austin", "US"))
                 .build();
 
@@ -301,7 +302,8 @@ class TestModeTaxCalculatorTest {
     }
 
     @Test
-    @DisplayName("Odoo vector: odd-priced 4-line cart across STATE/COUNTY/CITY reconciles to 3.74 (naive per-dim rounding drifts to 3.75)")
+    @DisplayName(
+            "Odoo vector: odd-priced 4-line cart across STATE/COUNTY/CITY reconciles to 3.74 (naive per-dim rounding drifts to 3.75)")
     void shouldReconcile_multiLine_threeJurisdictions() {
         // Given - STATE 6.25% / COUNTY 1.25% / CITY 0.75% over four odd prices.
         // Both the per-line row sum and the per-jurisdiction column sum of the
@@ -364,8 +366,9 @@ class TestModeTaxCalculatorTest {
     private static final int PROPERTY_ITERATIONS = 2000;
 
     @Test
-    @DisplayName("Property: for every randomized cart, sigma(line taxAmount) == totalTax == sigma(jurisdiction taxAmount), "
-            + "and each line's jurisdiction cells sum to its taxAmount")
+    @DisplayName(
+            "Property: for every randomized cart, sigma(line taxAmount) == totalTax == sigma(jurisdiction taxAmount), "
+                    + "and each line's jurisdiction cells sum to its taxAmount")
     void sigmaInvariantHoldsForRandomizedCarts() {
         Random random = new Random(PROPERTY_SEED);
         String[] typeCodes = {"STATE", "COUNTY", "CITY"};
@@ -421,7 +424,8 @@ class TestModeTaxCalculatorTest {
                         .map(TaxCalculationResponse.JurisdictionTax::getAmount)
                         .reduce(BigDecimal.ZERO, BigDecimal::add);
                 assertThat(cellSum)
-                        .as("sum(line " + line.getLineItemId() + " jurisdictions[].amount) == line.taxAmount [" + ctx + "]")
+                        .as("sum(line " + line.getLineItemId() + " jurisdictions[].amount) == line.taxAmount [" + ctx
+                                + "]")
                         .isEqualByComparingTo(line.getTaxAmount());
             }
         }
@@ -585,7 +589,9 @@ class TestModeTaxCalculatorTest {
         assertThat(calculator.calculate(requestOn("", oneHundredDollarLine())).getTotalTax())
                 .as("empty transactionDate -> clock today")
                 .isEqualByComparingTo("5.00");
-        assertThat(calculator.calculate(requestOn("   ", oneHundredDollarLine())).getTotalTax())
+        assertThat(calculator
+                        .calculate(requestOn("   ", oneHundredDollarLine()))
+                        .getTotalTax())
                 .as("blank transactionDate -> clock today")
                 .isEqualByComparingTo("5.00");
     }
@@ -687,9 +693,7 @@ class TestModeTaxCalculatorTest {
 
     private void assertLineTax(TaxCalculationResponse response, String lineItemId, String expected) {
         TaxCalculationResponse.LineItemTax line = findLine(response, lineItemId);
-        assertThat(line.getTaxAmount())
-                .as("line " + lineItemId + " taxAmount")
-                .isEqualByComparingTo(expected);
+        assertThat(line.getTaxAmount()).as("line " + lineItemId + " taxAmount").isEqualByComparingTo(expected);
     }
 
     private void assertLineCellAmounts(
@@ -699,15 +703,13 @@ class TestModeTaxCalculatorTest {
                 .filter(cell -> cell.getJurisdictionType() == type)
                 .map(TaxCalculationResponse.JurisdictionTax::getAmount)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError(
-                        "line " + lineItemId + " has no " + type + " jurisdiction cell"));
+                .orElseThrow(() -> new AssertionError("line " + lineItemId + " has no " + type + " jurisdiction cell"));
         assertThat(amount)
                 .as("line " + lineItemId + " " + type + " cell amount")
                 .isEqualByComparingTo(expected);
     }
 
-    private void assertJurisdictionAmount(
-            TaxCalculationResponse response, TaxJurisdictionType type, String expected) {
+    private void assertJurisdictionAmount(TaxCalculationResponse response, TaxJurisdictionType type, String expected) {
         BigDecimal amount = response.getJurisdictions().stream()
                 .filter(jur -> jur.getJurisdictionType() == type)
                 .map(jur -> jur.getTaxAmount())

--- a/pos-workorder/README.md
+++ b/pos-workorder/README.md
@@ -25,6 +25,7 @@ Core workorder service for the Durion Positivity ETSMS platform. Manages the ful
 - `WorkorderInvoiceService` — invokes `pos-invoice` to generate an invoice at close
 - `TechnicianAssignmentService` — assign and reassign technicians
 - `DashboardService` — aggregated shop dashboard data
+- `TaxClient` — outbound client for `pos-tax`; forwards `X-User: pos-workorder` and `X-Authorities: tax:calculate` on the tax-calculate call so the request satisfies `tax:calculate` enforcement (matching `pos-invoice`'s `TaxServiceClient`)
 
 ## API Endpoints
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/client/TaxClient.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/client/TaxClient.java
@@ -23,6 +23,12 @@ public class TaxClient {
         TaxCalculationResponse response = taxServiceRestClient
                 .post()
                 .uri("/v1/tax/calculate")
+                // pos-tax is internal-only and guards /v1/tax/calculate with
+                // @PreAuthorize('tax:calculate'). Propagate the required authority via the
+                // gateway authorities header for this service-to-service call (see
+                // GatewayAuthoritiesFilter and the pos-invoice TaxServiceClient pattern).
+                .header("X-User", "pos-workorder")
+                .header("X-Authorities", "tax:calculate")
                 .body(request)
                 .retrieve()
                 .body(TaxCalculationResponse.class);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/client/TaxClient.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/client/TaxClient.java
@@ -24,7 +24,7 @@ public class TaxClient {
                 .post()
                 .uri("/v1/tax/calculate")
                 // pos-tax is internal-only and guards /v1/tax/calculate with
-                // @PreAuthorize('tax:calculate'). Propagate the required authority via the
+                // @PreAuthorize("hasAuthority('tax:calculate')"). Propagate the required authority via the
                 // gateway authorities header for this service-to-service call (see
                 // GatewayAuthoritiesFilter and the pos-invoice TaxServiceClient pattern).
                 .header("X-User", "pos-workorder")

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/client/TaxClientTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/client/TaxClientTest.java
@@ -1,0 +1,76 @@
+package com.positivity.workorder.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.tax.common.dto.TaxCalculationRequest;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import com.positivity.tax.common.dto.TaxLineItem;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * {@link TaxClient} wire behavior against a {@link MockRestServiceServer}
+ * (same lightweight pattern as pos-warranty's {@code InvoiceClientTest}).
+ * <p>
+ * pos-tax guards {@code /v1/tax/calculate} with {@code @PreAuthorize("tax:calculate")},
+ * so this service-to-service call must propagate the gateway authority headers
+ * (mirrors the pos-invoice {@code TaxServiceClient} pattern).
+ */
+class TaxClientTest {
+
+    private static final String BASE = "http://pos-tax:8091";
+
+    private MockRestServiceServer server;
+    private TaxClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder().baseUrl(BASE);
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new TaxClient(builder.build());
+    }
+
+    @Test
+    void calculateTaxPropagatesServiceAuthorityHeadersAndMapsResponse() {
+        server.expect(requestTo(BASE + "/v1/tax/calculate"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("X-User", "pos-workorder"))
+                .andExpect(header("X-Authorities", "tax:calculate"))
+                .andRespond(withSuccess(
+                        "{\"subtotal\":150.00,\"totalTax\":15.00,\"total\":165.00,"
+                                + "\"effectiveTaxRate\":10.00,\"testMode\":false}",
+                        MediaType.APPLICATION_JSON));
+
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(TaxLineItem.builder()
+                        .lineItemId("1")
+                        .description("Oil Change Service")
+                        .quantity(BigDecimal.ONE)
+                        .unitPrice(new BigDecimal("150.00"))
+                        .build()))
+                .destinationAddress(TaxCalculationRequest.TaxAddress.builder()
+                        .countryCode("US")
+                        .regionCode("CA")
+                        .build())
+                .currencyCode("USD")
+                .build();
+
+        TaxCalculationResponse response = client.calculateTax(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getSubtotal()).isEqualByComparingTo("150.00");
+        assertThat(response.getTotalTax()).isEqualByComparingTo("15.00");
+        assertThat(response.getTotal()).isEqualByComparingTo("165.00");
+        server.verify();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/client/TaxClientTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/client/TaxClientTest.java
@@ -22,7 +22,7 @@ import org.springframework.web.client.RestClient;
  * {@link TaxClient} wire behavior against a {@link MockRestServiceServer}
  * (same lightweight pattern as pos-warranty's {@code InvoiceClientTest}).
  * <p>
- * pos-tax guards {@code /v1/tax/calculate} with {@code @PreAuthorize("tax:calculate")},
+ * pos-tax guards {@code /v1/tax/calculate} with {@code @PreAuthorize("hasAuthority('tax:calculate')")},
  * so this service-to-service call must propagate the gateway authority headers
  * (mirrors the pos-invoice {@code TaxServiceClient} pattern).
  */


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:CAP-tax-parity`
- Domain: `domain:tax`
- Child issues: louisburroughs/durion-positivity-backend#939 (T1), #940 (T2), #941 (T9a)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract change is additive on `pos-tax-common`: `TaxCalculationResponse.LineItemTax.jurisdictions[]` (new nested `JurisdictionTax`). No tax-domain `BACKEND_CONTRACT_GUIDE.md` exists yet; the tax contract detail lives in the parity plan (`domains/accounting/plan-odoo-parity-pos-tax.md` §2 T1) and the regenerated `pos-tax/openapi.yaml`. A tax-domain `BACKEND_CONTRACT_GUIDE.md` should be authored alongside T5 when the breakdown becomes a cross-service contract.

## Contract Chain
- [x] OpenAPI annotations updated (`TaxCalculationResponse.LineItemTax.jurisdictions[]`, `effectiveTaxRate` semantics)
- [x] `pos-tax/openapi.yaml` regenerated (`scripts/generate-openapi.sh pos-tax`, clean)
- [ ] Angular SDK regenerated — **required** (additive `jurisdictions[]` / new `JurisdictionTax` schema); frontend follow-up, not in this PR

## Scope — pos-tax Odoo-parity Wave 1
- **T1 #939 — rounding correctness.** New package-private `TaxTotalsReconciler`: single rounding stage over a per-line × per-jurisdiction raw matrix with deterministic largest-raw-first residual distribution (Odoo `_distribute_delta_amount_smoothly`), enforcing the invariant `Σ lineItemTaxes == totalTax == Σ jurisdictions.taxAmount` (and per-line `Σ cells == line.taxAmount`). Reusable for T4/T6 provider-response validation. `effectiveTaxRate` fixed to divide by the exempt-filtered taxable base (zero-base guarded). Additive `LineItemTax.jurisdictions[]` contract in `pos-tax-common`.
- **T2 #940 — honor `transactionDate`.** Effective-dated test-mode rates via `TaxProperties.testMode.rateSchedule`; the calculator selects the greatest `effectiveFrom <= transactionDate` (default today via injected `Clock`; `defaultRates` fallback preserved). Provider path already forwards the field — asserted by a contract test.
- **T9a #941 — pos-workorder auth.** `TaxClient` now sends `X-User: pos-workorder` + `X-Authorities: tax:calculate` (mirrors pos-invoice `TaxServiceClient`). Auth-header fix only; T9 remainder is Wave 4.

## Tests
- [x] T1: Odoo rounding vectors (17.79/17.80→2.49; 33.33/33.33/33.34→7.00; 4-line×3-jurisdiction, all 12 cells asserted) + **Σ-invariant property test** (seed `424242L`, 2000 randomized carts) — green.
- [x] T2: 6 effective-dating tests + `ExternalTaxServiceClientTest` (asserts `transactionDate` on the outbound body).
- [x] T9a: `TaxClientTest` asserts both headers on the outbound call.
- **`pos-tax` verify: 49 tests, 0 failures. `pos-tax-common` verify: exit 0.** Spotless/lint clean on all touched files.

## Risk & Rollback
- Risk: Medium (core tax computation restructure) — mitigated by the invariant property test + ported Odoo vectors. Contract change is additive-only.
- Rollback: revert the 2 commits.

## Known issue (pre-existing, NOT introduced here)
`pos-workorder` verify fails on 2 ITs in `EstimateTaxCalculationContractBehaviorIT` (`UnexpectedRollbackException` in `EstimateServiceImpl.calculateEstimateTaxesAndTotals`). Proven pre-existing via a three-way repro incl. a pristine `main` worktree — tracked in #979. Not in Wave 1 scope; the isolated T9a change and its `TaxClientTest` pass.

## Checklist
- [x] Branch `cap/odoo-parity-tax-w1`
- [x] Links to child issues present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
