### PR TITLE
fix(pos-accounting): resolve COA seed collisions breaking Flyway repeatable seed

### DIFF
--- a/pos-accounting/src/main/resources/db/migration/R__seed_reference_accounting.sql
+++ b/pos-accounting/src/main/resources/db/migration/R__seed_reference_accounting.sql
@@ -290,7 +290,7 @@ ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system
 -- Adjustments post a real balanced JE: Dr/Cr the reconciled cash account against
 -- the adjustment type's mapped counter account, resolved through the
 -- BANK_RECONCILIATION posting category (one mapping key per adjustment type).
---   BANK_FEE         -> 6010 Bank Service Charges (expense)
+--   BANK_FEE         -> 6030 Bank Service Charges (expense)
 --   NSF_FEE          -> 6020 NSF Fees (expense)
 --   INTEREST_EARNED  -> 4920 Interest Income (revenue)
 --   OTHER            -> 2360 Bank Reconciliation Adjustments (liability clearing)
@@ -299,7 +299,7 @@ ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system
 -- ============================================================================
 
 INSERT INTO gl_account (gl_account_id, account_code, account_name, account_type, account_subtype, reconcilable, created_at, created_by, modified_at, modified_by)
-VALUES ('5eed0acc-0000-4000-8000-000000006010'::uuid, '6010', 'Bank Service Charges', 'EXPENSE', 'OPERATING_EXPENSE', FALSE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+VALUES ('5eed0acc-0000-4000-8000-000000006030'::uuid, '6030', 'Bank Service Charges', 'EXPENSE', 'OPERATING_EXPENSE', FALSE, NOW(), 'seed-generator', NOW(), 'seed-generator')
 ON CONFLICT (account_code) DO UPDATE SET
     account_name = EXCLUDED.account_name, account_type = EXCLUDED.account_type, account_subtype = EXCLUDED.account_subtype,
     reconcilable = EXCLUDED.reconcilable, modified_at = NOW(), modified_by = 'seed-generator';
@@ -309,7 +309,7 @@ ON CONFLICT (account_code) DO UPDATE SET
     account_name = EXCLUDED.account_name, account_type = EXCLUDED.account_type, account_subtype = EXCLUDED.account_subtype,
     reconcilable = EXCLUDED.reconcilable, modified_at = NOW(), modified_by = 'seed-generator';
 INSERT INTO gl_account (gl_account_id, account_code, account_name, account_type, account_subtype, reconcilable, created_at, created_by, modified_at, modified_by)
-VALUES ('5eed0acc-0000-4000-8000-000000004920'::uuid, '4920', 'Interest Income', 'REVENUE', 'REVENUE', FALSE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+VALUES ('5eed0acc-0000-4000-8000-000000004920'::uuid, '4920', 'Interest Income', 'REVENUE', 'OTHER', FALSE, NOW(), 'seed-generator', NOW(), 'seed-generator')
 ON CONFLICT (account_code) DO UPDATE SET
     account_name = EXCLUDED.account_name, account_type = EXCLUDED.account_type, account_subtype = EXCLUDED.account_subtype,
     reconcilable = EXCLUDED.reconcilable, modified_at = NOW(), modified_by = 'seed-generator';
@@ -342,14 +342,14 @@ ON CONFLICT (mapping_key_id) DO UPDATE SET posting_category_id = EXCLUDED.postin
 
 -- GL mappings (fixed effective_start_date for idempotent re-runs).
 INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
-VALUES ('5eed0acc-0000-4000-8000-00000000d011'::uuid, 'ACCOUNTING', 'BANK_RECON_BANK_FEE', '5eed0acc-0000-4000-8000-00000000d001'::uuid, '5eed0acc-0000-4000-8000-00000000d002'::uuid, '5eed0acc-0000-4000-8000-000000006010'::uuid, TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
+VALUES ('5eed0acc-0000-4000-8000-00000000d011'::uuid, 'ACCOUNTING', 'BANK_RECON_BANK_FEE', '5eed0acc-0000-4000-8000-00000000d001'::uuid, '5eed0acc-0000-4000-8000-00000000d002'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '6030'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
 ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';
 INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
-VALUES ('5eed0acc-0000-4000-8000-00000000d012'::uuid, 'ACCOUNTING', 'BANK_RECON_NSF_FEE', '5eed0acc-0000-4000-8000-00000000d001'::uuid, '5eed0acc-0000-4000-8000-00000000d003'::uuid, '5eed0acc-0000-4000-8000-000000006020'::uuid, TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
+VALUES ('5eed0acc-0000-4000-8000-00000000d012'::uuid, 'ACCOUNTING', 'BANK_RECON_NSF_FEE', '5eed0acc-0000-4000-8000-00000000d001'::uuid, '5eed0acc-0000-4000-8000-00000000d003'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '6020'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
 ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';
 INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
-VALUES ('5eed0acc-0000-4000-8000-00000000d013'::uuid, 'ACCOUNTING', 'BANK_RECON_INTEREST_EARNED', '5eed0acc-0000-4000-8000-00000000d001'::uuid, '5eed0acc-0000-4000-8000-00000000d004'::uuid, '5eed0acc-0000-4000-8000-000000004920'::uuid, TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
+VALUES ('5eed0acc-0000-4000-8000-00000000d013'::uuid, 'ACCOUNTING', 'BANK_RECON_INTEREST_EARNED', '5eed0acc-0000-4000-8000-00000000d001'::uuid, '5eed0acc-0000-4000-8000-00000000d004'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '4920'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
 ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';
 INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
-VALUES ('5eed0acc-0000-4000-8000-00000000d015'::uuid, 'ACCOUNTING', 'BANK_RECON_OTHER', '5eed0acc-0000-4000-8000-00000000d001'::uuid, '5eed0acc-0000-4000-8000-00000000d006'::uuid, '5eed0acc-0000-4000-8000-000000002360'::uuid, TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
+VALUES ('5eed0acc-0000-4000-8000-00000000d015'::uuid, 'ACCOUNTING', 'BANK_RECON_OTHER', '5eed0acc-0000-4000-8000-00000000d001'::uuid, '5eed0acc-0000-4000-8000-00000000d006'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '2360'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
 ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';


### PR DESCRIPTION
## Capability & Traceability
- Domain: `domain:accounting`
- Fixes the accounting integration-test failures on `main` (CI run 29830020626, job "Integration Tests (pos-accounting)" — 3 errors) caused by `R__seed_reference_accounting.sql` failing against real Postgres. Surfaced by the first full Postgres-IT run after #986 merged; both bugs are pre-existing seed defects, not introduced by the tax work.

## Contract References
No API/event/contract change — data-seed migration only. See BACKEND_CONTRACT_GUIDE.md (no contract-relevant files touched).

## Scope
- **What changed:** two defects in the Flyway repeatable seed `R__seed_reference_accounting.sql` that aborted the whole seed on real Postgres (H2 unit tests do not enforce these, so it slipped through until the Docker/Postgres IT job ran on `main`).
- **Why:** the aborted seed left the accounting schema unpopulated, so every IT that boots the full accounting context or runs the migration failed at Flyway (`AccountingPeriodBackfillIT`, `JournalEntryBalanceTriggerIT`, `JournalEntryNumberingConcurrencyIT`).

### Bug 1 — invalid `account_subtype`
`gl_account` code `4920` "Interest Income" seeded `account_subtype='REVENUE'`, which is not a member of the `AccountSubtype` enum and violated `gl_account_account_subtype_check` (V11). Changed to `'OTHER'` (interest is non-operating/other income; `account_type` stays `REVENUE`).

### Bug 2 — `account_code` collision (6010)
`account_code=6010` is owned by `V3__seed_labor_overhead_mapping.sql` ("Retread Plant Hourly Wages", CAP-316), which runs before the repeatable seed. The bank-reconciliation section of `R__seed` re-used `6010` for "Bank Service Charges" via `ON CONFLICT (account_code) DO UPDATE`, so the conflict kept V3's original PK and the hardcoded bank-charges UUID `…6010` was never created. The `BANK_RECON_BANK_FEE` `gl_mapping` then referenced that non-existent id → FK `fkf8a3hgiabmsmxqds6vmaym8qr` (gl_mapping.gl_account_id → gl_account) violation.
- **Fix:** moved "Bank Service Charges" to unused COA code **6030** (verified free across V1 baseline, V3, and R__), keeping it in the 6000 operating-expense band next to `6000` Payment Processor Fees and `6020` NSF Fees. `6010` stays exclusively the wages account.
- **Hardening:** the four `BANK_RECONCILIATION` gl_mappings now resolve `gl_account_id` via `(SELECT gl_account_id FROM gl_account WHERE account_code = '…')` instead of hardcoded UUIDs, so the seed is immune to any future `ON CONFLICT` id divergence.
- **Audit:** gl_accounts are seeded only in V3 and R__; every other R__ account referenced by a gl_mapping (6020, 4920, 2360, …) appears only in R__, so its id survives ON CONFLICT. 6010 was the only true collision.

## Tests
- [ ] Unit tests added/updated — N/A (seed data fix)
- [x] Integration tests — the 3 previously-failing accounting ITs now pass
- How to run: `./mvnw -pl pos-accounting -am verify` → BUILD SUCCESS (1101 unit + 185 IT, 0 failures/errors)

## Risk & Rollback
- Risk level: Low
- Rollback plan: revert the single commit; repeatable-migration change re-applies on next deploy (no forward-only schema migration involved).

## Checklist
- [x] Branch off `main`
- [x] Required CI checks (to be confirmed on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)