### PR TITLE
feat(tax,invoice): persist SalesInvoice at finalization so provider commit() resolves (#985)

### DIFF
--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/client/TaxServiceClient.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/client/TaxServiceClient.java
@@ -63,6 +63,30 @@ public class TaxServiceClient {
     @NonNull
     public TaxCalculationResponse calculateTaxDetailed(
             @NonNull List<TaxLineItem> lineItems, @NonNull TaxAddress destination, @Nullable UUID referenceId) {
+        return calculateTaxDetailed(lineItems, destination, referenceId, false);
+    }
+
+    /**
+     * Calculate tax with an explicit lifecycle intent (#985).
+     *
+     * <p>{@code committable=true} marks the calculation as destined for the provider commit/void
+     * lifecycle: pos-tax then creates a PERSISTED provider document (AvaTax {@code SalesInvoice},
+     * uncommitted) under {@code code == referenceId}, so the later
+     * {@code /transactions/{referenceId}/commit} resolves. A committable call therefore REQUIRES
+     * a non-null {@code referenceId} (the invoice id) — pos-tax rejects it otherwise.
+     *
+     * @param lineItems   the taxable line items
+     * @param destination the tax jurisdiction address (shop location)
+     * @param referenceId the source invoice identifier (the provider document code)
+     * @param committable whether this calculation binds to the provider commit/void lifecycle
+     * @return the full tax calculation response
+     */
+    @NonNull
+    public TaxCalculationResponse calculateTaxDetailed(
+            @NonNull List<TaxLineItem> lineItems,
+            @NonNull TaxAddress destination,
+            @Nullable UUID referenceId,
+            boolean committable) {
         if (log.isDebugEnabled()) {
             log.debug(
                     "Calculating tax for {} line item(s) in jurisdiction {}/{}",
@@ -77,6 +101,7 @@ public class TaxServiceClient {
                 .currencyCode(DEFAULT_CURRENCY)
                 .referenceId(referenceId)
                 .referenceType(TaxReferenceType.INVOICE)
+                .committable(committable)
                 .build();
 
         TaxCalculationResponse response = restClient

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceFinalizationServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceFinalizationServiceImpl.java
@@ -15,11 +15,14 @@ import com.positivity.invoice.internal.exception.InvoiceNotFoundException;
 import com.positivity.invoice.internal.repository.InvoiceRepository;
 import com.positivity.invoice.service.InvoiceFinalizationService;
 import com.positivity.security.common.SecurityContextHelper;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -76,6 +79,8 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
     private final InvoiceEventPublisher invoiceEventPublisher;
     private final TaxLifecycleClient taxLifecycleClient;
     private final InvoiceDueDateService invoiceDueDateService;
+    private final InvoiceTaxCalculator invoiceTaxCalculator;
+    private final InvoiceTaxBreakdownWriter taxBreakdownWriter;
 
     public InvoiceFinalizationServiceImpl(
             InvoiceRepository invoiceRepository,
@@ -84,7 +89,9 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
             ElevationTokenService elevationTokenService,
             InvoiceEventPublisher invoiceEventPublisher,
             TaxLifecycleClient taxLifecycleClient,
-            InvoiceDueDateService invoiceDueDateService) {
+            InvoiceDueDateService invoiceDueDateService,
+            InvoiceTaxCalculator invoiceTaxCalculator,
+            InvoiceTaxBreakdownWriter taxBreakdownWriter) {
         this.clock = clock;
         this.invoiceRepository = invoiceRepository;
         this.eventPublisher = eventPublisher;
@@ -92,6 +99,8 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
         this.invoiceEventPublisher = invoiceEventPublisher;
         this.taxLifecycleClient = taxLifecycleClient;
         this.invoiceDueDateService = invoiceDueDateService;
+        this.invoiceTaxCalculator = invoiceTaxCalculator;
+        this.taxBreakdownWriter = taxBreakdownWriter;
     }
 
     /**
@@ -146,6 +155,7 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
         // AC4: only DRAFT invoices are eligible for finalization.
         // Reject any non-DRAFT state (e.g., FINALIZED, POSTED, ERROR) with conflict.
         Optional<Invoice> existingOpt = invoiceRepository.findById(invoiceId);
+        TaxCalculationResponse committableTax = null;
         if (existingOpt.isPresent()) {
             Invoice existing = existingOpt.get();
             if (existing.getStatus() != InvoiceStatus.DRAFT) {
@@ -159,6 +169,20 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
             if (existing.getTax() == null) {
                 throw new IllegalStateException(
                         "Invoice " + invoiceId + " cannot be finalized: tax has not been calculated");
+            }
+            // #985 (story T6, Option A): while the invoice is still DRAFT, run the COMMITTABLE
+            // tax calculation (committable=true, referenceId == invoiceId). The provider then
+            // persists an uncommitted SalesInvoice document under code == invoiceId, so the
+            // lifecycle commit below — and the PENDING_COMMIT re-commit job on provider outage —
+            // resolve by that code. A calculation failure propagates and blocks finalization
+            // (per D-T5; the estimate-and-true-up leniency of D-T3 applies to the COMMIT step,
+            // not to document creation — a PENDING_COMMIT row without a provider document could
+            // never converge). The invoice stays DRAFT and finalization can be retried. A null
+            // result means nothing is taxable: no provider document exists and the lifecycle
+            // commit is skipped.
+            committableTax = invoiceTaxCalculator.calculateCommittable(existing);
+            if (committableTax != null) {
+                applyCommittableTax(existing, committableTax);
             }
         }
 
@@ -195,7 +219,13 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
             // Story T6 / D-T3: commit the provider tax document for the finalized invoice.
             // Synchronous utility call; never blocks the sale (the client swallows failures and
             // pos-tax records PENDING_COMMIT for the scheduled re-commit job on provider outage).
-            taxLifecycleClient.commit(saved.getId());
+            // #985: only when the committable calculation above created a provider document —
+            // with nothing taxable there is no document and a commit could never resolve.
+            if (committableTax != null) {
+                taxLifecycleClient.commit(saved.getId());
+            } else {
+                log.debug("Invoice {} has no taxable lines; skipping provider tax commit", saved.getId());
+            }
 
             return toDetailsResponse(saved);
         } else {
@@ -282,6 +312,24 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * #985: adopt the finalization-time committable calculation as the invoice's frozen tax.
+     * Runs while the invoice is still DRAFT (before the freeze-after-finalize boundary, story
+     * T5a): sets tax, recomputes the total ({@code subtotal + adjustments + tax}, matching the
+     * draft re-price formula) and refreshes the persisted per-line breakdown so the frozen
+     * figures exactly match the provider document that will be committed.
+     */
+    private void applyCommittableTax(@NonNull Invoice invoice, @NonNull TaxCalculationResponse taxResponse) {
+        BigDecimal tax = (taxResponse.getTotalTax() != null ? taxResponse.getTotalTax() : BigDecimal.ZERO)
+                .setScale(4, RoundingMode.HALF_UP);
+        BigDecimal subtotal = invoice.getSubtotal() != null ? invoice.getSubtotal() : BigDecimal.ZERO;
+        BigDecimal adjustments =
+                invoice.getAdjustmentsAmount() != null ? invoice.getAdjustmentsAmount() : BigDecimal.ZERO;
+        invoice.setTax(tax);
+        invoice.setTotal(subtotal.add(adjustments).add(tax).setScale(4, RoundingMode.HALF_UP));
+        taxBreakdownWriter.replace(Objects.requireNonNull(invoice.getId(), "invoiceId is required"), taxResponse);
+    }
 
     /**
      * True when the current actor may finalize/revert without a manager approval

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceFinalizationServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceFinalizationServiceImpl.java
@@ -22,10 +22,10 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
@@ -155,7 +155,6 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
         // AC4: only DRAFT invoices are eligible for finalization.
         // Reject any non-DRAFT state (e.g., FINALIZED, POSTED, ERROR) with conflict.
         Optional<Invoice> existingOpt = invoiceRepository.findById(invoiceId);
-        TaxCalculationResponse committableTax = null;
         if (existingOpt.isPresent()) {
             Invoice existing = existingOpt.get();
             if (existing.getStatus() != InvoiceStatus.DRAFT) {
@@ -170,6 +169,24 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
                 throw new IllegalStateException(
                         "Invoice " + invoiceId + " cannot be finalized: tax has not been calculated");
             }
+        }
+
+        // Total from the stored invoice; ZERO when no invoice found (in-memory path)
+        BigDecimal invoiceTotal = existingOpt
+                .map(inv -> inv.getTotal() != null ? inv.getTotal() : BigDecimal.ZERO)
+                .orElse(BigDecimal.ZERO);
+
+        // AC3: Permission matrix enforcement — role derived from SecurityContext.
+        // PR #1020 review: enforced BEFORE the committable tax calculation below so an
+        // unauthorized/unapproved request never triggers the provider-persisting call
+        // (no orphan AvaTax document from a rejected finalization). The manager-approval
+        // matrix therefore gates on the STORED total as it stands when finalization is
+        // requested (the last draft re-price), not on the recalculated one.
+        enforcePermissions(request, invoiceId, invoiceTotal);
+
+        TaxCalculationResponse committableTax = null;
+        if (existingOpt.isPresent()) {
+            Invoice existing = existingOpt.get();
             // #985 (story T6, Option A): while the invoice is still DRAFT, run the COMMITTABLE
             // tax calculation (committable=true, referenceId == invoiceId). The provider then
             // persists an uncommitted SalesInvoice document under code == invoiceId, so the
@@ -178,21 +195,11 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
             // (per D-T5; the estimate-and-true-up leniency of D-T3 applies to the COMMIT step,
             // not to document creation — a PENDING_COMMIT row without a provider document could
             // never converge). The invoice stays DRAFT and finalization can be retried. A null
-            // result means nothing is taxable: no provider document exists and the lifecycle
-            // commit is skipped.
+            // result means nothing is taxable: no provider document exists, the lifecycle
+            // commit is skipped, and any previously frozen tax is zeroed (stale-tax guard).
             committableTax = invoiceTaxCalculator.calculateCommittable(existing);
-            if (committableTax != null) {
-                applyCommittableTax(existing, committableTax);
-            }
+            applyCommittableTax(invoiceId, existing, committableTax);
         }
-
-        // Total from the stored invoice; ZERO when no invoice found (in-memory path)
-        BigDecimal invoiceTotal = existingOpt
-                .map(inv -> inv.getTotal() != null ? inv.getTotal() : BigDecimal.ZERO)
-                .orElse(BigDecimal.ZERO);
-
-        // AC3: Permission matrix enforcement — role derived from SecurityContext
-        enforcePermissions(request, invoiceId, invoiceTotal);
 
         // AC4: Transition DRAFT → FINALIZED
         Instant now = Instant.now(clock);
@@ -319,16 +326,23 @@ public class InvoiceFinalizationServiceImpl implements InvoiceFinalizationServic
      * T5a): sets tax, recomputes the total ({@code subtotal + adjustments + tax}, matching the
      * draft re-price formula) and refreshes the persisted per-line breakdown so the frozen
      * figures exactly match the provider document that will be committed.
+     *
+     * <p>A {@code null} response means nothing is taxable at finalization time: the frozen tax
+     * is ZERO and the persisted breakdown is cleared — a previously computed (now stale) draft
+     * tax must not survive into the FINALIZED invoice when no provider document exists.
      */
-    private void applyCommittableTax(@NonNull Invoice invoice, @NonNull TaxCalculationResponse taxResponse) {
-        BigDecimal tax = (taxResponse.getTotalTax() != null ? taxResponse.getTotalTax() : BigDecimal.ZERO)
+    private void applyCommittableTax(
+            @NonNull UUID invoiceId, @NonNull Invoice invoice, @Nullable TaxCalculationResponse taxResponse) {
+        BigDecimal tax = (taxResponse != null && taxResponse.getTotalTax() != null
+                        ? taxResponse.getTotalTax()
+                        : BigDecimal.ZERO)
                 .setScale(4, RoundingMode.HALF_UP);
         BigDecimal subtotal = invoice.getSubtotal() != null ? invoice.getSubtotal() : BigDecimal.ZERO;
         BigDecimal adjustments =
                 invoice.getAdjustmentsAmount() != null ? invoice.getAdjustmentsAmount() : BigDecimal.ZERO;
         invoice.setTax(tax);
         invoice.setTotal(subtotal.add(adjustments).add(tax).setScale(4, RoundingMode.HALF_UP));
-        taxBreakdownWriter.replace(Objects.requireNonNull(invoice.getId(), "invoiceId is required"), taxResponse);
+        taxBreakdownWriter.replace(invoiceId, taxResponse);
     }
 
     /**

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceServiceImpl.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceServiceImpl.java
@@ -1,6 +1,5 @@
 package com.positivity.invoice.internal.service;
 
-import com.positivity.invoice.internal.client.TaxServiceClient;
 import com.positivity.invoice.internal.config.InvoiceEventPublisher;
 import com.positivity.invoice.internal.dto.AdjustmentRequest;
 import com.positivity.invoice.internal.dto.InvoiceAdjustmentResponse;
@@ -19,9 +18,7 @@ import com.positivity.shared.dto.InvoiceGenerationRequest;
 import com.positivity.shared.dto.InvoiceGenerationResponse;
 import com.positivity.shared.dto.InvoiceLineItem;
 import com.positivity.shared.id.UUIDv7Generator;
-import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
 import com.positivity.tax.common.dto.TaxCalculationResponse;
-import com.positivity.tax.common.dto.TaxLineItem;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Clock;
@@ -46,8 +43,7 @@ public class InvoiceServiceImpl implements InvoiceService {
     private final Clock clock;
 
     private final InvoiceRepository invoiceRepository;
-    private final TaxServiceClient taxServiceClient;
-    private final LocationReferenceService locationReferenceService;
+    private final InvoiceTaxCalculator invoiceTaxCalculator;
     private final WorkorderReferenceService workorderReferenceService;
     private final InvoiceEventPublisher invoiceEventPublisher;
     private final InvoiceTaxBreakdownWriter taxBreakdownWriter;
@@ -67,16 +63,14 @@ public class InvoiceServiceImpl implements InvoiceService {
 
     public InvoiceServiceImpl(
             @NonNull InvoiceRepository invoiceRepository,
-            @NonNull TaxServiceClient taxServiceClient,
-            @NonNull LocationReferenceService locationReferenceService,
+            @NonNull InvoiceTaxCalculator invoiceTaxCalculator,
             @NonNull WorkorderReferenceService workorderReferenceService,
             @NonNull InvoiceEventPublisher invoiceEventPublisher,
             @NonNull InvoiceTaxBreakdownWriter taxBreakdownWriter,
             Clock clock) {
         this.clock = clock;
         this.invoiceRepository = invoiceRepository;
-        this.taxServiceClient = taxServiceClient;
-        this.locationReferenceService = locationReferenceService;
+        this.invoiceTaxCalculator = invoiceTaxCalculator;
         this.workorderReferenceService = workorderReferenceService;
         this.invoiceEventPublisher = invoiceEventPublisher;
         this.taxBreakdownWriter = taxBreakdownWriter;
@@ -296,51 +290,14 @@ public class InvoiceServiceImpl implements InvoiceService {
 
     /**
      * Calculate tax for the invoice against its shop-location jurisdiction, returning the full
-     * response (including the per-line jurisdiction breakdown story T5 persists).
-     *
-     * <p>Tax is computed on the invoice line items (the goods/services sold), matching the
-     * estimate flow. Invoice-level adjustments (discounts/fees) are applied to the total
-     * after tax and are not part of the taxable base. When there is nothing taxable the tax
-     * service is not called and {@code null} is returned.
+     * response (including the per-line jurisdiction breakdown story T5 persists). Delegates to
+     * {@link InvoiceTaxCalculator#calculateDraft(Invoice)} — a read-only re-price
+     * ({@code committable=false}); the finalization-time committable calculation lives in
+     * {@code InvoiceFinalizationServiceImpl} (#985).
      */
     @Nullable
     private TaxCalculationResponse calculateTaxResponse(@NonNull Invoice invoice) {
-        List<TaxLineItem> taxLineItems = buildTaxLineItems(invoice);
-        if (taxLineItems.isEmpty()) {
-            return null;
-        }
-
-        UUID locationId = invoice.getLocationId();
-        if (locationId == null) {
-            throw new IllegalStateException(
-                    "invoice has taxable line items but no locationId to resolve the tax jurisdiction");
-        }
-
-        TaxAddress destination = locationReferenceService.resolveTaxAddress(locationId);
-        return taxServiceClient.calculateTaxDetailed(taxLineItems, destination, invoice.getWorkorderId());
-    }
-
-    @NonNull
-    private List<TaxLineItem> buildTaxLineItems(@NonNull Invoice invoice) {
-        List<TaxLineItem> taxLineItems = new ArrayList<>();
-        int index = 0;
-        for (InvoiceItem item : invoice.getItems()) {
-            BigDecimal quantity = safeMoney(item.getQuantity(), BigDecimal.ONE);
-            BigDecimal unitPrice = safeMoney(item.getUnitPrice(), BigDecimal.ZERO);
-            // pos-tax requires positive quantity and unit price; non-positive lines contribute
-            // no tax, so skip them rather than tripping bean validation (400) on the request.
-            if (quantity.signum() <= 0 || unitPrice.signum() <= 0) {
-                continue;
-            }
-            taxLineItems.add(TaxLineItem.builder()
-                    .lineItemId(String.valueOf(++index))
-                    .description(item.getDescription())
-                    .quantity(quantity)
-                    .unitPrice(unitPrice)
-                    .taxExempt(false)
-                    .build());
-        }
-        return taxLineItems;
+        return invoiceTaxCalculator.calculateDraft(invoice);
     }
 
     @NonNull

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxBreakdownWriter.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxBreakdownWriter.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-class InvoiceTaxBreakdownWriter {
+public class InvoiceTaxBreakdownWriter {
 
     private static final int MONEY_SCALE = 4;
 
@@ -45,7 +45,7 @@ class InvoiceTaxBreakdownWriter {
      * @param response  the calculation response to materialize; {@code null} (nothing taxable)
      *                  clears the breakdown
      */
-    void replace(@NonNull UUID invoiceId, @Nullable TaxCalculationResponse response) {
+    public void replace(@NonNull UUID invoiceId, @Nullable TaxCalculationResponse response) {
         lineTaxRepository.deleteByInvoiceId(invoiceId);
         taxSummaryRepository.deleteByInvoiceId(invoiceId);
         if (response == null || response.getLineItemTaxes() == null) {

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxCalculator.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxCalculator.java
@@ -1,0 +1,122 @@
+package com.positivity.invoice.internal.service;
+
+import com.positivity.invoice.internal.client.TaxServiceClient;
+import com.positivity.invoice.internal.entity.Invoice;
+import com.positivity.invoice.internal.entity.InvoiceItem;
+import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import com.positivity.tax.common.dto.TaxLineItem;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Computes an invoice's tax against its shop-location jurisdiction (extracted from
+ * {@code InvoiceServiceImpl} for #985 so draft re-pricing and finalization share one
+ * line-item/jurisdiction mapping).
+ *
+ * <p>Tax is computed on the invoice line items (the goods/services sold). Invoice-level
+ * adjustments (discounts/fees) are applied to the total after tax and are not part of the
+ * taxable base. When there is nothing taxable the tax service is not called and {@code null}
+ * is returned.
+ *
+ * <p>Two intents (#985):
+ * <ul>
+ *   <li>{@link #calculateDraft(Invoice)} — a read-only re-price while DRAFT
+ *       ({@code committable=false}); the provider does not persist a document.</li>
+ *   <li>{@link #calculateCommittable(Invoice)} — the finalization-time calculation
+ *       ({@code committable=true}, {@code referenceId == invoiceId}); the provider persists an
+ *       uncommitted document under {@code code == invoiceId} that the subsequent lifecycle
+ *       {@code commit(invoiceId)} promotes.</li>
+ * </ul>
+ */
+@Component
+public class InvoiceTaxCalculator {
+
+    private final TaxServiceClient taxServiceClient;
+    private final LocationReferenceService locationReferenceService;
+
+    public InvoiceTaxCalculator(TaxServiceClient taxServiceClient, LocationReferenceService locationReferenceService) {
+        this.taxServiceClient = taxServiceClient;
+        this.locationReferenceService = locationReferenceService;
+    }
+
+    /**
+     * Read-only draft re-price calculation ({@code committable=false}).
+     *
+     * @param invoice the DRAFT invoice being re-priced
+     * @return the full tax response, or {@code null} when the invoice has no taxable line items
+     */
+    @Nullable
+    public TaxCalculationResponse calculateDraft(@NonNull Invoice invoice) {
+        return calculate(invoice, false, invoice.getWorkorderId());
+    }
+
+    /**
+     * Finalization-time committable calculation (#985): {@code committable=true} with
+     * {@code referenceId == invoiceId}, so the provider persists the tax document under the
+     * code the lifecycle {@code commit}/{@code void} calls resolve by.
+     *
+     * @param invoice the invoice being finalized (still DRAFT)
+     * @return the full tax response, or {@code null} when the invoice has no taxable line items
+     *         (then no provider document exists and no lifecycle commit must be attempted)
+     */
+    @Nullable
+    public TaxCalculationResponse calculateCommittable(@NonNull Invoice invoice) {
+        UUID invoiceId =
+                Objects.requireNonNull(invoice.getId(), "invoiceId is required for a committable tax calculation");
+        return calculate(invoice, true, invoiceId);
+    }
+
+    @Nullable
+    private TaxCalculationResponse calculate(
+            @NonNull Invoice invoice, boolean committable, @Nullable UUID referenceId) {
+        List<TaxLineItem> taxLineItems = buildTaxLineItems(invoice);
+        if (taxLineItems.isEmpty()) {
+            return null;
+        }
+
+        UUID locationId = invoice.getLocationId();
+        if (locationId == null) {
+            throw new IllegalStateException(
+                    "invoice has taxable line items but no locationId to resolve the tax jurisdiction");
+        }
+
+        TaxAddress destination = locationReferenceService.resolveTaxAddress(locationId);
+        return taxServiceClient.calculateTaxDetailed(taxLineItems, destination, referenceId, committable);
+    }
+
+    @NonNull
+    private List<TaxLineItem> buildTaxLineItems(@NonNull Invoice invoice) {
+        List<TaxLineItem> taxLineItems = new ArrayList<>();
+        int index = 0;
+        for (InvoiceItem item : invoice.getItems()) {
+            BigDecimal quantity = safeMoney(item.getQuantity(), BigDecimal.ONE);
+            BigDecimal unitPrice = safeMoney(item.getUnitPrice(), BigDecimal.ZERO);
+            // pos-tax requires positive quantity and unit price; non-positive lines contribute
+            // no tax, so skip them rather than tripping bean validation (400) on the request.
+            if (quantity.signum() <= 0 || unitPrice.signum() <= 0) {
+                continue;
+            }
+            taxLineItems.add(TaxLineItem.builder()
+                    .lineItemId(String.valueOf(++index))
+                    .description(item.getDescription())
+                    .quantity(quantity)
+                    .unitPrice(unitPrice)
+                    .taxExempt(false)
+                    .build());
+        }
+        return taxLineItems;
+    }
+
+    @NonNull
+    private static BigDecimal safeMoney(@Nullable BigDecimal value, @NonNull BigDecimal fallback) {
+        return (value != null ? value : fallback).setScale(4, RoundingMode.HALF_UP);
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxCalculator.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/InvoiceTaxCalculator.java
@@ -42,7 +42,8 @@ public class InvoiceTaxCalculator {
     private final TaxServiceClient taxServiceClient;
     private final LocationReferenceService locationReferenceService;
 
-    public InvoiceTaxCalculator(TaxServiceClient taxServiceClient, LocationReferenceService locationReferenceService) {
+    public InvoiceTaxCalculator(
+            @NonNull TaxServiceClient taxServiceClient, @NonNull LocationReferenceService locationReferenceService) {
         this.taxServiceClient = taxServiceClient;
         this.locationReferenceService = locationReferenceService;
     }

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceServiceImplTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/InvoiceServiceImplTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.positivity.invoice.internal.client.TaxServiceClient;
 import com.positivity.invoice.internal.dto.AdjustmentRequest;
 import com.positivity.invoice.internal.dto.InvoiceDetailsResponse;
 import com.positivity.invoice.internal.entity.Invoice;
@@ -23,7 +22,6 @@ import com.positivity.shared.dto.InvoiceCreationRequest;
 import com.positivity.shared.dto.InvoiceGenerationRequest;
 import com.positivity.shared.dto.InvoiceGenerationResponse;
 import com.positivity.shared.dto.InvoiceLineItem;
-import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
@@ -51,10 +49,7 @@ class InvoiceServiceImplTest {
     private InvoiceRepository invoiceRepository;
 
     @Mock
-    private TaxServiceClient taxServiceClient;
-
-    @Mock
-    private LocationReferenceService locationReferenceService;
+    private InvoiceTaxCalculator invoiceTaxCalculator;
 
     @Mock
     private WorkorderReferenceService workorderReferenceService;
@@ -84,16 +79,6 @@ class InvoiceServiceImplTest {
     private UUID invoiceId;
     private UUID workorderId;
     private UUID locationId;
-
-    private static TaxAddress sampleTaxAddress() {
-        return TaxAddress.builder()
-                .countryCode("US")
-                .regionCode("NC")
-                .city("Charlotte")
-                .postalCode("28202")
-                .line1("100 Trade Street")
-                .build();
-    }
 
     @BeforeEach
     void setUp() {
@@ -239,8 +224,7 @@ class InvoiceServiceImplTest {
                 .build();
 
         when(invoiceRepository.findByWorkorderId(workorderId)).thenReturn(Optional.empty());
-        when(locationReferenceService.resolveTaxAddress(any())).thenReturn(sampleTaxAddress());
-        when(taxServiceClient.calculateTaxDetailed(any(), any(), any())).thenReturn(taxResponse(5));
+        when(invoiceTaxCalculator.calculateDraft(any())).thenReturn(taxResponse(5));
         when(invoiceRepository.save(any())).thenReturn(draftInvoice);
 
         InvoiceGenerationResponse response = invoiceService.createInvoice(request);
@@ -449,8 +433,7 @@ class InvoiceServiceImplTest {
         request.setAuthorizedBy("manager1");
 
         when(invoiceRepository.findById(invoiceId)).thenReturn(Optional.of(draftInvoice));
-        when(locationReferenceService.resolveTaxAddress(any())).thenReturn(sampleTaxAddress());
-        when(taxServiceClient.calculateTaxDetailed(any(), any(), any())).thenReturn(taxResponse(8));
+        when(invoiceTaxCalculator.calculateDraft(any())).thenReturn(taxResponse(8));
         when(invoiceRepository.save(any())).thenReturn(draftInvoice);
 
         InvoiceDetailsResponse result = invoiceService.applyAdjustment(invoiceId, request);

--- a/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceFinalizationPermissionTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceFinalizationPermissionTest.java
@@ -81,6 +81,12 @@ class InvoiceFinalizationPermissionTest {
     @Mock
     private com.positivity.invoice.internal.service.InvoiceDueDateService invoiceDueDateService;
 
+    @Mock
+    private com.positivity.invoice.internal.service.InvoiceTaxCalculator invoiceTaxCalculator;
+
+    @Mock
+    private com.positivity.invoice.internal.service.InvoiceTaxBreakdownWriter taxBreakdownWriter;
+
     @InjectMocks
     private InvoiceFinalizationServiceImpl service;
 

--- a/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceFinalizationServiceTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceFinalizationServiceTest.java
@@ -86,6 +86,12 @@ class InvoiceFinalizationServiceTest {
     @Mock
     private com.positivity.invoice.internal.service.InvoiceDueDateService invoiceDueDateService;
 
+    @Mock
+    private com.positivity.invoice.internal.service.InvoiceTaxCalculator invoiceTaxCalculator;
+
+    @Mock
+    private com.positivity.invoice.internal.service.InvoiceTaxBreakdownWriter taxBreakdownWriter;
+
     @InjectMocks
     private InvoiceFinalizationServiceImpl service;
 
@@ -535,8 +541,9 @@ class InvoiceFinalizationServiceTest {
     }
 
     /**
-     * Story T6 / D-T3: finalization commits the provider tax document for the finalized
-     * invoice (synchronous utility call; never blocks the sale).
+     * Story T6 / D-T3 + #985: finalization first runs the COMMITTABLE tax calculation (which
+     * persists the provider SalesInvoice document under {@code code == invoiceId}) and only then
+     * commits the provider tax document for the finalized invoice.
      */
     @Test
     void finalize_commitsProviderTaxDocument() {
@@ -546,10 +553,88 @@ class InvoiceFinalizationServiceTest {
         draft.setId(invoiceId);
         when(invoiceRepository.findById(invoiceId)).thenReturn(Optional.of(draft));
         when(invoiceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(invoiceTaxCalculator.calculateCommittable(draft)).thenReturn(taxResponse(new BigDecimal("7.42")));
 
         service.completeInvoice(invoiceId, shopManagerRequest());
 
-        verify(taxLifecycleClient).commit(invoiceId);
+        // #985: document creation (committable calc) strictly precedes the lifecycle commit.
+        org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(invoiceTaxCalculator, taxLifecycleClient);
+        inOrder.verify(invoiceTaxCalculator).calculateCommittable(draft);
+        inOrder.verify(taxLifecycleClient).commit(invoiceId);
+    }
+
+    /**
+     * #985: the committable calculation is the invoice's frozen tax — the entity's tax/total and
+     * the persisted breakdown are refreshed from it before the DRAFT → FINALIZED transition.
+     */
+    @Test
+    void finalize_adoptsCommittableTaxAsFrozenTax() {
+        UUID invoiceId = UUID.fromString("00000000-0000-0000-0000-0000000000c3");
+        Invoice draft = draftInvoice(UUID.fromString("00000000-0000-0000-0000-0000000000c4"), BigDecimal.ZERO);
+        draft.setId(invoiceId);
+        draft.setSubtotal(new BigDecimal("100.00"));
+        when(invoiceRepository.findById(invoiceId)).thenReturn(Optional.of(draft));
+        when(invoiceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        var response = taxResponse(new BigDecimal("8.25"));
+        when(invoiceTaxCalculator.calculateCommittable(draft)).thenReturn(response);
+
+        service.completeInvoice(invoiceId, shopManagerRequest());
+
+        assertThat(draft.getTax()).isEqualByComparingTo("8.25");
+        assertThat(draft.getTotal()).isEqualByComparingTo("108.25");
+        verify(taxBreakdownWriter).replace(invoiceId, response);
+    }
+
+    /**
+     * #985: with nothing taxable there is no provider document, so no lifecycle commit must be
+     * attempted (a commit could never resolve and would poison the PENDING_COMMIT backlog).
+     */
+    @Test
+    void finalize_skipsProviderCommit_whenNothingTaxable() {
+        UUID invoiceId = UUID.fromString("00000000-0000-0000-0000-0000000000c5");
+        Invoice draft = draftInvoice(UUID.fromString("00000000-0000-0000-0000-0000000000c6"), BigDecimal.ZERO);
+        draft.setId(invoiceId);
+        when(invoiceRepository.findById(invoiceId)).thenReturn(Optional.of(draft));
+        when(invoiceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(invoiceTaxCalculator.calculateCommittable(draft)).thenReturn(null);
+
+        InvoiceDetailsResponse response = service.completeInvoice(invoiceId, shopManagerRequest());
+
+        assertThat(response.getStatus()).isEqualTo(InvoiceStatus.FINALIZED);
+        org.mockito.Mockito.verifyNoInteractions(taxLifecycleClient);
+    }
+
+    /**
+     * #985: a failed committable calculation blocks finalization (D-T5) — without the persisted
+     * provider document the later commit could never resolve. The invoice stays DRAFT.
+     */
+    @Test
+    void finalize_propagates_whenCommittableTaxCalculationFails() {
+        UUID invoiceId = UUID.fromString("00000000-0000-0000-0000-0000000000c7");
+        Invoice draft = draftInvoice(UUID.fromString("00000000-0000-0000-0000-0000000000c8"), BigDecimal.ZERO);
+        draft.setId(invoiceId);
+        when(invoiceRepository.findById(invoiceId)).thenReturn(Optional.of(draft));
+        when(invoiceTaxCalculator.calculateCommittable(draft))
+                .thenThrow(new IllegalStateException("Tax service returned a null response for tax calculation"));
+
+        assertThatThrownBy(() -> service.completeInvoice(invoiceId, shopManagerRequest()))
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThat(draft.getStatus()).isEqualTo(InvoiceStatus.DRAFT);
+        verify(invoiceRepository, org.mockito.Mockito.never()).save(any());
+        org.mockito.Mockito.verifyNoInteractions(taxLifecycleClient);
+    }
+
+    private static com.positivity.tax.common.dto.TaxCalculationResponse taxResponse(BigDecimal totalTax) {
+        return com.positivity.tax.common.dto.TaxCalculationResponse.builder()
+                .subtotal(BigDecimal.ZERO)
+                .totalTax(totalTax)
+                .total(totalTax)
+                .effectiveTaxRate(BigDecimal.ZERO)
+                .jurisdictions(List.of())
+                .lineItemTaxes(List.of())
+                .calculatedAt(TEST_CLOCK.instant())
+                .build();
     }
 
     /**

--- a/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceFinalizationServiceTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/service/InvoiceFinalizationServiceTest.java
@@ -605,6 +605,55 @@ class InvoiceFinalizationServiceTest {
     }
 
     /**
+     * PR #1020 review (Copilot): permission enforcement must strictly precede the committable
+     * tax calculation — a rejected finalization (advisor above the $500 cap, no approval code)
+     * must NOT trigger the provider-persisting call, or an unauthorized request would leave an
+     * orphan uncommitted AvaTax document behind. The matrix gates on the STORED total.
+     */
+    @Test
+    void finalize_enforcesPermissions_beforeCommittableTaxCalculation() {
+        UUID invoiceId = UUID.fromString("00000000-0000-0000-0000-0000000000c9");
+        Invoice draft = draftInvoice(UUID.fromString("00000000-0000-0000-0000-0000000000ca"), new BigDecimal("750.00"));
+        draft.setId(invoiceId);
+        when(invoiceRepository.findById(invoiceId)).thenReturn(Optional.of(draft));
+        // SERVICE_ADVISOR context (default), > $500, no approval code → rejected.
+
+        assertThatThrownBy(() -> service.completeInvoice(invoiceId, serviceAdvisorRequest(null)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("(?i).*approval.*");
+
+        assertThat(draft.getStatus()).isEqualTo(InvoiceStatus.DRAFT);
+        org.mockito.Mockito.verifyNoInteractions(invoiceTaxCalculator, taxBreakdownWriter, taxLifecycleClient);
+        verify(invoiceRepository, org.mockito.Mockito.never()).save(any());
+    }
+
+    /**
+     * PR #1020 review (F2): a previously-taxed invoice whose lines are no longer taxable at
+     * finalization must not freeze the stale draft tax — the null committable result zeroes
+     * the tax, recomputes the total and clears the persisted breakdown (no provider document
+     * exists, so no lifecycle commit either).
+     */
+    @Test
+    void finalize_zeroesStaleTax_whenNothingTaxableAtFinalization() {
+        UUID invoiceId = UUID.fromString("00000000-0000-0000-0000-0000000000cb");
+        Invoice draft = draftInvoice(UUID.fromString("00000000-0000-0000-0000-0000000000cc"), new BigDecimal("107.42"));
+        draft.setId(invoiceId);
+        draft.setSubtotal(new BigDecimal("100.00"));
+        draft.setTax(new BigDecimal("7.42")); // stale draft tax from an earlier re-price
+        when(invoiceRepository.findById(invoiceId)).thenReturn(Optional.of(draft));
+        when(invoiceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(invoiceTaxCalculator.calculateCommittable(draft)).thenReturn(null);
+
+        InvoiceDetailsResponse response = service.completeInvoice(invoiceId, shopManagerRequest());
+
+        assertThat(response.getStatus()).isEqualTo(InvoiceStatus.FINALIZED);
+        assertThat(draft.getTax()).isEqualByComparingTo("0");
+        assertThat(draft.getTotal()).isEqualByComparingTo("100.00");
+        verify(taxBreakdownWriter).replace(invoiceId, null);
+        org.mockito.Mockito.verifyNoInteractions(taxLifecycleClient);
+    }
+
+    /**
      * #985: a failed committable calculation blocks finalization (D-T5) — without the persisted
      * provider document the later commit could never resolve. The invoice stays DRAFT.
      */

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/AvalaraTaxProvider.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/AvalaraTaxProvider.java
@@ -39,8 +39,15 @@ import org.springframework.web.client.RestClient;
  *
  * <h2>AvaTax method mapping</h2>
  * <ul>
- *   <li><b>estimate</b> &rarr; {@code POST /api/v2/transactions/create} with
- *       {@code type=SalesOrder, commit=false} — an uncommitted, non-persisted estimate.</li>
+ *   <li><b>estimate</b> (read-only, {@code committable=false}) &rarr;
+ *       {@code POST /api/v2/transactions/create} with {@code type=SalesOrder, commit=false} —
+ *       an uncommitted, non-persisted estimate.</li>
+ *   <li><b>estimate</b> ({@code committable=true}, #985) &rarr;
+ *       {@code POST /api/v2/transactions/createoradjust} with
+ *       {@code type=SalesInvoice, commit=false, code=referenceId} — a PERSISTED, uncommitted
+ *       document that the later {@code commit(referenceId)} promotes (Option A of #985).
+ *       {@code createoradjust} (not {@code create}) so a retried finalization adjusts the
+ *       existing document instead of failing on a duplicate code.</li>
  *   <li><b>refund</b> &rarr; {@code POST /api/v2/transactions/create} with
  *       {@code type=ReturnInvoice}, {@code referenceCode=originalReferenceId}, positive
  *       amounts (platform convention: callers negate at posting, story T4).</li>
@@ -83,6 +90,7 @@ public class AvalaraTaxProvider implements TaxProviderClient {
     private static final int MONEY_SCALE = 2;
     private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
     private static final String CREATE_URI = "/api/v2/transactions/create";
+    private static final String CREATE_OR_ADJUST_URI = "/api/v2/transactions/createoradjust";
     private static final String COMMIT_URI = "/api/v2/companies/{companyCode}/transactions/{code}/commit";
     private static final String VOID_URI = "/api/v2/companies/{companyCode}/transactions/{code}/void";
     private static final String SHIP_TO = "ShipTo";
@@ -110,6 +118,22 @@ public class AvalaraTaxProvider implements TaxProviderClient {
     @Override
     @NonNull
     public TaxCalculationResponse estimate(@NonNull TaxCalculationRequest request) {
+        // #985 Option A: a committable calculation must leave a PERSISTED provider document
+        // behind under code == referenceId, or the later commit(referenceId) resolves nothing
+        // (AvaTax never persists a SalesOrder). SalesInvoice + commit=false is that persisted,
+        // still-uncommitted document; TaxProviderLifecycleService.commit() promotes it.
+        if (request.isCommittable()) {
+            CreateTransactionModel model = buildCreateModel(request, "SalesInvoice", null);
+            // createoradjust: re-running finalization for the same invoice adjusts the existing
+            // document rather than erroring on a duplicate code — keeps the call idempotent.
+            TransactionModel tx = call(() -> restClient
+                    .post()
+                    .uri(CREATE_OR_ADJUST_URI)
+                    .body(new CreateOrAdjustTransactionModel(model))
+                    .retrieve()
+                    .body(TransactionModel.class));
+            return mapResponse(request, tx, TaxCalculationType.SALE);
+        }
         CreateTransactionModel model = buildCreateModel(request, "SalesOrder", null);
         TransactionModel tx = call(
                 () -> restClient.post().uri(CREATE_URI).body(model).retrieve().body(TransactionModel.class));
@@ -479,6 +503,9 @@ public class AvalaraTaxProvider implements TaxProviderClient {
             String taxCode,
             String description,
             String entityUseCode) {}
+
+    /** AvaTax {@code CreateOrAdjustTransactionModel} wrapper (#985 committable path). */
+    record CreateOrAdjustTransactionModel(CreateTransactionModel createTransactionModel) {}
 
     /** AvaTax {@code CommitTransactionModel}. */
     record CommitTransactionModel(boolean commit) {}

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxProviderLifecycleService.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxProviderLifecycleService.java
@@ -26,6 +26,13 @@ import org.springframework.transaction.annotation.Transactional;
  * propagates — it records a {@link TaxProviderTransactionStatus#PENDING_COMMIT} row for the
  * re-commit job. The PENDING_COMMIT backlog is exposed as a Micrometer gauge so true-up lag
  * is visible.
+ * <p>
+ * #985: a PENDING_COMMIT row presupposes the provider document already EXISTS under
+ * {@code code == referenceId} — {@code commit()} only promotes it. That precondition is
+ * guaranteed by the caller: invoice finalization first runs a {@code committable=true}
+ * calculation (which persists an uncommitted {@code SalesInvoice} document, and whose
+ * failure blocks finalization) before invoking commit. The re-commit job therefore always
+ * retries against an existing document and converges once the provider recovers.
  */
 @Slf4j
 @Service

--- a/pos-tax/src/test/java/com/positivity/tax/internal/service/AvalaraSandboxLifecycleIT.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/service/AvalaraSandboxLifecycleIT.java
@@ -1,0 +1,123 @@
+package com.positivity.tax.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.tax.common.dto.TaxCalculationRequest;
+import com.positivity.tax.common.dto.TaxCalculationRequest.TaxAddress;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import com.positivity.tax.common.dto.TaxLineItem;
+import com.positivity.tax.common.dto.TaxProviderTransactionResult;
+import com.positivity.tax.common.enums.TaxProviderTransactionStatus;
+import com.positivity.tax.internal.config.TaxProperties;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+/**
+ * #985 live-sandbox behavioral contract test: proves against the REAL Avalara AvaTax sandbox
+ * that a committable calculation ({@code SalesInvoice}, uncommitted, {@code code == referenceId})
+ * persists a document that a later {@code commit(referenceId)} resolves BY CODE — the exact
+ * provider behavior the mocked unit tests assume. Also proves the converse premise of #985:
+ * this only works because the committable path persists the document (a {@code SalesOrder}
+ * estimate would leave nothing for commit to resolve).
+ *
+ * <p>Gated on sandbox credentials so CI without secrets skips it:
+ * {@code AVALARA_SANDBOX_ACCOUNT_ID}, {@code AVALARA_SANDBOX_LICENSE_KEY}, and optionally
+ * {@code AVALARA_SANDBOX_COMPANY_CODE} (defaults to {@code DEFAULT}). Runs in the Failsafe
+ * {@code verify} phase ({@code *IT} suffix), never in {@code test}.
+ */
+@EnabledIfEnvironmentVariable(named = "AVALARA_SANDBOX_ACCOUNT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "AVALARA_SANDBOX_LICENSE_KEY", matches = ".+")
+class AvalaraSandboxLifecycleIT {
+
+    private static final String SANDBOX_URL = "https://sandbox-rest.avatax.com";
+
+    private AvalaraTaxProvider sandboxProvider() {
+        String accountId = System.getenv("AVALARA_SANDBOX_ACCOUNT_ID");
+        String licenseKey = System.getenv("AVALARA_SANDBOX_LICENSE_KEY");
+        String companyCode = System.getenv().getOrDefault("AVALARA_SANDBOX_COMPANY_CODE", "DEFAULT");
+
+        TaxProperties properties = new TaxProperties();
+        properties.setProvider(TaxProperties.Provider.AVALARA);
+        properties.getTestMode().setEnabled(false);
+        TaxProperties.Avalara avalara = new TaxProperties.Avalara();
+        avalara.setBaseUrl(SANDBOX_URL);
+        avalara.setAccountId(accountId);
+        avalara.setLicenseKey(licenseKey);
+        avalara.setCompanyCode(companyCode);
+        properties.setAvalara(avalara);
+
+        String basicAuth = "Basic "
+                + Base64.getEncoder().encodeToString((accountId + ":" + licenseKey).getBytes(StandardCharsets.UTF_8));
+        RestClient restClient = RestClient.builder()
+                .baseUrl(SANDBOX_URL)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, basicAuth)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+        Retry retry = Retry.of(
+                "avalara-sandbox-it", RetryConfig.custom().maxAttempts(1).build());
+        return new AvalaraTaxProvider(restClient, retry, properties, Clock.systemUTC());
+    }
+
+    private TaxCalculationRequest committableRequest(UUID referenceId) {
+        return TaxCalculationRequest.builder()
+                .lineItems(List.of(TaxLineItem.builder()
+                        .lineItemId("1")
+                        .description("Sandbox contract test line")
+                        .quantity(BigDecimal.ONE)
+                        .unitPrice(new BigDecimal("100.00"))
+                        .build()))
+                .destinationAddress(TaxAddress.builder()
+                        .countryCode("US")
+                        .regionCode("CA")
+                        .city("Irvine")
+                        .postalCode("92617")
+                        .line1("2000 Main Street")
+                        .build())
+                .currencyCode("USD")
+                .customerId("SANDBOX-CONTRACT-TEST")
+                .referenceId(referenceId)
+                .committable(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("#985: committable SalesInvoice create persists a document that commit() then resolves by code,"
+            + " and void() cleans it up")
+    void createThenCommitResolvesByCode() {
+        AvalaraTaxProvider provider = sandboxProvider();
+        UUID referenceId = UUID.randomUUID();
+
+        // 1) Finalization-time committable calculation: persists SalesInvoice, uncommitted.
+        TaxCalculationResponse estimate = provider.estimate(committableRequest(referenceId));
+        assertThat(estimate.getTotalTax()).isNotNull();
+        assertThat(estimate.getExternalTransactionId()).isNotNull();
+
+        // 2) Lifecycle commit resolves the persisted document BY CODE — the #985 contract.
+        //    Before #985 (SalesOrder estimate) this call 404'd: nothing was persisted.
+        TaxProviderTransactionResult committed = provider.commit(referenceId);
+        assertThat(committed.status()).isEqualTo(TaxProviderTransactionStatus.COMMITTED);
+        assertThat(committed.externalTransactionId()).isNotNull();
+
+        // 3) Idempotent re-run of the committable calculation must not fail on a duplicate
+        //    code (createoradjust adjusts in place) — the retried-finalization scenario.
+        TaxCalculationResponse adjusted = provider.estimate(committableRequest(referenceId));
+        assertThat(adjusted.getTotalTax()).isNotNull();
+
+        // 4) Cleanup: void the sandbox document (also proves void resolves by the same code).
+        TaxProviderTransactionResult voided = provider.voidTransaction(referenceId);
+        assertThat(voided.status()).isEqualTo(TaxProviderTransactionStatus.VOIDED);
+    }
+}

--- a/pos-tax/src/test/java/com/positivity/tax/internal/service/AvalaraTaxProviderTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/service/AvalaraTaxProviderTest.java
@@ -333,6 +333,59 @@ class AvalaraTaxProviderTest {
     }
 
     @Test
+    @DisplayName("#985: a committable calculation creates a PERSISTED SalesInvoice (uncommitted) via createoradjust,"
+            + " keyed by code == referenceId")
+    void committableEstimateCreatesPersistedSalesInvoice() {
+        Fixture f = fixture();
+        f.server()
+                .expect(once(), requestTo(BASE_URL + "/api/v2/transactions/createoradjust"))
+                .andExpect(method(HttpMethod.POST))
+                // SalesInvoice (persisted document), NOT SalesOrder (throwaway estimate).
+                .andExpect(jsonPath("$.createTransactionModel.type").value("SalesInvoice"))
+                // Option A: still uncommitted — the lifecycle commit() promotes it.
+                .andExpect(jsonPath("$.createTransactionModel.commit").value(false))
+                .andExpect(jsonPath("$.createTransactionModel.code").value("550e8400-e29b-41d4-a716-446655440000"))
+                .andExpect(jsonPath("$.createTransactionModel.companyCode").value("DEFAULT"))
+                .andRespond(withSuccess(estimateResponseJson(), MediaType.APPLICATION_JSON));
+
+        TaxCalculationRequest request = sampleRequest();
+        request.setCommittable(true);
+        TaxCalculationResponse response = f.provider().estimate(request);
+        f.server().verify();
+
+        assertThat(response.getTotalTax()).isEqualByComparingTo("10.88");
+        assertThat(response.getCalculationType()).isEqualTo(TaxCalculationType.SALE);
+    }
+
+    @Test
+    @DisplayName("#985 behavioral contract: create-then-commit resolves by the same document code")
+    void createThenCommitResolvesByCode() {
+        Fixture f = fixture();
+        UUID ref = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        // 1) Finalization-time committable calculation persists the document under code == ref.
+        f.server()
+                .expect(once(), requestTo(BASE_URL + "/api/v2/transactions/createoradjust"))
+                .andExpect(jsonPath("$.createTransactionModel.code").value(ref.toString()))
+                .andRespond(withSuccess(estimateResponseJson(), MediaType.APPLICATION_JSON));
+        // 2) The lifecycle commit resolves that document BY CODE (path variable == ref).
+        f.server()
+                .expect(once(), requestTo(containsString("/api/v2/companies/DEFAULT/transactions/" + ref + "/commit")))
+                .andExpect(jsonPath("$.commit").value(true))
+                .andRespond(withSuccess(
+                        "{\"id\":987654321,\"code\":\"" + ref + "\",\"status\":\"Committed\"}",
+                        MediaType.APPLICATION_JSON));
+
+        TaxCalculationRequest request = sampleRequest();
+        request.setCommittable(true);
+        f.provider().estimate(request);
+        TaxProviderTransactionResult result = f.provider().commit(ref);
+        f.server().verify();
+
+        assertThat(result.status()).isEqualTo(TaxProviderTransactionStatus.COMMITTED);
+        assertThat(result.referenceId()).isEqualTo(ref);
+    }
+
+    @Test
     @DisplayName("#984b: a read-only estimate (committable=false) still permits a null referenceId")
     void estimatePermitsNullReferenceId() {
         Fixture f = fixture();


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:985-persist-salesinvoice-at-finalization`
- Parent STORY (durion): N/A (T6-external follow-up split out of the Odoo-parity Wave 2–5 semantic-findings pass, #982/#983/#984)
- Child issue: louisburroughs/durion-positivity-backend#985
- Domain: `domain:tax` (plus `domain:invoice` wiring)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/tax/.business-rules/BACKEND_CONTRACT_GUIDE.md` → provider lifecycle anchor
- Durion contract PR (if applicable): N/A (no external API/contract surface change; provider-adapter and internal service behavior only)

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A, no controller changes
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A

## Scope
- What changed:

### Summary
Implements #985 (Option A). The AvaTax estimate path creates `type=SalesOrder, commit=false`, which AvaTax never persists — so at invoice finalization the lifecycle `commit(referenceId)` had no provider document to resolve and a real commit would 404. This PR makes the finalization-time tax calculation create a PERSISTED, uncommitted `SalesInvoice` under `code == referenceId` (the invoice id), which the lifecycle commit then promotes.

### Changes
- pos-tax `AvalaraTaxProvider`: `committable=true` calculations now go through `POST /api/v2/transactions/createoradjust` with `type=SalesInvoice, commit=false, code=referenceId`. `createoradjust` keeps retried finalizations idempotent (adjusts in place instead of failing on a duplicate code). Read-only estimates (`committable=false`) keep the non-persisted SalesOrder path.
- pos-tax `TaxProviderLifecycleService`: documented the #985 precondition — a PENDING_COMMIT row now always has an existing provider document, so the scheduled re-commit job converges once the provider recovers.
- pos-invoice: new `InvoiceTaxCalculator` (extracted from `InvoiceServiceImpl`) shared by draft re-pricing (`committable=false`, referenceId=workorderId) and finalization (`committable=true`, referenceId=invoiceId). This also fixes a latent code mismatch: the draft calc previously used workorderId as the provider document code while commit/void resolved by invoiceId.
- pos-invoice `InvoiceFinalizationServiceImpl.completeInvoice`: while the invoice is still DRAFT, runs the committable calculation, adopts the result as the frozen tax (tax, total, persisted per-line breakdown), then finalizes and commits the provider document. A failed committable calculation blocks finalization (per D-T5; the D-T3 estimate-and-true-up leniency applies to the commit step only — a PENDING_COMMIT row without a provider document could never converge). With nothing taxable there is no provider document and the lifecycle commit is skipped.

### Decision (issue scope bullet 3 — PENDING_COMMIT interplay)
Document creation is a hard prerequisite of finalization; commit stays soft (PENDING_COMMIT + re-commit job). This guarantees every PENDING_COMMIT row has a resolvable provider document.

- Why: `commit(referenceId)` resolves the AvaTax document by `code`, but the estimate path never persisted a document — a real commit at invoice finalization would 404 (#985).

## Tests
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Provider behavioral contract tests added/updated
- How to run: `./mvnw -pl pos-tax -am test` and `./mvnw -pl pos-invoice -am test`; sandbox IT via `./mvnw -pl pos-tax verify` with `AVALARA_SANDBOX_ACCOUNT_ID`/`AVALARA_SANDBOX_LICENSE_KEY` set.

Details:
- `AvalaraTaxProviderTest`: committable create maps to persisted SalesInvoice keyed by code; create-then-commit behavioral contract (commit resolves by the same code). 13/13 pass.
- `AvalaraSandboxLifecycleIT` (new): live AvaTax sandbox contract test — create → commit → adjust → void by one code; gated on `AVALARA_SANDBOX_ACCOUNT_ID`/`AVALARA_SANDBOX_LICENSE_KEY`, runs in Failsafe verify only.
- `InvoiceFinalizationServiceTest`: document-before-commit ordering, frozen-tax adoption, skip-commit-when-nothing-taxable, calc-failure-blocks-finalization.
- Full module suites green: pos-tax 249 tests, pos-invoice 112 tests. Spotless applied.

## Risk & Rollback
- Risk level: Medium — changes the AvaTax document type/endpoint used at finalization; draft estimates unchanged. Idempotent `createoradjust` limits retry blast radius.
- Rollback plan: revert this PR; the previous behavior (non-persisted SalesOrder estimates, commit resolving nothing) is restored with no schema migration to unwind.

## Checklist
- [x] Branch name matches `cap/<cap-id>` (`cap/985-persist-salesinvoice-at-finalization`)
- [ ] PR title starts with `[CAP:<cap-id>]` (title follows conventional-commit format per orchestrator direction)
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — referenced provider lifecycle anchor; no external contract semantics changed
- [ ] Required CI checks passing (pending on this PR)

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7SNBhxjWZFyVkjo6mncHW