### PR TITLE
[CAP:odoo-parity-accounting] D1 breakdown-upgrade — credit-memo tax reversal from ext_invoice_tax replica

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
@@ -221,7 +221,7 @@ public class CreditMemoServiceImpl implements CreditMemoService {
     @NonNull
     private BigDecimal resolveFrozenTax(@NonNull ExtInvoice invoice) {
         List<ExtInvoiceTax> breakdown = extInvoiceTaxRepository.findByInvoiceId(invoice.getInvoiceId());
-        if (!breakdown.isEmpty()) {
+        if (breakdown != null && !breakdown.isEmpty()) {
             return breakdown.stream()
                     .map(ExtInvoiceTax::getTaxAmount)
                     .filter(java.util.Objects::nonNull)

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
@@ -5,8 +5,10 @@ import com.positivity.accounting.internal.dto.CreateCreditMemoRequest;
 import com.positivity.accounting.internal.dto.CreditMemoResponse;
 import com.positivity.accounting.internal.entity.CreditMemo;
 import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.ExtInvoiceTax;
 import com.positivity.accounting.internal.enums.CreditMemoStatus;
 import com.positivity.accounting.internal.repository.CreditMemoRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
 import com.positivity.accounting.service.AccountingPeriodService;
 import com.positivity.accounting.service.CreditMemoService;
 import com.positivity.accounting.service.GLPostingService;
@@ -14,6 +16,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,6 +67,7 @@ public class CreditMemoServiceImpl implements CreditMemoService {
     private static final BigDecimal ZERO_TAX = new BigDecimal("0.00");
 
     private final CreditMemoRepository creditMemoRepository;
+    private final ExtInvoiceTaxRepository extInvoiceTaxRepository;
     private final InvoiceBalanceCalculator invoiceBalanceCalculator;
     private final GLPostingService glPostingService;
     private final AccountingPeriodService periodService;
@@ -160,9 +164,17 @@ public class CreditMemoServiceImpl implements CreditMemoService {
     }
 
     /**
-     * Derive the tax to reverse from the invoice's STORED tax scalar (issue #953, Odoo parity
-     * decision D-4). Tax is frozen at invoice finalization and is never recomputed from rates at
-     * credit time (rate-drift protection).
+     * Derive the tax to reverse from the invoice's STORED, frozen tax (issue #953 interim scalar;
+     * D1 breakdown-upgrade, Odoo parity decision D-4). Tax is frozen at invoice finalization and is
+     * never recomputed from rates at credit time (rate-drift protection).
+     *
+     * <p>Source of the total tax (D1 upgrade): the authoritative per-line × per-jurisdiction
+     * {@code ext_invoice_tax} replica populated by tax-plan T5 ({@code Σ taxAmount} of its rows).
+     * When no replica rows exist — a pre-T5 invoice, or one whose breakdown was never emitted — it
+     * falls back to the scalar {@code ExtInvoice.tax} rollup (strictly better than the retired 10%
+     * heuristic, and equal to the breakdown sum by the T5 {@code scalar == Σ breakdown} invariant).
+     * Per D-4/D2 the GL posting still reverses a single sales-tax-payable account; the jurisdiction
+     * detail is report-time aggregation (tax-plan T8), not a per-jurisdiction credit posting.
      *
      * <p>The credit amount is the revenue (pre-tax) portion being reversed, so the pro-rating
      * ratio is {@code creditAmount / net} where {@code net = total − tax}, and
@@ -175,13 +187,12 @@ public class CreditMemoServiceImpl implements CreditMemoService {
      */
     @NonNull
     private BigDecimal calculateTaxReversed(@NonNull BigDecimal creditAmount, @NonNull ExtInvoice invoice) {
-        BigDecimal storedTax = invoice.getTax();
-        if (storedTax == null || storedTax.signum() <= 0) {
+        BigDecimal totalTax = resolveFrozenTax(invoice);
+        if (totalTax.signum() <= 0) {
             return ZERO_TAX;
         }
-        BigDecimal totalTax = storedTax.setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
         BigDecimal total = invoice.getTotal() == null ? BigDecimal.ZERO : invoice.getTotal();
-        BigDecimal netAmount = total.subtract(storedTax);
+        BigDecimal netAmount = total.subtract(totalTax);
 
         BigDecimal previouslyCreditedNet = creditMemoRepository.sumCreditAmountByInvoiceIdAndStatus(
                 invoice.getInvoiceId(), CreditMemoStatus.POSTED);
@@ -199,6 +210,26 @@ public class CreditMemoServiceImpl implements CreditMemoService {
         // remainingNet > creditAmount > 0 implies netAmount > 0: division is safe.
         BigDecimal creditRatio = creditAmount.divide(netAmount, RATIO_SCALE, RoundingMode.HALF_UP);
         return totalTax.multiply(creditRatio).setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * The frozen total tax to reverse, at currency scale (D1 breakdown-upgrade). Prefers the
+     * authoritative {@code ext_invoice_tax} replica ({@code Σ taxAmount}); falls back to the scalar
+     * {@code ExtInvoice.tax} rollup when the invoice has no breakdown rows (pre-T5 invoices). A
+     * non-positive result (untaxed / fully exempt / absent) reverses no tax.
+     */
+    @NonNull
+    private BigDecimal resolveFrozenTax(@NonNull ExtInvoice invoice) {
+        List<ExtInvoiceTax> breakdown = extInvoiceTaxRepository.findByInvoiceId(invoice.getInvoiceId());
+        if (!breakdown.isEmpty()) {
+            return breakdown.stream()
+                    .map(ExtInvoiceTax::getTaxAmount)
+                    .filter(java.util.Objects::nonNull)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add)
+                    .setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
+        }
+        BigDecimal storedTax = invoice.getTax();
+        return storedTax == null ? ZERO_TAX : storedTax.setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
     }
 
     private void validateCreditDoesNotExceedBalance(

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/CreditMemoServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/CreditMemoServiceTest.java
@@ -14,8 +14,10 @@ import com.positivity.accounting.internal.dto.CreateCreditMemoRequest;
 import com.positivity.accounting.internal.dto.CreditMemoResponse;
 import com.positivity.accounting.internal.entity.CreditMemo;
 import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.ExtInvoiceTax;
 import com.positivity.accounting.internal.enums.CreditMemoStatus;
 import com.positivity.accounting.internal.repository.CreditMemoRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
 import com.positivity.accounting.internal.service.AccountingPeriodServiceImpl;
 import com.positivity.accounting.internal.service.CreditMemoServiceImpl;
 import com.positivity.accounting.internal.service.GLPostingServiceImpl;
@@ -63,6 +65,9 @@ class CreditMemoServiceTest {
 
     @Mock
     private CreditMemoRepository creditMemoRepository;
+
+    @Mock
+    private ExtInvoiceTaxRepository extInvoiceTaxRepository;
 
     @Mock
     private InvoiceBalanceCalculator invoiceBalanceCalculator;
@@ -515,6 +520,44 @@ class CreditMemoServiceTest {
                         anyString(),
                         eq(false),
                         eq(null));
+    }
+
+    @Test
+    @DisplayName("D1 breakdown-upgrade: tax reversal sums the ext_invoice_tax replica, not the scalar rollup")
+    void testBreakdown_SourcedFromReplicaNotScalar() {
+        // Given - the scalar ExtInvoice.tax is ABSENT (null), but the authoritative
+        // ext_invoice_tax replica carries the frozen per-jurisdiction breakdown summing to 35.59
+        // (STATE 30.00 + COUNTY 5.59). If the code read the scalar it would reverse 0.00; sourcing
+        // from the breakdown reverses 35.59.
+        testInvoice = replicaInvoice("FINALIZED", "235.59", null, Instant.now(TEST_CLOCK));
+        stubReplica(testInvoice, "235.59");
+        stubSaveEcho();
+        when(extInvoiceTaxRepository.findByInvoiceId(testInvoiceId))
+                .thenReturn(List.of(breakdownRow("STATE", "30.00"), breakdownRow("COUNTY", "5.59")));
+        // Full-net credit → final-line residual reverses the entire frozen tax.
+        testRequest.setCreditAmount(new BigDecimal("200.00"));
+
+        // When
+        CreditMemoResponse response = service.createCreditMemo(testRequest, "test-user");
+
+        // Then
+        assertThat(response.getTaxAmountReversed()).isEqualByComparingTo("35.59");
+        assertThat(response.getTotalAmount()).isEqualByComparingTo("235.59");
+    }
+
+    private ExtInvoiceTax breakdownRow(String jurisdictionType, String taxAmount) {
+        return ExtInvoiceTax.builder()
+                .invoiceId(testInvoiceId)
+                .lineItemId("1")
+                .jurisdictionType(jurisdictionType)
+                .jurisdictionCode(jurisdictionType)
+                .rate(new BigDecimal("0.0000"))
+                .taxableBase(new BigDecimal("0.00"))
+                .taxAmount(new BigDecimal(taxAmount))
+                .exempt(false)
+                .aggregateVersion(1L)
+                .updatedAt(Instant.now(TEST_CLOCK))
+                .build();
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-accounting`
- Domain: `domain:accounting`
- Story: **D1 breakdown-upgrade** (`durion domains/accounting/plan-odoo-parity-pos-accounting.md` §5). Completes the deferred breakdown half of D1 — issue #953 shipped the interim scalar in Wave 3; this sources the reversal from the per-jurisdiction breakdown now that tax-plan **T5** has landed.

## Contract References
No API/event/contract change — internal service logic + one added repository dependency. See BACKEND_CONTRACT_GUIDE.md (no contract-relevant files touched).

## Scope
- **What changed:** `CreditMemoServiceImpl` now derives the frozen total tax to reverse from the authoritative `ext_invoice_tax` replica (`Σ taxAmount` of the invoice's rows) instead of the `ExtInvoice.tax` scalar rollup.
- **Why:** tax-plan T5 landed (per-line × per-jurisdiction breakdown persisted → `InvoiceUpdatedV1.taxBreakdown[]` #950 → `ext_invoice_tax` replica #951/#952, populated via the #986 null-vs-empty producer contract). D1's Wave-3 interim used the scalar as a placeholder; this is the planned upgrade to the breakdown source.

### Details
- New `resolveFrozenTax(ExtInvoice)`: sums the invoice's `ext_invoice_tax` rows; **falls back** to the `ExtInvoice.tax` scalar when the invoice has no breakdown rows (pre-T5 invoices) — equal to the breakdown sum by the T5 `scalar == Σ breakdown` invariant, so no behavior change for those.
- Proration by credit ratio + final-line residual correction (Odoo last-partial pattern) **unchanged**; tax remains **frozen at finalization** (never recomputed from rates at credit time — rate-drift protection).
- Per **D-4 / D2 (non-goal)** the GL posting still reverses a **single** sales-tax-payable account; jurisdiction detail stays report-time aggregation (tax-plan **T8**), not a per-jurisdiction credit posting.

## Tests
- [x] Unit tests added/updated — new `testBreakdown_SourcedFromReplicaNotScalar` (scalar null, replica rows sum 35.59 → reversal 35.59, proving replica sourcing); existing scalar tests exercise the fallback path unchanged.
- [ ] Integration tests — N/A (no schema/event change)
- How to run: `./mvnw -pl pos-accounting test` → BUILD SUCCESS (full suite green)

## Risk & Rollback
- Risk level: Low
- Rollback plan: revert the single commit; additive (new repo dependency + new private method), no schema/contract change, fallback preserves prior behavior for invoices without a breakdown replica.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Contract guide referenced
- [ ] Required CI checks passing (to confirm on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)