### PR TITLE
[CAP:odoo-parity-accounting] Fix C1/C3 follow-up bugs: overpayment GL posting (#975) + OLDEST_FIRST aging key (#976)

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/CustomerCreditIssuanceGLPostingEvent.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/CustomerCreditIssuanceGLPostingEvent.java
@@ -1,0 +1,93 @@
+package com.positivity.accounting.internal.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Outbox work item enqueued when an overpayment converts its excess into a
+ * {@link com.positivity.accounting.internal.entity.CustomerCredit} (story
+ * parity-C1, issue #975), triggering asynchronous GL posting of the credit
+ * issuance:
+ * <ul>
+ * <li>Dr Undeposited Funds (the overpayment cash actually received)</li>
+ * <li>Cr Customer Credit Liability (the obligation now owed to the customer)</li>
+ * </ul>
+ *
+ * <p>
+ * Without this leg the overpayment cash never reaches the ledger: only the
+ * applied portion posts (Dr Undeposited Funds / Cr AR via
+ * {@link PaymentApplicationGLPostingEvent}), leaving Undeposited Funds
+ * understated and the customer-credit liability unrecognized. This entry
+ * restores double-entry completeness for the excess.
+ *
+ * <p>
+ * Enqueued in the same transaction as the {@code CustomerCredit} insert
+ * (transactional outbox) by
+ * {@link com.positivity.accounting.internal.service.PaymentApplicationServiceImpl}
+ * and consumed by
+ * {@link com.positivity.accounting.internal.handler.CustomerCreditIssuanceGLPostingEventHandler}.
+ * Accounts resolve through the {@code CUSTOMER_CREDIT_ISSUANCE} posting
+ * category and its {@code UNDEPOSITED_FUNDS} / {@code CUSTOMER_CREDIT_LIABILITY}
+ * mapping keys — never hardcoded.
+ *
+ * @see <a href=
+ *      "https://github.com/louisburroughs/durion-positivity-backend/issues/975">Issue
+ *      #975 (parity-C1)</a>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerCreditIssuanceGLPostingEvent {
+
+    /** Outbox event UUID (delivery identity, not the posting idempotency key). */
+    @NonNull
+    @JsonProperty("eventId")
+    private UUID eventId;
+
+    /**
+     * Caller-supplied application request id — the basis for the posting
+     * idempotency key (namespaced for the credit leg so it never collides with
+     * the AR cash-receipt leg) and the journal entry {@code sourceEventId}.
+     */
+    @NonNull
+    @JsonProperty("applicationRequestId")
+    private String applicationRequestId;
+
+    /** Persisted {@code CustomerCredit} id this issuance entry backs. */
+    @NonNull
+    @JsonProperty("creditId")
+    private UUID creditId;
+
+    /** Receivable payment UUID the overpayment drew from. */
+    @NonNull
+    @JsonProperty("paymentId")
+    private UUID paymentId;
+
+    /** Customer UUID. */
+    @NonNull
+    @JsonProperty("customerId")
+    private UUID customerId;
+
+    /** Payment currency (ISO 4217). */
+    @NonNull
+    @JsonProperty("currency")
+    private String currency;
+
+    /** Overpayment excess recorded as the customer credit (the entry amount). */
+    @NonNull
+    @JsonProperty("creditAmount")
+    private BigDecimal creditAmount;
+
+    /** Timestamp the payment application (and credit) was recorded. */
+    @NonNull
+    @JsonProperty("applicationTimestamp")
+    private Instant applicationTimestamp;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/handler/CustomerCreditIssuanceGLPostingEventHandler.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/handler/CustomerCreditIssuanceGLPostingEventHandler.java
@@ -121,6 +121,7 @@ public class CustomerCreditIssuanceGLPostingEventHandler {
 
             JournalEntry posted = glPostingService.postCustomerCreditIssuance(
                     sourceEventId,
+                    event.getCreditId(),
                     undepositedFundsAccountId,
                     creditLiabilityAccountId,
                     event.getCreditAmount(),

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/handler/CustomerCreditIssuanceGLPostingEventHandler.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/handler/CustomerCreditIssuanceGLPostingEventHandler.java
@@ -1,0 +1,173 @@
+package com.positivity.accounting.internal.handler;
+
+import com.positivity.accounting.internal.dto.CustomerCreditIssuanceGLPostingEvent;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.exception.AccountingPeriodClosedException;
+import com.positivity.accounting.internal.exception.AccountingPeriodHardLockedException;
+import com.positivity.accounting.service.GLMappingResolver;
+import com.positivity.accounting.service.GLPostingService;
+import com.positivity.accounting.service.IdempotencyService;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Event handler for customer-credit issuance GL posting work items (parity-C1,
+ * issue #975).
+ *
+ * <p>
+ * Consumes {@link CustomerCreditIssuanceGLPostingEvent} work items delivered
+ * from the transactional outbox (mirroring the
+ * {@link PaymentApplicationGLPostingEventHandler} async pattern) and posts the
+ * overpayment excess to the ledger via
+ * {@link GLPostingService#postCustomerCreditIssuance}:
+ * <ul>
+ * <li>Dr Undeposited Funds (the overpayment cash actually received)</li>
+ * <li>Cr Customer Credit Liability (the obligation now owed to the customer)</li>
+ * </ul>
+ *
+ * <p>
+ * Accounts are never hardcoded: both sides resolve through the
+ * {@code CUSTOMER_CREDIT_ISSUANCE} posting category and its
+ * {@code UNDEPOSITED_FUNDS} / {@code CUSTOMER_CREDIT_LIABILITY} mapping keys
+ * (seeded by {@code R__seed_reference_accounting.sql}).
+ *
+ * <p>
+ * Idempotency: the posting key is the caller-supplied application request id,
+ * namespaced with {@code CUSTOMER_CREDIT_ISSUANCE_GL_POSTING:} — distinct from
+ * the AR cash-receipt leg that shares the same request id — so a replayed or
+ * duplicate work item is a no-op and an issuance never double-posts. The key is
+ * registered in the same transaction as the posted journal entry.
+ *
+ * <p>
+ * Failure semantics mirror the AR cash-receipt flow: any exception propagates
+ * to {@link com.positivity.accounting.internal.service.OutboxProcessor}, which
+ * marks the work item failed and retries with backoff. Posting into a CLOSED or
+ * hard-locked period surfaces the Wave 2 period-gate exceptions unwrapped so the
+ * failure reason stays visible.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomerCreditIssuanceGLPostingEventHandler {
+
+    static final String POSTING_CATEGORY_NAME = "CUSTOMER_CREDIT_ISSUANCE";
+    static final String DEBIT_MAPPING_KEY = "UNDEPOSITED_FUNDS";
+    static final String CREDIT_MAPPING_KEY = "CUSTOMER_CREDIT_LIABILITY";
+    static final String IDEMPOTENCY_KEY_PREFIX = "CUSTOMER_CREDIT_ISSUANCE_GL_POSTING:";
+    static final String SOURCE_EVENT_NAMESPACE = "CUSTOMER_CREDIT_ISSUANCE:";
+
+    private final Clock clock;
+    private final IdempotencyService idempotencyService;
+    private final GLMappingResolver glMappingResolver;
+    private final GLPostingService glPostingService;
+
+    /**
+     * Handle customer-credit issuance GL posting work item → post balanced
+     * journal entry (Dr Undeposited Funds, Cr Customer Credit Liability).
+     *
+     * @param event customer-credit issuance GL posting work item
+     */
+    @EventListener
+    @Transactional
+    public void onCustomerCreditIssuanceGLPosting(@NonNull CustomerCreditIssuanceGLPostingEvent event) {
+        String applicationRequestId = event.getApplicationRequestId();
+        String idempotencyKey = IDEMPOTENCY_KEY_PREFIX + applicationRequestId;
+
+        if (idempotencyService.isKeyProcessed(idempotencyKey)) {
+            log.info(
+                    "Customer credit issuance GL posting already processed, skipping | applicationRequestId={} "
+                            + "| creditId={} | eventId={}",
+                    applicationRequestId,
+                    event.getCreditId(),
+                    event.getEventId());
+            return;
+        }
+
+        log.info(
+                "Received CustomerCreditIssuanceGLPostingEvent | eventId={} | applicationRequestId={} | creditId={} "
+                        + "| paymentId={} | creditAmount={}",
+                event.getEventId(),
+                applicationRequestId,
+                event.getCreditId(),
+                event.getPaymentId(),
+                event.getCreditAmount());
+
+        try {
+            // Transaction date is the event's business timestamp (when the
+            // overpayment/credit actually occurred), NOT the processing/clock
+            // time — matching the AR cash-receipt leg so both entries land in the
+            // same accounting period and resolve the same effective-dated GL
+            // mapping across replays.
+            LocalDateTime transactionDate = LocalDateTime.ofInstant(event.getApplicationTimestamp(), clock.getZone());
+
+            // Account resolution via posting category / mapping key configuration
+            // — no hardcoded account ids (issue #975 requirement).
+            UUID undepositedFundsAccountId =
+                    glMappingResolver.resolveGLAccount(POSTING_CATEGORY_NAME, DEBIT_MAPPING_KEY, transactionDate);
+            UUID creditLiabilityAccountId =
+                    glMappingResolver.resolveGLAccount(POSTING_CATEGORY_NAME, CREDIT_MAPPING_KEY, transactionDate);
+
+            UUID sourceEventId = toSourceEventId(applicationRequestId);
+            String description = "Customer credit issuance for overpayment on application request "
+                    + applicationRequestId + " (credit " + event.getCreditId() + ")";
+
+            JournalEntry posted = glPostingService.postCustomerCreditIssuance(
+                    sourceEventId,
+                    undepositedFundsAccountId,
+                    creditLiabilityAccountId,
+                    event.getCreditAmount(),
+                    transactionDate,
+                    description,
+                    null);
+
+            idempotencyService.registerKey(idempotencyKey, posted.getJournalEntryId());
+
+            log.info(
+                    "Customer credit issuance GL posting completed | applicationRequestId={} | creditId={} "
+                            + "| journalEntryId={}",
+                    applicationRequestId,
+                    event.getCreditId(),
+                    posted.getJournalEntryId());
+
+        } catch (AccountingPeriodClosedException | AccountingPeriodHardLockedException e) {
+            // Wave 2 period gate: propagate unwrapped so the failure reason stays
+            // visible in the outbox retry record; retry succeeds once the period
+            // is reopened (or the hard lock moved).
+            log.warn(
+                    "Customer credit issuance GL posting blocked by period gate | applicationRequestId={} | error={}",
+                    applicationRequestId,
+                    e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "Failed to process CustomerCreditIssuanceGLPostingEvent | applicationRequestId={} | eventId={} "
+                            + "| error={}",
+                    applicationRequestId,
+                    event.getEventId(),
+                    e.getMessage(),
+                    e);
+            throw new IllegalStateException(
+                    "GL posting failed for customer credit issuance on application request: " + applicationRequestId,
+                    e);
+        }
+    }
+
+    /**
+     * Derive the journal entry {@code sourceEventId} for the issuance leg from
+     * the caller-supplied application request id, namespaced so it never collides
+     * with the AR cash-receipt entry (which uses the request id verbatim). The
+     * mapping is deterministic, so replays of the same request id always produce
+     * the same source event id.
+     */
+    static @NonNull UUID toSourceEventId(@NonNull String applicationRequestId) {
+        return UUID.nameUUIDFromBytes((SOURCE_EVENT_NAMESPACE + applicationRequestId).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
@@ -240,6 +240,56 @@ public class GLPostingServiceImpl implements GLPostingService {
     }
 
     @Override
+    public JournalEntry postCustomerCreditIssuance(
+            @NonNull UUID sourceEventId,
+            @NonNull UUID undepositedFundsAccountId,
+            @NonNull UUID creditLiabilityAccountId,
+            @NonNull BigDecimal amount,
+            @NonNull LocalDateTime transactionDate,
+            @NonNull String description,
+            @Nullable String overrideJustification) {
+
+        log.info(
+                "Posting customer credit issuance GL entry {}: debit undeposited funds {}, "
+                        + "credit customer credit liability {}",
+                sourceEventId,
+                amount,
+                amount);
+
+        JournalEntry entry = new JournalEntry();
+        entry.setTransactionDate(transactionDate);
+        entry.setDescription(description);
+        entry.setSourceEventId(sourceEventId);
+
+        List<JournalEntryLine> lines = new ArrayList<>();
+
+        // Debit: Undeposited Funds (the overpayment cash received).
+        JournalEntryLine cashLine = new JournalEntryLine();
+        cashLine.setGlAccountId(undepositedFundsAccountId);
+        cashLine.setDebitAmount(amount);
+        cashLine.setCreditAmount(BigDecimal.ZERO);
+        cashLine.setDescription("Overpayment Cash - Credit#" + sourceEventId);
+        lines.add(cashLine);
+
+        // Credit: Customer Credit Liability (obligation now owed to the customer).
+        JournalEntryLine liabilityLine = new JournalEntryLine();
+        liabilityLine.setGlAccountId(creditLiabilityAccountId);
+        liabilityLine.setDebitAmount(BigDecimal.ZERO);
+        liabilityLine.setCreditAmount(amount);
+        liabilityLine.setDescription("Customer Credit Issued - Credit#" + sourceEventId);
+        lines.add(liabilityLine);
+
+        entry.setLines(lines);
+
+        JournalEntry created = journalEntryService.createJournalEntry(entry);
+        JournalEntry posted = journalEntryService.postJournalEntry(created.getJournalEntryId(), overrideJustification);
+
+        log.info("Posted customer credit issuance GL entry: journal entry ID {}", posted.getJournalEntryId());
+
+        return posted;
+    }
+
+    @Override
     public JournalEntry postSettlement(@NonNull SettlementPostingCommand command) {
         log.info(
                 "Posting settlement GL entry {}: Dr Cash {}, Dr Fees {}, Cr Undeposited {}, Cr Suspense {}",

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
@@ -242,6 +242,7 @@ public class GLPostingServiceImpl implements GLPostingService {
     @Override
     public JournalEntry postCustomerCreditIssuance(
             @NonNull UUID sourceEventId,
+            @NonNull UUID creditId,
             @NonNull UUID undepositedFundsAccountId,
             @NonNull UUID creditLiabilityAccountId,
             @NonNull BigDecimal amount,
@@ -268,7 +269,7 @@ public class GLPostingServiceImpl implements GLPostingService {
         cashLine.setGlAccountId(undepositedFundsAccountId);
         cashLine.setDebitAmount(amount);
         cashLine.setCreditAmount(BigDecimal.ZERO);
-        cashLine.setDescription("Overpayment Cash - Credit#" + sourceEventId);
+        cashLine.setDescription("Overpayment Cash - Credit#" + creditId);
         lines.add(cashLine);
 
         // Credit: Customer Credit Liability (obligation now owed to the customer).
@@ -276,7 +277,7 @@ public class GLPostingServiceImpl implements GLPostingService {
         liabilityLine.setGlAccountId(creditLiabilityAccountId);
         liabilityLine.setDebitAmount(BigDecimal.ZERO);
         liabilityLine.setCreditAmount(amount);
-        liabilityLine.setDescription("Customer Credit Issued - Credit#" + sourceEventId);
+        liabilityLine.setDescription("Customer Credit Issued - Credit#" + creditId);
         lines.add(liabilityLine);
 
         entry.setLines(lines);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/OutboxProcessor.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/OutboxProcessor.java
@@ -3,6 +3,7 @@ package com.positivity.accounting.internal.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.positivity.accounting.internal.dto.APPaymentGLPostingEvent;
+import com.positivity.accounting.internal.dto.CustomerCreditIssuanceGLPostingEvent;
 import com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent;
 import com.positivity.accounting.internal.dto.PaymentApplicationReversalGLPostingEvent;
 import com.positivity.accounting.internal.dto.SettlementGLPostingEvent;
@@ -65,7 +66,9 @@ public class OutboxProcessor {
             PaymentApplicationReversalGLPostingEvent.class.getName(),
             PaymentApplicationReversalGLPostingEvent.class,
             SettlementGLPostingEvent.class.getName(),
-            SettlementGLPostingEvent.class);
+            SettlementGLPostingEvent.class,
+            CustomerCreditIssuanceGLPostingEvent.class.getName(),
+            CustomerCreditIssuanceGLPostingEvent.class);
 
     /**
      * Scheduled task to process pending outbox events.

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PaymentApplicationServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/PaymentApplicationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.accounting.internal.service;
 
+import com.positivity.accounting.internal.dto.CustomerCreditIssuanceGLPostingEvent;
 import com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent;
 import com.positivity.accounting.internal.dto.PaymentApplicationRequest;
 import com.positivity.accounting.internal.dto.PaymentApplicationResponse;
@@ -216,6 +217,22 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
             BigDecimal unappliedAfterApplication = payment.getUnappliedAmount();
 
             creditInfo = createCustomerCredit(payment, unappliedAfterApplication, applicationTimestamp);
+
+            // Enqueue the credit-issuance GL posting work item in the SAME
+            // transaction as the CustomerCredit insert (transactional outbox,
+            // issue #975). The async consumer posts Dr Undeposited Funds / Cr
+            // Customer Credit Liability for the excess, so the overpayment cash
+            // and the customer-credit liability both reach the ledger. Keyed on
+            // the application request id (namespaced for the credit leg), so a
+            // replay never double-posts; if this transaction rolls back, the work
+            // item rolls back with it.
+            enqueueCustomerCreditIssuanceGLPostingWorkItem(
+                    paymentId,
+                    request.getApplicationRequestId(),
+                    payment,
+                    creditInfo.getCreditId(),
+                    unappliedAfterApplication,
+                    applicationTimestamp);
 
             // Mark payment as fully applied by converting remaining balance to credit
             // This ensures payment status becomes FULLY_APPLIED
@@ -585,6 +602,49 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
     }
 
     /**
+     * Persist a {@link CustomerCreditIssuanceGLPostingEvent} work item to the
+     * transactional outbox (issue #975). Runs inside the surrounding application
+     * transaction ({@code saveToOutbox} uses MANDATORY propagation), guaranteeing
+     * the issuance ledger work item exists iff the {@code CustomerCredit}
+     * committed. The application request id travels on the event as the posting
+     * idempotency-key basis (namespaced for the credit leg); the credit id links
+     * the entry back to the subledger row it backs.
+     */
+    private void enqueueCustomerCreditIssuanceGLPostingWorkItem(
+            @NonNull UUID paymentId,
+            @NonNull String applicationRequestId,
+            @NonNull ReceivablePayment payment,
+            @NonNull UUID creditId,
+            @NonNull BigDecimal creditAmount,
+            @NonNull Instant applicationTimestamp) {
+        CustomerCreditIssuanceGLPostingEvent issuanceEvent = CustomerCreditIssuanceGLPostingEvent.builder()
+                .eventId(UUIDv7Generator.generate())
+                .applicationRequestId(applicationRequestId)
+                .creditId(creditId)
+                .paymentId(paymentId)
+                .customerId(payment.getCustomerId())
+                .currency(payment.getCurrency())
+                .creditAmount(creditAmount)
+                .applicationTimestamp(applicationTimestamp)
+                .build();
+
+        outboxService.saveToOutbox(
+                issuanceEvent.getEventId(),
+                "CustomerCreditIssuance",
+                paymentId,
+                issuanceEvent.getClass().getName(),
+                issuanceEvent);
+
+        log.info(
+                "Customer credit issuance GL posting work item persisted to outbox | applicationRequestId={} "
+                        + "| eventId={} | creditId={} | creditAmount={}",
+                applicationRequestId,
+                issuanceEvent.getEventId(),
+                creditId,
+                creditAmount);
+    }
+
+    /**
      * Validate an invoice application against the {@code ext_invoice} replica and accounting's
      * derived balance (ADR-0044, #842). The invoice must exist in the replica, be in an
      * AR-eligible lifecycle state (FINALIZED/POSTED), and still carry a positive balance. No
@@ -715,14 +775,25 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
     }
 
     /**
-     * Resolve the allocation iteration order per the request's effective strategy (Issue #955).
+     * Resolve the allocation iteration order per the request's effective strategy (Issue #955,
+     * refined by Issue #976).
      *
      * <p>{@code CALLER_ORDER} (including an absent strategy) returns the caller-supplied list
      * untouched, keeping behavior byte-identical to requests predating the field.
-     * {@code OLDEST_FIRST} returns a sorted copy ordered by ascending replica invoice date
-     * ({@link ExtInvoice#getInvoiceCreatedAt()}); invoices with no replica date sort last, and
-     * equal dates tie-break deterministically by ascending invoice id. Reordering affects
-     * allocation order only — validation, capping, and idempotency semantics are unchanged.
+     * {@code OLDEST_FIRST} returns a sorted copy ordered by ascending <em>issue/finalization
+     * date</em> ({@link ExtInvoice#getFinalizedAt()} — the point the invoice became an
+     * outstanding receivable), not by record-creation time; invoices with no finalization date
+     * sort last, and equal dates tie-break deterministically by ascending invoice id. Reordering
+     * affects allocation order only — validation, capping, and idempotency semantics are unchanged.
+     *
+     * <p><strong>Documented limitation (Issue #976, AC-4):</strong> true collections aging orders
+     * by the invoice's <em>due date</em>, which the {@code ext_invoice} replica does not yet carry
+     * (it has neither a due date nor payment terms). {@code finalizedAt} is the closest
+     * business-correct key present on the replica and matches Odoo-parity "oldest first"
+     * reconciliation, which orders by invoice date. If/when the replica and the
+     * {@code invoice.events.v1} projection are enriched with a due date (a separate story against
+     * the pos-invoice event contract, ADR-0044), {@code OLDEST_FIRST} should prefer due date and
+     * fall back to {@code finalizedAt}.
      *
      * @param request the application request (strategy resolved via
      *                {@link PaymentApplicationRequest#resolveAllocationStrategy()})
@@ -744,7 +815,7 @@ public class PaymentApplicationServiceImpl implements com.positivity.accounting.
                         invoiceId,
                         invoiceBalanceCalculator
                                 .findInvoice(invoiceId)
-                                .map(ExtInvoice::getInvoiceCreatedAt)
+                                .map(ExtInvoice::getFinalizedAt)
                                 .orElse(null));
             }
         }

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
@@ -117,6 +117,39 @@ public interface GLPostingService {
             @Nullable String overrideJustification);
 
     /**
+     * Post a customer-credit issuance (overpayment excess) to GL (parity-C1,
+     * issue #975): {@code Dr Undeposited Funds / Cr Customer Credit Liability}
+     * for the credit amount. Recognizes the overpayment cash as an asset and the
+     * matching obligation to the customer as a liability, so the excess is no
+     * longer a pure subledger row with no ledger linkage.
+     *
+     * @param sourceEventId              deterministic JE source id for the
+     *                                   issuance (namespaced per credit leg so it
+     *                                   never collides with the AR cash-receipt
+     *                                   entry sharing the same request id)
+     * @param undepositedFundsAccountId  GL account for Undeposited Funds (debit)
+     * @param creditLiabilityAccountId   GL account for Customer Credit Liability
+     *                                   (credit)
+     * @param amount                     credit (overpayment excess) amount
+     * @param transactionDate            business transaction date (the payment
+     *                                   application timestamp) used as the journal
+     *                                   entry date; must not be derived from
+     *                                   processing/clock time so outbox retries
+     *                                   post into the correct period
+     * @param description                entry description
+     * @param overrideJustification      optional CLOSED-period override justification
+     * @return posted journal entry
+     */
+    JournalEntry postCustomerCreditIssuance(
+            @NonNull UUID sourceEventId,
+            @NonNull UUID undepositedFundsAccountId,
+            @NonNull UUID creditLiabilityAccountId,
+            @NonNull BigDecimal amount,
+            @NonNull LocalDateTime transactionDate,
+            @NonNull String description,
+            @Nullable String overrideJustification);
+
+    /**
      * Post the batched settlement journal entry (story F1c, issue #963, decision
      * D-13): {@code Dr Cash (net) / Dr Processor Fees (fee) / Cr Undeposited
      * Funds (matched gross) / Cr Settlement Suspense (unmatched gross)}. Zero

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
@@ -142,6 +142,7 @@ public interface GLPostingService {
      */
     JournalEntry postCustomerCreditIssuance(
             @NonNull UUID sourceEventId,
+            @NonNull UUID creditId,
             @NonNull UUID undepositedFundsAccountId,
             @NonNull UUID creditLiabilityAccountId,
             @NonNull BigDecimal amount,

--- a/pos-accounting/src/main/resources/db/migration/R__seed_reference_accounting.sql
+++ b/pos-accounting/src/main/resources/db/migration/R__seed_reference_accounting.sql
@@ -353,3 +353,37 @@ ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system
 INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
 VALUES ('5eed0acc-0000-4000-8000-00000000d015'::uuid, 'ACCOUNTING', 'BANK_RECON_OTHER', '5eed0acc-0000-4000-8000-00000000d001'::uuid, '5eed0acc-0000-4000-8000-00000000d006'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '2360'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
 ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';
+
+-- ============================================================================
+-- Parity-C1 (Issue #975): customer-credit issuance GL posting.
+-- When an overpayment converts its excess into a CustomerCredit, the cash must
+-- reach the ledger: Dr Undeposited Funds (1090) / Cr Customer Credit Liability
+-- (2300). Accounts resolve through the CUSTOMER_CREDIT_ISSUANCE posting
+-- category's two mapping keys — never hardcoded. gl_mapping.gl_account_id is
+-- resolved by account_code SELECT (not a hardcoded UUID) so the FK always binds
+-- to whichever id won the ON CONFLICT (account_code) upsert, matching the
+-- bank-rec (F2) pattern. 1090 and 2300 are seeded above (stories H1/parity-C1).
+-- ============================================================================
+
+-- Posting category.
+INSERT INTO posting_category (posting_category_id, category_name, description, is_active, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000cc01'::uuid, 'CUSTOMER_CREDIT_ISSUANCE', 'Overpayment credit issuance GL posting (Dr Undeposited Funds / Cr Customer Credit Liability, issue #975)', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (posting_category_id) DO UPDATE SET
+    category_name = EXCLUDED.category_name, description = EXCLUDED.description, is_active = EXCLUDED.is_active,
+    modified_at = NOW(), modified_by = 'seed-generator';
+
+-- Mapping keys: UNDEPOSITED_FUNDS (debit) + CUSTOMER_CREDIT_LIABILITY (credit).
+INSERT INTO mapping_key (mapping_key_id, posting_category_id, key_name, description, is_active, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000cc02'::uuid, '5eed0acc-0000-4000-8000-00000000cc01'::uuid, 'UNDEPOSITED_FUNDS', 'Debit side of customer credit issuance (overpayment cash received)', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (mapping_key_id) DO UPDATE SET posting_category_id = EXCLUDED.posting_category_id, key_name = EXCLUDED.key_name, description = EXCLUDED.description, is_active = EXCLUDED.is_active, modified_at = NOW(), modified_by = 'seed-generator';
+INSERT INTO mapping_key (mapping_key_id, posting_category_id, key_name, description, is_active, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000cc03'::uuid, '5eed0acc-0000-4000-8000-00000000cc01'::uuid, 'CUSTOMER_CREDIT_LIABILITY', 'Credit side of customer credit issuance (obligation owed to customer)', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (mapping_key_id) DO UPDATE SET posting_category_id = EXCLUDED.posting_category_id, key_name = EXCLUDED.key_name, description = EXCLUDED.description, is_active = EXCLUDED.is_active, modified_at = NOW(), modified_by = 'seed-generator';
+
+-- GL mappings (fixed effective_start_date for idempotent re-runs; FK by account_code).
+INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000cc04'::uuid, 'ACCOUNTING', 'CUSTOMER_CREDIT_ISSUANCE_UNDEPOSITED_FUNDS', '5eed0acc-0000-4000-8000-00000000cc01'::uuid, '5eed0acc-0000-4000-8000-00000000cc02'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '1090'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
+ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';
+INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000cc05'::uuid, 'ACCOUNTING', 'CUSTOMER_CREDIT_ISSUANCE_CUSTOMER_CREDIT_LIABILITY', '5eed0acc-0000-4000-8000-00000000cc01'::uuid, '5eed0acc-0000-4000-8000-00000000cc03'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '2300'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
+ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/CustomerCreditIssuanceGLPostingIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/CustomerCreditIssuanceGLPostingIT.java
@@ -1,0 +1,337 @@
+package com.positivity.accounting.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.positivity.accounting.internal.config.TestSecurityConfig;
+import com.positivity.accounting.internal.dto.CustomerCreditIssuanceGLPostingEvent;
+import com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent;
+import com.positivity.accounting.internal.dto.PaymentApplicationRequest;
+import com.positivity.accounting.internal.entity.EventOutbox;
+import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.entity.ReceivablePayment;
+import com.positivity.accounting.internal.entity.ReceivablePayment.ReceivablePaymentStatus;
+import com.positivity.accounting.internal.handler.CustomerCreditIssuanceGLPostingEventHandler;
+import com.positivity.accounting.internal.handler.PaymentApplicationGLPostingEventHandler;
+import com.positivity.accounting.internal.repository.AccountingSequenceRepository;
+import com.positivity.accounting.internal.repository.CustomerCreditRepository;
+import com.positivity.accounting.internal.repository.EventOutboxRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
+import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.IdempotencyKeyRepository;
+import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.PaymentApplicationRepository;
+import com.positivity.accounting.internal.repository.ReceivablePaymentRepository;
+import com.positivity.accounting.internal.service.PaymentApplicationServiceImpl;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+/**
+ * Real-Postgres IT for customer-credit issuance GL posting (parity-C1, issue
+ * #975). Runs the full Flyway chain + repeatable seed (which now carries the
+ * {@code CUSTOMER_CREDIT_ISSUANCE} posting category and its two mapping keys)
+ * on a Testcontainers Postgres, so the seed correctness and the
+ * {@link com.positivity.accounting.service.GLMappingResolver} account
+ * resolution are exercised end-to-end — H2 does not enforce the Postgres
+ * CHECK/FK constraints the seed relies on.
+ *
+ * <p>Exercises the overpayment path: applying more than an invoice's balance
+ * records a {@code CustomerCredit} for the excess and enqueues both GL legs
+ * (AR cash receipt + credit issuance). Both work items are then drained from the
+ * outbox and posted, and the ledger is asserted balanced across both entries.
+ *
+ * <p>Skipped cleanly when Docker is unavailable ({@code disabledWithoutDocker}).
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
+@DisplayName("Customer credit issuance GL posting (parity-C1 #975, real Postgres)")
+class CustomerCreditIssuanceGLPostingIT {
+
+    @Container
+    static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+        // Schema + seed come from the real Flyway chain, not Hibernate DDL.
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    @Autowired
+    private PaymentApplicationServiceImpl paymentApplicationService;
+
+    @Autowired
+    private PaymentApplicationGLPostingEventHandler cashReceiptHandler;
+
+    @Autowired
+    private CustomerCreditIssuanceGLPostingEventHandler issuanceHandler;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ExtInvoiceRepository extInvoiceRepository;
+
+    @Autowired
+    private ReceivablePaymentRepository receivablePaymentRepository;
+
+    @Autowired
+    private PaymentApplicationRepository paymentApplicationRepository;
+
+    @Autowired
+    private CustomerCreditRepository customerCreditRepository;
+
+    @Autowired
+    private EventOutboxRepository outboxRepository;
+
+    @Autowired
+    private IdempotencyKeyRepository idempotencyKeyRepository;
+
+    @Autowired
+    private JournalEntryRepository journalEntryRepository;
+
+    @Autowired
+    private AccountingSequenceRepository sequenceRepository;
+
+    @Autowired
+    private GLAccountRepository glAccountRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @AfterEach
+    void cleanUp() {
+        journalEntryRepository.deleteAll();
+        sequenceRepository.deleteAll();
+        outboxRepository.deleteAll();
+        idempotencyKeyRepository.deleteAll();
+        customerCreditRepository.deleteAll();
+        paymentApplicationRepository.deleteAll();
+        receivablePaymentRepository.deleteAll();
+        extInvoiceRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("AC-5: overpayment posts Dr Undeposited Funds=X across both legs; Cr AR=Y; Cr Credit Liability=X-Y")
+    void overpayment_postsBalancedCashReceiptAndCreditIssuance() {
+        // Payment X=1000 applied against a Y=400 invoice -> 400 applied, 600 excess.
+        BigDecimal paymentTotal = new BigDecimal("1000.00");
+        BigDecimal invoiceDue = new BigDecimal("400.00");
+        BigDecimal expectedCredit = new BigDecimal("600.00");
+
+        UUID invoiceId = seedFinalizedInvoice(invoiceDue);
+        UUID paymentId = seedAvailablePayment(paymentTotal);
+        String requestId = UUID.randomUUID().toString();
+
+        paymentApplicationService.applyPaymentToInvoices(paymentId, request(requestId, invoiceId, paymentTotal));
+
+        // AC-1: both GL legs enqueued in the same transaction as the application/credit.
+        List<EventOutbox> outbox = outboxRepository.findAll();
+        assertThat(outbox)
+                .extracting(EventOutbox::getEventType)
+                .containsExactlyInAnyOrder(
+                        PaymentApplicationGLPostingEvent.class.getName(),
+                        CustomerCreditIssuanceGLPostingEvent.class.getName());
+
+        // Credit recorded for the excess.
+        assertThat(customerCreditRepository.findAll())
+                .singleElement()
+                .satisfies(credit -> assertThat(credit.getAmount()).isEqualByComparingTo(expectedCredit));
+
+        // Drain both work items through their handlers (accounts resolved via the seed).
+        drainOutbox();
+
+        UUID undepositedFunds = accountId("1090");
+        UUID accountsReceivable = accountId("1200");
+        UUID creditLiability = accountId("2300");
+
+        Map<UUID, BigDecimal> debits = new HashMap<>();
+        Map<UUID, BigDecimal> credits = new HashMap<>();
+        sumLines(debits, credits);
+
+        // AC-5: total Dr Undeposited Funds across both entries = X.
+        assertThat(debits.getOrDefault(undepositedFunds, BigDecimal.ZERO)).isEqualByComparingTo(paymentTotal);
+        // Cr AR = Y (applied).
+        assertThat(credits.getOrDefault(accountsReceivable, BigDecimal.ZERO)).isEqualByComparingTo(invoiceDue);
+        // Cr Customer Credit Liability = X - Y (excess).
+        assertThat(credits.getOrDefault(creditLiability, BigDecimal.ZERO)).isEqualByComparingTo(expectedCredit);
+
+        // Two balanced POSTED entries in total.
+        assertThat(journalEntryRepository.count()).isEqualTo(2);
+
+        // AC-4: replaying the issuance work item is a no-op (no double-post).
+        CustomerCreditIssuanceGLPostingEvent issuance = issuanceEventFromEnqueued(requestId, invoiceId, paymentId);
+        issuanceHandler.onCustomerCreditIssuanceGLPosting(issuance);
+        assertThat(journalEntryRepository.count())
+                .as("replay adds no second issuance entry")
+                .isEqualTo(2);
+        Map<UUID, BigDecimal> creditsAfterReplay = new HashMap<>();
+        sumLines(new HashMap<>(), creditsAfterReplay);
+        assertThat(creditsAfterReplay.getOrDefault(creditLiability, BigDecimal.ZERO))
+                .isEqualByComparingTo(expectedCredit);
+    }
+
+    @Test
+    @DisplayName("AC-6: exact application (no excess) posts no credit-issuance entry")
+    void exactApplication_postsNoCreditIssuanceEntry() {
+        BigDecimal paymentTotal = new BigDecimal("1000.00");
+        BigDecimal applied = new BigDecimal("400.00");
+
+        UUID invoiceId = seedFinalizedInvoice(new BigDecimal("400.00"));
+        UUID paymentId = seedAvailablePayment(paymentTotal);
+        String requestId = UUID.randomUUID().toString();
+
+        // Apply exactly the balance due -> no excess, no credit.
+        paymentApplicationService.applyPaymentToInvoices(paymentId, request(requestId, invoiceId, applied));
+
+        // Only the AR cash-receipt leg is enqueued.
+        assertThat(outboxRepository.findAll())
+                .extracting(EventOutbox::getEventType)
+                .containsExactly(PaymentApplicationGLPostingEvent.class.getName());
+        assertThat(customerCreditRepository.count()).isZero();
+
+        drainOutbox();
+
+        // No line ever touches the customer-credit-liability account.
+        Map<UUID, BigDecimal> debits = new HashMap<>();
+        Map<UUID, BigDecimal> credits = new HashMap<>();
+        sumLines(debits, credits);
+        UUID creditLiability = accountId("2300");
+        assertThat(credits.getOrDefault(creditLiability, BigDecimal.ZERO)).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(debits.getOrDefault(creditLiability, BigDecimal.ZERO)).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(journalEntryRepository.count()).isEqualTo(1);
+    }
+
+    // ===== helpers =====
+
+    /** Drain all pending outbox work items through their handlers (deterministic, no scheduler). */
+    private void drainOutbox() {
+        for (EventOutbox outbox : outboxRepository.findAll()) {
+            dispatch(outbox);
+        }
+    }
+
+    private void dispatch(EventOutbox outbox) {
+        try {
+            String type = outbox.getEventType();
+            if (PaymentApplicationGLPostingEvent.class.getName().equals(type)) {
+                cashReceiptHandler.onPaymentApplicationGLPosting(
+                        objectMapper.readValue(outbox.getPayload(), PaymentApplicationGLPostingEvent.class));
+            } else if (CustomerCreditIssuanceGLPostingEvent.class.getName().equals(type)) {
+                issuanceHandler.onCustomerCreditIssuanceGLPosting(
+                        objectMapper.readValue(outbox.getPayload(), CustomerCreditIssuanceGLPostingEvent.class));
+            } else {
+                throw new IllegalStateException("Unexpected outbox event type: " + type);
+            }
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize outbox payload", e);
+        }
+    }
+
+    private CustomerCreditIssuanceGLPostingEvent issuanceEventFromEnqueued(
+            String requestId, UUID invoiceId, UUID paymentId) {
+        return outboxRepository.findAll().stream()
+                .filter(o ->
+                        CustomerCreditIssuanceGLPostingEvent.class.getName().equals(o.getEventType()))
+                .findFirst()
+                .map(o -> {
+                    try {
+                        return objectMapper.readValue(o.getPayload(), CustomerCreditIssuanceGLPostingEvent.class);
+                    } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+                        throw new IllegalStateException(e);
+                    }
+                })
+                .orElseThrow();
+    }
+
+    /** Sum debit and credit amounts per GL account across all journal entries (lazy assoc loaded in-tx). */
+    private void sumLines(Map<UUID, BigDecimal> debits, Map<UUID, BigDecimal> credits) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.executeWithoutResult(status -> {
+            for (JournalEntry entry : journalEntryRepository.findAll()) {
+                for (JournalEntryLine line : entry.getLines()) {
+                    BigDecimal debit = line.getDebitAmount() == null ? BigDecimal.ZERO : line.getDebitAmount();
+                    BigDecimal credit = line.getCreditAmount() == null ? BigDecimal.ZERO : line.getCreditAmount();
+                    debits.merge(line.getGlAccountId(), debit, BigDecimal::add);
+                    credits.merge(line.getGlAccountId(), credit, BigDecimal::add);
+                }
+            }
+        });
+    }
+
+    private UUID accountId(String accountCode) {
+        return glAccountRepository
+                .findByAccountCode(accountCode)
+                .orElseThrow(() -> new IllegalStateException("Seed missing GL account " + accountCode))
+                .getGlAccountId();
+    }
+
+    private UUID seedFinalizedInvoice(BigDecimal total) {
+        UUID invoiceId = UUID.randomUUID();
+        ExtInvoice invoice = ExtInvoice.builder()
+                .invoiceId(invoiceId)
+                .workorderId(UUID.randomUUID())
+                .partyId(UUID.randomUUID().toString())
+                .status("FINALIZED")
+                .total(total)
+                .invoiceCreatedAt(Instant.now())
+                .finalizedAt(Instant.now())
+                .aggregateVersion(1L)
+                .updatedAt(Instant.now())
+                .build();
+        return extInvoiceRepository.save(invoice).getInvoiceId();
+    }
+
+    private UUID seedAvailablePayment(BigDecimal total) {
+        UUID paymentId = UUID.randomUUID();
+        ReceivablePayment payment = new ReceivablePayment();
+        payment.setPaymentId(paymentId);
+        payment.setCustomerId(UUID.randomUUID());
+        payment.setCurrency("USD");
+        payment.setTotalAmount(total);
+        payment.setUnappliedAmount(total);
+        payment.setStatus(ReceivablePaymentStatus.AVAILABLE);
+        payment.setClearedAt(Instant.now());
+        payment.setSourceEventId(UUID.randomUUID());
+        payment.setCreatedBy("c1-975-it");
+        return receivablePaymentRepository.save(payment).getPaymentId();
+    }
+
+    private PaymentApplicationRequest request(String requestId, UUID invoiceId, BigDecimal amount) {
+        PaymentApplicationRequest.InvoiceApplication app = new PaymentApplicationRequest.InvoiceApplication();
+        app.setInvoiceId(invoiceId);
+        app.setAmountToApply(amount);
+        PaymentApplicationRequest request = new PaymentApplicationRequest();
+        request.setApplicationRequestId(requestId);
+        request.setApplications(List.of(app));
+        return request;
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/CustomerCreditIssuanceGLPostingIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/CustomerCreditIssuanceGLPostingIT.java
@@ -188,7 +188,7 @@ class CustomerCreditIssuanceGLPostingIT {
         assertThat(journalEntryRepository.count()).isEqualTo(2);
 
         // AC-4: replaying the issuance work item is a no-op (no double-post).
-        CustomerCreditIssuanceGLPostingEvent issuance = issuanceEventFromEnqueued(requestId, invoiceId, paymentId);
+        CustomerCreditIssuanceGLPostingEvent issuance = issuanceEventFromEnqueued();
         issuanceHandler.onCustomerCreditIssuanceGLPosting(issuance);
         assertThat(journalEntryRepository.count())
                 .as("replay adds no second issuance entry")
@@ -256,8 +256,7 @@ class CustomerCreditIssuanceGLPostingIT {
         }
     }
 
-    private CustomerCreditIssuanceGLPostingEvent issuanceEventFromEnqueued(
-            String requestId, UUID invoiceId, UUID paymentId) {
+    private CustomerCreditIssuanceGLPostingEvent issuanceEventFromEnqueued() {
         return outboxRepository.findAll().stream()
                 .filter(o ->
                         CustomerCreditIssuanceGLPostingEvent.class.getName().equals(o.getEventType()))

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/PaymentApplicationServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/PaymentApplicationServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.positivity.accounting.internal.dto.CustomerCreditIssuanceGLPostingEvent;
 import com.positivity.accounting.internal.dto.PaymentApplicationGLPostingEvent;
 import com.positivity.accounting.internal.dto.PaymentApplicationRequest;
 import com.positivity.accounting.internal.dto.PaymentApplicationResponse;
@@ -548,6 +549,92 @@ class PaymentApplicationServiceTest {
         assertThat(event.getCurrency()).isEqualTo("USD");
         assertThat(event.getAppliedAmount()).isEqualByComparingTo("500.00");
         assertThat(event.getApplicationTimestamp()).isEqualTo(Instant.now(TEST_CLOCK));
+    }
+
+    @Test
+    @DisplayName("Overpayment enqueues a CUSTOMER_CREDIT_ISSUANCE GL posting work item for the excess (Issue #975)")
+    void testApplyPaymentToInvoices_Overpayment_EnqueuesCreditIssuanceGLPostingWorkItem() {
+        // Arrange: payment 1000 applied against an invoice with only 400 due ->
+        // 400 applied, 600 excess converted to a CustomerCredit.
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId, List.of(createInvoiceApplication(testInvoiceId, "1000.00")));
+
+        UUID creditId = UUID.fromString("00000000-0000-0000-0000-0000000c1975");
+        when(paymentApplicationRepository.existsByApplicationRequestId(testApplicationRequestId))
+                .thenReturn(false);
+        when(receivablePaymentRepository.findById(testPaymentId)).thenReturn(Optional.of(testPayment));
+        when(paymentApplicationRepository.save(any(PaymentApplication.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(receivablePaymentRepository.save(any(ReceivablePayment.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(customerCreditRepository.save(any(CustomerCredit.class))).thenAnswer(invocation -> {
+            CustomerCredit credit = invocation.getArgument(0);
+            credit.setCreditId(creditId);
+            return credit;
+        });
+        stubInvoice(testInvoiceId, "400.00");
+
+        // Act
+        PaymentApplicationResponse response = service.applyPaymentToInvoices(testPaymentId, request);
+
+        // A CustomerCredit was recorded for the 600 excess.
+        verify(customerCreditRepository).save(any(CustomerCredit.class));
+        assertThat(response.getCustomerCredit()).isNotNull();
+        assertThat(response.getCustomerCredit().getAmount()).isEqualByComparingTo("600.00");
+
+        // Both legs enqueued: AR cash receipt (400) and credit issuance (600).
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(outboxService)
+                .saveToOutbox(
+                        any(UUID.class),
+                        eq("CustomerCreditIssuance"),
+                        eq(testPaymentId),
+                        eq(CustomerCreditIssuanceGLPostingEvent.class.getName()),
+                        eventCaptor.capture());
+
+        CustomerCreditIssuanceGLPostingEvent issuance = (CustomerCreditIssuanceGLPostingEvent) eventCaptor.getValue();
+        assertThat(issuance.getEventId()).isNotNull();
+        assertThat(issuance.getApplicationRequestId()).isEqualTo(testApplicationRequestId);
+        assertThat(issuance.getCreditId()).isEqualTo(creditId);
+        assertThat(issuance.getPaymentId()).isEqualTo(testPaymentId);
+        assertThat(issuance.getCustomerId()).isEqualTo(testCustomerId);
+        assertThat(issuance.getCurrency()).isEqualTo("USD");
+        assertThat(issuance.getCreditAmount()).isEqualByComparingTo("600.00");
+        assertThat(issuance.getApplicationTimestamp()).isEqualTo(Instant.now(TEST_CLOCK));
+
+        // The AR cash-receipt leg is still enqueued for the applied portion.
+        verify(outboxService)
+                .saveToOutbox(
+                        any(UUID.class),
+                        eq("PaymentApplication"),
+                        eq(testPaymentId),
+                        eq(PaymentApplicationGLPostingEvent.class.getName()),
+                        any());
+    }
+
+    @Test
+    @DisplayName("Exact application (no excess) enqueues no credit-issuance work item (Issue #975, AC-6)")
+    void testApplyPaymentToInvoices_ExactApplication_NoCreditIssuanceWorkItem() {
+        // Arrange: 500 applied against a 1000-due invoice -> no excess, no credit.
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId, List.of(createInvoiceApplication(testInvoiceId, "500.00")));
+
+        stubAppliableRequest();
+        stubInvoice(testInvoiceId, "1000.00");
+
+        // Act
+        PaymentApplicationResponse response = service.applyPaymentToInvoices(testPaymentId, request);
+
+        // No credit created, and only the AR cash-receipt leg reaches the outbox.
+        assertThat(response.getCustomerCredit()).isNull();
+        verify(customerCreditRepository, never()).save(any(CustomerCredit.class));
+        verify(outboxService, never())
+                .saveToOutbox(
+                        any(UUID.class),
+                        eq("CustomerCreditIssuance"),
+                        any(UUID.class),
+                        eq(CustomerCreditIssuanceGLPostingEvent.class.getName()),
+                        any());
     }
 
     @Test
@@ -1181,6 +1268,35 @@ class PaymentApplicationServiceTest {
     }
 
     @Test
+    @DisplayName("OLDEST_FIRST keys on finalizedAt, not invoiceCreatedAt, when the two orders differ (Issue #976)")
+    void testApplyPaymentToInvoices_OldestFirst_OrdersByFinalizedAtNotCreatedAt() {
+        // Issue #976 worked example: A created Jan 1, finalized Mar 1; B created Feb 1, finalized
+        // Feb 5. By invoiceCreatedAt, A is older; by finalizedAt, B became the receivable first.
+        // "Oldest first" must allocate to B before A.
+        UUID invoiceA = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+        UUID invoiceB = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+        PaymentApplicationRequest request = createApplicationRequest(
+                testApplicationRequestId,
+                List.of(createInvoiceApplication(invoiceA, "300.00"), createInvoiceApplication(invoiceB, "400.00")));
+        request.setAllocationStrategy(AllocationStrategy.OLDEST_FIRST);
+
+        stubAppliableRequest();
+        // A: created earliest, finalized latest.
+        stubInvoice(invoiceA, "1000.00", Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("2023-03-01T00:00:00Z"));
+        // B: created later, finalized earliest -> the older receivable.
+        stubInvoice(invoiceB, "1000.00", Instant.parse("2023-02-01T00:00:00Z"), Instant.parse("2023-02-05T00:00:00Z"));
+
+        // Act
+        service.applyPaymentToInvoices(testPaymentId, request);
+
+        // Assert: allocation follows finalizedAt (B before A), the opposite of invoiceCreatedAt order.
+        verify(paymentApplicationRepository, times(2)).save(paymentApplicationCaptor.capture());
+        assertThat(paymentApplicationCaptor.getAllValues())
+                .extracting(PaymentApplication::getInvoiceId)
+                .containsExactly(invoiceB, invoiceA);
+    }
+
+    @Test
     @DisplayName("Should keep unappliedAmount math unchanged for OLDEST_FIRST partial allocation")
     void testApplyPaymentToInvoices_OldestFirst_PartialAllocation_UnappliedMathUnchanged() {
         // Arrange: 700.00 requested of 1000.00 available, caller order [newer, older]
@@ -1256,12 +1372,27 @@ class PaymentApplicationServiceTest {
 
     /**
      * Stub variant that also sets the replica invoice date, used by allocation-strategy tests
-     * (Issue #955).
+     * (Issue #955). {@code OLDEST_FIRST} orders by the issue/finalization date (Issue #976), so the
+     * supplied date is set as {@code finalizedAt} (and mirrored on {@code invoiceCreatedAt}).
      */
-    private void stubInvoice(@NonNull UUID invoiceId, @NonNull String balanceDue, @Nullable Instant invoiceCreatedAt) {
+    private void stubInvoice(@NonNull UUID invoiceId, @NonNull String balanceDue, @Nullable Instant finalizedAt) {
+        stubInvoice(invoiceId, balanceDue, finalizedAt, finalizedAt);
+    }
+
+    /**
+     * Stub variant that sets {@code invoiceCreatedAt} and {@code finalizedAt} independently, so
+     * allocation-ordering tests can prove {@code OLDEST_FIRST} keys on the finalization date rather
+     * than the record-creation date (Issue #976, AC-2).
+     */
+    private void stubInvoice(
+            @NonNull UUID invoiceId,
+            @NonNull String balanceDue,
+            @Nullable Instant invoiceCreatedAt,
+            @Nullable Instant finalizedAt) {
         ExtInvoice invoice = ExtInvoice.builder()
                 .invoiceId(invoiceId)
                 .invoiceCreatedAt(invoiceCreatedAt)
+                .finalizedAt(finalizedAt)
                 .workorderId(UUID.fromString("00000000-0000-0000-0000-0000000000ff"))
                 .partyId(testCustomerId.toString())
                 .status("FINALIZED")


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-accounting`
- Domain: `domain:accounting`
- Closes #975 (parity-C1 overpayment CustomerCredit GL posting)
- Closes #976 (parity-C3 OLDEST_FIRST aging key)
- Both adjudicated by the Accounting Domain Agent from non-blocking review findings on PR #974.

## Contract References
Additive-only: new internal outbox event type + seeded posting category/mapping keys. No public API/event contract change. See BACKEND_CONTRACT_GUIDE.md.

## Scope

### #976 — OLDEST_FIRST orders by finalization (issue) date, not record-creation (LOW)
`PaymentApplicationServiceImpl.orderApplicationsForAllocation` now sorts `OLDEST_FIRST` by `ExtInvoice.finalizedAt` (the date the invoice became a receivable), nulls last, tie-broken by invoice id — instead of `invoiceCreatedAt` (which conflates DRAFT creation with issuance and misallocates when DRAFT dwell time varies). `CALLER_ORDER`/absent strategy unchanged. Javadoc updated to state the key is the issue/finalization date and to record the due-date-aging follow-on as a documented limitation. New unit test proves allocation follows `finalizedAt` using the issue's worked example (A created earlier but finalized later than B → B allocated first).

### #975 — Overpayment cash now reaches the GL (MEDIUM, financial correctness)
On overpayment, the excess was recorded as a `CustomerCredit` subledger row but never posted, so Undeposited Funds was understated and the customer-credit liability never hit the ledger. Now:
- On the overpayment branch, an issuance GL posting work item is enqueued in the **same transaction** as the `CustomerCredit` insert (transactional outbox, MANDATORY propagation), amount = the excess.
- New `CustomerCreditIssuanceGLPostingEventHandler` posts a balanced entry **Dr Undeposited Funds / Cr Customer Credit Liability** via `GLPostingService.postCustomerCreditIssuance`, accounts resolved through `GLMappingResolver` (no hardcoded ids).
- Idempotency key `CUSTOMER_CREDIT_ISSUANCE_GL_POSTING:<requestId>` and JE `sourceEventId` namespaced with `CUSTOMER_CREDIT_ISSUANCE:` so the credit leg never collides with the AR cash-receipt leg that shares the request id. Period-gated identically to the AR leg (CLOSED / hard-locked propagate unwrapped).
- Seed (`R__seed_reference_accounting.sql`): new `posting_category` `CUSTOMER_CREDIT_ISSUANCE` + `mapping_key`s `UNDEPOSITED_FUNDS` (debit) / `CUSTOMER_CREDIT_LIABILITY` (credit) + two `gl_mapping` rows whose `gl_account_id` is resolved by `(SELECT … WHERE account_code = '1090' / '2300')` — the account_code-FK pattern (never a hardcoded UUID) established by the #988 seed fix. Accounts 1090 Undeposited Funds and 2300 Customer Credit Liability were already seeded.

Per D-4/D2 this uses a single customer-credit-liability control account; jurisdiction/analytic detail is out of scope.

## Tests
- [x] Unit — `PaymentApplicationServiceTest` (#976 aging-key test; #975 enqueue behavior)
- [x] Integration — `CustomerCreditIssuanceGLPostingIT` (Testcontainers/real Postgres, full Flyway + seed):
  - **AC-5:** payment X=1000, applied Y=400 → total Dr Undeposited Funds = 1000, Cr AR = 400, Cr Customer-Credit-Liability = 600.
  - **AC-6:** exact application (excess=0) → no issuance entry.
  - **AC-4:** replayed issuance work item is a no-op.
- How to run: `./mvnw -pl pos-accounting -am verify` → BUILD SUCCESS (187 surefire + all failsafe ITs); `pos-archunit` green; Spotless clean.

## Known follow-ons (recommend filing)
1. **Credit lifecycle liability relief** — this leg only *recognizes* the liability; applying a `CustomerCredit` to a future invoice (Dr liability / Cr AR) or refunding it (Dr liability / Cr cash) must relieve it so it nets to zero. No credit-application flow exists yet (issue #975's own lifecycle note). AC-7 (subledger↔GL reconciliation) fully closes only once relief exists.
2. **Due-date replica enrichment** — true "oldest first" is by due date; `ext_invoice` carries neither due date nor terms. A projection-enrichment story against the pos-invoice event contract (ADR-0044) would let `OLDEST_FIRST` prefer due date, falling back to `finalizedAt` (#976 AC-5).

## Risk & Rollback
- Risk level: Low–Medium (#975 adds a GL posting path; fully covered by the balanced-entry IT). #976 is a one-line ordering-key change.
- Rollback: revert the single commit; additive (new event/handler/seed rows), no destructive schema change (seed is repeatable).

## Checklist
- [x] Branch matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Closes linked issues
- [x] Contract guide referenced
- [ ] Required CI checks passing (to confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)