### PR TITLE
[CAP:odoo-parity-tax-w2] pos-tax Odoo-parity Wave 2 — exemptions, refund mode, config rates (T3/T4/T7)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-07-19T21:43:43.822590+00:00"
+generatedAt: "2026-07-20T22:17:21.594221+00:00"
 root: "/home/louis-burroughs/IdeaProjects/durion-positivity-backend"
 summary:
   manifestCount: 40
-  permissionCount: 702
-  uniquePermissionCount: 352
+  permissionCount: 704
+  uniquePermissionCount: 354
   duplicatePermissionNameCount: 350
   parseIssueCount: 0
 manifests:
@@ -1499,12 +1499,16 @@ manifests:
     domain: "tax"
     serviceName: "pos-tax"
     version: "1.0"
-    permissionCount: 2
+    permissionCount: 4
     permissions:
       - name: "tax:calculate"
         description: "Calculate tax for line items based on destination and jurisdiction rules"
       - name: "tax:mode:view"
         description: "View current tax service mode (test or production)"
+      - name: "tax:exemption:view"
+        description: "View tax exemption certificates in the pos-tax exemption registry"
+      - name: "tax:exemption:manage"
+        description: "Create and update tax exemption certificates in the pos-tax exemption registry"
   - module: "pos-vehicle-fitment"
     path: "pos-vehicle-fitment/src/main/resources/permissions.yaml"
     domain: "vehicle-fitment"
@@ -4940,6 +4944,18 @@ permissions:
     source: ".worktrees/feat-api-spring-ai-migration/pos-tax/src/main/resources/permissions.yaml"
   - name: "tax:calculate"
     description: "Calculate tax for line items based on destination and jurisdiction rules"
+    domain: "tax"
+    serviceName: "pos-tax"
+    module: "pos-tax"
+    source: "pos-tax/src/main/resources/permissions.yaml"
+  - name: "tax:exemption:manage"
+    description: "Create and update tax exemption certificates in the pos-tax exemption registry"
+    domain: "tax"
+    serviceName: "pos-tax"
+    module: "pos-tax"
+    source: "pos-tax/src/main/resources/permissions.yaml"
+  - name: "tax:exemption:view"
+    description: "View tax exemption certificates in the pos-tax exemption registry"
     domain: "tax"
     serviceName: "pos-tax"
     module: "pos-tax"

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 24;
+    public static final int CATALOG_VERSION = 25;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -426,7 +426,11 @@ public final class GatewayPermissionCatalog {
 
         // ── New batch (bits 384–385) ──────────────────────────────────────────
         "PERM_accounting:reconciliation:adjust", // 384
-        "PERM_accounting:reconciliation:view" // 385
+        "PERM_accounting:reconciliation:view", // 385
+
+        // ── New batch (bits 386–387) ──────────────────────────────────────────
+        "PERM_tax:exemption:manage", // 386
+        "PERM_tax:exemption:view" // 387
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 24")
+    @DisplayName("CATALOG_VERSION is 25")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(24);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(25);
     }
 
     @Test
