### PR TITLE
[CAP:odoo-parity-tax] T8 — sales-tax liability report by jurisdiction and period (#966)

### DIFF
--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -3346,6 +3346,60 @@ paths:
         - reporting:view:financial-statements
       x-required-permissions:
       - reporting:view:financial-statements
+  /v1/accounting/reports/financial/tax-liability:
+    get:
+      tags:
+      - Financial Reporting
+      summary: Generate Sales-Tax Liability report
+      description: 'Generate the reconciliation-grade sales-tax liability report for a date range: per-jurisdiction (state/county/city/special) taxable base, exempt base with reasons, gross tax collected, POSTED credit-memo reversals netted pro-rata, and net tax; plus a GL-drift column reconciling total net tax against the Sales-Tax Payable (2200) account activity. Accrual basis: invoice tax bucketed by finalization period, credits by posting period.'
+      operationId: generateTaxLiability
+      parameters:
+      - name: startDate
+        in: query
+        description: Period start date (YYYY-MM-DD)
+        required: true
+        schema:
+          type: string
+          format: date
+        example: 2026-06-01
+      - name: endDate
+        in: query
+        description: Period end date (YYYY-MM-DD)
+        required: true
+        schema:
+          type: string
+          format: date
+        example: 2026-06-30
+      responses:
+        '200':
+          description: Tax liability report generated successfully (rows empty when no in-period tax exists)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxLiabilityReport'
+        '400':
+          description: Invalid date range
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '403':
+          description: Forbidden - missing reporting:view:financial-statements
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - reporting:view:financial-statements
+      x-required-permissions:
+      - reporting:view:financial-statements
   /v1/accounting/reports/financial/income-statement:
     get:
       tags:
@@ -8598,6 +8652,143 @@ components:
       - balance
       - totalCredit
       - totalDebit
+    TaxLiabilityReconciliation:
+      type: object
+      description: Reconciliation of report net tax against the Sales-Tax Payable (2200) GL account period activity
+      properties:
+        taxPayableAccountCode:
+          type: string
+          description: Sales-Tax Payable GL account code being reconciled against
+          example: '2200'
+        glNetActivity:
+          type: number
+          description: Credit-normal net activity of account 2200 in the period (Σ credit - Σ debit of POSTED lines); zero when the account has no activity or is not seeded
+          example: 948.75
+        reportNetTax:
+          type: number
+          description: Report's total net tax across all jurisdictions (echoes report totals.netTax)
+          example: 948.75
+        drift:
+          type: number
+          description: 'GL drift: reportNetTax - glNetActivity. Zero on a clean ledger; non-zero flags a mismatch'
+          example: 0.0
+        reconciled:
+          type: boolean
+          description: True when |drift| is within the 0.01 reconciliation tolerance
+          example: true
+      required:
+      - drift
+      - glNetActivity
+      - reconciled
+      - reportNetTax
+      - taxPayableAccountCode
+    TaxLiabilityReport:
+      type: object
+      description: 'Sales-Tax Liability report: per-jurisdiction taxable/exempt base, gross, credits, net tax, and GL drift'
+      properties:
+        startDate:
+          type: string
+          format: date
+          description: Period start date (inclusive)
+          example: 2026-06-01
+        endDate:
+          type: string
+          format: date
+          description: Period end date (inclusive)
+          example: 2026-06-30
+        generatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the report was generated (ISO 8601)
+          example: 2026-06-30 08:00:00+00:00
+        rows:
+          type: array
+          description: Per-jurisdiction rows ordered by level (state/county/city/special) then code; empty when no in-period tax exists
+          items:
+            $ref: '#/components/schemas/TaxLiabilityRow'
+        totalTaxableBase:
+          type: number
+          description: Grand total taxable base across all jurisdictions
+          example: 12500.0
+        totalExemptBase:
+          type: number
+          description: Grand total exempt base across all jurisdictions
+          example: 1500.0
+        totalTaxCollectedGross:
+          type: number
+          description: Grand total gross tax collected across all jurisdictions
+          example: 1031.25
+        totalCreditsNetted:
+          type: number
+          description: Grand total credits netted across all jurisdictions
+          example: 82.5
+        totalNetTax:
+          type: number
+          description: Grand total net tax across all jurisdictions
+          example: 948.75
+        reconciliation:
+          $ref: '#/components/schemas/TaxLiabilityReconciliation'
+      required:
+      - endDate
+      - generatedAt
+      - reconciliation
+      - rows
+      - startDate
+      - totalCreditsNetted
+      - totalExemptBase
+      - totalNetTax
+      - totalTaxCollectedGross
+      - totalTaxableBase
+    TaxLiabilityRow:
+      type: object
+      description: Per-jurisdiction sales-tax liability row (taxable/exempt base, gross, credits netted, net tax)
+      properties:
+        jurisdictionType:
+          type: string
+          description: 'Jurisdiction level: STATE, COUNTY, CITY, or SPECIAL'
+          example: STATE
+        jurisdictionCode:
+          type: string
+          description: Jurisdiction code as reported by the tax engine
+          example: WA
+        jurisdictionName:
+          type: string
+          description: Human-readable jurisdiction name when available; null when the replica carries only the code
+          example: Washington
+        taxableBase:
+          type: number
+          description: Sum of taxable base for non-exempt lines in this jurisdiction
+          example: 12500.0
+        exemptBase:
+          type: number
+          description: Sum of taxable base for exempt / zero-rate lines in this jurisdiction
+          example: 1500.0
+        exemptionReasons:
+          type: array
+          description: Distinct exemption reason codes contributing to the exempt base (ascending); empty when none
+          items:
+            type: string
+        taxCollectedGross:
+          type: number
+          description: Gross tax collected (Σ tax_amount of non-exempt lines) before credits
+          example: 1031.25
+        creditsNetted:
+          type: number
+          description: Credit/refund tax netted against this jurisdiction — POSTED credit-memo reversals allocated pro-rata to collected tax
+          example: 82.5
+        netTax:
+          type: number
+          description: 'Net tax owed for this jurisdiction: taxCollectedGross - creditsNetted'
+          example: 948.75
+      required:
+      - creditsNetted
+      - exemptBase
+      - exemptionReasons
+      - jurisdictionCode
+      - jurisdictionType
+      - netTax
+      - taxCollectedGross
+      - taxableBase
     IncomeStatementReport:
       type: object
       description: Income statement (Profit & Loss) report built from POSTED journal entries

--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -4704,7 +4704,7 @@ paths:
         schema:
           type: string
           format: date-time
-        example: 2026-01-01 00:00:00+00:00
+        example: 2026-01-01T00:00:00Z
       - name: endDate
         in: query
         description: End date in ISO 8601 format
@@ -4712,7 +4712,7 @@ paths:
         schema:
           type: string
           format: date-time
-        example: 2026-01-28 23:59:59+00:00
+        example: 2026-01-28T23:59:59Z
       responses:
         '200':
           description: Audit entries retrieved successfully
@@ -4756,7 +4756,7 @@ paths:
         schema:
           type: string
           format: date-time
-        example: 2026-01-01 00:00:00+00:00
+        example: 2026-01-01T00:00:00Z
       - name: endDate
         in: query
         description: End date in ISO 8601 format
@@ -4764,7 +4764,7 @@ paths:
         schema:
           type: string
           format: date-time
-        example: 2026-01-28 23:59:59+00:00
+        example: 2026-01-28T23:59:59Z
       responses:
         '200':
           description: Audit entries retrieved successfully
@@ -4947,7 +4947,7 @@ paths:
         schema:
           type: string
           format: date-time
-        example: 2026-01-01 00:00:00+00:00
+        example: 2026-01-01T00:00:00Z
       - name: endDate
         in: query
         description: End date in ISO 8601 format
@@ -4955,7 +4955,7 @@ paths:
         schema:
           type: string
           format: date-time
-        example: 2026-01-28 23:59:59+00:00
+        example: 2026-01-28T23:59:59Z
       responses:
         '200':
           description: Audit entries retrieved successfully
@@ -5173,7 +5173,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the rule set was created (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         createdBy:
           type: string
           description: Identifier of the user who created the rule set
@@ -5182,7 +5182,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the rule set was last modified (ISO 8601)
-          example: 2026-06-18 09:30:00+00:00
+          example: 2026-06-18T09:30:00Z
         modifiedBy:
           type: string
           description: Identifier of the user who last modified the rule set
@@ -5226,7 +5226,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the version was created (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         createdBy:
           type: string
           description: Identifier of the user who created the version
@@ -5235,7 +5235,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the version was last modified (ISO 8601)
-          example: 2026-06-18 09:30:00+00:00
+          example: 2026-06-18T09:30:00Z
         modifiedBy:
           type: string
           description: Identifier of the user who last modified the version
@@ -5293,7 +5293,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the posting category was created (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         createdBy:
           type: string
           description: Identifier of the user who created the posting category
@@ -5302,7 +5302,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the posting category was last modified (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         modifiedBy:
           type: string
           description: Identifier of the user who last modified the posting category
@@ -5359,7 +5359,7 @@ components:
         timestamp:
           type: string
           description: ISO 8601 UTC timestamp of the error
-          example: 2026-03-17 14:30:00+00:00
+          example: 2026-03-17T14:30:00Z
         correlationId:
           type: string
           description: Unique correlation ID for distributed request tracing
@@ -5461,7 +5461,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the mapping key was created (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         createdBy:
           type: string
           description: Identifier of the user who created the mapping key
@@ -5470,7 +5470,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the mapping key was last modified (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         modifiedBy:
           type: string
           description: Identifier of the user who last modified the mapping key
@@ -5492,7 +5492,7 @@ components:
           type: string
           format: date-time
           description: Journal transaction date and time
-          example: 2026-01-15 10:30:00
+          example: 2026-01-15T10:30:00Z
         description:
           type: string
           description: Journal entry description
@@ -5637,7 +5637,7 @@ components:
           type: string
           format: date-time
           description: Transaction date and time
-          example: 2026-01-15 10:30:00
+          example: 2026-01-15T10:30:00Z
         description:
           type: string
           description: Journal entry description
@@ -5688,7 +5688,7 @@ components:
           type: string
           format: date-time
           description: Created timestamp
-          example: 2026-01-15 10:31:00+00:00
+          example: 2026-01-15T10:31:00Z
         createdBy:
           type: string
           description: Created by username
@@ -5697,7 +5697,7 @@ components:
           type: string
           format: date-time
           description: Last modified timestamp
-          example: 2026-01-15 10:32:00+00:00
+          example: 2026-01-15T10:32:00Z
         modifiedBy:
           type: string
           description: Last modified by username
@@ -5706,7 +5706,7 @@ components:
           type: string
           format: date-time
           description: Posted timestamp
-          example: 2026-01-15 10:40:00+00:00
+          example: 2026-01-15T10:40:00Z
         postedBy:
           type: string
           description: Posted by username
@@ -5715,7 +5715,7 @@ components:
           type: string
           format: date-time
           description: Reversed timestamp
-          example: 2026-01-16 08:20:00+00:00
+          example: 2026-01-16T08:20:00Z
     GLAccountUpdateRequest:
       type: object
       description: Request payload for updating mutable GL account fields
@@ -5814,12 +5814,12 @@ components:
           type: string
           format: date-time
           description: Date the account becomes active
-          example: 2026-01-15 10:30:00
+          example: 2026-01-15T10:30:00Z
         deactivationDate:
           type: string
           format: date-time
           description: Date the account becomes inactive
-          example: 2026-06-18 08:00:00
+          example: 2026-06-18T08:00:00Z
         status:
           type: string
           description: Derived account status (ACTIVE, INACTIVE, NOT_YET_ACTIVE)
@@ -5832,7 +5832,7 @@ components:
           type: string
           format: date-time
           description: Created timestamp
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         createdBy:
           type: string
           description: Created by username
@@ -5841,7 +5841,7 @@ components:
           type: string
           format: date-time
           description: Last modified timestamp
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         modifiedBy:
           type: string
           description: Last modified by username
@@ -5949,7 +5949,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the mapping was created (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         createdBy:
           type: string
           description: Identifier of the user who created the mapping
@@ -5958,7 +5958,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the mapping was last modified (ISO 8601)
-          example: 2026-06-18 09:00:00+00:00
+          example: 2026-06-18T09:00:00Z
         modifiedBy:
           type: string
           description: Identifier of the user who last modified the mapping
@@ -6000,7 +6000,7 @@ components:
           type: string
           format: date-time
           description: Date goods were received
-          example: 2026-01-15 10:30:00
+          example: 2026-01-15T10:30:00Z
         lineItems:
           type: array
           description: Line items received
@@ -6079,12 +6079,12 @@ components:
           type: string
           format: date-time
           description: Bill date
-          example: 2026-01-15 00:00:00
+          example: 2026-01-15T00:00:00Z
         dueDate:
           type: string
           format: date-time
           description: Due date
-          example: 2026-02-14 00:00:00
+          example: 2026-02-14T00:00:00Z
         totalAmount:
           type: number
           description: Total bill amount
@@ -6123,7 +6123,7 @@ components:
           type: string
           format: date-time
           description: Created timestamp
-          example: 2026-01-15 10:30:00+00:00
+          example: 2026-01-15T10:30:00Z
         createdBy:
           type: string
           description: Created by user
@@ -6225,12 +6225,12 @@ components:
           type: string
           format: date-time
           description: Invoice date
-          example: 2026-01-16 00:00:00
+          example: 2026-01-16T00:00:00Z
         dueDate:
           type: string
           format: date-time
           description: Invoice due date
-          example: 2026-02-15 00:00:00
+          example: 2026-02-15T00:00:00Z
         lineItems:
           type: array
           description: Invoice line items
@@ -6423,12 +6423,12 @@ components:
           type: string
           format: date-time
           description: ISO-8601 timestamp when the export was requested
-          example: 2026-04-25 10:00:00+00:00
+          example: 2026-04-25T10:00:00Z
         completedAt:
           type: string
           format: date-time
           description: ISO-8601 timestamp when export completed (null if not finished)
-          example: 2026-04-25 10:00:05+00:00
+          example: 2026-04-25T10:00:05Z
         downloadUrl:
           type: string
           description: Download URL (only present when status is COMPLETED)
@@ -6910,7 +6910,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the credit was created (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
     PaymentApplicationResponse:
       type: object
       description: Result of applying a payment to one or more invoices
@@ -6952,7 +6952,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the payment was applied (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         applicationRequestId:
           type: string
           description: Idempotency key echoed from the application request
@@ -6982,12 +6982,12 @@ components:
           type: string
           format: date-time
           description: Inclusive start of the mapping's temporal validity
-          example: 2026-01-15 10:30:00
+          example: 2026-01-15T10:30:00Z
         effectiveEndDate:
           type: string
           format: date-time
           description: Exclusive end of the mapping's temporal validity (open-ended when null)
-          example: 2026-06-18 08:00:00
+          example: 2026-06-18T08:00:00Z
         dimensions:
           type: object
           additionalProperties:
@@ -7042,12 +7042,12 @@ components:
           type: string
           format: date-time
           description: Inclusive start of the mapping's temporal validity
-          example: 2026-01-15 10:30:00
+          example: 2026-01-15T10:30:00Z
         effectiveEndDate:
           type: string
           format: date-time
           description: Exclusive end of the mapping's temporal validity (open-ended when null)
-          example: 2026-06-18 08:00:00
+          example: 2026-06-18T08:00:00Z
         dimensions:
           type: object
           additionalProperties:
@@ -7064,7 +7064,7 @@ components:
           type: string
           format: date-time
           description: Created timestamp
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         createdBy:
           type: string
           description: Created by username
@@ -7089,7 +7089,7 @@ components:
           type: string
           format: date-time
           description: Transaction date used for temporal mapping resolution
-          example: 2026-01-15 10:30:00
+          example: 2026-01-15T10:30:00Z
       required:
       - externalCode
       - sourceSystem
@@ -7387,7 +7387,7 @@ components:
           type: string
           format: date-time
           description: Creation timestamp (UTC).
-          example: 2026-02-27 12:00:00+00:00
+          example: 2026-02-27T12:00:00Z
       required:
       - createdAt
       - invoiceId
@@ -7456,7 +7456,7 @@ components:
           type: string
           format: date-time
           description: Date and time the account becomes active (ISO 8601)
-          example: 2026-06-18 08:00:00
+          example: 2026-06-18T08:00:00Z
       required:
       - accountCode
       - accountName
@@ -7514,14 +7514,14 @@ components:
           type: string
           format: date-time
           description: When the export was requested (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         completedAt:
           type:
           - string
           - 'null'
           format: date-time
           description: When the export completed (ISO 8601)
-          example: 2026-06-18 08:05:00+00:00
+          example: 2026-06-18T08:05:00Z
         downloadUrl:
           type:
           - string
@@ -7568,7 +7568,7 @@ components:
           type: string
           format: date-time
           description: Event transaction timestamp. If omitted, defaults to current time.
-          example: 2026-01-15 10:30:00
+          example: 2026-01-15T10:30:00Z
         payload:
           type: object
           description: Event-specific payload content
@@ -7602,7 +7602,7 @@ components:
           type: string
           format: date-time
           description: Business transaction timestamp
-          example: 2026-06-18 10:30:00
+          example: 2026-06-18T10:30:00Z
         payload:
           type: object
           description: Event-specific payload content
@@ -7629,12 +7629,12 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was received (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         processedAt:
           type: string
           format: date-time
           description: Timestamp when the event was processed (ISO 8601)
-          example: 2026-06-18 08:00:05+00:00
+          example: 2026-06-18T08:00:05Z
         sequenceNumber:
           type: integer
           format: int64
@@ -7790,12 +7790,12 @@ components:
           type: string
           format: date-time
           description: Timestamp when the credit memo was created (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         postedTimestamp:
           type: string
           format: date-time
           description: Timestamp when the credit memo was posted (ISO 8601)
-          example: 2026-06-18 09:00:00+00:00
+          example: 2026-06-18T09:00:00Z
         createdByUserId:
           type: string
           description: Identifier of the user who created the credit memo
@@ -7906,7 +7906,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the audit event occurred (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         reason:
           type: string
           description: Reason captured for the action
@@ -8294,7 +8294,7 @@ components:
           type: string
           format: date-time
           description: Gateway response timestamp
-          example: 2026-02-09 10:30:00+00:00
+          example: 2026-02-09T10:30:00Z
         glJournalEntryId:
           type: string
           format: uuid
@@ -8304,7 +8304,7 @@ components:
           type: string
           format: date-time
           description: GL posting timestamp
-          example: 2026-02-09 10:31:00+00:00
+          example: 2026-02-09T10:31:00Z
         glPostError:
           type: string
           description: GL posting error message (if failed)
@@ -8322,7 +8322,7 @@ components:
           type: string
           format: date-time
           description: Payment created timestamp
-          example: 2026-02-09 10:29:00+00:00
+          example: 2026-02-09T10:29:00Z
         createdBy:
           type: string
           description: User who initiated payment
@@ -8430,7 +8430,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the candidate record was created (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
       required:
       - candidateId
       - invoiceEventId
@@ -8586,7 +8586,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the report was generated (ISO 8601)
-          example: 2026-06-30 08:00:00+00:00
+          example: 2026-06-30T08:00:00Z
         rows:
           type: array
           description: Per-account trial balance rows ordered by account number; empty when no POSTED data exists
@@ -8700,7 +8700,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the report was generated (ISO 8601)
-          example: 2026-06-30 08:00:00+00:00
+          example: 2026-06-30T08:00:00Z
         rows:
           type: array
           description: Per-jurisdiction rows ordered by level (state/county/city/special) then code; empty when no in-period tax exists
@@ -8807,7 +8807,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the report was generated
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         lineItems:
           type: object
           additionalProperties:
@@ -8945,7 +8945,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the report was generated (ISO 8601)
-          example: 2026-06-30 08:00:00+00:00
+          example: 2026-06-30T08:00:00Z
         accounts:
           type: array
           description: Per-account sections ordered by account number; empty when no POSTED activity exists
@@ -9042,7 +9042,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the report was generated (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         lineItems:
           type: object
           additionalProperties:
@@ -9085,7 +9085,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the report was generated (ISO 8601)
-          example: 2026-06-30 08:00:00+00:00
+          example: 2026-06-30T08:00:00Z
         rows:
           type: array
           description: Per-customer aging rows ordered by customer name; empty when no open receivables exist
@@ -9181,7 +9181,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the report was generated (ISO 8601)
-          example: 2026-06-30 08:00:00+00:00
+          example: 2026-06-30T08:00:00Z
         rows:
           type: array
           description: Per-vendor aging rows ordered by vendor name; empty when no open payables exist
@@ -9651,7 +9651,7 @@ components:
           type: string
           format: date-time
           description: Last updated timestamp
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
       required:
       - invoiceId
       - status
@@ -9768,7 +9768,7 @@ components:
           type: string
           format: date-time
           description: Point in time the balance is computed as of (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
       required:
       - asOfDate
       - balance
@@ -9855,7 +9855,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the reprocessing was attempted (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         triggeredByUserId:
           type: string
           description: Identifier of the user who triggered the attempt
@@ -9891,7 +9891,7 @@ components:
           type: string
           format: date-time
           description: When this log entry was created (ISO 8601)
-          example: 2026-06-18 08:00:00+00:00
+          example: 2026-06-18T08:00:00Z
         severity:
           type: string
           description: 'Severity level: INFO, WARN, or ERROR'
@@ -10092,12 +10092,12 @@ components:
           type: string
           format: date-time
           description: Bill date
-          example: 2026-01-15 00:00:00
+          example: 2026-01-15T00:00:00Z
         dueDate:
           type: string
           format: date-time
           description: Due date
-          example: 2026-02-14 00:00:00
+          example: 2026-02-14T00:00:00Z
         totalAmount:
           type: number
           description: Total bill amount

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
@@ -16,7 +16,8 @@ public final class EventTypes {
 
     /**
      * All event type registrations for the accounting module.
-     * Total: 81 event types (includes +10 from manual CSV bank reconciliation
+     * Total: 82 event types (includes +1 from the sales-tax liability report
+     * (Story T8, Issue #966): REPORT_TAX_LIABILITY_GENERATE, +10 from manual CSV bank reconciliation
      * (Story F2, Issue #965): ACCOUNTING_RECONCILIATION_IMPORT,
      * ACCOUNTING_RECONCILIATION_MATCH, ACCOUNTING_RECONCILIATION_UNMATCH,
      * ACCOUNTING_RECONCILIATION_ADJUSTMENT, ACCOUNTING_RECONCILIATION_FINALIZE,
@@ -167,6 +168,12 @@ public final class EventTypes {
                 EventTypeRegistration.search(
                                 "REPORT_AGED_PAYABLES_GENERATE",
                                 "Generate Aged Payables report (bucketed open vendor-bill balances)")
+                        .build(),
+
+                // FinancialReportingController sales-tax liability - 1 event (parity-T8, Issue #966)
+                EventTypeRegistration.search(
+                                "REPORT_TAX_LIABILITY_GENERATE",
+                                "Generate Sales-Tax Liability report (per-jurisdiction taxable/exempt base, net tax, GL drift)")
                         .build(),
 
                 // LaborOverheadReportController - 1 event (CAP-316)

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/FinancialReportingController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/FinancialReportingController.java
@@ -7,6 +7,7 @@ import com.positivity.accounting.internal.dto.BalanceSheetReport;
 import com.positivity.accounting.internal.dto.GeneralLedgerReport;
 import com.positivity.accounting.internal.dto.IncomeStatementReport;
 import com.positivity.accounting.internal.dto.JournalLineDrilldownResponse;
+import com.positivity.accounting.internal.dto.TaxLiabilityReport;
 import com.positivity.accounting.internal.dto.TrialBalanceReport;
 import com.positivity.accounting.service.FinancialReportingService;
 import com.positivity.events.EmitEvent;
@@ -426,6 +427,57 @@ public class FinancialReportingController {
         // here; the module's @RestControllerAdvice maps it to 400 Bad Request with the
         // accounting domain's standard ApiError format (ADR-0017).
         AgedPayablesReport report = financialReportingService.generateAgedPayables(asOfDate);
+        return ResponseEntity.ok(report);
+    }
+
+    /**
+     * Generate the Sales-Tax Liability report for a date range (Story T8, Issue
+     * #966).
+     */
+    @GetMapping(value = "/tax-liability", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
+    @EmitEvent(id = "REPORT_TAX_LIABILITY_GENERATE", apiVersion = "1")
+    @Operation(
+            summary = "Generate Sales-Tax Liability report",
+            description =
+                    "Generate the reconciliation-grade sales-tax liability report for a date range: per-jurisdiction (state/county/city/special) taxable base, exempt base with reasons, gross tax collected, POSTED credit-memo reversals netted pro-rata, and net tax; plus a GL-drift column reconciling total net tax against the Sales-Tax Payable (2200) account activity. Accrual basis: invoice tax bucketed by finalization period, credits by posting period.",
+            tags = {"Financial Reporting"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Tax liability report generated successfully (rows empty when no in-period tax exists)",
+            content = @Content(schema = @Schema(implementation = TaxLiabilityReport.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid date range",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Forbidden - missing reporting:view:financial-statements",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<TaxLiabilityReport> generateTaxLiability(
+            @Parameter(description = "Period start date (YYYY-MM-DD)", required = true, example = "2026-06-01")
+                    @RequestParam
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    @NonNull
+                    LocalDate startDate,
+            @Parameter(description = "Period end date (YYYY-MM-DD)", required = true, example = "2026-06-30")
+                    @RequestParam
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    @NonNull
+                    LocalDate endDate) {
+
+        // Use IllegalArgumentException for validation errors to leverage the module's
+        // @RestControllerAdvice (APPaymentExceptionHandler) which maps it to 400 Bad
+        // Request with the accounting domain's standard ApiError format (ADR-0017).
+        if (endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("End date cannot be before start date");
+        }
+
+        TaxLiabilityReport report = financialReportingService.generateTaxLiability(startDate, endDate);
         return ResponseEntity.ok(report);
     }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TaxLiabilityReconciliation.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TaxLiabilityReconciliation.java
@@ -1,0 +1,65 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import lombok.*;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * GL-drift / reconciliation block of the Sales-Tax Liability report (story T8,
+ * issue #966).
+ *
+ * <p>Under D-4 (single Sales-Tax-Payable GL account, report-time aggregation) the
+ * report's total net tax is reconciled against the credit-normal period activity of
+ * the Sales-Tax Payable account (code {@code 2200}). Invoice finalization posts
+ * {@code Cr 2200}; a POSTED credit memo posts {@code Dr 2200}. On a clean ledger the
+ * platform-calculated net tax equals the 2200 net activity and {@link #drift} is zero;
+ * a non-zero drift flags a mismatch between calculated and posted tax.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(
+        description =
+                "Reconciliation of report net tax against the Sales-Tax Payable (2200) GL account period activity")
+public class TaxLiabilityReconciliation {
+
+    @Schema(
+            description = "Sales-Tax Payable GL account code being reconciled against",
+            example = "2200",
+            requiredMode = REQUIRED)
+    @NonNull
+    private String taxPayableAccountCode;
+
+    @Schema(
+            description =
+                    "Credit-normal net activity of account 2200 in the period (Σ credit - Σ debit of POSTED lines); zero when the account has no activity or is not seeded",
+            example = "948.75",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal glNetActivity;
+
+    @Schema(
+            description = "Report's total net tax across all jurisdictions (echoes report totals.netTax)",
+            example = "948.75",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal reportNetTax;
+
+    @Schema(
+            description = "GL drift: reportNetTax - glNetActivity. Zero on a clean ledger; non-zero flags a mismatch",
+            example = "0.00",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal drift;
+
+    @Schema(
+            description = "True when |drift| is within the 0.01 reconciliation tolerance",
+            example = "true",
+            requiredMode = REQUIRED)
+    @NonNull
+    private Boolean reconciled;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TaxLiabilityReport.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TaxLiabilityReport.java
@@ -1,0 +1,101 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.*;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Sales-Tax Liability report response (story T8, issue #966).
+ *
+ * <p>Reconciliation-grade report (R-T4 decision A): AvaTax remains the filing
+ * system of record; this report confirms that platform-collected tax equals
+ * GL-posted tax. Accrual basis — invoice tax is bucketed by the invoice's
+ * finalization (posting) date and credit-memo reversals by the credit's posting
+ * date, both within the requested date range.
+ *
+ * <p>Rows are grouped by {@code (jurisdictionType, jurisdictionCode)} at all
+ * available geographic levels, ordered state → county → city → special then by
+ * code. Exempt/zero-rate sales appear per jurisdiction (exempt base + reasons).
+ * Credits net within the jurisdiction+period bucket while gross collected stays
+ * visible. A GL-drift block reconciles total net tax against the Sales-Tax Payable
+ * (2200) account activity.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(
+        description =
+                "Sales-Tax Liability report: per-jurisdiction taxable/exempt base, gross, credits, net tax, and GL drift")
+public class TaxLiabilityReport {
+
+    @Schema(description = "Period start date (inclusive)", example = "2026-06-01", requiredMode = REQUIRED)
+    @NonNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @Schema(description = "Period end date (inclusive)", example = "2026-06-30", requiredMode = REQUIRED)
+    @NonNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    @Schema(
+            description = "Timestamp when the report was generated (ISO 8601)",
+            example = "2026-06-30T08:00:00Z",
+            requiredMode = REQUIRED)
+    @NonNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    private Instant generatedAt;
+
+    @Schema(
+            description =
+                    "Per-jurisdiction rows ordered by level (state/county/city/special) then code; empty when no in-period tax exists",
+            requiredMode = REQUIRED)
+    @NonNull
+    private List<TaxLiabilityRow> rows;
+
+    @Schema(
+            description = "Grand total taxable base across all jurisdictions",
+            example = "12500.0000",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal totalTaxableBase;
+
+    @Schema(
+            description = "Grand total exempt base across all jurisdictions",
+            example = "1500.0000",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal totalExemptBase;
+
+    @Schema(
+            description = "Grand total gross tax collected across all jurisdictions",
+            example = "1031.25",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal totalTaxCollectedGross;
+
+    @Schema(
+            description = "Grand total credits netted across all jurisdictions",
+            example = "82.50",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal totalCreditsNetted;
+
+    @Schema(description = "Grand total net tax across all jurisdictions", example = "948.75", requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal totalNetTax;
+
+    @Schema(
+            description = "GL-drift reconciliation against the Sales-Tax Payable (2200) account",
+            requiredMode = REQUIRED)
+    @NonNull
+    private TaxLiabilityReconciliation reconciliation;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TaxLiabilityRow.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/TaxLiabilityRow.java
@@ -1,0 +1,89 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.*;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One jurisdiction row of the Sales-Tax Liability report (story T8, issue #966).
+ *
+ * <p>Rows are grouped by {@code (jurisdictionType, jurisdictionCode)} at all
+ * available geographic levels (state / county / city / special). Each row shows
+ * gross tax collected, credits netted (pro-rata attribution of POSTED credit-memo
+ * reversals), and net tax, alongside the taxable and exempt bases.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Per-jurisdiction sales-tax liability row (taxable/exempt base, gross, credits netted, net tax)")
+public class TaxLiabilityRow {
+
+    @Schema(
+            description = "Jurisdiction level: STATE, COUNTY, CITY, or SPECIAL",
+            example = "STATE",
+            requiredMode = REQUIRED)
+    @NonNull
+    private String jurisdictionType;
+
+    @Schema(description = "Jurisdiction code as reported by the tax engine", example = "WA", requiredMode = REQUIRED)
+    @NonNull
+    private String jurisdictionCode;
+
+    @Schema(
+            description =
+                    "Human-readable jurisdiction name when available; null when the replica carries only the code",
+            example = "Washington",
+            requiredMode = NOT_REQUIRED)
+    @Nullable
+    private String jurisdictionName;
+
+    @Schema(
+            description = "Sum of taxable base for non-exempt lines in this jurisdiction",
+            example = "12500.0000",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal taxableBase;
+
+    @Schema(
+            description = "Sum of taxable base for exempt / zero-rate lines in this jurisdiction",
+            example = "1500.0000",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal exemptBase;
+
+    @Schema(
+            description =
+                    "Distinct exemption reason codes contributing to the exempt base (ascending); empty when none",
+            requiredMode = REQUIRED)
+    @NonNull
+    private List<String> exemptionReasons;
+
+    @Schema(
+            description = "Gross tax collected (Σ tax_amount of non-exempt lines) before credits",
+            example = "1031.25",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal taxCollectedGross;
+
+    @Schema(
+            description =
+                    "Credit/refund tax netted against this jurisdiction — POSTED credit-memo reversals allocated pro-rata to collected tax",
+            example = "82.50",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal creditsNetted;
+
+    @Schema(
+            description = "Net tax owed for this jurisdiction: taxCollectedGross - creditsNetted",
+            example = "948.75",
+            requiredMode = REQUIRED)
+    @NonNull
+    private BigDecimal netTax;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/CreditMemoRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/CreditMemoRepository.java
@@ -2,6 +2,7 @@ package com.positivity.accounting.internal.repository;
 
 import com.positivity.accounting.internal.entity.CreditMemo;
 import com.positivity.accounting.internal.enums.CreditMemoStatus;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -21,6 +22,18 @@ public interface CreditMemoRepository extends JpaRepository<CreditMemo, UUID> {
      * @return list of credit memos
      */
     List<CreditMemo> findByOriginalInvoiceId(UUID originalInvoiceId);
+
+    /**
+     * Find credit memos in a given status whose posting timestamp falls in the inclusive
+     * instant range. Used by the Sales-Tax Liability report (story T8, issue #966) to net
+     * POSTED credit-memo tax reversals by the credit's posting period (accrual basis).
+     *
+     * @param status the lifecycle status to include (normally {@code POSTED})
+     * @param start  inclusive lower bound (start-of-day of the period start, UTC)
+     * @param end    inclusive upper bound (end-of-day of the period end, UTC)
+     * @return matching credit memos (unordered)
+     */
+    List<CreditMemo> findByStatusAndPostedTimestampBetween(CreditMemoStatus status, Instant start, Instant end);
 
     /**
      * Find all credit memos for an invoice with pagination.

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/ExtInvoiceRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/ExtInvoiceRepository.java
@@ -1,12 +1,24 @@
 package com.positivity.accounting.internal.repository;
 
 import com.positivity.accounting.internal.entity.ExtInvoice;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExtInvoiceRepository extends JpaRepository<ExtInvoice, UUID> {
+
+    /**
+     * Find replicated invoices whose finalization (accrual posting) timestamp falls in
+     * the inclusive instant range. Used by the Sales-Tax Liability report (story T8,
+     * issue #966) to bucket invoice tax by the invoice's posting period.
+     *
+     * @param start inclusive lower bound (start-of-day of the period start, UTC)
+     * @param end   inclusive upper bound (end-of-day of the period end, UTC)
+     * @return invoices finalized within the range (unordered)
+     */
+    List<ExtInvoice> findByFinalizedAtBetween(Instant start, Instant end);
 
     /**
      * Find replicated invoices whose (pos-invoice) lifecycle status is one of the

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/ExtInvoiceTaxRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/ExtInvoiceTaxRepository.java
@@ -1,6 +1,7 @@
 package com.positivity.accounting.internal.repository;
 
 import com.positivity.accounting.internal.entity.ExtInvoiceTax;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +12,17 @@ import org.springframework.data.repository.query.Param;
 public interface ExtInvoiceTaxRepository extends JpaRepository<ExtInvoiceTax, UUID> {
 
     List<ExtInvoiceTax> findByInvoiceId(UUID invoiceId);
+
+    /**
+     * Load all per-jurisdiction tax rows for a set of invoices in one query. Used by
+     * the Sales-Tax Liability report (story T8, issue #966) to aggregate an in-period
+     * invoice set and to build per-invoice jurisdiction weights for credit netting,
+     * avoiding a per-invoice N+1.
+     *
+     * @param invoiceIds invoice ids to load tax rows for
+     * @return matching tax rows (unordered; the report groups/orders in-service)
+     */
+    List<ExtInvoiceTax> findByInvoiceIdIn(Collection<UUID> invoiceIds);
 
     @Modifying
     @Query("delete from ExtInvoiceTax t where t.invoiceId = :invoiceId")

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
@@ -879,6 +879,20 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         }
 
         Map<JurisdictionKey, BigDecimal> allocated = TaxCreditAllocator.allocate(reversed, weights);
+        if (allocated.isEmpty()) {
+            // Weights are non-empty but every replicated tax row has zero tax_amount (e.g. a
+            // fully-exempt original invoice), so the allocator cannot split the reversal by
+            // collected-tax share. Like the no-rows case, leave it unattributed rather than net
+            // a credit against a jurisdiction that collected no tax — it surfaces as GL drift.
+            log.warn(
+                    "Credit memo {} reverses tax {} but its original invoice {} has replicated tax rows that all "
+                            + "carry zero tax_amount; reversal cannot be attributed to a jurisdiction and is left "
+                            + "unattributed (will appear as GL drift)",
+                    credit.getCreditMemoId(),
+                    reversed,
+                    credit.getOriginalInvoiceId());
+            return;
+        }
         for (Map.Entry<JurisdictionKey, BigDecimal> entry : allocated.entrySet()) {
             byJurisdiction.get(entry.getKey()).creditsNetted =
                     byJurisdiction.get(entry.getKey()).creditsNetted.add(entry.getValue());

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
@@ -13,22 +13,30 @@ import com.positivity.accounting.internal.dto.GeneralLedgerLine;
 import com.positivity.accounting.internal.dto.GeneralLedgerReport;
 import com.positivity.accounting.internal.dto.IncomeStatementReport;
 import com.positivity.accounting.internal.dto.JournalLineDrilldownResponse;
+import com.positivity.accounting.internal.dto.TaxLiabilityReconciliation;
+import com.positivity.accounting.internal.dto.TaxLiabilityReport;
+import com.positivity.accounting.internal.dto.TaxLiabilityRow;
 import com.positivity.accounting.internal.dto.TrialBalanceAccountTotal;
 import com.positivity.accounting.internal.dto.TrialBalanceReport;
 import com.positivity.accounting.internal.dto.TrialBalanceRow;
 import com.positivity.accounting.internal.entity.AccountingSequence;
+import com.positivity.accounting.internal.entity.CreditMemo;
 import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.ExtInvoiceTax;
 import com.positivity.accounting.internal.entity.GLAccount;
 import com.positivity.accounting.internal.entity.JournalEntry;
 import com.positivity.accounting.internal.entity.JournalEntryLine;
 import com.positivity.accounting.internal.entity.StatementLineMapping;
 import com.positivity.accounting.internal.entity.VendorBill;
+import com.positivity.accounting.internal.enums.CreditMemoStatus;
 import com.positivity.accounting.internal.enums.OperationType;
 import com.positivity.accounting.internal.enums.StatementType;
 import com.positivity.accounting.internal.enums.VendorBillStatus;
 import com.positivity.accounting.internal.repository.APPaymentAllocationRepository;
 import com.positivity.accounting.internal.repository.AccountingSequenceRepository;
+import com.positivity.accounting.internal.repository.CreditMemoRepository;
 import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
 import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
@@ -47,8 +55,10 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
@@ -96,11 +106,30 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
     private static final Set<VendorBillStatus> OPEN_PAYABLE_STATUSES =
             Set.of(VendorBillStatus.PENDING_RECEIPT_MATCH, VendorBillStatus.MATCH_EXCEPTION, VendorBillStatus.APPROVED);
 
+    /**
+     * Chart-of-accounts code of the single Sales-Tax Payable account (D-4: one GL
+     * account, report-time jurisdiction aggregation). The T8 report reconciles its
+     * total net tax against this account's credit-normal period activity.
+     */
+    private static final String SALES_TAX_PAYABLE_ACCOUNT_CODE = "2200";
+
+    /** Reconciliation tolerance for the GL-drift flag (1 cent). */
+    private static final BigDecimal RECON_TOLERANCE = new BigDecimal("0.01");
+
+    /**
+     * Jurisdiction-level ordering for report rows and residual tie-breaks: state
+     * first, then county, city, special; unknown levels sort last.
+     */
+    private static final Map<String, Integer> JURISDICTION_TYPE_RANK =
+            Map.of("STATE", 0, "COUNTY", 1, "CITY", 2, "SPECIAL", 3);
+
     private final JournalEntryRepository journalEntryRepository;
     private final StatementLineMappingRepository statementLineMappingRepository;
     private final AccountingSequenceRepository accountingSequenceRepository;
     private final GLAccountRepository glAccountRepository;
     private final ExtInvoiceRepository extInvoiceRepository;
+    private final ExtInvoiceTaxRepository extInvoiceTaxRepository;
+    private final CreditMemoRepository creditMemoRepository;
     private final VendorBillRepository vendorBillRepository;
     private final APPaymentAllocationRepository apPaymentAllocationRepository;
     private final InvoiceBalanceCalculator invoiceBalanceCalculator;
@@ -112,6 +141,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
             AccountingSequenceRepository accountingSequenceRepository,
             GLAccountRepository glAccountRepository,
             ExtInvoiceRepository extInvoiceRepository,
+            ExtInvoiceTaxRepository extInvoiceTaxRepository,
+            CreditMemoRepository creditMemoRepository,
             VendorBillRepository vendorBillRepository,
             APPaymentAllocationRepository apPaymentAllocationRepository,
             InvoiceBalanceCalculator invoiceBalanceCalculator,
@@ -121,6 +152,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         this.accountingSequenceRepository = accountingSequenceRepository;
         this.glAccountRepository = glAccountRepository;
         this.extInvoiceRepository = extInvoiceRepository;
+        this.extInvoiceTaxRepository = extInvoiceTaxRepository;
+        this.creditMemoRepository = creditMemoRepository;
         this.vendorBillRepository = vendorBillRepository;
         this.apPaymentAllocationRepository = apPaymentAllocationRepository;
         this.invoiceBalanceCalculator = invoiceBalanceCalculator;
@@ -708,6 +741,242 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                 .rows(rows)
                 .totals(totals)
                 .build();
+    }
+
+    // ========================================================================
+    // Story T8 (Issue #966) — Sales-Tax Liability report (reconciliation-grade).
+    // ========================================================================
+
+    @Override
+    public @NonNull TaxLiabilityReport generateTaxLiability(@NonNull LocalDate startDate, @NonNull LocalDate endDate) {
+
+        if (endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("End date cannot be before start date");
+        }
+
+        log.info("Generating sales-tax liability report for period {} to {}", startDate, endDate);
+
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+        Instant startInstant = startDateTime.toInstant(ZoneOffset.UTC);
+        Instant endInstant = endDateTime.toInstant(ZoneOffset.UTC);
+
+        Map<JurisdictionKey, JurisdictionAccumulator> byJurisdiction = new HashMap<>();
+
+        // --- Invoice side (accrual): tax bucketed by the invoice's finalization period ---
+        List<ExtInvoice> invoices = extInvoiceRepository.findByFinalizedAtBetween(startInstant, endInstant);
+        List<UUID> invoiceIds =
+                invoices.stream().map(ExtInvoice::getInvoiceId).distinct().toList();
+        List<ExtInvoiceTax> invoiceTaxRows =
+                invoiceIds.isEmpty() ? List.of() : extInvoiceTaxRepository.findByInvoiceIdIn(invoiceIds);
+
+        for (ExtInvoiceTax row : invoiceTaxRows) {
+            JurisdictionAccumulator acc = accumulatorFor(byJurisdiction, row);
+            if (row.isExempt()) {
+                acc.exemptBase = acc.exemptBase.add(nullSafe(row.getTaxableBase()));
+                String reason = row.getExemptionReasonCode();
+                if (reason != null && !reason.isBlank()) {
+                    acc.exemptionReasons.add(reason);
+                }
+            } else {
+                acc.taxableBase = acc.taxableBase.add(nullSafe(row.getTaxableBase()));
+                acc.taxCollectedGross = acc.taxCollectedGross.add(nullSafe(row.getTaxAmount()));
+            }
+        }
+
+        // --- Credit side (accrual): POSTED reversals bucketed by the credit's posting
+        // period, allocated per jurisdiction pro-rata to the original invoice's collected tax ---
+        List<CreditMemo> credits = creditMemoRepository.findByStatusAndPostedTimestampBetween(
+                CreditMemoStatus.POSTED, startInstant, endInstant);
+        if (!credits.isEmpty()) {
+            List<UUID> originalInvoiceIds = credits.stream()
+                    .map(CreditMemo::getOriginalInvoiceId)
+                    .distinct()
+                    .toList();
+            Map<UUID, List<ExtInvoiceTax>> taxByOriginalInvoice =
+                    extInvoiceTaxRepository.findByInvoiceIdIn(originalInvoiceIds).stream()
+                            .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
+
+            for (CreditMemo credit : credits) {
+                netCreditAcrossJurisdictions(credit, taxByOriginalInvoice, byJurisdiction);
+            }
+        }
+
+        // --- Rows ordered state -> county -> city -> special, then by code ---
+        List<TaxLiabilityRow> rows = byJurisdiction.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> entry.getValue().toRow(entry.getKey()))
+                .toList();
+
+        BigDecimal totalTaxableBase = sum(rows, TaxLiabilityRow::getTaxableBase);
+        BigDecimal totalExemptBase = sum(rows, TaxLiabilityRow::getExemptBase);
+        BigDecimal totalGross = sum(rows, TaxLiabilityRow::getTaxCollectedGross);
+        BigDecimal totalCreditsNetted = sum(rows, TaxLiabilityRow::getCreditsNetted);
+        BigDecimal totalNetTax = sum(rows, TaxLiabilityRow::getNetTax);
+
+        TaxLiabilityReconciliation reconciliation = reconcileAgainstTaxPayable(totalNetTax, startDateTime, endDateTime);
+
+        log.info(
+                "Sales-tax liability generated for {}..{}: jurisdictions={}, gross={}, credits={}, netTax={}, glDrift={}",
+                startDate,
+                endDate,
+                rows.size(),
+                totalGross,
+                totalCreditsNetted,
+                totalNetTax,
+                reconciliation.getDrift());
+
+        return TaxLiabilityReport.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .generatedAt(Instant.now(clock))
+                .rows(rows)
+                .totalTaxableBase(totalTaxableBase)
+                .totalExemptBase(totalExemptBase)
+                .totalTaxCollectedGross(totalGross)
+                .totalCreditsNetted(totalCreditsNetted)
+                .totalNetTax(totalNetTax)
+                .reconciliation(reconciliation)
+                .build();
+    }
+
+    /**
+     * Allocate one POSTED credit memo's {@code taxAmountReversed} across the
+     * jurisdictions of its original invoice, pro-rata to that invoice's per-jurisdiction
+     * collected tax, and add each allocated part to the matching jurisdiction's netted
+     * credits (creating the jurisdiction row if the invoice fell outside the period).
+     */
+    private void netCreditAcrossJurisdictions(
+            CreditMemo credit,
+            Map<UUID, List<ExtInvoiceTax>> taxByOriginalInvoice,
+            Map<JurisdictionKey, JurisdictionAccumulator> byJurisdiction) {
+
+        BigDecimal reversed = nullSafe(credit.getTaxAmountReversed());
+        if (reversed.signum() == 0) {
+            return;
+        }
+        List<ExtInvoiceTax> originalRows = taxByOriginalInvoice.getOrDefault(credit.getOriginalInvoiceId(), List.of());
+
+        // Weights are the original invoice's per-jurisdiction collected tax. Ensure every
+        // jurisdiction the credit touches has a row so its type/code is recoverable.
+        Map<JurisdictionKey, BigDecimal> weights = new LinkedHashMap<>();
+        for (ExtInvoiceTax row : originalRows) {
+            JurisdictionKey key = keyFor(row);
+            byJurisdiction.computeIfAbsent(key, JurisdictionAccumulator::new);
+            weights.merge(key, nullSafe(row.getTaxAmount()), BigDecimal::add);
+        }
+        if (weights.isEmpty()) {
+            // Original invoice has no replicated tax rows — the reversal cannot be attributed
+            // to a jurisdiction in this reconciliation-grade v1 (Phase-2: carry the breakdown
+            // on the credit itself). It is intentionally excluded so it surfaces as GL drift.
+            log.warn(
+                    "Credit memo {} reverses tax {} but its original invoice {} has no ext_invoice_tax rows; "
+                            + "reversal left unattributed (will appear as GL drift)",
+                    credit.getCreditMemoId(),
+                    reversed,
+                    credit.getOriginalInvoiceId());
+            return;
+        }
+
+        Map<JurisdictionKey, BigDecimal> allocated = TaxCreditAllocator.allocate(reversed, weights);
+        for (Map.Entry<JurisdictionKey, BigDecimal> entry : allocated.entrySet()) {
+            byJurisdiction.get(entry.getKey()).creditsNetted =
+                    byJurisdiction.get(entry.getKey()).creditsNetted.add(entry.getValue());
+        }
+    }
+
+    /**
+     * Reconcile the report's total net tax against the Sales-Tax Payable (2200) account's
+     * credit-normal period activity. {@code sumPostedBalanceForAccount} returns
+     * {@code Σdebit - Σcredit}; the credit-normal (liability) net owed is its negation.
+     * Invoice finalization posts {@code Cr 2200}, credit memos post {@code Dr 2200}, so on
+     * a clean ledger the 2200 net activity equals the report net tax and drift is zero.
+     */
+    private TaxLiabilityReconciliation reconcileAgainstTaxPayable(
+            BigDecimal reportNetTax, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+
+        BigDecimal glNetActivity = glAccountRepository
+                .findByAccountCode(SALES_TAX_PAYABLE_ACCOUNT_CODE)
+                .map(account -> nullSafe(journalEntryRepository.sumPostedBalanceForAccount(
+                                account.getGlAccountId(), startDateTime, endDateTime))
+                        .negate())
+                .orElse(BigDecimal.ZERO);
+
+        BigDecimal drift = reportNetTax.subtract(glNetActivity);
+        boolean reconciled = drift.abs().compareTo(RECON_TOLERANCE) <= 0;
+
+        return TaxLiabilityReconciliation.builder()
+                .taxPayableAccountCode(SALES_TAX_PAYABLE_ACCOUNT_CODE)
+                .glNetActivity(glNetActivity)
+                .reportNetTax(reportNetTax)
+                .drift(drift)
+                .reconciled(reconciled)
+                .build();
+    }
+
+    private static JurisdictionKey keyFor(ExtInvoiceTax row) {
+        return new JurisdictionKey(row.getJurisdictionType(), row.getJurisdictionCode());
+    }
+
+    private static JurisdictionAccumulator accumulatorFor(
+            Map<JurisdictionKey, JurisdictionAccumulator> byJurisdiction, ExtInvoiceTax row) {
+        return byJurisdiction.computeIfAbsent(keyFor(row), JurisdictionAccumulator::new);
+    }
+
+    private static BigDecimal sum(
+            List<TaxLiabilityRow> rows, java.util.function.Function<TaxLiabilityRow, BigDecimal> extractor) {
+        return rows.stream().map(extractor).reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Grouping key for a tax jurisdiction: level type + code. Ordering (state, county,
+     * city, special, then code) drives both report row order and the allocator's residual
+     * tie-break, so equal-share residuals land deterministically on the highest level.
+     */
+    private record JurisdictionKey(String type, String code) implements Comparable<JurisdictionKey> {
+        @Override
+        public int compareTo(JurisdictionKey other) {
+            int byRank = Integer.compare(rank(type), rank(other.type));
+            if (byRank != 0) {
+                return byRank;
+            }
+            int byType = type.compareToIgnoreCase(other.type);
+            if (byType != 0) {
+                return byType;
+            }
+            return code.compareTo(other.code);
+        }
+
+        private static int rank(String type) {
+            return JURISDICTION_TYPE_RANK.getOrDefault(type.toUpperCase(Locale.ROOT), 99);
+        }
+    }
+
+    /** Mutable per-jurisdiction accumulator, materialized into a {@link TaxLiabilityRow}. */
+    private static final class JurisdictionAccumulator {
+        private BigDecimal taxableBase = BigDecimal.ZERO;
+        private BigDecimal exemptBase = BigDecimal.ZERO;
+        private BigDecimal taxCollectedGross = BigDecimal.ZERO;
+        private BigDecimal creditsNetted = BigDecimal.ZERO;
+        private final TreeSet<String> exemptionReasons = new TreeSet<>();
+
+        JurisdictionAccumulator(JurisdictionKey key) {
+            // key retained implicitly by the map; fields default to zero
+        }
+
+        TaxLiabilityRow toRow(JurisdictionKey key) {
+            return TaxLiabilityRow.builder()
+                    .jurisdictionType(key.type())
+                    .jurisdictionCode(key.code())
+                    .jurisdictionName(null) // replica carries only the code
+                    .taxableBase(taxableBase)
+                    .exemptBase(exemptBase)
+                    .exemptionReasons(new ArrayList<>(exemptionReasons))
+                    .taxCollectedGross(taxCollectedGross)
+                    .creditsNetted(creditsNetted)
+                    .netTax(taxCollectedGross.subtract(creditsNetted))
+                    .build();
+        }
     }
 
     // ========== Story G2 Private Helpers ==========

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxCreditAllocator.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxCreditAllocator.java
@@ -47,8 +47,8 @@ final class TaxCreditAllocator {
      *                {@code tax_amount})
      * @param <K>     the (comparable) jurisdiction key type
      * @return a map whose values sum exactly to {@code amount} rounded to currency scale;
-     *         empty when {@code weights} is empty (the caller then treats the amount as
-     *         unattributable)
+     *         empty when {@code weights} is empty <em>or</em> when the total weight is zero
+     *         (the caller then treats the amount as unattributable)
      */
     static <K extends Comparable<K>> Map<K, BigDecimal> allocate(BigDecimal amount, Map<K, BigDecimal> weights) {
         Map<K, BigDecimal> result = new LinkedHashMap<>();
@@ -59,13 +59,12 @@ final class TaxCreditAllocator {
         BigDecimal target = amount.setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
         BigDecimal totalWeight = weights.values().stream().reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        // Degenerate weights (all zero): the whole amount cannot be split by share, so
-        // assign it entirely to the deterministic winner (smallest key) and zero the rest.
+        // Degenerate weights (all zero): every jurisdiction collected zero tax, so there is no
+        // collected-tax share to allocate against. Treat this identically to empty weights —
+        // do NOT attribute the reversal to any jurisdiction (assigning it to an arbitrary key
+        // would silently net a credit against a jurisdiction that collected no tax and hide the
+        // mismatch). Return empty so the caller leaves the reversal unattributed (GL drift).
         if (totalWeight.signum() == 0) {
-            K winner = weights.keySet().stream().min(K::compareTo).orElseThrow();
-            for (K key : weights.keySet()) {
-                result.put(key, winner.equals(key) ? target : zero());
-            }
             return result;
         }
 
@@ -101,9 +100,5 @@ final class TaxCreditAllocator {
             }
         }
         return winner;
-    }
-
-    private static BigDecimal zero() {
-        return BigDecimal.ZERO.setScale(CURRENCY_SCALE);
     }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxCreditAllocator.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxCreditAllocator.java
@@ -1,0 +1,109 @@
+package com.positivity.accounting.internal.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Deterministic pro-rata allocator for netting a credit memo's reversed tax
+ * across the jurisdictions of its original invoice (story T8, issue #966).
+ *
+ * <p><b>Why.</b> {@code ext_invoice_tax} is invoice-side only, so a POSTED credit
+ * memo's scalar {@code taxAmountReversed} carries no per-jurisdiction attribution.
+ * The reconciliation-grade report (R-T4 decision A) approximates that attribution
+ * by allocating the reversed tax across the original invoice's jurisdictions
+ * <em>pro-rata to each jurisdiction's collected tax</em> ({@code tax_amount}). True
+ * per-jurisdiction credit attribution (carrying the breakdown on the credit itself)
+ * is a Phase-2 concern.
+ *
+ * <p><b>Exact-sum guarantee.</b> Each jurisdiction's share is rounded HALF_UP at
+ * currency scale (2). The rounding residual ({@code amount - Σ rounded}) is then
+ * assigned to a single jurisdiction under a deterministic rule —
+ * <em>largest-weight-gets-the-remainder</em>, ties broken by the natural order of
+ * the key — so the allocated parts always sum <em>exactly</em> to {@code amount}.
+ * This is what lets the report's netted credits reconcile to the 2200 GL debits to
+ * the cent.
+ *
+ * <p>The result is independent of the input map's iteration order.
+ */
+final class TaxCreditAllocator {
+
+    /** Currency scale (dollars and cents) for allocation rounding (R-T4 decision). */
+    static final int CURRENCY_SCALE = 2;
+
+    private TaxCreditAllocator() {
+        // utility
+    }
+
+    /**
+     * Allocate {@code amount} across {@code weights} pro-rata to each weight, with an
+     * exact-sum residual correction.
+     *
+     * @param amount  the total to distribute (a credit memo's {@code taxAmountReversed});
+     *                a non-negative currency amount
+     * @param weights per-jurisdiction non-negative weights (each jurisdiction's collected
+     *                {@code tax_amount})
+     * @param <K>     the (comparable) jurisdiction key type
+     * @return a map whose values sum exactly to {@code amount} rounded to currency scale;
+     *         empty when {@code weights} is empty (the caller then treats the amount as
+     *         unattributable)
+     */
+    static <K extends Comparable<K>> Map<K, BigDecimal> allocate(BigDecimal amount, Map<K, BigDecimal> weights) {
+        Map<K, BigDecimal> result = new LinkedHashMap<>();
+        if (weights.isEmpty()) {
+            return result; // nothing to attribute to — caller decides how to surface this
+        }
+
+        BigDecimal target = amount.setScale(CURRENCY_SCALE, RoundingMode.HALF_UP);
+        BigDecimal totalWeight = weights.values().stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Degenerate weights (all zero): the whole amount cannot be split by share, so
+        // assign it entirely to the deterministic winner (smallest key) and zero the rest.
+        if (totalWeight.signum() == 0) {
+            K winner = weights.keySet().stream().min(K::compareTo).orElseThrow();
+            for (K key : weights.keySet()) {
+                result.put(key, winner.equals(key) ? target : zero());
+            }
+            return result;
+        }
+
+        BigDecimal running = BigDecimal.ZERO;
+        for (Entry<K, BigDecimal> entry : weights.entrySet()) {
+            BigDecimal share =
+                    target.multiply(entry.getValue()).divide(totalWeight, CURRENCY_SCALE, RoundingMode.HALF_UP);
+            result.put(entry.getKey(), share);
+            running = running.add(share);
+        }
+
+        BigDecimal residual = target.subtract(running);
+        if (residual.signum() != 0) {
+            result.merge(largestWeightKey(weights), residual, BigDecimal::add);
+        }
+        return result;
+    }
+
+    /**
+     * Key of the largest weight; ties broken by the smallest (natural-order) key so the
+     * choice is deterministic and reproducible across runs.
+     */
+    private static <K extends Comparable<K>> K largestWeightKey(Map<K, BigDecimal> weights) {
+        K winner = null;
+        BigDecimal best = null;
+        for (Entry<K, BigDecimal> entry : weights.entrySet()) {
+            BigDecimal weight = entry.getValue();
+            if (best == null
+                    || weight.compareTo(best) > 0
+                    || (weight.compareTo(best) == 0 && entry.getKey().compareTo(winner) < 0)) {
+                best = weight;
+                winner = entry.getKey();
+            }
+        }
+        return winner;
+    }
+
+    private static BigDecimal zero() {
+        return BigDecimal.ZERO.setScale(CURRENCY_SCALE);
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/FinancialReportingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/FinancialReportingService.java
@@ -219,4 +219,51 @@ public interface FinancialReportingService {
      */
     @NonNull
     AgedPayablesReport generateAgedPayables(@NonNull LocalDate asOfDate);
+
+    /**
+     * Generate the Sales-Tax Liability report for a date range (Story T8, Issue
+     * #966).
+     *
+     * <p>
+     * Reconciliation-grade report (R-T4 decision A): AvaTax is the filing system of
+     * record; this report confirms platform-collected tax equals GL-posted tax. It
+     * reads the {@code ext_invoice_tax} replica and nets POSTED credit-memo tax
+     * reversals, both on an accrual basis.
+     *
+     * <p>
+     * <b>Bucketing.</b> Invoice tax is included when the invoice's
+     * {@code finalizedAt} (accrual posting date) falls in the inclusive range;
+     * credit-memo reversals are included when the credit's {@code postedTimestamp}
+     * falls in the range. Rows are grouped by
+     * {@code (jurisdictionType, jurisdictionCode)} at all available geographic
+     * levels (state / county / city / special), ordered state → county → city →
+     * special then by code.
+     *
+     * <p>
+     * <b>Exempt.</b> Exempt / zero-rate lines contribute to a per-jurisdiction
+     * exempt base (Σ taxable base of exempt lines) with their distinct exemption
+     * reason codes; they add nothing to gross tax.
+     *
+     * <p>
+     * <b>Credits.</b> {@code ext_invoice_tax} is invoice-side only, so each POSTED
+     * credit memo's scalar {@code taxAmountReversed} is allocated across its original
+     * invoice's jurisdictions pro-rata to that invoice's per-jurisdiction collected
+     * tax, with a deterministic exact-sum residual rule (largest-share gets the
+     * remainder, HALF_UP at currency scale). Credits net within the
+     * jurisdiction+period bucket; gross collected stays visible. True per-jurisdiction
+     * credit attribution is a Phase-2 concern.
+     *
+     * <p>
+     * <b>GL drift.</b> Total net tax is reconciled against the credit-normal period
+     * activity of the Sales-Tax Payable account (code {@code 2200}); on a clean
+     * ledger the drift is zero.
+     *
+     * @param startDate period start date (inclusive)
+     * @param endDate   period end date (inclusive)
+     * @return sales-tax liability report with per-jurisdiction rows, totals, and GL
+     *         drift
+     * @throws IllegalArgumentException if {@code endDate} is before {@code startDate}
+     */
+    @NonNull
+    TaxLiabilityReport generateTaxLiability(@NonNull LocalDate startDate, @NonNull LocalDate endDate);
 }

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/TaxLiabilityReportContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/TaxLiabilityReportContractBehaviorIT.java
@@ -1,0 +1,259 @@
+package com.positivity.accounting.contract;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.accounting.BaseContractIntegrationTest;
+import com.positivity.accounting.internal.entity.CreditMemo;
+import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.ExtInvoiceTax;
+import com.positivity.accounting.internal.entity.GLAccount;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.enums.AccountType;
+import com.positivity.accounting.internal.enums.CreditMemoStatus;
+import com.positivity.accounting.internal.enums.JournalEntryStatus;
+import com.positivity.accounting.internal.repository.CreditMemoRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
+import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Contract behavior tests for the Story T8 (issue #966) Sales-Tax Liability
+ * endpoint: per-jurisdiction JSON figures with GL-drift reconciliation, plus a
+ * CSV/PDF export round-trip proving both formats reference the same report.
+ */
+@Transactional
+class TaxLiabilityReportContractBehaviorIT extends BaseContractIntegrationTest {
+
+    @Autowired
+    private GLAccountRepository glAccountRepository;
+
+    @Autowired
+    private JournalEntryRepository journalEntryRepository;
+
+    @Autowired
+    private ExtInvoiceRepository extInvoiceRepository;
+
+    @Autowired
+    private ExtInvoiceTaxRepository extInvoiceTaxRepository;
+
+    @Autowired
+    private CreditMemoRepository creditMemoRepository;
+
+    private static final UUID AR_ID = UUID.fromString("50000000-0000-7000-8000-000000001200");
+    private static final UUID TAX_ID = UUID.fromString("50000000-0000-7000-8000-000000002200");
+
+    private static final LocalDate START = LocalDate.of(2026, 6, 1);
+    private static final LocalDate END = LocalDate.of(2026, 6, 30);
+
+    @Test
+    @DisplayName("tax-liability returns per-jurisdiction totals with reasons, netted credits, and zero GL drift")
+    void taxLiabilityReconciles() throws Exception {
+        GLAccount ar = saveAccount(AR_ID, "1200", "Accounts Receivable", AccountType.ASSET);
+        GLAccount tax = saveAccount(TAX_ID, "2200", "Sales Tax Payable", AccountType.LIABILITY);
+
+        UUID inv1 = UUID.randomUUID();
+        UUID inv2 = UUID.randomUUID();
+        saveInvoice(inv1);
+        saveInvoice(inv2);
+        saveTax(inv1, "STATE", "WA", "1000.00", "65.00", false, null);
+        saveTax(inv1, "COUNTY", "KING", "1000.00", "35.00", false, null);
+        saveTax(inv1, "CITY", "SEATTLE", "1000.00", "25.00", false, null);
+        saveTax(inv1, "STATE", "WA", "500.00", "0.00", true, "RESALE");
+        saveTax(inv2, "STATE", "WA", "2000.00", "130.00", false, null);
+        saveCredit(inv1, "25.00");
+
+        // Balanced GL so the 2200 credit-normal activity (230) matches report net tax.
+        postBalancedEntry("JE-T8C-INV", LocalDateTime.of(2026, 6, 15, 0, 0), ar, tax, new BigDecimal("255.00"));
+        postBalancedEntry("JE-T8C-CRD", LocalDateTime.of(2026, 6, 20, 0, 0), tax, ar, new BigDecimal("25.00"));
+
+        mockMvc.perform(withAuth(get("/v1/accounting/reports/financial/tax-liability"))
+                        .param("startDate", START.toString())
+                        .param("endDate", END.toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.startDate").value("2026-06-01"))
+                .andExpect(jsonPath("$.endDate").value("2026-06-30"))
+                .andExpect(jsonPath("$.rows.length()").value(3))
+                // State WA first (ordering state -> county -> city).
+                .andExpect(jsonPath("$.rows[0].jurisdictionType").value("STATE"))
+                .andExpect(jsonPath("$.rows[0].jurisdictionCode").value("WA"))
+                .andExpect(jsonPath("$.rows[0].taxableBase").value(3000.00))
+                .andExpect(jsonPath("$.rows[0].exemptBase").value(500.00))
+                .andExpect(jsonPath("$.rows[0].exemptionReasons[0]").value("RESALE"))
+                .andExpect(jsonPath("$.rows[0].taxCollectedGross").value(195.00))
+                .andExpect(jsonPath("$.rows[0].creditsNetted").value(13.00))
+                .andExpect(jsonPath("$.rows[0].netTax").value(182.00))
+                .andExpect(jsonPath("$.rows[1].jurisdictionType").value("COUNTY"))
+                .andExpect(jsonPath("$.rows[1].netTax").value(28.00))
+                .andExpect(jsonPath("$.rows[2].jurisdictionType").value("CITY"))
+                .andExpect(jsonPath("$.rows[2].netTax").value(20.00))
+                .andExpect(jsonPath("$.totalTaxCollectedGross").value(255.00))
+                .andExpect(jsonPath("$.totalCreditsNetted").value(25.00))
+                .andExpect(jsonPath("$.totalNetTax").value(230.00))
+                .andExpect(jsonPath("$.reconciliation.taxPayableAccountCode").value("2200"))
+                .andExpect(jsonPath("$.reconciliation.glNetActivity").value(230.00))
+                .andExpect(jsonPath("$.reconciliation.drift").value(0))
+                .andExpect(jsonPath("$.reconciliation.reconciled").value(true));
+    }
+
+    @Test
+    @DisplayName("Invalid date range returns 400")
+    void invalidRange() throws Exception {
+        mockMvc.perform(withAuth(get("/v1/accounting/reports/financial/tax-liability"))
+                        .param("startDate", END.toString())
+                        .param("endDate", START.toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Export round-trip: TAX_LIABILITY flows through CSV and PDF export requests identically")
+    void exportRoundTripForTaxLiability() throws Exception {
+        for (String format : new String[] {"CSV", "PDF"}) {
+            String body = """
+                    {
+                      "format": "%s",
+                      "reportType": "TAX_LIABILITY",
+                      "startDate": "2026-06-01",
+                      "endDate": "2026-06-30",
+                      "organizationId": "d10217f9-3ec6-46b9-9c87-e7066c100c24"
+                    }
+                    """.formatted(format);
+
+            var created = mockMvc.perform(withAuth(post("/v1/accounting/reports/export"), "accounting:report:export")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.exportId").exists())
+                    .andExpect(jsonPath("$.status").value("PENDING"))
+                    .andExpect(jsonPath("$.format").value(format))
+                    .andExpect(jsonPath("$.reportType").value("TAX_LIABILITY"))
+                    .andReturn();
+
+            String exportId = objectMapper
+                    .readTree(created.getResponse().getContentAsString())
+                    .get("exportId")
+                    .asText();
+
+            mockMvc.perform(withAuth(
+                                    get("/v1/accounting/reports/export/{exportId}", exportId),
+                                    "accounting:report:export")
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.exportId").value(exportId))
+                    .andExpect(jsonPath("$.format").value(format))
+                    .andExpect(jsonPath("$.reportType").value("TAX_LIABILITY"));
+        }
+    }
+
+    // ===== fixtures =====
+
+    private GLAccount saveAccount(UUID id, String code, String name, AccountType type) {
+        GLAccount account = new GLAccount();
+        account.setGlAccountId(id);
+        account.setAccountCode(code);
+        account.setAccountName(name);
+        account.setAccountType(type);
+        account.setCreatedBy("TEST");
+        account.setModifiedBy("TEST");
+        return glAccountRepository.save(account);
+    }
+
+    private void saveInvoice(UUID invoiceId) {
+        ExtInvoice invoice = ExtInvoice.builder()
+                .invoiceId(invoiceId)
+                .workorderId(UUID.randomUUID())
+                .partyId(UUID.randomUUID().toString())
+                .status("FINALIZED")
+                .finalizedAt(Instant.parse("2026-06-15T00:00:00Z"))
+                .invoiceCreatedAt(Instant.parse("2026-06-15T00:00:00Z"))
+                .aggregateVersion(1L)
+                .updatedAt(Instant.parse("2026-06-30T00:00:00Z"))
+                .build();
+        extInvoiceRepository.save(invoice);
+    }
+
+    private void saveTax(
+            UUID invoiceId, String type, String code, String base, String tax, boolean exempt, String reason) {
+        ExtInvoiceTax row = ExtInvoiceTax.builder()
+                .invoiceId(invoiceId)
+                .lineItemId(code + "-line")
+                .jurisdictionType(type)
+                .jurisdictionCode(code)
+                .rate(new BigDecimal("0.065000"))
+                .taxableBase(new BigDecimal(base))
+                .taxAmount(new BigDecimal(tax))
+                .exempt(exempt)
+                .exemptionReasonCode(reason)
+                .aggregateVersion(1L)
+                .updatedAt(Instant.parse("2026-06-15T00:00:00Z"))
+                .build();
+        extInvoiceTaxRepository.save(row);
+    }
+
+    private void saveCredit(UUID originalInvoiceId, String taxReversed) {
+        CreditMemo credit = new CreditMemo();
+        credit.setOriginalInvoiceId(originalInvoiceId);
+        credit.setCustomerId(UUID.randomUUID());
+        credit.setCreditAmount(new BigDecimal("100.00"));
+        credit.setTaxAmountReversed(new BigDecimal(taxReversed));
+        credit.setReasonCode("RETURN");
+        credit.setStatus(CreditMemoStatus.POSTED);
+        credit.setCreationTimestamp(Instant.parse("2026-06-20T00:00:00Z"));
+        credit.setPostedTimestamp(Instant.parse("2026-06-20T00:00:00Z"));
+        credit.setCreatedByUserId("t8-it");
+        credit.setCurrency("USD");
+        creditMemoRepository.save(credit);
+    }
+
+    private void postBalancedEntry(
+            String entryNumber,
+            LocalDateTime txDate,
+            GLAccount debitAccount,
+            GLAccount creditAccount,
+            BigDecimal amount) {
+        JournalEntry entry = new JournalEntry();
+        entry.setStatus(JournalEntryStatus.POSTED);
+        entry.setEntryNumber(entryNumber);
+        entry.setTransactionDate(txDate);
+        entry.setSourceEventType("T8_TEST");
+        entry.setCreatedBy("t8-it");
+        entry.setModifiedBy("t8-it");
+        entry.setTotalDebits(amount);
+        entry.setTotalCredits(amount);
+        entry.setIsBalanced(true);
+        entry.addLine(line(entry, 1, debitAccount, amount, BigDecimal.ZERO));
+        entry.addLine(line(entry, 2, creditAccount, BigDecimal.ZERO, amount));
+        journalEntryRepository.save(entry);
+    }
+
+    private static JournalEntryLine line(
+            JournalEntry entry, int lineNumber, GLAccount account, BigDecimal debit, BigDecimal credit) {
+        JournalEntryLine line = new JournalEntryLine();
+        line.setJournalEntry(entry);
+        line.setLineNumber(lineNumber);
+        line.setGlAccount(account);
+        line.setAccountCode(account.getAccountCode());
+        line.setAccountName(account.getAccountName());
+        line.setDebitAmount(debit);
+        line.setCreditAmount(credit);
+        line.setDescription("t8 test line");
+        return line;
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingG2ServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingG2ServiceTest.java
@@ -18,7 +18,9 @@ import com.positivity.accounting.internal.entity.VendorBill;
 import com.positivity.accounting.internal.enums.VendorBillStatus;
 import com.positivity.accounting.internal.repository.APPaymentAllocationRepository;
 import com.positivity.accounting.internal.repository.AccountingSequenceRepository;
+import com.positivity.accounting.internal.repository.CreditMemoRepository;
 import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
 import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
@@ -77,6 +79,12 @@ class FinancialReportingG2ServiceTest {
     private ExtInvoiceRepository extInvoiceRepository;
 
     @Mock
+    private ExtInvoiceTaxRepository extInvoiceTaxRepository;
+
+    @Mock
+    private CreditMemoRepository creditMemoRepository;
+
+    @Mock
     private VendorBillRepository vendorBillRepository;
 
     @Mock
@@ -95,6 +103,8 @@ class FinancialReportingG2ServiceTest {
                 accountingSequenceRepository,
                 glAccountRepository,
                 extInvoiceRepository,
+                extInvoiceTaxRepository,
+                creditMemoRepository,
                 vendorBillRepository,
                 apPaymentAllocationRepository,
                 invoiceBalanceCalculator,

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingServiceImplTest.java
@@ -62,6 +62,12 @@ class FinancialReportingServiceImplTest {
     private com.positivity.accounting.internal.repository.ExtInvoiceRepository extInvoiceRepository;
 
     @Mock
+    private com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository extInvoiceTaxRepository;
+
+    @Mock
+    private com.positivity.accounting.internal.repository.CreditMemoRepository creditMemoRepository;
+
+    @Mock
     private com.positivity.accounting.internal.repository.VendorBillRepository vendorBillRepository;
 
     @Mock
@@ -80,6 +86,8 @@ class FinancialReportingServiceImplTest {
                 accountingSequenceRepository,
                 glAccountRepository,
                 extInvoiceRepository,
+                extInvoiceTaxRepository,
+                creditMemoRepository,
                 vendorBillRepository,
                 apPaymentAllocationRepository,
                 invoiceBalanceCalculator,

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingTaxLiabilityServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingTaxLiabilityServiceTest.java
@@ -1,0 +1,255 @@
+package com.positivity.accounting.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.positivity.accounting.internal.dto.TaxLiabilityReport;
+import com.positivity.accounting.internal.dto.TaxLiabilityRow;
+import com.positivity.accounting.internal.entity.CreditMemo;
+import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.ExtInvoiceTax;
+import com.positivity.accounting.internal.entity.GLAccount;
+import com.positivity.accounting.internal.enums.CreditMemoStatus;
+import com.positivity.accounting.internal.repository.APPaymentAllocationRepository;
+import com.positivity.accounting.internal.repository.AccountingSequenceRepository;
+import com.positivity.accounting.internal.repository.CreditMemoRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
+import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
+import com.positivity.accounting.internal.repository.VendorBillRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link FinancialReportingServiceImpl#generateTaxLiability} (story
+ * T8, issue #966): per-jurisdiction aggregation across state/county/city, exempt
+ * base + reasons, POSTED credit-memo pro-rata netting, and the GL-drift column.
+ */
+@ExtendWith(MockitoExtension.class)
+class FinancialReportingTaxLiabilityServiceTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-07-01T12:00:00Z");
+    private static final LocalDate START = LocalDate.of(2026, 6, 1);
+    private static final LocalDate END = LocalDate.of(2026, 6, 30);
+
+    private static final UUID INV1 = UUID.fromString("b1000000-0000-7000-8000-000000000001");
+    private static final UUID INV2 = UUID.fromString("b1000000-0000-7000-8000-000000000002");
+    private static final UUID TAX_ACCT = UUID.fromString("5eed0acc-0000-4000-8000-000000002200");
+
+    @Mock
+    private JournalEntryRepository journalEntryRepository;
+
+    @Mock
+    private StatementLineMappingRepository statementLineMappingRepository;
+
+    @Mock
+    private AccountingSequenceRepository accountingSequenceRepository;
+
+    @Mock
+    private GLAccountRepository glAccountRepository;
+
+    @Mock
+    private ExtInvoiceRepository extInvoiceRepository;
+
+    @Mock
+    private ExtInvoiceTaxRepository extInvoiceTaxRepository;
+
+    @Mock
+    private CreditMemoRepository creditMemoRepository;
+
+    @Mock
+    private VendorBillRepository vendorBillRepository;
+
+    @Mock
+    private APPaymentAllocationRepository apPaymentAllocationRepository;
+
+    @Mock
+    private InvoiceBalanceCalculator invoiceBalanceCalculator;
+
+    private FinancialReportingServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FinancialReportingServiceImpl(
+                journalEntryRepository,
+                statementLineMappingRepository,
+                accountingSequenceRepository,
+                glAccountRepository,
+                extInvoiceRepository,
+                extInvoiceTaxRepository,
+                creditMemoRepository,
+                vendorBillRepository,
+                apPaymentAllocationRepository,
+                invoiceBalanceCalculator,
+                Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
+    }
+
+    @Test
+    @DisplayName("Aggregates per jurisdiction, nets a POSTED credit pro-rata, and reconciles GL drift to zero")
+    void aggregatesNetsAndReconciles() {
+        ExtInvoice inv1 = invoiceFinalized(INV1);
+        ExtInvoice inv2 = invoiceFinalized(INV2);
+        when(extInvoiceRepository.findByFinalizedAtBetween(any(), any())).thenReturn(List.of(inv1, inv2));
+
+        // INV1: WA state 65, King county 35, Seattle city 25 (all on 1000 base each), plus a
+        // 500 exempt (resale) line on WA. INV2: WA state 130 on 2000 base.
+        List<ExtInvoiceTax> master = List.of(
+                taxRow(INV1, "STATE", "WA", "1000.00", "65.00", false, null),
+                taxRow(INV1, "COUNTY", "KING", "1000.00", "35.00", false, null),
+                taxRow(INV1, "CITY", "SEATTLE", "1000.00", "25.00", false, null),
+                taxRow(INV1, "STATE", "WA", "500.00", "0.00", true, "RESALE"),
+                taxRow(INV2, "STATE", "WA", "2000.00", "130.00", false, null));
+        when(extInvoiceTaxRepository.findByInvoiceIdIn(anyCollection())).thenAnswer(call -> {
+            Collection<UUID> ids = call.getArgument(0);
+            return master.stream().filter(r -> ids.contains(r.getInvoiceId())).toList();
+        });
+
+        // One POSTED credit against INV1 reversing 25.00 of tax, posted in-period.
+        when(creditMemoRepository.findByStatusAndPostedTimestampBetween(eq(CreditMemoStatus.POSTED), any(), any()))
+                .thenReturn(List.of(creditMemo(INV1, "25.00")));
+
+        // GL 2200: Σdebit - Σcredit. Clean ledger -> equals -(report net tax) = -230.00,
+        // so credit-normal activity = 230.00 and drift = 0.
+        GLAccount taxPayable = new GLAccount();
+        taxPayable.setGlAccountId(TAX_ACCT);
+        taxPayable.setAccountCode("2200");
+        taxPayable.setAccountName("Sales Tax Payable");
+        when(glAccountRepository.findByAccountCode("2200")).thenReturn(Optional.of(taxPayable));
+        when(journalEntryRepository.sumPostedBalanceForAccount(eq(TAX_ACCT), any(), any()))
+                .thenReturn(new BigDecimal("-230.00"));
+
+        TaxLiabilityReport report = service.generateTaxLiability(START, END);
+
+        assertThat(report.getStartDate()).isEqualTo(START);
+        assertThat(report.getEndDate()).isEqualTo(END);
+        assertThat(report.getGeneratedAt()).isEqualTo(FIXED_NOW);
+
+        // Rows ordered state -> county -> city.
+        assertThat(report.getRows())
+                .extracting(TaxLiabilityRow::getJurisdictionType, TaxLiabilityRow::getJurisdictionCode)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("STATE", "WA"),
+                        org.assertj.core.groups.Tuple.tuple("COUNTY", "KING"),
+                        org.assertj.core.groups.Tuple.tuple("CITY", "SEATTLE"));
+
+        TaxLiabilityRow wa = report.getRows().get(0);
+        assertThat(wa.getTaxableBase()).isEqualByComparingTo("3000.00"); // 1000 + 2000
+        assertThat(wa.getExemptBase()).isEqualByComparingTo("500.00");
+        assertThat(wa.getExemptionReasons()).containsExactly("RESALE");
+        assertThat(wa.getTaxCollectedGross()).isEqualByComparingTo("195.00"); // 65 + 130
+        assertThat(wa.getCreditsNetted()).isEqualByComparingTo("13.00"); // 25 * 65/125
+        assertThat(wa.getNetTax()).isEqualByComparingTo("182.00");
+
+        TaxLiabilityRow king = report.getRows().get(1);
+        assertThat(king.getTaxCollectedGross()).isEqualByComparingTo("35.00");
+        assertThat(king.getCreditsNetted()).isEqualByComparingTo("7.00"); // 25 * 35/125
+        assertThat(king.getNetTax()).isEqualByComparingTo("28.00");
+        assertThat(king.getExemptBase()).isEqualByComparingTo("0");
+
+        TaxLiabilityRow seattle = report.getRows().get(2);
+        assertThat(seattle.getTaxCollectedGross()).isEqualByComparingTo("25.00");
+        assertThat(seattle.getCreditsNetted()).isEqualByComparingTo("5.00"); // 25 * 25/125
+        assertThat(seattle.getNetTax()).isEqualByComparingTo("20.00");
+
+        assertThat(report.getTotalTaxableBase()).isEqualByComparingTo("5000.00");
+        assertThat(report.getTotalExemptBase()).isEqualByComparingTo("500.00");
+        assertThat(report.getTotalTaxCollectedGross()).isEqualByComparingTo("255.00");
+        assertThat(report.getTotalCreditsNetted()).isEqualByComparingTo("25.00");
+        assertThat(report.getTotalNetTax()).isEqualByComparingTo("230.00");
+
+        assertThat(report.getReconciliation().getTaxPayableAccountCode()).isEqualTo("2200");
+        assertThat(report.getReconciliation().getGlNetActivity()).isEqualByComparingTo("230.00");
+        assertThat(report.getReconciliation().getReportNetTax()).isEqualByComparingTo("230.00");
+        assertThat(report.getReconciliation().getDrift()).isEqualByComparingTo("0.00");
+        assertThat(report.getReconciliation().getReconciled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Empty period yields no rows, zero totals, and a zero-drift reconciliation")
+    void emptyPeriod() {
+        when(extInvoiceRepository.findByFinalizedAtBetween(any(), any())).thenReturn(List.of());
+        when(creditMemoRepository.findByStatusAndPostedTimestampBetween(eq(CreditMemoStatus.POSTED), any(), any()))
+                .thenReturn(List.of());
+        when(glAccountRepository.findByAccountCode("2200")).thenReturn(Optional.empty());
+
+        TaxLiabilityReport report = service.generateTaxLiability(START, END);
+
+        assertThat(report.getRows()).isEmpty();
+        assertThat(report.getTotalNetTax()).isEqualByComparingTo("0");
+        assertThat(report.getReconciliation().getGlNetActivity()).isEqualByComparingTo("0");
+        assertThat(report.getReconciliation().getDrift()).isEqualByComparingTo("0");
+        assertThat(report.getReconciliation().getReconciled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Rejects an inverted date range")
+    void rejectsInvertedRange() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.generateTaxLiability(END, START))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ===== fixtures =====
+
+    private static ExtInvoice invoiceFinalized(UUID id) {
+        return ExtInvoice.builder()
+                .invoiceId(id)
+                .workorderId(UUID.randomUUID())
+                .partyId(UUID.randomUUID().toString())
+                .status("FINALIZED")
+                .finalizedAt(Instant.parse("2026-06-15T00:00:00Z"))
+                .aggregateVersion(1L)
+                .updatedAt(FIXED_NOW)
+                .build();
+    }
+
+    private static ExtInvoiceTax taxRow(
+            UUID invoiceId, String type, String code, String base, String tax, boolean exempt, String reason) {
+        return ExtInvoiceTax.builder()
+                .invoiceId(invoiceId)
+                .lineItemId(code + "-line")
+                .jurisdictionType(type)
+                .jurisdictionCode(code)
+                .rate(new BigDecimal("0.065000"))
+                .taxableBase(new BigDecimal(base))
+                .taxAmount(new BigDecimal(tax))
+                .exempt(exempt)
+                .exemptionReasonCode(reason)
+                .aggregateVersion(1L)
+                .updatedAt(FIXED_NOW)
+                .build();
+    }
+
+    private static CreditMemo creditMemo(UUID originalInvoiceId, String taxReversed) {
+        CreditMemo credit = new CreditMemo();
+        credit.setCreditMemoId(UUID.randomUUID());
+        credit.setOriginalInvoiceId(originalInvoiceId);
+        credit.setCustomerId(UUID.randomUUID());
+        credit.setCreditAmount(new BigDecimal("100.00"));
+        credit.setTaxAmountReversed(new BigDecimal(taxReversed));
+        credit.setReasonCode("RETURN");
+        credit.setStatus(CreditMemoStatus.POSTED);
+        credit.setCreationTimestamp(Instant.parse("2026-06-20T00:00:00Z"));
+        credit.setPostedTimestamp(Instant.parse("2026-06-20T00:00:00Z"));
+        credit.setCreatedByUserId("t8-test");
+        credit.setCurrency("USD");
+        return credit;
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxCreditAllocatorTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxCreditAllocatorTest.java
@@ -86,12 +86,11 @@ class TaxCreditAllocatorTest {
     }
 
     @Test
-    @DisplayName("All-zero weights assign the full amount to the smallest key")
+    @DisplayName("All-zero weights yield an empty allocation (reversal left unattributed, like empty weights)")
     void zeroWeights() {
-        Map<String, BigDecimal> out = TaxCreditAllocator.allocate(new BigDecimal("10.00"), weights("Z", 0, "A", 0));
-
-        assertThat(out.get("A")).isEqualByComparingTo("10.00");
-        assertThat(out.get("Z")).isEqualByComparingTo("0.00");
-        assertThat(sum(out)).isEqualByComparingTo("10.00");
+        // Every jurisdiction collected zero tax: there is no collected-tax share to net against,
+        // so the reversal is left unattributed (caller logs a WARN and surfaces it as GL drift).
+        assertThat(TaxCreditAllocator.allocate(new BigDecimal("25.00"), weights("Z", 0, "A", 0)))
+                .isEmpty();
     }
 }

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxCreditAllocatorTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxCreditAllocatorTest.java
@@ -1,0 +1,97 @@
+package com.positivity.accounting.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TaxCreditAllocator} (story T8, issue #966): the exact-sum
+ * pro-rata split of a credit memo's reversed tax across jurisdictions, and its
+ * deterministic residual rule (largest-weight-gets-the-remainder, ties by key).
+ */
+class TaxCreditAllocatorTest {
+
+    private static Map<String, BigDecimal> weights(Object... kv) {
+        Map<String, BigDecimal> map = new LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            map.put((String) kv[i], new BigDecimal(kv[i + 1].toString()));
+        }
+        return map;
+    }
+
+    private static BigDecimal sum(Map<String, BigDecimal> m) {
+        return m.values().stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    @Test
+    @DisplayName("Splits pro-rata to weights with no residual when shares are exact")
+    void exactShares() {
+        Map<String, BigDecimal> out =
+                TaxCreditAllocator.allocate(new BigDecimal("25.00"), weights("WA", 65, "KING", 35, "SEATTLE", 25));
+
+        assertThat(out.get("WA")).isEqualByComparingTo("13.00");
+        assertThat(out.get("KING")).isEqualByComparingTo("7.00");
+        assertThat(out.get("SEATTLE")).isEqualByComparingTo("5.00");
+        assertThat(sum(out)).isEqualByComparingTo("25.00");
+    }
+
+    @Test
+    @DisplayName("Equal weights: positive residual goes to the smallest key (deterministic tie-break)")
+    void equalWeightsResidualToSmallestKey() {
+        Map<String, BigDecimal> out =
+                TaxCreditAllocator.allocate(new BigDecimal("1.00"), weights("A", 1, "B", 1, "C", 1));
+
+        // 0.33 each -> 0.99, residual 0.01 to smallest key A.
+        assertThat(out.get("A")).isEqualByComparingTo("0.34");
+        assertThat(out.get("B")).isEqualByComparingTo("0.33");
+        assertThat(out.get("C")).isEqualByComparingTo("0.33");
+        assertThat(sum(out)).isEqualByComparingTo("1.00");
+    }
+
+    @Test
+    @DisplayName("Distinct largest weight absorbs a negative residual")
+    void distinctLargestWeightAbsorbsResidual() {
+        Map<String, BigDecimal> out =
+                TaxCreditAllocator.allocate(new BigDecimal("1.00"), weights("A", 1, "B", 1, "D", 4));
+
+        // A=0.17, B=0.17, D=0.67 -> 1.01, residual -0.01 to largest weight D.
+        assertThat(out.get("A")).isEqualByComparingTo("0.17");
+        assertThat(out.get("B")).isEqualByComparingTo("0.17");
+        assertThat(out.get("D")).isEqualByComparingTo("0.66");
+        assertThat(sum(out)).isEqualByComparingTo("1.00");
+    }
+
+    @Test
+    @DisplayName("Allocation is independent of input map iteration order")
+    void orderIndependent() {
+        Map<String, BigDecimal> forward =
+                TaxCreditAllocator.allocate(new BigDecimal("1.00"), weights("A", 1, "B", 1, "D", 4));
+        Map<String, BigDecimal> reversed =
+                TaxCreditAllocator.allocate(new BigDecimal("1.00"), weights("D", 4, "B", 1, "A", 1));
+
+        assertThat(reversed.get("A")).isEqualByComparingTo(forward.get("A"));
+        assertThat(reversed.get("B")).isEqualByComparingTo(forward.get("B"));
+        assertThat(reversed.get("D")).isEqualByComparingTo(forward.get("D"));
+    }
+
+    @Test
+    @DisplayName("Empty weights yield an empty allocation (caller treats amount as unattributable)")
+    void emptyWeights() {
+        assertThat(TaxCreditAllocator.allocate(new BigDecimal("10.00"), weights()))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("All-zero weights assign the full amount to the smallest key")
+    void zeroWeights() {
+        Map<String, BigDecimal> out = TaxCreditAllocator.allocate(new BigDecimal("10.00"), weights("Z", 0, "A", 0));
+
+        assertThat(out.get("A")).isEqualByComparingTo("10.00");
+        assertThat(out.get("Z")).isEqualByComparingTo("0.00");
+        assertThat(sum(out)).isEqualByComparingTo("10.00");
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/TaxLiabilityReportIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/TaxLiabilityReportIT.java
@@ -1,0 +1,261 @@
+package com.positivity.accounting.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.accounting.internal.config.TestSecurityConfig;
+import com.positivity.accounting.internal.dto.TaxLiabilityReport;
+import com.positivity.accounting.internal.dto.TaxLiabilityRow;
+import com.positivity.accounting.internal.entity.CreditMemo;
+import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.ExtInvoiceTax;
+import com.positivity.accounting.internal.entity.GLAccount;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.enums.CreditMemoStatus;
+import com.positivity.accounting.internal.enums.JournalEntryStatus;
+import com.positivity.accounting.internal.repository.CreditMemoRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
+import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
+import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+/**
+ * Real-Postgres IT for the Sales-Tax Liability report (parity-T8, issue #966).
+ * Runs the full Flyway chain + repeatable seed (which carries the Sales-Tax
+ * Payable account, code 2200) on a Testcontainers Postgres, so the report's
+ * jurisdiction aggregation, POSTED credit-memo pro-rata netting, and GL-drift
+ * reconciliation are exercised end-to-end against the real ledger — H2 does not
+ * enforce the Postgres balance trigger the seeded fixtures rely on.
+ *
+ * <p>Fixtures: two invoices finalized in-period across WA state / King county /
+ * Seattle city (one exempt resale line), a matching balanced {@code Cr 2200}
+ * invoice-tax journal entry, one POSTED credit memo reversing $25 with its
+ * balanced {@code Dr 2200} entry. On this balanced ledger the report's net tax
+ * equals the 2200 credit-normal period activity and GL drift is exactly zero.
+ *
+ * <p>Skipped cleanly when Docker is unavailable ({@code disabledWithoutDocker}).
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
+@Transactional
+@DisplayName("Sales-Tax Liability report (parity-T8 #966, real Postgres)")
+class TaxLiabilityReportIT {
+
+    @Container
+    static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+        // Schema + seed come from the real Flyway chain, not Hibernate DDL.
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    private static final LocalDate START = LocalDate.of(2026, 6, 1);
+    private static final LocalDate END = LocalDate.of(2026, 6, 30);
+
+    @Autowired
+    private FinancialReportingService financialReportingService;
+
+    @Autowired
+    private ExtInvoiceRepository extInvoiceRepository;
+
+    @Autowired
+    private ExtInvoiceTaxRepository extInvoiceTaxRepository;
+
+    @Autowired
+    private CreditMemoRepository creditMemoRepository;
+
+    @Autowired
+    private GLAccountRepository glAccountRepository;
+
+    @Autowired
+    private JournalEntryRepository journalEntryRepository;
+
+    // Test runs in a rolled-back transaction (fixtures + report share one persistence
+    // context, so seeded GL accounts stay managed); no explicit cleanup needed.
+
+    @Test
+    @DisplayName("Per-jurisdiction taxable/exempt/gross/net reconcile to the cent and GL drift == 0")
+    void reconcilesToTheCentWithZeroDrift() {
+        UUID inv1 = UUID.randomUUID();
+        UUID inv2 = UUID.randomUUID();
+
+        saveInvoice(inv1);
+        saveInvoice(inv2);
+
+        // INV1: state 65, county 35, city 25 (1000 base each) + a 500 exempt resale line.
+        saveTax(inv1, "STATE", "WA", "1000.00", "65.00", false, null);
+        saveTax(inv1, "COUNTY", "KING", "1000.00", "35.00", false, null);
+        saveTax(inv1, "CITY", "SEATTLE", "1000.00", "25.00", false, null);
+        saveTax(inv1, "STATE", "WA", "500.00", "0.00", true, "RESALE");
+        // INV2: state 130 on 2000 base.
+        saveTax(inv2, "STATE", "WA", "2000.00", "130.00", false, null);
+
+        // One POSTED credit against INV1 reversing $25 of tax, posted in-period.
+        saveCredit(inv1, "25.00");
+
+        GLAccount ar = account("1200");
+        GLAccount taxPayable = account("2200");
+
+        // Invoice-side GL: Dr AR 255 / Cr 2200 255 (total collected tax), dated in-period.
+        postBalancedEntry("JE-T8-INV", LocalDateTime.of(2026, 6, 15, 0, 0), ar, taxPayable, new BigDecimal("255.00"));
+        // Credit-side GL: Dr 2200 25 / Cr AR 25, dated in-period.
+        postBalancedEntry("JE-T8-CRD", LocalDateTime.of(2026, 6, 20, 0, 0), taxPayable, ar, new BigDecimal("25.00"));
+
+        TaxLiabilityReport report = financialReportingService.generateTaxLiability(START, END);
+
+        assertThat(report.getRows())
+                .extracting(TaxLiabilityRow::getJurisdictionType, TaxLiabilityRow::getJurisdictionCode)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("STATE", "WA"),
+                        org.assertj.core.groups.Tuple.tuple("COUNTY", "KING"),
+                        org.assertj.core.groups.Tuple.tuple("CITY", "SEATTLE"));
+
+        TaxLiabilityRow wa = report.getRows().get(0);
+        assertThat(wa.getTaxableBase()).isEqualByComparingTo("3000.00");
+        assertThat(wa.getExemptBase()).isEqualByComparingTo("500.00");
+        assertThat(wa.getExemptionReasons()).containsExactly("RESALE");
+        assertThat(wa.getTaxCollectedGross()).isEqualByComparingTo("195.00");
+        assertThat(wa.getCreditsNetted()).isEqualByComparingTo("13.00");
+        assertThat(wa.getNetTax()).isEqualByComparingTo("182.00");
+
+        TaxLiabilityRow king = report.getRows().get(1);
+        assertThat(king.getTaxCollectedGross()).isEqualByComparingTo("35.00");
+        assertThat(king.getCreditsNetted()).isEqualByComparingTo("7.00");
+        assertThat(king.getNetTax()).isEqualByComparingTo("28.00");
+
+        TaxLiabilityRow seattle = report.getRows().get(2);
+        assertThat(seattle.getTaxCollectedGross()).isEqualByComparingTo("25.00");
+        assertThat(seattle.getCreditsNetted()).isEqualByComparingTo("5.00");
+        assertThat(seattle.getNetTax()).isEqualByComparingTo("20.00");
+
+        assertThat(report.getTotalTaxableBase()).isEqualByComparingTo("5000.00");
+        assertThat(report.getTotalExemptBase()).isEqualByComparingTo("500.00");
+        assertThat(report.getTotalTaxCollectedGross()).isEqualByComparingTo("255.00");
+        assertThat(report.getTotalCreditsNetted()).isEqualByComparingTo("25.00");
+        assertThat(report.getTotalNetTax()).isEqualByComparingTo("230.00");
+
+        // GL drift reconciles to exactly zero on a balanced ledger.
+        assertThat(report.getReconciliation().getTaxPayableAccountCode()).isEqualTo("2200");
+        assertThat(report.getReconciliation().getGlNetActivity()).isEqualByComparingTo("230.00");
+        assertThat(report.getReconciliation().getReportNetTax()).isEqualByComparingTo("230.00");
+        assertThat(report.getReconciliation().getDrift()).isEqualByComparingTo("0");
+        assertThat(report.getReconciliation().getReconciled()).isTrue();
+    }
+
+    // ===== fixtures =====
+
+    private void saveInvoice(UUID invoiceId) {
+        ExtInvoice invoice = ExtInvoice.builder()
+                .invoiceId(invoiceId)
+                .workorderId(UUID.randomUUID())
+                .partyId(UUID.randomUUID().toString())
+                .status("FINALIZED")
+                .finalizedAt(Instant.parse("2026-06-15T00:00:00Z"))
+                .invoiceCreatedAt(Instant.parse("2026-06-15T00:00:00Z"))
+                .aggregateVersion(1L)
+                .updatedAt(Instant.parse("2026-06-30T00:00:00Z"))
+                .build();
+        extInvoiceRepository.save(invoice);
+    }
+
+    private void saveTax(
+            UUID invoiceId, String type, String code, String base, String tax, boolean exempt, String reason) {
+        ExtInvoiceTax row = ExtInvoiceTax.builder()
+                .invoiceId(invoiceId)
+                .lineItemId(code + "-line")
+                .jurisdictionType(type)
+                .jurisdictionCode(code)
+                .rate(new BigDecimal("0.065000"))
+                .taxableBase(new BigDecimal(base))
+                .taxAmount(new BigDecimal(tax))
+                .exempt(exempt)
+                .exemptionReasonCode(reason)
+                .aggregateVersion(1L)
+                .updatedAt(Instant.parse("2026-06-15T00:00:00Z"))
+                .build();
+        extInvoiceTaxRepository.save(row);
+    }
+
+    private void saveCredit(UUID originalInvoiceId, String taxReversed) {
+        CreditMemo credit = new CreditMemo();
+        credit.setOriginalInvoiceId(originalInvoiceId);
+        credit.setCustomerId(UUID.randomUUID());
+        credit.setCreditAmount(new BigDecimal("100.00"));
+        credit.setTaxAmountReversed(new BigDecimal(taxReversed));
+        credit.setReasonCode("RETURN");
+        credit.setStatus(CreditMemoStatus.POSTED);
+        credit.setCreationTimestamp(Instant.parse("2026-06-20T00:00:00Z"));
+        credit.setPostedTimestamp(Instant.parse("2026-06-20T00:00:00Z"));
+        credit.setCreatedByUserId("t8-it");
+        credit.setCurrency("USD");
+        creditMemoRepository.save(credit);
+    }
+
+    private GLAccount account(String code) {
+        return glAccountRepository
+                .findByAccountCode(code)
+                .orElseThrow(() -> new IllegalStateException("Seed missing GL account " + code));
+    }
+
+    private void postBalancedEntry(
+            String entryNumber,
+            LocalDateTime txDate,
+            GLAccount debitAccount,
+            GLAccount creditAccount,
+            BigDecimal amount) {
+        JournalEntry entry = new JournalEntry();
+        entry.setStatus(JournalEntryStatus.POSTED);
+        entry.setEntryNumber(entryNumber);
+        entry.setTransactionDate(txDate);
+        entry.setSourceEventType("T8_TEST");
+        entry.setCreatedBy("t8-it");
+        entry.setModifiedBy("t8-it");
+        entry.setTotalDebits(amount);
+        entry.setTotalCredits(amount);
+        entry.setIsBalanced(true);
+        entry.addLine(line(entry, 1, debitAccount, amount, BigDecimal.ZERO));
+        entry.addLine(line(entry, 2, creditAccount, BigDecimal.ZERO, amount));
+        journalEntryRepository.save(entry);
+    }
+
+    private static JournalEntryLine line(
+            JournalEntry entry, int lineNumber, GLAccount account, BigDecimal debit, BigDecimal credit) {
+        JournalEntryLine line = new JournalEntryLine();
+        line.setJournalEntry(entry);
+        line.setLineNumber(lineNumber);
+        line.setGlAccount(account);
+        line.setAccountCode(account.getAccountCode());
+        line.setAccountName(account.getAccountName());
+        line.setDebitAmount(debit);
+        line.setCreditAmount(credit);
+        line.setDescription("t8 test line");
+        return line;
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-tax`
- Domain: `domain:accounting`
- Closes #966 (parity-T8 sales-tax liability report)
- Story T8, decisions D-T4 / D-4. R-T4 resolved on #966 (Decision A — reconciliation-grade v1).

## Contract References
Additive: new read-only report endpoint + response schemas; new outbox event id. No breaking API/event change. See BACKEND_CONTRACT_GUIDE.md. OpenAPI regenerated (`tax-liability` path + 3 schemas).

## Scope (built to the resolved R-T4 decision)
Reconciliation-grade sales-tax liability report from the `ext_invoice_tax` replica — confirms platform-collected == GL-posted (AvaTax remains the filing SoR).
- **Endpoint:** `GET /v1/accounting/reports/financial/tax-liability?startDate=&endDate=` on `FinancialReportingController`, `@PreAuthorize("hasAuthority('reporting:view:financial-statements')")`, `@EmitEvent REPORT_TAX_LIABILITY_GENERATE`. Uses `startDate`+`endDate` to match the sibling period reports (income-statement / general-ledger) rather than the `?period=` in the issue title.
- **Granularity:** state + county + city (+ special). **Basis:** accrual — invoice tax bucketed by the invoice posting/finalization period (`ext_invoice.finalizedAt`); credits by the credit's posting period.
- **`TaxLiabilityReport`** rows carry: jurisdictionType/code, taxable base, **exempt base** (Σ taxable base of exempt lines) + exemption reasons, **tax collected (gross)**, **credits netted**, **net tax**; plus report totals and a **GL-drift reconciliation** block.
- **Credit netting (`TaxCreditAllocator`):** `ext_invoice_tax` is invoice-side only, so each POSTED credit memo's scalar `taxAmountReversed` is split across its original invoice's jurisdictions **pro-rata to that invoice's per-jurisdiction `tax_amount`**, HALF_UP at currency scale with a largest-weight residual so allocations sum **exactly** to the reversed amount; netted within jurisdiction+period, gross preserved. Documented as the reconciliation-grade approximation (true per-jurisdiction credit attribution is Phase-2).
- **GL-drift column:** report net tax vs the **Sales Tax Payable (code 2200)** net period activity (Cr on invoice finalization, Dr on credit memos). On a clean ledger `drift == 0` (tol 0.01). Account resolved by code, not hardcoded UUID.
- **Export:** CSV/PDF via the existing `ReportExportService` rails.

Explicitly deferred per the R-T4 decision (Phase-2, not in this PR): filing-grade return-package output, cash-basis variant, amendment/true-up, automated provider-vs-platform variance workflow.

## Tests
- [x] Unit — `TaxCreditAllocatorTest` (exact-sum pro-rata residual), `FinancialReportingTaxLiabilityServiceTest`.
- [x] Integration (real Postgres, Testcontainers + full Flyway/seed) — `TaxLiabilityReportIT`: 2 invoices across WA state / King county / Seattle city (+ exempt RESALE line) + one POSTED credit reversing \$25 with balanced Cr/Dr 2200 entries. Asserted to the cent: STATE WA taxable 3000.00 / exempt 500.00 [RESALE] / gross 195.00 / credits 13.00 / net 182.00; COUNTY KING 35/7/28; CITY SEATTLE 25/5/20; totals gross 255 / credits 25 / net 230; glNetActivity 230.00, **drift 0**, reconciled. Plus `TaxLiabilityReportContractBehaviorIT` (CSV/PDF export round-trip).
- How to run: `./mvnw -pl pos-accounting -am verify` → BUILD SUCCESS (189 ITs); `pos-archunit` 20/0; spotless clean.

## Recommended Phase-2 follow-ons (to file)
1. **True per-jurisdiction credit attribution** — carry the tax breakdown on the credit memo itself (removes the pro-rata approximation + empty-weights edge case).
2. **Credit lifecycle beyond POSTED** — a credit moving POSTED→APPLIED drops from the report while its Dr 2200 remains → drift; decide whether APPLIED/VOIDED still count.
3. **Filing-grade output** — return-package generation, period-close alignment/auditable freeze, cash-basis, amendment/true-up, provider-vs-platform variance exceptions.
4. **Real export rendering** — `ReportExportService` is still an in-memory stub; actual CSV/PDF byte rendering is not yet implemented.

## Risk & Rollback
- Risk level: Low–Medium (read-only report; no posting path changed). Rollback: revert the single commit; additive (new endpoint/DTOs/repos/allocator + tests), no schema/seed change.

## Checklist
- [x] Branch matches `cap/<cap-id>`
- [x] PR title `[CAP:<cap-id>]`
- [x] Closes linked issue
- [x] OpenAPI regenerated
- [x] Contract guide referenced
- [ ] Required CI checks passing (to confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)