### PR TITLE
fix(pos-tax): wire Postgres datasource for deployed profiles (stop embedded-H2 fallback on alpha)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -712,10 +712,18 @@ services:
       OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
       SERVER_PORT: 8091
       MANAGEMENT_SERVER_PORT: 8091
-      SPRING_FLYWAY_ENABLED: "false"
+      # pos-tax owns a schema since Wave 2 (exemption_certificate V1, tax_provider_transaction V2);
+      # inject Postgres + run Flyway. Without SPRING_DATASOURCE_URL, Boot falls back to embedded H2.
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_tax_db
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+      SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
+      SPRING_FLYWAY_ENABLED: "true"
       # Use the built-in test tax calculator locally; no real external tax service exists yet.
       TAX_TEST_MODE: "true"
     depends_on:
+      postgres:
+        condition: service_healthy
       eureka-server:
         condition: service_healthy
       pos-security-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -700,7 +700,9 @@ services:
 
   # Internal-only tax calculation service. Never routed through the gateway (ADR-0014);
   # reached directly over pos-network by pos-invoice at http://pos-tax:8091/v1/tax.
-  # Stateless: no datasource configured, so Spring Boot uses an embedded H2; Flyway off.
+  # Owns a Postgres schema (exemption_certificate V1, tax_provider_transaction V2); Flyway runs
+  # the migrations against pos_tax_db. Without SPRING_DATASOURCE_URL, Boot would fall back to
+  # embedded H2 (H2 is a runtime dep for local dev/test).
   pos-tax:
     build:
       context: ./pos-tax

--- a/postgres/init-databases.sql
+++ b/postgres/init-databases.sql
@@ -18,6 +18,7 @@ CREATE DATABASE pos_people_contact_db;
 CREATE DATABASE pos_price_db;
 CREATE DATABASE pos_security_db;
 CREATE DATABASE pos_shop_manager_db;
+CREATE DATABASE pos_tax_db;
 CREATE DATABASE pos_vehicle_fitment_db;
 CREATE DATABASE pos_vehicle_inventory_db;
 CREATE DATABASE pos_vehicle_reference_carapi_db;


### PR DESCRIPTION
## Problem
pos-tax deploys on alpha with an **H2 datasource URL**. Root cause: pos-tax was set up as a stateless service (no datasource env, `SPRING_FLYWAY_ENABLED: "false"`). Since **Wave 2** it owns a schema — `exemption_certificate` (V1) and `tax_provider_transaction` (V2) — but its `docker-compose.yml` service block was never updated. With `SPRING_DATASOURCE_URL` unset and H2 on the runtime classpath, Spring Boot auto-configures an **embedded H2** database → the H2 URL seen in the alpha deploy.

The alpha pipeline (`.github/workflows/build-push-ecr.yml`) ships `docker-compose.yml` + `postgres/init-databases.sql` to the alpha host and runs base + `deployment/alpha/docker-compose.prod.yml`. The prod override only sets `image`/`restart`/`logging` per service — **per-service datasource env lives in the base `docker-compose.yml`**. pos-accounting works on alpha because the base has its datasource; pos-tax didn't.

## Fix
- **`docker-compose.yml`** pos-tax block — mirror pos-accounting:
  - `SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_tax_db` + `USERNAME`/`PASSWORD`/`DRIVER`
  - `SPRING_FLYWAY_ENABLED: "true"` (so V1/V2 run — was `"false"` from the stateless era)
  - `depends_on: postgres: condition: service_healthy`
  - corrected the stale service header comment (was "Stateless / embedded H2 / Flyway off")
- **`postgres/init-databases.sql`** — add `CREATE DATABASE pos_tax_db;` (was missing).

pos-tax config (`application.yml`) was already correct: `url: ${SPRING_DATASOURCE_URL:}`, postgres driver default, `ddl-auto: validate`. The gap was purely the missing deploy-time injection + DB.

Note: domain services run with **no Spring profile** on alpha (verified — pos-accounting sets `SPRING_PROFILES_ACTIVE` nowhere either); alpha config is env-injected, not from `application-alpha.yml`. So no `SPRING_PROFILES_ACTIVE` wiring is added — that keeps pos-tax consistent with the fleet.

## Deploy note (auto-handled — no manual step)
The alpha deploy script (`deployment/alpha/deploy-backend.sh`) reconciles databases: it parses `postgres/init-databases.sql` and `CREATE DATABASE`s any missing on the existing cluster. Since this PR adds `CREATE DATABASE pos_tax_db;` (matching the script's `sed` pattern), the alpha deploy **auto-creates `pos_tax_db`** — no manual step required. `pos_user` grants follow the existing pattern.

## Verification
- `docker compose config` resolves pos-tax with `SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_tax_db`, `SPRING_FLYWAY_ENABLED: "true"`, and postgres in `depends_on`; compose file validates.
- `SPRING_DATASOURCE_USERNAME`/`PASSWORD` are already defined in `.env.example` (same vars the other stateful services use).

## Risk & Rollback
- Risk: Low (deploy-config + comment only; no app-code change). Rollback: revert. Local `dev`/`test` profiles unaffected (own H2 in `application-dev/test.yml`).

## Checklist
- [x] Base compose datasource env added (mirrors pos-accounting)
- [x] pos_tax_db in init-databases.sql (auto-created by the alpha deploy script)
- [x] Flyway enabled for deployed pos-tax
- [x] Stale header comment corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