-    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 385")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 387")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1208,8 +1208,11 @@ class SecurityGatewayConfigTest {
         // catalog v24 (#963/wave-4): settlement reconciliation authorities appended (bits 384-385)
         assertThat(GatewayPermissionCatalog.authorityForBit(384)).isEqualTo("PERM_accounting:reconciliation:adjust");
         assertThat(GatewayPermissionCatalog.authorityForBit(385)).isEqualTo("PERM_accounting:reconciliation:view");
+        // catalog v25 (#981/wave-2): tax exemption authorities appended (bits 386-387)
+        assertThat(GatewayPermissionCatalog.authorityForBit(386)).isEqualTo("PERM_tax:exemption:manage");
+        assertThat(GatewayPermissionCatalog.authorityForBit(387)).isEqualTo("PERM_tax:exemption:view");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(386)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(388)).isNull();
     }
 
     @Test

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -451,8 +451,12 @@ public final class DownstreamPermissionCatalog {
         "PERM_accounting:period:override", // 383
 
         // ── New batch (bits 384–385) ──────────────────────────────────────────
-        "PERM_accounting:reconciliation:adjust",             // 384
-        "PERM_accounting:reconciliation:view"               // 385
+        "PERM_accounting:reconciliation:adjust", // 384
+        "PERM_accounting:reconciliation:view", // 385
+
+        // ── New batch (bits 386–387) ──────────────────────────────────────────
+        "PERM_tax:exemption:view", // 386
+        "PERM_tax:exemption:manage" // 387
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 24;
+    public static final int CATALOG_VERSION = 25;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -455,8 +455,8 @@ public final class DownstreamPermissionCatalog {
         "PERM_accounting:reconciliation:view", // 385
 
         // ── New batch (bits 386–387) ──────────────────────────────────────────
-        "PERM_tax:exemption:view", // 386
-        "PERM_tax:exemption:manage" // 387
+        "PERM_tax:exemption:manage", // 386
+        "PERM_tax:exemption:view" // 387
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -499,13 +499,16 @@ public enum PermissionCode {
     ACCOUNTING__PERIOD__OVERRIDE(383, "accounting:period:override"),
     // ── Accounting (new) ───────────────────────────────────────────────────────
     ACCOUNTING__RECONCILIATION__ADJUST(384, "accounting:reconciliation:adjust"),
-    ACCOUNTING__RECONCILIATION__VIEW(385, "accounting:reconciliation:view");
+    ACCOUNTING__RECONCILIATION__VIEW(385, "accounting:reconciliation:view"),
+    // ── Tax (new) ──────────────────────────────────────────────────────────────
+    TAX__EXEMPTION__MANAGE(386, "tax:exemption:manage"),
+    TAX__EXEMPTION__VIEW(387, "tax:exemption:view");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 24;
+    public static final int CATALOG_VERSION = 25;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 386;
-    private static final int EXPECTED_CATALOG_VERSION = 24;
+    private static final int EXPECTED_PERMISSION_COUNT = 388;
+    private static final int EXPECTED_CATALOG_VERSION = 25;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — 379 entries
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("catalog contains exactly 379 permissions")
+    @DisplayName("catalog contains exactly 388 permissions")
     void catalogContainsExpectedPermissions() {
         assertThat(PermissionCode.values()).hasSize(EXPECTED_PERMISSION_COUNT);
     }

--- a/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationRequest.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationRequest.java
@@ -1,5 +1,7 @@
 package com.positivity.tax.common.dto;
 
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.common.enums.TaxCalculationType;
 import com.positivity.tax.common.enums.TaxReferenceType;
 import com.positivity.tax.common.validation.IsoCountryCode;
 import com.positivity.tax.common.validation.IsoCurrencyCode;
@@ -102,6 +104,47 @@ public class TaxCalculationRequest {
     private String customerId;
 
     /**
+     * Optional transaction-level exemption claim applying to every line (story T3).
+     * <p>
+     * When set, all lines are evaluated as certificate-backed exemption claims: honored
+     * only if an active, effective, non-expired certificate is found; otherwise taxed
+     * anyway and flagged {@code exemptionDenied} (decision D-T2).
+     */
+    @Valid
+    @Schema(
+            description = "Optional transaction-level exemption claim applying to all lines",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private CustomerExemption customerExemption;
+
+    /**
+     * Calculation direction/intent (story T4). Defaults to {@link TaxCalculationType#SALE}.
+     * <p>
+     * {@link TaxCalculationType#REFUND} computes positive refund tax priced at the
+     * supplied {@code transactionDate} (the original sale date); the value is echoed on
+     * the response.
+     */
+    @Builder.Default
+    @Schema(
+            description = "Calculation direction: SALE (default) or REFUND. REFUND amounts are positive and"
+                    + " priced at the supplied transactionDate (the original sale date); callers negate at"
+                    + " posting. Finalized-invoice credits must use the stored breakdown, not REFUND recompute.",
+            example = "SALE",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private TaxCalculationType calculationType = TaxCalculationType.SALE;
+
+    /**
+     * Optional identifier of the original sale transaction being refunded (story T4).
+     * <p>
+     * Carried through for provider refund-document correlation (story T6); ignored by the
+     * test-mode calculator beyond being accepted.
+     */
+    @Schema(
+            description = "Optional reference to the original sale transaction being refunded",
+            example = "550e8400-e29b-41d4-a716-446655440000",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private UUID originalReferenceId;
+
+    /**
      * Optional transaction date (ISO 8601 format).
      * <p>
      * If not provided, current date is used.
@@ -168,6 +211,35 @@ public class TaxCalculationRequest {
             return null;
         }
         return destinationAddress.getLine1();
+    }
+
+    /**
+     * Transaction-level exemption claim applying to all line items (story T3).
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "CustomerExemption", description = "Transaction-level exemption claim applying to all lines")
+    public static class CustomerExemption {
+
+        /**
+         * Reason the customer claims exemption for this transaction.
+         */
+        @Schema(
+                description = "Exemption reason (RESALE, GOVERNMENT, NONPROFIT, AGRICULTURAL, OTHER)",
+                example = "GOVERNMENT",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        private ExemptionReasonCode reasonCode;
+
+        /**
+         * Optional exemption-certificate identifier backing the claim.
+         */
+        @Schema(
+                description = "Optional exemption-certificate identifier backing the claim",
+                example = "018f0000-0000-7000-8000-0000000000aa",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        private UUID certificateId;
     }
 
     /**

--- a/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationResponse.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationResponse.java
@@ -1,5 +1,7 @@
 package com.positivity.tax.common.dto;
 
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.common.enums.TaxCalculationType;
 import com.positivity.tax.common.enums.TaxJurisdictionType;
 import com.positivity.tax.common.enums.TaxReferenceType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -133,6 +135,21 @@ public class TaxCalculationResponse {
     private String externalTransactionId;
 
     /**
+     * Calculation direction echoed from the request (story T4).
+     * <p>
+     * Never {@code null}; defaults to {@link TaxCalculationType#SALE}. For
+     * {@link TaxCalculationType#REFUND} the amounts are positive refund tax priced at the
+     * original sale date; callers negate at posting.
+     */
+    @Builder.Default
+    @Schema(
+            description = "Calculation direction echoed from the request: SALE or REFUND. REFUND amounts are"
+                    + " positive; callers negate at posting.",
+            example = "SALE",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private TaxCalculationType calculationType = TaxCalculationType.SALE;
+
+    /**
      * Nested class for line item tax breakdown.
      */
     @Data
@@ -167,10 +184,38 @@ public class TaxCalculationResponse {
         private BigDecimal total;
 
         @Schema(
-                description = "Whether this line item is tax exempt",
+                description = "Whether this line item is tax exempt (resolved exemption produced zero-rate rows)",
                 example = "false",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         private boolean taxExempt;
+
+        /**
+         * Resolved exemption reason echoed onto this line (story T3).
+         * <p>
+         * Set for an honored certificate-backed exemption (with {@link #taxExempt} true) and
+         * for a denied exemption (with {@link #exemptionDenied} true). {@code null} for a
+         * plain taxable line or an intrinsic {@code taxExempt} line carrying no reason.
+         */
+        @Schema(
+                description = "Resolved exemption reason echoed onto this line (honored or denied)",
+                example = "RESALE",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        private ExemptionReasonCode exemptionReasonCode;
+
+        /**
+         * Whether an exemption was claimed for this line but denied for lack of an active,
+         * effective, non-expired certificate (decision D-T2).
+         * <p>
+         * When {@code true} the line is taxed normally (never hard-blocked); the flag is an
+         * auditable signal persisted downstream (story T5).
+         */
+        @Builder.Default
+        @Schema(
+                description = "Whether a claimed exemption was denied (unbacked by a valid certificate) and the"
+                        + " line taxed anyway",
+                example = "false",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        private boolean exemptionDenied = false;
 
         /**
          * Additive per-jurisdiction tax breakdown for this line item.
@@ -233,5 +278,30 @@ public class TaxCalculationResponse {
                 example = "6.53",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         private BigDecimal amount;
+
+        /**
+         * Whether this is a zero-rate exempt row (story T3, reportable zero-tax).
+         * <p>
+         * When {@code true}, {@link #rate} carries the jurisdiction rate that would have
+         * applied and {@link #amount} is zero, so tax-liability reports can attribute exempt
+         * sales to the correct jurisdiction.
+         */
+        @Builder.Default
+        @Schema(
+                description = "Whether this is a zero-rate exempt row (rate is the would-be jurisdiction rate,"
+                        + " amount is zero)",
+                example = "false",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        private boolean exempt = false;
+
+        /**
+         * Exemption reason echoed onto a zero-rate exempt row (story T3); {@code null} for a
+         * normal taxed row.
+         */
+        @Schema(
+                description = "Exemption reason echoed onto a zero-rate exempt row",
+                example = "RESALE",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        private ExemptionReasonCode exemptionReasonCode;
     }
 }

--- a/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationResponse.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxCalculationResponse.java
@@ -150,6 +150,17 @@ public class TaxCalculationResponse {
     private TaxCalculationType calculationType = TaxCalculationType.SALE;
 
     /**
+     * Reference to the original sale transaction, echoed from the request (story T4).
+     * <p>
+     * Populated only for {@link TaxCalculationType#REFUND} calculations so callers can tie the
+     * refund tax back to the sale it reverses; {@code null} for SALE.
+     */
+    @Schema(
+            description = "Original sale reference echoed on REFUND calculations; null for SALE.",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private UUID originalReferenceId;
+
+    /**
      * Nested class for line item tax breakdown.
      */
     @Data

--- a/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxLineItem.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxLineItem.java
@@ -3,11 +3,13 @@ package com.positivity.tax.common.dto;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import com.positivity.tax.common.enums.ExemptionReasonCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -91,6 +93,32 @@ public class TaxLineItem {
     @Builder.Default
     @Schema(description = "Whether this item is tax-exempt", example = "false", requiredMode = NOT_REQUIRED)
     private boolean taxExempt = false;
+
+    /**
+     * Optional reason a certificate-backed exemption is claimed for this line (story T3).
+     * <p>
+     * When present (or when a {@code certificateId} is supplied, or a request-level
+     * {@code customerExemption} is set), the exemption is treated as a
+     * certificate-backed claim: it is honored only if an active, effective, non-expired
+     * exemption certificate is found; otherwise the line is taxed anyway and flagged
+     * {@code exemptionDenied} in the response (decision D-T2). A bare {@code taxExempt=true}
+     * with no reason/certificate remains an intrinsic non-taxable declaration.
+     */
+    @Schema(
+            description = "Optional certificate-backed exemption reason for this line (RESALE, GOVERNMENT,"
+                    + " NONPROFIT, AGRICULTURAL, OTHER)",
+            example = "RESALE",
+            requiredMode = NOT_REQUIRED)
+    private ExemptionReasonCode exemptionReasonCode;
+
+    /**
+     * Optional exemption-certificate identifier backing this line's exemption claim (story T3).
+     */
+    @Schema(
+            description = "Optional exemption-certificate identifier backing this line's exemption claim",
+            example = "018f0000-0000-7000-8000-0000000000aa",
+            requiredMode = NOT_REQUIRED)
+    private UUID exemptionCertificateId;
 
     /**
      * Gets the subtotal, calculating it if not explicitly provided.

--- a/pos-tax-common/src/main/java/com/positivity/tax/common/enums/ExemptionReasonCode.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/enums/ExemptionReasonCode.java
@@ -1,0 +1,23 @@
+package com.positivity.tax.common.enums;
+
+/**
+ * Reason a line item (or an entire transaction) is claimed to be exempt from tax.
+ * <p>
+ * Exemptions are modeled as "reportable zero-tax" (Odoo parity, story T3): an
+ * exempt line still emits zero-rate jurisdiction rows so tax-liability reports can
+ * show exempt sales per jurisdiction. The reason is echoed onto the exempt rows and,
+ * for a denied exemption (claimed but unbacked by a valid certificate), onto the
+ * taxed line together with the {@code exemptionDenied} flag (decision D-T2).
+ */
+public enum ExemptionReasonCode {
+    /** Purchase for resale (reseller / wholesale). */
+    RESALE,
+    /** Government or public-authority purchaser. */
+    GOVERNMENT,
+    /** Registered non-profit / charitable organization. */
+    NONPROFIT,
+    /** Agricultural / farming use exemption. */
+    AGRICULTURAL,
+    /** Any other documented exemption reason. */
+    OTHER
+}

--- a/pos-tax-common/src/main/java/com/positivity/tax/common/enums/TaxCalculationType.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/enums/TaxCalculationType.java
@@ -1,0 +1,24 @@
+package com.positivity.tax.common.enums;
+
+/**
+ * Direction/intent of a tax calculation (Odoo parity, story T4).
+ * <p>
+ * {@link #SALE} is the default forward calculation. {@link #REFUND} computes the
+ * tax to reverse for a partial/line-level refund or a provider refund document:
+ * amounts are computed <strong>positive</strong> (callers negate at posting, which
+ * keeps {@code @Positive} request validation intact and avoids sign bugs) and rates
+ * are resolved as of the {@code transactionDate} the caller supplies — for a refund
+ * that is the <em>original sale date</em>, so effective-dated rates (story T2)
+ * reprice correctly.
+ * <p>
+ * Note the platform rule: finalized-invoice credits use the <em>stored</em> tax
+ * breakdown and must never be recomputed; {@code REFUND} mode is only for
+ * partial/line-level refunds where a fresh proration is genuinely needed and for
+ * provider-side refund documents (freeze-after-finalize).
+ */
+public enum TaxCalculationType {
+    /** Forward sale calculation (default). */
+    SALE,
+    /** Refund/credit calculation: positive amounts priced at the original sale date. */
+    REFUND
+}

--- a/pos-tax/pom.xml
+++ b/pos-tax/pom.xml
@@ -84,6 +84,17 @@
             <groupId>com.positivity</groupId>
             <artifactId>pos-tax-common</artifactId>
         </dependency>
+        <!-- pos-shared-dtos for UUID v7 identifier generation (ADR-0013) -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-shared-dtos</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Utilities -->
         <dependency>
@@ -122,6 +133,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Spring Boot Data JPA test slice (@DataJpaTest) for the exemption-certificate repository test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pos-tax/src/main/java/com/positivity/tax/internal/config/EventTypes.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/config/EventTypes.java
@@ -21,9 +21,17 @@ public final class EventTypes {
      * @return list of event type registrations
      */
     public static List<EventTypeRegistration> all() {
-        return List.of(EventTypeRegistration.write("TAX_CALCULATE", "Calculate tax for line items")
-                .description(
-                        "Calculates tax based on line items and location. Routes to external service in production or test calculator in test mode.")
-                .build());
+        return List.of(
+                EventTypeRegistration.write("TAX_CALCULATE", "Calculate tax for line items")
+                        .description(
+                                "Calculates tax based on line items and location. Routes to external service in production or test calculator in test mode.")
+                        .build(),
+                EventTypeRegistration.approval("TAX_EXEMPTION_CERT_CREATE", "Create tax exemption certificate")
+                        .description(
+                                "Registers a customer tax exemption certificate in the pos-tax exemption registry.")
+                        .build(),
+                EventTypeRegistration.approval("TAX_EXEMPTION_CERT_UPDATE", "Update tax exemption certificate")
+                        .description("Updates a customer tax exemption certificate in the pos-tax exemption registry.")
+                        .build());
     }
 }

--- a/pos-tax/src/main/java/com/positivity/tax/internal/config/PermissionRegistration.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/config/PermissionRegistration.java
@@ -1,0 +1,22 @@
+package com.positivity.tax.internal.config;
+
+import com.positivity.security.common.PermissionRegistrationSupport;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Registers pos-tax permissions with pos-security-service at startup, mirroring the
+ * {@code EventTypeInitializer} pattern. Failures are swallowed by the shared support so
+ * startup never blocks (the service is internal-only and enforcement degrades safely).
+ */
+@Component
+public class PermissionRegistration extends PermissionRegistrationSupport {
+
+    public PermissionRegistration(
+            RestClient.Builder restClientBuilder,
+            @Value("${pos.security.base-url:http://pos-security-service:8080}") String securityServiceUrl,
+            @Value("${pos.security.permission-registration.enabled:true}") boolean enabled) {
+        super(restClientBuilder, securityServiceUrl, enabled, "permissions.yaml");
+    }
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxConfiguration.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxConfiguration.java
@@ -2,6 +2,8 @@ package com.positivity.tax.internal.config;
 
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
+import java.time.Clock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -21,12 +23,25 @@ public class TaxConfiguration {
     }
 
     /**
+     * System UTC clock used for effective-date resolution and {@code calculatedAt}
+     * timestamps. Declared {@link ConditionalOnMissingBean} so a shared library or test
+     * can supply a fixed clock instead.
+     *
+     * @return the system UTC clock
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    Clock clock() {
+        return Clock.systemUTC();
+    }
+
+    /**
      * Creates a RestClient for external tax service API calls.
      *
      * @return configured RestClient
      */
     @Bean
-    public RestClient taxServiceRestClient() {
+    RestClient taxServiceRestClient() {
         return RestClient.builder()
                 .baseUrl(properties.getExternalService().getBaseUrl())
                 .requestFactory(clientHttpRequestFactory())
@@ -53,7 +68,7 @@ public class TaxConfiguration {
      * @return configured Retry instance
      */
     @Bean
-    public Retry taxServiceRetry() {
+    Retry taxServiceRetry() {
         TaxProperties.Retry retryProps = properties.getRetry();
 
         RetryConfig config = RetryConfig.custom()

--- a/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxProperties.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxProperties.java
@@ -67,7 +67,7 @@ public class TaxProperties {
         /**
          * Address-driven, effective-dated jurisdiction rate rules (story T7).
          * <p>
-         * Each rule matches on {@code destinationAddress} facets (state, county, city,
+         * Each rule matches on {@code destinationAddress} facets (state, city,
          * postal-code prefix) and carries its own rates and optional per-category
          * exemptions. For a given transaction the rule is selected from those that match
          * the address and whose {@code effectiveFrom} is not after the transaction date;
@@ -121,9 +121,6 @@ public class TaxProperties {
     public static class JurisdictionMatch {
         /** State/region subdivision code (e.g. CA, TX). */
         private String stateCode;
-
-        /** County name. */
-        private String county;
 
         /** City/locality name. */
         private String city;

--- a/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxProperties.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxProperties.java
@@ -4,8 +4,10 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -50,13 +52,6 @@ public class TaxProperties {
         private Map<String, BigDecimal> defaultRates = new HashMap<>();
 
         /**
-         * Postal code to jurisdiction mapping for test mode.
-         * <p>
-         * Example: 90001={state=CA, county=LA}
-         */
-        private Map<String, Map<String, String>> postalCodeMapping = new HashMap<>();
-
-        /**
          * Effective-dated override schedule for test-mode rates.
          * <p>
          * Ordered list of {@link RateScheduleEntry}. When resolving rates for a
@@ -68,6 +63,73 @@ public class TaxProperties {
          * Never {@code null}; defaults to an empty list.
          */
         private List<RateScheduleEntry> rateSchedule = new ArrayList<>();
+
+        /**
+         * Address-driven, effective-dated jurisdiction rate rules (story T7).
+         * <p>
+         * Each rule matches on {@code destinationAddress} facets (state, county, city,
+         * postal-code prefix) and carries its own rates and optional per-category
+         * exemptions. For a given transaction the rule is selected from those that match
+         * the address and whose {@code effectiveFrom} is not after the transaction date;
+         * ties are broken by greatest {@code effectiveFrom}, then most-specific match, then
+         * configured order. When no rule matches, resolution falls back to
+         * {@link #rateSchedule} then {@link #defaultRates}, preserving prior behavior.
+         * <p>
+         * Never {@code null}; defaults to an empty list.
+         */
+        private List<JurisdictionRule> jurisdictions = new ArrayList<>();
+    }
+
+    /**
+     * An address-driven, effective-dated jurisdiction rate rule (story T7).
+     */
+    @Data
+    public static class JurisdictionRule {
+        /**
+         * Address facets this rule matches on. All populated facets must match.
+         */
+        private JurisdictionMatch match = new JurisdictionMatch();
+
+        /**
+         * Tax rates by jurisdiction type code for this rule (e.g. STATE=0.0625).
+         */
+        private Map<String, BigDecimal> rates = new HashMap<>();
+
+        /**
+         * Inclusive date on which this rule becomes effective. When {@code null} the rule is
+         * treated as always effective.
+         */
+        private LocalDate effectiveFrom;
+
+        /**
+         * Tax categories that are exempt within this rule (story T7 category override).
+         * <p>
+         * A line whose {@code taxCategory} is listed here is treated as a (rule-based)
+         * exempt line: it emits zero-rate jurisdiction rows and is excluded from the taxable
+         * base — the minimal config-only sliver of a fiscal position (e.g. {@code LABOR}
+         * exempt in some states). Matching is case-insensitive.
+         */
+        private Set<String> exemptCategories = new LinkedHashSet<>();
+    }
+
+    /**
+     * Address facets a {@link JurisdictionRule} matches on. A {@code null}/blank facet is a
+     * wildcard; a populated facet must equal (case-insensitively) the corresponding request
+     * value, except {@code postalCodePrefix} which matches by prefix.
+     */
+    @Data
+    public static class JurisdictionMatch {
+        /** State/region subdivision code (e.g. CA, TX). */
+        private String stateCode;
+
+        /** County name. */
+        private String county;
+
+        /** City/locality name. */
+        private String city;
+
+        /** Postal-code prefix (matches when the request postal code starts with this value). */
+        private String postalCodePrefix;
     }
 
     /**

--- a/pos-tax/src/main/java/com/positivity/tax/internal/controller/ExemptionCertificateController.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/controller/ExemptionCertificateController.java
@@ -1,0 +1,123 @@
+package com.positivity.tax.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.tax.internal.dto.ExemptionCertificateRequest;
+import com.positivity.tax.internal.dto.ExemptionCertificateResponse;
+import com.positivity.tax.service.ExemptionCertificateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * CRUD endpoints for the tax exemption-certificate registry (story T3, decision D-T1).
+ * <p>
+ * Thin controller: delegates to {@link ExemptionCertificateService}. Reads require
+ * {@code tax:exemption:view}; mutations require {@code tax:exemption:manage} and emit
+ * approval-preset audit events.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/v1/tax/exemption-certificates")
+@Tag(name = "Tax Exemption Certificates", description = "Registry of customer tax exemption certificates")
+public class ExemptionCertificateController {
+
+    private final ExemptionCertificateService service;
+
+    public ExemptionCertificateController(ExemptionCertificateService service) {
+        this.service = service;
+    }
+
+    /**
+     * List exemption certificates, optionally filtered by customer.
+     *
+     * @param customerId optional customer filter
+     * @return the certificates
+     */
+    @GetMapping
+    @PreAuthorize("hasAuthority('tax:exemption:view')")
+    @Operation(summary = "List exemption certificates", description = "List certificates, optionally by customer")
+    @ApiResponse(responseCode = "200", description = "Certificates listed")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"tax:exemption:view"})
+    public ResponseEntity<List<ExemptionCertificateResponse>> list(@RequestParam(required = false) String customerId) {
+        return ResponseEntity.ok(service.list(customerId));
+    }
+
+    /**
+     * Get an exemption certificate by id.
+     *
+     * @param id the certificate id
+     * @return the certificate
+     */
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('tax:exemption:view')")
+    @Operation(summary = "Get an exemption certificate", description = "Fetch a single certificate by id")
+    @ApiResponse(responseCode = "200", description = "Certificate found")
+    @ApiResponse(responseCode = "404", description = "Certificate not found")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"tax:exemption:view"})
+    public ResponseEntity<ExemptionCertificateResponse> get(@PathVariable UUID id) {
+        return ResponseEntity.ok(service.get(id));
+    }
+
+    /**
+     * Create an exemption certificate.
+     *
+     * @param request the create payload
+     * @return the created certificate
+     */
+    @PostMapping
+    @PreAuthorize("hasAuthority('tax:exemption:manage')")
+    @EmitEvent(id = "TAX_EXEMPTION_CERT_CREATE", apiVersion = "1")
+    @Operation(summary = "Create an exemption certificate", description = "Register a new certificate")
+    @ApiResponse(responseCode = "201", description = "Certificate created")
+    @ApiResponse(responseCode = "400", description = "Invalid certificate payload")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"tax:exemption:manage"})
+    public ResponseEntity<ExemptionCertificateResponse> create(
+            @Valid @RequestBody ExemptionCertificateRequest request) {
+        ExemptionCertificateResponse created = service.create(request);
+        return ResponseEntity.created(URI.create("/v1/tax/exemption-certificates/" + created.id()))
+                .body(created);
+    }
+
+    /**
+     * Update an exemption certificate.
+     *
+     * @param id      the certificate id
+     * @param request the update payload
+     * @return the updated certificate
+     */
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('tax:exemption:manage')")
+    @EmitEvent(id = "TAX_EXEMPTION_CERT_UPDATE", apiVersion = "1")
+    @Operation(summary = "Update an exemption certificate", description = "Update an existing certificate")
+    @ApiResponse(responseCode = "200", description = "Certificate updated")
+    @ApiResponse(responseCode = "404", description = "Certificate not found")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"tax:exemption:manage"})
+    public ResponseEntity<ExemptionCertificateResponse> update(
+            @PathVariable UUID id, @Valid @RequestBody ExemptionCertificateRequest request) {
+        return ResponseEntity.ok(service.update(id, request));
+    }
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/dto/ExemptionCertificateRequest.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/dto/ExemptionCertificateRequest.java
@@ -1,0 +1,68 @@
+package com.positivity.tax.internal.dto;
+
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.internal.enums.ExemptionCertificateStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Create/update payload for a tax exemption certificate (story T3).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "ExemptionCertificateRequest", description = "Create or update a tax exemption certificate")
+public class ExemptionCertificateRequest {
+
+    @NotBlank(message = "customerId is required")
+    @Schema(
+            description = "Customer this certificate belongs to",
+            example = "CUST-100234",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String customerId;
+
+    @Schema(
+            description = "State/region scope (subdivision code); null applies to all states",
+            example = "CA",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String stateScope;
+
+    @NotNull(message = "reasonCode is required")
+    @Schema(
+            description = "Exemption reason (RESALE, GOVERNMENT, NONPROFIT, AGRICULTURAL, OTHER)",
+            example = "RESALE",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private ExemptionReasonCode reasonCode;
+
+    @Schema(
+            description = "Optional external/paper certificate number",
+            example = "RESALE-2026-0001",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String certificateNumber;
+
+    @NotNull(message = "effectiveFrom is required")
+    @Schema(
+            description = "Inclusive date the certificate becomes effective",
+            example = "2026-01-01",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDate effectiveFrom;
+
+    @Schema(
+            description = "Inclusive expiry date; null means no expiry",
+            example = "2027-12-31",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private LocalDate expiresAt;
+
+    @Schema(
+            description = "Lifecycle status; defaults to ACTIVE when omitted on create",
+            example = "ACTIVE",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private ExemptionCertificateStatus status;
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/dto/ExemptionCertificateResponse.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/dto/ExemptionCertificateResponse.java
@@ -1,0 +1,75 @@
+package com.positivity.tax.internal.dto;
+
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.internal.entity.ExemptionCertificate;
+import com.positivity.tax.internal.enums.ExemptionCertificateStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Read model for a tax exemption certificate (story T3).
+ *
+ * @param id                 certificate identifier (UUID v7)
+ * @param customerId         owning customer
+ * @param stateScope         state/region scope; {@code null} applies to all states
+ * @param reasonCode         exemption reason
+ * @param certificateNumber  optional external/paper certificate number
+ * @param effectiveFrom      inclusive effective date
+ * @param expiresAt          inclusive expiry date; {@code null} means no expiry
+ * @param status             lifecycle status
+ * @param createdAt          creation timestamp
+ * @param updatedAt          last-modification timestamp
+ */
+@Schema(name = "ExemptionCertificateResponse", description = "A tax exemption certificate")
+public record ExemptionCertificateResponse(
+        @Schema(description = "Certificate identifier", example = "018f0000-0000-7000-8000-0000000000aa")
+        UUID id,
+
+        @Schema(description = "Owning customer", example = "CUST-100234")
+        String customerId,
+
+        @Schema(description = "State/region scope; null = all states", example = "CA")
+        String stateScope,
+
+        @Schema(description = "Exemption reason", example = "RESALE")
+        ExemptionReasonCode reasonCode,
+
+        @Schema(description = "External/paper certificate number", example = "RESALE-2026-0001")
+        String certificateNumber,
+
+        @Schema(description = "Inclusive effective date", example = "2026-01-01")
+        LocalDate effectiveFrom,
+
+        @Schema(description = "Inclusive expiry date; null = no expiry", example = "2027-12-31")
+        LocalDate expiresAt,
+
+        @Schema(description = "Lifecycle status", example = "ACTIVE")
+        ExemptionCertificateStatus status,
+
+        @Schema(description = "Creation timestamp") Instant createdAt,
+        @Schema(description = "Last-modification timestamp") Instant updatedAt) {
+
+    /**
+     * Map a persisted entity to its read model.
+     *
+     * @param entity the certificate entity
+     * @return the response view
+     */
+    @NonNull
+    public static ExemptionCertificateResponse from(@NonNull ExemptionCertificate entity) {
+        return new ExemptionCertificateResponse(
+                entity.getId(),
+                entity.getCustomerId(),
+                entity.getStateScope(),
+                entity.getReasonCode(),
+                entity.getCertificateNumber(),
+                entity.getEffectiveFrom(),
+                entity.getExpiresAt(),
+                entity.getStatus(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt());
+    }
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/entity/ExemptionCertificate.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/entity/ExemptionCertificate.java
@@ -1,0 +1,103 @@
+package com.positivity.tax.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.internal.enums.ExemptionCertificateStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Tax exemption certificate registry entry (story T3, decision D-T1).
+ * <p>
+ * pos-tax owns this small table because an exemption is tax semantics, not CRM
+ * identity. The calculate path stays a pure function of request + config + a registry
+ * lookup: given a {@code customerId} (or a line/request certificate id), an active,
+ * effective, non-expired certificate drives an honored exemption; otherwise a claimed
+ * exemption is denied and the line taxed anyway (D-T2).
+ * <p>
+ * Audit timestamps are maintained by JPA lifecycle callbacks so persistence works
+ * without Spring Data auditing infrastructure (this is a utility service with no user
+ * security context on the calculate path).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "exemption_certificate")
+public class ExemptionCertificate {
+
+    /** UUID v7 primary key (ADR-0013). */
+    @Id
+    @UUIDv7Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    /** Customer this certificate belongs to (matches {@code TaxCalculationRequest.customerId}). */
+    @Column(name = "customer_id", nullable = false, length = 100)
+    private String customerId;
+
+    /**
+     * State/region scope this certificate applies to (subdivision code, e.g. CA). When
+     * {@code null}, the certificate applies in any state.
+     */
+    @Column(name = "state_scope", length = 10)
+    private String stateScope;
+
+    /** Exemption reason this certificate documents. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason_code", nullable = false, length = 32)
+    private ExemptionReasonCode reasonCode;
+
+    /** Optional external/paper certificate number. */
+    @Column(name = "certificate_number", length = 100)
+    private String certificateNumber;
+
+    /** Inclusive date on which the certificate becomes effective. */
+    @Column(name = "effective_from", nullable = false)
+    private LocalDate effectiveFrom;
+
+    /** Inclusive expiry date; {@code null} means no expiry. */
+    @Column(name = "expires_at")
+    private LocalDate expiresAt;
+
+    /** Lifecycle status. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private ExemptionCertificateStatus status;
+
+    /** Creation timestamp (ADR-0018/0024). */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    /** Last-modification timestamp (ADR-0018/0024). */
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/enums/ExemptionCertificateStatus.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/enums/ExemptionCertificateStatus.java
@@ -1,0 +1,17 @@
+package com.positivity.tax.internal.enums;
+
+/**
+ * Lifecycle status of an exemption certificate (story T3).
+ * <p>
+ * Only {@link #ACTIVE} certificates (and only within their effective/expiry window)
+ * drive an honored exemption; any other status causes a claimed exemption to be denied
+ * and the line taxed anyway (decision D-T2).
+ */
+public enum ExemptionCertificateStatus {
+    /** Certificate is valid and may drive exemptions within its date window. */
+    ACTIVE,
+    /** Certificate has been administratively deactivated. */
+    INACTIVE,
+    /** Certificate has been revoked and must never drive an exemption. */
+    REVOKED
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/repository/ExemptionCertificateRepository.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/repository/ExemptionCertificateRepository.java
@@ -1,0 +1,60 @@
+package com.positivity.tax.internal.repository;
+
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.internal.entity.ExemptionCertificate;
+import com.positivity.tax.internal.enums.ExemptionCertificateStatus;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.lang.Nullable;
+
+/**
+ * Spring Data repository for {@link ExemptionCertificate} (story T3).
+ */
+public interface ExemptionCertificateRepository extends JpaRepository<ExemptionCertificate, java.util.UUID> {
+
+    /**
+     * List certificates for a customer, newest effective first.
+     *
+     * @param customerId the customer id
+     * @return certificates for the customer
+     */
+    List<ExemptionCertificate> findByCustomerIdOrderByEffectiveFromDesc(String customerId);
+
+    /**
+     * Find the certificates active for a customer on {@code date}, ordered most-recently
+     * effective first.
+     * <p>
+     * "Active" means status {@link ExemptionCertificateStatus#ACTIVE},
+     * {@code effectiveFrom <= date} and ({@code expiresAt} is {@code null} or
+     * {@code expiresAt >= date}). When {@code stateScope} is supplied, a certificate matches
+     * if its own scope is {@code null} (all states) or equals the supplied scope; when
+     * {@code reasonCode} is supplied it must match. The caller takes the first result.
+     *
+     * @param customerId the customer id (required)
+     * @param stateScope optional state scope filter
+     * @param reasonCode optional reason filter
+     * @param date       the transaction date
+     * @param limit      row limit (caller passes {@code Limit.of(1)})
+     * @return matching active certificates, most-recently effective first
+     */
+    @Query("""
+            select c from ExemptionCertificate c
+            where c.customerId = :customerId
+              and c.status = com.positivity.tax.internal.enums.ExemptionCertificateStatus.ACTIVE
+              and c.effectiveFrom <= :date
+              and (c.expiresAt is null or c.expiresAt >= :date)
+              and (:stateScope is null or c.stateScope is null or upper(c.stateScope) = upper(:stateScope))
+              and (:reasonCode is null or c.reasonCode = :reasonCode)
+            order by c.effectiveFrom desc
+            """)
+    List<ExemptionCertificate> findActiveForCustomer(
+            @Param("customerId") String customerId,
+            @Param("stateScope") @Nullable String stateScope,
+            @Param("reasonCode") @Nullable ExemptionReasonCode reasonCode,
+            @Param("date") LocalDate date,
+            Limit limit);
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/ActiveCertificateLookup.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/ActiveCertificateLookup.java
@@ -1,0 +1,48 @@
+package com.positivity.tax.internal.service;
+
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Read-only port used by {@link ExemptionResolver} to resolve an active exemption
+ * certificate on the calculate path (story T3). Keeping the lookup behind a small port
+ * lets the calculator/resolver be unit-tested without a database.
+ */
+public interface ActiveCertificateLookup {
+
+    /**
+     * Resolve an active, effective, non-expired certificate backing an exemption claim.
+     * <p>
+     * When {@code certificateId} is supplied it is resolved by id and validated (active,
+     * within its date window, and — when {@code customerId} is supplied — belonging to that
+     * customer). Otherwise the most-recently-effective active certificate for
+     * {@code customerId} (optionally scoped by {@code stateScope}/{@code requestedReason}) on
+     * {@code date} is returned.
+     *
+     * @param customerId      the customer id from the request (may be {@code null})
+     * @param certificateId   an explicit certificate id from the line/request (may be {@code null})
+     * @param stateScope      destination state scope (may be {@code null})
+     * @param requestedReason the claimed reason (may be {@code null})
+     * @param date            the transaction date
+     * @return the resolved active certificate, or empty when none is valid
+     */
+    @NonNull
+    Optional<ActiveCertificate> findActive(
+            @Nullable String customerId,
+            @Nullable UUID certificateId,
+            @Nullable String stateScope,
+            @Nullable ExemptionReasonCode requestedReason,
+            @NonNull LocalDate date);
+
+    /**
+     * A resolved active certificate.
+     *
+     * @param id         the certificate id
+     * @param reasonCode the certificate's exemption reason
+     */
+    record ActiveCertificate(@NonNull UUID id, @NonNull ExemptionReasonCode reasonCode) {}
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/ExemptionCertificateServiceImpl.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/ExemptionCertificateServiceImpl.java
@@ -105,7 +105,7 @@ public class ExemptionCertificateServiceImpl implements ExemptionCertificateServ
         if (certificateId != null) {
             return repository
                     .findById(certificateId)
-                    .filter(c -> isValid(c, customerId, date))
+                    .filter(c -> isValid(c, customerId, stateScope, requestedReason, date))
                     .map(c -> new ActiveCertificate(c.getId(), c.getReasonCode()));
         }
         if (customerId == null || customerId.isBlank()) {
@@ -116,12 +116,29 @@ public class ExemptionCertificateServiceImpl implements ExemptionCertificateServ
                 .map(c -> new ActiveCertificate(c.getId(), c.getReasonCode()));
     }
 
-    private static boolean isValid(ExemptionCertificate c, @Nullable String customerId, LocalDate date) {
+    /**
+     * Mirrors the predicate of {@link ExemptionCertificateRepository#findActiveForCustomer} so the
+     * by-id lookup honors the same status/date-window, customer, state-scope, and reason constraints
+     * as the customer-query path. A null/blank {@code cert.stateScope} means all states; otherwise it
+     * must match the requested scope case-insensitively. When a {@code requestedReason} is supplied it
+     * must equal the certificate's reason.
+     */
+    private static boolean isValid(
+            ExemptionCertificate c,
+            @Nullable String customerId,
+            @Nullable String stateScope,
+            @Nullable ExemptionReasonCode requestedReason,
+            LocalDate date) {
         boolean active = c.getStatus() == ExemptionCertificateStatus.ACTIVE;
         boolean effective = !c.getEffectiveFrom().isAfter(date);
         boolean notExpired = c.getExpiresAt() == null || !c.getExpiresAt().isBefore(date);
         boolean customerMatches = customerId == null || customerId.isBlank() || customerId.equals(c.getCustomerId());
-        return active && effective && notExpired && customerMatches;
+        boolean scopeMatches = stateScope == null
+                || c.getStateScope() == null
+                || c.getStateScope().isBlank()
+                || c.getStateScope().equalsIgnoreCase(stateScope);
+        boolean reasonMatches = requestedReason == null || requestedReason == c.getReasonCode();
+        return active && effective && notExpired && customerMatches && scopeMatches && reasonMatches;
     }
 
     private static ResponseStatusException notFound(UUID id) {

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/ExemptionCertificateServiceImpl.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/ExemptionCertificateServiceImpl.java
@@ -1,0 +1,130 @@
+package com.positivity.tax.internal.service;
+
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.internal.dto.ExemptionCertificateRequest;
+import com.positivity.tax.internal.dto.ExemptionCertificateResponse;
+import com.positivity.tax.internal.entity.ExemptionCertificate;
+import com.positivity.tax.internal.enums.ExemptionCertificateStatus;
+import com.positivity.tax.internal.repository.ExemptionCertificateRepository;
+import com.positivity.tax.service.ExemptionCertificateService;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Limit;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Registry service for tax exemption certificates (story T3). Also implements the
+ * read-only {@link ActiveCertificateLookup} port used by the calculate path so a single
+ * component owns certificate persistence and validity resolution.
+ */
+@Slf4j
+@Service
+@Transactional
+public class ExemptionCertificateServiceImpl implements ExemptionCertificateService, ActiveCertificateLookup {
+
+    private final ExemptionCertificateRepository repository;
+
+    public ExemptionCertificateServiceImpl(ExemptionCertificateRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public List<ExemptionCertificateResponse> list(@Nullable String customerId) {
+        List<ExemptionCertificate> certificates = (customerId == null || customerId.isBlank())
+                ? repository.findAll()
+                : repository.findByCustomerIdOrderByEffectiveFromDesc(customerId);
+        return certificates.stream().map(ExemptionCertificateResponse::from).toList();
+    }
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public ExemptionCertificateResponse get(@NonNull UUID id) {
+        return repository.findById(id).map(ExemptionCertificateResponse::from).orElseThrow(() -> notFound(id));
+    }
+
+    @Override
+    @NonNull
+    public ExemptionCertificateResponse create(@NonNull ExemptionCertificateRequest request) {
+        ExemptionCertificate entity = ExemptionCertificate.builder()
+                .customerId(request.getCustomerId())
+                .stateScope(request.getStateScope())
+                .reasonCode(request.getReasonCode())
+                .certificateNumber(request.getCertificateNumber())
+                .effectiveFrom(request.getEffectiveFrom())
+                .expiresAt(request.getExpiresAt())
+                .status(request.getStatus() != null ? request.getStatus() : ExemptionCertificateStatus.ACTIVE)
+                .build();
+        ExemptionCertificate saved = repository.save(entity);
+        log.info("Created exemption certificate {} for customer {}", saved.getId(), saved.getCustomerId());
+        return ExemptionCertificateResponse.from(saved);
+    }
+
+    @Override
+    @NonNull
+    public ExemptionCertificateResponse update(@NonNull UUID id, @NonNull ExemptionCertificateRequest request) {
+        ExemptionCertificate entity = repository.findById(id).orElseThrow(() -> notFound(id));
+        entity.setCustomerId(request.getCustomerId());
+        entity.setStateScope(request.getStateScope());
+        entity.setReasonCode(request.getReasonCode());
+        entity.setCertificateNumber(request.getCertificateNumber());
+        entity.setEffectiveFrom(request.getEffectiveFrom());
+        entity.setExpiresAt(request.getExpiresAt());
+        if (request.getStatus() != null) {
+            entity.setStatus(request.getStatus());
+        }
+        ExemptionCertificate saved = repository.save(entity);
+        log.info("Updated exemption certificate {}", saved.getId());
+        return ExemptionCertificateResponse.from(saved);
+    }
+
+    // ------------------------------------------------------------------
+    // ActiveCertificateLookup (calculate path)
+    // ------------------------------------------------------------------
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public Optional<ActiveCertificate> findActive(
+            @Nullable String customerId,
+            @Nullable UUID certificateId,
+            @Nullable String stateScope,
+            @Nullable ExemptionReasonCode requestedReason,
+            @NonNull LocalDate date) {
+
+        if (certificateId != null) {
+            return repository
+                    .findById(certificateId)
+                    .filter(c -> isValid(c, customerId, date))
+                    .map(c -> new ActiveCertificate(c.getId(), c.getReasonCode()));
+        }
+        if (customerId == null || customerId.isBlank()) {
+            return Optional.empty();
+        }
+        return repository.findActiveForCustomer(customerId, stateScope, requestedReason, date, Limit.of(1)).stream()
+                .findFirst()
+                .map(c -> new ActiveCertificate(c.getId(), c.getReasonCode()));
+    }
+
+    private static boolean isValid(ExemptionCertificate c, @Nullable String customerId, LocalDate date) {
+        boolean active = c.getStatus() == ExemptionCertificateStatus.ACTIVE;
+        boolean effective = !c.getEffectiveFrom().isAfter(date);
+        boolean notExpired = c.getExpiresAt() == null || !c.getExpiresAt().isBefore(date);
+        boolean customerMatches = customerId == null || customerId.isBlank() || customerId.equals(c.getCustomerId());
+        return active && effective && notExpired && customerMatches;
+    }
+
+    private static ResponseStatusException notFound(UUID id) {
+        return new ResponseStatusException(HttpStatus.NOT_FOUND, "Exemption certificate not found: " + id);
+    }
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/ExemptionResolver.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/ExemptionResolver.java
@@ -1,0 +1,120 @@
+package com.positivity.tax.internal.service;
+
+import com.positivity.tax.common.dto.TaxCalculationRequest;
+import com.positivity.tax.common.dto.TaxLineItem;
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.internal.service.ActiveCertificateLookup.ActiveCertificate;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Classifies a line's exemption outcome for the calculate path (story T3, decision D-T2).
+ * <p>
+ * A line is a <em>certificate-backed exemption claim</em> when it carries an
+ * {@code exemptionReasonCode} or {@code exemptionCertificateId}, or when the request
+ * carries a transaction-level {@code customerExemption}. A claim is honored only if an
+ * active, effective, non-expired certificate is found ({@link Outcome#EXEMPT}); otherwise
+ * the line is taxed anyway and flagged ({@link Outcome#DENIED}) — a sale is never
+ * hard-blocked. A bare {@code taxExempt=true} with no claim remains an intrinsic
+ * non-taxable declaration ({@link Outcome#EXEMPT} with no reason), preserving prior
+ * behavior. Everything else is {@link Outcome#TAXABLE}.
+ */
+@Slf4j
+@Component
+public class ExemptionResolver {
+
+    private final ActiveCertificateLookup lookup;
+
+    public ExemptionResolver(ActiveCertificateLookup lookup) {
+        this.lookup = lookup;
+    }
+
+    /** Per-line exemption outcome. */
+    public enum Outcome {
+        /** Line is taxed normally. */
+        TAXABLE,
+        /** Line is exempt: zero-rate jurisdiction rows, excluded from the taxable base. */
+        EXEMPT,
+        /** Exemption claimed but unbacked by a valid certificate: taxed anyway and flagged. */
+        DENIED
+    }
+
+    /**
+     * Resolved classification for a single line.
+     *
+     * @param outcome the exemption outcome
+     * @param reason  the resolved/claimed reason, or {@code null} for an intrinsic exemption or a taxable line
+     */
+    public record LineExemption(
+            @NonNull Outcome outcome, @Nullable ExemptionReasonCode reason) {
+        static LineExemption taxable() {
+            return new LineExemption(Outcome.TAXABLE, null);
+        }
+
+        static LineExemption exempt(@Nullable ExemptionReasonCode reason) {
+            return new LineExemption(Outcome.EXEMPT, reason);
+        }
+
+        static LineExemption denied(@Nullable ExemptionReasonCode reason) {
+            return new LineExemption(Outcome.DENIED, reason);
+        }
+    }
+
+    /**
+     * Classify a line's exemption outcome.
+     *
+     * @param request    the calculation request (for the transaction-level exemption and customerId)
+     * @param line       the line item
+     * @param stateScope destination state scope used for certificate matching (may be {@code null})
+     * @param date       the transaction date used for certificate validity
+     * @return the resolved classification
+     */
+    @NonNull
+    public LineExemption classify(
+            @NonNull TaxCalculationRequest request,
+            @NonNull TaxLineItem line,
+            @Nullable String stateScope,
+            @NonNull LocalDate date) {
+
+        TaxCalculationRequest.CustomerExemption customerExemption = request.getCustomerExemption();
+        ExemptionReasonCode claimedReason = firstNonNull(
+                line.getExemptionReasonCode(), customerExemption == null ? null : customerExemption.getReasonCode());
+        UUID claimedCertificateId = firstNonNull(
+                line.getExemptionCertificateId(),
+                customerExemption == null ? null : customerExemption.getCertificateId());
+
+        boolean certificateBackedClaim =
+                claimedReason != null || claimedCertificateId != null || customerExemption != null;
+
+        if (!certificateBackedClaim) {
+            // No certificate-backed claim: a bare taxExempt flag is an intrinsic non-taxable
+            // declaration (reportable zero-tax); anything else is taxable.
+            return line.isTaxExempt() ? LineExemption.exempt(null) : LineExemption.taxable();
+        }
+
+        Optional<ActiveCertificate> certificate =
+                lookup.findActive(request.getCustomerId(), claimedCertificateId, stateScope, claimedReason, date);
+        if (certificate.isPresent()) {
+            ExemptionReasonCode resolvedReason = firstNonNull(certificate.get().reasonCode(), claimedReason);
+            return LineExemption.exempt(resolvedReason);
+        }
+
+        log.debug(
+                "Exemption denied for line {} (customerId present={}, reason={}): no active certificate on {}",
+                line.getLineItemId(),
+                request.getCustomerId() != null,
+                claimedReason,
+                date);
+        return LineExemption.denied(claimedReason);
+    }
+
+    @Nullable
+    private static <T> T firstNonNull(@Nullable T a, @Nullable T b) {
+        return a != null ? a : b;
+    }
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/ExemptionResolver.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/ExemptionResolver.java
@@ -16,8 +16,10 @@ import org.springframework.stereotype.Component;
  * Classifies a line's exemption outcome for the calculate path (story T3, decision D-T2).
  * <p>
  * A line is a <em>certificate-backed exemption claim</em> when it carries an
- * {@code exemptionReasonCode} or {@code exemptionCertificateId}, or when the request
- * carries a transaction-level {@code customerExemption}. A claim is honored only if an
+ * {@code exemptionReasonCode} or {@code exemptionCertificateId} — either on the line
+ * itself or folded in from the request's transaction-level {@code customerExemption}.
+ * A present-but-empty {@code customerExemption} ({@code {}}) is a no-op, not a claim.
+ * A claim is honored only if an
  * active, effective, non-expired certificate is found ({@link Outcome#EXEMPT}); otherwise
  * the line is taxed anyway and flagged ({@link Outcome#DENIED}) — a sale is never
  * hard-blocked. A bare {@code taxExempt=true} with no claim remains an intrinsic
@@ -88,8 +90,9 @@ public class ExemptionResolver {
                 line.getExemptionCertificateId(),
                 customerExemption == null ? null : customerExemption.getCertificateId());
 
-        boolean certificateBackedClaim =
-                claimedReason != null || claimedCertificateId != null || customerExemption != null;
+        // A present-but-empty customerExemption ({}) is a no-op, not a claim: a claim
+        // requires an actual reason code or certificate id (top-level or folded in above).
+        boolean certificateBackedClaim = claimedReason != null || claimedCertificateId != null;
 
         if (!certificateBackedClaim) {
             // No certificate-backed claim: a bare taxExempt flag is an intrinsic non-taxable

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
@@ -4,8 +4,11 @@ import com.positivity.tax.common.dto.TaxCalculationRequest;
 import com.positivity.tax.common.dto.TaxCalculationResponse;
 import com.positivity.tax.common.dto.TaxJurisdiction;
 import com.positivity.tax.common.dto.TaxLineItem;
+import com.positivity.tax.common.enums.TaxCalculationType;
 import com.positivity.tax.common.enums.TaxJurisdictionType;
 import com.positivity.tax.internal.config.TaxProperties;
+import com.positivity.tax.internal.service.ExemptionResolver.LineExemption;
+import com.positivity.tax.internal.service.ExemptionResolver.Outcome;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Clock;
@@ -14,10 +17,14 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -41,12 +48,15 @@ public class TestModeTaxCalculator {
 
     private final TaxProperties properties;
 
+    private final ExemptionResolver exemptionResolver;
+
     /** Stateless, deterministic single-stage rounding reconciler. */
     private final TaxTotalsReconciler reconciler = new TaxTotalsReconciler();
 
-    public TestModeTaxCalculator(TaxProperties properties, Clock clock) {
+    public TestModeTaxCalculator(TaxProperties properties, Clock clock, ExemptionResolver exemptionResolver) {
         this.clock = clock;
         this.properties = properties;
+        this.exemptionResolver = exemptionResolver;
     }
 
     /**
@@ -69,18 +79,29 @@ public class TestModeTaxCalculator {
         BigDecimal subtotal = lineItems.stream().map(TaxLineItem::getSubtotal).reduce(BigDecimal.ZERO, BigDecimal::add);
 
         // Resolve the effective transaction date (defaulting to today via the shared
-        // Clock) and the rates map effective on that date.
+        // Clock). For a REFUND this is the original sale date the caller supplies, so
+        // effective-dated rates reprice correctly (story T4 + T2).
         LocalDate transactionDate = resolveTransactionDate(request.getTransactionDate());
-        Map<String, BigDecimal> effectiveRates = resolveEffectiveRates(transactionDate);
+
+        // Resolve the applicable rates and per-category exemptions from the destination
+        // address + transaction date (story T7), falling back to the effective-dated
+        // schedule then flat default rates.
+        ResolvedRates resolvedRates = resolveRates(request, transactionDate);
 
         // Applicable jurisdictions (type + decimal-fraction rate); rate order is stable.
-        List<JurisdictionSpec> specs = determineJurisdictionSpecs(effectiveRates);
+        List<JurisdictionSpec> specs = determineJurisdictionSpecs(resolvedRates.rates());
 
-        // Non-exempt lines form the taxable rows of the matrix (row order preserved).
-        List<TaxLineItem> taxableLines =
-                lineItems.stream().filter(item -> !item.isTaxExempt()).toList();
-        List<BigDecimal> lineTaxableAmounts =
-                taxableLines.stream().map(TaxLineItem::getSubtotal).toList();
+        // Classify each line's exemption outcome (story T3 + T7 category exemption).
+        List<LineExemption> classifications = classifyLines(request, lineItems, resolvedRates, transactionDate);
+
+        // Non-exempt lines (TAXABLE + DENIED, both taxed) form the taxable rows of the
+        // matrix (row order preserved). Fully-exempt lines are excluded from the base.
+        List<BigDecimal> lineTaxableAmounts = new ArrayList<>();
+        for (int i = 0; i < lineItems.size(); i++) {
+            if (classifications.get(i).outcome() != Outcome.EXEMPT) {
+                lineTaxableAmounts.add(lineItems.get(i).getSubtotal());
+            }
+        }
         List<BigDecimal> jurisdictionRates =
                 specs.stream().map(JurisdictionSpec::rate).toList();
 
@@ -92,7 +113,8 @@ public class TestModeTaxCalculator {
 
         BigDecimal totalTax = reconciled.totalTax();
         List<TaxJurisdiction> jurisdictions = buildJurisdictions(request, specs, reconciled.jurisdictionAmounts());
-        List<TaxCalculationResponse.LineItemTax> lineItemTaxes = buildLineItemTaxes(lineItems, specs, reconciled);
+        List<TaxCalculationResponse.LineItemTax> lineItemTaxes =
+                buildLineItemTaxes(lineItems, classifications, specs, reconciled);
 
         // Effective tax rate = totalTax / exempt-filtered taxable base (ADR-0042),
         // NOT totalTax / raw subtotal. Guard an all-exempt / zero base.
@@ -101,6 +123,9 @@ public class TestModeTaxCalculator {
                         .multiply(PERCENT_FACTOR)
                         .setScale(MONEY_SCALE, RoundingMode.HALF_UP)
                 : BigDecimal.ZERO.setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+
+        TaxCalculationType calculationType =
+                request.getCalculationType() != null ? request.getCalculationType() : TaxCalculationType.SALE;
 
         return TaxCalculationResponse.builder()
                 .subtotal(subtotal)
@@ -113,7 +138,34 @@ public class TestModeTaxCalculator {
                 .calculatedAt(Instant.now(clock))
                 .referenceId(request.getReferenceId())
                 .referenceType(request.getReferenceType())
+                .calculationType(calculationType)
                 .build();
+    }
+
+    /**
+     * Classify each line's exemption outcome, combining the config-driven per-category
+     * exemption (story T7) with the certificate-backed resolver (story T3, D-T2). A
+     * category-exempt line short-circuits to {@link Outcome#EXEMPT}; otherwise the
+     * resolver decides.
+     */
+    @NonNull
+    private List<LineExemption> classifyLines(
+            @NonNull TaxCalculationRequest request,
+            @NonNull List<TaxLineItem> lineItems,
+            @NonNull ResolvedRates resolvedRates,
+            @NonNull LocalDate transactionDate) {
+        String stateScope = request.getStateCode();
+        Set<String> exemptCategories = resolvedRates.exemptCategories();
+        List<LineExemption> classifications = new ArrayList<>(lineItems.size());
+        for (TaxLineItem item : lineItems) {
+            String category = item.getTaxCategory();
+            if (category != null && exemptCategories.contains(category.toUpperCase(Locale.ROOT))) {
+                classifications.add(new LineExemption(Outcome.EXEMPT, null));
+            } else {
+                classifications.add(exemptionResolver.classify(request, item, stateScope, transactionDate));
+            }
+        }
+        return classifications;
     }
 
     /**
@@ -202,6 +254,139 @@ public class TestModeTaxCalculator {
     }
 
     /**
+     * Resolve the rates and per-category exemptions for a request (story T7).
+     * <p>
+     * Address-driven {@code jurisdictions[]} rules take precedence: among rules whose
+     * {@code match} facets match the destination address and whose {@code effectiveFrom}
+     * is not after the transaction date, the one with the greatest {@code effectiveFrom}
+     * wins (ties broken by most-specific match, then configured order). When no rule
+     * matches, resolution falls back to the effective-dated {@link #resolveEffectiveRates
+     * schedule} then flat default rates, and no categories are exempt.
+     *
+     * @param request         the calculation request
+     * @param transactionDate the resolved transaction date
+     * @return the resolved rates and exempt categories
+     */
+    @NonNull
+    private ResolvedRates resolveRates(@NonNull TaxCalculationRequest request, @NonNull LocalDate transactionDate) {
+        List<TaxProperties.JurisdictionRule> rules = properties.getTestMode().getJurisdictions();
+        TaxProperties.JurisdictionRule best = null;
+        int bestSpecificity = -1;
+        LocalDate bestFrom = null;
+        for (TaxProperties.JurisdictionRule rule : rules) {
+            if (rule.getRates() == null || rule.getRates().isEmpty()) {
+                continue;
+            }
+            LocalDate from = rule.getEffectiveFrom();
+            if (from != null && from.isAfter(transactionDate)) {
+                continue;
+            }
+            if (!matches(rule.getMatch(), request)) {
+                continue;
+            }
+            int specificity = specificity(rule.getMatch());
+            // Prefer the most-recently-effective rule; break ties by most-specific match,
+            // then by configured order (first wins, so require strict improvement).
+            boolean better;
+            if (best == null) {
+                better = true;
+            } else if (!nullSafeEquals(from, bestFrom)) {
+                better = isAfter(from, bestFrom);
+            } else {
+                better = specificity > bestSpecificity;
+            }
+            if (better) {
+                best = rule;
+                bestSpecificity = specificity;
+                bestFrom = from;
+            }
+        }
+        if (best != null) {
+            Set<String> exemptCategories = new LinkedHashSet<>();
+            for (String category : best.getExemptCategories()) {
+                if (category != null && !category.isBlank()) {
+                    exemptCategories.add(category.toUpperCase(Locale.ROOT));
+                }
+            }
+            return new ResolvedRates(best.getRates(), exemptCategories);
+        }
+        return new ResolvedRates(resolveEffectiveRates(transactionDate), Set.of());
+    }
+
+    /**
+     * Whether a rule's match facets all match the request's destination address. A
+     * {@code null}/blank facet is a wildcard; {@code postalCodePrefix} matches by prefix,
+     * other facets by case-insensitive equality.
+     */
+    private boolean matches(TaxProperties.@Nullable JurisdictionMatch match, @NonNull TaxCalculationRequest request) {
+        if (match == null) {
+            return true;
+        }
+        return facetMatches(match.getStateCode(), request.getStateCode())
+                && facetMatches(match.getCity(), request.getCity())
+                && prefixMatches(match.getPostalCodePrefix(), request.getPostalCode());
+    }
+
+    private boolean facetMatches(@Nullable String expected, @Nullable String actual) {
+        if (expected == null || expected.isBlank()) {
+            return true;
+        }
+        return actual != null && expected.equalsIgnoreCase(actual.trim());
+    }
+
+    private boolean prefixMatches(@Nullable String prefix, @Nullable String actual) {
+        if (prefix == null || prefix.isBlank()) {
+            return true;
+        }
+        return actual != null && actual.trim().startsWith(prefix);
+    }
+
+    /** Count of populated match facets: a more specific match wins ties. */
+    private int specificity(TaxProperties.@Nullable JurisdictionMatch match) {
+        if (match == null) {
+            return 0;
+        }
+        int count = 0;
+        if (match.getStateCode() != null && !match.getStateCode().isBlank()) {
+            count++;
+        }
+        if (match.getCounty() != null && !match.getCounty().isBlank()) {
+            count++;
+        }
+        if (match.getCity() != null && !match.getCity().isBlank()) {
+            count++;
+        }
+        if (match.getPostalCodePrefix() != null && !match.getPostalCodePrefix().isBlank()) {
+            count++;
+        }
+        return count;
+    }
+
+    private static boolean nullSafeEquals(@Nullable LocalDate a, @Nullable LocalDate b) {
+        return a == null ? b == null : a.equals(b);
+    }
+
+    /** Treats a {@code null} effectiveFrom (always-effective) as earliest. */
+    private static boolean isAfter(@Nullable LocalDate a, @Nullable LocalDate b) {
+        if (a == null) {
+            return false;
+        }
+        if (b == null) {
+            return true;
+        }
+        return a.isAfter(b);
+    }
+
+    /**
+     * Resolved rates and exempt categories for a request.
+     *
+     * @param rates            rates by jurisdiction type code
+     * @param exemptCategories tax categories (upper-cased) exempt in the resolved jurisdiction
+     */
+    private record ResolvedRates(
+            @NonNull Map<String, BigDecimal> rates, @NonNull Set<String> exemptCategories) {}
+
+    /**
      * Build the top-level jurisdiction rows from the reconciler's column totals.
      */
     @NonNull
@@ -227,31 +412,58 @@ public class TestModeTaxCalculator {
     }
 
     /**
-     * Build the per-line tax breakdown, pulling reconciled line totals and
-     * per-jurisdiction cell amounts for non-exempt lines. Exempt lines carry zero
-     * tax and an empty jurisdiction breakdown (zero-rate rows are deferred to T3).
+     * Build the per-line tax breakdown from the reconciled matrix and per-line exemption
+     * classifications (story T3).
+     * <ul>
+     *   <li>{@link Outcome#EXEMPT}: zero tax, and one <em>zero-rate</em> jurisdiction row
+     *       per applicable jurisdiction (rate = jurisdiction rate, amount = 0, exempt=true,
+     *       reason echoed) so liability reports can attribute exempt sales per jurisdiction.</li>
+     *   <li>{@link Outcome#TAXABLE}: normal taxed row.</li>
+     *   <li>{@link Outcome#DENIED}: taxed normally, but {@code exemptionDenied=true} with the
+     *       claimed reason echoed (decision D-T2).</li>
+     * </ul>
      */
     @NonNull
     private List<TaxCalculationResponse.LineItemTax> buildLineItemTaxes(
             @NonNull List<TaxLineItem> lineItems,
+            @NonNull List<LineExemption> classifications,
             @NonNull List<JurisdictionSpec> specs,
             TaxTotalsReconciler.@NonNull ReconciledTax reconciled) {
+        BigDecimal zeroMoney = BigDecimal.ZERO.setScale(MONEY_SCALE, RoundingMode.HALF_UP);
         List<TaxCalculationResponse.LineItemTax> result = new ArrayList<>(lineItems.size());
         int taxableIndex = 0;
-        for (TaxLineItem item : lineItems) {
+        for (int idx = 0; idx < lineItems.size(); idx++) {
+            TaxLineItem item = lineItems.get(idx);
+            LineExemption classification = classifications.get(idx);
             BigDecimal itemSubtotal = item.getSubtotal();
-            if (item.isTaxExempt()) {
+
+            if (classification.outcome() == Outcome.EXEMPT) {
+                // Reportable zero-tax: emit zero-rate rows for every applicable jurisdiction.
+                List<TaxCalculationResponse.JurisdictionTax> exemptCells = new ArrayList<>(specs.size());
+                for (JurisdictionSpec spec : specs) {
+                    exemptCells.add(TaxCalculationResponse.JurisdictionTax.builder()
+                            .jurisdictionType(spec.type())
+                            .code(spec.type().code())
+                            .rate(spec.rate())
+                            .amount(zeroMoney)
+                            .exempt(true)
+                            .exemptionReasonCode(classification.reason())
+                            .build());
+                }
                 result.add(TaxCalculationResponse.LineItemTax.builder()
                         .lineItemId(item.getLineItemId())
                         .subtotal(itemSubtotal)
-                        .taxAmount(BigDecimal.ZERO.setScale(MONEY_SCALE, RoundingMode.HALF_UP))
+                        .taxAmount(zeroMoney)
                         .total(itemSubtotal)
                         .taxExempt(true)
-                        .jurisdictions(new ArrayList<>())
+                        .exemptionReasonCode(classification.reason())
+                        .exemptionDenied(false)
+                        .jurisdictions(exemptCells)
                         .build());
                 continue;
             }
 
+            // TAXABLE or DENIED: both are taxed via the reconciled matrix.
             int i = taxableIndex++;
             BigDecimal lineTax = reconciled.lineAmounts().get(i);
             List<BigDecimal> cellAmounts = reconciled.cellAmounts().get(i);
@@ -266,12 +478,15 @@ public class TestModeTaxCalculator {
                         .build());
             }
 
+            boolean denied = classification.outcome() == Outcome.DENIED;
             result.add(TaxCalculationResponse.LineItemTax.builder()
                     .lineItemId(item.getLineItemId())
                     .subtotal(itemSubtotal)
                     .taxAmount(lineTax)
                     .total(itemSubtotal.add(lineTax))
                     .taxExempt(false)
+                    .exemptionDenied(denied)
+                    .exemptionReasonCode(denied ? classification.reason() : null)
                     .jurisdictions(cells)
                     .build());
         }

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
@@ -350,9 +350,6 @@ public class TestModeTaxCalculator {
         if (match.getStateCode() != null && !match.getStateCode().isBlank()) {
             count++;
         }
-        if (match.getCounty() != null && !match.getCounty().isBlank()) {
-            count++;
-        }
         if (match.getCity() != null && !match.getCity().isBlank()) {
             count++;
         }

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TestModeTaxCalculator.java
@@ -139,6 +139,8 @@ public class TestModeTaxCalculator {
                 .referenceId(request.getReferenceId())
                 .referenceType(request.getReferenceType())
                 .calculationType(calculationType)
+                .originalReferenceId(
+                        calculationType == TaxCalculationType.REFUND ? request.getOriginalReferenceId() : null)
                 .build();
     }
 

--- a/pos-tax/src/main/java/com/positivity/tax/service/ExemptionCertificateService.java
+++ b/pos-tax/src/main/java/com/positivity/tax/service/ExemptionCertificateService.java
@@ -1,0 +1,57 @@
+package com.positivity.tax.service;
+
+import com.positivity.tax.internal.dto.ExemptionCertificateRequest;
+import com.positivity.tax.internal.dto.ExemptionCertificateResponse;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Registry API for tax exemption certificates (story T3, decision D-T1).
+ * <p>
+ * The certificate registry lives in pos-tax because an exemption is tax semantics, not
+ * CRM identity. This is a minimally-stateful surface: certificates drive whether a
+ * claimed exemption on the calculate path is honored or denied (D-T2).
+ */
+public interface ExemptionCertificateService {
+
+    /**
+     * List certificates, optionally filtered by customer.
+     *
+     * @param customerId optional customer filter; when {@code null} all certificates are returned
+     * @return matching certificates
+     */
+    @NonNull
+    List<ExemptionCertificateResponse> list(@Nullable String customerId);
+
+    /**
+     * Get a certificate by id.
+     *
+     * @param id the certificate id
+     * @return the certificate
+     * @throws org.springframework.web.server.ResponseStatusException 404 when not found
+     */
+    @NonNull
+    ExemptionCertificateResponse get(@NonNull UUID id);
+
+    /**
+     * Create a certificate.
+     *
+     * @param request the create payload
+     * @return the created certificate
+     */
+    @NonNull
+    ExemptionCertificateResponse create(@NonNull ExemptionCertificateRequest request);
+
+    /**
+     * Update an existing certificate.
+     *
+     * @param id      the certificate id
+     * @param request the update payload
+     * @return the updated certificate
+     * @throws org.springframework.web.server.ResponseStatusException 404 when not found
+     */
+    @NonNull
+    ExemptionCertificateResponse update(@NonNull UUID id, @NonNull ExemptionCertificateRequest request);
+}

--- a/pos-tax/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/pos-tax/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -12,9 +12,9 @@
       "description": "Default tax rates used in test mode by jurisdiction type."
     },
     {
-      "name": "pos.tax.test-mode.postal-code-mapping",
-      "type": "java.util.Map<java.lang.String, java.util.Map<java.lang.String, java.lang.String>>",
-      "description": "Postal-code to jurisdiction mappings used in test mode."
+      "name": "pos.tax.test-mode.jurisdictions",
+      "type": "java.util.List<com.positivity.tax.internal.config.TaxProperties$JurisdictionRule>",
+      "description": "Address-driven, effective-dated jurisdiction rate rules (story T7). Each rule matches on destination-address facets and carries its own rates, effective-from date, and optional per-category exemptions."
     },
     {
       "name": "pos.tax.external-service.base-url",

--- a/pos-tax/src/main/resources/application-dev.yml
+++ b/pos-tax/src/main/resources/application-dev.yml
@@ -1,4 +1,41 @@
+spring:
+  # In-memory H2 (PostgreSQL compatibility mode) for local dev; Flyway V1 runs on it.
+  datasource:
+    url: jdbc:h2:mem:pos_tax;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ''
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: validate
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
 eureka:
   client:
     serviceUrl:
       defaultZone: http://localhost:8761/eureka/
+
+# Story T7: sample address-driven jurisdiction rules demonstrating two states with
+# different breakdowns, plus a per-category exemption (LABOR exempt in TX). Unknown
+# addresses fall back to pos.tax.test-mode.default-rates (see application.yml).
+pos:
+  tax:
+    test-mode:
+      jurisdictions:
+        - match:
+            state-code: CA
+          rates:
+            STATE: 0.0625
+            COUNTY: 0.0100
+            CITY: 0.0075
+        - match:
+            state-code: TX
+          rates:
+            STATE: 0.0625
+            COUNTY: 0.0050
+          exempt-categories:
+            - LABOR

--- a/pos-tax/src/main/resources/application-test.yml
+++ b/pos-tax/src/main/resources/application-test.yml
@@ -3,6 +3,20 @@ spring:
   cloud:
     discovery:
       enabled: false
+  # In-memory H2 (PostgreSQL mode); Flyway V1 owns the schema, Hibernate validates.
+  datasource:
+    url: jdbc:h2:mem:pos_tax_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ''
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
 eureka:
   client:
@@ -19,11 +33,6 @@ pos:
         STATE: 0.08        # 8% state tax for tests
         COUNTY: 0.01       # 1% county tax for tests
         CITY: 0.01         # 1% city tax for tests
-      postal-code-mapping:
-        "12345":
-          state: "TS"
-          county: "Test County"
-          city: "Test City"
     retry:
       max-attempts: 1      # No retries in tests
       initial-backoff: 0

--- a/pos-tax/src/main/resources/application.yml
+++ b/pos-tax/src/main/resources/application.yml
@@ -6,6 +6,23 @@ spring:
       # Disabled by default - pos-tax is internal-only and should not be externally accessible
       # Enable only if deploying as standalone internal microservice
       enabled: false
+  # Persistence for the T3 exemption-certificate registry (pos-tax's only table).
+  # Deployed profiles (docker/alpha/prod) inject a Postgres datasource via env; dev/test
+  # use in-memory H2 (see application-dev.yml / application-test.yml). Flyway owns the
+  # schema; Hibernate only validates the mapping.
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:}
+    username: ${SPRING_DATASOURCE_USERNAME:}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.postgresql.Driver}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    database-platform: ${SPRING_JPA_DATABASE_PLATFORM:org.hibernate.dialect.PostgreSQLDialect}
+    open-in-view: false
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
 server:
   port: 8091

--- a/pos-tax/src/main/resources/db/migration/V1__exemption_certificate.sql
+++ b/pos-tax/src/main/resources/db/migration/V1__exemption_certificate.sql
@@ -1,0 +1,23 @@
+-- Story T3 (decision D-T1): the tax exemption-certificate registry lives in pos-tax
+-- because an exemption is tax semantics, not CRM identity. This is the first table in
+-- pos-tax (previously a stateless calculator). An active, effective, non-expired
+-- certificate drives an honored exemption on the calculate path; a claimed exemption with
+-- no valid certificate is denied and the line taxed anyway (D-T2). Written Postgres-style
+-- and validated on H2 (PostgreSQL mode) in tests.
+CREATE TABLE exemption_certificate (
+    id                 uuid NOT NULL,
+    customer_id        character varying(100) NOT NULL,
+    state_scope        character varying(10),
+    reason_code        character varying(32) NOT NULL,
+    certificate_number character varying(100),
+    effective_from     date NOT NULL,
+    expires_at         date,
+    status             character varying(16) NOT NULL,
+    created_at         timestamp(6) with time zone NOT NULL,
+    updated_at         timestamp(6) with time zone NOT NULL,
+    CONSTRAINT exemption_certificate_pkey PRIMARY KEY (id)
+);
+
+-- Calculate-path lookup: active certificates for a customer effective on a given date.
+CREATE INDEX idx_exemption_certificate_customer
+    ON exemption_certificate (customer_id, status, effective_from);

--- a/pos-tax/src/main/resources/permissions.yaml
+++ b/pos-tax/src/main/resources/permissions.yaml
@@ -6,3 +6,7 @@ permissions:
     description: "Calculate tax for line items based on destination and jurisdiction rules"
   - name: "tax:mode:view"
     description: "View current tax service mode (test or production)"
+  - name: "tax:exemption:view"
+    description: "View tax exemption certificates in the pos-tax exemption registry"
+  - name: "tax:exemption:manage"
+    description: "Create and update tax exemption certificates in the pos-tax exemption registry"

--- a/pos-tax/src/test/java/com/positivity/tax/internal/repository/ExemptionCertificateRepositoryTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/repository/ExemptionCertificateRepositoryTest.java
@@ -1,0 +1,104 @@
+package com.positivity.tax.internal.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.internal.entity.ExemptionCertificate;
+import com.positivity.tax.internal.enums.ExemptionCertificateStatus;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.data.domain.Limit;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Database-level contract for {@link ExemptionCertificateRepository} (story T3), exercised
+ * against H2 with the real Flyway {@code V1__exemption_certificate.sql} migration and
+ * Hibernate schema validation, so the migration and the entity mapping are proven
+ * consistent.
+ */
+@DataJpaTest(
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:pos_tax_repo;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "spring.jpa.hibernate.ddl-auto=validate",
+            "spring.flyway.enabled=true",
+            "spring.flyway.locations=classpath:db/migration"
+        })
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class ExemptionCertificateRepositoryTest {
+
+    private static final LocalDate TXN = LocalDate.parse("2026-06-01");
+
+    @Autowired
+    private ExemptionCertificateRepository repository;
+
+    private ExemptionCertificate cert(
+            String customerId,
+            String stateScope,
+            ExemptionCertificateStatus status,
+            String effectiveFrom,
+            String expiresAt) {
+        return ExemptionCertificate.builder()
+                .customerId(customerId)
+                .stateScope(stateScope)
+                .reasonCode(ExemptionReasonCode.RESALE)
+                .effectiveFrom(LocalDate.parse(effectiveFrom))
+                .expiresAt(expiresAt == null ? null : LocalDate.parse(expiresAt))
+                .status(status)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Migration + mapping round-trips: UUID v7 id and audit timestamps are populated on save")
+    void savesAndGeneratesIdAndTimestamps() {
+        ExemptionCertificate saved =
+                repository.save(cert("CUST-1", "CA", ExemptionCertificateStatus.ACTIVE, "2026-01-01", "2026-12-31"));
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("findActiveForCustomer returns only active, effective, non-expired certificates")
+    void findActiveFiltersByWindowAndStatus() {
+        repository.save(cert("CUST-1", "CA", ExemptionCertificateStatus.ACTIVE, "2026-01-01", "2026-12-31"));
+        repository.save(cert("CUST-1", "CA", ExemptionCertificateStatus.ACTIVE, "2026-05-01", null)); // most recent
+        repository.save(cert("CUST-1", "CA", ExemptionCertificateStatus.REVOKED, "2026-01-01", null)); // excluded
+        repository.save(cert("CUST-1", "CA", ExemptionCertificateStatus.ACTIVE, "2026-05-01", "2026-05-15")); // expired
+        repository.save(cert("CUST-2", "CA", ExemptionCertificateStatus.ACTIVE, "2026-01-01", null)); // other customer
+
+        var results = repository.findActiveForCustomer("CUST-1", "CA", ExemptionReasonCode.RESALE, TXN, Limit.of(5));
+
+        // Two qualify (effective, not expired, active); most-recently-effective first.
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).getEffectiveFrom()).isEqualTo(LocalDate.parse("2026-05-01"));
+    }
+
+    @Test
+    @DisplayName("findActiveForCustomer matches a null-scope certificate for any requested state")
+    void findActiveMatchesNullScope() {
+        repository.save(cert("CUST-9", null, ExemptionCertificateStatus.ACTIVE, "2026-01-01", null));
+
+        var results = repository.findActiveForCustomer("CUST-9", "TX", ExemptionReasonCode.RESALE, TXN, Limit.of(5));
+
+        assertThat(results).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("findActiveForCustomer excludes a future-dated certificate")
+    void findActiveExcludesFuture() {
+        repository.save(cert("CUST-3", "CA", ExemptionCertificateStatus.ACTIVE, "2026-07-01", null));
+
+        var results = repository.findActiveForCustomer("CUST-3", "CA", ExemptionReasonCode.RESALE, TXN, Limit.of(5));
+
+        assertThat(results).isEmpty();
+    }
+}

--- a/pos-tax/src/test/java/com/positivity/tax/service/ExemptionCertificateServiceImplTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/service/ExemptionCertificateServiceImplTest.java
@@ -1,0 +1,163 @@
+package com.positivity.tax.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.internal.dto.ExemptionCertificateRequest;
+import com.positivity.tax.internal.dto.ExemptionCertificateResponse;
+import com.positivity.tax.internal.entity.ExemptionCertificate;
+import com.positivity.tax.internal.enums.ExemptionCertificateStatus;
+import com.positivity.tax.internal.repository.ExemptionCertificateRepository;
+import com.positivity.tax.internal.service.ActiveCertificateLookup;
+import com.positivity.tax.internal.service.ExemptionCertificateServiceImpl;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Limit;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ExemptionCertificateServiceImpl (T3)")
+class ExemptionCertificateServiceImplTest {
+
+    private static final LocalDate TXN = LocalDate.parse("2026-06-01");
+
+    @Mock
+    private ExemptionCertificateRepository repository;
+
+    private ExemptionCertificateServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ExemptionCertificateServiceImpl(repository);
+    }
+
+    private ExemptionCertificate persisted(UUID id, String customerId) {
+        return ExemptionCertificate.builder()
+                .id(id)
+                .customerId(customerId)
+                .stateScope("CA")
+                .reasonCode(ExemptionReasonCode.RESALE)
+                .effectiveFrom(LocalDate.parse("2026-01-01"))
+                .expiresAt(LocalDate.parse("2026-12-31"))
+                .status(ExemptionCertificateStatus.ACTIVE)
+                .build();
+    }
+
+    @Test
+    @DisplayName("create defaults status to ACTIVE and persists the payload")
+    void createDefaultsStatusToActive() {
+        ExemptionCertificateRequest request = ExemptionCertificateRequest.builder()
+                .customerId("CUST-1")
+                .stateScope("CA")
+                .reasonCode(ExemptionReasonCode.RESALE)
+                .effectiveFrom(LocalDate.parse("2026-01-01"))
+                .build();
+        when(repository.save(any(ExemptionCertificate.class))).thenAnswer(inv -> {
+            ExemptionCertificate e = inv.getArgument(0);
+            e.setId(UUID.randomUUID());
+            return e;
+        });
+
+        ExemptionCertificateResponse response = service.create(request);
+
+        ArgumentCaptor<ExemptionCertificate> captor = ArgumentCaptor.forClass(ExemptionCertificate.class);
+        org.mockito.Mockito.verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(ExemptionCertificateStatus.ACTIVE);
+        assertThat(response.customerId()).isEqualTo("CUST-1");
+        assertThat(response.status()).isEqualTo(ExemptionCertificateStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("get throws 404 when not found")
+    void getThrows404() {
+        UUID id = UUID.randomUUID();
+        when(repository.findById(id)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.get(id))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    @DisplayName("list filters by customer when supplied")
+    void listFiltersByCustomer() {
+        UUID id = UUID.randomUUID();
+        when(repository.findByCustomerIdOrderByEffectiveFromDesc("CUST-1"))
+                .thenReturn(List.of(persisted(id, "CUST-1")));
+        List<ExemptionCertificateResponse> result = service.list("CUST-1");
+        assertThat(result).singleElement().satisfies(r -> assertThat(r.id()).isEqualTo(id));
+    }
+
+    // ------------------------------------------------------------------
+    // ActiveCertificateLookup (calculate path) validity semantics
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findActive by id honors a valid active certificate")
+    void findActiveByIdHonorsValid() {
+        UUID id = UUID.randomUUID();
+        when(repository.findById(id)).thenReturn(Optional.of(persisted(id, "CUST-1")));
+
+        Optional<ActiveCertificateLookup.ActiveCertificate> result =
+                service.findActive("CUST-1", id, "CA", ExemptionReasonCode.RESALE, TXN);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().reasonCode()).isEqualTo(ExemptionReasonCode.RESALE);
+    }
+
+    @Test
+    @DisplayName("findActive by id rejects an expired certificate (denied path)")
+    void findActiveByIdRejectsExpired() {
+        UUID id = UUID.randomUUID();
+        ExemptionCertificate expired = persisted(id, "CUST-1");
+        expired.setExpiresAt(LocalDate.parse("2026-05-01")); // before TXN 2026-06-01
+        when(repository.findById(id)).thenReturn(Optional.of(expired));
+
+        assertThat(service.findActive("CUST-1", id, "CA", ExemptionReasonCode.RESALE, TXN))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("findActive by id rejects a certificate belonging to another customer")
+    void findActiveByIdRejectsWrongCustomer() {
+        UUID id = UUID.randomUUID();
+        when(repository.findById(id)).thenReturn(Optional.of(persisted(id, "CUST-1")));
+
+        assertThat(service.findActive("CUST-2", id, "CA", ExemptionReasonCode.RESALE, TXN))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("findActive by customer delegates to the active-window query and takes the first row")
+    void findActiveByCustomerQuery() {
+        UUID id = UUID.randomUUID();
+        when(repository.findActiveForCustomer(
+                        eq("CUST-1"), eq("CA"), eq(ExemptionReasonCode.RESALE), eq(TXN), any(Limit.class)))
+                .thenReturn(List.of(persisted(id, "CUST-1")));
+
+        Optional<ActiveCertificateLookup.ActiveCertificate> result =
+                service.findActive("CUST-1", null, "CA", ExemptionReasonCode.RESALE, TXN);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().id()).isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("findActive returns empty when neither certificateId nor customerId is supplied")
+    void findActiveEmptyWithoutKeys() {
+        assertThat(service.findActive(null, null, "CA", ExemptionReasonCode.RESALE, TXN))
+                .isEmpty();
+    }
+}

--- a/pos-tax/src/test/java/com/positivity/tax/service/ExemptionCertificateServiceImplTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/service/ExemptionCertificateServiceImplTest.java
@@ -140,6 +140,45 @@ class ExemptionCertificateServiceImplTest {
     }
 
     @Test
+    @DisplayName("F3: findActive by id honors a certificate scoped to the requested state (CA cert, CA request)")
+    void findActiveByIdHonorsMatchingStateScope() {
+        // persisted(...) has stateScope='CA'. A request scoped to CA must be honored.
+        UUID id = UUID.randomUUID();
+        when(repository.findById(id)).thenReturn(Optional.of(persisted(id, "CUST-1")));
+
+        Optional<ActiveCertificateLookup.ActiveCertificate> result =
+                service.findActive("CUST-1", id, "CA", ExemptionReasonCode.RESALE, TXN);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().id()).isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("F3: findActive by id rejects a certificate scoped to a different state (CA cert, TX request)")
+    void findActiveByIdRejectsMismatchedStateScope() {
+        // persisted(...) has stateScope='CA'. A TX-scoped request must NOT be honored, mirroring
+        // findActiveForCustomer's stateScope predicate -> classify() sees empty -> DENIED.
+        UUID id = UUID.randomUUID();
+        when(repository.findById(id)).thenReturn(Optional.of(persisted(id, "CUST-1")));
+
+        assertThat(service.findActive("CUST-1", id, "TX", ExemptionReasonCode.RESALE, TXN))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("F3: findActive by id honors a certificate with blank stateScope against any requested state")
+    void findActiveByIdHonorsBlankStateScopeForAnyState() {
+        // A null/blank cert stateScope means all states: a TX-scoped request is still honored.
+        UUID id = UUID.randomUUID();
+        ExemptionCertificate allStates = persisted(id, "CUST-1");
+        allStates.setStateScope(null);
+        when(repository.findById(id)).thenReturn(Optional.of(allStates));
+
+        assertThat(service.findActive("CUST-1", id, "TX", ExemptionReasonCode.RESALE, TXN))
+                .isPresent();
+    }
+
+    @Test
     @DisplayName("findActive by customer delegates to the active-window query and takes the first row")
     void findActiveByCustomerQuery() {
         UUID id = UUID.randomUUID();

--- a/pos-tax/src/test/java/com/positivity/tax/service/TaxCalculationServiceTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/service/TaxCalculationServiceTest.java
@@ -9,6 +9,7 @@ import com.positivity.tax.common.dto.TaxCalculationRequest;
 import com.positivity.tax.common.dto.TaxCalculationResponse;
 import com.positivity.tax.common.dto.TaxLineItem;
 import com.positivity.tax.internal.config.TaxProperties;
+import com.positivity.tax.internal.service.ExemptionResolver;
 import com.positivity.tax.internal.service.ExternalTaxServiceClient;
 import com.positivity.tax.internal.service.TaxCalculationServiceImpl;
 import com.positivity.tax.internal.service.TestModeTaxCalculator;
@@ -54,7 +55,11 @@ class TaxCalculationServiceTest {
         testMode.setDefaultRates(rates);
         properties.setTestMode(testMode);
 
-        TestModeTaxCalculator testCalculator = new TestModeTaxCalculator(properties, FIXED_CLOCK);
+        TestModeTaxCalculator testCalculator = new TestModeTaxCalculator(
+                properties,
+                FIXED_CLOCK,
+                new ExemptionResolver(
+                        (customerId, certificateId, stateScope, reason, date) -> java.util.Optional.empty()));
         service = new TaxCalculationServiceImpl(properties, testCalculator, externalClient);
     }
 

--- a/pos-tax/src/test/java/com/positivity/tax/service/TestModeTaxCalculatorTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/service/TestModeTaxCalculatorTest.java
@@ -6,9 +6,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.positivity.tax.common.dto.TaxCalculationRequest;
 import com.positivity.tax.common.dto.TaxCalculationResponse;
 import com.positivity.tax.common.dto.TaxLineItem;
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.common.enums.TaxCalculationType;
 import com.positivity.tax.common.enums.TaxJurisdictionType;
 import com.positivity.tax.common.enums.TaxReferenceType;
 import com.positivity.tax.internal.config.TaxProperties;
+import com.positivity.tax.internal.service.ActiveCertificateLookup;
+import com.positivity.tax.internal.service.ExemptionResolver;
 import com.positivity.tax.internal.service.TestModeTaxCalculator;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -19,7 +23,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,6 +42,7 @@ class TestModeTaxCalculatorTest {
 
     private TaxProperties properties;
     private TestModeTaxCalculator calculator;
+    private StubLookup lookup;
 
     @BeforeEach
     void setUp() {
@@ -48,7 +55,27 @@ class TestModeTaxCalculatorTest {
         rates.put("CITY", new BigDecimal("0.01"));
         testMode.setDefaultRates(rates);
         properties.setTestMode(testMode);
-        calculator = new TestModeTaxCalculator(properties, FIXED_CLOCK);
+        lookup = new StubLookup();
+        calculator = new TestModeTaxCalculator(properties, FIXED_CLOCK, new ExemptionResolver(lookup));
+    }
+
+    /** Configurable stub certificate lookup: returns {@link #result} for any query. */
+    private static final class StubLookup implements ActiveCertificateLookup {
+        private Optional<ActiveCertificate> result = Optional.empty();
+
+        void returns(ActiveCertificate certificate) {
+            this.result = Optional.of(certificate);
+        }
+
+        @Override
+        public Optional<ActiveCertificate> findActive(
+                String customerId,
+                UUID certificateId,
+                String stateScope,
+                ExemptionReasonCode requestedReason,
+                LocalDate date) {
+            return result;
+        }
     }
 
     @Test
@@ -658,7 +685,276 @@ class TestModeTaxCalculatorTest {
         assertSigmaInvariant(response);
     }
 
+    // ------------------------------------------------------------------
+    // T3: Exemptions as reportable zero-tax
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T3: certificate-backed exemption yields zero-rate jurisdiction rows with reason echoed")
+    void shouldEmitZeroRateRowsForHonoredExemption() {
+        // Given - a $100 exempt line (claim: RESALE) backed by a valid certificate, plus a
+        // $50 taxable line. Combined rate is 10%.
+        lookup.returns(new ActiveCertificateLookup.ActiveCertificate(UUID.randomUUID(), ExemptionReasonCode.RESALE));
+        TaxLineItem exempt = TaxLineItem.builder()
+                .lineItemId("1")
+                .description("Resale part")
+                .quantity(BigDecimal.ONE)
+                .unitPrice(new BigDecimal("100"))
+                .taxExempt(true)
+                .exemptionReasonCode(ExemptionReasonCode.RESALE)
+                .build();
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(exempt, createLineItem("2", "Taxable", "1", "50")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then - only the taxable $50 line contributes: 50 * 0.10 = 5.00.
+        assertThat(response.getSubtotal()).isEqualByComparingTo("150.00");
+        assertThat(response.getTotalTax()).isEqualByComparingTo("5.00");
+        TaxCalculationResponse.LineItemTax exemptLine = findLine(response, "1");
+        assertThat(exemptLine.isTaxExempt()).isTrue();
+        assertThat(exemptLine.isExemptionDenied()).isFalse();
+        assertThat(exemptLine.getExemptionReasonCode()).isEqualTo(ExemptionReasonCode.RESALE);
+        assertThat(exemptLine.getTaxAmount()).isEqualByComparingTo("0.00");
+        // Zero-rate rows: one per applicable jurisdiction, rate = jurisdiction rate, amount 0.
+        assertThat(exemptLine.getJurisdictions()).hasSize(3);
+        assertThat(exemptLine.getJurisdictions()).allSatisfy(cell -> {
+            assertThat(cell.isExempt()).isTrue();
+            assertThat(cell.getExemptionReasonCode()).isEqualTo(ExemptionReasonCode.RESALE);
+            assertThat(cell.getAmount()).isEqualByComparingTo("0.00");
+            assertThat(cell.getRate()).isGreaterThan(BigDecimal.ZERO);
+        });
+        assertSigmaInvariant(response);
+    }
+
+    @Test
+    @DisplayName("T3/D-T2: claimed exemption with no valid certificate is taxed anyway and flagged denied")
+    void shouldTaxAndFlagDeniedWhenCertificateMissing() {
+        // Given - a $100 line claims GOVERNMENT exemption but the registry returns nothing
+        // (stub defaults to empty).
+        TaxLineItem claimed = TaxLineItem.builder()
+                .lineItemId("1")
+                .description("Claimed exempt")
+                .quantity(BigDecimal.ONE)
+                .unitPrice(new BigDecimal("100"))
+                .taxExempt(true)
+                .exemptionReasonCode(ExemptionReasonCode.GOVERNMENT)
+                .build();
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(claimed))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then - taxed normally (never hard-blocked): 100 * 0.10 = 10.00, flagged denied.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.00");
+        TaxCalculationResponse.LineItemTax line = findLine(response, "1");
+        assertThat(line.isTaxExempt()).isFalse();
+        assertThat(line.isExemptionDenied()).isTrue();
+        assertThat(line.getExemptionReasonCode()).isEqualTo(ExemptionReasonCode.GOVERNMENT);
+        assertThat(line.getTaxAmount()).isEqualByComparingTo("10.00");
+        assertSigmaInvariant(response);
+    }
+
+    @Test
+    @DisplayName(
+            "T3: bare taxExempt with no claim stays intrinsically exempt (backward compatible) with zero-rate rows")
+    void shouldKeepBareTaxExemptLineExempt() {
+        // Given - taxExempt=true, no reason/certificate/customerExemption; registry empty.
+        TaxLineItem bare = TaxLineItem.builder()
+                .lineItemId("1")
+                .description("Non-taxable")
+                .quantity(BigDecimal.ONE)
+                .unitPrice(new BigDecimal("100"))
+                .taxExempt(true)
+                .build();
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(bare, createLineItem("2", "Taxable", "1", "100")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then - only the taxable line contributes: 100 * 0.10 = 10.00.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.00");
+        TaxCalculationResponse.LineItemTax exemptLine = findLine(response, "1");
+        assertThat(exemptLine.isTaxExempt()).isTrue();
+        assertThat(exemptLine.isExemptionDenied()).isFalse();
+        assertThat(exemptLine.getExemptionReasonCode()).isNull();
+        assertThat(exemptLine.getJurisdictions()).hasSize(3);
+        assertThat(exemptLine.getJurisdictions())
+                .allSatisfy(cell -> assertThat(cell.isExempt()).isTrue());
+        assertSigmaInvariant(response);
+    }
+
+    @Test
+    @DisplayName("T3: request-level customerExemption applies to all lines")
+    void shouldApplyRequestLevelCustomerExemption() {
+        lookup.returns(new ActiveCertificateLookup.ActiveCertificate(UUID.randomUUID(), ExemptionReasonCode.NONPROFIT));
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(createLineItem("1", "A", "1", "100"), createLineItem("2", "B", "1", "40")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .customerId("CUST-1")
+                .customerExemption(TaxCalculationRequest.CustomerExemption.builder()
+                        .reasonCode(ExemptionReasonCode.NONPROFIT)
+                        .build())
+                .build();
+
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Both lines exempt -> zero total tax, both flagged exempt with reason echoed.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("0.00");
+        assertThat(response.getLineItemTaxes()).allSatisfy(line -> {
+            assertThat(line.isTaxExempt()).isTrue();
+            assertThat(line.getExemptionReasonCode()).isEqualTo(ExemptionReasonCode.NONPROFIT);
+        });
+        assertThat(response.getEffectiveTaxRate()).isEqualByComparingTo("0.00");
+        assertSigmaInvariant(response);
+    }
+
+    // ------------------------------------------------------------------
+    // T4: Refund/credit calculation mode
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T4: REFUND echoes calculationType, prices at the supplied (original) date, amounts positive")
+    void shouldComputeRefundModePositiveAtOriginalDate() {
+        // Effective-dated schedule: 5% before 2024-06-01, 10% after. A refund priced at the
+        // original sale date (2024-03-15) must use 5%, not today's/default rate.
+        configureSchedule(
+                scheduleEntry("2024-01-01", Map.of("STATE", new BigDecimal("0.05"))),
+                scheduleEntry("2024-06-01", Map.of("STATE", new BigDecimal("0.10"))));
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(createLineItem("1", "Returned part", "1", "100")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .transactionDate("2024-03-15")
+                .calculationType(TaxCalculationType.REFUND)
+                .originalReferenceId(UUID.randomUUID())
+                .build();
+
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        assertThat(response.getCalculationType()).isEqualTo(TaxCalculationType.REFUND);
+        // Positive amount priced at the original date (5%), callers negate at posting.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("5.00");
+        assertThat(response.getTotalTax()).isGreaterThan(BigDecimal.ZERO);
+        assertSigmaInvariant(response);
+    }
+
+    @Test
+    @DisplayName("T4: calculationType defaults to SALE and is echoed on the response")
+    void shouldDefaultCalculationTypeToSale() {
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(createLineItem("1", "Part", "1", "100")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .build();
+
+        assertThat(calculator.calculate(request).getCalculationType()).isEqualTo(TaxCalculationType.SALE);
+    }
+
+    // ------------------------------------------------------------------
+    // T7: Config-driven rate resolution in test mode
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T7: two different destination states produce different breakdowns")
+    void shouldResolveDifferentRatesPerState() {
+        configureJurisdictions(
+                rule("CA", null, Map.of("STATE", new BigDecimal("0.0625"), "COUNTY", new BigDecimal("0.0100"))),
+                rule("TX", null, Map.of("STATE", new BigDecimal("0.0625"))));
+
+        TaxCalculationResponse ca =
+                calculator.calculate(requestForState("CA", List.of(createLineItem("1", "P", "1", "100"))));
+        TaxCalculationResponse tx =
+                calculator.calculate(requestForState("TX", List.of(createLineItem("1", "P", "1", "100"))));
+
+        // CA: 6.25% + 1% = 7.25% over two jurisdictions; TX: 6.25% over one.
+        assertThat(ca.getTotalTax()).isEqualByComparingTo("7.25");
+        assertThat(ca.getJurisdictions()).hasSize(2);
+        assertThat(tx.getTotalTax()).isEqualByComparingTo("6.25");
+        assertThat(tx.getJurisdictions()).hasSize(1);
+        assertThat(ca.getTotalTax()).isNotEqualByComparingTo(tx.getTotalTax());
+    }
+
+    @Test
+    @DisplayName("T7: unknown address falls back to default-rates (current behavior preserved)")
+    void shouldFallBackToDefaultRatesForUnknownAddress() {
+        configureJurisdictions(rule("CA", null, Map.of("STATE", new BigDecimal("0.0625"))));
+
+        // NY has no matching rule -> default-rates (combined 10%) across 3 jurisdictions.
+        TaxCalculationResponse response =
+                calculator.calculate(requestForState("NY", List.of(createLineItem("1", "P", "1", "100"))));
+
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.00");
+        assertThat(response.getJurisdictions()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("T7: per-category exemption (LABOR exempt in TX) is honored and documented")
+    void shouldHonorCategoryExemption() {
+        configureJurisdictions(rule("TX", Set.of("LABOR"), Map.of("STATE", new BigDecimal("0.0625"))));
+
+        TaxLineItem labor = TaxLineItem.builder()
+                .lineItemId("1")
+                .description("Diagnostic labor")
+                .quantity(BigDecimal.ONE)
+                .unitPrice(new BigDecimal("100"))
+                .taxCategory("LABOR")
+                .build();
+        TaxLineItem goods = TaxLineItem.builder()
+                .lineItemId("2")
+                .description("Oil filter")
+                .quantity(BigDecimal.ONE)
+                .unitPrice(new BigDecimal("100"))
+                .taxCategory("GOODS")
+                .build();
+
+        TaxCalculationResponse response = calculator.calculate(requestForState("TX", List.of(labor, goods)));
+
+        // Only GOODS taxed: 100 * 0.0625 = 6.25. LABOR is a zero-rate exempt line.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("6.25");
+        TaxCalculationResponse.LineItemTax laborLine = findLine(response, "1");
+        assertThat(laborLine.isTaxExempt()).isTrue();
+        assertThat(laborLine.getTaxAmount()).isEqualByComparingTo("0.00");
+        assertThat(laborLine.getJurisdictions()).isNotEmpty();
+        assertThat(laborLine.getJurisdictions())
+                .allSatisfy(cell -> assertThat(cell.isExempt()).isTrue());
+        assertThat(findLine(response, "2").getTaxAmount()).isEqualByComparingTo("6.25");
+        assertSigmaInvariant(response);
+    }
+
     // Helper methods
+
+    /** Replace the test-mode jurisdiction rules with the given rules. */
+    private void configureJurisdictions(TaxProperties.JurisdictionRule... rules) {
+        properties.getTestMode().setJurisdictions(new ArrayList<>(List.of(rules)));
+    }
+
+    private TaxProperties.JurisdictionRule rule(
+            String stateCode, Set<String> exemptCategories, Map<String, BigDecimal> rates) {
+        TaxProperties.JurisdictionRule rule = new TaxProperties.JurisdictionRule();
+        TaxProperties.JurisdictionMatch match = new TaxProperties.JurisdictionMatch();
+        match.setStateCode(stateCode);
+        rule.setMatch(match);
+        rule.setRates(new HashMap<>(rates));
+        if (exemptCategories != null) {
+            rule.setExemptCategories(new java.util.LinkedHashSet<>(exemptCategories));
+        }
+        return rule;
+    }
+
+    private TaxCalculationRequest requestForState(String state, List<TaxLineItem> items) {
+        return TaxCalculationRequest.builder()
+                .lineItems(items)
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, state, "Anytown", "US"))
+                .build();
+    }
 
     /** Assert the three-way keystone invariant on a single response. */
     private void assertSigmaInvariant(TaxCalculationResponse response) {

--- a/pos-tax/src/test/java/com/positivity/tax/service/TestModeTaxCalculatorTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/service/TestModeTaxCalculatorTest.java
@@ -819,6 +819,74 @@ class TestModeTaxCalculatorTest {
     }
 
     // ------------------------------------------------------------------
+    // F2: present-but-EMPTY customerExemption {} is a no-op, not a claim
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName(
+            "F2: empty customerExemption {} on an intrinsic taxExempt line stays intrinsically exempt (not denied, not taxed)")
+    void emptyCustomerExemptionKeepsIntrinsicExemptLineExempt() {
+        // Given - request carries a present-but-empty customerExemption ({} : no reasonCode,
+        // no certificateId) and NO certificate is available (stub defaults to empty). One
+        // intrinsic taxExempt=true line plus a $100 taxable line. Combined rate is 10%.
+        TaxLineItem intrinsicExempt = TaxLineItem.builder()
+                .lineItemId("1")
+                .description("Non-taxable")
+                .quantity(BigDecimal.ONE)
+                .unitPrice(new BigDecimal("100"))
+                .taxExempt(true)
+                .build();
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(intrinsicExempt, createLineItem("2", "Taxable", "1", "100")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .customerId("CUST-1")
+                .customerExemption(TaxCalculationRequest.CustomerExemption.builder().build())
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then - the empty exemption is a no-op: the intrinsic line stays exempt via the
+        // intrinsic path (reason null), is NOT flagged denied, and is NOT taxed. Only the
+        // taxable $100 line contributes: 100 * 0.10 = 10.00.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.00");
+        TaxCalculationResponse.LineItemTax exemptLine = findLine(response, "1");
+        assertThat(exemptLine.isTaxExempt()).isTrue();
+        assertThat(exemptLine.isExemptionDenied()).isFalse();
+        assertThat(exemptLine.getExemptionReasonCode()).isNull();
+        assertThat(exemptLine.getTaxAmount()).isEqualByComparingTo("0.00");
+        assertThat(exemptLine.getJurisdictions())
+                .allSatisfy(cell -> assertThat(cell.isExempt()).isTrue());
+        assertSigmaInvariant(response);
+    }
+
+    @Test
+    @DisplayName("F2: empty customerExemption {} on a plain taxable line taxes normally with no exemptionDenied flag")
+    void emptyCustomerExemptionLeavesTaxableLineNormallyTaxed() {
+        // Given - a present-but-empty customerExemption ({}) and a plain taxable line
+        // (taxExempt=false, no reason/certificate). No certificate available. Combined rate 10%.
+        TaxCalculationRequest request = TaxCalculationRequest.builder()
+                .lineItems(List.of(createLineItem("1", "Plain taxable", "1", "100")))
+                .destinationAddress(createAddress(TEST_POSTAL_CODE, "CA", "Los Angeles", "US"))
+                .customerId("CUST-1")
+                .customerExemption(TaxCalculationRequest.CustomerExemption.builder().build())
+                .build();
+
+        // When
+        TaxCalculationResponse response = calculator.calculate(request);
+
+        // Then - taxed normally (100 * 0.10 = 10.00); the empty exemption never turns into a
+        // claim, so the line is neither exempt nor flagged denied.
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.00");
+        TaxCalculationResponse.LineItemTax line = findLine(response, "1");
+        assertThat(line.isTaxExempt()).isFalse();
+        assertThat(line.isExemptionDenied()).isFalse();
+        assertThat(line.getExemptionReasonCode()).isNull();
+        assertThat(line.getTaxAmount()).isEqualByComparingTo("10.00");
+        assertSigmaInvariant(response);
+    }
+
+    // ------------------------------------------------------------------
     // T4: Refund/credit calculation mode
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-tax-w2`
- Child issues: louisburroughs/durion-positivity-backend#947 (T3), #948 (T4), #949 (T7)
- Domain: `domain:tax`

Wave 2 of the pos-tax Odoo-parity plan (`durion/domains/accounting/plan-odoo-parity-pos-tax.md`), following merged Wave 1 (PR #980). Research gates R-T1/R-T2/R-T3 resolved in `.research/RESEARCH-GATE-DECISIONS.md`.

## Contract References
- Contract guide entry (durion): `domains/tax/.business-rules/BACKEND_CONTRACT_GUIDE.md` → tax-calculation contract. All `pos-tax-common` DTO changes in this PR are **additive-only** (new optional fields / new enums); no existing field changed type or nullability.
- Durion contract PR (if applicable): n/a — additive within `.v1`.

## Contract Chain (Controller changed — new `ExemptionCertificateController`)
- [x] OpenAPI annotations on the new controller + all new/changed DTO fields
- [ ] `openapi.yaml` (+ gateway aggregate) regeneration — follow-up (pos-tax is internal-only, no gateway route)
- [ ] Angular SDK regeneration — follow-up (additive `LineItemTax`/request fields)

## Scope
**What changed** — three coupled stories over the shared `pos-tax-common` contract + `TestModeTaxCalculator`:

- **T3 Exemptions as reportable zero-tax** (#947, D-T1/D-T2, R-T3=FULL): `ExemptionReasonCode` enum {RESALE, GOVERNMENT, NONPROFIT, AGRICULTURAL, OTHER}; additive DTO fields (`TaxLineItem.exemptionReasonCode/exemptionCertificateId`, `TaxCalculationRequest.customerExemption`, `LineItemTax.exemptionReasonCode/exemptionDenied`, `JurisdictionTax.exempt/exemptionReasonCode`); exempt lines emit zero-rate jurisdiction rows. First stateful table in pos-tax — `exemption_certificate` registry (V1 Flyway, `effective_from`+`expires_at`), JPA entity (UUID v7), repository, CRUD `/v1/tax/exemption-certificates` (`tax:exemption:view|manage`, `@EmitEvent TAX_EXEMPTION_CERT_CREATE|UPDATE` approval preset, bitset positions 386–387). D-T2: claim with missing/expired cert → taxed anyway + `exemptionDenied=true` (never blocks the sale).
- **T4 Refund/credit mode** (#948): `TaxCalculationType` enum {SALE, REFUND}; `calculationType`/`originalReferenceId` on request, echoed on response; REFUND prices at supplied `transactionDate`, amounts positive (callers negate). Freeze-after-finalize boundary documented in OpenAPI.
- **T7 Config-driven rates** (#949): replaced dead `postalCodeMapping` with `testMode.jurisdictions[]` resolved by address + date; consumes previously-ignored `taxCategory` for per-category exemption.

Reuses the Wave 1 `TaxTotalsReconciler` unchanged.

**Why** — closes gaps T-G3/T-G4 (exemptions), T-G5 (refunds), T-G9 (dead rate config) toward Odoo tax-engine parity while keeping pos-tax stateless-by-default and internal-only (the one new table is narrow and justified).

## Tests
- [x] Unit tests added/updated (`ExemptionResolver`, calculator T3/T4/T7 paths, service)
- [x] Integration tests added/updated (`ExemptionCertificateRepositoryTest` `@DataJpaTest` exercising V1 on H2)
- [x] Σ-invariant property test extended to hold with exempt lines (seed 424242, 2000 carts)
- **How to run:** `./mvnw -pl pos-tax-common,pos-tax -am -DskipTests=false clean test` → pos-tax **70 tests green** (ArchUnit incl.). Additive-only proven: `./mvnw -pl pos-invoice,pos-workorder -am -DskipTests compile` → SUCCESS.

## Risk & Rollback
- Risk level: **Medium** — introduces first persistence + Flyway migration in pos-tax (new datasource/JPA config per profile).
- Rollback plan: revert the branch; the `exemption_certificate` table is greenfield with no consumers outside pos-tax, so drop-on-revert is safe.

## Checklist
- [x] Branch name matches `cap/odoo-parity-tax-w2`
- [x] Links to child issues present
- [x] Contract guide referenced (BACKEND_CONTRACT_GUIDE.md)
- [x] Additive-only contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
