### PR TITLE
[CAP:odoo-parity-tax-w5] pos-tax Odoo-parity Wave 5 (partial) — Avalara AvaTax external adapter (T6-external)

### DIFF
--- a/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxConfiguration.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxConfiguration.java
@@ -2,10 +2,14 @@ package com.positivity.tax.internal.config;
 
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
+import java.util.Base64;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
@@ -59,6 +63,36 @@ public class TaxConfiguration {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(properties.getExternalService().getConnectTimeout());
         factory.setReadTimeout(properties.getExternalService().getReadTimeout());
+        return factory;
+    }
+
+    /**
+     * Dedicated RestClient for the Avalara AvaTax REST v2 adapter (story T6-external).
+     * <p>
+     * Authenticates with HTTP Basic ({@code accountId:licenseKey}). The license key is a
+     * secret and is deliberately only ever placed into the pre-encoded {@code Authorization}
+     * header value here — it is never logged.
+     *
+     * @return configured Avalara RestClient
+     */
+    @Bean
+    RestClient avalaraRestClient() {
+        TaxProperties.Avalara avalara = properties.getAvalara();
+        String credentials = avalara.getAccountId() + ":" + avalara.getLicenseKey();
+        String basicAuth = "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        return RestClient.builder()
+                .baseUrl(avalara.getBaseUrl())
+                .requestFactory(avalaraRequestFactory())
+                .defaultHeader(HttpHeaders.AUTHORIZATION, basicAuth)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    private ClientHttpRequestFactory avalaraRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.getAvalara().getConnectTimeout());
+        factory.setReadTimeout(properties.getAvalara().getReadTimeout());
         return factory;
     }
 

