### PR TITLE
feat(accounting): real CSV/PDF rendering for T8 report export (#999)

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/client/DocumentRenderClient.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/client/DocumentRenderClient.java
@@ -1,0 +1,66 @@
+package com.positivity.accounting.internal.client;
+
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Renders financial-report artifacts to PDF via the internal pos-documents service
+ * (ADR-0020: centralized document creation).
+ *
+ * <p>pos-documents is internal-only (no gateway route); reached directly over the service
+ * network. The render endpoint is guarded by {@code documents:render}, propagated via the
+ * gateway authorities header for this service-to-service call (see the pos-invoice
+ * {@code DocumentRenderClient} pattern).
+ */
+@Component
+public class DocumentRenderClient {
+
+    private static final Logger log = LoggerFactory.getLogger(DocumentRenderClient.class);
+
+    private final RestClient restClient;
+
+    public DocumentRenderClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${accounting.documents.base-url:http://pos-documents:8092/v1/documents}") String documentsBaseUrl) {
+        this.restClient = restClientBuilder.baseUrl(documentsBaseUrl).build();
+    }
+
+    /**
+     * Render CSV report content to a PDF document.
+     *
+     * <p>pos-documents converts the CSV payload to an HTML table and binds it into the
+     * given template before converting to PDF.
+     *
+     * @param templateId the pos-documents template to apply (blank falls back to the
+     *                   service default template)
+     * @param csvContent the report data as a CSV string
+     * @return the rendered PDF bytes
+     */
+    @NonNull
+    public byte[] renderPdfFromCsv(@NonNull String templateId, @NonNull String csvContent) {
+        if (log.isDebugEnabled()) {
+            log.debug("Rendering PDF via pos-documents using template {}", templateId);
+        }
+        byte[] pdf = restClient
+                .post()
+                .uri("/render")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_PDF)
+                .header("X-User", "pos-accounting")
+                .header("X-Authorities", "documents:render")
+                .body(Map.of("format", "CSV", "templateId", templateId, "content", csvContent))
+                .retrieve()
+                .body(byte[].class);
+
+        if (pdf == null || pdf.length == 0) {
+            throw new IllegalStateException("pos-documents returned an empty PDF for template " + templateId);
+        }
+        return pdf;
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
@@ -251,12 +251,15 @@ public final class EventTypes {
                                 "ACCOUNTING_STATUS_VIEW", "View current accounting status for an invoice")
                         .build(),
 
-                // ReportExportController — 3 events (PRD missing endpoints)
+                // ReportExportController — 4 events (PRD missing endpoints + issue #999 download)
                 EventTypeRegistration.write("ACCOUNTING_REPORT_EXPORT_REQUEST", "Request async report export")
                         .build(),
                 EventTypeRegistration.fastRead("ACCOUNTING_REPORT_EXPORT_STATUS", "Get report export status by ID")
                         .build(),
                 EventTypeRegistration.search("ACCOUNTING_REPORT_EXPORT_LIST", "List report export history")
+                        .build(),
+                EventTypeRegistration.fastRead(
+                                "ACCOUNTING_REPORT_EXPORT_DOWNLOAD", "Download rendered report export artifact")
                         .build(),
 
                 // TimekeepingExportController — 1 event (Wave 4 SDK migration)

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/ReportExportController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/ReportExportController.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -134,8 +135,12 @@ public class ReportExportController {
             @Parameter(description = "Export job UUID", required = true) @PathVariable UUID exportId) {
 
         ReportExportArtifact artifact = reportExportService.downloadExport(exportId);
+        // The filename is sanitized to a safe character set when the artifact is created;
+        // ContentDisposition additionally quotes/escapes it, preventing header injection.
         return ResponseEntity.ok()
-                .header("Content-Disposition", "attachment; filename=\"" + artifact.filename() + "\"")
+                .headers(headers -> headers.setContentDisposition(ContentDisposition.attachment()
+                        .filename(artifact.filename())
+                        .build()))
                 .contentType(MediaType.parseMediaType(artifact.contentType()))
                 .body(artifact.content());
     }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/ReportExportController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/ReportExportController.java
@@ -1,5 +1,6 @@
 package com.positivity.accounting.internal.controller;
 
+import com.positivity.accounting.internal.dto.ReportExportArtifact;
 import com.positivity.accounting.internal.dto.ReportExportRequest;
 import com.positivity.accounting.internal.dto.ReportExportResponse;
 import com.positivity.accounting.service.ReportExportService;
@@ -107,6 +108,36 @@ public class ReportExportController {
 
         ReportExportResponse response = reportExportService.getExportStatus(exportId);
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Download the rendered artifact of a completed export.
+     *
+     * <p>
+     * Guarded by {@code reporting:view:financial-statements} (in addition to the
+     * export permission on the submit/status endpoints) because the artifact
+     * carries the actual financial-statement figures.
+     */
+    @GetMapping(value = "/{exportId}/download")
+    @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
+    @EmitEvent(id = "ACCOUNTING_REPORT_EXPORT_DOWNLOAD", apiVersion = "1")
+    @Operation(
+            summary = "Download rendered export artifact",
+            description = "Download the rendered CSV or PDF artifact of a COMPLETED export job.",
+            tags = {"Financial Reporting"})
+    @ApiResponse(responseCode = "200", description = "Rendered artifact returned")
+    @ApiResponse(responseCode = "401", description = "Unauthorized")
+    @ApiResponse(responseCode = "403", description = "Forbidden - missing reporting:view:financial-statements")
+    @ApiResponse(responseCode = "404", description = "Export job or artifact not found")
+    @ApiResponse(responseCode = "409", description = "Export job is not COMPLETED")
+    public ResponseEntity<byte[]> downloadExport(
+            @Parameter(description = "Export job UUID", required = true) @PathVariable UUID exportId) {
+
+        ReportExportArtifact artifact = reportExportService.downloadExport(exportId);
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=\"" + artifact.filename() + "\"")
+                .contentType(MediaType.parseMediaType(artifact.contentType()))
+                .body(artifact.content());
     }
 
     /**

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportArtifact.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportArtifact.java
@@ -1,0 +1,15 @@
+package com.positivity.accounting.internal.dto;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Rendered export artifact held for download (issue #999).
+ *
+ * @param content     rendered bytes (CSV text or PDF binary)
+ * @param contentType MIME type of the artifact ({@code text/csv} or {@code application/pdf})
+ * @param filename    suggested download filename including extension
+ */
+public record ReportExportArtifact(
+        byte @NonNull [] content,
+        @NonNull String contentType,
+        @NonNull String filename) {}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportResponse.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportResponse.java
@@ -61,6 +61,15 @@ public class ReportExportResponse {
     @Schema(description = "Export format", example = "CSV", requiredMode = NOT_REQUIRED)
     private ExportFormat format;
 
+    /**
+     * Human-readable reason the export failed. Only set when status is FAILED.
+     */
+    @Schema(
+            description = "Failure reason (only present when status is FAILED)",
+            example = "Rendering is not supported for reportType 'INCOME_STATEMENT'",
+            requiredMode = NOT_REQUIRED)
+    private String failureReason;
+
     @Schema(description = "Report type that was exported", example = "JOURNAL_LINES", requiredMode = NOT_REQUIRED)
     private String reportType;
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/ReportExportServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/ReportExportServiceImpl.java
@@ -1,10 +1,16 @@
 package com.positivity.accounting.internal.service;
 
+import com.positivity.accounting.internal.client.DocumentRenderClient;
+import com.positivity.accounting.internal.dto.ReportExportArtifact;
 import com.positivity.accounting.internal.dto.ReportExportRequest;
 import com.positivity.accounting.internal.dto.ReportExportResponse;
+import com.positivity.accounting.internal.dto.TaxLiabilityReport;
+import com.positivity.accounting.internal.enums.ExportFormat;
 import com.positivity.accounting.internal.enums.ExportStatus;
+import com.positivity.accounting.service.FinancialReportingService;
 import com.positivity.accounting.service.ReportExportService;
 import com.positivity.security.common.LogSanitizer;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Comparator;
@@ -23,27 +29,48 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
- * Stub implementation of {@link ReportExportService}.
+ * Implementation of {@link ReportExportService} with real rendering (issue #999).
  *
- * <p>
- * Creates export jobs with PENDING status and persists them in-memory.
- * Actual async processing (S3 upload, job queue) is deferred to a future
- * capability sprint.
+ * <p>Exports render synchronously at request time: CSV is produced locally by
+ * {@link TaxLiabilityCsvRenderer} (deterministic column/row order, figures matching
+ * the JSON report to the cent) and PDF is produced by the pos-documents service per
+ * ADR-0020 (the deterministic CSV is sent as render content). Successful renders
+ * complete immediately with a download URL; failures are recorded as FAILED with a
+ * reason. Job state and artifacts are persisted in-memory (JPA entity + object
+ * storage deferred to a future capability sprint).
  */
 @Service
 public class ReportExportServiceImpl implements ReportExportService {
 
     private static final Logger log = LoggerFactory.getLogger(ReportExportServiceImpl.class);
 
+    /** The only report type with rendering support so far (story T8). */
+    static final String TAX_LIABILITY = "TAX_LIABILITY";
+
+    private static final String PDF_TEMPLATE_ID = "DEFAULT_STANDARD_TEMPLATE";
+
     private final Clock clock;
+    private final FinancialReportingService financialReportingService;
+    private final TaxLiabilityCsvRenderer csvRenderer;
+    private final DocumentRenderClient documentRenderClient;
 
     /**
-     * In-memory store for export jobs (replaced by JPA entity in a future sprint).
+     * In-memory stores for export jobs and rendered artifacts (replaced by JPA
+     * entity + object storage in a future sprint).
      */
     private final ConcurrentHashMap<UUID, ReportExportResponse> exportStore = new ConcurrentHashMap<>();
 
-    public ReportExportServiceImpl(Clock clock) {
+    private final ConcurrentHashMap<UUID, ReportExportArtifact> artifactStore = new ConcurrentHashMap<>();
+
+    public ReportExportServiceImpl(
+            Clock clock,
+            FinancialReportingService financialReportingService,
+            TaxLiabilityCsvRenderer csvRenderer,
+            DocumentRenderClient documentRenderClient) {
         this.clock = clock;
+        this.financialReportingService = financialReportingService;
+        this.csvRenderer = csvRenderer;
+        this.documentRenderClient = documentRenderClient;
     }
 
     @Override
@@ -52,21 +79,68 @@ public class ReportExportServiceImpl implements ReportExportService {
         UUID exportId = UUID.randomUUID();
         Instant now = Instant.now(clock);
 
-        ReportExportResponse response = ReportExportResponse.builder()
-                .exportId(exportId)
-                .status(ExportStatus.PENDING)
-                .requestedAt(now)
-                .format(request.getFormat())
-                .reportType(request.getReportType())
-                .build();
+        ReportExportResponse response = render(exportId, request, now);
 
         exportStore.put(exportId, response);
         log.info(
-                "Report export requested: exportId={} reportType={} operator={}",
+                "Report export requested: exportId={} reportType={} format={} status={} operator={}",
                 exportId,
                 LogSanitizer.forLog(request.getReportType()),
+                request.getFormat(),
+                response.getStatus(),
                 LogSanitizer.forLog(operatorId));
         return response;
+    }
+
+    private ReportExportResponse render(UUID exportId, ReportExportRequest request, Instant requestedAt) {
+        ReportExportResponse.ReportExportResponseBuilder builder = ReportExportResponse.builder()
+                .exportId(exportId)
+                .requestedAt(requestedAt)
+                .format(request.getFormat())
+                .reportType(request.getReportType());
+
+        if (!TAX_LIABILITY.equals(request.getReportType())) {
+            return builder.status(ExportStatus.FAILED)
+                    .completedAt(Instant.now(clock))
+                    .failureReason("Rendering is not supported for reportType '" + request.getReportType() + "'")
+                    .build();
+        }
+        if (request.getFormat() != ExportFormat.CSV && request.getFormat() != ExportFormat.PDF) {
+            return builder.status(ExportStatus.FAILED)
+                    .completedAt(Instant.now(clock))
+                    .failureReason("Rendering is not supported for format '" + request.getFormat() + "'")
+                    .build();
+        }
+
+        try {
+            TaxLiabilityReport report =
+                    financialReportingService.generateTaxLiability(request.getStartDate(), request.getEndDate());
+            String csv = csvRenderer.render(report);
+            ReportExportArtifact artifact = toArtifact(request, csv);
+            artifactStore.put(exportId, artifact);
+            return builder.status(ExportStatus.COMPLETED)
+                    .completedAt(Instant.now(clock))
+                    .downloadUrl("/v1/accounting/reports/export/" + exportId + "/download")
+                    .build();
+        } catch (RuntimeException e) {
+            log.warn("Report export rendering failed: exportId={} reason={}", exportId, e.getMessage());
+            return builder.status(ExportStatus.FAILED)
+                    .completedAt(Instant.now(clock))
+                    .failureReason("Rendering failed: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    private ReportExportArtifact toArtifact(ReportExportRequest request, String csv) {
+        String baseName =
+                (request.getFilename() != null && !request.getFilename().isBlank())
+                        ? request.getFilename()
+                        : "tax-liability-" + request.getStartDate() + "-" + request.getEndDate();
+        if (request.getFormat() == ExportFormat.CSV) {
+            return new ReportExportArtifact(csv.getBytes(StandardCharsets.UTF_8), "text/csv", baseName + ".csv");
+        }
+        byte[] pdf = documentRenderClient.renderPdfFromCsv(PDF_TEMPLATE_ID, csv);
+        return new ReportExportArtifact(pdf, "application/pdf", baseName + ".pdf");
     }
 
     @Override
@@ -77,6 +151,26 @@ public class ReportExportServiceImpl implements ReportExportService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No export found with ID: " + exportId);
         }
         return response;
+    }
+
+    @Override
+    @NonNull
+    public ReportExportArtifact downloadExport(@NonNull UUID exportId) {
+        ReportExportResponse response = exportStore.get(exportId);
+        if (response == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No export found with ID: " + exportId);
+        }
+        if (response.getStatus() != ExportStatus.COMPLETED) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Export " + exportId + " is not COMPLETED (status: " + response.getStatus()
+                            + "); no artifact is available");
+        }
+        ReportExportArtifact artifact = artifactStore.get(exportId);
+        if (artifact == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No artifact found for export ID: " + exportId);
+        }
+        return artifact;
     }
 
     @Override

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/ReportExportServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/ReportExportServiceImpl.java
@@ -13,8 +13,11 @@ import com.positivity.security.common.LogSanitizer;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jspecify.annotations.NonNull;
@@ -49,6 +52,13 @@ public class ReportExportServiceImpl implements ReportExportService {
 
     private static final String PDF_TEMPLATE_ID = "DEFAULT_STANDARD_TEMPLATE";
 
+    /**
+     * Maximum rendered artifacts held in memory until object storage lands (issue
+     * #999 follow-up). Oldest artifacts are evicted first; downloading an evicted
+     * export returns 404.
+     */
+    static final int MAX_ARTIFACTS = 100;
+
     private final Clock clock;
     private final FinancialReportingService financialReportingService;
     private final TaxLiabilityCsvRenderer csvRenderer;
@@ -60,7 +70,12 @@ public class ReportExportServiceImpl implements ReportExportService {
      */
     private final ConcurrentHashMap<UUID, ReportExportResponse> exportStore = new ConcurrentHashMap<>();
 
-    private final ConcurrentHashMap<UUID, ReportExportArtifact> artifactStore = new ConcurrentHashMap<>();
+    /**
+     * Bounded LRU store for rendered artifact bytes so full CSV/PDF payloads cannot
+     * accumulate without limit (memory-pressure/DoS guard until object storage lands).
+     */
+    private final Map<UUID, ReportExportArtifact> artifactStore =
+            Collections.synchronizedMap(new BoundedLruMap<>(MAX_ARTIFACTS));
 
     public ReportExportServiceImpl(
             Clock clock,
@@ -123,24 +138,34 @@ public class ReportExportServiceImpl implements ReportExportService {
                     .downloadUrl("/v1/accounting/reports/export/" + exportId + "/download")
                     .build();
         } catch (RuntimeException e) {
-            log.warn("Report export rendering failed: exportId={} reason={}", exportId, e.getMessage());
+            log.warn("Report export rendering failed: exportId={}", exportId, e);
             return builder.status(ExportStatus.FAILED)
                     .completedAt(Instant.now(clock))
-                    .failureReason("Rendering failed: " + e.getMessage())
+                    .failureReason("Rendering failed; see service logs for exportId " + exportId)
                     .build();
         }
     }
 
     private ReportExportArtifact toArtifact(ReportExportRequest request, String csv) {
-        String baseName =
+        String baseName = sanitizeFilename(
                 (request.getFilename() != null && !request.getFilename().isBlank())
                         ? request.getFilename()
-                        : "tax-liability-" + request.getStartDate() + "-" + request.getEndDate();
+                        : "tax-liability-" + request.getStartDate() + "-" + request.getEndDate());
         if (request.getFormat() == ExportFormat.CSV) {
             return new ReportExportArtifact(csv.getBytes(StandardCharsets.UTF_8), "text/csv", baseName + ".csv");
         }
         byte[] pdf = documentRenderClient.renderPdfFromCsv(PDF_TEMPLATE_ID, csv);
         return new ReportExportArtifact(pdf, "application/pdf", baseName + ".pdf");
+    }
+
+    /**
+     * Restrict the (potentially caller-supplied) download filename to a safe character
+     * set so it can never carry CR/LF, quotes, or path separators into the
+     * {@code Content-Disposition} header.
+     */
+    private static String sanitizeFilename(String name) {
+        String cleaned = name.replaceAll("[^A-Za-z0-9._-]", "_");
+        return cleaned.isBlank() ? "report-export" : cleaned;
     }
 
     @Override
@@ -203,5 +228,27 @@ public class ReportExportServiceImpl implements ReportExportService {
         int end = Math.toIntExact(Math.min(offset + pageable.getPageSize(), total));
         var page = all.subList(start, end);
         return new PageImpl<>(page, pageable, total);
+    }
+
+    /**
+     * Access-order LRU map that evicts the eldest entry once {@code maxEntries} is
+     * exceeded. Wrapped in {@link Collections#synchronizedMap} by the caller for
+     * thread safety.
+     */
+    private static final class BoundedLruMap<K, V> extends LinkedHashMap<K, V> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int maxEntries;
+
+        BoundedLruMap(int maxEntries) {
+            super(16, 0.75f, true);
+            this.maxEntries = maxEntries;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+            return size() > maxEntries;
+        }
     }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRenderer.java
@@ -1,0 +1,114 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.dto.TaxLiabilityReconciliation;
+import com.positivity.accounting.internal.dto.TaxLiabilityReport;
+import com.positivity.accounting.internal.dto.TaxLiabilityRow;
+import java.math.BigDecimal;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Renders a {@link TaxLiabilityReport} as deterministic CSV (story T8, issue #999).
+ *
+ * <p>Column order and row order are fixed: metadata block, per-jurisdiction rows in
+ * the order produced by the report (state → county → city → special, then code), a
+ * TOTAL row, and a reconciliation block. All figures are emitted with
+ * {@link BigDecimal#toPlainString()} so the CSV matches the JSON report to the cent.
+ * The volatile {@code generatedAt} timestamp is intentionally excluded so identical
+ * report data always renders byte-identical CSV.
+ */
+@Component
+public class TaxLiabilityCsvRenderer {
+
+    private static final String ROW_HEADER = "Jurisdiction Type,Jurisdiction Code,Jurisdiction Name,Taxable Base,"
+            + "Exempt Base,Exemption Reasons,Tax Collected Gross,Credits Netted,Net Tax";
+    private static final String RECONCILIATION_HEADER =
+            "Tax Payable Account,GL Net Activity,Report Net Tax,Unattributed Credits,Drift,Reconciled";
+
+    /**
+     * Render the report to CSV.
+     *
+     * @param report the generated tax-liability report
+     * @return CSV text with CRLF-free Unix line endings and a trailing newline
+     */
+    @NonNull
+    public String render(@NonNull TaxLiabilityReport report) {
+        StringBuilder csv = new StringBuilder();
+
+        csv.append("Report,Start Date,End Date\n");
+        csv.append("TAX_LIABILITY,")
+                .append(report.getStartDate())
+                .append(',')
+                .append(report.getEndDate())
+                .append("\n\n");
+
+        csv.append(ROW_HEADER).append('\n');
+        for (TaxLiabilityRow row : report.getRows()) {
+            csv.append(escape(row.getJurisdictionType()))
+                    .append(',')
+                    .append(escape(row.getJurisdictionCode()))
+                    .append(',')
+                    .append(escape(row.getJurisdictionName()))
+                    .append(',')
+                    .append(amount(row.getTaxableBase()))
+                    .append(',')
+                    .append(amount(row.getExemptBase()))
+                    .append(',')
+                    .append(escape(joinReasons(row.getExemptionReasons())))
+                    .append(',')
+                    .append(amount(row.getTaxCollectedGross()))
+                    .append(',')
+                    .append(amount(row.getCreditsNetted()))
+                    .append(',')
+                    .append(amount(row.getNetTax()))
+                    .append('\n');
+        }
+        csv.append("TOTAL,,,")
+                .append(amount(report.getTotalTaxableBase()))
+                .append(',')
+                .append(amount(report.getTotalExemptBase()))
+                .append(",,")
+                .append(amount(report.getTotalTaxCollectedGross()))
+                .append(',')
+                .append(amount(report.getTotalCreditsNetted()))
+                .append(',')
+                .append(amount(report.getTotalNetTax()))
+                .append("\n\n");
+
+        TaxLiabilityReconciliation reconciliation = report.getReconciliation();
+        csv.append(RECONCILIATION_HEADER).append('\n');
+        csv.append(escape(reconciliation.getTaxPayableAccountCode()))
+                .append(',')
+                .append(amount(reconciliation.getGlNetActivity()))
+                .append(',')
+                .append(amount(reconciliation.getReportNetTax()))
+                .append(',')
+                .append(amount(reconciliation.getUnattributedCredits()))
+                .append(',')
+                .append(amount(reconciliation.getDrift()))
+                .append(',')
+                .append(reconciliation.getReconciled())
+                .append('\n');
+
+        return csv.toString();
+    }
+
+    private static String amount(BigDecimal value) {
+        return value == null ? "" : value.toPlainString();
+    }
+
+    private static String joinReasons(List<String> reasons) {
+        return (reasons == null || reasons.isEmpty()) ? "" : String.join("|", reasons);
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            return '"' + value.replace("\"", "\"\"") + '"';
+        }
+        return value;
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRenderer.java
@@ -106,7 +106,7 @@ public class TaxLiabilityCsvRenderer {
         if (value == null) {
             return "";
         }
-        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+        if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
             return '"' + value.replace("\"", "\"\"") + '"';
         }
         return value;

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/ReportExportService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/ReportExportService.java
@@ -1,5 +1,6 @@
 package com.positivity.accounting.service;
 
+import com.positivity.accounting.internal.dto.ReportExportArtifact;
 import com.positivity.accounting.internal.dto.ReportExportRequest;
 import com.positivity.accounting.internal.dto.ReportExportResponse;
 import java.util.UUID;
@@ -48,4 +49,20 @@ public interface ReportExportService {
      */
     @NonNull
     Page<ReportExportResponse> getExportHistory(@NonNull Pageable pageable);
+
+    /**
+     * Download the rendered artifact of a completed export.
+     *
+     * @param exportId export job UUID
+     * @return rendered artifact (content bytes, content type, filename)
+     * @throws org.springframework.web.server.ResponseStatusException with HTTP 404
+     *                                                                when no export
+     *                                                                exists for the
+     *                                                                given ID, or
+     *                                                                HTTP 409 when
+     *                                                                the export is
+     *                                                                not COMPLETED
+     */
+    @NonNull
+    ReportExportArtifact downloadExport(@NonNull UUID exportId);
 }

--- a/pos-accounting/src/main/resources/permissions.yaml
+++ b/pos-accounting/src/main/resources/permissions.yaml
@@ -100,3 +100,5 @@ permissions:
     description: "View processor settlements and reconciliation lines"
   - name: "accounting:report:export"
     description: "Export report"
+  - name: "reporting:view:financial-statements"
+    description: "View financial statements and download rendered report exports"

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/TaxLiabilityReportContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/TaxLiabilityReportContractBehaviorIT.java
@@ -1,11 +1,19 @@
 package com.positivity.accounting.contract;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.positivity.accounting.BaseContractIntegrationTest;
+import com.positivity.accounting.internal.client.DocumentRenderClient;
 import com.positivity.accounting.internal.entity.CreditMemo;
 import com.positivity.accounting.internal.entity.ExtInvoice;
 import com.positivity.accounting.internal.entity.ExtInvoiceTax;
@@ -21,14 +29,17 @@ import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -54,6 +65,9 @@ class TaxLiabilityReportContractBehaviorIT extends BaseContractIntegrationTest {
     @Autowired
     private CreditMemoRepository creditMemoRepository;
 
+    @MockitoBean
+    private DocumentRenderClient documentRenderClient;
+
     private static final UUID AR_ID = UUID.fromString("50000000-0000-7000-8000-000000001200");
     private static final UUID TAX_ID = UUID.fromString("50000000-0000-7000-8000-000000002200");
 
@@ -63,23 +77,7 @@ class TaxLiabilityReportContractBehaviorIT extends BaseContractIntegrationTest {
     @Test
     @DisplayName("tax-liability returns per-jurisdiction totals with reasons, netted credits, and zero GL drift")
     void taxLiabilityReconciles() throws Exception {
-        GLAccount ar = saveAccount(AR_ID, "1200", "Accounts Receivable", AccountType.ASSET);
-        GLAccount tax = saveAccount(TAX_ID, "2200", "Sales Tax Payable", AccountType.LIABILITY);
-
-        UUID inv1 = UUID.randomUUID();
-        UUID inv2 = UUID.randomUUID();
-        saveInvoice(inv1);
-        saveInvoice(inv2);
-        saveTax(inv1, "STATE", "WA", "1000.00", "65.00", false, null);
-        saveTax(inv1, "COUNTY", "KING", "1000.00", "35.00", false, null);
-        saveTax(inv1, "CITY", "SEATTLE", "1000.00", "25.00", false, null);
-        saveTax(inv1, "STATE", "WA", "500.00", "0.00", true, "RESALE");
-        saveTax(inv2, "STATE", "WA", "2000.00", "130.00", false, null);
-        saveCredit(inv1, "25.00");
-
-        // Balanced GL so the 2200 credit-normal activity (230) matches report net tax.
-        postBalancedEntry("JE-T8C-INV", LocalDateTime.of(2026, 6, 15, 0, 0), ar, tax, new BigDecimal("255.00"));
-        postBalancedEntry("JE-T8C-CRD", LocalDateTime.of(2026, 6, 20, 0, 0), tax, ar, new BigDecimal("25.00"));
+        seedJune2026TaxData();
 
         mockMvc.perform(withAuth(get("/v1/accounting/reports/financial/tax-liability"))
                         .param("startDate", START.toString())
@@ -122,47 +120,206 @@ class TaxLiabilityReportContractBehaviorIT extends BaseContractIntegrationTest {
     }
 
     @Test
-    @DisplayName("Export round-trip: TAX_LIABILITY flows through CSV and PDF export requests identically")
-    void exportRoundTripForTaxLiability() throws Exception {
-        for (String format : new String[] {"CSV", "PDF"}) {
-            String body = """
-                    {
-                      "format": "%s",
-                      "reportType": "TAX_LIABILITY",
-                      "startDate": "2026-06-01",
-                      "endDate": "2026-06-30",
-                      "organizationId": "d10217f9-3ec6-46b9-9c87-e7066c100c24"
-                    }
-                    """.formatted(format);
+    @DisplayName("CSV export renders real rows matching the JSON report to the cent, deterministically")
+    void exportRendersCsv() throws Exception {
+        seedJune2026TaxData();
 
-            var created = mockMvc.perform(withAuth(post("/v1/accounting/reports/export"), "accounting:report:export")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(body)
-                            .accept(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.exportId").exists())
-                    .andExpect(jsonPath("$.status").value("PENDING"))
-                    .andExpect(jsonPath("$.format").value(format))
-                    .andExpect(jsonPath("$.reportType").value("TAX_LIABILITY"))
-                    .andReturn();
+        String firstCsv = requestExportAndDownload("CSV", "text/csv");
+        String[] lines = firstCsv.split("\n");
 
-            String exportId = objectMapper
-                    .readTree(created.getResponse().getContentAsString())
-                    .get("exportId")
-                    .asText();
+        assertEquals("Report,Start Date,End Date", lines[0]);
+        assertEquals("TAX_LIABILITY,2026-06-01,2026-06-30", lines[1]);
+        assertEquals(
+                "Jurisdiction Type,Jurisdiction Code,Jurisdiction Name,Taxable Base,Exempt Base,"
+                        + "Exemption Reasons,Tax Collected Gross,Credits Netted,Net Tax",
+                lines[3]);
 
-            mockMvc.perform(withAuth(
-                                    get("/v1/accounting/reports/export/{exportId}", exportId),
-                                    "accounting:report:export")
-                            .accept(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.exportId").value(exportId))
-                    .andExpect(jsonPath("$.format").value(format))
-                    .andExpect(jsonPath("$.reportType").value("TAX_LIABILITY"));
-        }
+        // Figures match the JSON report assertions in taxLiabilityReconciles() to the cent.
+        assertCsvRow(lines[4], "STATE", "WA", "3000.00", "500.00", "RESALE", "195.00", "13.00", "182.00");
+        String[] county = lines[5].split(",", -1);
+        assertEquals("COUNTY", county[0]);
+        assertEquals(0, new BigDecimal("28.00").compareTo(new BigDecimal(county[8])));
+        String[] city = lines[6].split(",", -1);
+        assertEquals("CITY", city[0]);
+        assertEquals(0, new BigDecimal("20.00").compareTo(new BigDecimal(city[8])));
+
+        String[] total = lines[7].split(",", -1);
+        assertEquals("TOTAL", total[0]);
+        assertEquals(0, new BigDecimal("255.00").compareTo(new BigDecimal(total[6])));
+        assertEquals(0, new BigDecimal("25.00").compareTo(new BigDecimal(total[7])));
+        assertEquals(0, new BigDecimal("230.00").compareTo(new BigDecimal(total[8])));
+
+        assertEquals(
+                "Tax Payable Account,GL Net Activity,Report Net Tax,Unattributed Credits,Drift,Reconciled", lines[9]);
+        String[] reconciliation = lines[10].split(",", -1);
+        assertEquals("2200", reconciliation[0]);
+        assertEquals(0, new BigDecimal("230.00").compareTo(new BigDecimal(reconciliation[1])));
+        assertEquals(0, BigDecimal.ZERO.compareTo(new BigDecimal(reconciliation[4])));
+        assertEquals("true", reconciliation[5]);
+
+        // Determinism: a second export of the same period renders byte-identical CSV.
+        assertEquals(firstCsv, requestExportAndDownload("CSV", "text/csv"));
+    }
+
+    @Test
+    @DisplayName("PDF export renders a non-empty PDF via pos-documents from the deterministic CSV")
+    void exportRendersPdf() throws Exception {
+        seedJune2026TaxData();
+        byte[] fakePdf = "%PDF-1.4 t8-rendered".getBytes(StandardCharsets.UTF_8);
+        when(documentRenderClient.renderPdfFromCsv(anyString(), anyString())).thenReturn(fakePdf);
+
+        String exportId = requestExport("PDF")
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.downloadUrl").exists())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String id = objectMapper.readTree(exportId).get("exportId").asText();
+
+        byte[] pdf = mockMvc.perform(withAuth(
+                        get("/v1/accounting/reports/export/{exportId}/download", id),
+                        "reporting:view:financial-statements"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/pdf"))
+                .andReturn()
+                .getResponse()
+                .getContentAsByteArray();
+        assertTrue(pdf.length > 0);
+        assertArrayEquals(fakePdf, pdf);
+
+        // The CSV sent to pos-documents carries the real report figures.
+        ArgumentCaptor<String> csvCaptor = ArgumentCaptor.forClass(String.class);
+        verify(documentRenderClient).renderPdfFromCsv(anyString(), csvCaptor.capture());
+        assertTrue(csvCaptor.getValue().contains("STATE,WA"));
+    }
+
+    @Test
+    @DisplayName("Download requires reporting:view:financial-statements")
+    void downloadForbiddenWithoutViewPermission() throws Exception {
+        seedJune2026TaxData();
+        String created = requestExport("CSV")
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String id = objectMapper.readTree(created).get("exportId").asText();
+
+        mockMvc.perform(withAuth(
+                        get("/v1/accounting/reports/export/{exportId}/download", id), "accounting:report:export"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Unsupported report type fails the export with a reason instead of pretending PENDING")
+    void unsupportedReportTypeFails() throws Exception {
+        String body = """
+                {
+                  "format": "CSV",
+                  "reportType": "INCOME_STATEMENT",
+                  "startDate": "2026-06-01",
+                  "endDate": "2026-06-30",
+                  "organizationId": "d10217f9-3ec6-46b9-9c87-e7066c100c24"
+                }
+                """;
+        mockMvc.perform(withAuth(post("/v1/accounting/reports/export"), "accounting:report:export")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("FAILED"))
+                .andExpect(jsonPath("$.failureReason").exists());
+    }
+
+    // ===== export helpers =====
+
+    private org.springframework.test.web.servlet.ResultActions requestExport(String format) throws Exception {
+        String body = """
+                {
+                  "format": "%s",
+                  "reportType": "TAX_LIABILITY",
+                  "startDate": "2026-06-01",
+                  "endDate": "2026-06-30",
+                  "organizationId": "d10217f9-3ec6-46b9-9c87-e7066c100c24"
+                }
+                """.formatted(format);
+        return mockMvc.perform(withAuth(post("/v1/accounting/reports/export"), "accounting:report:export")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .accept(MediaType.APPLICATION_JSON));
+    }
+
+    private String requestExportAndDownload(String format, String expectedContentType) throws Exception {
+        String created = requestExport(format)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.exportId").exists())
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.format").value(format))
+                .andExpect(jsonPath("$.reportType").value("TAX_LIABILITY"))
+                .andExpect(jsonPath("$.downloadUrl").exists())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String id = objectMapper.readTree(created).get("exportId").asText();
+
+        mockMvc.perform(withAuth(get("/v1/accounting/reports/export/{exportId}", id), "accounting:report:export")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.exportId").value(id))
+                .andExpect(jsonPath("$.status").value("COMPLETED"));
+
+        return mockMvc.perform(withAuth(
+                        get("/v1/accounting/reports/export/{exportId}/download", id),
+                        "reporting:view:financial-statements"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", expectedContentType))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+    }
+
+    private void assertCsvRow(
+            String line,
+            String type,
+            String code,
+            String taxableBase,
+            String exemptBase,
+            String reasons,
+            String gross,
+            String credits,
+            String net) {
+        String[] parts = line.split(",", -1);
+        assertEquals(type, parts[0]);
+        assertEquals(code, parts[1]);
+        assertEquals(0, new BigDecimal(taxableBase).compareTo(new BigDecimal(parts[3])));
+        assertEquals(0, new BigDecimal(exemptBase).compareTo(new BigDecimal(parts[4])));
+        assertEquals(reasons, parts[5]);
+        assertEquals(0, new BigDecimal(gross).compareTo(new BigDecimal(parts[6])));
+        assertEquals(0, new BigDecimal(credits).compareTo(new BigDecimal(parts[7])));
+        assertEquals(0, new BigDecimal(net).compareTo(new BigDecimal(parts[8])));
     }
 
     // ===== fixtures =====
+
+    private void seedJune2026TaxData() {
+        GLAccount ar = saveAccount(AR_ID, "1200", "Accounts Receivable", AccountType.ASSET);
+        GLAccount tax = saveAccount(TAX_ID, "2200", "Sales Tax Payable", AccountType.LIABILITY);
+
+        UUID inv1 = UUID.randomUUID();
+        UUID inv2 = UUID.randomUUID();
+        saveInvoice(inv1);
+        saveInvoice(inv2);
+        saveTax(inv1, "STATE", "WA", "1000.00", "65.00", false, null);
+        saveTax(inv1, "COUNTY", "KING", "1000.00", "35.00", false, null);
+        saveTax(inv1, "CITY", "SEATTLE", "1000.00", "25.00", false, null);
+        saveTax(inv1, "STATE", "WA", "500.00", "0.00", true, "RESALE");
+        saveTax(inv2, "STATE", "WA", "2000.00", "130.00", false, null);
+        saveCredit(inv1, "25.00");
+
+        // Balanced GL so the 2200 credit-normal activity (230) matches report net tax.
+        postBalancedEntry("JE-T8C-INV", LocalDateTime.of(2026, 6, 15, 0, 0), ar, tax, new BigDecimal("255.00"));
+        postBalancedEntry("JE-T8C-CRD", LocalDateTime.of(2026, 6, 20, 0, 0), tax, ar, new BigDecimal("25.00"));
+    }
 
     private GLAccount saveAccount(UUID id, String code, String name, AccountType type) {
         GLAccount account = new GLAccount();

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/TaxLiabilityReportContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/TaxLiabilityReportContractBehaviorIT.java
@@ -33,6 +33,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -136,14 +138,14 @@ class TaxLiabilityReportContractBehaviorIT extends BaseContractIntegrationTest {
 
         // Figures match the JSON report assertions in taxLiabilityReconciles() to the cent.
         assertCsvRow(lines[4], "STATE", "WA", "3000.00", "500.00", "RESALE", "195.00", "13.00", "182.00");
-        String[] county = lines[5].split(",", -1);
+        String[] county = splitCsv(lines[5]);
         assertEquals("COUNTY", county[0]);
         assertEquals(0, new BigDecimal("28.00").compareTo(new BigDecimal(county[8])));
-        String[] city = lines[6].split(",", -1);
+        String[] city = splitCsv(lines[6]);
         assertEquals("CITY", city[0]);
         assertEquals(0, new BigDecimal("20.00").compareTo(new BigDecimal(city[8])));
 
-        String[] total = lines[7].split(",", -1);
+        String[] total = splitCsv(lines[7]);
         assertEquals("TOTAL", total[0]);
         assertEquals(0, new BigDecimal("255.00").compareTo(new BigDecimal(total[6])));
         assertEquals(0, new BigDecimal("25.00").compareTo(new BigDecimal(total[7])));
@@ -151,7 +153,7 @@ class TaxLiabilityReportContractBehaviorIT extends BaseContractIntegrationTest {
 
         assertEquals(
                 "Tax Payable Account,GL Net Activity,Report Net Tax,Unattributed Credits,Drift,Reconciled", lines[9]);
-        String[] reconciliation = lines[10].split(",", -1);
+        String[] reconciliation = splitCsv(lines[10]);
         assertEquals("2200", reconciliation[0]);
         assertEquals(0, new BigDecimal("230.00").compareTo(new BigDecimal(reconciliation[1])));
         assertEquals(0, BigDecimal.ZERO.compareTo(new BigDecimal(reconciliation[4])));
@@ -288,7 +290,7 @@ class TaxLiabilityReportContractBehaviorIT extends BaseContractIntegrationTest {
             String gross,
             String credits,
             String net) {
-        String[] parts = line.split(",", -1);
+        String[] parts = splitCsv(line);
         assertEquals(type, parts[0]);
         assertEquals(code, parts[1]);
         assertEquals(0, new BigDecimal(taxableBase).compareTo(new BigDecimal(parts[3])));
@@ -297,6 +299,40 @@ class TaxLiabilityReportContractBehaviorIT extends BaseContractIntegrationTest {
         assertEquals(0, new BigDecimal(gross).compareTo(new BigDecimal(parts[6])));
         assertEquals(0, new BigDecimal(credits).compareTo(new BigDecimal(parts[7])));
         assertEquals(0, new BigDecimal(net).compareTo(new BigDecimal(parts[8])));
+    }
+
+    /**
+     * CSV-aware single-line field split: honors RFC-4180 quoting so fields containing
+     * commas or escaped quotes are not broken apart (unlike {@code String.split(",")}).
+     */
+    private static String[] splitCsv(String line) {
+        List<String> fields = new ArrayList<>();
+        StringBuilder field = new StringBuilder();
+        boolean inQuotes = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inQuotes) {
+                if (c == '"') {
+                    if (i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                        field.append('"');
+                        i++;
+                    } else {
+                        inQuotes = false;
+                    }
+                } else {
+                    field.append(c);
+                }
+            } else if (c == '"') {
+                inQuotes = true;
+            } else if (c == ',') {
+                fields.add(field.toString());
+                field.setLength(0);
+            } else {
+                field.append(c);
+            }
+        }
+        fields.add(field.toString());
+        return fields.toArray(new String[0]);
     }
 
     // ===== fixtures =====

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRendererTest.java
@@ -1,0 +1,97 @@
+package com.positivity.accounting.internal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.positivity.accounting.internal.dto.TaxLiabilityReconciliation;
+import com.positivity.accounting.internal.dto.TaxLiabilityReport;
+import com.positivity.accounting.internal.dto.TaxLiabilityRow;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TaxLiabilityCsvRenderer}: deterministic column order,
+ * plain-string figures, CSV escaping, and exclusion of the volatile generatedAt
+ * timestamp.
+ */
+class TaxLiabilityCsvRendererTest {
+
+    private final TaxLiabilityCsvRenderer renderer = new TaxLiabilityCsvRenderer();
+
+    @Test
+    @DisplayName("Renders metadata, jurisdiction rows, totals, and reconciliation in fixed order")
+    void rendersDeterministicCsv() {
+        TaxLiabilityReport report = report();
+
+        String expected = """
+                Report,Start Date,End Date
+                TAX_LIABILITY,2026-06-01,2026-06-30
+
+                Jurisdiction Type,Jurisdiction Code,Jurisdiction Name,Taxable Base,Exempt Base,Exemption Reasons,Tax Collected Gross,Credits Netted,Net Tax
+                STATE,WA,Washington,3000.00,500.00,RESALE|GOVT,195.00,13.00,182.00
+                CITY,SEATTLE,"Seattle, WA",1000.00,0.00,,25.00,0.00,25.00
+                TOTAL,,,4000.00,500.00,,220.00,13.00,207.00
+
+                Tax Payable Account,GL Net Activity,Report Net Tax,Unattributed Credits,Drift,Reconciled
+                2200,207.00,207.00,0.00,0.00,true
+                """;
+        assertEquals(expected, renderer.render(report));
+    }
+
+    @Test
+    @DisplayName("Identical report data renders byte-identical CSV regardless of generatedAt")
+    void generatedAtDoesNotAffectOutput() {
+        TaxLiabilityReport first = report();
+        TaxLiabilityReport second = report();
+        second.setGeneratedAt(Instant.parse("2030-01-01T00:00:00Z"));
+
+        assertEquals(renderer.render(first), renderer.render(second));
+    }
+
+    private static TaxLiabilityReport report() {
+        return TaxLiabilityReport.builder()
+                .startDate(LocalDate.of(2026, 6, 1))
+                .endDate(LocalDate.of(2026, 6, 30))
+                .generatedAt(Instant.parse("2026-06-30T08:00:00Z"))
+                .rows(List.of(
+                        TaxLiabilityRow.builder()
+                                .jurisdictionType("STATE")
+                                .jurisdictionCode("WA")
+                                .jurisdictionName("Washington")
+                                .taxableBase(new BigDecimal("3000.00"))
+                                .exemptBase(new BigDecimal("500.00"))
+                                .exemptionReasons(List.of("RESALE", "GOVT"))
+                                .taxCollectedGross(new BigDecimal("195.00"))
+                                .creditsNetted(new BigDecimal("13.00"))
+                                .netTax(new BigDecimal("182.00"))
+                                .build(),
+                        TaxLiabilityRow.builder()
+                                .jurisdictionType("CITY")
+                                .jurisdictionCode("SEATTLE")
+                                .jurisdictionName("Seattle, WA")
+                                .taxableBase(new BigDecimal("1000.00"))
+                                .exemptBase(new BigDecimal("0.00"))
+                                .exemptionReasons(List.of())
+                                .taxCollectedGross(new BigDecimal("25.00"))
+                                .creditsNetted(new BigDecimal("0.00"))
+                                .netTax(new BigDecimal("25.00"))
+                                .build()))
+                .totalTaxableBase(new BigDecimal("4000.00"))
+                .totalExemptBase(new BigDecimal("500.00"))
+                .totalTaxCollectedGross(new BigDecimal("220.00"))
+                .totalCreditsNetted(new BigDecimal("13.00"))
+                .totalNetTax(new BigDecimal("207.00"))
+                .reconciliation(TaxLiabilityReconciliation.builder()
+                        .taxPayableAccountCode("2200")
+                        .glNetActivity(new BigDecimal("207.00"))
+                        .reportNetTax(new BigDecimal("207.00"))
+                        .unattributedCredits(new BigDecimal("0.00"))
+                        .drift(new BigDecimal("0.00"))
+                        .reconciled(true)
+                        .build())
+                .build();
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRendererTest.java
@@ -1,6 +1,7 @@
 package com.positivity.accounting.internal.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.positivity.accounting.internal.dto.TaxLiabilityReconciliation;
 import com.positivity.accounting.internal.dto.TaxLiabilityReport;
@@ -49,6 +50,19 @@ class TaxLiabilityCsvRendererTest {
         second.setGeneratedAt(Instant.parse("2030-01-01T00:00:00Z"));
 
         assertEquals(renderer.render(first), renderer.render(second));
+    }
+
+    @Test
+    @DisplayName("Fields containing CR, LF, or quotes are quoted and quote-escaped")
+    void escapesCarriageReturnsLineFeedsAndQuotes() {
+        TaxLiabilityReport report = report();
+        report.getRows().getFirst().setJurisdictionName("Wash\r\nington \"Evergreen\"");
+
+        String csv = renderer.render(report);
+
+        assertTrue(
+                csv.contains("STATE,WA,\"Wash\r\nington \"\"Evergreen\"\"\",3000.00"),
+                "CR/LF and quotes must be contained inside a quoted, quote-escaped field");
     }
 
     private static TaxLiabilityReport report() {


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## Capability & Traceability
- Capability: `cap:999`
- Parent STORY (durion): Odoo parity plan `domains/accounting/plan-odoo-parity-pos-tax.md` §2, Story T8 (backend story: louisburroughs/durion-positivity-backend#966, follow-ups louisburroughs/durion-positivity-backend#995)
- Child issue: louisburroughs/durion-positivity-backend#999
- Domain: `domain:accounting`

Closes #999.

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` → financial-reports export/download
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope
- What changed:
  - `ReportExportServiceImpl` was an in-memory stub that only round-tripped report-type/format metadata. It now renders real export bytes at request time for `reportType=TAX_LIABILITY` (story T8, #966/#995).
  - New `TaxLiabilityCsvRenderer` (pos-accounting `internal/service`): deterministic CSV — fixed column order, metadata block, per-jurisdiction rows in report order, TOTAL row, reconciliation block. Figures use `BigDecimal.toPlainString` so the CSV matches the JSON report to the cent. The volatile `generatedAt` timestamp is excluded so identical report data renders byte-identical CSV.
  - PDF renders via the internal pos-documents service per ADR-0020 through a new `DocumentRenderClient` (`internal/client`, mirrors the pos-invoice `DocumentRenderClient` pattern: direct service call, `X-Authorities: documents:render`). The deterministic CSV is sent as CSV-format render content; pos-documents converts it to an HTML table and produces the PDF. Note: the `pos-document-helper` library's `DocumentServiceClient` sends a `Map` content payload which pos-documents' render endpoint does not accept (it expects a `String`), so the direct `RestClient` shape was used instead.
  - New endpoint `GET /v1/accounting/reports/export/{exportId}/download` returns the rendered artifact (`Content-Disposition: attachment`, `text/csv` or `application/pdf`). Guarded by `reporting:view:financial-statements` (permission newly added to pos-accounting `permissions.yaml` — it was used by `FinancialReportingController` but never registered). New event type `ACCOUNTING_REPORT_EXPORT_DOWNLOAD` registered in EventTypes.
  - `ReportExportResponse` gains a `failureReason` field; unsupported report types/formats now complete as `FAILED` with a reason instead of sitting `PENDING` forever. Successful renders complete immediately with `completedAt` and `downloadUrl`. Artifacts and job state remain in-memory (JPA + object storage still deferred, as before).
- Why: Issue #999 — the T8 acceptance (and sibling financial reports) list CSV/PDF export, but the export path produced no real document; the prior IT only asserted the report-type/format round-trip.

Acceptance mapping (issue #999):
1. Real CSV + PDF for T8, figures match JSON to the cent → CSV renderer + IT assertions.
2. Deterministic export + `reporting:view:financial-statements` respected → byte-identical determinism test + download permission guard + 403 test.
3. IT asserts rendered CSV rows, not just metadata → `exportRendersCsv`.

Out of scope / follow-up: rendering for the other financial report types (income statement, balance sheet, trial balance, GL, aged AR/AP) still goes through the same rails but fails fast with a clear `failureReason`; wiring those renderers is follow-up work.

## Tests
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Provider behavioral contract tests added/updated
- How to run: `./mvnw -pl pos-accounting -am test`
  - `TaxLiabilityCsvRendererTest` — exact deterministic CSV, escaping, `generatedAt`-independence.
  - `TaxLiabilityReportContractBehaviorIT` — rewritten export tests: CSV rows asserted against the seeded JSON figures to the cent, byte-identical re-render determinism, non-empty PDF via mocked `DocumentRenderClient` with captured CSV content, 403 download without `reporting:view:financial-statements`, `FAILED` path for unsupported report type.
  - Verification: full pos-accounting suite 1151 tests green (incl. `ArchitectureTest`); package build with checkstyle/spotbugs green; spotless applied.

## Risk & Rollback
- Risk level: Low — new rendering path is additive; export jobs and artifacts remain in-memory; PDF rendering is isolated behind `DocumentRenderClient`.
- Rollback plan: revert the single commit `4c82c35a7`; the export endpoint falls back to the previous metadata-only stub behavior. No schema migrations involved.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [ ] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TW2kZJJP95TKxrCTEJd6Ha