### PR TITLE
[CAP:odoo-parity-tax] Credit-memo void with GL reversal and T8 void-period symmetry (#997)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,5 +1,5 @@
-generatedAt: "2026-07-22T18:11:41.979278+00:00"
-root: "/home/user/durion-positivity-backend"
+generatedAt: "2026-07-22T18:36:28.032791+00:00"
+root: "."
 summary:
   manifestCount: 20
   permissionCount: 361

--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-07-22T17:22:40.242373+00:00"
-root: "/home/runner/work/durion-positivity-backend/durion-positivity-backend"
+generatedAt: "2026-07-22T18:11:41.979278+00:00"
+root: "/home/user/durion-positivity-backend"
 summary:
   manifestCount: 20
-  permissionCount: 359
-  uniquePermissionCount: 359
+  permissionCount: 361
+  uniquePermissionCount: 361
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -12,7 +12,7 @@ manifests:
     domain: "accounting"
     serviceName: "pos-accounting"
     version: "1.0"
-    permissionCount: 50
+    permissionCount: 52
     permissions:
       - name: "accounting:ap:pay"
         description: "Process payments"
@@ -30,6 +30,8 @@ manifests:
         description: "Create credit memo"
       - name: "accounting:credit-memo:read"
         description: "Read credit memo"
+      - name: "accounting:credit-memo:void"
+        description: "Void a posted credit memo, restoring AR and the reversed tax liability"
       - name: "accounting:customer-credit:apply"
         description: "Apply an open customer credit to an invoice"
       - name: "accounting:customer-credit:refund"
@@ -114,6 +116,8 @@ manifests:
         description: "Export report"
       - name: "accounting:tax-snapshot:freeze"
         description: "Freeze the sales-tax liability report for a closed accounting period"
+      - name: "reporting:view:financial-statements"
+        description: "View financial statements and download rendered report exports"
   - module: "pos-bulk-loader"
     path: "pos-bulk-loader/src/main/resources/permissions.yaml"
     domain: "bulk-import"
@@ -910,6 +914,12 @@ permissions:
     source: "pos-accounting/src/main/resources/permissions.yaml"
   - name: "accounting:credit-memo:read"
     description: "Read credit memo"
+    domain: "accounting"
+    serviceName: "pos-accounting"
+    module: "pos-accounting"
+    source: "pos-accounting/src/main/resources/permissions.yaml"
+  - name: "accounting:credit-memo:void"
+    description: "Void a posted credit memo, restoring AR and the reversed tax liability"
     domain: "accounting"
     serviceName: "pos-accounting"
     module: "pos-accounting"
@@ -2342,6 +2352,12 @@ permissions:
     serviceName: "pos-catalog"
     module: "pos-catalog"
     source: "pos-catalog/src/main/resources/permissions.yaml"
+  - name: "reporting:view:financial-statements"
+    description: "View financial statements and download rendered report exports"
+    domain: "accounting"
+    serviceName: "pos-accounting"
+    module: "pos-accounting"
+    source: "pos-accounting/src/main/resources/permissions.yaml"
   - name: "security:audit:create"
     description: "Create audit events and pricing snapshots"
     domain: "security"

--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -3094,6 +3094,57 @@ paths:
         - accounting:credit-memo:create
       x-required-permissions:
       - accounting:credit-memo:create
+  /v1/accounting/credit-memos/{creditMemoId}/void:
+    post:
+      tags:
+      - Credit Memos
+      summary: Void a posted credit memo
+      description: 'Void a POSTED Credit Memo: posts the mirror GL entry (Dr AR / Cr Revenue + Cr Sales-Tax Payable) dated at void time and restores the invoice''s outstanding balance. The memo''s original posting-period figures are never restated; the tax-liability report restores the reversed tax in the void''s period. Only POSTED memos are voidable — APPLIED memos have been consumed and VOIDED is terminal.'
+      operationId: voidCreditMemo
+      parameters:
+      - name: creditMemoId
+        in: path
+        description: Credit Memo id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoidCreditMemoRequest'
+        required: true
+      responses:
+        '200':
+          description: Credit memo voided
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreditMemoResponse'
+        '400':
+          description: Missing or invalid void reason
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreditMemoResponse'
+        '404':
+          description: Credit memo not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreditMemoResponse'
+        '409':
+          description: Credit memo is not in POSTED status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreditMemoResponse'
+      security:
+      - bearerAuth:
+        - accounting:credit-memo:void
+      x-required-permissions:
+      - accounting:credit-memo:void
   /v1/accounting/audit/refund:
     post:
       tags:
@@ -4142,6 +4193,62 @@ paths:
         - accounting:report:export
       x-required-permissions:
       - accounting:report:export
+  /v1/accounting/reports/export/{exportId}/download:
+    get:
+      tags:
+      - Financial Reporting
+      summary: Download rendered export artifact
+      description: Download the rendered CSV or PDF artifact of a COMPLETED export job.
+      operationId: downloadExport
+      parameters:
+      - name: exportId
+        in: path
+        description: Export job UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Rendered artifact returned
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
+        '403':
+          description: Forbidden - missing reporting:view:financial-statements
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
+        '404':
+          description: Export job or artifact not found
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
+        '409':
+          description: Export job is not COMPLETED
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
+      security:
+      - bearerAuth:
+        - accounting:report:export
+      x-required-permissions:
+      - reporting:view:financial-statements
   /v1/accounting/reconciliations:
     get:
       tags:
@@ -7044,6 +7151,10 @@ components:
           - XLSX
           - JSON
           example: CSV
+        failureReason:
+          type: string
+          description: Failure reason (only present when status is FAILED)
+          example: Rendering is not supported for reportType 'INCOME_STATEMENT'
         reportType:
           type: string
           description: Report type that was exported
@@ -8508,6 +8619,16 @@ components:
           type: string
           description: ISO 4217 currency code
           example: USD
+        voidedTimestamp:
+          type: string
+          format: date-time
+          description: When the memo was voided; null unless status is VOIDED
+        voidedByUserId:
+          type: string
+          description: User who voided the memo; null unless status is VOIDED
+        voidReason:
+          type: string
+          description: Reason the memo was voided; null unless status is VOIDED
         invoiceBalanceAfter:
           type: number
           description: Invoice outstanding balance after the credit was applied
@@ -8518,6 +8639,18 @@ components:
       - creditMemoId
       - originalInvoiceId
       - status
+    VoidCreditMemoRequest:
+      type: object
+      description: Void a POSTED credit memo, restoring AR and the reversed tax liability
+      properties:
+        voidReason:
+          type: string
+          description: Reason the memo is being voided (audit trail)
+          example: Issued against the wrong invoice
+          maxLength: 1000
+          minLength: 0
+      required:
+      - voidReason
     RefundRequest:
       type: object
       description: Request to record a refund audit event

--- a/pos-accounting/openapi.yaml
+++ b/pos-accounting/openapi.yaml
@@ -3127,19 +3127,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreditMemoResponse'
+                $ref: '#/components/schemas/ApiError'
         '404':
           description: Credit memo not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreditMemoResponse'
+                $ref: '#/components/schemas/ApiError'
         '409':
           description: Credit memo is not in POSTED status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreditMemoResponse'
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - accounting:credit-memo:void
@@ -4210,12 +4210,12 @@ paths:
           format: uuid
       responses:
         '200':
-          description: Rendered artifact returned
+          description: Rendered artifact returned (content type matches the export format, e.g. text/csv or application/pdf)
           content:
-            application/json:
+            application/octet-stream:
               schema:
                 type: string
-                format: byte
+                format: binary
         '401':
           description: Unauthorized
           content:

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/config/EventTypes.java
@@ -16,7 +16,11 @@ public final class EventTypes {
 
     /**
      * All event type registrations for the accounting module.
-     * Total: 86 event types (includes +4 from the tax-liability period-close freeze
+     * Total: 92 event types (includes +1 from the credit-memo void (issue #997
+     * symmetry): ACCOUNTING_CREDIT_MEMO_VOID, +4 from the customer-credit lifecycle
+     * (PR #1004): ACCOUNTING_CUSTOMER_CREDIT_LIST, ACCOUNTING_CUSTOMER_CREDIT_GET,
+     * ACCOUNTING_CUSTOMER_CREDIT_APPLY, ACCOUNTING_CUSTOMER_CREDIT_REFUND,
+     * +4 from the tax-liability period-close freeze
      * (Issue #998 Phase-2 item 2): TAX_LIABILITY_SNAPSHOT_FREEZE,
      * TAX_LIABILITY_SNAPSHOT_LIST, TAX_LIABILITY_SNAPSHOT_GET,
      * TAX_LIABILITY_SNAPSHOT_VERIFY, +1 from the sales-tax liability report
@@ -130,9 +134,13 @@ public final class EventTypes {
                 EventTypeRegistration.write("ACCOUNTING_AUDIT_CANCELLATION", "Record an order or invoice cancellation")
                         .build(),
 
-                // CreditMemoController - 3 events (CAP-052)
+                // CreditMemoController - 4 events (CAP-052; +1 void, issue #997 symmetry)
                 EventTypeRegistration.write(
                                 "ACCOUNTING_CREDIT_MEMO_CREATE", "Create a credit memo to reverse invoice charges")
+                        .build(),
+                EventTypeRegistration.approval(
+                                "ACCOUNTING_CREDIT_MEMO_VOID",
+                                "Void a posted credit memo, restoring AR and the reversed tax liability")
                         .build(),
                 EventTypeRegistration.fastRead("ACCOUNTING_CREDIT_MEMO_LIST", "List credit memos with optional filters")
                         .build(),

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/CreditMemoController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/CreditMemoController.java
@@ -7,8 +7,11 @@ import com.positivity.accounting.internal.enums.CreditMemoStatus;
 import com.positivity.accounting.service.CreditMemoService;
 import com.positivity.events.EmitEvent;
 import com.positivity.security.common.SecurityContextHelper;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -125,10 +128,22 @@ public class CreditMemoController {
                     + " reversed tax in the void's period. Only POSTED memos are voidable — APPLIED memos have been"
                     + " consumed and VOIDED is terminal.",
             tags = {"Credit Memos"})
-    @ApiResponse(responseCode = "200", description = "Credit memo voided")
-    @ApiResponse(responseCode = "400", description = "Missing or invalid void reason")
-    @ApiResponse(responseCode = "404", description = "Credit memo not found")
-    @ApiResponse(responseCode = "409", description = "Credit memo is not in POSTED status")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Credit memo voided",
+            content = @Content(schema = @Schema(implementation = CreditMemoResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "Missing or invalid void reason",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Credit memo not found",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Credit memo is not in POSTED status",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
     @EmitEvent(id = "ACCOUNTING_CREDIT_MEMO_VOID", apiVersion = "1")
     public ResponseEntity<CreditMemoResponse> voidCreditMemo(
             @Parameter(description = "Credit Memo id", required = true) @PathVariable UUID creditMemoId,

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/CreditMemoController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/CreditMemoController.java
@@ -2,6 +2,7 @@ package com.positivity.accounting.internal.controller;
 
 import com.positivity.accounting.internal.dto.CreateCreditMemoRequest;
 import com.positivity.accounting.internal.dto.CreditMemoResponse;
+import com.positivity.accounting.internal.dto.VoidCreditMemoRequest;
 import com.positivity.accounting.internal.enums.CreditMemoStatus;
 import com.positivity.accounting.service.CreditMemoService;
 import com.positivity.events.EmitEvent;
@@ -96,6 +97,49 @@ public class CreditMemoController {
         CreditMemoResponse response = creditMemoService.createCreditMemo(request, currentUser);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * Void a POSTED Credit Memo (issue #997 symmetry).
+     *
+     * The memo keeps its posting-period contribution to the tax-liability report (no retroactive
+     * restatement of closed/frozen periods); the void posts the mirror journal entry
+     * (Dr AR / Cr Revenue + Cr Sales-Tax Payable) dated now, and the report restores the reversed
+     * tax in the void's period — GL drift stays zero on both sides of the transition. The
+     * invoice's outstanding balance is restored automatically.
+     *
+     * @param creditMemoId Credit Memo to void
+     * @param request      Void request (mandatory reason)
+     * @return Voided Credit Memo details
+     */
+    @PostMapping("/{creditMemoId}/void")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:credit-memo:void"})
+    @PreAuthorize("hasAuthority('accounting:credit-memo:void')")
+    @Operation(
+            summary = "Void a posted credit memo",
+            description = "Void a POSTED Credit Memo: posts the mirror GL entry (Dr AR / Cr Revenue + Cr Sales-Tax"
+                    + " Payable) dated at void time and restores the invoice's outstanding balance. The memo's"
+                    + " original posting-period figures are never restated; the tax-liability report restores the"
+                    + " reversed tax in the void's period. Only POSTED memos are voidable — APPLIED memos have been"
+                    + " consumed and VOIDED is terminal.",
+            tags = {"Credit Memos"})
+    @ApiResponse(responseCode = "200", description = "Credit memo voided")
+    @ApiResponse(responseCode = "400", description = "Missing or invalid void reason")
+    @ApiResponse(responseCode = "404", description = "Credit memo not found")
+    @ApiResponse(responseCode = "409", description = "Credit memo is not in POSTED status")
+    @EmitEvent(id = "ACCOUNTING_CREDIT_MEMO_VOID", apiVersion = "1")
+    public ResponseEntity<CreditMemoResponse> voidCreditMemo(
+            @Parameter(description = "Credit Memo id", required = true) @PathVariable UUID creditMemoId,
+            @Valid @RequestBody VoidCreditMemoRequest request) {
+
+        String currentUser = SecurityContextHelper.getCurrentUsername()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not authenticated"));
+
+        log.info("Voiding Credit Memo {} requested by user {}", creditMemoId, currentUser);
+
+        return ResponseEntity.ok(creditMemoService.voidCreditMemo(creditMemoId, request.getVoidReason(), currentUser));
     }
 
     /**

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/ReportExportController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/ReportExportController.java
@@ -120,13 +120,23 @@ public class ReportExportController {
      * carries the actual financial-statement figures.
      */
     @GetMapping(value = "/{exportId}/download")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"reporting:view:financial-statements"})
     @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
     @EmitEvent(id = "ACCOUNTING_REPORT_EXPORT_DOWNLOAD", apiVersion = "1")
     @Operation(
             summary = "Download rendered export artifact",
             description = "Download the rendered CSV or PDF artifact of a COMPLETED export job.",
             tags = {"Financial Reporting"})
