### PR TITLE
[CAP:odoo-parity-tax-w3] pos-tax Odoo-parity Wave 3 — persist tax breakdown + propagate to accounting (T5)

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/ExtInvoiceTax.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/ExtInvoiceTax.java
@@ -1,0 +1,80 @@
+package com.positivity.accounting.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Read-only replica of pos-invoice's per-line × per-jurisdiction tax breakdown (story T5c,
+ * ADR-0044 R3 naming: owner = invoice), materialized from {@code InvoiceUpdatedV1.taxBreakdown}.
+ *
+ * <p>Unlike {@link ExtInvoice} (which keeps the owner's invoice id verbatim as its PK), these
+ * detail rows carry no owner-assigned id, so a local UUIDv7 is generated per row. The rows are
+ * replaced wholesale (delete-then-insert) for an invoice whenever a non-stale
+ * {@code invoice.invoice.updated} arrives carrying a breakdown; {@code aggregate_version} records
+ * the invoice version the rows were materialized from. Accounting plan D1 / T8 read this replica;
+ * {@link ExtInvoice#getTax()} remains the scalar rollup.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "ext_invoice_tax",
+        indexes = {@Index(name = "idx_ext_invoice_tax_invoice", columnList = "invoice_id")})
+public class ExtInvoiceTax {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "id", columnDefinition = "UUID", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "invoice_id", columnDefinition = "UUID", nullable = false)
+    private UUID invoiceId;
+
+    @Column(name = "line_item_id", length = 64)
+    private String lineItemId;
+
+    @Column(name = "jurisdiction_type", nullable = false, length = 32)
+    private String jurisdictionType;
+
+    @Column(name = "jurisdiction_code", nullable = false, length = 64)
+    private String jurisdictionCode;
+
+    @Column(name = "rate", nullable = false, precision = 9, scale = 6)
+    private BigDecimal rate;
+
+    @Column(name = "taxable_base", nullable = false, precision = 19, scale = 4)
+    private BigDecimal taxableBase;
+
+    @Column(name = "tax_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal taxAmount;
+
+    @Column(name = "exempt", nullable = false)
+    private boolean exempt;
+
+    @Column(name = "exemption_reason_code", length = 32)
+    private String exemptionReasonCode;
+
+    @Column(name = "aggregate_version", nullable = false)
+    private long aggregateVersion;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/ExtInvoiceTaxRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/ExtInvoiceTaxRepository.java
@@ -1,0 +1,18 @@
+package com.positivity.accounting.internal.repository;
+
+import com.positivity.accounting.internal.entity.ExtInvoiceTax;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ExtInvoiceTaxRepository extends JpaRepository<ExtInvoiceTax, UUID> {
+
+    List<ExtInvoiceTax> findByInvoiceId(UUID invoiceId);
+
+    @Modifying
+    @Query("delete from ExtInvoiceTax t where t.invoiceId = :invoiceId")
+    int deleteByInvoiceId(@Param("invoiceId") UUID invoiceId);
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InvoiceEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InvoiceEventsListener.java
@@ -1,16 +1,21 @@
 package com.positivity.accounting.internal.service;
 
 import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.ExtInvoiceTax;
 import com.positivity.accounting.internal.entity.ProcessedEvent;
 import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import com.positivity.domainevents.invoice.InvoiceUpdatedV1;
+import com.positivity.domainevents.invoice.TaxBreakdownLine;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -37,6 +42,7 @@ public class InvoiceEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtInvoiceRepository extInvoiceRepository;
+    private final ExtInvoiceTaxRepository extInvoiceTaxRepository;
 
     @KafkaListener(
             topics = "${pos.accounting.kafka.invoice-events-topic:invoice.events.v1}",
@@ -114,10 +120,45 @@ public class InvoiceEventsListener {
                 .aggregateVersion(aggregateVersion)
                 .updatedAt(Instant.now(clock))
                 .build());
+        replaceTaxBreakdown(invoiceId, aggregateVersion, payload.taxBreakdown());
         log.info(
                 "Updated ext_invoice replica invoiceId={} status={} version={}",
                 invoiceId,
                 payload.status(),
                 aggregateVersion);
+    }
+
+    /**
+     * Replicate the per-line jurisdiction breakdown into {@code ext_invoice_tax} (story T5c),
+     * replacing the invoice's rows to match to the cent. Runs only on the non-stale path (the
+     * same {@code aggregateVersion} guard that protects {@link ExtInvoice} above). A {@code null}
+     * breakdown (older events / non-breakdown producers) leaves existing tax rows untouched.
+     */
+    private void replaceTaxBreakdown(
+            @NonNull UUID invoiceId, long aggregateVersion, @Nullable List<TaxBreakdownLine> breakdown) {
+        if (breakdown == null) {
+            return;
+        }
+        extInvoiceTaxRepository.deleteByInvoiceId(invoiceId);
+        if (breakdown.isEmpty()) {
+            return;
+        }
+        Instant now = Instant.now(clock);
+        List<ExtInvoiceTax> rows = breakdown.stream()
+                .map(line -> ExtInvoiceTax.builder()
+                        .invoiceId(invoiceId)
+                        .lineItemId(line.lineItemId())
+                        .jurisdictionType(line.jurisdictionType())
+                        .jurisdictionCode(line.jurisdictionCode())
+                        .rate(line.rate())
+                        .taxableBase(line.taxableBase())
+                        .taxAmount(line.taxAmount())
+                        .exempt(line.exempt())
+                        .exemptionReasonCode(line.exemptionReasonCode())
+                        .aggregateVersion(aggregateVersion)
+                        .updatedAt(now)
+                        .build())
+                .toList();
+        extInvoiceTaxRepository.saveAll(rows);
     }
 }

--- a/pos-accounting/src/main/resources/db/migration/V19__create_ext_invoice_tax.sql
+++ b/pos-accounting/src/main/resources/db/migration/V19__create_ext_invoice_tax.sql
@@ -1,0 +1,25 @@
+-- Story T5c (ADR-0044 R3, owner = invoice): read-only replica of pos-invoice's per-line x
+-- per-jurisdiction tax breakdown, materialized from invoice.invoice.updated (taxBreakdown[]).
+-- Detail rows carry no owner-assigned id, so a local UUIDv7 PK is generated per row. Rows are
+-- replaced wholesale for an invoice on each non-stale event that carries a breakdown; ext_invoice
+-- keeps the scalar tax rollup. Accounting plan D1 / T8 read this replica.
+--
+-- FLYWAY COLLISION NOTE: numbered V19 as the next contiguous version after V18. Unmerged
+-- accounting-plan branches may also claim a V1x on pos-accounting; if they merge first this file
+-- must be renumbered on rebase.
+CREATE TABLE ext_invoice_tax (
+    id uuid NOT NULL,
+    invoice_id uuid NOT NULL,
+    line_item_id varchar(64),
+    jurisdiction_type varchar(32) NOT NULL,
+    jurisdiction_code varchar(64) NOT NULL,
+    rate numeric(9, 6) NOT NULL,
+    taxable_base numeric(19, 4) NOT NULL,
+    tax_amount numeric(19, 4) NOT NULL,
+    exempt boolean NOT NULL DEFAULT false,
+    exemption_reason_code varchar(32),
+    aggregate_version bigint NOT NULL DEFAULT 0,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT ext_invoice_tax_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_ext_invoice_tax_invoice ON ext_invoice_tax (invoice_id);

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InvoiceEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InvoiceEventsListenerTest.java
@@ -9,12 +9,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.ExtInvoiceTax;
 import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,12 +34,29 @@ class InvoiceEventsListenerTest {
 
     private final ProcessedEventRepository processedEvents = mock(ProcessedEventRepository.class);
     private final ExtInvoiceRepository replica = mock(ExtInvoiceRepository.class);
+    private final ExtInvoiceTaxRepository taxReplica = mock(ExtInvoiceTaxRepository.class);
 
     private InvoiceEventsListener listener;
 
     @BeforeEach
     void setUp() {
-        listener = new InvoiceEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, replica);
+        listener = new InvoiceEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, replica, taxReplica);
+    }
+
+    private String eventWithBreakdown(String eventId, long version) {
+        return """
+                {"eventId":"%s","eventType":"invoice.invoice.updated","schemaVersion":1,
+                 "aggregateId":"%s","aggregateVersion":%d,
+                 "payload":{"invoiceId":"%s","workorderId":"%s","status":"FINALIZED",
+                            "invoiceNumber":"INV-2026-000123","total":216.53,"subtotal":200.00,"tax":16.53,
+                            "taxBreakdown":[
+                              {"lineItemId":"1","jurisdictionType":"STATE","jurisdictionCode":"STATE",
+                               "rate":0.0725,"taxableBase":200.00,"taxAmount":14.50,"exempt":false,
+                               "exemptionReasonCode":null},
+                              {"lineItemId":"1","jurisdictionType":"COUNTY","jurisdictionCode":"COUNTY",
+                               "rate":0.0102,"taxableBase":200.00,"taxAmount":2.03,"exempt":false,
+                               "exemptionReasonCode":null}]}}
+                """.formatted(eventId, INVOICE_ID, version, INVOICE_ID, WORKORDER_ID);
     }
 
     private String event(String eventId, long version) {
@@ -64,6 +84,60 @@ class InvoiceEventsListenerTest {
         assertThat(saved.getValue().getTotal()).isEqualByComparingTo(new BigDecimal("216.00"));
         assertThat(saved.getValue().getAggregateVersion()).isEqualTo(5L);
         verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Materializes the tax breakdown into ext_invoice_tax matching the scalar to the cent")
+    void materializesTaxBreakdown() {
+        when(processedEvents.existsById("e-tb")).thenReturn(false);
+        when(replica.findById(INVOICE_ID)).thenReturn(Optional.empty());
+
+        listener.onInvoiceEvent(eventWithBreakdown("e-tb", 7));
+
+        verify(taxReplica).deleteByInvoiceId(INVOICE_ID);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ExtInvoiceTax>> saved = ArgumentCaptor.forClass(List.class);
+        verify(taxReplica).saveAll(saved.capture());
+        List<ExtInvoiceTax> rows = saved.getValue();
+        assertThat(rows).hasSize(2);
+        assertThat(rows).allSatisfy(r -> {
+            assertThat(r.getInvoiceId()).isEqualTo(INVOICE_ID);
+            assertThat(r.getAggregateVersion()).isEqualTo(7L);
+        });
+        // T1 invariant: the replicated per-jurisdiction amounts sum to the scalar tax (16.53).
+        BigDecimal sum = rows.stream().map(ExtInvoiceTax::getTaxAmount).reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(sum).isEqualByComparingTo(new BigDecimal("16.53"));
+    }
+
+    @Test
+    @DisplayName("Leaves ext_invoice_tax untouched when the event carries no breakdown")
+    void skipsTaxBreakdownWhenAbsent() {
+        when(processedEvents.existsById("e-nobreak")).thenReturn(false);
+        when(replica.findById(INVOICE_ID)).thenReturn(Optional.empty());
+
+        listener.onInvoiceEvent(event("e-nobreak", 3));
+
+        verify(taxReplica, never()).deleteByInvoiceId(any());
+        verify(taxReplica, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("Does not replicate the breakdown for a stale event")
+    void skipsTaxBreakdownForStaleEvent() {
+        when(processedEvents.existsById("e-stale-tb")).thenReturn(false);
+        when(replica.findById(INVOICE_ID))
+                .thenReturn(Optional.of(ExtInvoice.builder()
+                        .invoiceId(INVOICE_ID)
+                        .workorderId(WORKORDER_ID)
+                        .status("POSTED")
+                        .aggregateVersion(9L)
+                        .updatedAt(Instant.now(TEST_CLOCK))
+                        .build()));
+
+        listener.onInvoiceEvent(eventWithBreakdown("e-stale-tb", 5));
+
+        verify(taxReplica, never()).deleteByInvoiceId(any());
+        verify(taxReplica, never()).saveAll(any());
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/invoice/InvoiceUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/invoice/InvoiceUpdatedV1.java
@@ -2,6 +2,7 @@ package com.positivity.domainevents.invoice;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -19,6 +20,13 @@ import org.jspecify.annotations.Nullable;
  * <p>{@code partyId} is a free-form string because pos-invoice stores it that way (usually a
  * commercial-party UUID). The envelope's {@code aggregateVersion} is the invoice row's JPA
  * optimistic-lock version, so consumers can drop stale out-of-order deliveries.
+ *
+ * <p>{@code taxBreakdown} (story T5b) is the additive per-line × per-jurisdiction tax matrix
+ * pos-invoice persists ({@code invoice_line_tax}). It stays within schema v1 (ADR-0044 §3:
+ * additive, consumers tolerate unknown/absent fields) — there is no {@code InvoiceUpdatedV2} and
+ * no dual-publish. It is {@code null} for producers/older events that carry no breakdown; the
+ * scalar {@code tax} above remains the denormalized rollup (decision D-T6), and where the
+ * breakdown is present {@code tax == Σ taxBreakdown.taxAmount} holds.
  */
 public record InvoiceUpdatedV1(
         @NonNull UUID invoiceId,
@@ -33,7 +41,8 @@ public record InvoiceUpdatedV1(
         @Nullable BigDecimal total,
         @Nullable BigDecimal adjustmentsAmount,
         @Nullable Instant createdAt,
-        @Nullable Instant finalizedAt) {
+        @Nullable Instant finalizedAt,
+        @Nullable List<TaxBreakdownLine> taxBreakdown) {
 
     public static final String EVENT_TYPE = "invoice.invoice.updated";
     public static final int SCHEMA_VERSION = 1;

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/invoice/TaxBreakdownLine.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/invoice/TaxBreakdownLine.java
@@ -1,0 +1,44 @@
+package com.positivity.domainevents.invoice;
+
+import java.math.BigDecimal;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One persisted per-line × per-jurisdiction tax row carried additively on
+ * {@link InvoiceUpdatedV1#taxBreakdown()} (story T5b, ADR-0044 §3).
+ *
+ * <p>This is the event-contract projection of pos-invoice's {@code invoice_line_tax} rows, which
+ * in turn mirror the per-line jurisdiction matrix produced by pos-tax
+ * ({@code TaxCalculationResponse.LineItemTax.jurisdictions[]}). It is deliberately
+ * dependency-light: {@code jurisdictionType} and {@code exemptionReasonCode} are plain
+ * {@code String}s rather than pos-tax-common enums, so {@code pos-domain-events} need not depend
+ * on {@code pos-tax-common}. Consumers that want the typed enums re-parse the codes.
+ *
+ * <p>Money is {@link BigDecimal} at currency scale (HALF_UP). The scalar
+ * {@link InvoiceUpdatedV1#tax()} remains the denormalized rollup; where a full breakdown is
+ * present the invariant {@code tax == Σ taxAmount} holds (decision D-T6).
+ *
+ * @param lineItemId          the invoice line identifier this row was priced from; {@code null}
+ *                            for a summary-only row or when the producer could not attribute it
+ * @param jurisdictionType    the jurisdiction type code (e.g. {@code STATE}, {@code COUNTY},
+ *                            {@code CITY}, {@code DISTRICT})
+ * @param jurisdictionCode    the taxing-authority code within that type
+ * @param rate                the applied rate as a decimal fraction (e.g. {@code 0.0725} for
+ *                            7.25%)
+ * @param taxableBase         the base amount the rate was applied to for this line/jurisdiction
+ * @param taxAmount           the calculated tax for this line/jurisdiction ({@code 0} on an
+ *                            exempt zero-rate row)
+ * @param exempt              whether this is a reportable zero-rate exempt row (story T3)
+ * @param exemptionReasonCode the exemption reason echoed onto an exempt (or exemption-denied)
+ *                            row; {@code null} for a normal taxed row
+ */
+public record TaxBreakdownLine(
+        @Nullable String lineItemId,
+        @NonNull String jurisdictionType,
+        @NonNull String jurisdictionCode,
+        @NonNull BigDecimal rate,
+        @NonNull BigDecimal taxableBase,
+        @NonNull BigDecimal taxAmount,
+        boolean exempt,
+        @Nullable String exemptionReasonCode) {}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/invoice/InvoiceUpdatedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/invoice/InvoiceUpdatedV1Test.java
@@ -1,0 +1,108 @@
+package com.positivity.domainevents.invoice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class InvoiceUpdatedV1Test {
+
+    private static final ObjectMapper MAPPER =
+            JsonMapper.builder().findAndAddModules().build();
+
+    private static final UUID INVOICE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000001");
+    private static final UUID WORKORDER_ID = UUID.fromString("01980a58-0000-7000-8000-000000000002");
+
+    private static InvoiceUpdatedV1 event(List<TaxBreakdownLine> breakdown) {
+        return new InvoiceUpdatedV1(
+                INVOICE_ID,
+                "INV-2026-000123",
+                WORKORDER_ID,
+                null,
+                null,
+                "party-1",
+                "FINALIZED",
+                new BigDecimal("200.00"),
+                new BigDecimal("16.53"),
+                new BigDecimal("216.53"),
+                BigDecimal.ZERO,
+                Instant.parse("2026-07-20T10:00:00Z"),
+                Instant.parse("2026-07-20T10:05:00Z"),
+                breakdown);
+    }
+
+    @Test
+    void roundTripPreservesTaxBreakdown() {
+        TaxBreakdownLine state = new TaxBreakdownLine(
+                "1",
+                "STATE",
+                "STATE",
+                new BigDecimal("0.0725"),
+                new BigDecimal("200.00"),
+                new BigDecimal("14.50"),
+                false,
+                null);
+        TaxBreakdownLine county = new TaxBreakdownLine(
+                "1",
+                "COUNTY",
+                "COUNTY",
+                new BigDecimal("0.0102"),
+                new BigDecimal("200.00"),
+                new BigDecimal("2.03"),
+                false,
+                null);
+        InvoiceUpdatedV1 evt = event(List.of(state, county));
+
+        String json = MAPPER.writeValueAsString(evt);
+        InvoiceUpdatedV1 read = MAPPER.readValue(json, InvoiceUpdatedV1.class);
+
+        assertThat(read).isEqualTo(evt);
+        assertThat(read.taxBreakdown()).hasSize(2);
+        // Scalar rollup equals the sum of the breakdown taxAmounts (decision D-T6 invariant).
+        BigDecimal breakdownSum =
+                read.taxBreakdown().stream().map(TaxBreakdownLine::taxAmount).reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(read.tax()).isEqualByComparingTo(breakdownSum);
+    }
+
+    @Test
+    void roundTripToleratesAbsentTaxBreakdown() {
+        // Older producers / non-breakdown transitions omit the field entirely.
+        String legacyJson = MAPPER.writeValueAsString(event(null));
+        assertThat(legacyJson).doesNotContain("\"taxBreakdown\":[");
+
+        InvoiceUpdatedV1 read = MAPPER.readValue(legacyJson, InvoiceUpdatedV1.class);
+        assertThat(read.taxBreakdown()).isNull();
+        assertThat(read.status()).isEqualTo("FINALIZED");
+    }
+
+    @Test
+    void schemaStaysAtVersionOne() {
+        assertThat(InvoiceUpdatedV1.SCHEMA_VERSION).isEqualTo(1);
+        assertThat(InvoiceUpdatedV1.EVENT_TYPE).isEqualTo("invoice.invoice.updated");
+    }
+
+    @Test
+    void exemptZeroRateRowSurvivesRoundTrip() {
+        TaxBreakdownLine exemptRow = new TaxBreakdownLine(
+                "2",
+                "STATE",
+                "STATE",
+                new BigDecimal("0.0725"),
+                new BigDecimal("50.00"),
+                BigDecimal.ZERO,
+                true,
+                "RESALE");
+        InvoiceUpdatedV1 read =
+                MAPPER.readValue(MAPPER.writeValueAsString(event(List.of(exemptRow))), InvoiceUpdatedV1.class);
+
+        TaxBreakdownLine row = read.taxBreakdown().get(0);
+        assertThat(row.exempt()).isTrue();
+        assertThat(row.exemptionReasonCode()).isEqualTo("RESALE");
+        assertThat(row.taxAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/client/TaxServiceClient.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/client/TaxServiceClient.java
@@ -34,7 +34,7 @@ public class TaxServiceClient {
     }
 
     /**
-     * Calculate tax for an invoice against the shop-location jurisdiction.
+     * Calculate tax for an invoice against the shop-location jurisdiction, returning the total.
      *
      * @param lineItems   the taxable line items
      * @param destination the tax jurisdiction address (shop location)
@@ -43,6 +43,25 @@ public class TaxServiceClient {
      */
     @NonNull
     public BigDecimal calculateTax(
+            @NonNull List<TaxLineItem> lineItems, @NonNull TaxAddress destination, @Nullable UUID referenceId) {
+        return safeMoney(
+                calculateTaxDetailed(lineItems, destination, referenceId).getTotalTax(), BigDecimal.ZERO);
+    }
+
+    /**
+     * Calculate tax and return the full {@link TaxCalculationResponse} — including the per-line ×
+     * per-jurisdiction breakdown ({@code LineItemTax.jurisdictions[]}) that story T5 persists.
+     *
+     * <p>Unlike {@link #calculateTax}, this does NOT truncate to the scalar total; callers that
+     * only need the rollup should prefer {@link #calculateTax}.
+     *
+     * @param lineItems   the taxable line items
+     * @param destination the tax jurisdiction address (shop location)
+     * @param referenceId the source invoice/workorder identifier, for traceability
+     * @return the full tax calculation response
+     */
+    @NonNull
+    public TaxCalculationResponse calculateTaxDetailed(
             @NonNull List<TaxLineItem> lineItems, @NonNull TaxAddress destination, @Nullable UUID referenceId) {
         if (log.isDebugEnabled()) {
             log.debug(
@@ -78,7 +97,7 @@ public class TaxServiceClient {
             throw new IllegalStateException("Tax service returned a null response for tax calculation");
         }
 
-        return safeMoney(response.getTotalTax(), BigDecimal.ZERO);
+        return response;
     }
 
     @NonNull

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/config/InvoiceEventPublisher.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/config/InvoiceEventPublisher.java
@@ -4,15 +4,20 @@ import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.DomainTopics;
 import com.positivity.domainevents.invoice.BillingRulesUpdatedV1;
 import com.positivity.domainevents.invoice.InvoiceUpdatedV1;
+import com.positivity.domainevents.invoice.TaxBreakdownLine;
 import com.positivity.invoice.internal.entity.BillingRules;
 import com.positivity.invoice.internal.entity.Invoice;
+import com.positivity.invoice.internal.entity.InvoiceLineTax;
+import com.positivity.invoice.internal.repository.InvoiceLineTaxRepository;
 import jakarta.persistence.EntityManager;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 
@@ -32,6 +37,7 @@ public class InvoiceEventPublisher {
     private final Clock clock;
     private final EntityManager entityManager;
     private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+    private final InvoiceLineTaxRepository invoiceLineTaxRepository;
 
     public void publishInvoiceUpdated(@NonNull Invoice invoice) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
@@ -55,7 +61,8 @@ public class InvoiceEventPublisher {
                 invoice.getTotal(),
                 invoice.getAdjustmentsAmount(),
                 invoice.getCreatedAt(),
-                invoice.getFinalizedAt());
+                invoice.getFinalizedAt(),
+                buildTaxBreakdown(invoice.getId()));
         DomainEventEnvelope<InvoiceUpdatedV1> envelope = DomainEventEnvelope.of(
                 InvoiceUpdatedV1.EVENT_TYPE,
                 InvoiceUpdatedV1.SCHEMA_VERSION,
@@ -68,6 +75,33 @@ public class InvoiceEventPublisher {
                 clock);
         writer.publish(DomainTopics.events("invoice"), envelope);
         log.debug("Queued invoice.invoice.updated invoiceId={} status={}", invoice.getId(), invoice.getStatus());
+    }
+
+    /**
+     * Projects the persisted {@code invoice_line_tax} rows onto the additive event breakdown
+     * (story T5b). Returns {@code null} when there are no rows so downstream replicas leave any
+     * existing tax rows untouched (matches the accounting listener's null-tolerant contract).
+     */
+    @Nullable
+    private List<TaxBreakdownLine> buildTaxBreakdown(@Nullable UUID invoiceId) {
+        if (invoiceId == null) {
+            return null;
+        }
+        List<InvoiceLineTax> rows = invoiceLineTaxRepository.findByInvoiceId(invoiceId);
+        if (rows.isEmpty()) {
+            return null;
+        }
+        return rows.stream()
+                .map(r -> new TaxBreakdownLine(
+                        r.getLineItemId(),
+                        r.getJurisdictionType(),
+                        r.getJurisdictionCode(),
+                        r.getRate(),
+                        r.getTaxableBase(),
+                        r.getTaxAmount(),
+                        r.isExempt(),
+                        r.getExemptionReasonCode()))
+                .toList();
     }
 
     /** Emits {@code invoice.billing-rules.updated} after a rules mutation (ADR-0044, #902). */

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/InvoiceLineTax.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/InvoiceLineTax.java
@@ -1,0 +1,82 @@
+package com.positivity.invoice.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Persisted per-line × per-jurisdiction tax row for an invoice (story T5a).
+ *
+ * <p>Materialized wholesale from {@code TaxCalculationResponse.LineItemTax.jurisdictions[]} each
+ * time a DRAFT invoice is (re)priced; frozen once the invoice is finalized (the re-price path is
+ * guarded to DRAFT only). The rollup companion is {@link InvoiceTaxSummary}. The invariant
+ * {@code Invoice.tax == Σ taxAmount} holds across these rows (decision D-T6).
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "invoice_line_tax",
+        indexes = {@Index(name = "idx_invoice_line_tax_invoice", columnList = "invoice_id")})
+public class InvoiceLineTax {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "id", columnDefinition = "UUID", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "invoice_id", columnDefinition = "UUID", nullable = false)
+    private UUID invoiceId;
+
+    /** The taxed line's identifier as sent to pos-tax; nullable for provider rows without one. */
+    @Column(name = "line_item_id", length = 64)
+    private String lineItemId;
+
+    @Column(name = "jurisdiction_type", nullable = false, length = 32)
+    private String jurisdictionType;
+
+    @Column(name = "jurisdiction_code", nullable = false, length = 64)
+    private String jurisdictionCode;
+
+    @Column(name = "rate", nullable = false, precision = 9, scale = 6)
+    private BigDecimal rate;
+
+    @Column(name = "taxable_base", nullable = false, precision = 19, scale = 4)
+    private BigDecimal taxableBase;
+
+    @Column(name = "tax_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal taxAmount;
+
+    @Column(name = "exempt", nullable = false)
+    private boolean exempt;
+
+    @Column(name = "exemption_reason_code", length = 32)
+    private String exemptionReasonCode;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/InvoiceTaxSummary.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/InvoiceTaxSummary.java
@@ -1,0 +1,66 @@
+package com.positivity.invoice.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Per-jurisdiction rollup of an invoice's tax (story T5a): one row per jurisdiction, aggregating
+ * the {@link InvoiceLineTax} rows across all lines. Rebuilt wholesale alongside the line rows on
+ * each DRAFT re-price; frozen after finalization.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "invoice_tax_summary",
+        indexes = {@Index(name = "idx_invoice_tax_summary_invoice", columnList = "invoice_id")})
+public class InvoiceTaxSummary {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "id", columnDefinition = "UUID", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "invoice_id", columnDefinition = "UUID", nullable = false)
+    private UUID invoiceId;
+
+    @Column(name = "jurisdiction_type", nullable = false, length = 32)
+    private String jurisdictionType;
+
+    @Column(name = "jurisdiction_code", nullable = false, length = 64)
+    private String jurisdictionCode;
+
+    @Column(name = "taxable_base", nullable = false, precision = 19, scale = 4)
+    private BigDecimal taxableBase;
+
+    @Column(name = "tax_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal taxAmount;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/InvoiceLineTaxRepository.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/InvoiceLineTaxRepository.java
@@ -1,0 +1,20 @@
+package com.positivity.invoice.internal.repository;
+
+import com.positivity.invoice.internal.entity.InvoiceLineTax;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface InvoiceLineTaxRepository extends JpaRepository<InvoiceLineTax, UUID> {
+
+    @NonNull
+    List<InvoiceLineTax> findByInvoiceId(@NonNull UUID invoiceId);
+
+    @Modifying
+    @Query("delete from InvoiceLineTax lt where lt.invoiceId = :invoiceId")
+    int deleteByInvoiceId(@Param("invoiceId") @NonNull UUID invoiceId);
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/InvoiceTaxSummaryRepository.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/repository/InvoiceTaxSummaryRepository.java
@@ -1,0 +1,20 @@
+package com.positivity.invoice.internal.repository;
+
+import com.positivity.invoice.internal.entity.InvoiceTaxSummary;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface InvoiceTaxSummaryRepository extends JpaRepository<InvoiceTaxSummary, UUID> {
+
+    @NonNull
+    List<InvoiceTaxSummary> findByInvoiceId(@NonNull UUID invoiceId);
+
+    @Modifying
+    @Query("delete from InvoiceTaxSummary ts where ts.invoiceId = :invoiceId")
+    int deleteByInvoiceId(@Param("invoiceId") @NonNull UUID invoiceId);
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceServiceImpl.java
@@ -20,6 +20,7 @@ import com.positivity.shared.dto.InvoiceGenerationResponse;
 import com.positivity.shared.dto.InvoiceLineItem;
 import com.positivity.shared.id.UUIDv7Generator;
 import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
 import com.positivity.tax.common.dto.TaxLineItem;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -49,6 +50,7 @@ public class InvoiceServiceImpl implements InvoiceService {
     private final LocationReferenceService locationReferenceService;
     private final WorkorderReferenceService workorderReferenceService;
     private final InvoiceEventPublisher invoiceEventPublisher;
+    private final InvoiceTaxBreakdownWriter taxBreakdownWriter;
 
     /**
      * Self-reference (lazy to break the construction cycle) used so the public
@@ -69,6 +71,7 @@ public class InvoiceServiceImpl implements InvoiceService {
             @NonNull LocationReferenceService locationReferenceService,
             @NonNull WorkorderReferenceService workorderReferenceService,
             @NonNull InvoiceEventPublisher invoiceEventPublisher,
+            @NonNull InvoiceTaxBreakdownWriter taxBreakdownWriter,
             Clock clock) {
         this.clock = clock;
         this.invoiceRepository = invoiceRepository;
@@ -76,6 +79,7 @@ public class InvoiceServiceImpl implements InvoiceService {
         this.locationReferenceService = locationReferenceService;
         this.workorderReferenceService = workorderReferenceService;
         this.invoiceEventPublisher = invoiceEventPublisher;
+        this.taxBreakdownWriter = taxBreakdownWriter;
     }
 
     @Override
@@ -160,9 +164,12 @@ public class InvoiceServiceImpl implements InvoiceService {
         adjustment.setExternalReference(externalReference);
 
         invoice.addAdjustment(adjustment);
-        recalculateTotals(invoice);
+        TaxCalculationResponse taxResponse = recalculateTotals(invoice);
 
         Invoice saved = invoiceRepository.save(invoice);
+        // Rebuild the persisted breakdown wholesale, then publish it (freeze-after-finalize:
+        // reachable only while DRAFT, enforced by validateDraftState above and recalculateTotals).
+        taxBreakdownWriter.replace(Objects.requireNonNull(saved.getId(), "invoiceId is required"), taxResponse);
         invoiceEventPublisher.publishInvoiceUpdated(saved);
         InvoiceDetailsResponse response = toDetailsResponse(saved);
         response.setWorkorderNumber(resolveWorkorderNumber(saved.getWorkorderId()));
@@ -202,7 +209,7 @@ public class InvoiceServiceImpl implements InvoiceService {
                 .setScale(4, RoundingMode.HALF_UP);
 
         invoice.setSubtotal(subtotal);
-        recalculateTotals(invoice);
+        TaxCalculationResponse taxResponse = recalculateTotals(invoice);
 
         Invoice saved = invoiceRepository.save(invoice);
         // Assign the invoice number at draft creation. The number is the invoice's stable
@@ -213,6 +220,9 @@ public class InvoiceServiceImpl implements InvoiceService {
             saved.setInvoiceNumber(generateInvoiceNumber(saved));
             saved = invoiceRepository.save(saved);
         }
+        // Persist the per-line jurisdiction breakdown once the id is assigned, before the event
+        // is built (the publisher reads these rows to populate taxBreakdown[]).
+        taxBreakdownWriter.replace(Objects.requireNonNull(saved.getId(), "invoiceId is required"), taxResponse);
         invoiceEventPublisher.publishInvoiceUpdated(saved);
         return toGenerationResponse(saved);
     }
@@ -241,7 +251,12 @@ public class InvoiceServiceImpl implements InvoiceService {
         }
     }
 
-    private void recalculateTotals(@NonNull Invoice invoice) {
+    @Nullable
+    private TaxCalculationResponse recalculateTotals(@NonNull Invoice invoice) {
+        // Freeze-after-finalize (story T5a): tax and its persisted breakdown are immutable once
+        // the invoice leaves DRAFT. Reject any re-price/tax-write attempt on a finalized invoice.
+        assertRepricingAllowed(invoice);
+
         BigDecimal adjustmentTotal = invoice.getAdjustmentEntries().stream()
                 .map(this::toSignedAdjustmentAmount)
                 .reduce(BigDecimal.ZERO, BigDecimal::add)
@@ -250,7 +265,10 @@ public class InvoiceServiceImpl implements InvoiceService {
         invoice.setAdjustments(adjustmentTotal);
         invoice.setAdjustmentsAmount(adjustmentTotal);
 
-        BigDecimal tax = calculateTax(invoice);
+        TaxCalculationResponse taxResponse = calculateTaxResponse(invoice);
+        BigDecimal tax = taxResponse == null
+                ? BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP)
+                : safeMoney(taxResponse.getTotalTax(), BigDecimal.ZERO);
         invoice.setTax(tax);
 
         BigDecimal total = invoice.getSubtotal().add(tax).add(adjustmentTotal).setScale(4, RoundingMode.HALF_UP);
@@ -260,21 +278,36 @@ public class InvoiceServiceImpl implements InvoiceService {
                     "invoice total cannot be negative; adjustments would require a credit memo");
         }
         invoice.setTotal(total);
+        return taxResponse;
     }
 
     /**
-     * Calculate tax for the invoice against its shop-location jurisdiction.
+     * Freeze-after-finalize guard (story T5a): the invoice's tax and persisted breakdown may only
+     * be (re)computed while DRAFT. A finalized/posted invoice's tax is immutable.
+     */
+    private void assertRepricingAllowed(@NonNull Invoice invoice) {
+        if (invoice.getStatus() != InvoiceStatus.DRAFT) {
+            throw new InvalidInvoiceStateException(
+                    Objects.requireNonNull(invoice.getId(), "invoiceId is required"),
+                    invoice.getStatus(),
+                    InvoiceStatus.DRAFT);
+        }
+    }
+
+    /**
+     * Calculate tax for the invoice against its shop-location jurisdiction, returning the full
+     * response (including the per-line jurisdiction breakdown story T5 persists).
      *
      * <p>Tax is computed on the invoice line items (the goods/services sold), matching the
      * estimate flow. Invoice-level adjustments (discounts/fees) are applied to the total
      * after tax and are not part of the taxable base. When there is nothing taxable the tax
-     * service is not called.
+     * service is not called and {@code null} is returned.
      */
-    @NonNull
-    private BigDecimal calculateTax(@NonNull Invoice invoice) {
+    @Nullable
+    private TaxCalculationResponse calculateTaxResponse(@NonNull Invoice invoice) {
         List<TaxLineItem> taxLineItems = buildTaxLineItems(invoice);
         if (taxLineItems.isEmpty()) {
-            return BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP);
+            return null;
         }
 
         UUID locationId = invoice.getLocationId();
@@ -284,9 +317,7 @@ public class InvoiceServiceImpl implements InvoiceService {
         }
 
         TaxAddress destination = locationReferenceService.resolveTaxAddress(locationId);
-        return taxServiceClient
-                .calculateTax(taxLineItems, destination, invoice.getWorkorderId())
-                .setScale(4, RoundingMode.HALF_UP);
+        return taxServiceClient.calculateTaxDetailed(taxLineItems, destination, invoice.getWorkorderId());
     }
 
     @NonNull

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxBreakdownWriter.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxBreakdownWriter.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Component;
  * DRAFT re-price is idempotent. Callers guard finalized invoices before invoking this (the freeze
  * lives in the service). Mechanical only — no state or lifecycle knowledge here.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 class InvoiceTaxBreakdownWriter {
@@ -62,6 +64,20 @@ class InvoiceTaxBreakdownWriter {
                 String type = j.getJurisdictionType() == null
                         ? null
                         : j.getJurisdictionType().code();
+                // jurisdiction_type/code/rate are NOT NULL in the schema. A row missing any of
+                // them cannot be persisted; skip it defensively rather than fail the whole
+                // finalization (pos-tax always populates these for real tax rows).
+                if (type == null || j.getCode() == null || j.getRate() == null) {
+                    log.warn(
+                            "Skipping tax breakdown row for invoice {} line {}: incomplete jurisdiction"
+                                    + " identity (type={}, code={}, rate={})",
+                            invoiceId,
+                            line.getLineItemId(),
+                            type,
+                            j.getCode(),
+                            j.getRate());
+                    continue;
+                }
                 String reason = j.getExemptionReasonCode() == null
                         ? null
                         : j.getExemptionReasonCode().name();

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxBreakdownWriter.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxBreakdownWriter.java
@@ -1,0 +1,106 @@
+package com.positivity.invoice.internal.service;
+
+import com.positivity.invoice.internal.entity.InvoiceLineTax;
+import com.positivity.invoice.internal.entity.InvoiceTaxSummary;
+import com.positivity.invoice.internal.repository.InvoiceLineTaxRepository;
+import com.positivity.invoice.internal.repository.InvoiceTaxSummaryRepository;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import com.positivity.tax.common.dto.TaxCalculationResponse.JurisdictionTax;
+import com.positivity.tax.common.dto.TaxCalculationResponse.LineItemTax;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Materializes the persisted per-line × per-jurisdiction tax matrix (story T5a) for an invoice.
+ *
+ * <p>Rebuilds {@code invoice_line_tax} and its {@code invoice_tax_summary} rollup wholesale from a
+ * {@link TaxCalculationResponse}: every existing row for the invoice is deleted and replaced, so a
+ * DRAFT re-price is idempotent. Callers guard finalized invoices before invoking this (the freeze
+ * lives in the service). Mechanical only — no state or lifecycle knowledge here.
+ */
+@Component
+@RequiredArgsConstructor
+class InvoiceTaxBreakdownWriter {
+
+    private static final int MONEY_SCALE = 4;
+
+    private final InvoiceLineTaxRepository lineTaxRepository;
+    private final InvoiceTaxSummaryRepository taxSummaryRepository;
+
+    /**
+     * Replace the stored breakdown for {@code invoiceId} with the rows in {@code response}.
+     *
+     * @param invoiceId the invoice whose breakdown is rebuilt
+     * @param response  the calculation response to materialize; {@code null} (nothing taxable)
+     *                  clears the breakdown
+     */
+    void replace(@NonNull UUID invoiceId, @Nullable TaxCalculationResponse response) {
+        lineTaxRepository.deleteByInvoiceId(invoiceId);
+        taxSummaryRepository.deleteByInvoiceId(invoiceId);
+        if (response == null || response.getLineItemTaxes() == null) {
+            return;
+        }
+
+        List<InvoiceLineTax> lineRows = new ArrayList<>();
+        Map<String, InvoiceTaxSummary> summaries = new LinkedHashMap<>();
+
+        for (LineItemTax line : response.getLineItemTaxes()) {
+            if (line.getJurisdictions() == null) {
+                continue;
+            }
+            BigDecimal taxableBase = scale(line.getSubtotal());
+            for (JurisdictionTax j : line.getJurisdictions()) {
+                String type = j.getJurisdictionType() == null
+                        ? null
+                        : j.getJurisdictionType().code();
+                String reason = j.getExemptionReasonCode() == null
+                        ? null
+                        : j.getExemptionReasonCode().name();
+                BigDecimal amount = scale(j.getAmount());
+                lineRows.add(InvoiceLineTax.builder()
+                        .invoiceId(invoiceId)
+                        .lineItemId(line.getLineItemId())
+                        .jurisdictionType(type)
+                        .jurisdictionCode(j.getCode())
+                        .rate(j.getRate())
+                        .taxableBase(taxableBase)
+                        .taxAmount(amount)
+                        .exempt(j.isExempt())
+                        .exemptionReasonCode(reason)
+                        .build());
+
+                String key = type + "|" + j.getCode();
+                InvoiceTaxSummary summary = summaries.computeIfAbsent(
+                        key,
+                        k -> InvoiceTaxSummary.builder()
+                                .invoiceId(invoiceId)
+                                .jurisdictionType(type)
+                                .jurisdictionCode(j.getCode())
+                                .taxableBase(BigDecimal.ZERO)
+                                .taxAmount(BigDecimal.ZERO)
+                                .build());
+                summary.setTaxableBase(scale(summary.getTaxableBase().add(taxableBase)));
+                summary.setTaxAmount(scale(summary.getTaxAmount().add(amount)));
+            }
+        }
+
+        if (!lineRows.isEmpty()) {
+            lineTaxRepository.saveAll(lineRows);
+            taxSummaryRepository.saveAll(new ArrayList<>(summaries.values()));
+        }
+    }
+
+    @NonNull
+    private static BigDecimal scale(@Nullable BigDecimal value) {
+        return (value == null ? BigDecimal.ZERO : value).setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+    }
+}

--- a/pos-invoice/src/main/resources/db/migration/V13__invoice_tax_breakdown.sql
+++ b/pos-invoice/src/main/resources/db/migration/V13__invoice_tax_breakdown.sql
@@ -20,6 +20,8 @@ CREATE TABLE invoice_line_tax (
     CONSTRAINT invoice_line_tax_pkey PRIMARY KEY (id)
 );
 CREATE INDEX idx_invoice_line_tax_invoice ON invoice_line_tax (invoice_id);
+ALTER TABLE invoice_line_tax
+    ADD CONSTRAINT fk_invoice_line_tax_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id);
 
 CREATE TABLE invoice_tax_summary (
     id uuid NOT NULL,
@@ -33,3 +35,5 @@ CREATE TABLE invoice_tax_summary (
     CONSTRAINT invoice_tax_summary_pkey PRIMARY KEY (id)
 );
 CREATE INDEX idx_invoice_tax_summary_invoice ON invoice_tax_summary (invoice_id);
+ALTER TABLE invoice_tax_summary
+    ADD CONSTRAINT fk_invoice_tax_summary_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id);

--- a/pos-invoice/src/main/resources/db/migration/V13__invoice_tax_breakdown.sql
+++ b/pos-invoice/src/main/resources/db/migration/V13__invoice_tax_breakdown.sql
@@ -1,0 +1,35 @@
+-- Story T5a: persist the per-line x per-jurisdiction tax matrix produced by pos-tax
+-- (TaxCalculationResponse.LineItemTax.jurisdictions[]) so it can be frozen at finalization,
+-- propagated on invoice.invoice.updated (taxBreakdown[]), and replicated by pos-accounting.
+-- Both tables are rebuilt wholesale on each DRAFT re-price; frozen once the invoice finalizes.
+-- Invoice.tax_amount is retained as the denormalized rollup (invariant: tax = SUM(tax_amount)).
+
+CREATE TABLE invoice_line_tax (
+    id uuid NOT NULL,
+    invoice_id uuid NOT NULL,
+    line_item_id varchar(64),
+    jurisdiction_type varchar(32) NOT NULL,
+    jurisdiction_code varchar(64) NOT NULL,
+    rate numeric(9, 6) NOT NULL,
+    taxable_base numeric(19, 4) NOT NULL,
+    tax_amount numeric(19, 4) NOT NULL,
+    exempt boolean NOT NULL DEFAULT false,
+    exemption_reason_code varchar(32),
+    created_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT invoice_line_tax_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_invoice_line_tax_invoice ON invoice_line_tax (invoice_id);
+
+CREATE TABLE invoice_tax_summary (
+    id uuid NOT NULL,
+    invoice_id uuid NOT NULL,
+    jurisdiction_type varchar(32) NOT NULL,
+    jurisdiction_code varchar(64) NOT NULL,
+    taxable_base numeric(19, 4) NOT NULL,
+    tax_amount numeric(19, 4) NOT NULL,
+    created_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT invoice_tax_summary_pkey PRIMARY KEY (id)
+);
+CREATE INDEX idx_invoice_tax_summary_invoice ON invoice_tax_summary (invoice_id);

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceServiceImplTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceServiceImplTest.java
@@ -62,8 +62,23 @@ class InvoiceServiceImplTest {
     @Mock
     private com.positivity.invoice.internal.config.InvoiceEventPublisher invoiceEventPublisher;
 
+    @Mock
+    private InvoiceTaxBreakdownWriter taxBreakdownWriter;
+
     @InjectMocks
     private InvoiceServiceImpl invoiceService;
+
+    private static com.positivity.tax.common.dto.TaxCalculationResponse taxResponse(double totalTax) {
+        return com.positivity.tax.common.dto.TaxCalculationResponse.builder()
+                .subtotal(BigDecimal.ZERO)
+                .totalTax(BigDecimal.valueOf(totalTax))
+                .total(BigDecimal.valueOf(totalTax))
+                .effectiveTaxRate(BigDecimal.ZERO)
+                .jurisdictions(List.of())
+                .lineItemTaxes(List.of())
+                .calculatedAt(Instant.parse("2024-01-01T00:00:00Z"))
+                .build();
+    }
 
     private Invoice draftInvoice;
     private UUID invoiceId;
@@ -225,7 +240,7 @@ class InvoiceServiceImplTest {
 
         when(invoiceRepository.findByWorkorderId(workorderId)).thenReturn(Optional.empty());
         when(locationReferenceService.resolveTaxAddress(any())).thenReturn(sampleTaxAddress());
-        when(taxServiceClient.calculateTax(any(), any(), any())).thenReturn(BigDecimal.valueOf(5));
+        when(taxServiceClient.calculateTaxDetailed(any(), any(), any())).thenReturn(taxResponse(5));
         when(invoiceRepository.save(any())).thenReturn(draftInvoice);
 
         InvoiceGenerationResponse response = invoiceService.createInvoice(request);
@@ -435,7 +450,7 @@ class InvoiceServiceImplTest {
 
         when(invoiceRepository.findById(invoiceId)).thenReturn(Optional.of(draftInvoice));
         when(locationReferenceService.resolveTaxAddress(any())).thenReturn(sampleTaxAddress());
-        when(taxServiceClient.calculateTax(any(), any(), any())).thenReturn(BigDecimal.valueOf(8));
+        when(taxServiceClient.calculateTaxDetailed(any(), any(), any())).thenReturn(taxResponse(8));
         when(invoiceRepository.save(any())).thenReturn(draftInvoice);
 
         InvoiceDetailsResponse result = invoiceService.applyAdjustment(invoiceId, request);

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceTaxBreakdownWriterTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceTaxBreakdownWriterTest.java
@@ -1,0 +1,161 @@
+package com.positivity.invoice.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.positivity.invoice.internal.entity.InvoiceLineTax;
+import com.positivity.invoice.internal.entity.InvoiceTaxSummary;
+import com.positivity.invoice.internal.repository.InvoiceLineTaxRepository;
+import com.positivity.invoice.internal.repository.InvoiceTaxSummaryRepository;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import com.positivity.tax.common.dto.TaxCalculationResponse.JurisdictionTax;
+import com.positivity.tax.common.dto.TaxCalculationResponse.LineItemTax;
+import com.positivity.tax.common.enums.ExemptionReasonCode;
+import com.positivity.tax.common.enums.TaxJurisdictionType;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class InvoiceTaxBreakdownWriterTest {
+
+    private static final UUID INVOICE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    private final InvoiceLineTaxRepository lineTaxRepository = mock(InvoiceLineTaxRepository.class);
+    private final InvoiceTaxSummaryRepository taxSummaryRepository = mock(InvoiceTaxSummaryRepository.class);
+    private final InvoiceTaxBreakdownWriter writer =
+            new InvoiceTaxBreakdownWriter(lineTaxRepository, taxSummaryRepository);
+
+    private static JurisdictionTax jurisdiction(TaxJurisdictionType type, String rate, String amount) {
+        return JurisdictionTax.builder()
+                .jurisdictionType(type)
+                .code(type.code())
+                .rate(new BigDecimal(rate))
+                .amount(new BigDecimal(amount))
+                .build();
+    }
+
+    private static TaxCalculationResponse response(List<LineItemTax> lines) {
+        return TaxCalculationResponse.builder()
+                .subtotal(BigDecimal.ZERO)
+                .totalTax(BigDecimal.ZERO)
+                .total(BigDecimal.ZERO)
+                .effectiveTaxRate(BigDecimal.ZERO)
+                .jurisdictions(List.of())
+                .lineItemTaxes(lines)
+                .calculatedAt(Instant.parse("2026-07-20T00:00:00Z"))
+                .build();
+    }
+
+    @Test
+    @DisplayName("Deletes existing rows first (wholesale replace) on every call")
+    void deletesBeforeInsert() {
+        writer.replace(INVOICE_ID, null);
+        verify(lineTaxRepository).deleteByInvoiceId(INVOICE_ID);
+        verify(taxSummaryRepository).deleteByInvoiceId(INVOICE_ID);
+    }
+
+    @Test
+    @DisplayName("Maps each line x jurisdiction to a line-tax row and rolls up per jurisdiction")
+    void mapsLinesAndBuildsSummary() {
+        LineItemTax line1 = LineItemTax.builder()
+                .lineItemId("1")
+                .subtotal(new BigDecimal("100.00"))
+                .taxAmount(new BigDecimal("8.27"))
+                .total(new BigDecimal("108.27"))
+                .jurisdictions(List.of(
+                        jurisdiction(TaxJurisdictionType.STATE, "0.0725", "7.25"),
+                        jurisdiction(TaxJurisdictionType.COUNTY, "0.0102", "1.02")))
+                .build();
+        LineItemTax line2 = LineItemTax.builder()
+                .lineItemId("2")
+                .subtotal(new BigDecimal("50.00"))
+                .taxAmount(new BigDecimal("3.63"))
+                .total(new BigDecimal("53.63"))
+                .jurisdictions(List.of(jurisdiction(TaxJurisdictionType.STATE, "0.0725", "3.63")))
+                .build();
+
+        writer.replace(INVOICE_ID, response(List.of(line1, line2)));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<InvoiceLineTax>> lineRows = ArgumentCaptor.forClass(List.class);
+        verify(lineTaxRepository).saveAll(lineRows.capture());
+        assertThat(lineRows.getValue()).hasSize(3);
+        assertThat(lineRows.getValue())
+                .allSatisfy(r -> assertThat(r.getInvoiceId()).isEqualTo(INVOICE_ID));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<InvoiceTaxSummary>> summaryRows = ArgumentCaptor.forClass(List.class);
+        verify(taxSummaryRepository).saveAll(summaryRows.capture());
+        // STATE rolls up across both lines (7.25 + 3.63), COUNTY only from line 1.
+        assertThat(summaryRows.getValue()).hasSize(2);
+        InvoiceTaxSummary state = summaryRows.getValue().stream()
+                .filter(s -> "STATE".equals(s.getJurisdictionType()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(state.getTaxAmount()).isEqualByComparingTo("10.88");
+        assertThat(state.getTaxableBase()).isEqualByComparingTo("150.00");
+    }
+
+    @Test
+    @DisplayName("Preserves the exempt flag and reason on zero-rate rows")
+    void preservesExemption() {
+        LineItemTax exemptLine = LineItemTax.builder()
+                .lineItemId("1")
+                .subtotal(new BigDecimal("100.00"))
+                .taxAmount(BigDecimal.ZERO)
+                .total(new BigDecimal("100.00"))
+                .taxExempt(true)
+                .jurisdictions(List.of(JurisdictionTax.builder()
+                        .jurisdictionType(TaxJurisdictionType.STATE)
+                        .code("STATE")
+                        .rate(new BigDecimal("0.0725"))
+                        .amount(BigDecimal.ZERO)
+                        .exempt(true)
+                        .exemptionReasonCode(ExemptionReasonCode.RESALE)
+                        .build()))
+                .build();
+
+        writer.replace(INVOICE_ID, response(List.of(exemptLine)));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<InvoiceLineTax>> lineRows = ArgumentCaptor.forClass(List.class);
+        verify(lineTaxRepository).saveAll(lineRows.capture());
+        InvoiceLineTax row = lineRows.getValue().get(0);
+        assertThat(row.isExempt()).isTrue();
+        assertThat(row.getExemptionReasonCode()).isEqualTo("RESALE");
+        assertThat(row.getTaxAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("Null response clears rows without inserting")
+    void nullResponseClearsOnly() {
+        writer.replace(INVOICE_ID, null);
+        verify(lineTaxRepository, org.mockito.Mockito.never()).saveAll(any());
+        verify(taxSummaryRepository, org.mockito.Mockito.never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("Idempotent replay yields identical rows on re-price")
+    void idempotentReplace() {
+        LineItemTax line = LineItemTax.builder()
+                .lineItemId("1")
+                .subtotal(new BigDecimal("100.00"))
+                .taxAmount(new BigDecimal("7.25"))
+                .total(new BigDecimal("107.25"))
+                .jurisdictions(List.of(jurisdiction(TaxJurisdictionType.STATE, "0.0725", "7.25")))
+                .build();
+
+        writer.replace(INVOICE_ID, response(List.of(line)));
+        writer.replace(INVOICE_ID, response(List.of(line)));
+
+        // Each re-price deletes then re-inserts wholesale, so replays converge on identical rows.
+        verify(lineTaxRepository, org.mockito.Mockito.times(2)).deleteByInvoiceId(INVOICE_ID);
+        verify(lineTaxRepository, org.mockito.Mockito.times(2)).saveAll(any());
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-tax-w3`
- Child issues: louisburroughs/durion-positivity-backend#950 (T5b events), #951 (T5a invoice), #952 (T5c accounting)
- Domain: `domain:tax` / `domain:invoice` / `domain:accounting`

Wave 3 (keystone) of the pos-tax Odoo-parity plan. **Stacked on #981 (Wave 2)** — base branch is `cap/odoo-parity-tax-w2`; retarget to `main` once #981 merges. Research gate R-T2 resolved in `.research/RESEARCH-GATE-DECISIONS.md`.

## Contract References
- Contract guide entry (durion): `domains/tax/.business-rules/BACKEND_CONTRACT_GUIDE.md` → invoice tax-breakdown propagation. `InvoiceUpdatedV1` change is **additive** (new trailing `@Nullable taxBreakdown[]`, stays schema v1 per R-T2 — no V2, no dual-publish, ADR-0044 §3). `pos-domain-events` takes **no** new dependency (`TaxBreakdownLine` uses plain `String`s).
- Durion contract PR (if applicable): n/a — additive within `.v1`.

## Contract Chain
- [x] Event schema documented; scalar `tax` retained as denormalized rollup (D-T6)
- [ ] `openapi.yaml` / SDK — n/a (no controller signature change; internal persistence + event)

## Scope
Persist the per-line × per-jurisdiction tax matrix past calculation, carry it on the invoice event, replicate it into accounting. Implemented T5b → T5a → T5c.

- **T5b events (#950):** `InvoiceUpdatedV1` gains trailing `@Nullable List<TaxBreakdownLine> taxBreakdown`; new record `TaxBreakdownLine(lineItemId?, jurisdictionType, jurisdictionCode, rate, taxableBase, taxAmount, exempt, exemptionReasonCode)` (Strings, dependency-light).
- **T5a invoice (#951):** `TaxServiceClient` stops truncating to `getTotalTax()`; new tables `invoice_line_tax` + `invoice_tax_summary` (Flyway **V13**), entities + repos, `InvoiceTaxBreakdownWriter` (wholesale replace). **Freeze-after-finalize** guard (rewrite only while DRAFT). `Invoice.tax` scalar kept as rollup. `InvoiceEventPublisher` fills `taxBreakdown[]` from stored rows.
- **T5c accounting (#952):** new replica table `ext_invoice_tax` (Flyway **V19**), `ExtInvoiceTax` + repo (ADR-0044 R3, owner=invoice); `InvoiceEventsListener` replaces `ext_invoice_tax` rows (delete-then-insert) under the same aggregate-version staleness + `processed_events` idempotency guards as `ExtInvoice`; null/absent breakdown leaves rows untouched. `ExtInvoice.tax` scalar unchanged. (accounting-plan D1 credit-memo real-tax consumes this later — not in this PR.)

## Tests
- [x] Unit tests per module (writer rollup/exemption, event record, listener replica)
- [x] Integration tests (repository `@DataJpaTest` on new tables; listener materialization)
- [x] T1 Σ-invariant holds end-to-end (Σ lineItemTaxes == totalTax == Σ jurisdictions.taxAmount)
- **How to run:** `./mvnw -pl pos-domain-events,pos-invoice,pos-accounting -am -DskipTests=false clean test` → pos-domain-events green · **pos-invoice 233** (ArchUnit 11) · **pos-accounting 1101** (ArchUnit 13). `./mvnw -pl pos-workorder -am -DskipTests compile` → SUCCESS (2nd `invoice.events.v1` consumer, additive proven).

## Risk & Rollback
- Risk level: **Medium** — two new table sets + event field across three modules; all additive.
- **Flyway version note:** pos-invoice **V13** and pos-accounting **V19** clear the unmerged parallel accounting-plan branches. If those waves merge first, these migrations must be renumbered on rebase (Flyway orders numerically; gaps after V9 are harmless).
- Rollback: revert the branch; new tables are greenfield replicas/derived data with no external consumers yet.

## Checklist
- [x] Branch name matches `cap/odoo-parity-tax-w3`
- [x] Links to child issues present
- [x] Contract guide referenced (BACKEND_CONTRACT_GUIDE.md)
- [x] Additive-only event change (R-T2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