--- a/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxProperties.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/config/TaxProperties.java
@@ -26,9 +26,42 @@ public class TaxProperties {
     private TestMode testMode = new TestMode();
 
     /**
+     * Active external provider selection when test mode is disabled (story T6-external).
+     * <p>
+     * The {@code testMode.enabled} flag still wins: when it is {@code true} the internal
+     * test calculator is always used regardless of this value. When test mode is disabled
+     * this selects the concrete adapter — {@link Provider#AVALARA} for the real Avalara
+     * AvaTax REST v2 adapter, otherwise the legacy generic {@code EXTERNAL} stub.
+     * <p>
+     * Defaults to {@link Provider#TEST_MODE}, which — when the test-mode flag is off —
+     * resolves to the legacy external stub, preserving prior behavior when unset.
+     */
+    private Provider provider = Provider.TEST_MODE;
+
+    /**
      * External tax service configuration.
      */
     private ExternalService externalService = new ExternalService();
+
+    /**
+     * Avalara AvaTax REST v2 adapter configuration (story T6-external, decision R-T1).
+     */
+    private Avalara avalara = new Avalara();
+
+    /**
+     * Concrete external tax provider (story T6-external).
+     */
+    public enum Provider {
+        /**
+         * No explicit external provider selected. When test mode is disabled this resolves to
+         * the legacy {@link #EXTERNAL} stub, preserving prior behavior for existing deployments.
+         */
+        TEST_MODE,
+        /** Real Avalara AvaTax REST v2 adapter. */
+        AVALARA,
+        /** Legacy generic HTTP external stub. */
+        EXTERNAL
+    }
 
     /**
      * Retry configuration for external service calls.
@@ -162,6 +195,52 @@ public class TaxProperties {
          * API key for authentication.
          */
         private String apiKey;
+
+        /**
+         * Connection timeout in milliseconds.
+         */
+        private int connectTimeout = 5000;
+
+        /**
+         * Read timeout in milliseconds.
+         */
+        private int readTimeout = 10000;
+    }
+
+    /**
+     * Avalara AvaTax REST v2 adapter configuration (story T6-external).
+     * <p>
+     * Authenticates with HTTP Basic ({@code accountId:licenseKey}); the license key is a
+     * secret and is never logged. Env-var driven with empty defaults so the adapter is inert
+     * until configured. Sandbox base URL is {@code https://sandbox-rest.avatax.com}; production
+     * is {@code https://rest.avatax.com}.
+     * <p>
+     * <strong>D-T1 note (not built):</strong> Avalara CertCapture (ECM) could later become the
+     * system of record for the T3 exemption-certificate registry. For now the in-platform
+     * registry stays authoritative and no CertCapture integration exists in this story.
+     */
+    @Data
+    public static class Avalara {
+        /**
+         * AvaTax REST base URL. Sandbox {@code https://sandbox-rest.avatax.com},
+         * production {@code https://rest.avatax.com}.
+         */
+        private String baseUrl = "https://sandbox-rest.avatax.com";
+
+        /**
+         * Avalara account id (HTTP Basic username). Empty until configured.
+         */
+        private String accountId = "";
+
+        /**
+         * Avalara license key (HTTP Basic password) — secret, never logged. Empty until configured.
+         */
+        private String licenseKey = "";
+
+        /**
+         * AvaTax company code used as the document company on every transaction.
+         */
+        private String companyCode = "DEFAULT";
 
         /**
          * Connection timeout in milliseconds.

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/AvalaraTaxProvider.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/AvalaraTaxProvider.java
@@ -204,18 +204,22 @@ public class AvalaraTaxProvider implements TaxProviderClient {
     @NonNull
     private String transactionDate(@NonNull TaxCalculationRequest request) {
         String raw = request.getTransactionDate();
-        if (raw != null && !raw.isBlank()) {
+        if (raw == null || raw.isBlank()) {
+            return LocalDate.now(clock).toString();
+        }
+        try {
+            return Instant.parse(raw).atZone(ZoneOffset.UTC).toLocalDate().toString();
+        } catch (DateTimeParseException _) {
             try {
-                return Instant.parse(raw).atZone(ZoneOffset.UTC).toLocalDate().toString();
-            } catch (DateTimeParseException ex) {
-                try {
-                    return LocalDate.parse(raw).toString();
-                } catch (DateTimeParseException ignored) {
-                    log.debug("Unparseable transactionDate '{}'; defaulting to today", raw);
-                }
+                return LocalDate.parse(raw).toString();
+            } catch (DateTimeParseException _) {
+                // Match the test-mode calculator: a non-blank but unparseable date is a client
+                // error, not a silent fall-back to today (which would hide the bug and make
+                // effective-dated rates depend on the provider).
+                throw new IllegalArgumentException(
+                        "transactionDate must be a valid ISO-8601 date or date-time: " + raw);
             }
         }
-        return LocalDate.now(clock).toString();
     }
 
     // ---- response mapping ------------------------------------------------------------
@@ -394,7 +398,10 @@ public class AvalaraTaxProvider implements TaxProviderClient {
             } catch (TaxCalculationException ex) {
                 throw ex;
             } catch (Exception ex) {
-                throw new TaxCalculationException("AvaTax call failed: " + ex.getMessage(), ex);
+                // Keep the client-facing message stable; log the provider detail rather than
+                // leaking it into the exception message.
+                log.warn("AvaTax call failed: {}", ex.getMessage(), ex);
+                throw new TaxCalculationException("AvaTax call failed", ex);
             }
         };
         return Retry.decorateSupplier(retry, supplier).get();

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/AvalaraTaxProvider.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/AvalaraTaxProvider.java
@@ -1,0 +1,481 @@
+package com.positivity.tax.internal.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.positivity.tax.common.dto.TaxCalculationRequest;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import com.positivity.tax.common.dto.TaxCalculationResponse.JurisdictionTax;
+import com.positivity.tax.common.dto.TaxCalculationResponse.LineItemTax;
+import com.positivity.tax.common.dto.TaxJurisdiction;
+import com.positivity.tax.common.dto.TaxLineItem;
+import com.positivity.tax.common.dto.TaxProviderTransactionResult;
+import com.positivity.tax.common.enums.TaxCalculationType;
+import com.positivity.tax.common.enums.TaxJurisdictionType;
+import com.positivity.tax.common.enums.TaxProviderTransactionStatus;
+import com.positivity.tax.internal.config.TaxProperties;
+import com.positivity.tax.internal.exception.TaxCalculationException;
+import com.positivity.tax.service.TaxProviderClient;
+import io.github.resilience4j.retry.Retry;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Concrete Avalara AvaTax REST v2 adapter (story T6-external, decision R-T1).
+ *
+ * <h2>AvaTax method mapping</h2>
+ * <ul>
+ *   <li><b>estimate</b> &rarr; {@code POST /api/v2/transactions/create} with
+ *       {@code type=SalesOrder, commit=false} — an uncommitted, non-persisted estimate.</li>
+ *   <li><b>refund</b> &rarr; {@code POST /api/v2/transactions/create} with
+ *       {@code type=ReturnInvoice}, {@code referenceCode=originalReferenceId}, positive
+ *       amounts (platform convention: callers negate at posting, story T4).</li>
+ *   <li><b>commit</b> &rarr;
+ *       {@code POST /api/v2/companies/{companyCode}/transactions/{referenceId}/commit}
+ *       (documentType {@code SalesInvoice}, body {@code {"commit":true}}); the source
+ *       {@code referenceId} is the AvaTax document {@code code}, so retries never
+ *       double-commit (idempotency).</li>
+ *   <li><b>voidTransaction</b> &rarr;
+ *       {@code POST /api/v2/companies/{companyCode}/transactions/{referenceId}/void}
+ *       (body {@code {"code":"DocVoided"}}).</li>
+ * </ul>
+ * Endpoints/models per Avalara Developer docs
+ * (<a href="https://developer.avalara.com/api-reference/avatax/rest/v2/methods/Transactions/">
+ * Transactions API</a>) and the AvaTax REST V2 SDK.
+ *
+ * <h2>Totals reconciliation</h2>
+ * AvaTax per-line and per-jurisdiction tax figures are validated/repaired against the
+ * {@code Sum(lineTax) == totalTax == Sum(jurisdictionTax)} invariant with the Wave-1
+ * {@link TaxTotalsReconciler} (same deterministic cent-drift rule, story T1).
+ *
+ * <h2>Error handling (ADR-0021)</h2>
+ * Transport/HTTP failures are wrapped in {@link TaxCalculationException}; the shared
+ * {@code TaxRetryPredicate} on the injected {@link Retry} retries only {@code 5xx}/timeouts
+ * and never {@code 4xx} (a 400 address/validation error is deterministic and surfaces
+ * immediately).
+ *
+ * <h2>D-T1 note (not built)</h2>
+ * Avalara CertCapture (ECM) could later become the system of record for the T3
+ * exemption-certificate registry. For now the in-platform registry stays authoritative and
+ * this story ships no CertCapture integration.
+ */
+@Slf4j
+@Component
+public class AvalaraTaxProvider implements TaxProviderClient {
+
+    /** Stable provider label recorded on the transaction log. */
+    static final String PROVIDER_NAME = "AVALARA";
+
+    private static final int MONEY_SCALE = 2;
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+    private static final String CREATE_URI = "/api/v2/transactions/create";
+    private static final String COMMIT_URI = "/api/v2/companies/{companyCode}/transactions/{code}/commit";
+    private static final String VOID_URI = "/api/v2/companies/{companyCode}/transactions/{code}/void";
+    private static final String SHIP_TO = "ShipTo";
+
+    private final RestClient restClient;
+    private final Retry retry;
+    private final TaxProperties properties;
+    private final Clock clock;
+    private final TaxTotalsReconciler reconciler = new TaxTotalsReconciler();
+
+    public AvalaraTaxProvider(
+            RestClient avalaraRestClient, Retry taxServiceRetry, TaxProperties properties, Clock clock) {
+        this.restClient = avalaraRestClient;
+        this.retry = taxServiceRetry;
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    @Override
+    @NonNull
+    public String providerName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    @NonNull
+    public TaxCalculationResponse estimate(@NonNull TaxCalculationRequest request) {
+        CreateTransactionModel model = buildCreateModel(request, "SalesOrder", null);
+        TransactionModel tx = call(
+                () -> restClient.post().uri(CREATE_URI).body(model).retrieve().body(TransactionModel.class));
+        return mapResponse(request, tx, TaxCalculationType.SALE);
+    }
+
+    @Override
+    @NonNull
+    public TaxCalculationResponse refund(@NonNull TaxCalculationRequest request, @NonNull UUID originalReferenceId) {
+        // ReturnInvoice referencing the original sale; amounts stay positive (story T4 —
+        // callers negate at posting). AvaTax reprices at the supplied original sale date.
+        CreateTransactionModel model = buildCreateModel(request, "ReturnInvoice", originalReferenceId.toString());
+        TransactionModel tx = call(
+                () -> restClient.post().uri(CREATE_URI).body(model).retrieve().body(TransactionModel.class));
+        return mapResponse(request, tx, TaxCalculationType.REFUND);
+    }
+
+    @Override
+    @NonNull
+    public TaxProviderTransactionResult commit(@NonNull UUID referenceId) {
+        String companyCode = properties.getAvalara().getCompanyCode();
+        TransactionModel tx = call(() -> restClient
+                .post()
+                .uri(uriBuilder -> uriBuilder
+                        .path(COMMIT_URI)
+                        .queryParam("documentType", "SalesInvoice")
+                        .build(companyCode, referenceId.toString()))
+                .body(new CommitTransactionModel(true))
+                .retrieve()
+                .body(TransactionModel.class));
+        return new TaxProviderTransactionResult(
+                referenceId, TaxProviderTransactionStatus.COMMITTED, externalId(tx), "committed at AvaTax");
+    }
+
+    @Override
+    @NonNull
+    public TaxProviderTransactionResult voidTransaction(@NonNull UUID referenceId) {
+        String companyCode = properties.getAvalara().getCompanyCode();
+        TransactionModel tx = call(() -> restClient
+                .post()
+                .uri(uriBuilder -> uriBuilder.path(VOID_URI).build(companyCode, referenceId.toString()))
+                .body(new VoidTransactionModel("DocVoided"))
+                .retrieve()
+                .body(TransactionModel.class));
+        return new TaxProviderTransactionResult(
+                referenceId, TaxProviderTransactionStatus.VOIDED, externalId(tx), "voided at AvaTax");
+    }
+
+    // ---- request mapping -------------------------------------------------------------
+
+    @NonNull
+    private CreateTransactionModel buildCreateModel(
+            @NonNull TaxCalculationRequest request, @NonNull String type, @Nullable String referenceCode) {
+        TaxProperties.Avalara avalara = properties.getAvalara();
+        TaxCalculationRequest.TaxAddress dest = request.getDestinationAddress();
+        AvalaraAddress shipTo = new AvalaraAddress(
+                dest == null ? null : dest.getLine1(),
+                dest == null ? null : dest.getLine2(),
+                dest == null ? null : dest.getCity(),
+                dest == null ? null : dest.getRegionCode(),
+                dest == null ? null : dest.getCountryCode(),
+                dest == null ? null : dest.getPostalCode());
+
+        List<AvalaraLine> lines = new ArrayList<>();
+        for (TaxLineItem item : request.getLineItems()) {
+            lines.add(new AvalaraLine(
+                    item.getLineItemId(),
+                    item.getQuantity(),
+                    item.getSubtotal(),
+                    item.getTaxCategory(),
+                    item.getDescription(),
+                    item.isTaxExempt()
+                            ? item.getExemptionReasonCode() != null
+                                    ? item.getExemptionReasonCode().name()
+                                    : null
+                            : null));
+        }
+
+        return new CreateTransactionModel(
+                type,
+                avalara.getCompanyCode(),
+                transactionDate(request),
+                request.getCustomerId() != null ? request.getCustomerId() : "GUEST",
+                request.getReferenceId() != null ? request.getReferenceId().toString() : null,
+                request.getCurrencyCode(),
+                false,
+                referenceCode,
+                Map.of(SHIP_TO, shipTo),
+                lines);
+    }
+
+    @NonNull
+    private String transactionDate(@NonNull TaxCalculationRequest request) {
+        String raw = request.getTransactionDate();
+        if (raw != null && !raw.isBlank()) {
+            try {
+                return Instant.parse(raw).atZone(ZoneOffset.UTC).toLocalDate().toString();
+            } catch (DateTimeParseException ex) {
+                try {
+                    return LocalDate.parse(raw).toString();
+                } catch (DateTimeParseException ignored) {
+                    log.debug("Unparseable transactionDate '{}'; defaulting to today", raw);
+                }
+            }
+        }
+        return LocalDate.now(clock).toString();
+    }
+
+    // ---- response mapping ------------------------------------------------------------
+
+    @NonNull
+    private TaxCalculationResponse mapResponse(
+            @NonNull TaxCalculationRequest request,
+            @Nullable TransactionModel tx,
+            @NonNull TaxCalculationType calculationType) {
+        if (tx == null) {
+            throw new TaxCalculationException("AvaTax returned an empty transaction response");
+        }
+
+        BigDecimal subtotal = round(sumLineSubtotals(request));
+        BigDecimal totalTax = round(tx.totalTax() != null ? tx.totalTax() : BigDecimal.ZERO);
+
+        Map<String, BigDecimal> requestSubtotals = new LinkedHashMap<>();
+        for (TaxLineItem item : request.getLineItems()) {
+            requestSubtotals.put(item.getLineItemId(), round(item.getSubtotal()));
+        }
+
+        // Per-line tax breakdown + jurisdiction aggregation from AvaTax lines[].details[].
+        List<LineItemTax> lineItemTaxes = new ArrayList<>();
+        List<BigDecimal> rawLineTaxes = new ArrayList<>();
+        Map<String, JurisdictionAccumulator> jurisdictionByCode = new LinkedHashMap<>();
+
+        List<TransactionLineModel> avaLines = tx.lines() != null ? tx.lines() : List.of();
+        for (TransactionLineModel avaLine : avaLines) {
+            BigDecimal lineTax = avaLine.tax() != null ? avaLine.tax() : BigDecimal.ZERO;
+            rawLineTaxes.add(lineTax);
+
+            List<JurisdictionTax> lineJurisdictions = new ArrayList<>();
+            List<TransactionLineDetailModel> details = avaLine.details() != null ? avaLine.details() : List.of();
+            for (TransactionLineDetailModel detail : details) {
+                BigDecimal rate = detail.rate() != null ? detail.rate() : BigDecimal.ZERO;
+                BigDecimal amount = detail.tax() != null ? detail.tax() : BigDecimal.ZERO;
+                TaxJurisdictionType type = mapJurisdictionType(detail.jurisdictionType());
+                String code = detail.jurisCode() != null ? detail.jurisCode() : type.code();
+                lineJurisdictions.add(JurisdictionTax.builder()
+                        .jurisdictionType(type)
+                        .code(code)
+                        .rate(rate)
+                        .amount(round(amount))
+                        .exempt(false)
+                        .build());
+                jurisdictionByCode
+                        .computeIfAbsent(type.code() + "|" + code, k -> new JurisdictionAccumulator(type, rate))
+                        .add(amount);
+            }
+
+            String lineId = avaLine.lineNumber();
+            BigDecimal lineSubtotal = requestSubtotals.getOrDefault(lineId, round(safeAmount(avaLine.taxableAmount())));
+            lineItemTaxes.add(LineItemTax.builder()
+                    .lineItemId(lineId != null ? lineId : "")
+                    .subtotal(lineSubtotal)
+                    .taxAmount(round(lineTax))
+                    .total(lineSubtotal.add(round(lineTax)))
+                    .taxExempt(false)
+                    .jurisdictions(lineJurisdictions)
+                    .build());
+        }
+
+        // Sigma-invariant repair: reconcile line tax amounts to the AvaTax grand total.
+        if (!lineItemTaxes.isEmpty()) {
+            List<BigDecimal> reconciledLineTaxes = reconciler.reconcileAmountsToTarget(rawLineTaxes, totalTax);
+            for (int i = 0; i < lineItemTaxes.size(); i++) {
+                LineItemTax lit = lineItemTaxes.get(i);
+                lit.setTaxAmount(reconciledLineTaxes.get(i));
+                lit.setTotal(lit.getSubtotal().add(reconciledLineTaxes.get(i)));
+            }
+        }
+
+        // Aggregate top-level jurisdictions and reconcile their amounts to the grand total.
+        List<TaxJurisdiction> jurisdictions = new ArrayList<>();
+        List<BigDecimal> jurisdictionAmounts = new ArrayList<>();
+        for (JurisdictionAccumulator acc : jurisdictionByCode.values()) {
+            jurisdictionAmounts.add(acc.amount);
+        }
+        List<BigDecimal> reconciledJurisdiction = jurisdictionAmounts.isEmpty()
+                ? jurisdictionAmounts
+                : reconciler.reconcileAmountsToTarget(jurisdictionAmounts, totalTax);
+        int j = 0;
+        String country = request.getCountryCode();
+        for (JurisdictionAccumulator acc : jurisdictionByCode.values()) {
+            jurisdictions.add(TaxJurisdiction.builder()
+                    .countryCode(country)
+                    .regionCode(request.getStateCode())
+                    .city(request.getCity())
+                    .postalCode(request.getPostalCode())
+                    // Top-level taxRate is expressed as percentage points (e.g. 7.25).
+                    .taxRate(acc.rate.multiply(HUNDRED))
+                    .jurisdictionType(acc.type)
+                    .taxAmount(reconciledJurisdiction.get(j++))
+                    .build());
+        }
+
+        BigDecimal taxableBase = subtotal;
+        BigDecimal effectiveRate = taxableBase.signum() == 0
+                ? BigDecimal.ZERO.setScale(MONEY_SCALE, RoundingMode.HALF_UP)
+                : totalTax.multiply(HUNDRED).divide(taxableBase, MONEY_SCALE, RoundingMode.HALF_UP);
+
+        return TaxCalculationResponse.builder()
+                .subtotal(subtotal)
+                .totalTax(totalTax)
+                .total(subtotal.add(totalTax))
+                .effectiveTaxRate(effectiveRate)
+                .jurisdictions(jurisdictions)
+                .lineItemTaxes(lineItemTaxes)
+                .testMode(false)
+                .calculatedAt(clock.instant())
+                .referenceId(request.getReferenceId())
+                .referenceType(request.getReferenceType())
+                .externalTransactionId(externalId(tx))
+                .calculationType(calculationType)
+                .build();
+    }
+
+    @NonNull
+    private BigDecimal sumLineSubtotals(@NonNull TaxCalculationRequest request) {
+        BigDecimal sum = BigDecimal.ZERO;
+        for (TaxLineItem item : request.getLineItems()) {
+            sum = sum.add(item.getSubtotal());
+        }
+        return sum;
+    }
+
+    @NonNull
+    private static TaxJurisdictionType mapJurisdictionType(@Nullable String avalaraType) {
+        if (avalaraType == null) {
+            return TaxJurisdictionType.SPECIAL;
+        }
+        return switch (avalaraType.trim().toUpperCase()) {
+            case "COUNTRY" -> TaxJurisdictionType.COUNTRY;
+            case "STATE" -> TaxJurisdictionType.STATE;
+            case "COUNTY" -> TaxJurisdictionType.COUNTY;
+            case "CITY" -> TaxJurisdictionType.CITY;
+            default -> TaxJurisdictionType.SPECIAL;
+        };
+    }
+
+    @Nullable
+    private static String externalId(@Nullable TransactionModel tx) {
+        if (tx == null) {
+            return null;
+        }
+        if (tx.id() != null) {
+            return String.valueOf(tx.id());
+        }
+        return tx.code();
+    }
+
+    @NonNull
+    private static BigDecimal safeAmount(@Nullable BigDecimal value) {
+        return value != null ? value : BigDecimal.ZERO;
+    }
+
+    @NonNull
+    private static BigDecimal round(@NonNull BigDecimal value) {
+        return value.setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Decorate the AvaTax HTTP call with the shared retry and wrap transport/HTTP failures in
+     * {@link TaxCalculationException}. The retry predicate walks the cause chain and retries
+     * only {@code 5xx}/timeouts (ADR-0021); {@code 4xx} surfaces deterministically.
+     */
+    @NonNull
+    private <T> T call(@NonNull Supplier<T> httpCall) {
+        Supplier<T> supplier = () -> {
+            try {
+                T result = httpCall.get();
+                if (result == null) {
+                    throw new TaxCalculationException("AvaTax returned a null response");
+                }
+                return result;
+            } catch (TaxCalculationException ex) {
+                throw ex;
+            } catch (Exception ex) {
+                throw new TaxCalculationException("AvaTax call failed: " + ex.getMessage(), ex);
+            }
+        };
+        return Retry.decorateSupplier(retry, supplier).get();
+    }
+
+    /** Running per-jurisdiction accumulator keyed by type+code. */
+    private static final class JurisdictionAccumulator {
+        private final TaxJurisdictionType type;
+        private final BigDecimal rate;
+        private BigDecimal amount = BigDecimal.ZERO;
+
+        private JurisdictionAccumulator(TaxJurisdictionType type, BigDecimal rate) {
+            this.type = type;
+            this.rate = rate;
+        }
+
+        private void add(BigDecimal delta) {
+            amount = amount.add(delta != null ? delta : BigDecimal.ZERO);
+        }
+    }
+
+    // ---- AvaTax REST v2 wire models --------------------------------------------------
+
+    /** AvaTax {@code CreateTransactionModel} (subset used by this adapter). */
+    record CreateTransactionModel(
+            String type,
+            String companyCode,
+            String date,
+            String customerCode,
+            String code,
+            String currencyCode,
+            boolean commit,
+            String referenceCode,
+            Map<String, AvalaraAddress> addresses,
+            List<AvalaraLine> lines) {}
+
+    /** AvaTax {@code AddressLocationInfo}. */
+    record AvalaraAddress(String line1, String line2, String city, String region, String country, String postalCode) {}
+
+    /** AvaTax {@code LineItemModel} (subset). */
+    record AvalaraLine(
+            String number,
+            BigDecimal quantity,
+            BigDecimal amount,
+            String taxCode,
+            String description,
+            String entityUseCode) {}
+
+    /** AvaTax {@code CommitTransactionModel}. */
+    record CommitTransactionModel(boolean commit) {}
+
+    /** AvaTax {@code VoidTransactionModel}. */
+    record VoidTransactionModel(String code) {}
+
+    /** AvaTax {@code TransactionModel} response (subset). */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record TransactionModel(
+            Long id,
+            String code,
+            String status,
+            BigDecimal totalAmount,
+            BigDecimal totalTax,
+            BigDecimal totalTaxable,
+            List<TransactionLineModel> lines) {}
+
+    /** AvaTax {@code TransactionLineModel} response (subset). */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record TransactionLineModel(
+            String lineNumber,
+            BigDecimal lineAmount,
+            BigDecimal tax,
+            BigDecimal taxableAmount,
+            List<TransactionLineDetailModel> details) {}
+
+    /** AvaTax {@code TransactionLineDetailModel} response (subset). */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record TransactionLineDetailModel(
+            String jurisdictionType,
+            String jurisCode,
+            String jurisName,
+            BigDecimal rate,
+            BigDecimal tax,
+            String taxName) {}
+}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxProviderSelector.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxProviderSelector.java
@@ -1,12 +1,19 @@
 package com.positivity.tax.internal.service;
 
 import com.positivity.tax.internal.config.TaxProperties;
+import com.positivity.tax.internal.config.TaxProperties.Provider;
 import com.positivity.tax.service.TaxProviderClient;
 import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Component;
 
 /**
- * Selects the active {@link TaxProviderClient} from the test-mode flag (story T6).
+ * Selects the active {@link TaxProviderClient} (stories T6, T6-external).
+ * <p>
+ * The {@code test-mode.enabled} flag wins: when set, the internal test calculator is always
+ * used. When test mode is disabled, {@code pos.tax.provider} chooses the concrete adapter —
+ * {@link Provider#AVALARA} for the real Avalara AvaTax REST v2 adapter, otherwise the legacy
+ * generic {@code EXTERNAL} stub (also the fallback for the default/unset
+ * {@link Provider#TEST_MODE} value, preserving prior behavior).
  * <p>
  * Shared by {@code TaxCalculationServiceImpl} (estimate path) and
  * {@link TaxProviderLifecycleService} (commit/void/re-commit) so both always resolve the
@@ -18,22 +25,34 @@ public class TaxProviderSelector {
     private final TaxProperties properties;
     private final TestModeTaxProvider testModeProvider;
     private final ExternalTaxProvider externalProvider;
+    private final AvalaraTaxProvider avalaraProvider;
 
     public TaxProviderSelector(
-            TaxProperties properties, TestModeTaxProvider testModeProvider, ExternalTaxProvider externalProvider) {
+            TaxProperties properties,
+            TestModeTaxProvider testModeProvider,
+            ExternalTaxProvider externalProvider,
+            AvalaraTaxProvider avalaraProvider) {
         this.properties = properties;
         this.testModeProvider = testModeProvider;
         this.externalProvider = externalProvider;
+        this.avalaraProvider = avalaraProvider;
     }
 
     /**
-     * The provider for the current mode: test-mode calculator when test mode is enabled,
-     * otherwise the external provider.
+     * The provider for the current mode: test-mode calculator when test mode is enabled;
+     * otherwise the Avalara adapter or the legacy external stub per {@code pos.tax.provider}.
      *
      * @return the active provider
      */
     @NonNull
     public TaxProviderClient select() {
-        return properties.getTestMode().isEnabled() ? testModeProvider : externalProvider;
+        if (properties.getTestMode().isEnabled()) {
+            return testModeProvider;
+        }
+        return switch (properties.getProvider()) {
+            case AVALARA -> avalaraProvider;
+            // EXTERNAL and the default/unset TEST_MODE both resolve to the legacy stub.
+            default -> externalProvider;
+        };
     }
 }

--- a/pos-tax/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/pos-tax/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -20,7 +20,7 @@
       "name": "pos.tax.provider",
       "type": "com.positivity.tax.internal.config.TaxProperties$Provider",
       "description": "Concrete external tax provider used when test mode is disabled: AVALARA (real AvaTax adapter) or EXTERNAL (legacy stub). Default/unset (TEST_MODE) resolves to the legacy external stub, preserving prior behavior.",
-      "defaultValue": "test-mode"
+      "defaultValue": "TEST_MODE"
     },
     {
       "name": "pos.tax.avalara.base-url",

--- a/pos-tax/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/pos-tax/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,6 +17,46 @@
       "description": "Address-driven, effective-dated jurisdiction rate rules (story T7). Each rule matches on destination-address facets and carries its own rates, effective-from date, and optional per-category exemptions."
     },
     {
+      "name": "pos.tax.provider",
+      "type": "com.positivity.tax.internal.config.TaxProperties$Provider",
+      "description": "Concrete external tax provider used when test mode is disabled: AVALARA (real AvaTax adapter) or EXTERNAL (legacy stub). Default/unset (TEST_MODE) resolves to the legacy external stub, preserving prior behavior.",
+      "defaultValue": "test-mode"
+    },
+    {
+      "name": "pos.tax.avalara.base-url",
+      "type": "java.lang.String",
+      "description": "Avalara AvaTax REST base URL. Sandbox https://sandbox-rest.avatax.com, production https://rest.avatax.com.",
+      "defaultValue": "https://sandbox-rest.avatax.com"
+    },
+    {
+      "name": "pos.tax.avalara.account-id",
+      "type": "java.lang.String",
+      "description": "Avalara account id (HTTP Basic username). Env-var driven; empty until configured."
+    },
+    {
+      "name": "pos.tax.avalara.license-key",
+      "type": "java.lang.String",
+      "description": "Avalara license key (HTTP Basic password). Secret, never logged. Env-var driven; empty until configured."
+    },
+    {
+      "name": "pos.tax.avalara.company-code",
+      "type": "java.lang.String",
+      "description": "AvaTax company code used as the document company on every transaction.",
+      "defaultValue": "DEFAULT"
+    },
+    {
+      "name": "pos.tax.avalara.connect-timeout",
+      "type": "java.lang.Integer",
+      "description": "Connection timeout for AvaTax calls in milliseconds.",
+      "defaultValue": 5000
+    },
+    {
+      "name": "pos.tax.avalara.read-timeout",
+      "type": "java.lang.Integer",
+      "description": "Read timeout for AvaTax calls in milliseconds.",
+      "defaultValue": 10000
+    },
+    {
       "name": "pos.tax.external-service.base-url",
       "type": "java.lang.String",
       "description": "Base URL for external tax provider API.",

--- a/pos-tax/src/main/resources/application-alpha.yml
+++ b/pos-tax/src/main/resources/application-alpha.yml
@@ -1,5 +1,20 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
 
+# Story T6-external: to route tax to the real Avalara AvaTax adapter in staging, set
+# TAX_TEST_MODE=false and TAX_PROVIDER=AVALARA, then supply the (secret) AvaTax credentials
+# via env. Sample non-secret shape below; the license key must come from the secret store,
+# never committed and never logged.
+# pos:
+#   tax:
+#     test-mode:
+#       enabled: false
+#     provider: AVALARA
+#     avalara:
+#       base-url: https://sandbox-rest.avatax.com
+#       account-id: ${AVALARA_ACCOUNT_ID}
+#       license-key: ${AVALARA_LICENSE_KEY}   # secret — inject via env/secret store only
+#       company-code: ${AVALARA_COMPANY_CODE:DEFAULT}
+
 logging:
   level:
     # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN

--- a/pos-tax/src/main/resources/application-prod.yml
+++ b/pos-tax/src/main/resources/application-prod.yml
@@ -1,5 +1,20 @@
 # Environment-specific runtime intentionally inherits env-driven base settings.
 
+# Story T6-external: to route tax to the real Avalara AvaTax adapter in production, set
+# TAX_TEST_MODE=false and TAX_PROVIDER=AVALARA, then supply the (secret) AvaTax credentials
+# via env/secret store. Sample non-secret shape below; the license key must NEVER be committed
+# or logged — inject it from the secret store only. Use base-url https://rest.avatax.com in prod.
+# pos:
+#   tax:
+#     test-mode:
+#       enabled: false
+#     provider: AVALARA
+#     avalara:
+#       base-url: https://rest.avatax.com
+#       account-id: ${AVALARA_ACCOUNT_ID}
+#       license-key: ${AVALARA_LICENSE_KEY}   # secret — inject via env/secret store only
+#       company-code: ${AVALARA_COMPANY_CODE:DEFAULT}
+
 # ADR-0046: deployed environments run INFO baseline; framework noise capped at WARN
 logging:
   level:

--- a/pos-tax/src/main/resources/application.yml
+++ b/pos-tax/src/main/resources/application.yml
@@ -74,9 +74,21 @@ pos:
         STATE: 0.0725 # 7.25% state tax
         COUNTY: 0.01 # 1% county tax
         CITY: 0.0025 # 0.25% city tax
+    # Concrete external provider used when test-mode is disabled (story T6-external).
+    # TEST_MODE (default/unset) -> legacy external stub; AVALARA -> real AvaTax adapter; EXTERNAL -> stub.
+    provider: ${TAX_PROVIDER:TEST_MODE}
     external-service:
       base-url: ${TAX_SERVICE_URL:https://api.taxservice.example.com}
       api-key: ${TAX_SERVICE_API_KEY:}
+      connect-timeout: 5000
+      read-timeout: 10000
+    # Avalara AvaTax REST v2 adapter (story T6-external). Env-var driven; license key is a
+    # secret and is never logged. Sandbox base https://sandbox-rest.avatax.com, prod https://rest.avatax.com.
+    avalara:
+      base-url: ${AVALARA_BASE_URL:https://sandbox-rest.avatax.com}
+      account-id: ${AVALARA_ACCOUNT_ID:}
+      license-key: ${AVALARA_LICENSE_KEY:}
+      company-code: ${AVALARA_COMPANY_CODE:DEFAULT}
       connect-timeout: 5000
       read-timeout: 10000
     retry:

--- a/pos-tax/src/test/java/com/positivity/tax/internal/service/AvalaraTaxProviderTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/service/AvalaraTaxProviderTest.java
@@ -1,0 +1,335 @@
+package com.positivity.tax.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.ExpectedCount.times;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.tax.common.dto.TaxCalculationRequest;
+import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import com.positivity.tax.common.dto.TaxLineItem;
+import com.positivity.tax.common.dto.TaxProviderTransactionResult;
+import com.positivity.tax.common.enums.TaxCalculationType;
+import com.positivity.tax.common.enums.TaxProviderTransactionStatus;
+import com.positivity.tax.internal.config.TaxProperties;
+import com.positivity.tax.internal.config.TaxRetryPredicate;
+import com.positivity.tax.internal.exception.TaxCalculationException;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Story T6-external: {@link AvalaraTaxProvider} maps our request/response DTOs to the Avalara
+ * AvaTax REST v2 wire shape, reconciles totals against the Sigma invariant, and honors the
+ * ADR-0021 retry policy (retry 5xx, never 4xx). All HTTP is mocked — no live sandbox calls.
+ */
+@DisplayName("AvalaraTaxProvider Tests")
+class AvalaraTaxProviderTest {
+
+    private static final String BASE_URL = "https://sandbox-rest.avatax.com";
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-02-21T09:30:00Z"), ZoneOffset.UTC);
+
+    private TaxProperties properties() {
+        TaxProperties props = new TaxProperties();
+        props.setProvider(TaxProperties.Provider.AVALARA);
+        props.getTestMode().setEnabled(false);
+        TaxProperties.Avalara avalara = new TaxProperties.Avalara();
+        avalara.setCompanyCode("DEFAULT");
+        avalara.setBaseUrl(BASE_URL);
+        props.setAvalara(avalara);
+        return props;
+    }
+
+    private Retry retryWithProductionPredicate() {
+        RetryConfig config = RetryConfig.custom()
+                .maxAttempts(3)
+                .intervalFunction(attempt -> 1L)
+                .retryOnException(new TaxRetryPredicate())
+                .build();
+        return Retry.of("avalara-test", config);
+    }
+
+    private record Fixture(AvalaraTaxProvider provider, MockRestServiceServer server) {}
+
+    private Fixture fixture() {
+        return fixture(
+                Retry.of("avalara-test", RetryConfig.custom().maxAttempts(1).build()));
+    }
+
+    private Fixture fixture(Retry retry) {
+        RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        RestClient restClient = builder.build();
+        AvalaraTaxProvider provider = new AvalaraTaxProvider(restClient, retry, properties(), FIXED_CLOCK);
+        return new Fixture(provider, server);
+    }
+
+    private TaxCalculationRequest sampleRequest() {
+        return TaxCalculationRequest.builder()
+                .lineItems(List.of(
+                        TaxLineItem.builder()
+                                .lineItemId("1")
+                                .description("Oil Change Service")
+                                .quantity(BigDecimal.ONE)
+                                .unitPrice(new BigDecimal("100.00"))
+                                .taxCategory("SERVICES")
+                                .build(),
+                        TaxLineItem.builder()
+                                .lineItemId("2")
+                                .description("Wiper Blades")
+                                .quantity(BigDecimal.ONE)
+                                .unitPrice(new BigDecimal("50.00"))
+                                .build()))
+                .destinationAddress(TaxAddress.builder()
+                        .countryCode("US")
+                        .regionCode("CA")
+                        .city("Los Angeles")
+                        .postalCode("90001")
+                        .line1("123 Main St")
+                        .build())
+                .currencyCode("USD")
+                .customerId("CUST-1")
+                .referenceId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+                .transactionDate("2026-02-21T09:30:00Z")
+                .build();
+    }
+
+    @Test
+    @DisplayName("providerName is the stable AVALARA label")
+    void providerName() {
+        assertThat(fixture().provider().providerName()).isEqualTo("AVALARA");
+    }
+
+    @Test
+    @DisplayName("estimate maps to a non-committing SalesOrder and parses per-line jurisdictions")
+    void estimateMapsSalesOrderAndParses() {
+        Fixture f = fixture();
+        f.server()
+                .expect(once(), requestTo(BASE_URL + "/api/v2/transactions/create"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.type").value("SalesOrder"))
+                .andExpect(jsonPath("$.commit").value(false))
+                .andExpect(jsonPath("$.companyCode").value("DEFAULT"))
+                .andExpect(jsonPath("$.date").value("2026-02-21"))
+                .andExpect(jsonPath("$.code").value("550e8400-e29b-41d4-a716-446655440000"))
+                .andExpect(jsonPath("$.customerCode").value("CUST-1"))
+                .andExpect(jsonPath("$.addresses.ShipTo.region").value("CA"))
+                .andExpect(jsonPath("$.addresses.ShipTo.postalCode").value("90001"))
+                .andExpect(jsonPath("$.lines[0].number").value("1"))
+                .andExpect(jsonPath("$.lines[1].number").value("2"))
+                .andRespond(withSuccess(estimateResponseJson(), MediaType.APPLICATION_JSON));
+
+        TaxCalculationResponse response = f.provider().estimate(sampleRequest());
+        f.server().verify();
+
+        assertThat(response.isTestMode()).isFalse();
+        assertThat(response.getExternalTransactionId()).isEqualTo("987654321");
+        assertThat(response.getSubtotal()).isEqualByComparingTo("150.00");
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.88");
+        assertThat(response.getTotal()).isEqualByComparingTo("160.88");
+        assertThat(response.getCalculationType()).isEqualTo(TaxCalculationType.SALE);
+        assertThat(response.getLineItemTaxes()).hasSize(2);
+        assertThat(response.getLineItemTaxes().get(0).getLineItemId()).isEqualTo("1");
+        assertThat(response.getLineItemTaxes().get(0).getJurisdictions()).hasSize(2);
+        assertThat(response.getLineItemTaxes().get(0).getJurisdictions().get(0).getRate())
+                .isEqualByComparingTo("0.0600");
+        // Top-level jurisdiction aggregation (STATE + COUNTY) with percentage-point rate.
+        assertThat(response.getJurisdictions()).hasSize(2);
+        assertThat(response.getJurisdictions().get(0).getTaxRate()).isEqualByComparingTo("6.00");
+    }
+
+    @Test
+    @DisplayName("estimate repairs a cent-level drift so line taxes sum to the AvaTax total (Sigma invariant)")
+    void estimateReconcilesDrift() {
+        Fixture f = fixture();
+        // AvaTax totalTax=10.00 but line taxes sum to 9.99 (drift of +0.01).
+        f.server()
+                .expect(once(), requestTo(BASE_URL + "/api/v2/transactions/create"))
+                .andRespond(withSuccess(driftResponseJson(), MediaType.APPLICATION_JSON));
+
+        TaxCalculationResponse response = f.provider().estimate(sampleRequest());
+        f.server().verify();
+
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.00");
+        BigDecimal lineSum = response.getLineItemTaxes().stream()
+                .map(TaxCalculationResponse.LineItemTax::getTaxAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(lineSum).isEqualByComparingTo("10.00");
+    }
+
+    @Test
+    @DisplayName("refund maps to a ReturnInvoice referencing the original sale, calculationType=REFUND")
+    void refundMapsReturnInvoice() {
+        Fixture f = fixture();
+        UUID original = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        f.server()
+                .expect(once(), requestTo(BASE_URL + "/api/v2/transactions/create"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.type").value("ReturnInvoice"))
+                .andExpect(jsonPath("$.referenceCode").value(original.toString()))
+                .andRespond(withSuccess(estimateResponseJson(), MediaType.APPLICATION_JSON));
+
+        TaxCalculationRequest request = sampleRequest();
+        request.setCalculationType(TaxCalculationType.REFUND);
+        TaxCalculationResponse response = f.provider().refund(request, original);
+        f.server().verify();
+
+        assertThat(response.getCalculationType()).isEqualTo(TaxCalculationType.REFUND);
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.88");
+    }
+
+    @Test
+    @DisplayName("commit posts commit=true keyed by referenceId and returns COMMITTED with the AvaTax id")
+    void commitReturnsCommitted() {
+        Fixture f = fixture();
+        UUID ref = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        f.server()
+                .expect(once(), requestTo(containsString("/api/v2/companies/DEFAULT/transactions/" + ref + "/commit")))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.commit").value(true))
+                .andRespond(withSuccess(
+                        "{\"id\":987654321,\"code\":\"" + ref + "\",\"status\":\"Committed\"}",
+                        MediaType.APPLICATION_JSON));
+
+        TaxProviderTransactionResult result = f.provider().commit(ref);
+        f.server().verify();
+
+        assertThat(result.status()).isEqualTo(TaxProviderTransactionStatus.COMMITTED);
+        assertThat(result.referenceId()).isEqualTo(ref);
+        assertThat(result.externalTransactionId()).isEqualTo("987654321");
+    }
+
+    @Test
+    @DisplayName("void posts code=DocVoided keyed by referenceId and returns VOIDED")
+    void voidReturnsVoided() {
+        Fixture f = fixture();
+        UUID ref = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        f.server()
+                .expect(once(), requestTo(containsString("/api/v2/companies/DEFAULT/transactions/" + ref + "/void")))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.code").value("DocVoided"))
+                .andRespond(withSuccess(
+                        "{\"id\":987654321,\"code\":\"" + ref + "\",\"status\":\"DocVoided\"}",
+                        MediaType.APPLICATION_JSON));
+
+        TaxProviderTransactionResult result = f.provider().voidTransaction(ref);
+        f.server().verify();
+
+        assertThat(result.status()).isEqualTo(TaxProviderTransactionStatus.VOIDED);
+        assertThat(result.externalTransactionId()).isEqualTo("987654321");
+    }
+
+    @Test
+    @DisplayName("a 4xx from AvaTax is a deterministic TaxCalculationException, not retried")
+    void clientErrorIsNotRetried() {
+        Fixture f = fixture(retryWithProductionPredicate());
+        f.server()
+                .expect(once(), requestTo(BASE_URL + "/api/v2/transactions/create"))
+                .andRespond(withStatus(HttpStatus.BAD_REQUEST).body("{\"error\":\"invalid address\"}"));
+
+        assertThatThrownBy(() -> f.provider().estimate(sampleRequest())).isInstanceOf(TaxCalculationException.class);
+        // Exactly one call — a 400 is never retried (ADR-0021).
+        f.server().verify();
+    }
+
+    @Test
+    @DisplayName("a 5xx from AvaTax is retried per the shared predicate, then surfaces as TaxCalculationException")
+    void serverErrorIsRetried() {
+        Fixture f = fixture(retryWithProductionPredicate());
+        // Retried up to maxAttempts (3) — each attempt re-hits the mock server.
+        f.server()
+                .expect(times(3), requestTo(BASE_URL + "/api/v2/transactions/create"))
+                .andRespond(withServerError());
+
+        assertThatThrownBy(() -> f.provider().estimate(sampleRequest())).isInstanceOf(TaxCalculationException.class);
+        f.server().verify();
+    }
+
+    private String estimateResponseJson() {
+        return """
+                {
+                  "id": 987654321,
+                  "code": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": "Temporary",
+                  "totalAmount": 150.00,
+                  "totalTax": 10.88,
+                  "totalTaxable": 150.00,
+                  "lines": [
+                    {
+                      "lineNumber": "1",
+                      "lineAmount": 100.00,
+                      "tax": 7.25,
+                      "taxableAmount": 100.00,
+                      "details": [
+                        {"jurisdictionType": "State", "jurisCode": "06", "jurisName": "CALIFORNIA", "rate": 0.06, "tax": 6.00, "taxName": "CA STATE TAX"},
+                        {"jurisdictionType": "County", "jurisCode": "037", "jurisName": "LOS ANGELES", "rate": 0.0125, "tax": 1.25, "taxName": "LA COUNTY TAX"}
+                      ]
+                    },
+                    {
+                      "lineNumber": "2",
+                      "lineAmount": 50.00,
+                      "tax": 3.63,
+                      "taxableAmount": 50.00,
+                      "details": [
+                        {"jurisdictionType": "State", "jurisCode": "06", "jurisName": "CALIFORNIA", "rate": 0.06, "tax": 3.00, "taxName": "CA STATE TAX"},
+                        {"jurisdictionType": "County", "jurisCode": "037", "jurisName": "LOS ANGELES", "rate": 0.0125, "tax": 0.63, "taxName": "LA COUNTY TAX"}
+                      ]
+                    }
+                  ]
+                }
+                """;
+    }
+
+    private String driftResponseJson() {
+        return """
+                {
+                  "id": 987654321,
+                  "code": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": "Temporary",
+                  "totalAmount": 150.00,
+                  "totalTax": 10.00,
+                  "totalTaxable": 150.00,
+                  "lines": [
+                    {
+                      "lineNumber": "1",
+                      "lineAmount": 100.00,
+                      "tax": 6.53,
+                      "taxableAmount": 100.00,
+                      "details": [
+                        {"jurisdictionType": "State", "jurisCode": "06", "jurisName": "CALIFORNIA", "rate": 0.0653, "tax": 6.53, "taxName": "CA STATE TAX"}
+                      ]
+                    },
+                    {
+                      "lineNumber": "2",
+                      "lineAmount": 50.00,
+                      "tax": 3.46,
+                      "taxableAmount": 50.00,
+                      "details": [
+                        {"jurisdictionType": "State", "jurisCode": "06", "jurisName": "CALIFORNIA", "rate": 0.0692, "tax": 3.46, "taxName": "CA STATE TAX"}
+                      ]
+                    }
+                  ]
+                }
+                """;
+    }
+}

--- a/pos-tax/src/test/java/com/positivity/tax/internal/service/TaxProviderSelectorTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/service/TaxProviderSelectorTest.java
@@ -1,0 +1,61 @@
+package com.positivity.tax.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.positivity.tax.internal.config.TaxProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story T6-external: {@link TaxProviderSelector} routing. The test-mode flag wins; when it is
+ * off, {@code pos.tax.provider} selects Avalara vs the legacy external stub, and the
+ * default/unset value preserves prior (external stub) behavior.
+ */
+@DisplayName("TaxProviderSelector routing Tests")
+class TaxProviderSelectorTest {
+
+    private final TestModeTaxProvider testMode = mock(TestModeTaxProvider.class);
+    private final ExternalTaxProvider external = mock(ExternalTaxProvider.class);
+    private final AvalaraTaxProvider avalara = mock(AvalaraTaxProvider.class);
+
+    private TaxProviderSelector selector(TaxProperties props) {
+        return new TaxProviderSelector(props, testMode, external, avalara);
+    }
+
+    @Test
+    @DisplayName("test-mode enabled always selects the test-mode provider")
+    void testModeWins() {
+        TaxProperties props = new TaxProperties();
+        props.getTestMode().setEnabled(true);
+        props.setProvider(TaxProperties.Provider.AVALARA);
+        assertThat(selector(props).select()).isSameAs(testMode);
+    }
+
+    @Test
+    @DisplayName("test-mode off + provider=AVALARA selects the Avalara adapter")
+    void avalaraSelectedWhenTestModeOff() {
+        TaxProperties props = new TaxProperties();
+        props.getTestMode().setEnabled(false);
+        props.setProvider(TaxProperties.Provider.AVALARA);
+        assertThat(selector(props).select()).isSameAs(avalara);
+    }
+
+    @Test
+    @DisplayName("test-mode off + provider=EXTERNAL selects the legacy external stub")
+    void externalSelectedWhenTestModeOff() {
+        TaxProperties props = new TaxProperties();
+        props.getTestMode().setEnabled(false);
+        props.setProvider(TaxProperties.Provider.EXTERNAL);
+        assertThat(selector(props).select()).isSameAs(external);
+    }
+
+    @Test
+    @DisplayName("test-mode off + default/unset provider preserves the legacy external stub")
+    void defaultPreservesExternal() {
+        TaxProperties props = new TaxProperties();
+        props.getTestMode().setEnabled(false);
+        // provider defaults to TEST_MODE (unset) -> legacy external stub when test-mode is off.
+        assertThat(selector(props).select()).isSameAs(external);
+    }
+}

--- a/pos-tax/src/test/java/com/positivity/tax/service/TaxCalculationServiceTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/service/TaxCalculationServiceTest.java
@@ -64,7 +64,8 @@ class TaxCalculationServiceTest {
                 new com.positivity.tax.internal.service.TaxProviderSelector(
                         properties,
                         new com.positivity.tax.internal.service.TestModeTaxProvider(testCalculator),
-                        new com.positivity.tax.internal.service.ExternalTaxProvider(externalClient));
+                        new com.positivity.tax.internal.service.ExternalTaxProvider(externalClient),
+                        mock(com.positivity.tax.internal.service.AvalaraTaxProvider.class));
         service = new TaxCalculationServiceImpl(properties, selector);
     }
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-tax-w5`
- Child issue: louisburroughs/durion-positivity-backend#964 (T6 external adapter)
- Domain: `domain:tax`

Wave 5 (partial) of the pos-tax Odoo-parity plan — the T6 **external adapter**, unblocked by the provider decision **Avalara AvaTax** (research gate R-T1). **Stacked on #983 (Wave 4)** — base `cap/odoo-parity-tax-w4`; retarget down the stack as earlier waves merge.

> **T8 (sales-tax liability reporting) is NOT in this PR** — it remains blocked on R-T4 (Finance's filing workflow, deferred by research) and accounting-plan Wave 1 (period model). See "Remaining" below.

## Contract References
- Contract guide entry (durion): `domains/tax/.business-rules/BACKEND_CONTRACT_GUIDE.md` → provider abstraction / external adapter. No contract (DTO/event) change — the adapter implements the existing `TaxProviderClient` interface shipped in Wave 4. Config-only additions.
- Durion contract PR: n/a.

## Contract Chain
- [ ] No controller/DTO/event change — internal provider implementation + config only.

## Scope
Concrete `AvalaraTaxProvider` behind the existing `TaxProviderClient` seam (test-mode path, lifecycle wiring, and DB schema untouched).

- AvaTax REST v2 mapping: `estimate` → `transactions/create` `SalesOrder` (uncommitted, `lines[].details[]` → per-line jurisdiction rows); `refund` → `ReturnInvoice`; `commit(referenceId)` → `CommitTransaction` on document `code`=referenceId (idempotency); `voidTransaction` → `VoidTransaction` (`DocVoided`, hooks invoice revert-to-DRAFT, R-T2). `externalTransactionId` from the AvaTax id/code.
- **Σ-invariant:** AvaTax totals reconciled to `totalTax` via the Wave-1 `TaxTotalsReconciler` (logs + repairs cent-level provider drift, plan T1).
- **Retry hygiene (ADR-0021):** transport errors run through the shared resilience4j Retry + `TaxRetryPredicate` — 5xx/timeouts retried, 4xx never.
- **Config:** `pos.tax.avalara {base-url (sandbox/prod), account-id, license-key, company-code, timeouts}`; dedicated Basic-auth RestClient. License key only read where it is encoded into the `Authorization` header — never logged. `pos.tax.provider` (TEST_MODE default | AVALARA | EXTERNAL) drives `TaxProviderSelector`; default/unset stays backward-compatible.
- **D-T1 note (not built):** AvaTax CertCapture could later become system of record for the T3 exemption-cert registry; the in-platform registry stays authoritative for now.

## Tests
- [x] Unit tests (`AvalaraTaxProviderTest` 8 — request mapping, response parsing, Σ-drift repair, 400=non-retry, 500=retry; `TaxProviderSelectorTest` 4 — routing). Mocked `RestClient` (`MockRestServiceServer`) — **no live AvaTax calls**.
- **How to run:** `./mvnw -pl pos-tax -am -DskipTests=false clean test` → **pos-tax 97** tests, 0 fail (ArchUnit 12).

## Risk & Rollback
- Risk level: **Medium** — new external integration, but inert unless `pos.tax.provider=AVALARA` with test-mode off and real credentials; default config path is unchanged.
- **Deviations (MVP-thin):** estimate creates a non-persisted `SalesOrder`, so production finalization must persist a `SalesInvoice` under the same document code for commit to resolve (noted in class javadoc); the adapter's `effectiveTaxRate` uses the raw subtotal (no exempt-line filtering) — narrower than the test-mode calculator's T1 fix. No live-sandbox contract test (needs AvaTax credentials).
- Rollback: revert branch; adapter is unreferenced unless explicitly selected by config.

## Remaining Wave-5 backlog (blocked, NOT in this PR)
- **T8 sales-tax liability reporting (#966)** — blocked on R-T4 (Finance filing workflow) + accounting-plan Wave 1 (period model). Owned by pos-accounting (D-T4) reading its `ext_invoice_tax` replica (now populated by Wave 3).
- **AvaTax hardening (follow-ups):** live-sandbox contract test; persist `SalesInvoice` at finalization for commit resolution; exempt-line-aware `effectiveTaxRate` in the adapter path; CertCapture evaluation (D-T1).

## Checklist
- [x] Branch name matches `cap/odoo-parity-tax-w5`
- [x] Links to child issue present
- [x] Contract guide referenced (BACKEND_CONTRACT_GUIDE.md)
- [x] No contract change (config + internal impl only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