-    @ApiResponse(responseCode = "200", description = "Rendered artifact returned")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Rendered artifact returned (content type matches the export format, e.g. text/csv or"
+                    + " application/pdf)",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE,
+                            schema = @Schema(type = "string", format = "binary")))
     @ApiResponse(responseCode = "401", description = "Unauthorized")
     @ApiResponse(responseCode = "403", description = "Forbidden - missing reporting:view:financial-statements")
     @ApiResponse(responseCode = "404", description = "Export job or artifact not found")

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/CreditMemoResponse.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/CreditMemoResponse.java
@@ -98,6 +98,15 @@ public class CreditMemoResponse {
     @Schema(description = "ISO 4217 currency code", example = "USD", requiredMode = NOT_REQUIRED)
     private String currency;
 
+    @Schema(description = "When the memo was voided; null unless status is VOIDED", requiredMode = NOT_REQUIRED)
+    private Instant voidedTimestamp;
+
+    @Schema(description = "User who voided the memo; null unless status is VOIDED", requiredMode = NOT_REQUIRED)
+    private String voidedByUserId;
+
+    @Schema(description = "Reason the memo was voided; null unless status is VOIDED", requiredMode = NOT_REQUIRED)
+    private String voidReason;
+
     @Schema(
             description = "Invoice outstanding balance after the credit was applied",
             example = "0.00",

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/VoidCreditMemoRequest.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/VoidCreditMemoRequest.java
@@ -21,7 +21,9 @@ public class VoidCreditMemoRequest {
     @Schema(
             description = "Reason the memo is being voided (audit trail)",
             example = "Issued against the wrong invoice",
-            requiredMode = REQUIRED)
+            requiredMode = REQUIRED,
+            minLength = 1,
+            maxLength = 1000)
     @NotBlank(message = "voidReason is required")
     @Size(max = 1000, message = "voidReason must not exceed 1000 characters")
     private String voidReason;

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/VoidCreditMemoRequest.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/VoidCreditMemoRequest.java
@@ -1,0 +1,28 @@
+package com.positivity.accounting.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+/**
+ * Request to void a POSTED Credit Memo (issue #997 symmetry). The reason is mandatory for the
+ * audit trail, mirroring the creation-side {@code reasonCode} requirement.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Void a POSTED credit memo, restoring AR and the reversed tax liability")
+public class VoidCreditMemoRequest {
+
+    @Schema(
+            description = "Reason the memo is being voided (audit trail)",
+            example = "Issued against the wrong invoice",
+            requiredMode = REQUIRED)
+    @NotBlank(message = "voidReason is required")
+    @Size(max = 1000, message = "voidReason must not exceed 1000 characters")
+    private String voidReason;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/CreditMemo.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/CreditMemo.java
@@ -106,6 +106,16 @@ public class CreditMemo {
     @Column(name = "currency", nullable = false, length = 3)
     private String currency;
 
+    /** When the memo was voided (issue #997 symmetry); null unless status is VOIDED. */
+    @Column(name = "voided_timestamp")
+    private Instant voidedTimestamp;
+
+    @Column(name = "voided_by_user_id", length = 50)
+    private String voidedByUserId;
+
+    @Column(name = "void_reason", length = 1000)
+    private String voidReason;
+
     @PrePersist
     protected void onCreate() {
         if (creationTimestamp == null) {

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/CreditMemoRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/CreditMemoRepository.java
@@ -2,12 +2,15 @@ package com.positivity.accounting.internal.repository;
 
 import com.positivity.accounting.internal.entity.CreditMemo;
 import com.positivity.accounting.internal.enums.CreditMemoStatus;
+import jakarta.persistence.LockModeType;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 /**
  * Repository for CreditMemo entity.
@@ -59,6 +62,15 @@ public interface CreditMemoRepository extends JpaRepository<CreditMemo, UUID> {
      * @return matching credit memos (unordered)
      */
     List<CreditMemo> findByStatusAndVoidedTimestampBetween(CreditMemoStatus status, Instant start, Instant end);
+
+    /**
+     * Locked variant ({@code SELECT ... FOR UPDATE}) for the void transition (issue #997
+     * symmetry): concurrent voids of the same memo serialize on the row, so exactly one posts
+     * the mirror GL entry and the loser sees VOIDED (409). Must run inside an active
+     * transaction.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<CreditMemo> findWithLockByCreditMemoId(UUID creditMemoId);
 
     /**
      * Find all credit memos for an invoice with pagination.

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/CreditMemoRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/CreditMemoRepository.java
@@ -49,6 +49,18 @@ public interface CreditMemoRepository extends JpaRepository<CreditMemo, UUID> {
             CreditMemoStatus excludedStatus, Instant start, Instant end);
 
     /**
+     * Credit memos voided within the window — the T8 report's void-period restoration term
+     * (issue #997 symmetry): a void posts a reversing {@code Cr 2200} entry when it happens, so
+     * the report restores the reversed tax in that same period.
+     *
+     * @param status always {@code VOIDED}
+     * @param start  inclusive lower bound (start-of-day of the period start, UTC)
+     * @param end    inclusive upper bound (end-of-day of the period end, UTC)
+     * @return matching credit memos (unordered)
+     */
+    List<CreditMemo> findByStatusAndVoidedTimestampBetween(CreditMemoStatus status, Instant start, Instant end);
+
+    /**
      * Find all credit memos for an invoice with pagination.
      *
      * @param originalInvoiceId invoice identifier

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
@@ -411,6 +411,70 @@ public class CreditMemoServiceImpl implements CreditMemoService {
     }
 
     /**
+     * Void a POSTED Credit Memo (issue #997 symmetry). The memo's posting-period T8 contribution
+     * and its original journal entry are never touched; the void posts the mirror entry
+     * ({@code Dr AR / Cr Revenue + Cr Sales-Tax Payable}) dated now, and the T8 report restores
+     * the reversed tax in the void's period. Invoice balance restoration is automatic: every
+     * balance sum counts POSTED memos only.
+     */
+    @Override
+    public CreditMemoResponse voidCreditMemo(
+            @NonNull UUID creditMemoId, @NonNull String voidReason, @NonNull String currentUser) {
+
+        CreditMemo creditMemo = creditMemoRepository
+                .findById(creditMemoId)
+                .orElseThrow(() ->
+                        new ResponseStatusException(HttpStatus.NOT_FOUND, "Credit Memo not found: " + creditMemoId));
+
+        if (creditMemo.getStatus() != CreditMemoStatus.POSTED) {
+            String detail = creditMemo.getStatus() == CreditMemoStatus.APPLIED
+                    ? "it has been consumed (APPLIED); handle through the customer-credit lifecycle"
+                    : "current status is " + creditMemo.getStatus();
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT, "Credit Memo " + creditMemoId + " cannot be voided: " + detail);
+        }
+
+        creditMemo.setStatus(CreditMemoStatus.VOIDED);
+        creditMemo.setVoidedTimestamp(Instant.now(clock));
+        creditMemo.setVoidedByUserId(currentUser);
+        creditMemo.setVoidReason(voidReason);
+        creditMemoRepository.save(creditMemo);
+
+        try {
+            glPostingService.postCreditMemoVoid(
+                    creditMemo.getCreditMemoId(),
+                    glConfig.getRevenueAccountId(),
+                    glConfig.getTaxPayableAccountId(),
+                    glConfig.getArAccountId(),
+                    creditMemo.getCreditAmount(),
+                    creditMemo.getTaxAmountReversed(),
+                    "Void Credit Memo " + creditMemo.getCreditMemoId() + " - " + voidReason);
+        } catch (Exception e) {
+            log.error(
+                    "Failed to post VOID GL entries for Credit Memo {}: {}",
+                    creditMemo.getCreditMemoId(),
+                    e.getMessage(),
+                    e);
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Failed to post void GL entries: " + e.getMessage());
+        }
+
+        BigDecimal balanceAfter = invoiceBalanceCalculator
+                .findInvoice(creditMemo.getOriginalInvoiceId())
+                .map(invoiceBalanceCalculator::balanceDue)
+                .orElse(BigDecimal.ZERO);
+
+        log.info(
+                "Voided Credit Memo {} (invoice {}): AR restored by {}, tax liability restored by {}",
+                creditMemo.getCreditMemoId(),
+                creditMemo.getOriginalInvoiceId(),
+                creditMemo.calculateTotalAmount(),
+                creditMemo.getTaxAmountReversed());
+
+        return buildResponse(creditMemo, balanceAfter);
+    }
+
+    /**
      * Build CreditMemoResponse from entity.
      */
     private CreditMemoResponse buildResponse(CreditMemo creditMemo, BigDecimal invoiceBalanceAfter) {
@@ -430,6 +494,9 @@ public class CreditMemoServiceImpl implements CreditMemoService {
         response.setPriorPeriodAdjustment(creditMemo.isPriorPeriodAdjustment());
         response.setOriginalPeriodId(creditMemo.getOriginalPeriodId());
         response.setCurrency(creditMemo.getCurrency());
+        response.setVoidedTimestamp(creditMemo.getVoidedTimestamp());
+        response.setVoidedByUserId(creditMemo.getVoidedByUserId());
+        response.setVoidReason(creditMemo.getVoidReason());
         response.setInvoiceBalanceAfter(invoiceBalanceAfter);
         return response;
     }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CreditMemoServiceImpl.java
@@ -421,8 +421,10 @@ public class CreditMemoServiceImpl implements CreditMemoService {
     public CreditMemoResponse voidCreditMemo(
             @NonNull UUID creditMemoId, @NonNull String voidReason, @NonNull String currentUser) {
 
+        // Locked read (SELECT ... FOR UPDATE): two concurrent voids serialize here, so the
+        // second sees VOIDED and gets the 409 instead of double-posting the mirror GL entry.
         CreditMemo creditMemo = creditMemoRepository
-                .findById(creditMemoId)
+                .findWithLockByCreditMemoId(creditMemoId)
                 .orElseThrow(() ->
                         new ResponseStatusException(HttpStatus.NOT_FOUND, "Credit Memo not found: " + creditMemoId));
 
@@ -455,8 +457,11 @@ public class CreditMemoServiceImpl implements CreditMemoService {
                     creditMemo.getCreditMemoId(),
                     e.getMessage(),
                     e);
+            // Generic message only — the cause is logged above; raw exception text can leak
+            // internal details (DB messages, class names) to API callers.
             throw new ResponseStatusException(
-                    HttpStatus.INTERNAL_SERVER_ERROR, "Failed to post void GL entries: " + e.getMessage());
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to post void GL entries for credit memo " + creditMemo.getCreditMemoId());
         }
 
         BigDecimal balanceAfter = invoiceBalanceCalculator

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
@@ -807,7 +807,36 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
             for (CreditMemo credit : credits) {
                 unattributedCredits = unattributedCredits.add(netCreditAcrossJurisdictions(
-                        credit, attributionByCredit, taxByOriginalInvoice, byJurisdiction));
+                        credit, attributionByCredit, taxByOriginalInvoice, byJurisdiction, false));
+            }
+        }
+
+        // --- Void side (issue #997 symmetry): a void posts a reversing Cr 2200 entry in the
+        // period it happens, so the report restores the reversed tax per jurisdiction in that
+        // same period (negative creditsNetted). The memo's original posting-period contribution
+        // above is untouched — no retroactive restatement; a memo posted and voided in the same
+        // period contributes net zero. ---
+        List<CreditMemo> voids = creditMemoRepository.findByStatusAndVoidedTimestampBetween(
+                CreditMemoStatus.VOIDED, startInstant, endInstant);
+        if (!voids.isEmpty()) {
+            List<UUID> voidInvoiceIds = voids.stream()
+                    .map(CreditMemo::getOriginalInvoiceId)
+                    .distinct()
+                    .toList();
+            Map<UUID, List<ExtInvoiceTax>> taxByVoidInvoice =
+                    extInvoiceTaxRepository.findByInvoiceIdIn(voidInvoiceIds).stream()
+                            .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
+            Map<UUID, List<CreditMemoTax>> attributionByVoid =
+                    creditMemoTaxRepository
+                            .findByCreditMemoIdIn(voids.stream()
+                                    .map(CreditMemo::getCreditMemoId)
+                                    .toList())
+                            .stream()
+                            .collect(Collectors.groupingBy(CreditMemoTax::getCreditMemoId));
+
+            for (CreditMemo voided : voids) {
+                unattributedCredits = unattributedCredits.subtract(netCreditAcrossJurisdictions(
+                        voided, attributionByVoid, taxByVoidInvoice, byJurisdiction, true));
             }
         }
 
@@ -864,20 +893,28 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
      *       per-jurisdiction collected tax.</li>
      * </ol>
      *
+     * @param restore when true (issue #997 void symmetry) every attributed amount is applied with
+     *                the opposite sign — the void-period restoration of a previously netted
+     *                reversal — using the identical attribution source, so restore amounts mirror
+     *                the netted ones jurisdiction-for-jurisdiction
      * @return the portion of this credit's reversed tax that could <em>not</em> be attributed
      *         to any jurisdiction (zero in the normal case). Surfacing it in the reconciliation
-     *         block explains the resulting GL drift instead of leaving it phantom.
+     *         block explains the resulting GL drift instead of leaving it phantom. Callers on the
+     *         restore path subtract this value so an unattributed void cancels its unattributed
+     *         posting symmetrically.
      */
     private BigDecimal netCreditAcrossJurisdictions(
             CreditMemo credit,
             Map<UUID, List<CreditMemoTax>> attributionByCredit,
             Map<UUID, List<ExtInvoiceTax>> taxByOriginalInvoice,
-            Map<JurisdictionKey, JurisdictionAccumulator> byJurisdiction) {
+            Map<JurisdictionKey, JurisdictionAccumulator> byJurisdiction,
+            boolean restore) {
 
         BigDecimal reversed = nullSafe(credit.getTaxAmountReversed());
         if (reversed.signum() == 0) {
             return BigDecimal.ZERO;
         }
+        BigDecimal sign = restore ? BigDecimal.ONE.negate() : BigDecimal.ONE;
 
         // (1) Preferred: the credit's own frozen per-jurisdiction attribution.
         List<CreditMemoTax> attribution = attributionByCredit.get(credit.getCreditMemoId());
@@ -885,7 +922,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
             for (CreditMemoTax row : attribution) {
                 JurisdictionKey key = new JurisdictionKey(row.getJurisdictionType(), row.getJurisdictionCode());
                 JurisdictionAccumulator acc = byJurisdiction.computeIfAbsent(key, JurisdictionAccumulator::new);
-                acc.creditsNetted = acc.creditsNetted.add(nullSafe(row.getTaxAmountReversed()));
+                acc.creditsNetted = acc.creditsNetted.add(
+                        nullSafe(row.getTaxAmountReversed()).multiply(sign));
             }
             return BigDecimal.ZERO;
         }
@@ -921,7 +959,7 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         }
         for (Map.Entry<JurisdictionKey, BigDecimal> entry : allocated.entrySet()) {
             JurisdictionAccumulator acc = byJurisdiction.computeIfAbsent(entry.getKey(), JurisdictionAccumulator::new);
-            acc.creditsNetted = acc.creditsNetted.add(entry.getValue());
+            acc.creditsNetted = acc.creditsNetted.add(entry.getValue().multiply(sign));
         }
         return BigDecimal.ZERO;
     }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
@@ -156,6 +156,67 @@ public class GLPostingServiceImpl implements GLPostingService {
         return posted;
     }
 
+    @Override
+    public JournalEntry postCreditMemoVoid(
+            @NonNull UUID creditMemoId,
+            @NonNull UUID revenueAccountId,
+            @NonNull UUID taxPayableAccountId,
+            @NonNull UUID arAccountId,
+            @NonNull BigDecimal creditAmount,
+            @NonNull BigDecimal taxReversed,
+            @NonNull String description) {
+
+        BigDecimal totalAmount = creditAmount.add(taxReversed);
+
+        log.info(
+                "Posting Credit Memo VOID GL entry {}: debit AR {}, credit revenue {}, credit tax {}",
+                creditMemoId,
+                totalAmount,
+                creditAmount,
+                taxReversed);
+
+        JournalEntry entry = new JournalEntry();
+        entry.setTransactionDate(LocalDateTime.now(clock));
+        entry.setDescription(description);
+        entry.setSourceEventId(creditMemoId);
+
+        List<JournalEntryLine> lines = new ArrayList<>();
+
+        // Line 1: Debit AR (restore the receivable the memo had reduced)
+        JournalEntryLine arLine = new JournalEntryLine();
+        arLine.setGlAccountId(arAccountId);
+        arLine.setDebitAmount(totalAmount);
+        arLine.setCreditAmount(BigDecimal.ZERO);
+        arLine.setDescription("AR Restoration - CM VOID#" + creditMemoId);
+        lines.add(arLine);
+
+        // Line 2: Credit Revenue (re-recognize the reversed revenue)
+        JournalEntryLine revenueLine = new JournalEntryLine();
+        revenueLine.setGlAccountId(revenueAccountId);
+        revenueLine.setDebitAmount(BigDecimal.ZERO);
+        revenueLine.setCreditAmount(creditAmount);
+        revenueLine.setDescription("Revenue Restoration - CM VOID#" + creditMemoId);
+        lines.add(revenueLine);
+
+        // Line 3: Credit Sales-Tax Payable (restore the reversed tax liability)
+        JournalEntryLine taxLine = new JournalEntryLine();
+        taxLine.setGlAccountId(taxPayableAccountId);
+        taxLine.setDebitAmount(BigDecimal.ZERO);
+        taxLine.setCreditAmount(taxReversed);
+        taxLine.setDescription("Tax Restoration - CM VOID#" + creditMemoId);
+        lines.add(taxLine);
+
+        entry.setLines(lines);
+
+        // Create and post entry (period gate applies inside post — voids land in an open period)
+        JournalEntry created = journalEntryService.createJournalEntry(entry);
+        JournalEntry posted = journalEntryService.postJournalEntry(created.getJournalEntryId(), null);
+
+        log.info("Posted Credit Memo VOID GL entry: journal entry ID {}", posted.getJournalEntryId());
+
+        return posted;
+    }
+
     /**
      * Post a payment application (AR cash receipt) to GL.
      *

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/CreditMemoService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/CreditMemoService.java
@@ -47,4 +47,24 @@ public interface CreditMemoService {
      * @throws ResponseStatusException 404 if Credit Memo not found
      */
     CreditMemoResponse getCreditMemo(UUID creditMemoId);
+
+    /**
+     * Void a POSTED Credit Memo (issue #997 symmetry).
+     *
+     * <p>The void is a new economic event in the period it happens: the memo keeps its original
+     * posting-period contribution to the T8 liability report (no retroactive restatement of
+     * closed/frozen periods), and the void posts the mirror journal entry ({@code Dr AR / Cr
+     * Revenue + Cr Sales-Tax Payable}) dated now, in an open period. The invoice's outstanding
+     * balance is restored automatically (balance sums count POSTED memos only).
+     *
+     * <p>Only POSTED memos are voidable: an APPLIED memo has been consumed and must be handled
+     * through the customer-credit lifecycle; a VOIDED memo is terminal.
+     *
+     * @param creditMemoId Credit Memo identifier
+     * @param voidReason   Mandatory reason for the audit trail
+     * @param currentUser  User voiding the Credit Memo
+     * @return Voided Credit Memo details
+     * @throws ResponseStatusException 404 if not found; 409 if not POSTED
+     */
+    CreditMemoResponse voidCreditMemo(UUID creditMemoId, String voidReason, String currentUser);
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/CreditMemoService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/CreditMemoService.java
@@ -4,6 +4,7 @@ import com.positivity.accounting.internal.dto.CreateCreditMemoRequest;
 import com.positivity.accounting.internal.dto.CreditMemoResponse;
 import com.positivity.accounting.internal.enums.CreditMemoStatus;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.server.ResponseStatusException;
@@ -66,5 +67,6 @@ public interface CreditMemoService {
      * @return Voided Credit Memo details
      * @throws ResponseStatusException 404 if not found; 409 if not POSTED
      */
-    CreditMemoResponse voidCreditMemo(UUID creditMemoId, String voidReason, String currentUser);
+    CreditMemoResponse voidCreditMemo(
+            @NonNull UUID creditMemoId, @NonNull String voidReason, @NonNull String currentUser);
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
@@ -65,6 +65,31 @@ public interface GLPostingService {
             @Nullable String overrideJustification);
 
     /**
+     * Post the mirror of a Credit Memo reversal when the memo is voided (issue #997 symmetry):
+     * {@code Dr AR (creditAmount + taxReversed) / Cr Revenue (creditAmount) + Cr Sales-Tax
+     * Payable (taxReversed)}, dated at void time in the current open period (period gate
+     * applies). Together with the T8 report's void-period restoration term this keeps GL drift
+     * at zero across the POSTED → VOIDED transition without restating the posting period.
+     *
+     * @param creditMemoId       Voided credit memo id (source event)
+     * @param revenueAccountId   Revenue account (credit side of the void)
+     * @param taxPayableAccountId Sales-Tax Payable account (credit side of the void)
+     * @param arAccountId        Accounts Receivable account (debit side of the void)
+     * @param creditAmount       Revenue portion originally credited
+     * @param taxReversed        Tax portion originally reversed
+     * @param description        Journal entry description
+     * @return Posted journal entry
+     */
+    JournalEntry postCreditMemoVoid(
+            @NonNull UUID creditMemoId,
+            @NonNull UUID revenueAccountId,
+            @NonNull UUID taxPayableAccountId,
+            @NonNull UUID arAccountId,
+            @NonNull BigDecimal creditAmount,
+            @NonNull BigDecimal taxReversed,
+            @NonNull String description);
+
+    /**
      * Post a payment application (AR cash receipt) to GL.
      *
      * Creates journal entry with:

--- a/pos-accounting/src/main/resources/db/migration/V24__credit_memo_void.sql
+++ b/pos-accounting/src/main/resources/db/migration/V24__credit_memo_void.sql
@@ -1,0 +1,20 @@
+-- Issue #997 follow-through: implement the POSTED -> VOIDED credit-memo transition with the
+-- GL/report symmetry the #997 rule requires. A void is a new economic event in the period it
+-- happens: the memo's original posting-period contribution to the T8 liability report is never
+-- restated (no retroactive restatement of closed/frozen periods); instead the void posts a
+-- reversing journal entry (Dr AR / Cr Revenue + Cr Sales-Tax Payable 2200) dated at void time and
+-- the T8 report restores the reversed tax per jurisdiction in the void's period, keeping GL drift
+-- at zero on both sides of the transition.
+--
+-- FLYWAY COLLISION NOTE: numbered V24 as the next contiguous version after V23. Unmerged
+-- accounting-plan branches may also claim a V2x on pos-accounting; if they merge first this file
+-- must be renumbered on rebase.
+
+ALTER TABLE credit_memo
+    ADD COLUMN voided_timestamp timestamp(6) with time zone,
+    ADD COLUMN voided_by_user_id character varying(50),
+    ADD COLUMN void_reason character varying(1000);
+
+-- The T8 void-period restoration term queries voided credits by when they were voided.
+CREATE INDEX idx_credit_memo_voided_timestamp ON credit_memo (voided_timestamp)
+    WHERE voided_timestamp IS NOT NULL;

--- a/pos-accounting/src/main/resources/permissions.yaml
+++ b/pos-accounting/src/main/resources/permissions.yaml
@@ -18,6 +18,8 @@ permissions:
     description: "Create credit memo"
   - name: "accounting:credit-memo:read"
     description: "Read credit memo"
+  - name: "accounting:credit-memo:void"
+    description: "Void a posted credit memo, restoring AR and the reversed tax liability"
   - name: "accounting:customer-credit:apply"
     description: "Apply an open customer credit to an invoice"
   - name: "accounting:customer-credit:refund"

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingTaxLiabilityServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingTaxLiabilityServiceTest.java
@@ -375,6 +375,73 @@ class FinancialReportingTaxLiabilityServiceTest {
                 .build();
     }
 
+    @Test
+    @DisplayName("#997 void symmetry: a credit voided in-period restores its reversed tax in the void's period")
+    void creditVoidedInPeriod_restoresReversedTax() {
+        // Invoice side: 65.00 collected in-period.
+        when(extInvoiceRepository.findByFinalizedAtBetween(any(), any())).thenReturn(List.of(invoiceFinalized(INV1)));
+        List<ExtInvoiceTax> master = List.of(taxRow(INV1, "STATE", "WA", "1000.00", "65.00", false, null));
+        when(extInvoiceTaxRepository.findByInvoiceIdIn(anyCollection())).thenAnswer(call -> {
+            Collection<UUID> ids = call.getArgument(0);
+            return master.stream().filter(r -> ids.contains(r.getInvoiceId())).toList();
+        });
+
+        // The credit posted in a PRIOR period (not selected by the posted-credit query), was
+        // voided in THIS period. Its void reversal (Cr 2200 25.00) is on this period's ledger,
+        // so the report must restore 25.00 here: creditsNetted -25, net tax 65 + 25 = 90.
+        CreditMemo voided = creditMemo(INV1, "25.00");
+        voided.setStatus(CreditMemoStatus.VOIDED);
+        voided.setPostedTimestamp(Instant.parse("2026-05-15T00:00:00Z"));
+        voided.setVoidedTimestamp(Instant.parse("2026-06-20T00:00:00Z"));
+        when(creditMemoRepository.findByStatusNotAndPostedTimestampBetween(eq(CreditMemoStatus.DRAFT), any(), any()))
+                .thenReturn(List.of());
+        when(creditMemoRepository.findByStatusAndVoidedTimestampBetween(eq(CreditMemoStatus.VOIDED), any(), any()))
+                .thenReturn(List.of(voided));
+        when(creditMemoTaxRepository.findByCreditMemoIdIn(anyList()))
+                .thenReturn(List.of(attribution(voided.getCreditMemoId(), "STATE", "WA", "25.00")));
+        // Ledger: Cr 2200 65.00 (invoice) + Cr 2200 25.00 (void restoration) = 90.00 net.
+        stubTaxPayableActivity("-90.00");
+
+        TaxLiabilityReport report = service.generateTaxLiability(START, END);
+
+        assertThat(report.getRows().get(0).getCreditsNetted()).isEqualByComparingTo("-25.00");
+        assertThat(report.getRows().get(0).getNetTax()).isEqualByComparingTo("90.00");
+        assertThat(report.getTotalNetTax()).isEqualByComparingTo("90.00");
+        assertThat(report.getReconciliation().getUnattributedCredits()).isEqualByComparingTo("0");
+        assertThat(report.getReconciliation().getDrift()).isEqualByComparingTo("0.00");
+        assertThat(report.getReconciliation().getReconciled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("#997 void symmetry: posted and voided in the same period nets to zero credit contribution")
+    void creditPostedAndVoidedSamePeriod_netsToZero() {
+        when(extInvoiceRepository.findByFinalizedAtBetween(any(), any())).thenReturn(List.of(invoiceFinalized(INV1)));
+        List<ExtInvoiceTax> master = List.of(taxRow(INV1, "STATE", "WA", "1000.00", "65.00", false, null));
+        when(extInvoiceTaxRepository.findByInvoiceIdIn(anyCollection())).thenAnswer(call -> {
+            Collection<UUID> ids = call.getArgument(0);
+            return master.stream().filter(r -> ids.contains(r.getInvoiceId())).toList();
+        });
+
+        CreditMemo voided = creditMemo(INV1, "25.00");
+        voided.setStatus(CreditMemoStatus.VOIDED);
+        voided.setVoidedTimestamp(Instant.parse("2026-06-25T00:00:00Z"));
+        // Selected by BOTH queries: posted in-period (status != DRAFT) and voided in-period.
+        when(creditMemoRepository.findByStatusNotAndPostedTimestampBetween(eq(CreditMemoStatus.DRAFT), any(), any()))
+                .thenReturn(List.of(voided));
+        when(creditMemoRepository.findByStatusAndVoidedTimestampBetween(eq(CreditMemoStatus.VOIDED), any(), any()))
+                .thenReturn(List.of(voided));
+        when(creditMemoTaxRepository.findByCreditMemoIdIn(anyList()))
+                .thenReturn(List.of(attribution(voided.getCreditMemoId(), "STATE", "WA", "25.00")));
+        // Ledger: Cr 65 (invoice) + Dr 25 (posting) + Cr 25 (void) = 65 net.
+        stubTaxPayableActivity("-65.00");
+
+        TaxLiabilityReport report = service.generateTaxLiability(START, END);
+
+        assertThat(report.getRows().get(0).getCreditsNetted()).isEqualByComparingTo("0.00");
+        assertThat(report.getTotalNetTax()).isEqualByComparingTo("65.00");
+        assertThat(report.getReconciliation().getDrift()).isEqualByComparingTo("0.00");
+    }
+
     private static CreditMemo creditMemo(UUID originalInvoiceId, String taxReversed) {
         CreditMemo credit = new CreditMemo();
         credit.setCreditMemoId(UUID.randomUUID());

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/CreditMemoServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/CreditMemoServiceTest.java
@@ -740,4 +740,74 @@ class CreditMemoServiceTest {
             return memo;
         });
     }
+
+    // ===== Void (issue #997 symmetry) =====
+
+    @Test
+    @DisplayName("void: POSTED memo flips to VOIDED and posts the mirror GL entry")
+    void voidPostedMemo() {
+        when(creditMemoRepository.findById(testCreditMemoId)).thenReturn(java.util.Optional.of(testCreditMemo));
+        when(creditMemoRepository.save(any(CreditMemo.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(invoiceBalanceCalculator.findInvoice(testInvoiceId)).thenReturn(java.util.Optional.of(testInvoice));
+        when(invoiceBalanceCalculator.balanceDue(testInvoice)).thenReturn(new BigDecimal("110.00"));
+
+        CreditMemoResponse response = service.voidCreditMemo(testCreditMemoId, "Wrong invoice", "void-user");
+
+        assertThat(response.getStatus()).isEqualTo(CreditMemoStatus.VOIDED);
+        assertThat(response.getVoidedTimestamp()).isEqualTo(Instant.now(TEST_CLOCK));
+        assertThat(response.getVoidedByUserId()).isEqualTo("void-user");
+        assertThat(response.getVoidReason()).isEqualTo("Wrong invoice");
+        assertThat(response.getInvoiceBalanceAfter()).isEqualByComparingTo("110.00");
+        // Mirror entry: Dr AR total / Cr Revenue creditAmount + Cr Tax taxReversed.
+        verify(glPostingService)
+                .postCreditMemoVoid(
+                        eq(testCreditMemoId),
+                        eq(testRevenueAccountId),
+                        eq(testTaxAccountId),
+                        eq(testArAccountId),
+                        eq(new BigDecimal("50.00")),
+                        eq(new BigDecimal("5.00")),
+                        anyString());
+    }
+
+    @Test
+    @DisplayName("void: APPLIED memo is rejected 409 (consumed), nothing saved or posted")
+    void voidAppliedMemoRejected() {
+        testCreditMemo.setStatus(CreditMemoStatus.APPLIED);
+        when(creditMemoRepository.findById(testCreditMemoId)).thenReturn(java.util.Optional.of(testCreditMemo));
+
+        assertThatThrownBy(() -> service.voidCreditMemo(testCreditMemoId, "reason", "void-user"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(
+                                ((ResponseStatusException) ex).getStatusCode().value())
+                        .isEqualTo(409));
+        verify(creditMemoRepository, org.mockito.Mockito.never()).save(any());
+        verify(glPostingService, org.mockito.Mockito.never())
+                .postCreditMemoVoid(any(), any(), any(), any(), any(), any(), anyString());
+    }
+
+    @Test
+    @DisplayName("void: already-VOIDED memo is rejected 409 (terminal)")
+    void voidVoidedMemoRejected() {
+        testCreditMemo.setStatus(CreditMemoStatus.VOIDED);
+        when(creditMemoRepository.findById(testCreditMemoId)).thenReturn(java.util.Optional.of(testCreditMemo));
+
+        assertThatThrownBy(() -> service.voidCreditMemo(testCreditMemoId, "reason", "void-user"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(
+                                ((ResponseStatusException) ex).getStatusCode().value())
+                        .isEqualTo(409));
+    }
+
+    @Test
+    @DisplayName("void: unknown memo -> 404")
+    void voidUnknownMemo() {
+        when(creditMemoRepository.findById(testCreditMemoId)).thenReturn(java.util.Optional.empty());
+
+        assertThatThrownBy(() -> service.voidCreditMemo(testCreditMemoId, "reason", "void-user"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(
+                                ((ResponseStatusException) ex).getStatusCode().value())
+                        .isEqualTo(404));
+    }
 }

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/CreditMemoServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/CreditMemoServiceTest.java
@@ -746,7 +746,8 @@ class CreditMemoServiceTest {
     @Test
     @DisplayName("void: POSTED memo flips to VOIDED and posts the mirror GL entry")
     void voidPostedMemo() {
-        when(creditMemoRepository.findById(testCreditMemoId)).thenReturn(java.util.Optional.of(testCreditMemo));
+        when(creditMemoRepository.findWithLockByCreditMemoId(testCreditMemoId))
+                .thenReturn(java.util.Optional.of(testCreditMemo));
         when(creditMemoRepository.save(any(CreditMemo.class))).thenAnswer(inv -> inv.getArgument(0));
         when(invoiceBalanceCalculator.findInvoice(testInvoiceId)).thenReturn(java.util.Optional.of(testInvoice));
         when(invoiceBalanceCalculator.balanceDue(testInvoice)).thenReturn(new BigDecimal("110.00"));
@@ -774,7 +775,8 @@ class CreditMemoServiceTest {
     @DisplayName("void: APPLIED memo is rejected 409 (consumed), nothing saved or posted")
     void voidAppliedMemoRejected() {
         testCreditMemo.setStatus(CreditMemoStatus.APPLIED);
-        when(creditMemoRepository.findById(testCreditMemoId)).thenReturn(java.util.Optional.of(testCreditMemo));
+        when(creditMemoRepository.findWithLockByCreditMemoId(testCreditMemoId))
+                .thenReturn(java.util.Optional.of(testCreditMemo));
 
         assertThatThrownBy(() -> service.voidCreditMemo(testCreditMemoId, "reason", "void-user"))
                 .isInstanceOf(ResponseStatusException.class)
@@ -790,7 +792,8 @@ class CreditMemoServiceTest {
     @DisplayName("void: already-VOIDED memo is rejected 409 (terminal)")
     void voidVoidedMemoRejected() {
         testCreditMemo.setStatus(CreditMemoStatus.VOIDED);
-        when(creditMemoRepository.findById(testCreditMemoId)).thenReturn(java.util.Optional.of(testCreditMemo));
+        when(creditMemoRepository.findWithLockByCreditMemoId(testCreditMemoId))
+                .thenReturn(java.util.Optional.of(testCreditMemo));
 
         assertThatThrownBy(() -> service.voidCreditMemo(testCreditMemoId, "reason", "void-user"))
                 .isInstanceOf(ResponseStatusException.class)
@@ -802,7 +805,7 @@ class CreditMemoServiceTest {
     @Test
     @DisplayName("void: unknown memo -> 404")
     void voidUnknownMemo() {
-        when(creditMemoRepository.findById(testCreditMemoId)).thenReturn(java.util.Optional.empty());
+        when(creditMemoRepository.findWithLockByCreditMemoId(testCreditMemoId)).thenReturn(java.util.Optional.empty());
 
         assertThatThrownBy(() -> service.voidCreditMemo(testCreditMemoId, "reason", "void-user"))
                 .isInstanceOf(ResponseStatusException.class)

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -441,10 +441,10 @@ public final class GatewayPermissionCatalog {
         "PERM_accounting:customer-credit:refund", // 391
 
         // ── New batch (bits 392–392) ──────────────────────────────────────────
-        "PERM_accounting:tax-snapshot:freeze",               // 392
+        "PERM_accounting:tax-snapshot:freeze", // 392
 
         // ── New batch (bits 393–393) ──────────────────────────────────────────
-        "PERM_accounting:credit-memo:void"                  // 393
+        "PERM_accounting:credit-memo:void" // 393
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 28;
+    public static final int CATALOG_VERSION = 29;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -441,7 +441,10 @@ public final class GatewayPermissionCatalog {
         "PERM_accounting:customer-credit:refund", // 391
 
         // ── New batch (bits 392–392) ──────────────────────────────────────────
-        "PERM_accounting:tax-snapshot:freeze"               // 392
+        "PERM_accounting:tax-snapshot:freeze",               // 392
+
+        // ── New batch (bits 393–393) ──────────────────────────────────────────
+        "PERM_accounting:credit-memo:void"                  // 393
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 28")
+    @DisplayName("CATALOG_VERSION is 29")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(28);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(29);
     }
 
     @Test
-    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 392")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 393")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1219,8 +1219,10 @@ class SecurityGatewayConfigTest {
         assertThat(GatewayPermissionCatalog.authorityForBit(391)).isEqualTo("PERM_accounting:customer-credit:refund");
         // catalog v28 (#998): tax snapshot freeze authority appended (bit 392)
         assertThat(GatewayPermissionCatalog.authorityForBit(392)).isEqualTo("PERM_accounting:tax-snapshot:freeze");
+        // catalog v29 (#997 void symmetry): credit-memo void authority appended (bit 393)
+        assertThat(GatewayPermissionCatalog.authorityForBit(393)).isEqualTo("PERM_accounting:credit-memo:void");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(393)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(394)).isNull();
     }
 
     @Test

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -467,10 +467,10 @@ public final class DownstreamPermissionCatalog {
         "PERM_accounting:customer-credit:refund", // 391
 
         // ── New batch (bits 392–392) ──────────────────────────────────────────
-        "PERM_accounting:tax-snapshot:freeze",               // 392
+        "PERM_accounting:tax-snapshot:freeze", // 392
 
         // ── New batch (bits 393–393) ──────────────────────────────────────────
-        "PERM_accounting:credit-memo:void"                  // 393
+        "PERM_accounting:credit-memo:void" // 393
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 28;
+    public static final int CATALOG_VERSION = 29;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -467,7 +467,10 @@ public final class DownstreamPermissionCatalog {
         "PERM_accounting:customer-credit:refund", // 391
 
         // ── New batch (bits 392–392) ──────────────────────────────────────────
-        "PERM_accounting:tax-snapshot:freeze"               // 392
+        "PERM_accounting:tax-snapshot:freeze",               // 392
+
+        // ── New batch (bits 393–393) ──────────────────────────────────────────
+        "PERM_accounting:credit-memo:void"                  // 393
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -510,13 +510,15 @@ public enum PermissionCode {
     ACCOUNTING__CUSTOMER_CREDIT__APPLY(390, "accounting:customer-credit:apply"),
     ACCOUNTING__CUSTOMER_CREDIT__REFUND(391, "accounting:customer-credit:refund"),
     // ── Accounting (new) ───────────────────────────────────────────────────────
-    ACCOUNTING__TAX_SNAPSHOT__FREEZE(392, "accounting:tax-snapshot:freeze");
+    ACCOUNTING__TAX_SNAPSHOT__FREEZE(392, "accounting:tax-snapshot:freeze"),
+    // ── Accounting (new) ───────────────────────────────────────────────────────
+    ACCOUNTING__CREDIT_MEMO__VOID(393, "accounting:credit-memo:void");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 28;
+    public static final int CATALOG_VERSION = 29;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 393;
-    private static final int EXPECTED_CATALOG_VERSION = 28;
+    private static final int EXPECTED_PERMISSION_COUNT = 394;
+    private static final int EXPECTED_CATALOG_VERSION = 29;
 
     // -------------------------------------------------------------------------
-    // AC-1: Catalog size — 393 entries
+    // AC-1: Catalog size — 394 entries
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("catalog contains exactly 393 permissions")
+    @DisplayName("catalog contains exactly 394 permissions")
     void catalogContainsExpectedPermissions() {
         assertThat(PermissionCode.values()).hasSize(EXPECTED_PERMISSION_COUNT);
     }

--- a/scripts/export-permission-registrations-yaml.py
+++ b/scripts/export-permission-registrations-yaml.py
@@ -280,7 +280,9 @@ def build_report_yaml(root: Path, manifests: List[PermissionManifest], issues: L
 
     lines: List[str] = []
     append_yaml_line(lines, 0, f'generatedAt: {yaml_quote(datetime.now(timezone.utc).isoformat())}')
-    append_yaml_line(lines, 0, f'root: {yaml_quote(str(root))}')
+    # Repo-relative marker, not the absolute scan path: embedding the machine-local
+    # path made the committed report differ per machine/CI run for no content change.
+    append_yaml_line(lines, 0, 'root: "."')
     append_yaml_line(lines, 0, "summary:")
     append_yaml_line(lines, 1, f"manifestCount: {len(manifests)}")
     append_yaml_line(lines, 1, f"permissionCount: {len(flattened)}")


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-tax`
- Parent STORY (durion): follow-through on the #997 credit-selection rule (PR #1004) and the #1007 decision record; no separate durion STORY
- Child issue: closes the residual flagged on louisburroughs/durion-positivity-backend#1007 (closed as duplicate of #997) — the "future void implementer" obligations from its decision record are discharged here. Do not reopen #997.
- Domain: `domain:accounting`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Additive only: 1 new endpoint (`POST /v1/accounting/credit-memos/{id}/void`), 1 request schema, 3 nullable response fields on `CreditMemoResponse`, 1 new permission, 1 new outbox event id. No existing API or event changed. See BACKEND_CONTRACT_GUIDE.md (`domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md`).

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [x] `pos-accounting/openapi.yaml` regenerated (`-Popenapi` profile)
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — usual release flow

## Scope
- **What changed:** implements the POSTED → VOIDED credit-memo transition, which the shipped #997 rule anticipated but which had no production path (`VOIDED` was enum-only). Design follows the #1007 decision record's no-retroactive-restatement principle: a void is a new economic event in the period it happens.
  - **Transition:** `POST /v1/accounting/credit-memos/{creditMemoId}/void` (mandatory `voidReason`), guarded by new permission `accounting:credit-memo:void` (bit 393, CATALOG_VERSION 29), `@EmitEvent ACCOUNTING_CREDIT_MEMO_VOID` (approval preset). POSTED-only: APPLIED → 409 (consumed; belongs to the customer-credit lifecycle), VOIDED → 409 (terminal), unknown → 404. V24 adds `voided_timestamp` / `voided_by_user_id` / `void_reason` + a partial index on `voided_timestamp`.
  - **GL mirror:** `GLPostingService.postCreditMemoVoid` posts `Dr AR (total) / Cr Revenue (creditAmount) + Cr Sales-Tax Payable 2200 (taxReversed)`, dated at void time, in an open period (period gate applies). The memo's original journal entry is never touched. Invoice outstanding balance restores automatically — every balance sum counts POSTED memos only.
  - **T8 report symmetry:** the tax-liability report gains a void-period restoration term — credits selected by `voidedTimestamp` restore their reversed tax per jurisdiction (negative `creditsNetted`), using the identical attribution source as the netting side (frozen `credit_memo_tax` rows from #996, pro-rata fallback, symmetric unattributed handling). The posting period's figures are never restated, so **frozen snapshots (#998/PR #1009) of the posting period stay `consistent=true`** and GL drift is zero on both sides of the transition. A memo posted and voided in the same period contributes net zero.
- **Why:** without this, the first void implementation would have forced a choice between GL drift in the void period (reversing entry, no report term) or permanently netting tax for a voided credit (status flip, no GL entry). Both break the #997 "drift stays 0 across transitions" invariant; this PR closes the gap before any void exists in production.

## Tests
- [x] Unit tests added/updated — `CreditMemoServiceTest`: void happy path (status/audit fields, mirror GL args, balance restore), APPLIED/VOIDED 409s with nothing persisted or posted, unknown 404. `FinancialReportingTaxLiabilityServiceTest`: cross-period void restores 25.00 with drift 0; posted-and-voided-same-period nets to zero with drift 0.
- [ ] Integration tests added/updated — not in this PR; the existing `CustomerCreditLifecycleGLPostingIT` covers the #997 credit-selection query, and the void GL path composes the already-IT-covered `JournalEntryService` posting rails.
- [ ] Provider behavioral contract tests — n/a (no provider interaction).
- How to run: `./mvnw -pl pos-accounting test` → 1173/1173 green; `scripts/generate-permissions.sh --sync --check` passes; spotless clean.

## Risk & Rollback
- Risk level: Low–Medium — additive endpoint + additive report term; the only touched existing code path is the T8 credit section (new query returns empty until a void exists, so current behavior is byte-identical until the first void).
- Rollback plan: revert the single commit (`4d7bcfc`). V24 columns are nullable and unreferenced after revert.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — session branch `claude/session-11yo0x` per the remote-session workflow
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — additive only
- [ ] Required CI checks passing — to confirm after CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z1thyXfFSBHfqPwi1tbvj

---
_Generated by [Claude Code](https://claude.ai/code/session_014z1thyXfFSBHfqPwi1tbvj)_