### PR TITLE
[CAP:987] Fix Spring AI startup wiring and callback test coverage

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/DocumentEmbeddingIngestor.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/DocumentEmbeddingIngestor.java
@@ -13,6 +13,7 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
 import org.springframework.ai.vectorstore.pgvector.PgVectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -36,6 +37,7 @@ public class DocumentEmbeddingIngestor {
     private final int segmentStepSize;
     private final int maxChunksPerDocument;
 
+    @Autowired
     public DocumentEmbeddingIngestor(
             @NonNull PgVectorStore embeddingStore,
             @NonNull EmbeddingModel embeddingModel,

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
@@ -30,7 +30,7 @@ class SpringAiPosAssistantTest {
     }
 
     @Test
-    void chat_includesRagContextAndPersistsMemoryIdConversation() {
+    void chat_includesRagContextAndPersistsConversationMemory() {
         ChatModel chatModel = mock(ChatModel.class);
         QueryDocumentRetriever ragRetriever = mock(QueryDocumentRetriever.class);
         ChatMemory chatMemory = mock(ChatMemory.class);

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
@@ -1,0 +1,89 @@
+package com.positivity.mcp.internal.orchestration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
+import com.positivity.mcp.internal.service.OpenApiToolProvider;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.document.Document;
+
+class SpringAiPosAssistantTest {
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static ArgumentCaptor<List<Message>> messageListCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
+    }
+
+    @Test
+    void chat_includesRagContextAndPersistsMemoryIdConversation() {
+        ChatModel chatModel = mock(ChatModel.class);
+        QueryDocumentRetriever ragRetriever = mock(QueryDocumentRetriever.class);
+        ChatMemory chatMemory = mock(ChatMemory.class);
+        OpenApiToolProvider openApiToolProvider = mock(OpenApiToolProvider.class);
+        when(openApiToolProvider.resolveToolCallbacks(any())).thenReturn(List.of());
+        when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse("resolved answer"));
+        when(ragRetriever.retrieve("where is stock")).thenReturn(List.of(new Document("Inventory policy A")));
+        when(chatMemory.get("user-1::ROLE_TECH"))
+                .thenReturn(List.of(new AssistantMessage("previous assistant turn")));
+
+        SpringAiPosAssistant assistant = new SpringAiPosAssistant(
+                chatModel,
+                () -> "base prompt",
+                List.of(new PingTool()),
+                ragRetriever,
+                ignored -> chatMemory,
+                openApiToolProvider);
+
+        String response = assistant.chat("user-1::ROLE_TECH", "where is stock", "ctx:role=TECH");
+
+        assertThat(response).isEqualTo("resolved answer");
+        verify(ragRetriever).retrieve("where is stock");
+        verify(openApiToolProvider).resolveToolCallbacks("where is stock");
+
+        ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+        verify(chatModel).call(promptCaptor.capture());
+        List<Message> promptMessages = promptCaptor.getValue().getInstructions();
+        assertThat(promptMessages).hasSize(3);
+        assertThat(promptMessages.getFirst().getText()).isEqualTo("previous assistant turn");
+        assertThat(promptMessages.get(1).getText())
+                .contains("base prompt")
+                .contains("ctx:role=TECH")
+                .contains("Relevant retrieved context:")
+                .contains("Inventory policy A");
+        assertThat(promptMessages.get(2).getText()).isEqualTo("where is stock");
+
+        ArgumentCaptor<List<Message>> persistedMessages = messageListCaptor();
+        verify(chatMemory).add(eq("user-1::ROLE_TECH"), persistedMessages.capture());
+        assertThat(persistedMessages.getValue()).hasSize(2);
+        assertThat(persistedMessages.getValue().getFirst()).isInstanceOf(UserMessage.class);
+        assertThat(persistedMessages.getValue().getFirst().getText()).isEqualTo("where is stock");
+        assertThat(persistedMessages.getValue().get(1)).isInstanceOf(AssistantMessage.class);
+        assertThat(persistedMessages.getValue().get(1).getText()).isEqualTo("resolved answer");
+    }
+
+    private static ChatResponse chatResponse(String text) {
+        return new ChatResponse(List.of(new Generation(new AssistantMessage(text))));
+    }
+
+    static final class PingTool {
+        @org.springframework.ai.tool.annotation.Tool(description = "Health check")
+        String ping() {
+            return "pong";
+        }
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
@@ -1,0 +1,99 @@
+package com.positivity.mcp.internal.orchestration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
+import com.positivity.mcp.internal.service.OpenApiToolProvider;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.StreamingChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.document.Document;
+import reactor.core.publisher.Flux;
+
+class SpringAiStreamingPosAssistantTest {
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        private static ArgumentCaptor<List<Message>> messageListCaptor() {
+                return (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
+        }
+
+    @Test
+    void chat_usesRagRetrieverAndPersistsMemoryIdOnStreamCompletion() {
+        StreamingChatModel streamingChatModel = mock(StreamingChatModel.class);
+        QueryDocumentRetriever ragRetriever = mock(QueryDocumentRetriever.class);
+        ChatMemory chatMemory = mock(ChatMemory.class);
+        OpenApiToolProvider openApiToolProvider = mock(OpenApiToolProvider.class);
+
+        when(openApiToolProvider.resolveToolCallbacks(any())).thenReturn(List.of());
+        when(ragRetriever.retrieve("where is stock")).thenReturn(List.of(new Document("Inventory doc")));
+        when(chatMemory.get("user-2::ROLE_TECH")).thenReturn(List.of(new AssistantMessage("previous turn")));
+        when(streamingChatModel.stream(any(Prompt.class)))
+                .thenReturn(Flux.just(chatResponse("Hel"), chatResponse(""), chatResponse("lo")));
+
+        SpringAiStreamingPosAssistant assistant = new SpringAiStreamingPosAssistant(
+                streamingChatModel,
+                () -> "base prompt",
+                List.of(new PingTool()),
+                ragRetriever,
+                ignored -> chatMemory,
+                openApiToolProvider);
+
+        List<String> tokens = assistant
+                .chat("user-2::ROLE_TECH", "where is stock", "ctx:role=TECH")
+                .collectList()
+                .block();
+
+        assertThat(tokens).containsExactly("Hel", "lo");
+        verify(ragRetriever).retrieve("where is stock");
+        verify(openApiToolProvider).resolveToolCallbacks("where is stock");
+
+        ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+        verify(streamingChatModel).stream(promptCaptor.capture());
+        List<Message> promptMessages = promptCaptor.getValue().getInstructions();
+        assertThat(promptMessages).hasSize(3);
+        assertThat(promptMessages.getFirst().getText()).isEqualTo("previous turn");
+        assertThat(promptMessages.get(1).getText())
+                .contains("base prompt")
+                .contains("ctx:role=TECH")
+                .contains("Relevant retrieved context:")
+                .contains("Inventory doc");
+        assertThat(promptMessages.get(2).getText()).isEqualTo("where is stock");
+
+                ArgumentCaptor<List<Message>> persistedCalls = messageListCaptor();
+                verify(chatMemory, times(2)).add(eq("user-2::ROLE_TECH"), persistedCalls.capture());
+                assertThat(persistedCalls.getAllValues()).hasSize(2);
+
+                List<Message> firstCall = persistedCalls.getAllValues().getFirst();
+                assertThat(firstCall).hasSize(1);
+                assertThat(firstCall.getFirst().getText()).isEqualTo("where is stock");
+
+                List<Message> secondCall = persistedCalls.getAllValues().get(1);
+                assertThat(secondCall).hasSize(1);
+                assertThat(secondCall.getFirst()).isInstanceOf(AssistantMessage.class);
+                assertThat(secondCall.getFirst().getText()).isEqualTo("Hello");
+    }
+
+    private static ChatResponse chatResponse(String token) {
+        return new ChatResponse(List.of(new Generation(new AssistantMessage(token))));
+    }
+
+    static final class PingTool {
+        @org.springframework.ai.tool.annotation.Tool(description = "Health check")
+        String ping() {
+            return "pong";
+        }
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
+import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -54,7 +55,7 @@ class SpringAiStreamingPosAssistantTest {
         List<String> tokens = assistant
                 .chat("user-2::ROLE_TECH", "where is stock", "ctx:role=TECH")
                 .collectList()
-                .block();
+                .block(Duration.ofSeconds(5));
 
         assertThat(tokens).containsExactly("Hel", "lo");
         verify(ragRetriever).retrieve("where is stock");
@@ -72,18 +73,18 @@ class SpringAiStreamingPosAssistantTest {
                 .contains("Inventory doc");
         assertThat(promptMessages.get(2).getText()).isEqualTo("where is stock");
 
-                ArgumentCaptor<List<Message>> persistedCalls = messageListCaptor();
-                verify(chatMemory, times(2)).add(eq("user-2::ROLE_TECH"), persistedCalls.capture());
-                assertThat(persistedCalls.getAllValues()).hasSize(2);
+        ArgumentCaptor<List<Message>> persistedCalls = messageListCaptor();
+        verify(chatMemory, times(2)).add(eq("user-2::ROLE_TECH"), persistedCalls.capture());
+        assertThat(persistedCalls.getAllValues()).hasSize(2);
 
-                List<Message> firstCall = persistedCalls.getAllValues().getFirst();
-                assertThat(firstCall).hasSize(1);
-                assertThat(firstCall.getFirst().getText()).isEqualTo("where is stock");
+        List<Message> firstCall = persistedCalls.getAllValues().getFirst();
+        assertThat(firstCall).hasSize(1);
+        assertThat(firstCall.getFirst().getText()).isEqualTo("where is stock");
 
-                List<Message> secondCall = persistedCalls.getAllValues().get(1);
-                assertThat(secondCall).hasSize(1);
-                assertThat(secondCall.getFirst()).isInstanceOf(AssistantMessage.class);
-                assertThat(secondCall.getFirst().getText()).isEqualTo("Hello");
+        List<Message> secondCall = persistedCalls.getAllValues().get(1);
+        assertThat(secondCall).hasSize(1);
+        assertThat(secondCall.getFirst()).isInstanceOf(AssistantMessage.class);
+        assertThat(secondCall.getFirst().getText()).isEqualTo("Hello");
     }
 
     private static ChatResponse chatResponse(String token) {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
@@ -26,10 +26,10 @@ import reactor.core.publisher.Flux;
 
 class SpringAiStreamingPosAssistantTest {
 
-        @SuppressWarnings({"rawtypes", "unchecked"})
-        private static ArgumentCaptor<List<Message>> messageListCaptor() {
-                return (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
-        }
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static ArgumentCaptor<List<Message>> messageListCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
+    }
 
     @Test
     void chat_usesRagRetrieverAndPersistsMemoryIdOnStreamCompletion() {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolverTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolverTest.java
@@ -40,7 +40,7 @@ class SpringAiToolCallbackResolverTest {
         List<String> required = (List<String>) schema.get("required");
 
         assertThat(properties).hasSize(3);
-        assertThat(required).containsExactlyElementsOf(properties.keySet());
+        assertThat(required).containsExactlyInAnyOrderElementsOf(properties.keySet());
 
         List<String> names = properties.keySet().stream().toList();
         Map<String, Object> payload = new LinkedHashMap<>();

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolverTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolverTest.java
@@ -1,0 +1,74 @@
+package com.positivity.mcp.internal.orchestration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+class SpringAiToolCallbackResolverTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void call_bindsArgumentsUsingArgIndexFallbackNames() {
+        ToolCallback callback = SpringAiToolCallbackResolver.fromObjects(List.of(new SampleTool()))
+                .getFirst();
+
+        String output = callback.call("{\"arg0\":\"SKU-1\",\"arg1\":3,\"arg2\":true}");
+
+        assertThat(output).isEqualTo("SKU-1|3|true");
+    }
+
+    @Test
+    void schemaNames_bindSuccessfullyWithoutDependingOnReflectedParameterNames() throws Exception {
+        ToolCallback callback = SpringAiToolCallbackResolver.fromObjects(List.of(new SampleTool()))
+                .getFirst();
+
+        Map<String, Object> schema =
+                OBJECT_MAPPER.readValue(callback.getToolDefinition().inputSchema(), new TypeReference<>() {});
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+        @SuppressWarnings("unchecked")
+        List<String> required = (List<String>) schema.get("required");
+
+        assertThat(properties).hasSize(3);
+        assertThat(required).containsExactlyElementsOf(properties.keySet());
+
+        List<String> names = properties.keySet().stream().toList();
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put(names.get(0), "SKU-9");
+        payload.put(names.get(1), 11);
+        payload.put(names.get(2), false);
+
+        String output = callback.call(OBJECT_MAPPER.writeValueAsString(payload));
+        assertThat(output).isEqualTo("SKU-9|11|false");
+    }
+
+    @Test
+    void call_rejectsInvalidJson() {
+        ToolCallback callback = SpringAiToolCallbackResolver.fromObjects(List.of(new SampleTool()))
+                .getFirst();
+
+        assertThatThrownBy(() -> callback.call("not-json"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid tool input JSON");
+    }
+
+    static final class SampleTool {
+        @Tool(description = "Test parameter binding")
+        public String lookup(
+                @ToolParam(description = "Product lookup key") String lookupKey,
+                Integer quantity,
+                boolean includeInactive) {
+            return lookupKey + "|" + quantity + "|" + includeInactive;
+        }
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/DocumentEmbeddingIngestorTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/DocumentEmbeddingIngestorTest.java
@@ -1,8 +1,10 @@
 package com.positivity.mcp.internal.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,5 +59,42 @@ class DocumentEmbeddingIngestorTest {
                                 new FilterExpressionBuilder().eq("document_id", "inventory.stock"),
                                 new FilterExpressionBuilder().eq("rag_scope", "inventory"))
                         .build());
+    }
+
+    @Test
+    void chunking_capsOverlapToHalfSegmentSizeToAvoidExplosiveChunkCounts() {
+        PgVectorStore embeddingStore = mock(PgVectorStore.class);
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+        // With segment size 10 and configured overlap 9, effective overlap is capped to 5.
+        when(embeddingModel.embed(anyList()))
+                .thenReturn(List.of(
+                        new float[] {1.0f},
+                        new float[] {1.0f},
+                        new float[] {1.0f},
+                        new float[] {1.0f},
+                        new float[] {1.0f}));
+        DocumentEmbeddingIngestor ingestor =
+                new DocumentEmbeddingIngestor(embeddingStore, embeddingModel, true, 10, 9, 100);
+
+        int chunks = ingestor.ingestDocument("abcdefghijklmnopqrstuvwxyz", Map.of("rag_scope", "inventory"));
+
+        assertEquals(5, chunks);
+    }
+
+    @Test
+    void chunking_enforcesMaxChunksPerDocumentLimit() {
+        PgVectorStore embeddingStore = mock(PgVectorStore.class);
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+        DocumentEmbeddingIngestor ingestor =
+                new DocumentEmbeddingIngestor(embeddingStore, embeddingModel, true, 10, 0, 2);
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> ingestor.ingestDocument("abcdefghijklmnopqrstuvwxyz", Map.of("rag_scope", "inventory")));
+
+        assertTrue(exception.getMessage().contains("RAG document ingestion failed"));
+        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+        assertTrue(exception.getCause().getMessage().contains("Document exceeds configured chunk limit"));
+        verify(embeddingModel, never()).embed(anyList());
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/DocumentEmbeddingIngestorTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/DocumentEmbeddingIngestorTest.java
@@ -67,12 +67,9 @@ class DocumentEmbeddingIngestorTest {
         EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
         // With segment size 10 and configured overlap 9, effective overlap is capped to 5.
         when(embeddingModel.embed(anyList()))
-                .thenReturn(List.of(
-                        new float[] {1.0f},
-                        new float[] {1.0f},
-                        new float[] {1.0f},
-                        new float[] {1.0f},
-                        new float[] {1.0f}));
+                .thenAnswer(invocation -> ((List<String>) invocation.getArgument(0)).stream()
+                        .map(ignored -> new float[] {1.0f})
+                        .toList());
         DocumentEmbeddingIngestor ingestor =
                 new DocumentEmbeddingIngestor(embeddingStore, embeddingModel, true, 10, 9, 100);
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:987`
- Parent STORY (durion): `UNRESOLVED` (no parent-story link found in source references)
- Child issue: `UNRESOLVED` (referenced `louisburroughs/durion-positivity-backend#987` is a PR, not an issue)
- Related PR: `louisburroughs/durion-positivity-backend#987`
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/mcp/.business-rules/BACKEND_CONTRACT_GUIDE.md` → N/A (no controller/DTO/event contract change)
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope
- What changed:
  - Marked the production constructor in `DocumentEmbeddingIngestor` with `@Autowired` to disambiguate Spring bean construction when multiple constructors exist.
  - Added/updated Spring AI orchestration and callback resolver tests in `pos-mcp-server`.
  - Added chunking guardrail tests in `DocumentEmbeddingIngestorTest`.
- Why:
  - Fixes startup failure: `BeanInstantiationException: No default constructor found` for `DocumentEmbeddingIngestor`.
  - Improves regression safety for Spring AI orchestration callback/tool resolution paths.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run:
  - `./mvnw -pl pos-mcp-server -DskipTests compile --no-transfer-progress`
  - `./mvnw -pl pos-mcp-server -Dtest=DocumentEmbeddingIngestorTest,DocumentIngestionServiceTest test --no-transfer-progress`

## Risk & Rollback
- Risk level: Low
- Rollback plan:
  - Revert commit `23cb6d43a` and redeploy previous artifact.

## Checklist
- [ ] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [ ] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing
