### PR TITLE
feat(accounting): wire all financial reports into report-export rendering rails (#1011-#1015)

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportRequest.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportRequest.java
@@ -32,11 +32,15 @@ public class ReportExportRequest {
     private ExportFormat format;
 
     /**
-     * Report type to export (e.g. JOURNAL_LINES, INCOME_STATEMENT).
+     * Report type to export.
      */
     @NotBlank(message = "reportType is required")
     @Size(max = 100, message = "reportType must not exceed 100 characters")
-    @Schema(description = "Report type key", example = "JOURNAL_LINES", requiredMode = REQUIRED)
+    @Schema(
+            description = "Report type key. Renderable types: TAX_LIABILITY, INCOME_STATEMENT, BALANCE_SHEET, "
+                    + "TRIAL_BALANCE, GENERAL_LEDGER, AGED_RECEIVABLES, AGED_PAYABLES.",
+            example = "INCOME_STATEMENT",
+            requiredMode = REQUIRED)
     private String reportType;
 
     /**
@@ -47,10 +51,14 @@ public class ReportExportRequest {
     private LocalDate startDate;
 
     /**
-     * Period end date (inclusive).
+     * Period end date (inclusive). For as-of reports this date is the as-of date.
      */
     @NotNull(message = "endDate is required")
-    @Schema(description = "Period end date (inclusive, YYYY-MM-DD)", example = "2026-03-31", requiredMode = REQUIRED)
+    @Schema(
+            description = "Period end date (inclusive, YYYY-MM-DD). For the as-of reports (BALANCE_SHEET, "
+                    + "TRIAL_BALANCE, AGED_RECEIVABLES, AGED_PAYABLES) this date is used as the as-of date.",
+            example = "2026-03-31",
+            requiredMode = REQUIRED)
     private LocalDate endDate;
 
     /**
@@ -62,6 +70,16 @@ public class ReportExportRequest {
             example = "d10217f9-3ec6-46b9-9c87-e7066c100c24",
             requiredMode = REQUIRED)
     private UUID organizationId;
+
+    /**
+     * Optional GL account filter for GENERAL_LEDGER exports.
+     */
+    @Schema(
+            description = "Optional GL account UUID filter, honored by GENERAL_LEDGER exports only; "
+                    + "null spans all accounts",
+            example = "123e4567-e89b-12d3-a456-426614174000",
+            requiredMode = NOT_REQUIRED)
+    private UUID accountId;
 
     /**
      * Optional filename (without extension).

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/AgedReportCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/AgedReportCsvRenderer.java
@@ -1,0 +1,134 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.dto.AgedPayablesReport;
+import com.positivity.accounting.internal.dto.AgedPayablesRow;
+import com.positivity.accounting.internal.dto.AgedReceivablesReport;
+import com.positivity.accounting.internal.dto.AgedReceivablesRow;
+import com.positivity.accounting.internal.dto.AgingSummary;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Renders {@link AgedReceivablesReport} and {@link AgedPayablesReport} as
+ * deterministic CSV (issue #1015). The two reports are mirrors, so one renderer
+ * covers both; only the report key and the party column headers differ.
+ *
+ * <p>Column and row order are fixed: metadata block (the export request's
+ * {@code endDate} is used as the as-of date), per-party rows in report order
+ * (ordered by party name) with the aging-bucket columns defined by the report
+ * DTOs (current / 31-60 / 61-90 / 90+), each row's total, and a grand-total row.
+ * All figures are emitted with {@link BigDecimal#toPlainString()} so the CSV
+ * matches the JSON report to the cent. The volatile {@code generatedAt}
+ * timestamp is intentionally excluded so identical report data always renders
+ * byte-identical CSV.
+ */
+@Component
+public class AgedReportCsvRenderer {
+
+    private static final String BUCKET_COLUMNS = "Current (0-30),31-60 Days,61-90 Days,90+ Days,Total Outstanding";
+
+    /**
+     * Render the aged receivables report to CSV.
+     *
+     * @param report the generated aged AR report
+     * @return CSV text with Unix line endings and a trailing newline
+     */
+    @NonNull
+    public String render(@NonNull AgedReceivablesReport report) {
+        List<PartyAgingRow> rows =
+                report.getRows().stream().map(AgedReportCsvRenderer::toPartyRow).toList();
+        return renderAging(
+                "AGED_RECEIVABLES", "Customer ID,Customer Name", report.getAsOfDate(), rows, report.getTotals());
+    }
+
+    /**
+     * Render the aged payables report to CSV.
+     *
+     * @param report the generated aged AP report
+     * @return CSV text with Unix line endings and a trailing newline
+     */
+    @NonNull
+    public String render(@NonNull AgedPayablesReport report) {
+        List<PartyAgingRow> rows =
+                report.getRows().stream().map(AgedReportCsvRenderer::toPartyRow).toList();
+        return renderAging("AGED_PAYABLES", "Vendor ID,Vendor Name", report.getAsOfDate(), rows, report.getTotals());
+    }
+
+    private static PartyAgingRow toPartyRow(AgedReceivablesRow row) {
+        return new PartyAgingRow(
+                row.getCustomerId().toString(),
+                row.getCustomerName(),
+                row.getCurrent(),
+                row.getDays31To60(),
+                row.getDays61To90(),
+                row.getDays90Plus(),
+                row.getTotalOutstanding());
+    }
+
+    private static PartyAgingRow toPartyRow(AgedPayablesRow row) {
+        return new PartyAgingRow(
+                row.getVendorId().toString(),
+                row.getVendorName(),
+                row.getCurrent(),
+                row.getDays31To60(),
+                row.getDays61To90(),
+                row.getDays90Plus(),
+                row.getTotalOutstanding());
+    }
+
+    private static String renderAging(
+            String reportKey, String partyHeader, LocalDate asOfDate, List<PartyAgingRow> rows, AgingSummary totals) {
+        StringBuilder csv = new StringBuilder();
+
+        csv.append("Report,As-Of Date\n");
+        csv.append(reportKey).append(',').append(asOfDate).append("\n\n");
+
+        csv.append(partyHeader).append(',').append(BUCKET_COLUMNS).append('\n');
+        for (PartyAgingRow row : rows) {
+            csv.append(CsvFormat.escape(row.partyId()))
+                    .append(',')
+                    .append(CsvFormat.escape(row.partyName()))
+                    .append(',')
+                    .append(amount(row.current()))
+                    .append(',')
+                    .append(amount(row.days31To60()))
+                    .append(',')
+                    .append(amount(row.days61To90()))
+                    .append(',')
+                    .append(amount(row.days90Plus()))
+                    .append(',')
+                    .append(amount(row.totalOutstanding()))
+                    .append('\n');
+        }
+        csv.append("TOTAL,,")
+                .append(amount(totals.getCurrent()))
+                .append(',')
+                .append(amount(totals.getDays31To60()))
+                .append(',')
+                .append(amount(totals.getDays61To90()))
+                .append(',')
+                .append(amount(totals.getDays90Plus()))
+                .append(',')
+                .append(amount(totals.getTotalOutstanding()))
+                .append('\n');
+
+        return csv.toString();
+    }
+
+    private static String amount(BigDecimal value) {
+        return CsvFormat.amount(value);
+    }
+
+    /** Common shape of one aged AR/AP row: party identity plus the aging buckets. */
+    private record PartyAgingRow(
+            String partyId,
+            String partyName,
+            BigDecimal current,
+            BigDecimal days31To60,
+            BigDecimal days61To90,
+            BigDecimal days90Plus,
+            BigDecimal totalOutstanding) {}
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/AgedReportCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/AgedReportCsvRenderer.java
@@ -17,9 +17,10 @@ import org.springframework.stereotype.Component;
  * covers both; only the report key and the party column headers differ.
  *
  * <p>Column and row order are fixed: metadata block (the export request's
- * {@code endDate} is used as the as-of date), per-party rows in report order
- * (ordered by party name) with the aging-bucket columns defined by the report
- * DTOs (current / 31-60 / 61-90 / 90+), each row's total, and a grand-total row.
+ * {@code endDate} is used as the as-of date), per-party rows in the
+ * deterministic order produced by the report DTO, with the aging-bucket columns
+ * defined by the report DTOs (current / 31-60 / 61-90 / 90+), each row's total,
+ * and a grand-total row.
  * All figures are emitted with {@link BigDecimal#toPlainString()} so the CSV
  * matches the JSON report to the cent. The volatile {@code generatedAt}
  * timestamp is intentionally excluded so identical report data always renders

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/BalanceSheetCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/BalanceSheetCsvRenderer.java
@@ -1,0 +1,57 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.dto.BalanceSheetReport;
+import java.math.BigDecimal;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Renders a {@link BalanceSheetReport} as deterministic CSV (issue #1012).
+ *
+ * <p>Column and row order are fixed: metadata block (the export request's
+ * {@code endDate} is used as the as-of date), then one row per statement line in
+ * report order (the service builds {@code lineItems} as a {@code LinkedHashMap}
+ * in statement-line display order), then total rows and the balanced flag. All
+ * figures are emitted with {@link BigDecimal#toPlainString()} so the CSV matches
+ * the JSON report to the cent. The volatile {@code generatedAt} timestamp is
+ * intentionally excluded so identical report data always renders byte-identical
+ * CSV.
+ */
+@Component
+public class BalanceSheetCsvRenderer {
+
+    /**
+     * Render the report to CSV.
+     *
+     * @param report the generated balance sheet report
+     * @return CSV text with Unix line endings and a trailing newline
+     */
+    @NonNull
+    public String render(@NonNull BalanceSheetReport report) {
+        StringBuilder csv = new StringBuilder();
+
+        csv.append("Report,As-Of Date\n");
+        csv.append("BALANCE_SHEET,").append(report.getAsOfDate()).append("\n\n");
+
+        csv.append("Line Item,Amount\n");
+        for (Map.Entry<String, BigDecimal> line : report.getLineItems().entrySet()) {
+            csv.append(CsvFormat.escape(line.getKey()))
+                    .append(',')
+                    .append(CsvFormat.amount(line.getValue()))
+                    .append('\n');
+        }
+        csv.append("TOTAL_ASSETS,")
+                .append(CsvFormat.amount(report.getTotalAssets()))
+                .append('\n');
+        csv.append("TOTAL_LIABILITIES,")
+                .append(CsvFormat.amount(report.getTotalLiabilities()))
+                .append('\n');
+        csv.append("TOTAL_EQUITY,")
+                .append(CsvFormat.amount(report.getTotalEquity()))
+                .append('\n');
+        csv.append("BALANCED,").append(report.getBalanced()).append('\n');
+
+        return csv.toString();
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CsvFormat.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CsvFormat.java
@@ -1,0 +1,30 @@
+package com.positivity.accounting.internal.service;
+
+import java.math.BigDecimal;
+
+/**
+ * Shared formatting helpers for the deterministic report CSV renderers
+ * (issues #999, #1011-#1015).
+ *
+ * <p>Figures are emitted with {@link BigDecimal#toPlainString()} so rendered CSV
+ * matches the JSON report to the cent; fields containing commas, quotes, CR, or
+ * LF are quoted and quote-escaped per RFC 4180.
+ */
+final class CsvFormat {
+
+    private CsvFormat() {}
+
+    static String amount(BigDecimal value) {
+        return value == null ? "" : value.toPlainString();
+    }
+
+    static String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
+            return '"' + value.replace("\"", "\"\"") + '"';
+        }
+        return value;
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GeneralLedgerCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GeneralLedgerCsvRenderer.java
@@ -1,0 +1,101 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.dto.GeneralLedgerAccountSection;
+import com.positivity.accounting.internal.dto.GeneralLedgerLine;
+import com.positivity.accounting.internal.dto.GeneralLedgerReport;
+import java.math.BigDecimal;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Renders a {@link GeneralLedgerReport} as deterministic CSV (issue #1014).
+ *
+ * <p>Column and row order are fixed: metadata block (including the optional
+ * account filter, {@code ALL} when unfiltered), then one flat table with
+ * per-account sections in report order (ordered by account number). Each section
+ * emits an OPENING BALANCE marker row, the chronological in-period lines with
+ * running balance, and an ACCOUNT TOTAL marker row carrying the period
+ * debit/credit totals and the closing balance; a GRAND TOTAL row closes the
+ * table. All figures are emitted with {@link BigDecimal#toPlainString()} so the
+ * CSV matches the JSON report to the cent. The volatile {@code generatedAt}
+ * timestamp is intentionally excluded so identical report data always renders
+ * byte-identical CSV.
+ */
+@Component
+public class GeneralLedgerCsvRenderer {
+
+    private static final String ROW_HEADER =
+            "Account Number,Account Name,Entry Number,Transaction Date,Description,Debit,Credit,Running Balance";
+
+    /**
+     * Render the report to CSV.
+     *
+     * @param report the generated general ledger report
+     * @return CSV text with Unix line endings and a trailing newline
+     */
+    @NonNull
+    public String render(@NonNull GeneralLedgerReport report) {
+        StringBuilder csv = new StringBuilder();
+
+        csv.append("Report,Start Date,End Date,Account Filter\n");
+        csv.append("GENERAL_LEDGER,")
+                .append(report.getStartDate())
+                .append(',')
+                .append(report.getEndDate())
+                .append(',')
+                .append(report.getAccountId() == null ? "ALL" : CsvFormat.escape(report.getAccountId()))
+                .append("\n\n");
+
+        csv.append(ROW_HEADER).append('\n');
+        for (GeneralLedgerAccountSection section : report.getAccounts()) {
+            String number = CsvFormat.escape(section.getAccountNumber());
+            String name = CsvFormat.escape(section.getAccountName());
+
+            csv.append(number)
+                    .append(',')
+                    .append(name)
+                    .append(",OPENING BALANCE,,,,,")
+                    .append(amount(section.getOpeningBalance()))
+                    .append('\n');
+            for (GeneralLedgerLine line : section.getLines()) {
+                csv.append(number)
+                        .append(',')
+                        .append(name)
+                        .append(',')
+                        .append(CsvFormat.escape(line.getEntryNumber()))
+                        .append(',')
+                        .append(line.getTransactionDate())
+                        .append(',')
+                        .append(CsvFormat.escape(line.getDescription()))
+                        .append(',')
+                        .append(amount(line.getDebitAmount()))
+                        .append(',')
+                        .append(amount(line.getCreditAmount()))
+                        .append(',')
+                        .append(amount(line.getRunningBalance()))
+                        .append('\n');
+            }
+            csv.append(number)
+                    .append(',')
+                    .append(name)
+                    .append(",ACCOUNT TOTAL,,,")
+                    .append(amount(section.getTotalDebit()))
+                    .append(',')
+                    .append(amount(section.getTotalCredit()))
+                    .append(',')
+                    .append(amount(section.getClosingBalance()))
+                    .append('\n');
+        }
+        csv.append("GRAND TOTAL,,,,,")
+                .append(amount(report.getTotalDebit()))
+                .append(',')
+                .append(amount(report.getTotalCredit()))
+                .append(",\n");
+
+        return csv.toString();
+    }
+
+    private static String amount(BigDecimal value) {
+        return CsvFormat.amount(value);
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/IncomeStatementCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/IncomeStatementCsvRenderer.java
@@ -1,0 +1,59 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.dto.IncomeStatementReport;
+import java.math.BigDecimal;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Renders an {@link IncomeStatementReport} as deterministic CSV (issue #1011).
+ *
+ * <p>Column and row order are fixed: metadata block, then one row per statement
+ * line in report order (the service builds {@code lineItems} as a
+ * {@code LinkedHashMap} in statement-line display order), then the total rows.
+ * All figures are emitted with {@link BigDecimal#toPlainString()} so the CSV
+ * matches the JSON report to the cent. The volatile {@code generatedAt}
+ * timestamp is intentionally excluded so identical report data always renders
+ * byte-identical CSV.
+ */
+@Component
+public class IncomeStatementCsvRenderer {
+
+    /**
+     * Render the report to CSV.
+     *
+     * @param report the generated income statement report
+     * @return CSV text with Unix line endings and a trailing newline
+     */
+    @NonNull
+    public String render(@NonNull IncomeStatementReport report) {
+        StringBuilder csv = new StringBuilder();
+
+        csv.append("Report,Start Date,End Date\n");
+        csv.append("INCOME_STATEMENT,")
+                .append(report.getStartDate())
+                .append(',')
+                .append(report.getEndDate())
+                .append("\n\n");
+
+        csv.append("Line Item,Amount\n");
+        for (Map.Entry<String, BigDecimal> line : report.getLineItems().entrySet()) {
+            csv.append(CsvFormat.escape(line.getKey()))
+                    .append(',')
+                    .append(CsvFormat.amount(line.getValue()))
+                    .append('\n');
+        }
+        csv.append("TOTAL_REVENUE,")
+                .append(CsvFormat.amount(report.getTotalRevenue()))
+                .append('\n');
+        csv.append("TOTAL_EXPENSES,")
+                .append(CsvFormat.amount(report.getTotalExpenses()))
+                .append('\n');
+        csv.append("NET_INCOME,")
+                .append(CsvFormat.amount(report.getNetIncome()))
+                .append('\n');
+
+        return csv.toString();
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/ReportExportServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/ReportExportServiceImpl.java
@@ -4,7 +4,6 @@ import com.positivity.accounting.internal.client.DocumentRenderClient;
 import com.positivity.accounting.internal.dto.ReportExportArtifact;
 import com.positivity.accounting.internal.dto.ReportExportRequest;
 import com.positivity.accounting.internal.dto.ReportExportResponse;
-import com.positivity.accounting.internal.dto.TaxLiabilityReport;
 import com.positivity.accounting.internal.enums.ExportFormat;
 import com.positivity.accounting.internal.enums.ExportStatus;
 import com.positivity.accounting.service.FinancialReportingService;
@@ -13,11 +12,14 @@ import com.positivity.security.common.LogSanitizer;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jspecify.annotations.NonNull;
@@ -29,26 +31,49 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
- * Implementation of {@link ReportExportService} with real rendering (issue #999).
+ * Implementation of {@link ReportExportService} with real rendering (issues #999,
+ * #1011-#1015).
  *
- * <p>Exports render synchronously at request time: CSV is produced locally by
- * {@link TaxLiabilityCsvRenderer} (deterministic column/row order, figures matching
- * the JSON report to the cent) and PDF is produced by the pos-documents service per
+ * <p>Exports render synchronously at request time: CSV is produced locally by the
+ * per-report-type renderers (deterministic column/row order, figures matching the
+ * JSON report to the cent) and PDF is produced by the pos-documents service per
  * ADR-0020 (the deterministic CSV is sent as render content). Successful renders
  * complete immediately with a download URL; failures are recorded as FAILED with a
  * reason. Job state and artifacts are persisted in-memory (JPA entity + object
  * storage deferred to a future capability sprint).
+ *
+ * <p><b>As-of-date mapping.</b> The export request carries {@code startDate} and
+ * {@code endDate}; for the as-of reports (BALANCE_SHEET, TRIAL_BALANCE,
+ * AGED_RECEIVABLES, AGED_PAYABLES) the request's {@code endDate} is used as the
+ * as-of date (decision recorded on issues #1012/#1013/#1015 and documented in the
+ * {@link ReportExportRequest} OpenAPI description).
  */
 @Service
 public class ReportExportServiceImpl implements ReportExportService {
 
     private static final Logger log = LoggerFactory.getLogger(ReportExportServiceImpl.class);
 
-    /** The only report type with rendering support so far (story T8). */
     static final String TAX_LIABILITY = "TAX_LIABILITY";
+    static final String INCOME_STATEMENT = "INCOME_STATEMENT";
+    static final String BALANCE_SHEET = "BALANCE_SHEET";
+    static final String TRIAL_BALANCE = "TRIAL_BALANCE";
+    static final String GENERAL_LEDGER = "GENERAL_LEDGER";
+    static final String AGED_RECEIVABLES = "AGED_RECEIVABLES";
+    static final String AGED_PAYABLES = "AGED_PAYABLES";
+
+    /** Report types with rendering support (stories T8 #999 and #1011-#1015). */
+    static final Set<String> SUPPORTED_REPORT_TYPES = Set.of(
+            TAX_LIABILITY,
+            INCOME_STATEMENT,
+            BALANCE_SHEET,
+            TRIAL_BALANCE,
+            GENERAL_LEDGER,
+            AGED_RECEIVABLES,
+            AGED_PAYABLES);
 
     private static final String PDF_TEMPLATE_ID = "DEFAULT_STANDARD_TEMPLATE";
 
@@ -61,7 +86,12 @@ public class ReportExportServiceImpl implements ReportExportService {
 
     private final Clock clock;
     private final FinancialReportingService financialReportingService;
-    private final TaxLiabilityCsvRenderer csvRenderer;
+    private final TaxLiabilityCsvRenderer taxLiabilityCsvRenderer;
+    private final IncomeStatementCsvRenderer incomeStatementCsvRenderer;
+    private final BalanceSheetCsvRenderer balanceSheetCsvRenderer;
+    private final TrialBalanceCsvRenderer trialBalanceCsvRenderer;
+    private final GeneralLedgerCsvRenderer generalLedgerCsvRenderer;
+    private final AgedReportCsvRenderer agedReportCsvRenderer;
     private final DocumentRenderClient documentRenderClient;
 
     /**
@@ -80,11 +110,21 @@ public class ReportExportServiceImpl implements ReportExportService {
     public ReportExportServiceImpl(
             Clock clock,
             FinancialReportingService financialReportingService,
-            TaxLiabilityCsvRenderer csvRenderer,
+            TaxLiabilityCsvRenderer taxLiabilityCsvRenderer,
+            IncomeStatementCsvRenderer incomeStatementCsvRenderer,
+            BalanceSheetCsvRenderer balanceSheetCsvRenderer,
+            TrialBalanceCsvRenderer trialBalanceCsvRenderer,
+            GeneralLedgerCsvRenderer generalLedgerCsvRenderer,
+            AgedReportCsvRenderer agedReportCsvRenderer,
             DocumentRenderClient documentRenderClient) {
         this.clock = clock;
         this.financialReportingService = financialReportingService;
-        this.csvRenderer = csvRenderer;
+        this.taxLiabilityCsvRenderer = taxLiabilityCsvRenderer;
+        this.incomeStatementCsvRenderer = incomeStatementCsvRenderer;
+        this.balanceSheetCsvRenderer = balanceSheetCsvRenderer;
+        this.trialBalanceCsvRenderer = trialBalanceCsvRenderer;
+        this.generalLedgerCsvRenderer = generalLedgerCsvRenderer;
+        this.agedReportCsvRenderer = agedReportCsvRenderer;
         this.documentRenderClient = documentRenderClient;
     }
 
@@ -114,7 +154,7 @@ public class ReportExportServiceImpl implements ReportExportService {
                 .format(request.getFormat())
                 .reportType(request.getReportType());
 
-        if (!TAX_LIABILITY.equals(request.getReportType())) {
+        if (!SUPPORTED_REPORT_TYPES.contains(request.getReportType())) {
             return builder.status(ExportStatus.FAILED)
                     .completedAt(Instant.now(clock))
                     .failureReason("Rendering is not supported for reportType '" + request.getReportType() + "'")
@@ -128,14 +168,21 @@ public class ReportExportServiceImpl implements ReportExportService {
         }
 
         try {
-            TaxLiabilityReport report =
-                    financialReportingService.generateTaxLiability(request.getStartDate(), request.getEndDate());
-            String csv = csvRenderer.render(report);
+            String csv = renderCsv(request);
             ReportExportArtifact artifact = toArtifact(request, csv);
             artifactStore.put(exportId, artifact);
             return builder.status(ExportStatus.COMPLETED)
                     .completedAt(Instant.now(clock))
                     .downloadUrl("/v1/accounting/reports/export/" + exportId + "/download")
+                    .build();
+        } catch (RestClientResponseException e) {
+            // pos-documents rejected the render (e.g. payload over its configured
+            // max-input-characters / max-table-rows limits) — fail cleanly, no 500.
+            log.warn("Report export PDF rendering rejected by pos-documents: exportId={}", exportId, e);
+            return builder.status(ExportStatus.FAILED)
+                    .completedAt(Instant.now(clock))
+                    .failureReason("PDF rendering failed (pos-documents returned "
+                            + e.getStatusCode().value() + "); see service logs for exportId " + exportId)
                     .build();
         } catch (RuntimeException e) {
             log.warn("Report export rendering failed: exportId={}", exportId, e);
@@ -146,16 +193,51 @@ public class ReportExportServiceImpl implements ReportExportService {
         }
     }
 
+    /**
+     * Generate the requested report and render it to deterministic CSV. As-of
+     * reports use the request's {@code endDate} as the as-of date; the general
+     * ledger honors the optional {@code accountId} filter.
+     */
+    private String renderCsv(ReportExportRequest request) {
+        LocalDate start = request.getStartDate();
+        LocalDate end = request.getEndDate();
+        return switch (request.getReportType()) {
+            case TAX_LIABILITY ->
+                taxLiabilityCsvRenderer.render(financialReportingService.generateTaxLiability(start, end));
+            case INCOME_STATEMENT ->
+                incomeStatementCsvRenderer.render(financialReportingService.generateIncomeStatement(start, end));
+            case BALANCE_SHEET -> balanceSheetCsvRenderer.render(financialReportingService.generateBalanceSheet(end));
+            case TRIAL_BALANCE -> trialBalanceCsvRenderer.render(financialReportingService.generateTrialBalance(end));
+            case GENERAL_LEDGER ->
+                generalLedgerCsvRenderer.render(financialReportingService.generateGeneralLedger(
+                        request.getAccountId() == null
+                                ? null
+                                : request.getAccountId().toString(),
+                        start,
+                        end));
+            case AGED_RECEIVABLES ->
+                agedReportCsvRenderer.render(financialReportingService.generateAgedReceivables(end));
+            case AGED_PAYABLES -> agedReportCsvRenderer.render(financialReportingService.generateAgedPayables(end));
+            default -> throw new IllegalStateException("Unexpected reportType '" + request.getReportType() + "'");
+        };
+    }
+
     private ReportExportArtifact toArtifact(ReportExportRequest request, String csv) {
         String baseName = sanitizeFilename(
                 (request.getFilename() != null && !request.getFilename().isBlank())
                         ? request.getFilename()
-                        : "tax-liability-" + request.getStartDate() + "-" + request.getEndDate());
+                        : defaultBaseName(request));
         if (request.getFormat() == ExportFormat.CSV) {
             return new ReportExportArtifact(csv.getBytes(StandardCharsets.UTF_8), "text/csv", baseName + ".csv");
         }
         byte[] pdf = documentRenderClient.renderPdfFromCsv(PDF_TEMPLATE_ID, csv);
         return new ReportExportArtifact(pdf, "application/pdf", baseName + ".pdf");
+    }
+
+    private static String defaultBaseName(ReportExportRequest request) {
+        return request.getReportType().toLowerCase(Locale.ROOT).replace('_', '-')
+                + "-" + request.getStartDate()
+                + "-" + request.getEndDate();
     }
 
     /**

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/ReportExportServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/ReportExportServiceImpl.java
@@ -75,6 +75,12 @@ public class ReportExportServiceImpl implements ReportExportService {
             AGED_RECEIVABLES,
             AGED_PAYABLES);
 
+    /**
+     * As-of report types: rendering uses the request's {@code endDate} as the
+     * as-of date, so default filenames carry only that date.
+     */
+    static final Set<String> AS_OF_REPORT_TYPES = Set.of(BALANCE_SHEET, TRIAL_BALANCE, AGED_RECEIVABLES, AGED_PAYABLES);
+
     private static final String PDF_TEMPLATE_ID = "DEFAULT_STANDARD_TEMPLATE";
 
     /**
@@ -235,9 +241,11 @@ public class ReportExportServiceImpl implements ReportExportService {
     }
 
     private static String defaultBaseName(ReportExportRequest request) {
-        return request.getReportType().toLowerCase(Locale.ROOT).replace('_', '-')
-                + "-" + request.getStartDate()
-                + "-" + request.getEndDate();
+        String key = request.getReportType().toLowerCase(Locale.ROOT).replace('_', '-');
+        if (AS_OF_REPORT_TYPES.contains(request.getReportType())) {
+            return key + "-" + request.getEndDate();
+        }
+        return key + "-" + request.getStartDate() + "-" + request.getEndDate();
     }
 
     /**

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRenderer.java
@@ -95,7 +95,7 @@ public class TaxLiabilityCsvRenderer {
     }
 
     private static String amount(BigDecimal value) {
-        return value == null ? "" : value.toPlainString();
+        return CsvFormat.amount(value);
     }
 
     private static String joinReasons(List<String> reasons) {
@@ -103,12 +103,6 @@ public class TaxLiabilityCsvRenderer {
     }
 
     private static String escape(String value) {
-        if (value == null) {
-            return "";
-        }
-        if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
-            return '"' + value.replace("\"", "\"\"") + '"';
-        }
-        return value;
+        return CsvFormat.escape(value);
     }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TrialBalanceCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TrialBalanceCsvRenderer.java
@@ -1,0 +1,78 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.dto.EntryNumberGapCheck;
+import com.positivity.accounting.internal.dto.TrialBalanceReport;
+import com.positivity.accounting.internal.dto.TrialBalanceRow;
+import java.math.BigDecimal;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Renders a {@link TrialBalanceReport} as deterministic CSV (issue #1013).
+ *
+ * <p>Column and row order are fixed: metadata block (the export request's
+ * {@code endDate} is used as the as-of date), per-account rows in report order
+ * (ordered by account number), a TOTAL row proving the debit/credit balance
+ * constraint, the balanced flag, and the entry-number gap-check footnote block
+ * (header always present; no rows on a clean ledger). All figures are emitted
+ * with {@link BigDecimal#toPlainString()} so the CSV matches the JSON report to
+ * the cent. The volatile {@code generatedAt} timestamp is intentionally excluded
+ * so identical report data always renders byte-identical CSV.
+ */
+@Component
+public class TrialBalanceCsvRenderer {
+
+    private static final String ROW_HEADER = "Account Number,Account Name,Total Debit,Total Credit,Balance";
+    private static final String GAP_HEADER = "Sequence Scope,Missing Entry Numbers";
+
+    /**
+     * Render the report to CSV.
+     *
+     * @param report the generated trial balance report
+     * @return CSV text with Unix line endings and a trailing newline
+     */
+    @NonNull
+    public String render(@NonNull TrialBalanceReport report) {
+        StringBuilder csv = new StringBuilder();
+
+        csv.append("Report,As-Of Date\n");
+        csv.append("TRIAL_BALANCE,").append(report.getAsOfDate()).append("\n\n");
+
+        csv.append(ROW_HEADER).append('\n');
+        for (TrialBalanceRow row : report.getRows()) {
+            csv.append(CsvFormat.escape(row.getAccountNumber()))
+                    .append(',')
+                    .append(CsvFormat.escape(row.getAccountName()))
+                    .append(',')
+                    .append(amount(row.getTotalDebit()))
+                    .append(',')
+                    .append(amount(row.getTotalCredit()))
+                    .append(',')
+                    .append(amount(row.getBalance()))
+                    .append('\n');
+        }
+        csv.append("TOTAL,,")
+                .append(amount(report.getTotalDebit()))
+                .append(',')
+                .append(amount(report.getTotalCredit()))
+                .append(",\n");
+        csv.append("BALANCED,").append(report.getBalanced()).append("\n\n");
+
+        csv.append(GAP_HEADER).append('\n');
+        for (EntryNumberGapCheck gap : report.getEntryNumberGaps()) {
+            csv.append(CsvFormat.escape(gap.getScopeKey()))
+                    .append(',')
+                    .append(CsvFormat.escape(gap.getMissingNumbers().stream()
+                            .map(String::valueOf)
+                            .collect(Collectors.joining("|"))))
+                    .append('\n');
+        }
+
+        return csv.toString();
+    }
+
+    private static String amount(BigDecimal value) {
+        return CsvFormat.amount(value);
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/GeneralLedgerAgedReportsContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/GeneralLedgerAgedReportsContractBehaviorIT.java
@@ -155,12 +155,12 @@ class GeneralLedgerAgedReportsContractBehaviorIT extends BaseContractIntegration
     }
 
     @Test
-    @DisplayName("Export round-trip: G2 report-type keys flow through request -> status")
+    @DisplayName("Export round-trip: G2 report-type keys render CSV and complete (issues #1014/#1015)")
     void exportRoundTripForG2ReportTypes() throws Exception {
         for (String reportType : new String[] {"GENERAL_LEDGER", "AGED_RECEIVABLES", "AGED_PAYABLES"}) {
             String body = """
                     {
-                      "format": "PDF",
+                      "format": "CSV",
                       "reportType": "%s",
                       "startDate": "2026-06-01",
                       "endDate": "2026-06-30",
@@ -175,7 +175,8 @@ class GeneralLedgerAgedReportsContractBehaviorIT extends BaseContractIntegration
                                     .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.exportId").exists())
-                    .andExpect(jsonPath("$.status").value("PENDING"))
+                    .andExpect(jsonPath("$.status").value("COMPLETED"))
+                    .andExpect(jsonPath("$.downloadUrl").exists())
                     .andExpect(jsonPath("$.reportType").value(reportType))
                     .andReturn();
 
@@ -190,6 +191,7 @@ class GeneralLedgerAgedReportsContractBehaviorIT extends BaseContractIntegration
                             .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.exportId").value(exportId))
+                    .andExpect(jsonPath("$.status").value("COMPLETED"))
                     .andExpect(jsonPath("$.reportType").value(reportType));
         }
     }

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/ReportExportRenderingContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/ReportExportRenderingContractBehaviorIT.java
@@ -171,7 +171,24 @@ class ReportExportRenderingContractBehaviorIT extends BaseContractIntegrationTes
         JsonNode json =
                 fetchJson(get("/v1/accounting/reports/financial/balance-sheet").param("asOfDate", END.toString()));
 
-        String csv = exportCsv("BALANCE_SHEET");
+        String created = requestExport("BALANCE_SHEET", "CSV", "")
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String id = objectMapper.readTree(created).get("exportId").asText();
+        // As-of default filename carries only the as-of date, not a period range.
+        String csv = mockMvc.perform(withAuth(
+                        get("/v1/accounting/reports/export/{exportId}/download", id),
+                        "reporting:view:financial-statements"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(
+                                "Content-Disposition",
+                                org.hamcrest.Matchers.containsString("balance-sheet-" + END + ".csv")))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
         String[] lines = csv.split("\n", -1);
 
         assertEquals("Report,As-Of Date", lines[0]);

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/ReportExportRenderingContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/ReportExportRenderingContractBehaviorIT.java
@@ -1,0 +1,590 @@
+package com.positivity.accounting.contract;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.accounting.BaseContractIntegrationTest;
+import com.positivity.accounting.internal.client.DocumentRenderClient;
+import com.positivity.accounting.internal.entity.ExtInvoice;
+import com.positivity.accounting.internal.entity.GLAccount;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.entity.StatementLineMapping;
+import com.positivity.accounting.internal.entity.VendorBill;
+import com.positivity.accounting.internal.enums.AccountType;
+import com.positivity.accounting.internal.enums.JournalEntryStatus;
+import com.positivity.accounting.internal.enums.OperationType;
+import com.positivity.accounting.internal.enums.StatementType;
+import com.positivity.accounting.internal.enums.VendorBillStatus;
+import com.positivity.accounting.internal.repository.ExtInvoiceRepository;
+import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
+import com.positivity.accounting.internal.repository.VendorBillRepository;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Contract behavior tests for the report-export rendering rails wired in issues
+ * #1011-#1015: INCOME_STATEMENT, BALANCE_SHEET, TRIAL_BALANCE, GENERAL_LEDGER,
+ * and AGED_RECEIVABLES / AGED_PAYABLES.
+ *
+ * <p>Each test proves the rendered CSV figures match the corresponding JSON
+ * report endpoint to the cent (not just export metadata), that re-rendering the
+ * same data is byte-identical, that the as-of reports use the export request's
+ * {@code endDate} as the as-of date, and that PDF rendering flows the
+ * deterministic CSV through pos-documents with clean FAILED handling when the
+ * render is rejected.
+ */
+@Transactional
+class ReportExportRenderingContractBehaviorIT extends BaseContractIntegrationTest {
+
+    @Autowired
+    private GLAccountRepository glAccountRepository;
+
+    @Autowired
+    private JournalEntryRepository journalEntryRepository;
+
+    @Autowired
+    private StatementLineMappingRepository statementLineMappingRepository;
+
+    @Autowired
+    private ExtInvoiceRepository extInvoiceRepository;
+
+    @Autowired
+    private VendorBillRepository vendorBillRepository;
+
+    @MockitoBean
+    private DocumentRenderClient documentRenderClient;
+
+    private static final UUID CASH_ID = UUID.fromString("60000000-0000-7000-8000-000000001000");
+    private static final UUID AP_ID = UUID.fromString("60000000-0000-7000-8000-000000002000");
+    private static final UUID EQUITY_ID = UUID.fromString("60000000-0000-7000-8000-000000003000");
+    private static final UUID REVENUE_ID = UUID.fromString("60000000-0000-7000-8000-000000004000");
+    private static final UUID COGS_ID = UUID.fromString("60000000-0000-7000-8000-000000005000");
+    private static final UUID CUSTOMER_ID = UUID.fromString("60000000-0000-7000-8000-000000000101");
+    private static final UUID VENDOR_ID = UUID.fromString("60000000-0000-7000-8000-000000000102");
+
+    private static final LocalDate START = LocalDate.of(2026, 6, 1);
+    private static final LocalDate END = LocalDate.of(2026, 6, 30);
+
+    private GLAccount cash;
+    private GLAccount ap;
+    private GLAccount revenue;
+    private GLAccount cogs;
+
+    @BeforeEach
+    void seedFixtures() {
+        cash = saveAccount(CASH_ID, "1000", "Cash - Operating", AccountType.ASSET);
+        ap = saveAccount(AP_ID, "2000", "Accounts Payable", AccountType.LIABILITY);
+        saveAccount(EQUITY_ID, "3000", "Owner's Equity", AccountType.EQUITY);
+        revenue = saveAccount(REVENUE_ID, "4000", "Sales Revenue", AccountType.REVENUE);
+        cogs = saveAccount(COGS_ID, "5000", "Cost of Goods Sold", AccountType.EXPENSE);
+
+        saveMapping(StatementType.INCOME_STATEMENT, "REVENUE_SALES", REVENUE_ID, "Sales Revenue", 10);
+        saveMapping(StatementType.INCOME_STATEMENT, "EXPENSE_COGS", COGS_ID, "Cost of Goods Sold", 20);
+        saveMapping(StatementType.BALANCE_SHEET, "ASSET_CURRENT_CASH", CASH_ID, "Cash", 10);
+        saveMapping(StatementType.BALANCE_SHEET, "LIABILITY_CURRENT_AP", AP_ID, "Accounts Payable", 50);
+        saveMapping(StatementType.BALANCE_SHEET, "EQUITY_OWNERS", EQUITY_ID, "Owner's Equity", 80);
+
+        // Balanced POSTED entries: cash 1000 D / revenue 1000 C, cogs 400 D / AP 400 C.
+        savePostedEntry(
+                "JE-202606-1",
+                LocalDateTime.of(2026, 6, 5, 0, 0),
+                cash,
+                new BigDecimal("1000.00"),
+                revenue,
+                new BigDecimal("1000.00"));
+        savePostedEntry(
+                "JE-202606-2",
+                LocalDateTime.of(2026, 6, 20, 0, 0),
+                cogs,
+                new BigDecimal("400.00"),
+                ap,
+                new BigDecimal("400.00"));
+
+        saveInvoice("INV-1", new BigDecimal("1000.00"), END.minusDays(15)); // current
+        saveInvoice("INV-2", new BigDecimal("500.00"), END.minusDays(45)); // 31-60
+        saveBill("BILL-1", new BigDecimal("800.00"), END.minusDays(70)); // 61-90
+    }
+
+    @Test
+    @DisplayName("INCOME_STATEMENT CSV matches the JSON report to the cent and re-renders byte-identical")
+    void incomeStatementCsvMatchesJson() throws Exception {
+        JsonNode json = fetchJson(get("/v1/accounting/reports/financial/income-statement")
+                .param("startDate", START.toString())
+                .param("endDate", END.toString()));
+
+        String csv = exportCsv("INCOME_STATEMENT");
+        String[] lines = csv.split("\n", -1);
+
+        assertEquals("Report,Start Date,End Date", lines[0]);
+        assertEquals("INCOME_STATEMENT,2026-06-01,2026-06-30", lines[1]);
+        assertEquals("Line Item,Amount", lines[3]);
+
+        int row = 4;
+        for (Map.Entry<String, JsonNode> field : json.get("lineItems").properties()) {
+            String[] parts = splitCsv(lines[row++]);
+            assertEquals(field.getKey(), parts[0]);
+            assertMoneyEquals(field.getValue(), parts[1]);
+        }
+        assertMoneyRow(lines[row++], "TOTAL_REVENUE", json.get("totalRevenue"));
+        assertMoneyRow(lines[row++], "TOTAL_EXPENSES", json.get("totalExpenses"));
+        assertMoneyRow(lines[row], "NET_INCOME", json.get("netIncome"));
+
+        assertEquals(csv, exportCsv("INCOME_STATEMENT"));
+    }
+
+    @Test
+    @DisplayName("BALANCE_SHEET CSV uses endDate as the as-of date and matches the JSON report to the cent")
+    void balanceSheetCsvMatchesJson() throws Exception {
+        JsonNode json =
+                fetchJson(get("/v1/accounting/reports/financial/balance-sheet").param("asOfDate", END.toString()));
+
+        String csv = exportCsv("BALANCE_SHEET");
+        String[] lines = csv.split("\n", -1);
+
+        assertEquals("Report,As-Of Date", lines[0]);
+        // The export request's endDate is the as-of date (issue #1012 decision).
+        assertEquals("BALANCE_SHEET," + END, lines[1]);
+        assertEquals("Line Item,Amount", lines[3]);
+
+        int row = 4;
+        for (Map.Entry<String, JsonNode> field : json.get("lineItems").properties()) {
+            String[] parts = splitCsv(lines[row++]);
+            assertEquals(field.getKey(), parts[0]);
+            assertMoneyEquals(field.getValue(), parts[1]);
+        }
+        assertMoneyRow(lines[row++], "TOTAL_ASSETS", json.get("totalAssets"));
+        assertMoneyRow(lines[row++], "TOTAL_LIABILITIES", json.get("totalLiabilities"));
+        assertMoneyRow(lines[row++], "TOTAL_EQUITY", json.get("totalEquity"));
+        assertEquals("BALANCED," + json.get("balanced").asBoolean(), lines[row]);
+
+        assertEquals(csv, exportCsv("BALANCE_SHEET"));
+    }
+
+    @Test
+    @DisplayName("TRIAL_BALANCE CSV matches per-account debits/credits and the balancing totals row to the cent")
+    void trialBalanceCsvMatchesJson() throws Exception {
+        JsonNode json =
+                fetchJson(get("/v1/accounting/reports/financial/trial-balance").param("asOf", END.toString()));
+
+        String csv = exportCsv("TRIAL_BALANCE");
+        String[] lines = csv.split("\n", -1);
+
+        assertEquals("Report,As-Of Date", lines[0]);
+        assertEquals("TRIAL_BALANCE," + END, lines[1]);
+        assertEquals("Account Number,Account Name,Total Debit,Total Credit,Balance", lines[3]);
+
+        JsonNode rows = json.get("rows");
+        assertFalse(rows.isEmpty(), "expected seeded accounts in the trial balance");
+        int row = 4;
+        for (JsonNode jsonRow : rows) {
+            String[] parts = splitCsv(lines[row++]);
+            assertEquals(jsonRow.get("accountNumber").asText(), parts[0]);
+            assertEquals(jsonRow.get("accountName").asText(), parts[1]);
+            assertMoneyEquals(jsonRow.get("totalDebit"), parts[2]);
+            assertMoneyEquals(jsonRow.get("totalCredit"), parts[3]);
+            assertMoneyEquals(jsonRow.get("balance"), parts[4]);
+        }
+        String[] total = splitCsv(lines[row++]);
+        assertEquals("TOTAL", total[0]);
+        assertMoneyEquals(json.get("totalDebit"), total[2]);
+        assertMoneyEquals(json.get("totalCredit"), total[3]);
+        assertEquals("BALANCED," + json.get("balanced").asBoolean(), lines[row]);
+        assertTrue(csv.contains("Sequence Scope,Missing Entry Numbers"));
+
+        assertEquals(csv, exportCsv("TRIAL_BALANCE"));
+    }
+
+    @Test
+    @DisplayName("GENERAL_LEDGER CSV matches sections, running balances, and grand totals to the cent")
+    void generalLedgerCsvMatchesJson() throws Exception {
+        JsonNode json = fetchJson(get("/v1/accounting/reports/financial/general-ledger")
+                .param("startDate", START.toString())
+                .param("endDate", END.toString()));
+
+        String csv = exportCsv("GENERAL_LEDGER");
+        String[] lines = csv.split("\n", -1);
+
+        assertEquals("Report,Start Date,End Date,Account Filter", lines[0]);
+        assertEquals("GENERAL_LEDGER,2026-06-01,2026-06-30,ALL", lines[1]);
+        assertEquals(
+                "Account Number,Account Name,Entry Number,Transaction Date,Description,Debit,Credit,Running Balance",
+                lines[3]);
+
+        int row = 4;
+        for (JsonNode section : json.get("accounts")) {
+            String number = section.get("accountNumber").asText();
+            String[] opening = splitCsv(lines[row++]);
+            assertEquals(number, opening[0]);
+            assertEquals("OPENING BALANCE", opening[2]);
+            assertMoneyEquals(section.get("openingBalance"), opening[7]);
+            for (JsonNode line : section.get("lines")) {
+                String[] parts = splitCsv(lines[row++]);
+                assertEquals(number, parts[0]);
+                assertEquals(line.get("entryNumber").asText(), parts[2]);
+                assertEquals(line.get("transactionDate").asText(), parts[3]);
+                assertMoneyEquals(line.get("runningBalance"), parts[7]);
+            }
+            String[] sectionTotal = splitCsv(lines[row++]);
+            assertEquals("ACCOUNT TOTAL", sectionTotal[2]);
+            assertMoneyEquals(section.get("totalDebit"), sectionTotal[5]);
+            assertMoneyEquals(section.get("totalCredit"), sectionTotal[6]);
+            assertMoneyEquals(section.get("closingBalance"), sectionTotal[7]);
+        }
+        String[] grand = splitCsv(lines[row]);
+        assertEquals("GRAND TOTAL", grand[0]);
+        assertMoneyEquals(json.get("totalDebit"), grand[5]);
+        assertMoneyEquals(json.get("totalCredit"), grand[6]);
+
+        assertEquals(csv, exportCsv("GENERAL_LEDGER"));
+    }
+
+    @Test
+    @DisplayName("GENERAL_LEDGER honors the optional accountId filter")
+    void generalLedgerAccountFilter() throws Exception {
+        String csv = exportCsv("GENERAL_LEDGER", "\"accountId\": \"" + CASH_ID + "\",");
+        String[] lines = csv.split("\n", -1);
+
+        assertEquals("GENERAL_LEDGER,2026-06-01,2026-06-30," + CASH_ID, lines[1]);
+        assertTrue(csv.contains("1000,Cash - Operating,OPENING BALANCE"));
+        assertFalse(csv.contains("4000,Sales Revenue"), "filtered export must not contain other accounts");
+    }
+
+    @Test
+    @DisplayName("AGED_RECEIVABLES CSV matches bucket figures to the cent using endDate as the as-of date")
+    void agedReceivablesCsvMatchesJson() throws Exception {
+        JsonNode json = fetchJson(
+                get("/v1/accounting/reports/financial/aged-receivables").param("asOfDate", END.toString()));
+
+        String csv = exportCsv("AGED_RECEIVABLES");
+        String[] lines = csv.split("\n", -1);
+
+        assertEquals("Report,As-Of Date", lines[0]);
+        assertEquals("AGED_RECEIVABLES," + END, lines[1]);
+        assertEquals(
+                "Customer ID,Customer Name,Current (0-30),31-60 Days,61-90 Days,90+ Days,Total Outstanding", lines[3]);
+
+        JsonNode rows = json.get("rows");
+        assertFalse(rows.isEmpty(), "expected seeded open receivables");
+        int row = 4;
+        for (JsonNode jsonRow : rows) {
+            String[] parts = splitCsv(lines[row++]);
+            assertEquals(jsonRow.get("customerId").asText(), parts[0]);
+            assertMoneyEquals(jsonRow.get("current"), parts[2]);
+            assertMoneyEquals(jsonRow.get("days31To60"), parts[3]);
+            assertMoneyEquals(jsonRow.get("days61To90"), parts[4]);
+            assertMoneyEquals(jsonRow.get("days90Plus"), parts[5]);
+            assertMoneyEquals(jsonRow.get("totalOutstanding"), parts[6]);
+        }
+        String[] total = splitCsv(lines[row]);
+        assertEquals("TOTAL", total[0]);
+        assertMoneyEquals(json.get("totals").get("current"), total[2]);
+        assertMoneyEquals(json.get("totals").get("days31To60"), total[3]);
+        assertMoneyEquals(json.get("totals").get("totalOutstanding"), total[6]);
+
+        assertEquals(csv, exportCsv("AGED_RECEIVABLES"));
+    }
+
+    @Test
+    @DisplayName("AGED_PAYABLES CSV matches bucket figures to the cent using endDate as the as-of date")
+    void agedPayablesCsvMatchesJson() throws Exception {
+        JsonNode json =
+                fetchJson(get("/v1/accounting/reports/financial/aged-payables").param("asOfDate", END.toString()));
+
+        String csv = exportCsv("AGED_PAYABLES");
+        String[] lines = csv.split("\n", -1);
+
+        assertEquals("Report,As-Of Date", lines[0]);
+        assertEquals("AGED_PAYABLES," + END, lines[1]);
+        assertEquals("Vendor ID,Vendor Name,Current (0-30),31-60 Days,61-90 Days,90+ Days,Total Outstanding", lines[3]);
+
+        JsonNode rows = json.get("rows");
+        assertFalse(rows.isEmpty(), "expected seeded open payables");
+        int row = 4;
+        for (JsonNode jsonRow : rows) {
+            String[] parts = splitCsv(lines[row++]);
+            assertEquals(jsonRow.get("vendorId").asText(), parts[0]);
+            assertMoneyEquals(jsonRow.get("current"), parts[2]);
+            assertMoneyEquals(jsonRow.get("days61To90"), parts[4]);
+            assertMoneyEquals(jsonRow.get("totalOutstanding"), parts[6]);
+        }
+        String[] total = splitCsv(lines[row]);
+        assertEquals("TOTAL", total[0]);
+        assertMoneyEquals(json.get("totals").get("days61To90"), total[4]);
+        assertMoneyEquals(json.get("totals").get("totalOutstanding"), total[6]);
+
+        assertEquals(csv, exportCsv("AGED_PAYABLES"));
+    }
+
+    @Test
+    @DisplayName("PDF export flows the deterministic CSV through pos-documents")
+    void pdfExportUsesRenderedCsv() throws Exception {
+        byte[] fakePdf = "%PDF-1.4 income-statement".getBytes(StandardCharsets.UTF_8);
+        when(documentRenderClient.renderPdfFromCsv(anyString(), anyString())).thenReturn(fakePdf);
+
+        String created = requestExport("INCOME_STATEMENT", "PDF", "")
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.downloadUrl").exists())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String id = objectMapper.readTree(created).get("exportId").asText();
+
+        byte[] pdf = mockMvc.perform(withAuth(
+                        get("/v1/accounting/reports/export/{exportId}/download", id),
+                        "reporting:view:financial-statements"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/pdf"))
+                .andReturn()
+                .getResponse()
+                .getContentAsByteArray();
+        assertArrayEquals(fakePdf, pdf);
+
+        ArgumentCaptor<String> csvCaptor = ArgumentCaptor.forClass(String.class);
+        verify(documentRenderClient).renderPdfFromCsv(anyString(), csvCaptor.capture());
+        assertTrue(csvCaptor.getValue().startsWith("Report,Start Date,End Date\nINCOME_STATEMENT,"));
+    }
+
+    @Test
+    @DisplayName("PDF render rejected by pos-documents fails cleanly with a failureReason, not a 500")
+    void oversizedPdfFailsCleanly() throws Exception {
+        when(documentRenderClient.renderPdfFromCsv(anyString(), anyString()))
+                .thenThrow(HttpClientErrorException.create(
+                        HttpStatus.PAYLOAD_TOO_LARGE, "Payload Too Large", HttpHeaders.EMPTY, new byte[0], null));
+
+        requestExport("GENERAL_LEDGER", "PDF", "")
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("FAILED"))
+                .andExpect(jsonPath("$.failureReason")
+                        .value(org.hamcrest.Matchers.containsString("pos-documents returned 413")));
+    }
+
+    // ===== export helpers =====
+
+    private org.springframework.test.web.servlet.ResultActions requestExport(
+            String reportType, String format, String extraFields) throws Exception {
+        String body = """
+                {
+                  "format": "%s",
+                  "reportType": "%s",
+                  %s
+                  "startDate": "%s",
+                  "endDate": "%s",
+                  "organizationId": "d10217f9-3ec6-46b9-9c87-e7066c100c24"
+                }
+                """.formatted(format, reportType, extraFields, START, END);
+        return mockMvc.perform(withAuth(post("/v1/accounting/reports/export"), "accounting:report:export")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .accept(MediaType.APPLICATION_JSON));
+    }
+
+    private String exportCsv(String reportType) throws Exception {
+        return exportCsv(reportType, "");
+    }
+
+    private String exportCsv(String reportType, String extraFields) throws Exception {
+        String created = requestExport(reportType, "CSV", extraFields)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.reportType").value(reportType))
+                .andExpect(jsonPath("$.downloadUrl").exists())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String id = objectMapper.readTree(created).get("exportId").asText();
+
+        return mockMvc.perform(withAuth(
+                        get("/v1/accounting/reports/export/{exportId}/download", id),
+                        "reporting:view:financial-statements"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "text/csv"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+    }
+
+    private JsonNode fetchJson(org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder request)
+            throws Exception {
+        String json = mockMvc.perform(withAuth(request).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return objectMapper.readTree(json);
+    }
+
+    private static void assertMoneyRow(String line, String label, JsonNode expected) {
+        String[] parts = splitCsv(line);
+        assertEquals(label, parts[0]);
+        assertMoneyEquals(expected, parts[1]);
+    }
+
+    private static void assertMoneyEquals(JsonNode expected, String actual) {
+        assertEquals(
+                0,
+                expected.decimalValue().compareTo(new BigDecimal(actual)),
+                "expected " + expected + " but CSV holds " + actual);
+    }
+
+    /**
+     * CSV-aware single-line field split: honors RFC-4180 quoting so fields containing
+     * commas or escaped quotes are not broken apart (unlike {@code String.split(",")}).
+     */
+    private static String[] splitCsv(String line) {
+        List<String> fields = new ArrayList<>();
+        StringBuilder field = new StringBuilder();
+        boolean inQuotes = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inQuotes) {
+                if (c == '"') {
+                    if (i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                        field.append('"');
+                        i++;
+                    } else {
+                        inQuotes = false;
+                    }
+                } else {
+                    field.append(c);
+                }
+            } else if (c == '"') {
+                inQuotes = true;
+            } else if (c == ',') {
+                fields.add(field.toString());
+                field.setLength(0);
+            } else {
+                field.append(c);
+            }
+        }
+        fields.add(field.toString());
+        return fields.toArray(new String[0]);
+    }
+
+    // ===== fixtures =====
+
+    private GLAccount saveAccount(UUID id, String code, String name, AccountType type) {
+        GLAccount account = new GLAccount();
+        account.setGlAccountId(id);
+        account.setAccountCode(code);
+        account.setAccountName(name);
+        account.setAccountType(type);
+        account.setCreatedBy("TEST");
+        account.setModifiedBy("TEST");
+        return glAccountRepository.save(account);
+    }
+
+    private void saveMapping(
+            StatementType statementType, String lineCode, UUID accountId, String accountName, int displayOrder) {
+        statementLineMappingRepository.save(StatementLineMapping.builder()
+                .mappingId(UUID.randomUUID())
+                .glAccount(new GLAccount(accountId))
+                .accountName(accountName)
+                .statementType(statementType)
+                .statementLineCode(lineCode)
+                .lineDescription(lineCode)
+                .displayOrder(displayOrder)
+                .operation(OperationType.SUM)
+                .build());
+    }
+
+    private void savePostedEntry(
+            String entryNumber,
+            LocalDateTime transactionDate,
+            GLAccount debitAccount,
+            BigDecimal debitAmount,
+            GLAccount creditAccount,
+            BigDecimal creditAmount) {
+        JournalEntry entry = new JournalEntry();
+        entry.setStatus(JournalEntryStatus.POSTED);
+        entry.setEntryNumber(entryNumber);
+        entry.setTransactionDate(transactionDate);
+        entry.setSourceEventType("TEST_EVENT");
+
+        JournalEntryLine debit = new JournalEntryLine();
+        debit.setGlAccount(debitAccount);
+        debit.setAccountCode(debitAccount.getAccountCode());
+        debit.setAccountName(debitAccount.getAccountName());
+        debit.setDebitAmount(debitAmount);
+        debit.setCreditAmount(BigDecimal.ZERO);
+        debit.setDescription("test debit");
+        entry.addLine(debit);
+
+        JournalEntryLine credit = new JournalEntryLine();
+        credit.setGlAccount(creditAccount);
+        credit.setAccountCode(creditAccount.getAccountCode());
+        credit.setAccountName(creditAccount.getAccountName());
+        credit.setDebitAmount(BigDecimal.ZERO);
+        credit.setCreditAmount(creditAmount);
+        credit.setDescription("test credit");
+        entry.addLine(credit);
+
+        entry.setTotalDebits(debitAmount);
+        entry.setTotalCredits(creditAmount);
+        entry.setIsBalanced(true);
+
+        journalEntryRepository.save(entry);
+    }
+
+    private void saveInvoice(String invoiceNumber, BigDecimal total, LocalDate invoiceDate) {
+        ExtInvoice invoice = ExtInvoice.builder()
+                .invoiceId(UUID.randomUUID())
+                .invoiceNumber(invoiceNumber)
+                .workorderId(UUID.randomUUID())
+                .partyId(CUSTOMER_ID.toString())
+                .status("POSTED")
+                .total(total)
+                .invoiceCreatedAt(invoiceDate.atStartOfDay().toInstant(ZoneOffset.UTC))
+                .aggregateVersion(1L)
+                .updatedAt(Instant.parse("2026-06-30T00:00:00Z"))
+                .build();
+        extInvoiceRepository.save(invoice);
+    }
+
+    private void saveBill(String billNumber, BigDecimal total, LocalDate dueDate) {
+        VendorBill bill = new VendorBill(UUID.randomUUID());
+        bill.setVendorId(VENDOR_ID);
+        bill.setVendorName("Global Parts Supply");
+        bill.setBillNumber(billNumber);
+        bill.setBillDate(dueDate.atStartOfDay());
+        bill.setDueDate(dueDate.atStartOfDay());
+        bill.setTotalAmount(total);
+        bill.setStatus(VendorBillStatus.APPROVED);
+        bill.setCreatedBy("TEST");
+        bill.setModifiedBy("TEST");
+        vendorBillRepository.save(bill);
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/TaxLiabilityReportContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/TaxLiabilityReportContractBehaviorIT.java
@@ -218,7 +218,7 @@ class TaxLiabilityReportContractBehaviorIT extends BaseContractIntegrationTest {
         String body = """
                 {
                   "format": "CSV",
-                  "reportType": "INCOME_STATEMENT",
+                  "reportType": "JOURNAL_LINES",
                   "startDate": "2026-06-01",
                   "endDate": "2026-06-30",
                   "organizationId": "d10217f9-3ec6-46b9-9c87-e7066c100c24"

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/AgedReportCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/AgedReportCsvRendererTest.java
@@ -1,0 +1,128 @@
+package com.positivity.accounting.internal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.positivity.accounting.internal.dto.AgedPayablesReport;
+import com.positivity.accounting.internal.dto.AgedPayablesRow;
+import com.positivity.accounting.internal.dto.AgedReceivablesReport;
+import com.positivity.accounting.internal.dto.AgedReceivablesRow;
+import com.positivity.accounting.internal.dto.AgingSummary;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link AgedReportCsvRenderer}: deterministic bucket columns for
+ * both the AR and AP sides, per-party rows in report order, grand-total row,
+ * plain-string figures, CSV escaping, and exclusion of the volatile generatedAt
+ * timestamp.
+ */
+class AgedReportCsvRendererTest {
+
+    private static final UUID CUSTOMER_ID = UUID.fromString("d10217f9-3ec6-46b9-9c87-e7066c100c24");
+    private static final UUID VENDOR_ID = UUID.fromString("d10217f9-3ec6-46b9-9c87-e7066c100c25");
+
+    private final AgedReportCsvRenderer renderer = new AgedReportCsvRenderer();
+
+    @Test
+    @DisplayName("Renders aged receivables with customer headers, bucket columns, and totals in fixed order")
+    void rendersAgedReceivablesCsv() {
+        String expected = """
+                Report,As-Of Date
+                AGED_RECEIVABLES,2026-06-30
+
+                Customer ID,Customer Name,Current (0-30),31-60 Days,61-90 Days,90+ Days,Total Outstanding
+                d10217f9-3ec6-46b9-9c87-e7066c100c24,Acme Fleet Services,1250.00,500.00,0.00,0.00,1750.00
+                TOTAL,,1250.00,500.00,0.00,0.00,1750.00
+                """;
+        assertEquals(expected, renderer.render(receivables()));
+    }
+
+    @Test
+    @DisplayName("Renders aged payables with vendor headers, bucket columns, and totals in fixed order")
+    void rendersAgedPayablesCsv() {
+        String expected = """
+                Report,As-Of Date
+                AGED_PAYABLES,2026-06-30
+
+                Vendor ID,Vendor Name,Current (0-30),31-60 Days,61-90 Days,90+ Days,Total Outstanding
+                d10217f9-3ec6-46b9-9c87-e7066c100c25,Global Parts Supply,3200.00,750.00,0.00,0.00,3950.00
+                TOTAL,,3200.00,750.00,0.00,0.00,3950.00
+                """;
+        assertEquals(expected, renderer.render(payables()));
+    }
+
+    @Test
+    @DisplayName("Party names containing commas or quotes are quoted and quote-escaped")
+    void escapesPartyNames() {
+        AgedReceivablesReport report = receivables();
+        report.getRows().getFirst().setCustomerName("Acme, Inc. \"Fleet\"");
+
+        String csv = renderer.render(report);
+
+        assertTrue(
+                csv.contains(",\"Acme, Inc. \"\"Fleet\"\"\",1250.00"),
+                "commas and quotes must be contained inside a quoted, quote-escaped field");
+    }
+
+    @Test
+    @DisplayName("Identical report data renders byte-identical CSV regardless of generatedAt")
+    void generatedAtDoesNotAffectOutput() {
+        AgedReceivablesReport first = receivables();
+        AgedReceivablesReport second = receivables();
+        second.setGeneratedAt(Instant.parse("2030-01-01T00:00:00Z"));
+
+        assertEquals(renderer.render(first), renderer.render(second));
+    }
+
+    private static AgedReceivablesReport receivables() {
+        return AgedReceivablesReport.builder()
+                .asOfDate(LocalDate.of(2026, 6, 30))
+                .generatedAt(Instant.parse("2026-06-30T08:00:00Z"))
+                .rows(List.of(AgedReceivablesRow.builder()
+                        .customerId(CUSTOMER_ID)
+                        .customerName("Acme Fleet Services")
+                        .current(new BigDecimal("1250.00"))
+                        .days31To60(new BigDecimal("500.00"))
+                        .days61To90(new BigDecimal("0.00"))
+                        .days90Plus(new BigDecimal("0.00"))
+                        .totalOutstanding(new BigDecimal("1750.00"))
+                        .build()))
+                .totals(AgingSummary.builder()
+                        .current(new BigDecimal("1250.00"))
+                        .days31To60(new BigDecimal("500.00"))
+                        .days61To90(new BigDecimal("0.00"))
+                        .days90Plus(new BigDecimal("0.00"))
+                        .totalOutstanding(new BigDecimal("1750.00"))
+                        .build())
+                .build();
+    }
+
+    private static AgedPayablesReport payables() {
+        return AgedPayablesReport.builder()
+                .asOfDate(LocalDate.of(2026, 6, 30))
+                .generatedAt(Instant.parse("2026-06-30T08:00:00Z"))
+                .rows(List.of(AgedPayablesRow.builder()
+                        .vendorId(VENDOR_ID)
+                        .vendorName("Global Parts Supply")
+                        .current(new BigDecimal("3200.00"))
+                        .days31To60(new BigDecimal("750.00"))
+                        .days61To90(new BigDecimal("0.00"))
+                        .days90Plus(new BigDecimal("0.00"))
+                        .totalOutstanding(new BigDecimal("3950.00"))
+                        .build()))
+                .totals(AgingSummary.builder()
+                        .current(new BigDecimal("3200.00"))
+                        .days31To60(new BigDecimal("750.00"))
+                        .days61To90(new BigDecimal("0.00"))
+                        .days90Plus(new BigDecimal("0.00"))
+                        .totalOutstanding(new BigDecimal("3950.00"))
+                        .build())
+                .build();
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/BalanceSheetCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/BalanceSheetCsvRendererTest.java
@@ -1,0 +1,67 @@
+package com.positivity.accounting.internal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.positivity.accounting.internal.dto.BalanceSheetReport;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link BalanceSheetCsvRenderer}: deterministic column order,
+ * line items in report order, plain-string figures, and exclusion of the
+ * volatile generatedAt timestamp.
+ */
+class BalanceSheetCsvRendererTest {
+
+    private final BalanceSheetCsvRenderer renderer = new BalanceSheetCsvRenderer();
+
+    @Test
+    @DisplayName("Renders metadata, line items in report order, totals, and balanced flag in fixed order")
+    void rendersDeterministicCsv() {
+        String expected = """
+                Report,As-Of Date
+                BALANCE_SHEET,2026-06-30
+
+                Line Item,Amount
+                ASSET_CURRENT_CASH,1250000.00
+                LIABILITY_CURRENT_AP,450000.00
+                EQUITY_OWNERS,800000.00
+                TOTAL_ASSETS,1250000.00
+                TOTAL_LIABILITIES,450000.00
+                TOTAL_EQUITY,800000.00
+                BALANCED,true
+                """;
+        assertEquals(expected, renderer.render(report()));
+    }
+
+    @Test
+    @DisplayName("Identical report data renders byte-identical CSV regardless of generatedAt")
+    void generatedAtDoesNotAffectOutput() {
+        BalanceSheetReport first = report();
+        BalanceSheetReport second = report();
+        second.setGeneratedAt(Instant.parse("2030-01-01T00:00:00Z"));
+
+        assertEquals(renderer.render(first), renderer.render(second));
+    }
+
+    private static BalanceSheetReport report() {
+        Map<String, BigDecimal> lineItems = new LinkedHashMap<>();
+        lineItems.put("ASSET_CURRENT_CASH", new BigDecimal("1250000.00"));
+        lineItems.put("LIABILITY_CURRENT_AP", new BigDecimal("450000.00"));
+        lineItems.put("EQUITY_OWNERS", new BigDecimal("800000.00"));
+        return BalanceSheetReport.builder()
+                .asOfDate(LocalDate.of(2026, 6, 30))
+                .generatedAt(Instant.parse("2026-06-30T08:00:00Z"))
+                .lineItems(lineItems)
+                .totalAssets(new BigDecimal("1250000.00"))
+                .totalLiabilities(new BigDecimal("450000.00"))
+                .totalEquity(new BigDecimal("800000.00"))
+                .balanced(true)
+                .build();
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/GeneralLedgerCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/GeneralLedgerCsvRendererTest.java
@@ -1,0 +1,100 @@
+package com.positivity.accounting.internal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.positivity.accounting.internal.dto.GeneralLedgerAccountSection;
+import com.positivity.accounting.internal.dto.GeneralLedgerLine;
+import com.positivity.accounting.internal.dto.GeneralLedgerReport;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link GeneralLedgerCsvRenderer}: deterministic column order,
+ * per-account sections with opening/closing markers and running balances, grand
+ * totals, plain-string figures, and exclusion of the volatile generatedAt
+ * timestamp.
+ */
+class GeneralLedgerCsvRendererTest {
+
+    private final GeneralLedgerCsvRenderer renderer = new GeneralLedgerCsvRenderer();
+
+    @Test
+    @DisplayName("Renders metadata, section marker rows, lines with running balance, and grand totals in fixed order")
+    void rendersDeterministicCsv() {
+        String expected = """
+                Report,Start Date,End Date,Account Filter
+                GENERAL_LEDGER,2026-06-01,2026-06-30,ALL
+
+                Account Number,Account Name,Entry Number,Transaction Date,Description,Debit,Credit,Running Balance
+                1000,Cash - Operating,OPENING BALANCE,,,,,50000.00
+                1000,Cash - Operating,JE-202606-1,2026-06-05,Customer payment,30000.00,,80000.00
+                1000,Cash - Operating,JE-202606-2,2026-06-20,Rent,,5000.00,75000.00
+                1000,Cash - Operating,ACCOUNT TOTAL,,,30000.00,5000.00,75000.00
+                GRAND TOTAL,,,,,30000.00,5000.00,
+                """;
+        assertEquals(expected, renderer.render(report(null)));
+    }
+
+    @Test
+    @DisplayName("Account filter echoes in the metadata block when present")
+    void rendersAccountFilter() {
+        String accountId = "123e4567-e89b-12d3-a456-426614174000";
+
+        String csv = renderer.render(report(accountId));
+
+        assertTrue(csv.contains("GENERAL_LEDGER,2026-06-01,2026-06-30," + accountId));
+    }
+
+    @Test
+    @DisplayName("Identical report data renders byte-identical CSV regardless of generatedAt")
+    void generatedAtDoesNotAffectOutput() {
+        GeneralLedgerReport first = report(null);
+        GeneralLedgerReport second = report(null);
+        second.setGeneratedAt(Instant.parse("2030-01-01T00:00:00Z"));
+
+        assertEquals(renderer.render(first), renderer.render(second));
+    }
+
+    private static GeneralLedgerReport report(String accountId) {
+        return GeneralLedgerReport.builder()
+                .accountId(accountId)
+                .startDate(LocalDate.of(2026, 6, 1))
+                .endDate(LocalDate.of(2026, 6, 30))
+                .generatedAt(Instant.parse("2026-06-30T08:00:00Z"))
+                .accounts(List.of(GeneralLedgerAccountSection.builder()
+                        .accountId("123e4567-e89b-12d3-a456-426614174000")
+                        .accountNumber("1000")
+                        .accountName("Cash - Operating")
+                        .openingBalance(new BigDecimal("50000.00"))
+                        .lines(List.of(
+                                GeneralLedgerLine.builder()
+                                        .journalEntryId(UUID.fromString("01960003-0000-7000-8000-000000000001"))
+                                        .entryNumber("JE-202606-1")
+                                        .transactionDate(LocalDate.of(2026, 6, 5))
+                                        .description("Customer payment")
+                                        .debitAmount(new BigDecimal("30000.00"))
+                                        .runningBalance(new BigDecimal("80000.00"))
+                                        .build(),
+                                GeneralLedgerLine.builder()
+                                        .journalEntryId(UUID.fromString("01960003-0000-7000-8000-000000000002"))
+                                        .entryNumber("JE-202606-2")
+                                        .transactionDate(LocalDate.of(2026, 6, 20))
+                                        .description("Rent")
+                                        .creditAmount(new BigDecimal("5000.00"))
+                                        .runningBalance(new BigDecimal("75000.00"))
+                                        .build()))
+                        .totalDebit(new BigDecimal("30000.00"))
+                        .totalCredit(new BigDecimal("5000.00"))
+                        .closingBalance(new BigDecimal("75000.00"))
+                        .build()))
+                .totalDebit(new BigDecimal("30000.00"))
+                .totalCredit(new BigDecimal("5000.00"))
+                .build();
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/IncomeStatementCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/IncomeStatementCsvRendererTest.java
@@ -1,0 +1,80 @@
+package com.positivity.accounting.internal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.positivity.accounting.internal.dto.IncomeStatementReport;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link IncomeStatementCsvRenderer}: deterministic column order,
+ * line items in report order, plain-string figures, CSV escaping, and exclusion
+ * of the volatile generatedAt timestamp.
+ */
+class IncomeStatementCsvRendererTest {
+
+    private final IncomeStatementCsvRenderer renderer = new IncomeStatementCsvRenderer();
+
+    @Test
+    @DisplayName("Renders metadata, line items in report order, and totals in fixed order")
+    void rendersDeterministicCsv() {
+        String expected = """
+                Report,Start Date,End Date
+                INCOME_STATEMENT,2026-01-01,2026-03-31
+
+                Line Item,Amount
+                REVENUE_SALES,1250.00
+                EXPENSE_COGS,400.00
+                TOTAL_REVENUE,1250.00
+                TOTAL_EXPENSES,400.00
+                NET_INCOME,850.00
+                """;
+        assertEquals(expected, renderer.render(report()));
+    }
+
+    @Test
+    @DisplayName("Identical report data renders byte-identical CSV regardless of generatedAt")
+    void generatedAtDoesNotAffectOutput() {
+        IncomeStatementReport first = report();
+        IncomeStatementReport second = report();
+        second.setGeneratedAt(Instant.parse("2030-01-01T00:00:00Z"));
+
+        assertEquals(renderer.render(first), renderer.render(second));
+    }
+
+    @Test
+    @DisplayName("Line codes containing commas or quotes are quoted and quote-escaped")
+    void escapesLineCodes() {
+        IncomeStatementReport report = report();
+        Map<String, BigDecimal> lineItems = new LinkedHashMap<>();
+        lineItems.put("REVENUE \"NET\", ADJUSTED", new BigDecimal("1250.00"));
+        report.setLineItems(lineItems);
+
+        String csv = renderer.render(report);
+
+        assertTrue(
+                csv.contains("\"REVENUE \"\"NET\"\", ADJUSTED\",1250.00"),
+                "commas and quotes must be contained inside a quoted, quote-escaped field");
+    }
+
+    private static IncomeStatementReport report() {
+        Map<String, BigDecimal> lineItems = new LinkedHashMap<>();
+        lineItems.put("REVENUE_SALES", new BigDecimal("1250.00"));
+        lineItems.put("EXPENSE_COGS", new BigDecimal("400.00"));
+        return IncomeStatementReport.builder()
+                .startDate(LocalDate.of(2026, 1, 1))
+                .endDate(LocalDate.of(2026, 3, 31))
+                .generatedAt(Instant.parse("2026-06-30T08:00:00Z"))
+                .lineItems(lineItems)
+                .totalRevenue(new BigDecimal("1250.00"))
+                .totalExpenses(new BigDecimal("400.00"))
+                .netIncome(new BigDecimal("850.00"))
+                .build();
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TrialBalanceCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TrialBalanceCsvRendererTest.java
@@ -1,0 +1,94 @@
+package com.positivity.accounting.internal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.positivity.accounting.internal.dto.EntryNumberGapCheck;
+import com.positivity.accounting.internal.dto.TrialBalanceReport;
+import com.positivity.accounting.internal.dto.TrialBalanceRow;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TrialBalanceCsvRenderer}: deterministic column order,
+ * per-account rows in report order, debit/credit totals row, gap footnote block,
+ * plain-string figures, and exclusion of the volatile generatedAt timestamp.
+ */
+class TrialBalanceCsvRendererTest {
+
+    private final TrialBalanceCsvRenderer renderer = new TrialBalanceCsvRenderer();
+
+    @Test
+    @DisplayName("Renders metadata, account rows, totals, balanced flag, and gap footnote in fixed order")
+    void rendersDeterministicCsv() {
+        String expected = """
+                Report,As-Of Date
+                TRIAL_BALANCE,2026-06-30
+
+                Account Number,Account Name,Total Debit,Total Credit,Balance
+                1000,Cash - Operating,125000.00,45000.00,80000.00
+                2000,Accounts Payable,10000.00,90000.00,-80000.00
+                TOTAL,,135000.00,135000.00,
+                BALANCED,true
+
+                Sequence Scope,Missing Entry Numbers
+                JE-202606,7|12
+                """;
+        assertEquals(expected, renderer.render(report()));
+    }
+
+    @Test
+    @DisplayName("Clean ledger renders an empty gap footnote under the header")
+    void cleanLedgerRendersEmptyGapBlock() {
+        TrialBalanceReport report = report();
+        report.setEntryNumberGaps(List.of());
+
+        String csv = renderer.render(report);
+
+        assertEquals("Sequence Scope,Missing Entry Numbers\n", csv.substring(csv.indexOf("Sequence Scope")));
+    }
+
+    @Test
+    @DisplayName("Identical report data renders byte-identical CSV regardless of generatedAt")
+    void generatedAtDoesNotAffectOutput() {
+        TrialBalanceReport first = report();
+        TrialBalanceReport second = report();
+        second.setGeneratedAt(Instant.parse("2030-01-01T00:00:00Z"));
+
+        assertEquals(renderer.render(first), renderer.render(second));
+    }
+
+    private static TrialBalanceReport report() {
+        return TrialBalanceReport.builder()
+                .asOfDate(LocalDate.of(2026, 6, 30))
+                .generatedAt(Instant.parse("2026-06-30T08:00:00Z"))
+                .rows(List.of(
+                        TrialBalanceRow.builder()
+                                .accountId("123e4567-e89b-12d3-a456-426614174000")
+                                .accountNumber("1000")
+                                .accountName("Cash - Operating")
+                                .totalDebit(new BigDecimal("125000.00"))
+                                .totalCredit(new BigDecimal("45000.00"))
+                                .balance(new BigDecimal("80000.00"))
+                                .build(),
+                        TrialBalanceRow.builder()
+                                .accountId("123e4567-e89b-12d3-a456-426614174001")
+                                .accountNumber("2000")
+                                .accountName("Accounts Payable")
+                                .totalDebit(new BigDecimal("10000.00"))
+                                .totalCredit(new BigDecimal("90000.00"))
+                                .balance(new BigDecimal("-80000.00"))
+                                .build()))
+                .totalDebit(new BigDecimal("135000.00"))
+                .totalCredit(new BigDecimal("135000.00"))
+                .balanced(true)
+                .entryNumberGaps(List.of(EntryNumberGapCheck.builder()
+                        .scopeKey("JE-202606")
+                        .missingNumbers(List.of(7L, 12L))
+                        .build()))
+                .build();
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:999-report-export-rendering` (follow-up wave to #999 / PR #1010)
- Parent STORY (durion): n/a (direct follow-up issues to #999)
- Child issue: louisburroughs/durion-positivity-backend#1011, #1012, #1013, #1014, #1015
- Domain: `domain:accounting`

Closes #1011
Closes #1012
Closes #1013
Closes #1014
Closes #1015

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` → report export rendering (CSV/PDF)
- Durion contract PR (if applicable): n/a — additive request field (`accountId`) and schema description updates only; no breaking contract changes

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller (`ReportExportRequest` schema descriptions: `reportType`, `endDate` as-of semantics, new nullable `accountId`)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope
- What changed:
  - Wired `INCOME_STATEMENT`, `BALANCE_SHEET`, `TRIAL_BALANCE`, `GENERAL_LEDGER`, `AGED_RECEIVABLES`, and `AGED_PAYABLES` into `ReportExportServiceImpl.render(...)` for both CSV and PDF. PDF goes through pos-documents per ADR-0020, reusing the deterministic CSV as the render content.
  - New renderers in `pos-accounting/internal/service`, all following the `TaxLiabilityCsvRenderer` pattern (fixed column order, `BigDecimal.toPlainString` figures, volatile `generatedAt` excluded so identical data renders byte-identical CSV, RFC-4180 escaping via a new shared `CsvFormat` helper): `IncomeStatementCsvRenderer`, `BalanceSheetCsvRenderer`, `TrialBalanceCsvRenderer`, `GeneralLedgerCsvRenderer`, and `AgedReportCsvRenderer` (shared by the AR/AP mirror report types).
  - As-of-date decision (#1012/#1013/#1015): the export request's `endDate` is used as the as-of date for `BALANCE_SHEET`, `TRIAL_BALANCE`, `AGED_RECEIVABLES`, and `AGED_PAYABLES`; documented in the `ReportExportRequest` OpenAPI descriptions and the service javadoc.
  - `ReportExportRequest` gains a nullable `accountId` (`GENERAL_LEDGER` filter; null spans all accounts) plus updated `reportType`/`endDate` schema descriptions.
  - pos-documents render rejections (`RestClientResponseException`, e.g. payload over `documents.pdf.max-input-characters` / `max-table-rows`) now fail the export cleanly with a specific `failureReason` that includes the upstream status code — no 500.
  - Per-report-type default filenames (e.g. `income-statement-2026-01-01-2026-03-31.csv`).
- Why: after #999 / PR #1010 built the rendering rails, only `TAX_LIABILITY` was wired; every other financial report type failed with "Rendering is not supported" despite `FinancialReportingService` producing the full JSON reports. This PR closes that gap for all remaining report types (#1011-#1015).

## Tests
- [x] Unit tests added/updated — 5 new renderer unit test classes covering exact CSV output, determinism, and RFC-4180 escaping
- [x] Integration tests added/updated — new `ReportExportRenderingContractBehaviorIT` (9 tests): each report type's rendered CSV matches its JSON endpoint to the cent, byte-identical re-render, `endDate`-as-asOfDate mapping, `accountId` filter, PDF round-trip with captured CSV, and clean `FAILED` on pos-documents rejection. Updated stale tests: G2 export round-trip now expects `COMPLETED` + `downloadUrl` (was `PENDING`); T8 unsupported-type test now uses `JOURNAL_LINES`.
- [x] Provider behavioral contract tests added/updated — `ReportExportRenderingContractBehaviorIT` asserts rendered CSV content against the JSON report contracts, not just metadata
- How to run:
  - `./mvnw -pl pos-accounting test`
  - Failsafe ITs: `ReportExportRenderingContractBehaviorIT`, `TaxLiabilityReportContractBehaviorIT`, `GeneralLedgerAgedReportsContractBehaviorIT` (run in `verify`)

## Risk & Rollback
- Risk level: Low — additive rendering paths behind existing report-export endpoints; the only contract change is an additive nullable request field and description updates. Determinism and to-the-cent parity are covered by ITs.
- Rollback plan: revert commit fce80004b (single commit); previously-wired `TAX_LIABILITY` rails and the export endpoints are untouched by the revert.

## Verification
- Full `./mvnw -pl pos-accounting test`: BUILD SUCCESS (28 test classes)
- Failsafe ITs green: `ReportExportRenderingContractBehaviorIT` (9/9), `TaxLiabilityReportContractBehaviorIT` (6/6), `GeneralLedgerAgedReportsContractBehaviorIT` (5/5)
- `./mvnw spotless:apply` run before commit

## Checklist
- [ ] Branch name matches `cap/<cap-id>` (branch is `claude/1011-1015-report-export-renderers` — multi-issue follow-up wave, not a single-capability branch)
- [ ] PR title starts with `[CAP:<cap-id>]` (conventional-commit title for the multi-issue follow-up wave)
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7SNBhxjWZFyVkjo6mncHW