### PR TITLE
fix(accounting): harden report CSV rendering — formula-injection neutralization + statement-line displayOrder tiebreak (#1018)

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/StatementLineMappingRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/StatementLineMappingRepository.java
@@ -13,13 +13,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface StatementLineMappingRepository extends JpaRepository<StatementLineMapping, UUID> {
 
     /**
-     * Find all mappings for a specific statement type, ordered by display order.
+     * Find all mappings for a specific statement type, ordered by display order
+     * with the statement line code as a deterministic tiebreak (issue #1018) —
+     * two mappings sharing a display order would otherwise come back in
+     * database-dependent relative order, breaking report {@code lineItems}
+     * ordering and the byte-identical CSV rendering guarantee.
      *
      * @param statementType the statement type (INCOME_STATEMENT or BALANCE_SHEET)
-     * @return list of mappings sorted by display order
+     * @return list of mappings sorted by display order, then statement line code
      */
     @NonNull
-    List<StatementLineMapping> findByStatementTypeOrderByDisplayOrder(@NonNull StatementType statementType);
+    List<StatementLineMapping> findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
+            @NonNull StatementType statementType);
 
     /**
      * Find all mappings for a specific statement line code.

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/AgedReportCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/AgedReportCsvRenderer.java
@@ -89,9 +89,9 @@ public class AgedReportCsvRenderer {
 
         csv.append(partyHeader).append(',').append(BUCKET_COLUMNS).append('\n');
         for (PartyAgingRow row : rows) {
-            csv.append(CsvFormat.escape(row.partyId()))
+            csv.append(CsvFormat.escapeText(row.partyId()))
                     .append(',')
-                    .append(CsvFormat.escape(row.partyName()))
+                    .append(CsvFormat.escapeText(row.partyName()))
                     .append(',')
                     .append(amount(row.current()))
                     .append(',')

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/BalanceSheetCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/BalanceSheetCsvRenderer.java
@@ -36,7 +36,7 @@ public class BalanceSheetCsvRenderer {
 
         csv.append("Line Item,Amount\n");
         for (Map.Entry<String, BigDecimal> line : report.getLineItems().entrySet()) {
-            csv.append(CsvFormat.escape(line.getKey()))
+            csv.append(CsvFormat.escapeText(line.getKey()))
                     .append(',')
                     .append(CsvFormat.amount(line.getValue()))
                     .append('\n');

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CsvFormat.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CsvFormat.java
@@ -11,7 +11,8 @@ import java.math.BigDecimal;
  * LF are quoted and quote-escaped per RFC 4180.
  *
  * <p>Text fields are additionally neutralized against spreadsheet formula
- * injection (CWE-1236): a cell whose first character is {@code =}, {@code +},
+ * injection (CWE-1236): a cell whose first character (ignoring a leading
+ * space-run, which spreadsheets trim on import) is {@code =}, {@code +},
  * {@code -}, {@code @}, tab, or CR is prefixed with a single quote {@code '}
  * per OWASP CSV Injection guidance, so Excel/LibreOffice treat it as text
  * instead of evaluating it. The prefix is part of the rendered bytes and is
@@ -51,10 +52,16 @@ final class CsvFormat {
     }
 
     private static boolean startsWithFormulaCharacter(String value) {
-        if (value.isEmpty()) {
+        // Skip a leading space-run: spreadsheets trim it on import, so " =2+5"
+        // would still evaluate as a formula.
+        int i = 0;
+        while (i < value.length() && value.charAt(i) == ' ') {
+            i++;
+        }
+        if (i == value.length()) {
             return false;
         }
-        char first = value.charAt(0);
+        char first = value.charAt(i);
         return first == '=' || first == '+' || first == '-' || first == '@' || first == '\t' || first == '\r';
     }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CsvFormat.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CsvFormat.java
@@ -4,27 +4,57 @@ import java.math.BigDecimal;
 
 /**
  * Shared formatting helpers for the deterministic report CSV renderers
- * (issues #999, #1011-#1015).
+ * (issues #999, #1011-#1015, #1018).
  *
  * <p>Figures are emitted with {@link BigDecimal#toPlainString()} so rendered CSV
  * matches the JSON report to the cent; fields containing commas, quotes, CR, or
  * LF are quoted and quote-escaped per RFC 4180.
+ *
+ * <p>Text fields are additionally neutralized against spreadsheet formula
+ * injection (CWE-1236): a cell whose first character is {@code =}, {@code +},
+ * {@code -}, {@code @}, tab, or CR is prefixed with a single quote {@code '}
+ * per OWASP CSV Injection guidance, so Excel/LibreOffice treat it as text
+ * instead of evaluating it. The prefix is part of the rendered bytes and is
+ * itself deterministic, so the byte-identical rendering guarantee still holds.
+ * Numeric fields go through {@link #amount(BigDecimal)}, which legitimately
+ * emits a leading {@code -} for negatives and is deliberately left untouched —
+ * never route figures through {@link #escapeText(String)}.
  */
 final class CsvFormat {
 
     private CsvFormat() {}
 
+    /**
+     * Format a figure with {@link BigDecimal#toPlainString()} (empty string for
+     * null). Negative values keep their plain leading {@code -}; no formula
+     * neutralization is applied.
+     */
     static String amount(BigDecimal value) {
         return value == null ? "" : value.toPlainString();
     }
 
-    static String escape(String value) {
+    /**
+     * Escape a free-text cell: neutralize a formula-leading first character with
+     * a {@code '} prefix, then apply RFC 4180 quoting.
+     */
+    static String escapeText(String value) {
         if (value == null) {
             return "";
+        }
+        if (startsWithFormulaCharacter(value)) {
+            value = "'" + value;
         }
         if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
             return '"' + value.replace("\"", "\"\"") + '"';
         }
         return value;
+    }
+
+    private static boolean startsWithFormulaCharacter(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        char first = value.charAt(0);
+        return first == '=' || first == '+' || first == '-' || first == '@' || first == '\t' || first == '\r';
     }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
@@ -172,7 +172,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
         // Load all income statement mappings (ordered by display order)
         List<StatementLineMapping> mappings =
-                statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(StatementType.INCOME_STATEMENT);
+                statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
+                        StatementType.INCOME_STATEMENT);
 
         if (mappings.isEmpty()) {
             log.warn("No statement line mappings configured for INCOME_STATEMENT");
@@ -252,7 +253,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
         // Load all balance sheet mappings (ordered by display order)
         List<StatementLineMapping> mappings =
-                statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(StatementType.BALANCE_SHEET);
+                statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
+                        StatementType.BALANCE_SHEET);
 
         if (mappings.isEmpty()) {
             log.warn("No statement line mappings configured for BALANCE_SHEET");

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GeneralLedgerCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GeneralLedgerCsvRenderer.java
@@ -43,13 +43,13 @@ public class GeneralLedgerCsvRenderer {
                 .append(',')
                 .append(report.getEndDate())
                 .append(',')
-                .append(report.getAccountId() == null ? "ALL" : CsvFormat.escape(report.getAccountId()))
+                .append(report.getAccountId() == null ? "ALL" : CsvFormat.escapeText(report.getAccountId()))
                 .append("\n\n");
 
         csv.append(ROW_HEADER).append('\n');
         for (GeneralLedgerAccountSection section : report.getAccounts()) {
-            String number = CsvFormat.escape(section.getAccountNumber());
-            String name = CsvFormat.escape(section.getAccountName());
+            String number = CsvFormat.escapeText(section.getAccountNumber());
+            String name = CsvFormat.escapeText(section.getAccountName());
 
             csv.append(number)
                     .append(',')
@@ -62,11 +62,11 @@ public class GeneralLedgerCsvRenderer {
                         .append(',')
                         .append(name)
                         .append(',')
-                        .append(CsvFormat.escape(line.getEntryNumber()))
+                        .append(CsvFormat.escapeText(line.getEntryNumber()))
                         .append(',')
                         .append(line.getTransactionDate())
                         .append(',')
-                        .append(CsvFormat.escape(line.getDescription()))
+                        .append(CsvFormat.escapeText(line.getDescription()))
                         .append(',')
                         .append(amount(line.getDebitAmount()))
                         .append(',')

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/IncomeStatementCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/IncomeStatementCsvRenderer.java
@@ -39,7 +39,7 @@ public class IncomeStatementCsvRenderer {
 
         csv.append("Line Item,Amount\n");
         for (Map.Entry<String, BigDecimal> line : report.getLineItems().entrySet()) {
-            csv.append(CsvFormat.escape(line.getKey()))
+            csv.append(CsvFormat.escapeText(line.getKey()))
                     .append(',')
                     .append(CsvFormat.amount(line.getValue()))
                     .append('\n');

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
@@ -96,7 +96,7 @@ public class LaborOverheadReportServiceImpl implements LaborOverheadReportServic
     private Map<String, Set<UUID>> resolveLeafToAccounts() {
         Map<String, Set<UUID>> leafToAccounts = new HashMap<>();
         statementLineMappingRepository
-                .findByStatementTypeOrderByDisplayOrder(StatementType.LABOR_OVERHEAD)
+                .findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(StatementType.LABOR_OVERHEAD)
                 .forEach(mapping -> {
                     UUID accountId = mapping.getGlAccountId();
                     if (accountId != null && mapping.getStatementLineCode() != null) {

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRenderer.java
@@ -45,17 +45,17 @@ public class TaxLiabilityCsvRenderer {
 
         csv.append(ROW_HEADER).append('\n');
         for (TaxLiabilityRow row : report.getRows()) {
-            csv.append(escape(row.getJurisdictionType()))
+            csv.append(escapeText(row.getJurisdictionType()))
                     .append(',')
-                    .append(escape(row.getJurisdictionCode()))
+                    .append(escapeText(row.getJurisdictionCode()))
                     .append(',')
-                    .append(escape(row.getJurisdictionName()))
+                    .append(escapeText(row.getJurisdictionName()))
                     .append(',')
                     .append(amount(row.getTaxableBase()))
                     .append(',')
                     .append(amount(row.getExemptBase()))
                     .append(',')
-                    .append(escape(joinReasons(row.getExemptionReasons())))
+                    .append(escapeText(joinReasons(row.getExemptionReasons())))
                     .append(',')
                     .append(amount(row.getTaxCollectedGross()))
                     .append(',')
@@ -78,7 +78,7 @@ public class TaxLiabilityCsvRenderer {
 
         TaxLiabilityReconciliation reconciliation = report.getReconciliation();
         csv.append(RECONCILIATION_HEADER).append('\n');
-        csv.append(escape(reconciliation.getTaxPayableAccountCode()))
+        csv.append(escapeText(reconciliation.getTaxPayableAccountCode()))
                 .append(',')
                 .append(amount(reconciliation.getGlNetActivity()))
                 .append(',')
@@ -102,7 +102,7 @@ public class TaxLiabilityCsvRenderer {
         return (reasons == null || reasons.isEmpty()) ? "" : String.join("|", reasons);
     }
 
-    private static String escape(String value) {
-        return CsvFormat.escape(value);
+    private static String escapeText(String value) {
+        return CsvFormat.escapeText(value);
     }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TrialBalanceCsvRenderer.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/TrialBalanceCsvRenderer.java
@@ -41,9 +41,9 @@ public class TrialBalanceCsvRenderer {
 
         csv.append(ROW_HEADER).append('\n');
         for (TrialBalanceRow row : report.getRows()) {
-            csv.append(CsvFormat.escape(row.getAccountNumber()))
+            csv.append(CsvFormat.escapeText(row.getAccountNumber()))
                     .append(',')
-                    .append(CsvFormat.escape(row.getAccountName()))
+                    .append(CsvFormat.escapeText(row.getAccountName()))
                     .append(',')
                     .append(amount(row.getTotalDebit()))
                     .append(',')
@@ -61,9 +61,9 @@ public class TrialBalanceCsvRenderer {
 
         csv.append(GAP_HEADER).append('\n');
         for (EntryNumberGapCheck gap : report.getEntryNumberGaps()) {
-            csv.append(CsvFormat.escape(gap.getScopeKey()))
+            csv.append(CsvFormat.escapeText(gap.getScopeKey()))
                     .append(',')
-                    .append(CsvFormat.escape(gap.getMissingNumbers().stream()
+                    .append(CsvFormat.escapeText(gap.getMissingNumbers().stream()
                             .map(String::valueOf)
                             .collect(Collectors.joining("|"))))
                     .append('\n');

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/FinancialReportingContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/FinancialReportingContractBehaviorIT.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.positivity.accounting.BaseContractIntegrationTest;
+import com.positivity.accounting.internal.dto.IncomeStatementReport;
 import com.positivity.accounting.internal.entity.GLAccount;
 import com.positivity.accounting.internal.entity.StatementLineMapping;
 import com.positivity.accounting.internal.enums.AccountType;
@@ -14,6 +15,10 @@ import com.positivity.accounting.internal.enums.OperationType;
 import com.positivity.accounting.internal.enums.StatementType;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
+import com.positivity.accounting.internal.service.IncomeStatementCsvRenderer;
+import com.positivity.accounting.service.FinancialReportingService;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,6 +51,12 @@ class FinancialReportingContractBehaviorIT extends BaseContractIntegrationTest {
 
     @Autowired
     private GLAccountRepository glAccountRepository;
+
+    @Autowired
+    private FinancialReportingService financialReportingService;
+
+    @Autowired
+    private IncomeStatementCsvRenderer incomeStatementCsvRenderer;
 
     // Fixed UUIDs for deterministic testing
     private static final UUID REVENUE_ACCOUNT_ID = UUID.fromString("10000000-0000-0000-0000-000000000001");
@@ -223,6 +234,41 @@ class FinancialReportingContractBehaviorIT extends BaseContractIntegrationTest {
         assertThat(json2).contains("\"startDate\":\"2024-01-01\"");
         assertThat(json1).contains("\"endDate\":\"2024-12-31\"");
         assertThat(json2).contains("\"endDate\":\"2024-12-31\"");
+    }
+
+    @Test
+    @DisplayName("Statement-line ordering is deterministic under displayOrder ties (issue #1018)")
+    void testStatementLineOrderingDeterministicUnderDisplayOrderTies() {
+        // Two extra income-statement lines sharing EXPENSE_COGS's displayOrder (20),
+        // saved in reverse-alphabetical order so insertion order cannot masquerade
+        // as the deterministic order.
+        saveIncomeStatementMapping("00000000-0000-0000-0000-000000000006", "EXPENSE_ZZ_TIE", 20);
+        saveIncomeStatementMapping("00000000-0000-0000-0000-000000000007", "EXPENSE_AA_TIE", 20);
+
+        IncomeStatementReport first =
+                financialReportingService.generateIncomeStatement(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31));
+        IncomeStatementReport second =
+                financialReportingService.generateIncomeStatement(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31));
+
+        // displayOrder ascending, statementLineCode ascending within the tie
+        assertThat(first.getLineItems().keySet())
+                .containsExactly("REVENUE_SALES", "EXPENSE_AA_TIE", "EXPENSE_COGS", "EXPENSE_ZZ_TIE");
+        assertThat(List.copyOf(second.getLineItems().keySet()))
+                .isEqualTo(List.copyOf(first.getLineItems().keySet()));
+        assertThat(incomeStatementCsvRenderer.render(second)).isEqualTo(incomeStatementCsvRenderer.render(first));
+    }
+
+    private void saveIncomeStatementMapping(String mappingId, String lineCode, int displayOrder) {
+        statementLineMappingRepository.save(StatementLineMapping.builder()
+                .mappingId(UUID.fromString(mappingId))
+                .glAccount(new GLAccount(COGS_ACCOUNT_ID))
+                .accountName("Cost of Goods Sold")
+                .statementType(StatementType.INCOME_STATEMENT)
+                .statementLineCode(lineCode)
+                .lineDescription("Tie-break test line")
+                .displayOrder(displayOrder)
+                .operation(OperationType.SUM)
+                .build());
     }
 
     // ========== Test Data Setup ==========

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/AgedReportCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/AgedReportCsvRendererTest.java
@@ -80,6 +80,22 @@ class AgedReportCsvRendererTest {
         assertEquals(renderer.render(first), renderer.render(second));
     }
 
+    @Test
+    @DisplayName("Party names starting with =, +, or @ are neutralized; negative amounts stay plain")
+    void neutralizesFormulaLeadingPartyNames() {
+        AgedReceivablesReport receivables = receivables();
+        receivables.getRows().getFirst().setCustomerName("=HYPERLINK(\"http://evil\",\"click\")");
+        receivables.getRows().getFirst().setCurrent(new BigDecimal("-123.45"));
+        AgedPayablesReport payables = payables();
+        payables.getRows().getFirst().setVendorName("+Global @Parts");
+
+        String arCsv = renderer.render(receivables);
+        String apCsv = renderer.render(payables);
+
+        assertTrue(arCsv.contains(",\"'=HYPERLINK(\"\"http://evil\"\",\"\"click\"\")\",-123.45"));
+        assertTrue(apCsv.contains(",'+Global @Parts,3200.00"));
+    }
+
     private static AgedReceivablesReport receivables() {
         return AgedReceivablesReport.builder()
                 .asOfDate(LocalDate.of(2026, 6, 30))

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/BalanceSheetCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/BalanceSheetCsvRendererTest.java
@@ -1,6 +1,7 @@
 package com.positivity.accounting.internal.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.positivity.accounting.internal.dto.BalanceSheetReport;
 import java.math.BigDecimal;
@@ -47,6 +48,25 @@ class BalanceSheetCsvRendererTest {
         second.setGeneratedAt(Instant.parse("2030-01-01T00:00:00Z"));
 
         assertEquals(renderer.render(first), renderer.render(second));
+    }
+
+    @Test
+    @DisplayName("Line codes starting with =, +, or @ are neutralized; negative amounts stay plain")
+    void neutralizesFormulaLeadingLineCodes() {
+        BalanceSheetReport report = report();
+        Map<String, BigDecimal> lineItems = new LinkedHashMap<>();
+        lineItems.put("=2+5", new BigDecimal("1.00"));
+        lineItems.put("+ASSET", new BigDecimal("2.00"));
+        lineItems.put("@EQUITY", new BigDecimal("3.00"));
+        report.setLineItems(lineItems);
+        report.setTotalEquity(new BigDecimal("-123.45"));
+
+        String csv = renderer.render(report);
+
+        assertTrue(csv.contains("'=2+5,1.00"));
+        assertTrue(csv.contains("'+ASSET,2.00"));
+        assertTrue(csv.contains("'@EQUITY,3.00"));
+        assertTrue(csv.contains("TOTAL_EQUITY,-123.45"), "negative figures must stay plain, not neutralized");
     }
 
     private static BalanceSheetReport report() {

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/CsvFormatTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/CsvFormatTest.java
@@ -1,0 +1,57 @@
+package com.positivity.accounting.internal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CsvFormat}: RFC 4180 quoting, spreadsheet
+ * formula-injection neutralization of text cells (issue #1018), and the
+ * guarantee that numeric cells keep their plain leading minus sign.
+ */
+class CsvFormatTest {
+
+    @Test
+    @DisplayName("Text cells starting with =, +, -, or @ are neutralized with a leading single quote")
+    void neutralizesFormulaLeadingCharacters() {
+        assertEquals("'=2+5", CsvFormat.escapeText("=2+5"));
+        assertEquals("'+1234567", CsvFormat.escapeText("+1234567"));
+        assertEquals("'-2+3", CsvFormat.escapeText("-2+3"));
+        assertEquals("'@SUM(A1:A9)", CsvFormat.escapeText("@SUM(A1:A9)"));
+    }
+
+    @Test
+    @DisplayName("Text cells starting with tab or CR are neutralized per OWASP guidance")
+    void neutralizesTabAndCarriageReturn() {
+        assertEquals("'\tpadded", CsvFormat.escapeText("\tpadded"));
+        assertEquals("\"'\rreturn\"", CsvFormat.escapeText("\rreturn"));
+    }
+
+    @Test
+    @DisplayName("Ordinary text is unchanged; interior formula characters need no neutralization")
+    void leavesOrdinaryTextAlone() {
+        assertEquals("Washington", CsvFormat.escapeText("Washington"));
+        assertEquals("A=B", CsvFormat.escapeText("A=B"));
+        assertEquals("", CsvFormat.escapeText(null));
+        assertEquals("", CsvFormat.escapeText(""));
+    }
+
+    @Test
+    @DisplayName("RFC 4180 quoting still applies after neutralization")
+    void quotesAfterNeutralization() {
+        assertEquals("\"'=1,2\"", CsvFormat.escapeText("=1,2"));
+        assertEquals(
+                "\"'=HYPERLINK(\"\"http://evil\"\",\"\"click\"\")\"",
+                CsvFormat.escapeText("=HYPERLINK(\"http://evil\",\"click\")"));
+    }
+
+    @Test
+    @DisplayName("Numeric cells keep their plain leading minus sign — no neutralization")
+    void amountKeepsLeadingMinus() {
+        assertEquals("-123.45", CsvFormat.amount(new BigDecimal("-123.45")));
+        assertEquals("123.45", CsvFormat.amount(new BigDecimal("123.45")));
+        assertEquals("", CsvFormat.amount(null));
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/CsvFormatTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/CsvFormatTest.java
@@ -23,6 +23,15 @@ class CsvFormatTest {
     }
 
     @Test
+    @DisplayName("A leading space-run does not bypass neutralization — spreadsheets trim it on import")
+    void neutralizesFormulaBehindLeadingSpaces() {
+        assertEquals("' =2+5", CsvFormat.escapeText(" =2+5"));
+        assertEquals("'   +1234567", CsvFormat.escapeText("   +1234567"));
+        assertEquals("   ", CsvFormat.escapeText("   "));
+        assertEquals(" Washington", CsvFormat.escapeText(" Washington"));
+    }
+
+    @Test
     @DisplayName("Text cells starting with tab or CR are neutralized per OWASP guidance")
     void neutralizesTabAndCarriageReturn() {
         assertEquals("'\tpadded", CsvFormat.escapeText("\tpadded"));

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/GeneralLedgerCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/GeneralLedgerCsvRendererTest.java
@@ -61,6 +61,24 @@ class GeneralLedgerCsvRendererTest {
         assertEquals(renderer.render(first), renderer.render(second));
     }
 
+    @Test
+    @DisplayName("Descriptions and names starting with =, +, or @ are neutralized; negative amounts stay plain")
+    void neutralizesFormulaLeadingText() {
+        GeneralLedgerReport report = report(null);
+        GeneralLedgerAccountSection section = report.getAccounts().getFirst();
+        section.setAccountName("=HYPERLINK(\"http://evil\",\"click\")");
+        section.getLines().getFirst().setDescription("+Customer payment");
+        section.getLines().get(1).setDescription("@Rent");
+        section.setClosingBalance(new BigDecimal("-123.45"));
+
+        String csv = renderer.render(report);
+
+        assertTrue(csv.contains("1000,\"'=HYPERLINK(\"\"http://evil\"\",\"\"click\"\")\",OPENING BALANCE"));
+        assertTrue(csv.contains(",'+Customer payment,"));
+        assertTrue(csv.contains(",'@Rent,"));
+        assertTrue(csv.contains(",-123.45\n"), "negative figures must stay plain, not neutralized");
+    }
+
     private static GeneralLedgerReport report(String accountId) {
         return GeneralLedgerReport.builder()
                 .accountId(accountId)

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/IncomeStatementCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/IncomeStatementCsvRendererTest.java
@@ -63,6 +63,25 @@ class IncomeStatementCsvRendererTest {
                 "commas and quotes must be contained inside a quoted, quote-escaped field");
     }
 
+    @Test
+    @DisplayName("Line codes starting with =, +, or @ are neutralized; negative amounts stay plain")
+    void neutralizesFormulaLeadingLineCodes() {
+        IncomeStatementReport report = report();
+        Map<String, BigDecimal> lineItems = new LinkedHashMap<>();
+        lineItems.put("=HYPERLINK(\"http://evil\",\"click\")", new BigDecimal("1.00"));
+        lineItems.put("+REVENUE", new BigDecimal("2.00"));
+        lineItems.put("@ADJUSTMENT", new BigDecimal("3.00"));
+        report.setLineItems(lineItems);
+        report.setNetIncome(new BigDecimal("-123.45"));
+
+        String csv = renderer.render(report);
+
+        assertTrue(csv.contains("\"'=HYPERLINK(\"\"http://evil\"\",\"\"click\"\")\",1.00"));
+        assertTrue(csv.contains("'+REVENUE,2.00"));
+        assertTrue(csv.contains("'@ADJUSTMENT,3.00"));
+        assertTrue(csv.contains("NET_INCOME,-123.45"), "negative figures must stay plain, not neutralized");
+    }
+
     private static IncomeStatementReport report() {
         Map<String, BigDecimal> lineItems = new LinkedHashMap<>();
         lineItems.put("REVENUE_SALES", new BigDecimal("1250.00"));

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
@@ -58,7 +58,8 @@ class LaborOverheadReportServiceImplTest {
     }
 
     private void mappings(StatementLineMapping... mappings) {
-        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(eq(StatementType.LABOR_OVERHEAD)))
+        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
+                        eq(StatementType.LABOR_OVERHEAD)))
                 .thenReturn(List.of(mappings));
     }
 
@@ -187,7 +188,7 @@ class LaborOverheadReportServiceImplTest {
 
     @Test
     void generate_withNoMappings_returnsFullLayoutAllZero() {
-        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(any()))
+        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(any()))
                 .thenReturn(List.of());
 
         LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
@@ -200,7 +201,7 @@ class LaborOverheadReportServiceImplTest {
 
     @Test
     void generate_populatesUsPlantCurrencyContext() {
-        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(any()))
+        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(any()))
                 .thenReturn(List.of());
 
         LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, null);
@@ -303,7 +304,7 @@ class LaborOverheadReportServiceImplTest {
 
     @Test
     void generate_flagsUsdOnlyOnLine2_11_4() {
-        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrder(any()))
+        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(any()))
                 .thenReturn(List.of());
 
         LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TaxLiabilityCsvRendererTest.java
@@ -65,6 +65,21 @@ class TaxLiabilityCsvRendererTest {
                 "CR/LF and quotes must be contained inside a quoted, quote-escaped field");
     }
 
+    @Test
+    @DisplayName("Names and reason codes starting with =, +, or @ are neutralized; negative amounts stay plain")
+    void neutralizesFormulaLeadingText() {
+        TaxLiabilityReport report = report();
+        report.getRows().getFirst().setJurisdictionName("=HYPERLINK(\"http://evil\",\"click\")");
+        report.getRows().getFirst().setExemptionReasons(List.of("+RESALE", "@GOVT"));
+        report.getRows().getFirst().setNetTax(new BigDecimal("-123.45"));
+
+        String csv = renderer.render(report);
+
+        assertTrue(csv.contains(",\"'=HYPERLINK(\"\"http://evil\"\",\"\"click\"\")\","));
+        assertTrue(csv.contains(",'+RESALE|@GOVT,"), "only the leading character of the joined cell is neutralized");
+        assertTrue(csv.contains(",-123.45\n"), "negative figures must stay plain, not neutralized");
+    }
+
     private static TaxLiabilityReport report() {
         return TaxLiabilityReport.builder()
                 .startDate(LocalDate.of(2026, 6, 1))

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TrialBalanceCsvRendererTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/TrialBalanceCsvRendererTest.java
@@ -1,6 +1,7 @@
 package com.positivity.accounting.internal.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.positivity.accounting.internal.dto.EntryNumberGapCheck;
 import com.positivity.accounting.internal.dto.TrialBalanceReport;
@@ -59,6 +60,20 @@ class TrialBalanceCsvRendererTest {
         second.setGeneratedAt(Instant.parse("2030-01-01T00:00:00Z"));
 
         assertEquals(renderer.render(first), renderer.render(second));
+    }
+
+    @Test
+    @DisplayName("Account names starting with =, +, or @ are neutralized; negative amounts stay plain")
+    void neutralizesFormulaLeadingAccountNames() {
+        TrialBalanceReport report = report();
+        report.getRows().get(0).setAccountName("=HYPERLINK(\"http://evil\",\"click\")");
+        report.getRows().get(1).setAccountName("+Accounts @Payable");
+
+        String csv = renderer.render(report);
+
+        assertTrue(csv.contains("1000,\"'=HYPERLINK(\"\"http://evil\"\",\"\"click\"\")\",125000.00"));
+        assertTrue(csv.contains("2000,'+Accounts @Payable,10000.00"));
+        assertTrue(csv.contains(",-80000.00\n"), "negative figures must stay plain, not neutralized");
     }
 
     private static TrialBalanceReport report() {


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (hardening follow-up to #999 / PR #1010 and #1011–#1015 / PR #1017)
- Parent STORY (durion): N/A
- Child issue: louisburroughs/durion-positivity-backend#1018
- Domain: `domain:accounting`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` (no controller/DTO/event contract changes in this PR; the rendered CSV cell content changes only for text cells beginning with a formula-leading character, per OWASP CSV Injection guidance)
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A, no controller changes
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A

## Scope
- What changed:
  - **Gap 1 — CSV/spreadsheet formula injection (CWE-1236):** `CsvFormat.escape` is split into `escapeText(...)`, which neutralizes cells whose first character is `=`, `+`, `-`, `@`, tab, or CR with a single-quote prefix (per OWASP CSV Injection guidance) before applying RFC 4180 quoting. `CsvFormat.amount(...)` is deliberately untouched so numeric cells keep their plain leading `-`. All seven report renderers (`TaxLiabilityCsvRenderer`, `IncomeStatementCsvRenderer`, `BalanceSheetCsvRenderer`, `TrialBalanceCsvRenderer`, `GeneralLedgerCsvRenderer`, `AgedReportCsvRenderer` for AR/AP) now route text cells through `escapeText`. The prefix is deterministic, so the byte-identical rendering guarantee still holds.
  - **Gap 2 — statement-line displayOrder tiebreak:** `StatementLineMappingRepository` now orders by `displayOrder` with `statementLineCode` as a deterministic secondary sort key (`findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc`). Callers in `FinancialReportingServiceImpl` and `LaborOverheadReportServiceImpl` updated.
- Why: DB-sourced strings (GL account names, journal-line descriptions, customer/vendor names, jurisdiction names, exemption reason codes) flow into exported CSV cells and would be evaluated as formulas by Excel/LibreOffice; and mappings sharing a `displayOrder` had database-dependent relative order, breaking JSON `lineItems` ordering and the byte-identical CSV determinism guarantee. See #1018.

## Tests
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated — N/A, no API contract change
- How to run:
  - `./mvnw -pl pos-accounting -am -DskipTests=false test` (full module suite: 1199 tests green, incl. ArchUnit)
  - `./mvnw -pl pos-accounting -am -DskipTests=false -Dit.test=FinancialReportingContractBehaviorIT -Dfailsafe.failIfNoSpecifiedTests=false verify` (new tiebreak IT: 10/10 green)
  - New `CsvFormatTest` covers neutralization, RFC 4180 interaction after neutralization, and plain negative amounts; each of the six renderer test classes gains a test proving `=`/`+`/`@`-leading names/descriptions render inert while negative amounts remain plain `-123.45`. The new IT saves two mappings sharing a `displayOrder` in reverse-alphabetical order and proves stable `lineItems` ordering plus byte-identical CSV across renders.

## Risk & Rollback
- Risk level: Low — internal rendering/query change; only CSV byte content for formula-leading text cells and tie ordering under duplicate `displayOrder` values change.
- Rollback plan: revert the single commit (`bcce2cc`); no schema or data migration involved.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, issue-execution branch `claude/execute-1018-ptk8xj`
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, no capability id for this hardening issue
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [x] Required CI checks passing (full module suite green locally)

Closes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep2BEZZbpXDfL7zVnNS6io

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ep2BEZZbpXDfL7zVnNS6io)_