### PR TITLE
[CAP:odoo-parity-inventory] Wave 1: stock summary + posting funnel, catalog contract v2, replenishment scan, count conflicts, negative-stock policy

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-07-22T21:26:02.054013+00:00"
+generatedAt: "2026-07-23T00:00:01.978745+00:00"
 root: "."
 summary:
   manifestCount: 20
-  permissionCount: 361
-  uniquePermissionCount: 361
+  permissionCount: 362
+  uniquePermissionCount: 362
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -271,7 +271,7 @@ manifests:
     domain: "inventory"
     serviceName: "pos-inventory"
     version: "1.0"
-    permissionCount: 41
+    permissionCount: 42
     permissions:
       - name: "inventory:adjustment:create"
         description: "Create an adjustment request (draft/pending), capture reason code, quantity, and supporting notes"
@@ -355,6 +355,8 @@ manifests:
         description: "Submit inventory returns to stock"
       - name: "inventory:shortage:view"
         description: "View shortage resolution options"
+      - name: "inventory:replenishment:manage"
+        description: "Manage replenishment policies and run the batch replenishment scan"
   - module: "pos-invoice"
     path: "pos-invoice/src/main/resources/permissions.yaml"
     domain: "invoice"
@@ -1760,6 +1762,12 @@ permissions:
     source: "pos-inventory/src/main/resources/permissions.yaml"
   - name: "inventory:receiving:view"
     description: "View receiving sessions and their lines"
+    domain: "inventory"
+    serviceName: "pos-inventory"
+    module: "pos-inventory"
+    source: "pos-inventory/src/main/resources/permissions.yaml"
+  - name: "inventory:replenishment:manage"
+    description: "Manage replenishment policies and run the batch replenishment scan"
     domain: "inventory"
     serviceName: "pos-inventory"
     module: "pos-inventory"

--- a/pos-catalog/README.md
+++ b/pos-catalog/README.md
@@ -5,6 +5,7 @@ Product catalog service for the Durion Positivity ETSMS platform. Manages the pr
 ## Responsibilities
 
 - Maintain product master data (inventory and non-inventory products)
+- Own product stock-attribute contract data for pos-inventory (#1023): per-product UoM conversion sets (purchase/pack UoM → base UoM factor + precision scale), stock tracking level (`NONE`/`LOT`/`SERIAL`), and substitution groups of interchangeable products
 - Manage price books and associated pricing rules
 - Handle unit-of-measure conversions between stocking and selling units
 - Track supplier item costs and MSRP records per product
@@ -33,6 +34,13 @@ Product catalog service for the Durion Positivity ETSMS platform. Manages the pr
 - `GET /v1/catalog/pricing/effective-price/{locationId}/{productId}` — effective price at a location
 - `GET /v1/catalog/{priceBookId}` — retrieve a price book
 - `POST /v1/catalog/bulk-ingest` — bulk import products (auth: `catalog:product:create`)
+- `PUT /v1/products/{productId}/tracking-level` — set stock tracking level (`NONE`/`LOT`/`SERIAL`)
+- `POST|GET /v1/products/{productId}/uoms`, `PUT|DELETE /v1/products/{productId}/uoms/{uomId}` — per-product UoM conversion set
+- `POST|GET /v1/products/substitution-groups`, `GET|DELETE /.../{groupId}`, `POST /.../{groupId}/members`, `DELETE /.../{groupId}/members/{productId}` — substitution groups (a product belongs to at most one group)
+
+## Domain Events
+
+Product mutations queue a `catalog.product.updated` fact (payload `ProductUpdatedV1`, schema version 2) on `catalog.events.v1` via the transactional outbox (`pos.catalog.kafka.enabled`), reconciled hourly on `catalog.manifest.v1`. Schema version 2 (#1023, additive) added `baseUom`, `trackingLevel`, `uomConversions[]` (`uomCode`, `uomType`, `factorToBase`, `precisionScale`), `substitutionGroupId`, and `substitutionProductIds[]` so pos-inventory can replicate UoM conversions, tracking level, and substitution membership (`ext_product_uom` et al.). UoM and substitution-membership mutations bump the product's `updatedAt` (the envelope `aggregateVersion`) and re-emit the fact for every affected product.
 
 ## Configuration
 

--- a/pos-catalog/openapi.json
+++ b/pos-catalog/openapi.json
@@ -4,21 +4,29 @@
         "title": "Positivity Product API",
         "description": "API documentation for the Product service, accessible via the API Gateway.",
         "contact": {
-            "name": "Durion Team",
+            "name": "Durion Support Services",
             "email": "louis.burroughs@gmail.com"
         },
         "version": "v1"
     },
     "servers": [
         {
-            "url": "http://api-gateway.local/api/catalog",
+            "url": "http://api-gateway.local/v1/catalog",
             "description": "API Gateway"
         }
     ],
     "tags": [
         {
+            "name": "Substitution Group API",
+            "description": "Groups of mutually interchangeable products; a product belongs to at most one group"
+        },
+        {
             "name": "UOM Conversion API",
             "description": "Unit of measure conversion API"
+        },
+        {
+            "name": "Catalog Bulk Ingest API",
+            "description": "Bulk import catalog products"
         },
         {
             "name": "Products API",
@@ -45,8 +53,16 @@
             "description": "Manage price books, pricing rules, and resolution"
         },
         {
+            "name": "Product UoM API",
+            "description": "Per-product unit-of-measure conversion set (purchase/pack UoMs with factor to base UoM)"
+        },
+        {
             "name": "Catalog Items API",
             "description": "API for managing catalog items by type"
+        },
+        {
+            "name": "Supplier Item Cost List API",
+            "description": "Query supplier item cost structures"
         }
     ],
     "paths": {
@@ -65,22 +81,11 @@
                         "description": "ID of the product to be obtained",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
                 "responses": {
-                    "404": {
-                        "description": "Product not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Successfully retrieved product",
                         "content": {
@@ -90,8 +95,30 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "Product not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             },
             "put": {
                 "tags": [
@@ -107,8 +134,7 @@
                         "description": "ID of the product to update",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -123,36 +149,6 @@
                     "required": true
                 },
                 "responses": {
-                    "400": {
-                        "description": "Validation error",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductDto"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Business conflict",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductDto"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Product not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Product updated",
                         "content": {
@@ -162,8 +158,257 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Product not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Business conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
+            }
+        },
+        "/v1/products/{productId}/uoms/{uomId}": {
+            "put": {
+                "tags": [
+                    "Product UoM API"
+                ],
+                "summary": "Update product UoM conversion",
+                "description": "Updates factor, precision scale, and optionally the UoM role. The UoM code is immutable. Re-emits the product contract event.",
+                "operationId": "updateProductUom",
+                "parameters": [
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "description": "Product ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "uomId",
+                        "in": "path",
+                        "description": "Product UoM ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProductUomUpdateRequestDto"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Product UoM updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductUomDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductUomDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Product or UoM not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductUomDto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Product UoM API"
+                ],
+                "summary": "Delete product UoM conversion",
+                "description": "Removes a UoM from the product's conversion set and re-emits the product contract event.",
+                "operationId": "deleteProductUom",
+                "parameters": [
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "description": "Product ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "uomId",
+                        "in": "path",
+                        "description": "Product UoM ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Product UoM deleted"
+                    },
+                    "404": {
+                        "description": "Product or UoM not found"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
+            }
+        },
+        "/v1/products/{productId}/tracking-level": {
+            "put": {
+                "tags": [
+                    "Products API"
+                ],
+                "summary": "Set product tracking level",
+                "description": "Sets the product's stock tracking level (NONE, LOT, or SERIAL; default NONE) and re-emits the product contract event for downstream replicas.",
+                "operationId": "updateTrackingLevel",
+                "parameters": [
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "description": "ID of the product",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProductTrackingLevelUpdateRequestDto"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Tracking level updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Product not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         },
         "/v1/products/{productId}/msrp/{msrpId}": {
@@ -180,8 +425,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     },
                     {
@@ -189,8 +433,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -205,28 +448,18 @@
                     "required": true
                 },
                 "responses": {
-                    "400": {
-                        "description": "Invalid payload",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductMsrpDto"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "MSRP record not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductMsrpDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "MSRP updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductMsrpDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -238,7 +471,17 @@
                     "403": {
                         "description": "Forbidden",
                         "content": {
-                            "*/*": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductMsrpDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "MSRP record not found",
+                        "content": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductMsrpDto"
                                 }
@@ -248,14 +491,24 @@
                     "409": {
                         "description": "Temporal overlap or optimistic locking conflict",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductMsrpDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:msrp:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:msrp:write"
+                ]
             }
         },
         "/v1/products/{productId}/lifecycle": {
@@ -273,8 +526,7 @@
                         "description": "ID of the product",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -292,14 +544,28 @@
                     "404": {
                         "description": "Product not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductLifecycleResponse"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW",
+                            "product:lifecycle:update"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW",
+                    "product:lifecycle:update"
+                ]
             },
             "put": {
                 "tags": [
@@ -315,8 +581,7 @@
                         "description": "ID of the product",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -331,18 +596,28 @@
                     "required": true
                 },
                 "responses": {
-                    "400": {
-                        "description": "Validation error",
+                    "200": {
+                        "description": "Lifecycle state updated successfully",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductLifecycleResponse"
                                 }
                             }
                         }
                     },
-                    "200": {
-                        "description": "Lifecycle state updated successfully",
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductLifecycleResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Missing override permission",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -354,17 +629,7 @@
                     "404": {
                         "description": "Product not found",
                         "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductLifecycleResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Missing override permission",
-                        "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductLifecycleResponse"
                                 }
@@ -374,14 +639,28 @@
                     "409": {
                         "description": "Lifecycle business rule conflict",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductLifecycleResponse"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT",
+                            "product:lifecycle:update"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT",
+                    "product:lifecycle:update"
+                ]
             }
         },
         "/v1/products/uom-conversions/{id}": {
@@ -390,15 +669,16 @@
                     "UOM Conversion API"
                 ],
                 "summary": "Get conversion",
-                "operationId": "get",
+                "description": "Retrieves a unit-of-measure conversion by its ID.",
+                "operationId": "getUomConversionById",
                 "parameters": [
                     {
                         "name": "id",
                         "in": "path",
+                        "description": "Conversion ID",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -406,29 +686,52 @@
                     "200": {
                         "description": "Conversion found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UomConversionDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Conversion not found",
+                        "content": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/UomConversionDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             },
             "put": {
                 "tags": [
                     "UOM Conversion API"
                 ],
                 "summary": "Update conversion factor",
-                "operationId": "update",
+                "description": "Updates the conversion factor and mutable fields for an existing conversion.",
+                "operationId": "updateUomConversion",
                 "parameters": [
                     {
                         "name": "id",
                         "in": "path",
+                        "description": "Conversion ID",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -446,37 +749,85 @@
                     "200": {
                         "description": "Conversion updated",
                         "content": {
-                            "*/*": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UomConversionDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UomConversionDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Conversion not found",
+                        "content": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/UomConversionDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             },
             "delete": {
                 "tags": [
                     "UOM Conversion API"
                 ],
                 "summary": "Deactivate conversion",
-                "operationId": "deactivate",
+                "description": "Deactivates a conversion so it is excluded from active conversion results.",
+                "operationId": "deactivateUomConversion",
                 "parameters": [
                     {
                         "name": "id",
                         "in": "path",
+                        "description": "Conversion ID",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
                 "responses": {
                     "204": {
                         "description": "Conversion deactivated"
+                    },
+                    "404": {
+                        "description": "Conversion not found"
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         },
         "/v1/products/supplier-costs/{id}": {
@@ -485,6 +836,7 @@
                     "Supplier Item Cost API"
                 ],
                 "summary": "Get supplier cost structure",
+                "description": "Returns the supplier item cost structure identified by the supplied cost structure ID.",
                 "operationId": "getCostStructure",
                 "parameters": [
                     {
@@ -492,22 +844,11 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
                 "responses": {
-                    "404": {
-                        "description": "Not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SupplierItemCostDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Found",
                         "content": {
@@ -517,14 +858,35 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SupplierItemCostDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:supplier_cost:read"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:supplier_cost:read"
+                ]
             },
             "put": {
                 "tags": [
                     "Supplier Item Cost API"
                 ],
                 "summary": "Update supplier cost structure",
+                "description": "Updates the supplier item cost structure identified by the supplied cost structure ID.",
                 "operationId": "updateCostStructure",
                 "parameters": [
                     {
@@ -532,8 +894,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -548,16 +909,6 @@
                     "required": true
                 },
                 "responses": {
-                    "404": {
-                        "description": "Not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SupplierItemCostDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Updated",
                         "content": {
@@ -567,14 +918,35 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SupplierItemCostDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:supplier_cost:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:supplier_cost:write"
+                ]
             },
             "delete": {
                 "tags": [
                     "Supplier Item Cost API"
                 ],
                 "summary": "Delete supplier cost structure",
+                "description": "Deletes the supplier item cost structure identified by the supplied cost structure ID.",
                 "operationId": "deleteCostStructure",
                 "parameters": [
                     {
@@ -582,8 +954,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -594,7 +965,17 @@
                     "404": {
                         "description": "Not found"
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:supplier_cost:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:supplier_cost:write"
+                ]
             }
         },
         "/v1/products/price-books/{priceBookId}": {
@@ -603,6 +984,7 @@
                     "Price Book API"
                 ],
                 "summary": "Get price book",
+                "description": "Retrieves a price book by ID, including its configuration metadata.",
                 "operationId": "getPriceBook",
                 "parameters": [
                     {
@@ -610,8 +992,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -629,20 +1010,31 @@
                     "404": {
                         "description": "Price book not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/PriceBookDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:price_book:read"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:price_book:read"
+                ]
             },
             "put": {
                 "tags": [
                     "Price Book API"
                 ],
                 "summary": "Update price book",
+                "description": "Updates mutable fields of an existing price book.",
                 "operationId": "updatePriceBook",
                 "parameters": [
                     {
@@ -650,8 +1042,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -666,16 +1057,6 @@
                     "required": true
                 },
                 "responses": {
-                    "404": {
-                        "description": "Price book not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PriceBookDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Price book updated",
                         "content": {
@@ -685,8 +1066,28 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "Price book not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PriceBookDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:price_book:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:price_book:write"
+                ]
             }
         },
         "/v1/products/price-books/{priceBookId}/rules/{ruleId}": {
@@ -695,6 +1096,7 @@
                     "Price Book API"
                 ],
                 "summary": "Update price book rule",
+                "description": "Updates an existing pricing rule in a price book.",
                 "operationId": "updateRule",
                 "parameters": [
                     {
@@ -702,8 +1104,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     },
                     {
@@ -711,8 +1112,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -727,16 +1127,6 @@
                     "required": true
                 },
                 "responses": {
-                    "409": {
-                        "description": "Rule conflict",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PriceBookRuleDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Price book rule updated",
                         "content": {
@@ -746,14 +1136,35 @@
                                 }
                             }
                         }
+                    },
+                    "409": {
+                        "description": "Rule conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PriceBookRuleDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:price_book:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:price_book:write"
+                ]
             },
             "delete": {
                 "tags": [
                     "Price Book API"
                 ],
                 "summary": "Deactivate price book rule",
+                "description": "Deactivates a price book rule so it is no longer considered in price resolution.",
                 "operationId": "deactivateRule",
                 "parameters": [
                     {
@@ -761,8 +1172,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     },
                     {
@@ -770,8 +1180,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -779,7 +1188,17 @@
                     "204": {
                         "description": "Rule deactivated"
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:price_book:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:price_book:write"
+                ]
             }
         },
         "/v1/products/items/{itemId}/standard-cost": {
@@ -788,6 +1207,7 @@
                     "Item Cost API"
                 ],
                 "summary": "Update standard item cost",
+                "description": "Updates the standard cost for the specified item and returns the refreshed item cost values.",
                 "operationId": "updateStandardCost",
                 "parameters": [
                     {
@@ -795,8 +1215,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -811,16 +1230,6 @@
                     "required": true
                 },
                 "responses": {
-                    "400": {
-                        "description": "Invalid payload",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ItemCostsDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Updated",
                         "content": {
@@ -830,8 +1239,32 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ItemCostsDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_MANAGER",
+                            "inventory.cost.standard.update"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "MANAGER",
+                    "inventory.cost.standard.update"
+                ]
             }
         },
         "/v1/catalogs/{catalogId}": {
@@ -849,8 +1282,7 @@
                         "description": "ID of the catalog to be obtained",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -868,14 +1300,26 @@
                     "404": {
                         "description": "Catalog not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/CatalogDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             },
             "put": {
                 "tags": [
@@ -891,8 +1335,7 @@
                         "description": "ID of the catalog to update",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -908,18 +1351,18 @@
                     "required": true
                 },
                 "responses": {
-                    "400": {
-                        "description": "Invalid request body",
+                    "200": {
+                        "description": "Catalog updated successfully",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/CatalogDto"
                                 }
                             }
                         }
                     },
-                    "200": {
-                        "description": "Catalog updated successfully",
+                    "400": {
+                        "description": "Invalid request body",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -931,14 +1374,26 @@
                     "404": {
                         "description": "Catalog not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/CatalogDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             },
             "delete": {
                 "tags": [
@@ -954,8 +1409,7 @@
                         "description": "ID of the catalog to delete",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -966,7 +1420,19 @@
                     "404": {
                         "description": "Catalog not found"
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_DELETE"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_DELETE"
+                ]
             }
         },
         "/v1/catalog-items/{type}/{catalogId}": {
@@ -993,8 +1459,7 @@
                         "description": "ID of the catalog item to update",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1022,7 +1487,7 @@
                     "400": {
                         "description": "Invalid item type or request body",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/CatalogItemResponseDto"
                                 }
@@ -1032,14 +1497,26 @@
                     "404": {
                         "description": "Catalog item not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/CatalogItemResponseDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             },
             "delete": {
                 "tags": [
@@ -1064,8 +1541,7 @@
                         "description": "ID of the catalog item to delete",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1079,7 +1555,19 @@
                     "404": {
                         "description": "Catalog item not found"
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_DELETE"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_DELETE"
+                ]
             }
         },
         "/v1/products": {
@@ -1101,26 +1589,6 @@
                     "required": true
                 },
                 "responses": {
-                    "400": {
-                        "description": "Validation error",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductDto"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Business conflict",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductDto"
-                                }
-                            }
-                        }
-                    },
                     "201": {
                         "description": "Product created",
                         "content": {
@@ -1130,8 +1598,187 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Business conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
+            }
+        },
+        "/v1/products/{productId}/uoms": {
+            "get": {
+                "tags": [
+                    "Product UoM API"
+                ],
+                "summary": "List product UoM conversions",
+                "description": "Returns the product's UoM conversion set ordered by UoM code.",
+                "operationId": "listProductUoms",
+                "parameters": [
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "description": "Product ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Product UoMs listed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "additionalProperties": {},
+                                    "contains": {},
+                                    "items": {
+                                        "$ref": "#/components/schemas/ProductUomDto"
+                                    },
+                                    "unevaluatedItems": {}
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Product not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/ProductUomDto"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Product UoM API"
+                ],
+                "summary": "Add product UoM conversion",
+                "description": "Adds a purchase/pack (or base) UoM with its conversion factor to the product's base UoM and a precision scale. Re-emits the product contract event.",
+                "operationId": "addProductUom",
+                "parameters": [
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "description": "Product ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProductUomCreateRequestDto"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Product UoM created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductUomDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductUomDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Product not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductUomDto"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "UoM code already defined for product",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductUomDto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         },
         "/v1/products/{productId}/replacements": {
@@ -1149,8 +1796,7 @@
                         "description": "ID of the product",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1158,7 +1804,7 @@
                     "200": {
                         "description": "Replacements listed",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "type": "array",
                                     "items": {
@@ -1168,7 +1814,21 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW",
+                            "product:lifecycle:update"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW",
+                    "product:lifecycle:update"
+                ]
             },
             "post": {
                 "tags": [
@@ -1184,8 +1844,7 @@
                         "description": "ID of discontinued product",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1203,7 +1862,7 @@
                     "201": {
                         "description": "Replacement added successfully",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ReplacementOption"
                                 }
@@ -1213,7 +1872,7 @@
                     "400": {
                         "description": "Validation error",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ReplacementOption"
                                 }
@@ -1223,14 +1882,28 @@
                     "404": {
                         "description": "Product not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ReplacementOption"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT",
+                            "product:lifecycle:update"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT",
+                    "product:lifecycle:update"
+                ]
             }
         },
         "/v1/products/{productId}/msrp": {
@@ -1247,8 +1920,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1263,7 +1935,17 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:msrp:read"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:msrp:read"
+                ]
             },
             "post": {
                 "tags": [
@@ -1278,8 +1960,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1294,16 +1975,6 @@
                     "required": true
                 },
                 "responses": {
-                    "409": {
-                        "description": "Temporal overlap conflict",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductMsrpDto"
-                                }
-                            }
-                        }
-                    },
                     "201": {
                         "description": "MSRP created",
                         "content": {
@@ -1317,7 +1988,7 @@
                     "400": {
                         "description": "Invalid payload",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductMsrpDto"
                                 }
@@ -1327,14 +1998,34 @@
                     "403": {
                         "description": "Forbidden",
                         "content": {
-                            "*/*": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductMsrpDto"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Temporal overlap conflict",
+                        "content": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductMsrpDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:msrp:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:msrp:write"
+                ]
             }
         },
         "/v1/products/uom-conversions": {
@@ -1343,29 +2034,46 @@
                     "UOM Conversion API"
                 ],
                 "summary": "List active conversions",
-                "operationId": "list",
+                "description": "Returns all active unit-of-measure conversion records.",
+                "operationId": "listUomConversions",
                 "responses": {
                     "200": {
                         "description": "Conversions listed",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "type": "array",
+                                    "additionalProperties": {},
+                                    "contains": {},
                                     "items": {
                                         "$ref": "#/components/schemas/UomConversionDto"
-                                    }
+                                    },
+                                    "unevaluatedItems": {}
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             },
             "post": {
                 "tags": [
                     "UOM Conversion API"
                 ],
                 "summary": "Create UOM conversion",
-                "operationId": "create",
+                "description": "Creates a new unit-of-measure conversion record.",
+                "operationId": "createUomConversion",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -1380,14 +2088,36 @@
                     "201": {
                         "description": "Conversion created",
                         "content": {
-                            "*/*": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UomConversionDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "content": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/UomConversionDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         },
         "/v1/products/supplier-costs": {
@@ -1396,6 +2126,7 @@
                     "Supplier Item Cost API"
                 ],
                 "summary": "Create supplier cost structure",
+                "description": "Creates a supplier-specific item cost structure with the submitted supplier, item, and tier details.",
                 "operationId": "createCostStructure",
                 "requestBody": {
                     "content": {
@@ -1408,26 +2139,6 @@
                     "required": true
                 },
                 "responses": {
-                    "400": {
-                        "description": "Invalid payload",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SupplierItemCostDto"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Duplicate supplier and item combination",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SupplierItemCostDto"
-                                }
-                            }
-                        }
-                    },
                     "201": {
                         "description": "Created",
                         "content": {
@@ -1437,8 +2148,215 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SupplierItemCostDto"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Duplicate supplier and item combination",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SupplierItemCostDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:supplier_cost:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:supplier_cost:write"
+                ]
+            }
+        },
+        "/v1/products/substitution-groups": {
+            "get": {
+                "tags": [
+                    "Substitution Group API"
+                ],
+                "summary": "List substitution groups",
+                "description": "Returns all substitution groups with their member product ids.",
+                "operationId": "listSubstitutionGroups",
+                "responses": {
+                    "200": {
+                        "description": "Substitution groups listed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "additionalProperties": {},
+                                    "contains": {},
+                                    "items": {
+                                        "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                    },
+                                    "unevaluatedItems": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Substitution Group API"
+                ],
+                "summary": "Create substitution group",
+                "description": "Creates an empty substitution group; add members afterwards.",
+                "operationId": "createSubstitutionGroup",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SubstitutionGroupCreateRequestDto"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Substitution group created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
+            }
+        },
+        "/v1/products/substitution-groups/{groupId}/members": {
+            "post": {
+                "tags": [
+                    "Substitution Group API"
+                ],
+                "summary": "Add product to substitution group",
+                "description": "Adds a product to the group (a product belongs to at most one group) and re-emits the product contract event for every member.",
+                "operationId": "addSubstitutionGroupMember",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Substitution group ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SubstitutionGroupMemberRequestDto"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Member added",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Substitution group or product not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Product already belongs to a substitution group",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         },
         "/v1/products/pricing/location-overrides": {
@@ -1460,26 +2378,6 @@
                     "required": true
                 },
                 "responses": {
-                    "400": {
-                        "description": "Guardrail validation failed",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
-                                }
-                            }
-                        }
-                    },
                     "201": {
                         "description": "Override created",
                         "content": {
@@ -1489,8 +2387,40 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "Guardrail validation failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         },
         "/v1/products/pricing/location-overrides/{overrideId}/reject": {
@@ -1508,8 +2438,7 @@
                         "description": "Override ID",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1534,20 +2463,20 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "Override or approval request not found",
+                    "400": {
+                        "description": "Invalid rejection request",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
                                 }
                             }
                         }
                     },
-                    "400": {
-                        "description": "Invalid rejection request",
+                    "404": {
+                        "description": "Override or approval request not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
                                 }
@@ -1557,14 +2486,26 @@
                     "409": {
                         "description": "Version conflict",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "pricing:override:approve"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "pricing:override:approve"
+                ]
             }
         },
         "/v1/products/pricing/location-overrides/{overrideId}/approve": {
@@ -1582,8 +2523,7 @@
                         "description": "Override ID",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1608,10 +2548,20 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Invalid approval request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
+                                }
+                            }
+                        }
+                    },
                     "404": {
                         "description": "Override or approval request not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
                                 }
@@ -1621,24 +2571,26 @@
                     "409": {
                         "description": "Version conflict",
                         "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid approval request",
-                        "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "pricing:override:approve"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "pricing:override:approve"
+                ]
             }
         },
         "/v1/products/pricing/guardrail-policies": {
@@ -1673,14 +2625,26 @@
                     "400": {
                         "description": "Invalid policy payload",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/LocationPriceOverrideResponseDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         },
         "/v1/products/price-books": {
@@ -1689,6 +2653,7 @@
                     "Price Book API"
                 ],
                 "summary": "Create price book",
+                "description": "Creates a new price book used to group and apply pricing rules.",
                 "operationId": "createPriceBook",
                 "requestBody": {
                     "content": {
@@ -1701,16 +2666,6 @@
                     "required": true
                 },
                 "responses": {
-                    "400": {
-                        "description": "Invalid payload",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PriceBookDto"
-                                }
-                            }
-                        }
-                    },
                     "201": {
                         "description": "Price book created",
                         "content": {
@@ -1720,8 +2675,28 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PriceBookDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:price_book:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:price_book:write"
+                ]
             }
         },
         "/v1/products/price-books/{priceBookId}/rules": {
@@ -1730,6 +2705,7 @@
                     "Price Book API"
                 ],
                 "summary": "List price book rules",
+                "description": "Returns all rules associated with a price book.",
                 "operationId": "listRules",
                 "parameters": [
                     {
@@ -1737,8 +2713,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1753,13 +2728,24 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:price_book:read"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:price_book:read"
+                ]
             },
             "post": {
                 "tags": [
                     "Price Book API"
                 ],
                 "summary": "Create price book rule",
+                "description": "Adds a new pricing rule to a specific price book.",
                 "operationId": "createRule",
                 "parameters": [
                     {
@@ -1767,8 +2753,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -1796,14 +2781,24 @@
                     "409": {
                         "description": "Rule conflict",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/PriceBookRuleDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:price_book:write"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:price_book:write"
+                ]
             }
         },
         "/v1/products/price-books/resolve-price": {
@@ -1812,6 +2807,7 @@
                     "Price Book API"
                 ],
                 "summary": "Resolve effective product price",
+                "description": "Calculates the effective price for a product using applicable price books and rules.",
                 "operationId": "resolvePrice",
                 "requestBody": {
                     "content": {
@@ -1834,7 +2830,17 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:price_book:read"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:price_book:read"
+                ]
             }
         },
         "/v1/catalogs": {
@@ -1870,14 +2876,78 @@
                     "400": {
                         "description": "Invalid request body",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/CatalogDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
+            }
+        },
+        "/v1/catalog/bulk-ingest": {
+            "post": {
+                "tags": [
+                    "Catalog Bulk Ingest API"
+                ],
+                "summary": "Bulk ingest records",
+                "description": "Accepts a batch of domain records for bulk import. Returns per-record results.",
+                "operationId": "bulkIngest",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BulkIngestRequestCatalogBulkIngestRecord"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Batch processed (check per-record success/failure in response)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BulkIngestResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request payload",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BulkIngestResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:product:create"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:product:create"
+                ]
             }
         },
         "/v1/catalog-items/{type}": {
@@ -1923,14 +2993,26 @@
                     "400": {
                         "description": "Invalid item type or request body",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/CatalogItemResponseDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         },
         "/v1/products/{productId}/substitutes": {
@@ -1948,16 +3030,25 @@
                         "description": "ID of the product",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
                 "responses": {
-                    "501": {
-                        "description": "Not implemented",
+                    "200": {
+                        "description": "Substitute parts returned",
                         "content": {
-                            "*/*": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Product not found",
+                        "content": {
+                            "application/json": {
                                 "schema": {
                                     "type": "array",
                                     "items": {
@@ -1967,7 +3058,19 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             }
         },
         "/v1/products/{productId}/msrp/active": {
@@ -1984,8 +3087,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     },
                     {
@@ -1999,16 +3101,6 @@
                     }
                 ],
                 "responses": {
-                    "404": {
-                        "description": "No active MSRP for date",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProductMsrpDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Active MSRP returned",
                         "content": {
@@ -2018,8 +3110,28 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "No active MSRP for date",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductMsrpDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:msrp:read"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:msrp:read"
+                ]
             }
         },
         "/v1/products/{productId}/detail": {
@@ -2037,8 +3149,7 @@
                         "description": "ID of the product",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     },
                     {
@@ -2047,24 +3158,23 @@
                         "description": "Location/store ID for location-specific data",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
                 "responses": {
-                    "400": {
-                        "description": "Invalid location ID",
+                    "200": {
+                        "description": "Successfully retrieved product details (may be partial if some services unavailable)",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductDetailView"
                                 }
                             }
                         }
                     },
-                    "200": {
-                        "description": "Successfully retrieved product details (may be partial if some services unavailable)",
+                    "400": {
+                        "description": "Invalid location ID",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2076,7 +3186,7 @@
                     "404": {
                         "description": "Product not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductDetailView"
                                 }
@@ -2086,14 +3196,120 @@
                     "500": {
                         "description": "Unexpected server error while retrieving product details",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProductDetailView"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
+            }
+        },
+        "/v1/products/substitution-groups/{groupId}": {
+            "get": {
+                "tags": [
+                    "Substitution Group API"
+                ],
+                "summary": "Get substitution group",
+                "description": "Retrieves a substitution group with its member product ids.",
+                "operationId": "getSubstitutionGroup",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Substitution group ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Substitution group found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Substitution group not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Substitution Group API"
+                ],
+                "summary": "Delete substitution group",
+                "description": "Deletes a group and its memberships, re-emitting the product contract event for every former member.",
+                "operationId": "deleteSubstitutionGroup",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Substitution group ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Substitution group deleted"
+                    },
+                    "404": {
+                        "description": "Substitution group not found"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         },
         "/v1/products/services/{serviceId}": {
@@ -2111,8 +3327,7 @@
                         "description": "ID of the service to be obtained",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -2130,14 +3345,86 @@
                     "404": {
                         "description": "Service not found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ServiceDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
+            }
+        },
+        "/v1/products/services/search": {
+            "get": {
+                "tags": [
+                    "Products API"
+                ],
+                "summary": "Search catalog services",
+                "description": "Free-text substring search over service names for typeahead selection.",
+                "operationId": "searchServices",
+                "parameters": [
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "description": "Free-text query matching service name (case-insensitive substring)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Maximum number of results (1–100)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Matching services",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "additionalProperties": {},
+                                    "contains": {},
+                                    "items": {
+                                        "$ref": "#/components/schemas/ServiceDto"
+                                    },
+                                    "unevaluatedItems": {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             }
         },
         "/v1/products/services/name/{name}": {
@@ -2170,7 +3457,128 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
+            }
+        },
+        "/v1/products/search": {
+            "get": {
+                "tags": [
+                    "Products API"
+                ],
+                "summary": "Search catalog products",
+                "description": "Cursor-based product search with optional free-text query and exact filters for brand, category, and SKU. Pass detailed=true to enrich each row inline with lifecycle state + effective instant and the product's active MSRP (amount, currency, effective window), resolved server-side in a single request. Products without an active MSRP return null price fields.",
+                "operationId": "searchProducts",
+                "parameters": [
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "description": "Free-text search query (matches product name and description)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "brand",
+                        "in": "query",
+                        "description": "Filter by manufacturer brand (exact, case-insensitive)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "category",
+                        "in": "query",
+                        "description": "Filter by category name (exact, case-insensitive)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sku",
+                        "in": "query",
+                        "description": "Filter by SKU (exact match, case-insensitive)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Pagination cursor from previous response",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Maximum number of results (1–100)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "detailed",
+                        "in": "query",
+                        "description": "When true, enrich each row with lifecycle state, effective instant, and active MSRP",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CatalogSearchResultDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter (e.g., non-numeric limit)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CatalogSearchResultDto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             }
         },
         "/v1/products/pricing/effective-price/{locationId}/{productId}": {
@@ -2188,8 +3596,7 @@
                         "description": "Location ID",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     },
                     {
@@ -2198,8 +3605,7 @@
                         "description": "Product ID",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -2217,14 +3623,26 @@
                     "404": {
                         "description": "No pricing context found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/EffectiveLocationPriceResponseDto"
                                 }
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             }
         },
         "/v1/products/noninventory/{productId}": {
@@ -2242,22 +3660,11 @@
                         "description": "ID of the non-inventory product to be obtained",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
                 "responses": {
-                    "404": {
-                        "description": "Non-inventory product not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NonInventoryProductDto"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Successfully retrieved non-inventory product",
                         "content": {
@@ -2267,8 +3674,30 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "Non-inventory product not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NonInventoryProductDto"
+                                }
+                            }
+                        }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             }
         },
         "/v1/products/noninventory/name/{name}": {
@@ -2301,7 +3730,19 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             }
         },
         "/v1/products/name/{name}": {
@@ -2334,7 +3775,19 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
             }
         },
         "/v1/products/items/{itemId}/costs": {
@@ -2343,6 +3796,7 @@
                     "Item Cost API"
                 ],
                 "summary": "Get current item costs",
+                "description": "Returns the current standard, average, and last known cost values for the specified item.",
                 "operationId": "getItemCosts",
                 "parameters": [
                     {
@@ -2350,8 +3804,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -2366,7 +3819,21 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_MANAGER",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "MANAGER",
+                    "CATALOG_VIEW"
+                ]
             }
         },
         "/v1/products/items/{itemId}/costs/audit": {
@@ -2375,6 +3842,7 @@
                     "Item Cost API"
                 ],
                 "summary": "Get item cost audit history",
+                "description": "Returns the recorded audit history entries for item cost changes on the specified item.",
                 "operationId": "getAuditHistory",
                 "parameters": [
                     {
@@ -2382,8 +3850,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string",
-                            "format": "uuid"
+                            "type": "string"
                         }
                     }
                 ],
@@ -2398,7 +3865,21 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_MANAGER",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "MANAGER",
+                    "CATALOG_VIEW"
+                ]
             }
         },
         "/v1/catalogs/name/{name}": {
@@ -2431,7 +3912,183 @@
                             }
                         }
                     }
-                }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_VIEW"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_VIEW"
+                ]
+            }
+        },
+        "/v1/catalog/supplier-item-costs": {
+            "get": {
+                "tags": [
+                    "Supplier Item Cost List API"
+                ],
+                "summary": "List supplier cost structures",
+                "description": "Returns a paginated list of supplier cost structures. At least one of itemId or supplierId must be provided.",
+                "operationId": "listCostStructures",
+                "parameters": [
+                    {
+                        "name": "itemId",
+                        "in": "query",
+                        "description": "Filter by catalog item ID",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "supplierId",
+                        "in": "query",
+                        "description": "Filter by supplier ID",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "pageable",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/Pageable"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Page"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "At least one filter is required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PageSupplierItemCostDto"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PageSupplierItemCostDto"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PageSupplierItemCostDto"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PageSupplierItemCostDto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "catalog:supplier_cost:read"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "catalog:supplier_cost:read"
+                ]
+            }
+        },
+        "/v1/products/substitution-groups/{groupId}/members/{productId}": {
+            "delete": {
+                "tags": [
+                    "Substitution Group API"
+                ],
+                "summary": "Remove product from substitution group",
+                "description": "Removes a product from the group and re-emits the product contract event for the removed product and every remaining member.",
+                "operationId": "removeSubstitutionGroupMember",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Substitution group ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "description": "Product ID to remove",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Member removed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Substitution group or membership not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubstitutionGroupDto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "ROLE_ADMIN",
+                            "ROLE_CATALOG_EDIT"
+                        ]
+                    }
+                ],
+                "x-required-permissions": [
+                    "ADMIN",
+                    "CATALOG_EDIT"
+                ]
             }
         }
     },
@@ -2442,42 +4099,56 @@
                 "description": "Update product request",
                 "properties": {
                     "name": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Product display name",
+                        "example": "Premium Brake Pad Set",
+                        "minLength": 1
                     },
                     "description": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Product description",
+                        "example": "Ceramic brake pads for front axle",
+                        "minLength": 1
                     },
                     "unitOfMeasure": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Unit of measure for the product",
+                        "example": "EACH",
+                        "minLength": 1
                     },
                     "manufacturerId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the product manufacturer",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "categoryId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the product category",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "sku": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Stock keeping unit",
+                        "example": "BP-CER-FRT-001"
                     },
                     "mpn": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Manufacturer part number",
+                        "example": "ACME-BP-1234",
+                        "minLength": 1
                     },
                     "upc": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Universal product code",
+                        "example": "012345678905"
                     },
                     "attributes": {
                         "type": "string",
                         "description": "JSON object represented as string"
                     }
-                },
-                "required": [
-                    "description",
-                    "mpn",
-                    "name",
-                    "unitOfMeasure"
-                ]
+                }
             },
             "CategoryDto": {
                 "type": "object",
@@ -2494,7 +4165,11 @@
                         "description": "Category name",
                         "example": "Tools"
                     }
-                }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
             },
             "DimensionDto": {
                 "type": "object",
@@ -2532,7 +4207,8 @@
                             "CURRENT",
                             "VOLTAGE",
                             "RESISTANCE"
-                        ]
+                        ],
+                        "example": "LENGTH"
                     },
                     "description": {
                         "type": "string",
@@ -2550,7 +4226,12 @@
                         "description": "Dimension value",
                         "example": 12.5
                     }
-                }
+                },
+                "required": [
+                    "dimensionType",
+                    "dimensionValue",
+                    "id"
+                ]
             },
             "ProductDto": {
                 "type": "object",
@@ -2569,67 +4250,86 @@
                     },
                     "shortDescription": {
                         "type": "string",
-                        "description": "Short product description"
+                        "description": "Short product description",
+                        "example": "Adjustable steel wrench"
                     },
                     "longDescription": {
                         "type": "string",
-                        "description": "Long product description"
+                        "description": "Long product description",
+                        "example": "Forged steel adjustable wrench with cushioned grip"
                     },
                     "description": {
                         "type": "string",
-                        "description": "Product description"
+                        "description": "Product description",
+                        "example": "Heavy duty wrench"
                     },
                     "images": {
                         "type": "array",
                         "description": "Product image URLs",
+                        "example": [
+                            "https://cdn.example.com/img/wrench.jpg"
+                        ],
                         "items": {
                             "type": "string"
                         }
                     },
                     "manufacturerPartNumber": {
                         "type": "string",
-                        "description": "Manufacturer part number"
+                        "description": "Manufacturer part number",
+                        "example": "MPN-9981"
                     },
                     "manufacturerId": {
                         "type": "string",
                         "format": "uuid",
-                        "description": "Manufacturer identifier"
+                        "description": "Manufacturer identifier",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "manufacturerName": {
                         "type": "string",
-                        "description": "Manufacturer name"
+                        "description": "Manufacturer name",
+                        "example": "AcmePro"
                     },
                     "manufacturerWarranty": {
                         "type": "string",
-                        "description": "Manufacturer warranty"
+                        "description": "Manufacturer warranty",
+                        "example": "2 years limited"
                     },
                     "manufacturerBrand": {
                         "type": "string",
-                        "description": "Manufacturer brand"
+                        "description": "Manufacturer brand",
+                        "example": "AcmePro"
                     },
                     "countryOfOrigin": {
                         "type": "string",
-                        "description": "Country of origin"
+                        "description": "Country of origin",
+                        "example": "US"
                     },
                     "sku": {
                         "type": "string",
-                        "description": "SKU"
+                        "description": "SKU",
+                        "example": "SKU-12345"
                     },
                     "mpn": {
                         "type": "string",
-                        "description": "Manufacturer part number"
+                        "description": "Manufacturer part number",
+                        "example": "MPN-9981"
                     },
                     "upc": {
                         "type": "string",
-                        "description": "UPC"
+                        "description": "UPC",
+                        "example": "012345678905"
                     },
                     "attributes": {
                         "type": "string",
-                        "description": "Attributes JSON"
+                        "description": "Attributes JSON",
+                        "example": {
+                            "color": "black"
+                        }
                     },
                     "unitOfMeasure": {
                         "type": "string",
-                        "description": "Unit of measure"
+                        "description": "Unit of measure",
+                        "example": "EACH"
                     },
                     "status": {
                         "type": "string",
@@ -2637,11 +4337,23 @@
                         "enum": [
                             "ACTIVE",
                             "INACTIVE"
-                        ]
+                        ],
+                        "example": "ACTIVE"
+                    },
+                    "trackingLevel": {
+                        "type": "string",
+                        "description": "Stock tracking level",
+                        "enum": [
+                            "NONE",
+                            "LOT",
+                            "SERIAL"
+                        ],
+                        "example": "NONE"
                     },
                     "productCode": {
                         "type": "string",
-                        "description": "Product code"
+                        "description": "Product code",
+                        "example": "012345678905"
                     },
                     "productCodeType": {
                         "type": "string",
@@ -2649,42 +4361,49 @@
                         "enum": [
                             "UPC",
                             "EAN"
-                        ]
+                        ],
+                        "example": "UPC"
                     },
                     "category": {
-                        "$ref": "#/components/schemas/CategoryDto",
-                        "description": "Category detail"
+                        "$ref": "#/components/schemas/CategoryDto"
                     },
                     "subcategory": {
-                        "$ref": "#/components/schemas/SubcategoryDto",
-                        "description": "Subcategory detail"
+                        "$ref": "#/components/schemas/SubcategoryDto"
                     },
                     "type": {
                         "type": "string",
-                        "description": "Product type"
+                        "description": "Product type",
+                        "example": "PHYSICAL"
                     },
                     "dimensions": {
                         "type": "array",
                         "description": "Product dimensions",
+                        "example": [],
                         "items": {
                             "$ref": "#/components/schemas/DimensionDto"
                         }
                     },
                     "material": {
                         "type": "string",
-                        "description": "Material"
+                        "description": "Material",
+                        "example": "Steel"
                     },
                     "color": {
                         "type": "string",
-                        "description": "Color"
+                        "description": "Color",
+                        "example": "Black"
                     },
                     "warranty": {
                         "type": "string",
-                        "description": "Warranty"
+                        "description": "Warranty",
+                        "example": "1 year"
                     },
                     "specifications": {
                         "type": "string",
-                        "description": "Detailed specifications JSON"
+                        "description": "Detailed specifications JSON",
+                        "example": {
+                            "weightKg": 1.2
+                        }
                     },
                     "lifecycleState": {
                         "type": "string",
@@ -2693,38 +4412,49 @@
                             "ACTIVE",
                             "INACTIVE",
                             "DISCONTINUED"
-                        ]
+                        ],
+                        "example": "ACTIVE"
                     },
                     "lifecycleStateEffectiveAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Lifecycle state effective instant"
+                        "description": "Lifecycle state effective instant",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "lastStateChangedBy": {
                         "type": "string",
                         "format": "uuid",
-                        "description": "User that last changed lifecycle state"
+                        "description": "User that last changed lifecycle state",
+                        "example": "8b8df63e-18d8-4bde-a8f4-88bc36bc57d7"
                     },
                     "lastStateChangedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Last lifecycle state change instant"
+                        "description": "Last lifecycle state change instant",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "lifecycleOverrideReason": {
                         "type": "string",
-                        "description": "Lifecycle override reason"
+                        "description": "Lifecycle override reason",
+                        "example": "Vendor discontinued"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Created timestamp"
+                        "description": "Created timestamp",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Updated timestamp"
+                        "description": "Updated timestamp",
+                        "example": "2026-01-16 11:00:00+00:00"
                     }
-                }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
             },
             "SubcategoryDto": {
                 "type": "object",
@@ -2743,30 +4473,162 @@
                     }
                 }
             },
+            "ProductUomUpdateRequestDto": {
+                "type": "object",
+                "description": "Request to update a product UoM conversion (the UoM code is immutable)",
+                "properties": {
+                    "uomType": {
+                        "type": "string",
+                        "description": "New role of this UoM for the product; unchanged when omitted",
+                        "enum": [
+                            "BASE",
+                            "PURCHASE",
+                            "PACK",
+                            "OTHER"
+                        ],
+                        "example": "PACK"
+                    },
+                    "factorToBase": {
+                        "type": "number",
+                        "description": "Multiplier converting one unit of this UoM into the product's base UoM",
+                        "example": 12,
+                        "minimum": 0
+                    },
+                    "precisionScale": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Decimal precision scale for quantities expressed in this UoM (0-6)",
+                        "example": 0,
+                        "maximum": 6,
+                        "minimum": 0
+                    }
+                },
+                "required": [
+                    "factorToBase",
+                    "precisionScale"
+                ]
+            },
+            "ProductUomDto": {
+                "type": "object",
+                "description": "A per-product unit-of-measure conversion to the product's base UoM",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier of the product UoM row",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
+                    },
+                    "productId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier of the product",
+                        "example": "018e1c9f-6b5a-7890-abcd-1234567890ab"
+                    },
+                    "uomCode": {
+                        "type": "string",
+                        "description": "Unit-of-measure code",
+                        "example": "CASE"
+                    },
+                    "uomType": {
+                        "type": "string",
+                        "description": "Role of this UoM for the product",
+                        "enum": [
+                            "BASE",
+                            "PURCHASE",
+                            "PACK",
+                            "OTHER"
+                        ],
+                        "example": "PURCHASE"
+                    },
+                    "factorToBase": {
+                        "type": "number",
+                        "description": "Multiplier converting one unit of this UoM into the product's base UoM",
+                        "example": 12
+                    },
+                    "precisionScale": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Decimal precision scale for quantities expressed in this UoM",
+                        "example": 0
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Created timestamp",
+                        "example": "2026-01-15 09:30:00+00:00"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updated timestamp",
+                        "example": "2026-01-16 11:00:00+00:00"
+                    }
+                },
+                "required": [
+                    "factorToBase",
+                    "id",
+                    "precisionScale",
+                    "productId",
+                    "uomCode",
+                    "uomType"
+                ]
+            },
+            "ProductTrackingLevelUpdateRequestDto": {
+                "type": "object",
+                "description": "Request to set a product's stock tracking level",
+                "properties": {
+                    "trackingLevel": {
+                        "type": "string",
+                        "description": "Stock tracking level",
+                        "enum": [
+                            "NONE",
+                            "LOT",
+                            "SERIAL"
+                        ],
+                        "example": "LOT"
+                    }
+                },
+                "required": [
+                    "trackingLevel"
+                ]
+            },
             "UpdateMsrpRequestDto": {
                 "type": "object",
+                "description": "Request to update the MSRP for a product",
                 "properties": {
                     "amount": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "MSRP amount",
+                        "example": 149.99
                     },
                     "currency": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "ISO currency code for the amount",
+                        "example": "USD"
                     },
                     "effectiveStartDate": {
                         "type": "string",
-                        "format": "date"
+                        "format": "date",
+                        "description": "Date the MSRP becomes effective",
+                        "example": "2026-01-01"
                     },
                     "effectiveEndDate": {
                         "type": "string",
-                        "format": "date"
+                        "format": "date",
+                        "description": "Date the MSRP stops being effective (null means open-ended)",
+                        "example": "2026-12-31"
                     },
                     "createdByUserId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user creating this MSRP entry",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "version": {
                         "type": "integer",
-                        "format": "int64"
+                        "format": "int64",
+                        "description": "Version for optimistic locking",
+                        "example": 1
                     }
                 },
                 "required": [
@@ -2778,46 +4640,76 @@
             },
             "ProductMsrpDto": {
                 "type": "object",
+                "description": "Product MSRP detail",
                 "properties": {
                     "msrpId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "MSRP identifier",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "productId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Product identifier the MSRP applies to",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "amount": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "MSRP amount",
+                        "example": "99.99"
                     },
                     "currency": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "ISO 4217 currency code",
+                        "example": "USD"
                     },
                     "effectiveStartDate": {
                         "type": "string",
-                        "format": "date"
+                        "format": "date",
+                        "description": "Date the MSRP becomes effective",
+                        "example": "2026-01-15"
                     },
                     "effectiveEndDate": {
                         "type": "string",
-                        "format": "date"
+                        "format": "date",
+                        "description": "Date the MSRP stops being effective",
+                        "example": "2026-12-31"
                     },
                     "createdAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the MSRP was created",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "updatedAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the MSRP was last updated",
+                        "example": "2026-01-16 11:00:00+00:00"
                     },
                     "updatedBy": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user that last updated the MSRP",
+                        "example": "8b8df63e-18d8-4bde-a8f4-88bc36bc57d7"
                     },
                     "version": {
                         "type": "integer",
-                        "format": "int64"
+                        "format": "int64",
+                        "description": "Version for optimistic locking",
+                        "example": 1
                     }
-                }
+                },
+                "required": [
+                    "amount",
+                    "createdAt",
+                    "currency",
+                    "effectiveStartDate",
+                    "msrpId",
+                    "productId",
+                    "version"
+                ]
             },
             "ProductLifecycleUpdateRequest": {
                 "type": "object",
@@ -2830,17 +4722,20 @@
                             "ACTIVE",
                             "INACTIVE",
                             "DISCONTINUED"
-                        ]
+                        ],
+                        "example": "DISCONTINUED"
                     },
                     "effectiveAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Effective instant for lifecycle change"
+                        "description": "Effective instant for lifecycle change",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "effectiveDate": {
                         "type": "string",
                         "format": "date",
-                        "description": "Effective date for lifecycle change (date-only)"
+                        "description": "Effective date for lifecycle change (date-only)",
+                        "example": "2026-01-15"
                     },
                     "changedBy": {
                         "type": "string",
@@ -2849,9 +4744,13 @@
                     },
                     "overrideReason": {
                         "type": "string",
-                        "description": "Reason for lifecycle override"
+                        "description": "Reason for lifecycle override",
+                        "example": "Vendor discontinued"
                     }
-                }
+                },
+                "required": [
+                    "lifecycleState"
+                ]
             },
             "ProductLifecycleResponse": {
                 "type": "object",
@@ -2870,12 +4769,14 @@
                             "ACTIVE",
                             "INACTIVE",
                             "DISCONTINUED"
-                        ]
+                        ],
+                        "example": "ACTIVE"
                     },
                     "lifecycleStateEffectiveAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Lifecycle state effective instant"
+                        "description": "Lifecycle state effective instant",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "lastStateChangedBy": {
                         "type": "string",
@@ -2886,20 +4787,27 @@
                     "lastStateChangedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Last lifecycle state change instant"
+                        "description": "Last lifecycle state change instant",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "lifecycleOverrideReason": {
                         "type": "string",
-                        "description": "Lifecycle override reason"
+                        "description": "Lifecycle override reason",
+                        "example": "Vendor discontinued"
                     },
                     "replacementOptions": {
                         "type": "array",
                         "description": "Replacement options for this product lifecycle state",
+                        "example": [],
                         "items": {
                             "$ref": "#/components/schemas/ReplacementOption"
                         }
                     }
-                }
+                },
+                "required": [
+                    "lifecycleState",
+                    "productId"
+                ]
             },
             "ReplacementOption": {
                 "type": "object",
@@ -2925,20 +4833,29 @@
                     },
                     "notes": {
                         "type": "string",
-                        "description": "Replacement notes"
+                        "description": "Replacement notes",
+                        "example": "Direct successor model"
                     },
                     "effectiveAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Replacement option effective instant"
+                        "description": "Replacement option effective instant",
+                        "example": "2026-01-15 09:30:00+00:00"
                     }
-                }
+                },
+                "required": [
+                    "replacementId",
+                    "replacementProductId"
+                ]
             },
             "UomConversionUpdateRequestDto": {
                 "type": "object",
+                "description": "Request to update a unit-of-measure conversion factor",
                 "properties": {
                     "conversionFactor": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Multiplier to convert one unit of the source UOM into the target UOM",
+                        "example": 12
                     }
                 },
                 "required": [
@@ -2947,35 +4864,61 @@
             },
             "UomConversionDto": {
                 "type": "object",
+                "description": "A unit-of-measure conversion between two UOM codes",
                 "properties": {
                     "id": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the conversion",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "fromUomCode": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Source unit-of-measure code",
+                        "example": "CASE"
                     },
                     "toUomCode": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Target unit-of-measure code",
+                        "example": "EACH"
                     },
                     "conversionFactor": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Multiplier to convert one unit of the source UOM into the target UOM",
+                        "example": 12
                     },
                     "active": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether this conversion is currently active",
+                        "example": true
                     },
                     "createdAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the conversion was created",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "updatedAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the conversion was last updated",
+                        "example": "2026-01-16 11:00:00+00:00"
                     },
                     "createdBy": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Identifier of the user who created the conversion",
+                        "example": "system"
                     }
-                }
+                },
+                "required": [
+                    "active",
+                    "conversionFactor",
+                    "createdAt",
+                    "fromUomCode",
+                    "id",
+                    "toUomCode"
+                ]
             },
             "CostTierDto": {
                 "type": "object",
@@ -2989,7 +4932,10 @@
                         "minimum": 1
                     },
                     "maxQuantity": {
-                        "type": "integer",
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
                         "format": "int32",
                         "description": "Inclusive maximum quantity; null means and above",
                         "example": 10
@@ -3022,7 +4968,8 @@
                     "currencyCode": {
                         "type": "string",
                         "description": "ISO 4217 currency code",
-                        "example": "USD"
+                        "example": "USD",
+                        "minLength": 1
                     },
                     "baseCost": {
                         "type": "number",
@@ -3092,31 +5039,43 @@
             },
             "PriceBookCreateRequestDto": {
                 "type": "object",
+                "description": "Request payload for creating a price book",
                 "properties": {
                     "name": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Price book name",
+                        "example": "West Region Pricing"
                     },
                     "scope": {
                         "type": "string",
+                        "description": "Scope the price book applies to",
                         "enum": [
                             "COMPANY_DEFAULT",
                             "LOCATION",
                             "CUSTOMER_TIER"
-                        ]
+                        ],
+                        "example": "LOCATION"
                     },
                     "scopeId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the scoped entity (location or customer tier)",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "isDefault": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether this is the default price book for the scope",
+                        "example": false
                     },
                     "status": {
                         "type": "string",
+                        "description": "Initial status of the price book",
                         "enum": [
                             "ACTIVE",
                             "INACTIVE"
-                        ]
+                        ],
+                        "example": "ACTIVE"
                     }
                 },
                 "required": [
@@ -3126,98 +5085,144 @@
             },
             "PriceBookDto": {
                 "type": "object",
+                "description": "Price book detail",
                 "properties": {
                     "priceBookId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Price book identifier",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "name": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Price book name",
+                        "example": "West Region Pricing"
                     },
                     "scope": {
                         "type": "string",
+                        "description": "Scope the price book applies to",
                         "enum": [
                             "COMPANY_DEFAULT",
                             "LOCATION",
                             "CUSTOMER_TIER"
-                        ]
+                        ],
+                        "example": "LOCATION"
                     },
                     "scopeId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the scoped entity (location or customer tier)",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "status": {
                         "type": "string",
+                        "description": "Current status of the price book",
                         "enum": [
                             "ACTIVE",
                             "INACTIVE"
-                        ]
+                        ],
+                        "example": "ACTIVE"
                     },
                     "createdAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the price book was created",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "updatedAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the price book was last updated",
+                        "example": "2026-01-16 11:00:00+00:00"
                     },
                     "version": {
                         "type": "integer",
-                        "format": "int64"
+                        "format": "int64",
+                        "description": "Version for optimistic locking",
+                        "example": 1
                     },
                     "default": {
                         "type": "boolean"
                     }
-                }
+                },
+                "required": [
+                    "createdAt",
+                    "name",
+                    "priceBookId",
+                    "scope",
+                    "status",
+                    "version"
+                ]
             },
             "PriceBookRuleCreateRequestDto": {
                 "type": "object",
+                "description": "Request payload for creating a price book rule",
                 "properties": {
                     "targetType": {
                         "type": "string",
+                        "description": "Target type the rule applies to",
                         "enum": [
                             "SKU",
                             "CATEGORY",
                             "GLOBAL"
-                        ]
+                        ],
+                        "example": "SKU"
                     },
                     "targetId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the targeted entity (SKU or category)",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "pricingLogic": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Pricing logic expression applied by the rule",
+                        "example": "MSRP * 0.9"
                     },
                     "conditionType": {
                         "type": "string",
+                        "description": "Condition type gating the rule",
                         "enum": [
                             "CUSTOMER_TIER",
                             "LOCATION",
                             "NONE"
-                        ]
+                        ],
+                        "example": "CUSTOMER_TIER"
                     },
                     "conditionValue": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Value evaluated against the condition type",
+                        "example": "GOLD"
                     },
                     "priority": {
                         "type": "integer",
-                        "format": "int32"
+                        "format": "int32",
+                        "description": "Evaluation priority; lower wins",
+                        "example": 10
                     },
                     "effectiveStartAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Instant the rule becomes effective",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "effectiveEndAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Instant the rule stops being effective",
+                        "example": "2026-12-31 23:59:59+00:00"
                     },
                     "createdByUserId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user creating the rule",
+                        "example": "8b8df63e-18d8-4bde-a8f4-88bc36bc57d7"
                     },
                     "version": {
                         "type": "integer",
-                        "format": "int64"
+                        "format": "int64",
+                        "description": "Version for optimistic locking",
+                        "example": 1
                     }
                 },
                 "required": [
@@ -3229,78 +5234,120 @@
             },
             "PriceBookRuleDto": {
                 "type": "object",
+                "description": "Price book rule detail",
                 "properties": {
                     "ruleId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Rule identifier",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "priceBookId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the owning price book",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "targetType": {
                         "type": "string",
+                        "description": "Target type the rule applies to",
                         "enum": [
                             "SKU",
                             "CATEGORY",
                             "GLOBAL"
-                        ]
+                        ],
+                        "example": "SKU"
                     },
                     "targetId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the targeted entity (SKU or category)",
+                        "example": "3d129775-efeb-57f0-b949-7c0ecf9f0c2e"
                     },
                     "pricingLogic": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Pricing logic expression applied by the rule",
+                        "example": "MSRP * 0.9"
                     },
                     "conditionType": {
                         "type": "string",
+                        "description": "Condition type gating the rule",
                         "enum": [
                             "CUSTOMER_TIER",
                             "LOCATION",
                             "NONE"
-                        ]
+                        ],
+                        "example": "CUSTOMER_TIER"
                     },
                     "conditionValue": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Value evaluated against the condition type",
+                        "example": "GOLD"
                     },
                     "priority": {
                         "type": "integer",
-                        "format": "int32"
+                        "format": "int32",
+                        "description": "Evaluation priority; lower wins",
+                        "example": 10
                     },
                     "effectiveStartAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Instant the rule becomes effective",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "effectiveEndAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Instant the rule stops being effective",
+                        "example": "2026-12-31 23:59:59+00:00"
                     },
                     "status": {
                         "type": "string",
+                        "description": "Current status of the rule",
                         "enum": [
                             "ACTIVE",
                             "INACTIVE",
                             "NOT_APPLICABLE_MISSING_BASE"
-                        ]
+                        ],
+                        "example": "ACTIVE"
                     },
                     "createdByUserId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user that created the rule",
+                        "example": "8b8df63e-18d8-4bde-a8f4-88bc36bc57d7"
                     },
                     "createdAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the rule was created",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "updatedAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the rule was last updated",
+                        "example": "2026-01-16 11:00:00+00:00"
                     },
                     "version": {
                         "type": "integer",
-                        "format": "int64"
+                        "format": "int64",
+                        "description": "Version for optimistic locking",
+                        "example": 1
                     }
-                }
+                },
+                "required": [
+                    "createdAt",
+                    "createdByUserId",
+                    "effectiveStartAt",
+                    "priceBookId",
+                    "pricingLogic",
+                    "ruleId",
+                    "status",
+                    "targetType",
+                    "version"
+                ]
             },
             "UpdateStandardCostRequestDto": {
                 "type": "object",
@@ -3312,7 +5359,8 @@
                     },
                     "reasonCode": {
                         "type": "string",
-                        "description": "Reason code for manual change"
+                        "description": "Reason code for manual change",
+                        "minLength": 1
                     }
                 },
                 "required": [
@@ -3326,18 +5374,29 @@
                 "properties": {
                     "itemId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Item identifier",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "standardCost": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Current standard cost",
+                        "example": 5.0
                     },
                     "lastCost": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Most recent purchase cost",
+                        "example": 6.25
                     },
                     "averageCost": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Weighted average cost",
+                        "example": 5.75
                     }
-                }
+                },
+                "required": [
+                    "itemId"
+                ]
             },
             "CatalogDto": {
                 "type": "object",
@@ -3356,11 +5415,15 @@
                     },
                     "description": {
                         "type": "string",
-                        "description": "Catalog description"
+                        "description": "Catalog description",
+                        "example": "Seasonal winter product catalog"
                     },
                     "productIds": {
                         "type": "array",
                         "description": "Product IDs included in the catalog",
+                        "example": [
+                            "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
+                        ],
                         "items": {
                             "type": "string",
                             "format": "uuid"
@@ -3369,6 +5432,9 @@
                     "serviceIds": {
                         "type": "array",
                         "description": "Service IDs included in the catalog",
+                        "example": [
+                            "0196cf6f-c8dd-7ee0-93e7-f48a5698a536"
+                        ],
                         "items": {
                             "type": "string",
                             "format": "uuid"
@@ -3377,12 +5443,19 @@
                     "nonInventoryProductIds": {
                         "type": "array",
                         "description": "Non-inventory product IDs included in the catalog",
+                        "example": [
+                            "0196cf6f-c8dd-7ee0-93e7-f48a5698a537"
+                        ],
                         "items": {
                             "type": "string",
                             "format": "uuid"
                         }
                     }
-                }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
             },
             "CatalogItemRequestDto": {
                 "type": "object",
@@ -3395,50 +5468,63 @@
                     },
                     "shortDescription": {
                         "type": "string",
-                        "description": "Short description"
+                        "description": "Short description",
+                        "example": "Adjustable steel wrench"
                     },
                     "longDescription": {
                         "type": "string",
-                        "description": "Long description"
+                        "description": "Long description",
+                        "example": "Forged steel adjustable wrench with cushioned grip"
                     },
                     "images": {
                         "type": "array",
                         "description": "Product image URLs for product type",
+                        "example": [
+                            "https://cdn.example.com/img/wrench.jpg"
+                        ],
                         "items": {
                             "type": "string"
                         }
                     },
                     "manufacturerPartNumber": {
                         "type": "string",
-                        "description": "Manufacturer part number for product type"
+                        "description": "Manufacturer part number for product type",
+                        "example": "MPN-9981"
                     },
                     "manufacturerId": {
                         "type": "string",
-                        "description": "Manufacturer identifier for product type"
+                        "description": "Manufacturer identifier for product type",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "manufacturerName": {
                         "type": "string",
-                        "description": "Manufacturer name for product type"
+                        "description": "Manufacturer name for product type",
+                        "example": "AcmePro"
                     },
                     "manufacturerWarranty": {
                         "type": "string",
-                        "description": "Manufacturer warranty for product type"
+                        "description": "Manufacturer warranty for product type",
+                        "example": "2 years limited"
                     },
                     "manufacturerBrand": {
                         "type": "string",
-                        "description": "Manufacturer brand for product type"
+                        "description": "Manufacturer brand for product type",
+                        "example": "AcmePro"
                     },
                     "countryOfOrigin": {
                         "type": "string",
-                        "description": "Country of origin for product type"
+                        "description": "Country of origin for product type",
+                        "example": "US"
                     },
                     "sku": {
                         "type": "string",
-                        "description": "SKU for product type"
+                        "description": "SKU for product type",
+                        "example": "SKU-12345"
                     },
                     "productCode": {
                         "type": "string",
-                        "description": "Product code for product type"
+                        "description": "Product code for product type",
+                        "example": "012345678905"
                     },
                     "type": {
                         "type": "string",
@@ -3447,19 +5533,25 @@
                     },
                     "material": {
                         "type": "string",
-                        "description": "Material for product type"
+                        "description": "Material for product type",
+                        "example": "Steel"
                     },
                     "color": {
                         "type": "string",
-                        "description": "Color for product type"
+                        "description": "Color for product type",
+                        "example": "Black"
                     },
                     "warranty": {
                         "type": "string",
-                        "description": "Warranty for product type"
+                        "description": "Warranty for product type",
+                        "example": "1 year"
                     },
                     "specifications": {
                         "type": "string",
-                        "description": "Detailed specifications JSON for product type"
+                        "description": "Detailed specifications JSON for product type",
+                        "example": {
+                            "weightKg": 1.2
+                        }
                     }
                 }
             },
@@ -3470,7 +5562,8 @@
                     "id": {
                         "type": "string",
                         "format": "uuid",
-                        "description": "Item identifier"
+                        "description": "Item identifier",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "itemType": {
                         "type": "string",
@@ -3479,51 +5572,82 @@
                     },
                     "name": {
                         "type": "string",
-                        "description": "Item name"
+                        "description": "Item name",
+                        "example": "Heavy Duty Wrench"
                     },
                     "shortDescription": {
                         "type": "string",
-                        "description": "Short description"
+                        "description": "Short description",
+                        "example": "Adjustable steel wrench"
                     },
                     "longDescription": {
                         "type": "string",
-                        "description": "Long description"
+                        "description": "Long description",
+                        "example": "Forged steel adjustable wrench with cushioned grip"
                     }
-                }
+                },
+                "required": [
+                    "id",
+                    "itemType"
+                ]
             },
             "ProductCreateRequestDto": {
                 "type": "object",
                 "description": "Create product request",
                 "properties": {
                     "name": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Product name",
+                        "example": "Heavy Duty Wrench",
+                        "minLength": 1
                     },
                     "description": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Product description",
+                        "example": "Forged steel adjustable wrench",
+                        "minLength": 1
                     },
                     "unitOfMeasure": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Unit of measure",
+                        "example": "EACH",
+                        "minLength": 1
                     },
                     "manufacturerId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Manufacturer identifier",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "categoryId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Category identifier",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "sku": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Stock keeping unit",
+                        "example": "SKU-12345",
+                        "minLength": 1
                     },
                     "mpn": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Manufacturer part number",
+                        "example": "MPN-9981",
+                        "minLength": 1
                     },
                     "upc": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Universal product code",
+                        "example": "012345678905"
                     },
                     "attributes": {
                         "type": "string",
-                        "description": "JSON object represented as string"
+                        "description": "JSON object represented as string",
+                        "example": {
+                            "color": "black"
+                        }
                     }
                 },
                 "required": [
@@ -3532,6 +5656,49 @@
                     "name",
                     "sku",
                     "unitOfMeasure"
+                ]
+            },
+            "ProductUomCreateRequestDto": {
+                "type": "object",
+                "description": "Request to add a UoM conversion to a product",
+                "properties": {
+                    "uomCode": {
+                        "type": "string",
+                        "description": "Unit-of-measure code",
+                        "example": "CASE",
+                        "minLength": 1
+                    },
+                    "uomType": {
+                        "type": "string",
+                        "description": "Role of this UoM for the product",
+                        "enum": [
+                            "BASE",
+                            "PURCHASE",
+                            "PACK",
+                            "OTHER"
+                        ],
+                        "example": "PURCHASE"
+                    },
+                    "factorToBase": {
+                        "type": "number",
+                        "description": "Multiplier converting one unit of this UoM into the product's base UoM",
+                        "example": 12,
+                        "minimum": 0
+                    },
+                    "precisionScale": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Decimal precision scale for quantities expressed in this UoM (0-6)",
+                        "example": 0,
+                        "maximum": 6,
+                        "minimum": 0
+                    }
+                },
+                "required": [
+                    "factorToBase",
+                    "precisionScale",
+                    "uomCode",
+                    "uomType"
                 ]
             },
             "ProductReplacementRequest": {
@@ -3552,35 +5719,51 @@
                     },
                     "notes": {
                         "type": "string",
-                        "description": "Replacement notes"
+                        "description": "Replacement notes",
+                        "example": "Direct successor model"
                     },
                     "effectiveAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Replacement effective instant"
+                        "description": "Replacement effective instant",
+                        "example": "2026-01-15 09:30:00+00:00"
                     }
-                }
+                },
+                "required": [
+                    "replacementProductId"
+                ]
             },
             "CreateMsrpRequestDto": {
                 "type": "object",
+                "description": "Request payload for creating a product MSRP",
                 "properties": {
                     "amount": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "MSRP amount",
+                        "example": 99.99
                     },
                     "currency": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "ISO 4217 currency code",
+                        "example": "USD"
                     },
                     "effectiveStartDate": {
                         "type": "string",
-                        "format": "date"
+                        "format": "date",
+                        "description": "Date the MSRP becomes effective",
+                        "example": "2026-01-15"
                     },
                     "effectiveEndDate": {
                         "type": "string",
-                        "format": "date"
+                        "format": "date",
+                        "description": "Date the MSRP stops being effective",
+                        "example": "2026-12-31"
                     },
                     "createdByUserId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user creating the MSRP",
+                        "example": "8b8df63e-18d8-4bde-a8f4-88bc36bc57d7"
                     }
                 },
                 "required": [
@@ -3592,18 +5775,29 @@
             },
             "UomConversionCreateRequestDto": {
                 "type": "object",
+                "description": "Request to create a unit-of-measure conversion",
                 "properties": {
                     "fromUomCode": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Source unit-of-measure code",
+                        "example": "CASE",
+                        "minLength": 1
                     },
                     "toUomCode": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Target unit-of-measure code",
+                        "example": "EACH",
+                        "minLength": 1
                     },
                     "conversionFactor": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Multiplier to convert one unit of the source UOM into the target UOM",
+                        "example": 12
                     },
                     "createdBy": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Identifier of the user creating the conversion",
+                        "example": "system"
                     }
                 },
                 "required": [
@@ -3629,7 +5823,8 @@
                     "currencyCode": {
                         "type": "string",
                         "description": "ISO 4217 currency code",
-                        "example": "USD"
+                        "example": "USD",
+                        "minLength": 1
                     },
                     "baseCost": {
                         "type": "number",
@@ -3650,32 +5845,130 @@
                     "supplierId"
                 ]
             },
+            "SubstitutionGroupCreateRequestDto": {
+                "type": "object",
+                "description": "Request to create a substitution group",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Group name",
+                        "example": "5W-30 full synthetic quarts",
+                        "maxLength": 128,
+                        "minLength": 0
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "Free-text notes",
+                        "example": "Any brand acceptable",
+                        "maxLength": 512,
+                        "minLength": 0
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "SubstitutionGroupDto": {
+                "type": "object",
+                "description": "A substitution group: a set of mutually interchangeable products",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier of the substitution group",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Group name",
+                        "example": "5W-30 full synthetic quarts"
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "Free-text notes",
+                        "example": "Any brand acceptable"
+                    },
+                    "productIds": {
+                        "type": "array",
+                        "description": "Product ids of all group members",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Created timestamp",
+                        "example": "2026-01-15 09:30:00+00:00"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updated timestamp",
+                        "example": "2026-01-16 11:00:00+00:00"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "productIds"
+                ]
+            },
+            "SubstitutionGroupMemberRequestDto": {
+                "type": "object",
+                "description": "Request to add a product to a substitution group",
+                "properties": {
+                    "productId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier of the product to add",
+                        "example": "018e1c9f-6b5a-7890-abcd-1234567890ab"
+                    }
+                },
+                "required": [
+                    "productId"
+                ]
+            },
             "LocationPriceOverrideCreateRequestDto": {
                 "type": "object",
+                "description": "Request payload for creating a location price override",
                 "properties": {
                     "locationId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Location identifier the override applies to",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "productId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Product identifier the override applies to",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "basePrice": {
                         "type": "number",
+                        "description": "Base price before override",
+                        "example": 100.0,
                         "minimum": 0.0
                     },
                     "cost": {
                         "type": "number",
+                        "description": "Item cost used for margin calculation",
+                        "example": 60.0,
                         "minimum": 0.0
                     },
                     "overridePrice": {
                         "type": "number",
+                        "description": "Requested override price",
+                        "example": 89.99,
                         "minimum": 0.0
                     },
                     "createdByUserId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user creating the override",
+                        "example": "8b8df63e-18d8-4bde-a8f4-88bc36bc57d7"
                     }
                 },
                 "required": [
@@ -3688,102 +5981,163 @@
             },
             "LocationPriceOverrideResponseDto": {
                 "type": "object",
+                "description": "Location price override detail",
                 "properties": {
                     "overrideId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Override identifier",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "version": {
                         "type": "integer",
-                        "format": "int64"
+                        "format": "int64",
+                        "description": "Version for optimistic locking",
+                        "example": 1
                     },
                     "locationId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Location identifier the override applies to",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "productId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Product identifier the override applies to",
+                        "example": "3d129775-efeb-57f0-b949-7c0ecf9f0c2e"
                     },
                     "basePrice": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Base price before override",
+                        "example": 100.0
                     },
                     "cost": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Item cost used for margin calculation",
+                        "example": 60.0
                     },
                     "overridePrice": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Override price",
+                        "example": 89.99
                     },
                     "discountPercent": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Computed discount percent versus base price",
+                        "example": 10.01
                     },
                     "marginPercent": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Computed margin percent versus cost",
+                        "example": 33.33
                     },
                     "status": {
                         "type": "string",
+                        "description": "Current override status",
                         "enum": [
                             "ACTIVE",
                             "PENDING_APPROVAL",
                             "REJECTED",
                             "INACTIVE"
-                        ]
+                        ],
+                        "example": "PENDING_APPROVAL"
                     },
                     "createdByUserId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user that created the override",
+                        "example": "8b8df63e-18d8-4bde-a8f4-88bc36bc57d7"
                     },
                     "createdAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the override was created",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "assignedApproverId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the assigned approver",
+                        "example": "9c9ef74f-29e9-5cef-b9f5-99cd47cd68e8"
                     },
                     "assignmentStrategy": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Strategy used to assign the approver",
+                        "example": "ROUND_ROBIN"
                     },
                     "approvedByUserId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user that approved the override",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a540"
                     },
                     "approvedAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the override was approved",
+                        "example": "2026-01-15 10:00:00+00:00"
                     },
                     "rejectedBy": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user that rejected the override",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a541"
                     },
                     "rejectedAt": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the override was rejected",
+                        "example": "2026-01-15 10:05:00+00:00"
                     },
                     "rejectionReasonCode": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Reason code for rejection",
+                        "example": "BELOW_MARGIN"
                     },
                     "rejectionNotes": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Free-text notes for rejection",
+                        "example": "Margin too low for this location"
                     }
-                }
+                },
+                "required": [
+                    "basePrice",
+                    "createdAt",
+                    "createdByUserId",
+                    "locationId",
+                    "overrideId",
+                    "overridePrice",
+                    "productId",
+                    "status",
+                    "version"
+                ]
             },
             "LocationPriceOverrideDecisionRequestDto": {
                 "type": "object",
+                "description": "Request payload for approving or rejecting a location price override",
                 "properties": {
                     "version": {
                         "type": "integer",
-                        "format": "int64"
+                        "format": "int64",
+                        "description": "Expected version for optimistic locking",
+                        "example": 1
                     },
                     "actorUserId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the user making the decision",
+                        "example": "8b8df63e-18d8-4bde-a8f4-88bc36bc57d7"
                     },
                     "rejectionReasonCode": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Reason code when rejecting the override",
+                        "example": "BELOW_MARGIN"
                     },
                     "rejectionNotes": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Free-text notes when rejecting the override",
+                        "example": "Margin too low for this location"
                     }
                 },
                 "required": [
@@ -3793,23 +6147,32 @@
             },
             "GuardrailPolicyUpsertRequestDto": {
                 "type": "object",
+                "description": "Request payload for upserting a pricing guardrail policy",
                 "properties": {
                     "scopeId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Scope identifier the guardrail policy applies to",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "minMarginPercent": {
                         "type": "number",
+                        "description": "Minimum allowed margin percent",
+                        "example": 20.0,
                         "maximum": 100.0,
                         "minimum": 0.0
                     },
                     "maxDiscountPercent": {
                         "type": "number",
+                        "description": "Maximum allowed discount percent",
+                        "example": 15.0,
                         "maximum": 100.0,
                         "minimum": 0.0
                     },
                     "autoApprovalThresholdPercent": {
                         "type": "number",
+                        "description": "Threshold percent below which overrides are auto-approved",
+                        "example": 5.0,
                         "maximum": 100.0,
                         "minimum": 0.0
                     }
@@ -3823,28 +6186,41 @@
             },
             "ResolvePriceRequestDto": {
                 "type": "object",
+                "description": "Request to resolve the effective price for a product in a given context",
                 "properties": {
                     "productId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the product to price",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "priceBookId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of a specific price book to resolve against (optional)",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "locationId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the location used to scope price book selection",
+                        "example": "01960003-0000-7000-8000-000000000001"
                     },
                     "customerTier": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Customer tier used to scope price book selection",
+                        "example": "GOLD"
                     },
                     "currency": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "ISO currency code for the resolved price",
+                        "example": "USD"
                     },
                     "asOf": {
                         "type": "string",
-                        "format": "date"
+                        "format": "date",
+                        "description": "Date for which the price should be resolved (defaults to today when omitted)",
+                        "example": "2026-06-18"
                     }
                 },
                 "required": [
@@ -3853,29 +6229,211 @@
             },
             "ResolvePriceResponseDto": {
                 "type": "object",
+                "description": "Resolved price result for a product in a given context",
                 "properties": {
                     "resolvedAmount": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Resolved price amount (null when source is UNAVAILABLE)",
+                        "example": "149.99"
                     },
                     "currency": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "ISO currency code of the resolved amount (null when source is UNAVAILABLE)",
+                        "example": "USD"
                     },
                     "source": {
                         "type": "string",
+                        "description": "Origin of the resolved price",
                         "enum": [
                             "PRICE_BOOK_RULE",
                             "MSRP",
                             "UNAVAILABLE"
-                        ]
+                        ],
+                        "example": "PRICE_BOOK_RULE"
                     },
                     "sourceRuleId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Identifier of the price book rule that produced the amount, when sourced from a price book",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "fallbackReason": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Explanation for a fallback or unavailable result",
+                        "example": "No active price book rule; MSRP used"
                     }
-                }
+                },
+                "required": [
+                    "source"
+                ]
+            },
+            "BulkIngestRequestCatalogBulkIngestRecord": {
+                "type": "object",
+                "description": "Generic bulk ingest request: a batch of records for a job scoped to a location",
+                "properties": {
+                    "jobId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier of the bulk ingest job",
+                        "example": "01960003-0000-7000-8000-000000000001"
+                    },
+                    "locationId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Location the records are ingested for",
+                        "example": "01960003-0000-7000-8000-000000000002"
+                    },
+                    "records": {
+                        "type": "array",
+                        "description": "The records to ingest (at least one); shape depends on the target domain",
+                        "items": {
+                            "$ref": "#/components/schemas/CatalogBulkIngestRecord"
+                        },
+                        "minItems": 1
+                    },
+                    "operatorId": {
+                        "type": "string",
+                        "description": "Identifier of the operator submitting the batch",
+                        "example": "user-jdoe"
+                    }
+                },
+                "required": [
+                    "jobId",
+                    "locationId",
+                    "records"
+                ]
+            },
+            "CatalogBulkIngestRecord": {
+                "type": "object",
+                "description": "Single record in a catalog bulk-ingest request",
+                "properties": {
+                    "sku": {
+                        "type": "string",
+                        "description": "Stock keeping unit for the record",
+                        "example": "SKU-12345",
+                        "minLength": 1
+                    },
+                    "upc": {
+                        "type": "string",
+                        "description": "Universal product code",
+                        "example": "012345678905"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name of the item",
+                        "example": "Heavy Duty Wrench",
+                        "minLength": 1
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Long description of the item",
+                        "example": "Forged steel adjustable wrench"
+                    },
+                    "categoryName": {
+                        "type": "string",
+                        "description": "Category name to associate the item with",
+                        "example": "Tools"
+                    },
+                    "subcategoryName": {
+                        "type": "string",
+                        "description": "Subcategory name to associate the item with",
+                        "example": "Hand Tools"
+                    },
+                    "price": {
+                        "type": "number",
+                        "description": "List price for the item",
+                        "example": 29.99
+                    },
+                    "mpn": {
+                        "type": "string",
+                        "description": "Manufacturer part number; falls back to the SKU when absent",
+                        "example": "MPN-98765"
+                    },
+                    "unitOfMeasure": {
+                        "type": "string",
+                        "description": "Unit of measure for the item; defaults to EA when absent",
+                        "example": "EA"
+                    }
+                },
+                "required": [
+                    "name",
+                    "sku"
+                ]
+            },
+            "BulkIngestResponse": {
+                "type": "object",
+                "description": "Summary outcome of a bulk ingest job: per-record results plus aggregate counts",
+                "properties": {
+                    "totalSubmitted": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of records submitted in the batch",
+                        "example": 100
+                    },
+                    "successCount": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Number of records ingested successfully",
+                        "example": 98
+                    },
+                    "failureCount": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Number of records that failed ingest",
+                        "example": 2
+                    },
+                    "results": {
+                        "type": "array",
+                        "description": "Per-record outcomes in submission order",
+                        "items": {
+                            "$ref": "#/components/schemas/BulkIngestResult"
+                        }
+                    }
+                },
+                "required": [
+                    "failureCount",
+                    "results",
+                    "successCount",
+                    "totalSubmitted"
+                ]
+            },
+            "BulkIngestResult": {
+                "type": "object",
+                "description": "Per-record outcome of a bulk ingest submission",
+                "properties": {
+                    "rowIndex": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Zero-based index of the record within the submitted batch",
+                        "example": 0
+                    },
+                    "entityId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier of the entity created/updated for this record, when successful",
+                        "example": "01960003-0000-7000-8000-000000000001"
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether this record was ingested successfully",
+                        "example": true
+                    },
+                    "errorCode": {
+                        "type": "string",
+                        "description": "Machine-readable error code when the record failed",
+                        "example": "VALIDATION_FAILED"
+                    },
+                    "errorMessage": {
+                        "type": "string",
+                        "description": "Human-readable error detail when the record failed",
+                        "example": "vin must be 17 characters"
+                    }
+                },
+                "required": [
+                    "rowIndex",
+                    "success"
+                ]
             },
             "AvailabilityInfo": {
                 "type": "object",
@@ -3894,8 +6452,7 @@
                         "example": 12
                     },
                     "leadTime": {
-                        "$ref": "#/components/schemas/LeadTimeInfo",
-                        "description": "Lead time information"
+                        "$ref": "#/components/schemas/LeadTimeInfo"
                     },
                     "status": {
                         "type": "string",
@@ -3911,7 +6468,8 @@
                     "asOf": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Timestamp of availability data"
+                        "description": "Timestamp of availability data",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "confidence": {
                         "type": "string",
@@ -3923,7 +6481,11 @@
                         ],
                         "example": "MEDIUM"
                     }
-                }
+                },
+                "required": [
+                    "confidence",
+                    "status"
+                ]
             },
             "LeadTimeInfo": {
                 "type": "object",
@@ -3959,7 +6521,8 @@
                     "asOf": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Timestamp of lead time data"
+                        "description": "Timestamp of lead time data",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "confidence": {
                         "type": "string",
@@ -3971,7 +6534,11 @@
                         ],
                         "example": "LOW"
                     }
-                }
+                },
+                "required": [
+                    "confidence",
+                    "source"
+                ]
             },
             "PricingInfo": {
                 "type": "object",
@@ -4008,7 +6575,8 @@
                     "asOf": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Timestamp of pricing data"
+                        "description": "Timestamp of pricing data",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "confidence": {
                         "type": "string",
@@ -4020,7 +6588,11 @@
                         ],
                         "example": "HIGH"
                     }
-                }
+                },
+                "required": [
+                    "confidence",
+                    "status"
+                ]
             },
             "ProductDetailView": {
                 "type": "object",
@@ -4039,21 +6611,21 @@
                     "specifications": {
                         "type": "array",
                         "description": "Product specifications",
+                        "example": [],
                         "items": {
                             "$ref": "#/components/schemas/ProductSpecification"
                         }
                     },
                     "pricing": {
-                        "$ref": "#/components/schemas/PricingInfo",
-                        "description": "Pricing information with status indicator"
+                        "$ref": "#/components/schemas/PricingInfo"
                     },
                     "availability": {
-                        "$ref": "#/components/schemas/AvailabilityInfo",
-                        "description": "Availability information with status indicator"
+                        "$ref": "#/components/schemas/AvailabilityInfo"
                     },
                     "substitutions": {
                         "type": "array",
                         "description": "Substitution product suggestions",
+                        "example": [],
                         "items": {
                             "$ref": "#/components/schemas/SubstitutionHint"
                         }
@@ -4061,7 +6633,8 @@
                     "generatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Timestamp when this response was generated"
+                        "description": "Timestamp when this response was generated",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "confidence": {
                         "type": "string",
@@ -4073,7 +6646,12 @@
                         ],
                         "example": "HIGH"
                     }
-                }
+                },
+                "required": [
+                    "confidence",
+                    "generatedAt",
+                    "productId"
+                ]
             },
             "ProductSpecification": {
                 "type": "object",
@@ -4089,7 +6667,11 @@
                         "description": "Specification value",
                         "example": "Steel"
                     }
-                }
+                },
+                "required": [
+                    "name",
+                    "value"
+                ]
             },
             "SubstitutionHint": {
                 "type": "object",
@@ -4105,7 +6687,10 @@
                         "description": "Reason for substitution",
                         "example": "Newer Model"
                     }
-                }
+                },
+                "required": [
+                    "productId"
+                ]
             },
             "ServiceDto": {
                 "type": "object",
@@ -4132,33 +6717,170 @@
                     }
                 }
             },
+            "CatalogSearchResultDto": {
+                "type": "object",
+                "description": "Cursor-based catalog search result",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "description": "Page of matching product summaries",
+                        "example": [],
+                        "items": {
+                            "$ref": "#/components/schemas/ProductSummary"
+                        }
+                    },
+                    "nextCursor": {
+                        "type": "string",
+                        "description": "Opaque cursor for the next page; null if no more results",
+                        "example": "2"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Number of items requested (limit)",
+                        "example": 20
+                    }
+                },
+                "required": [
+                    "data",
+                    "limit"
+                ]
+            },
+            "ProductSummary": {
+                "type": "object",
+                "description": "Lightweight product summary for search results",
+                "properties": {
+                    "productId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique product identifier"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Product name",
+                        "example": "Heavy Duty Wrench"
+                    },
+                    "sku": {
+                        "type": "string",
+                        "description": "Stock Keeping Unit",
+                        "example": "SKU-12345"
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "Category name",
+                        "example": "Hand Tools"
+                    },
+                    "thumbnailUrl": {
+                        "type": "string",
+                        "description": "URL of the primary product thumbnail image"
+                    },
+                    "manufacturerBrand": {
+                        "type": "string",
+                        "description": "Manufacturer brand name",
+                        "example": "AcmePro"
+                    },
+                    "lifecycleState": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Lifecycle state; only populated for detailed search",
+                        "enum": [
+                            "ACTIVE",
+                            "INACTIVE",
+                            "DISCONTINUED"
+                        ],
+                        "example": "ACTIVE"
+                    },
+                    "lifecycleStateEffectiveAt": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time",
+                        "description": "UTC instant the current lifecycle state took effect; only populated for detailed search",
+                        "example": "2026-01-15 09:30:00+00:00"
+                    },
+                    "msrpAmount": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Active MSRP amount; null when the product has no active MSRP or for lean search",
+                        "example": "99.99"
+                    },
+                    "msrpCurrency": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Active MSRP ISO 4217 currency code; null when no active MSRP or for lean search",
+                        "example": "USD"
+                    },
+                    "msrpEffectiveStartDate": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date",
+                        "description": "Start of the active MSRP effective window; null when no active MSRP or for lean search",
+                        "example": "2026-01-15"
+                    },
+                    "msrpEffectiveEndDate": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date",
+                        "description": "End of the active MSRP effective window; null for open-ended, no active MSRP, or lean search",
+                        "example": "2026-12-31"
+                    }
+                }
+            },
             "EffectiveLocationPriceResponseDto": {
                 "type": "object",
+                "description": "Effective location-specific price for a product",
                 "properties": {
                     "locationId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Location identifier",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "productId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Product identifier",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "basePrice": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Base price before any override",
+                        "example": 100.0
                     },
                     "effectivePrice": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Effective price after applying any override",
+                        "example": 89.99
                     },
                     "overrideStatus": {
                         "type": "string",
+                        "description": "Status of the override applied to derive the effective price",
                         "enum": [
                             "ACTIVE",
                             "PENDING_APPROVAL",
                             "REJECTED",
                             "INACTIVE"
-                        ]
+                        ],
+                        "example": "ACTIVE"
                     }
-                }
+                },
+                "required": [
+                    "basePrice",
+                    "effectivePrice",
+                    "locationId",
+                    "productId"
+                ]
             },
             "NonInventoryProductDto": {
                 "type": "object",
@@ -4172,17 +6894,24 @@
                     },
                     "name": {
                         "type": "string",
-                        "description": "Name"
+                        "description": "Name",
+                        "example": "Shop Supplies Fee"
                     },
                     "longDescription": {
                         "type": "string",
-                        "description": "Long description"
+                        "description": "Long description",
+                        "example": "Miscellaneous consumable shop supplies"
                     },
                     "shortDescription": {
                         "type": "string",
-                        "description": "Short description"
+                        "description": "Short description",
+                        "example": "Shop supplies"
                     }
-                }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
             },
             "ItemCostAuditDto": {
                 "type": "object",
@@ -4190,47 +6919,231 @@
                 "properties": {
                     "auditId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Audit event identifier",
+                        "example": "0196cf6f-c8dd-7ee0-93e7-f48a5698a535"
                     },
                     "itemId": {
                         "type": "string",
-                        "format": "uuid"
+                        "format": "uuid",
+                        "description": "Item identifier the audit event belongs to",
+                        "example": "2c018664-dfea-46ef-a838-6b9dbf8f9b1d"
                     },
                     "timestamp": {
                         "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "description": "Timestamp the cost change occurred",
+                        "example": "2026-01-15 09:30:00+00:00"
                     },
                     "costTypeChanged": {
                         "type": "string",
+                        "description": "Type of cost that changed",
                         "enum": [
                             "STANDARD",
                             "LAST",
                             "AVERAGE"
-                        ]
+                        ],
+                        "example": "STANDARD"
                     },
                     "oldValue": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "Previous cost value",
+                        "example": 5.0
                     },
                     "newValue": {
-                        "type": "number"
+                        "type": "number",
+                        "description": "New cost value",
+                        "example": 6.25
                     },
                     "changeSourceType": {
                         "type": "string",
+                        "description": "Source that triggered the cost change",
                         "enum": [
                             "MANUAL",
                             "PURCHASE_ORDER"
-                        ]
+                        ],
+                        "example": "MANUAL"
                     },
                     "changeSourceId": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Identifier of the change source",
+                        "example": "PO-10045"
                     },
                     "actor": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Actor responsible for the change",
+                        "example": "jane.doe"
                     },
                     "reasonCode": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Reason code for the change",
+                        "example": "PRICE_CORRECTION"
+                    }
+                },
+                "required": [
+                    "auditId",
+                    "changeSourceType",
+                    "costTypeChanged",
+                    "itemId",
+                    "timestamp"
+                ]
+            },
+            "Pageable": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": 0
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": 1
+                    },
+                    "sort": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
+            },
+            "Page": {
+                "type": "object",
+                "properties": {
+                    "totalElements": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "totalPages": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "content": {
+                        "type": "array"
+                    },
+                    "number": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "pageable": {
+                        "$ref": "#/components/schemas/PageableObject"
+                    },
+                    "sort": {
+                        "$ref": "#/components/schemas/SortObject"
+                    },
+                    "first": {
+                        "type": "boolean"
+                    },
+                    "last": {
+                        "type": "boolean"
+                    },
+                    "numberOfElements": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "empty": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "PageableObject": {
+                "type": "object",
+                "properties": {
+                    "offset": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "pageNumber": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "paged": {
+                        "type": "boolean"
+                    },
+                    "sort": {
+                        "$ref": "#/components/schemas/SortObject"
+                    },
+                    "unpaged": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "SortObject": {
+                "type": "object",
+                "properties": {
+                    "empty": {
+                        "type": "boolean"
+                    },
+                    "sorted": {
+                        "type": "boolean"
+                    },
+                    "unsorted": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "PageSupplierItemCostDto": {
+                "type": "object",
+                "properties": {
+                    "totalElements": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "totalPages": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "content": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SupplierItemCostDto"
+                        }
+                    },
+                    "number": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "pageable": {
+                        "$ref": "#/components/schemas/PageableObject"
+                    },
+                    "sort": {
+                        "$ref": "#/components/schemas/SortObject"
+                    },
+                    "first": {
+                        "type": "boolean"
+                    },
+                    "last": {
+                        "type": "boolean"
+                    },
+                    "numberOfElements": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "empty": {
+                        "type": "boolean"
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
             }
         }
     }

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -1022,11 +1022,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/ProductUomDto'
-                unevaluatedItems: {}
         '404':
           description: Product not found
           content:
@@ -1259,11 +1256,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/UomConversionDto'
-                unevaluatedItems: {}
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -1354,11 +1348,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/SubstitutionGroupDto'
-                unevaluatedItems: {}
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -2093,11 +2084,8 @@ paths:
             application/json:
               schema:
                 type: array
-                additionalProperties: {}
-                contains: {}
                 items:
                   $ref: '#/components/schemas/ServiceDto'
-                unevaluatedItems: {}
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -4865,13 +4853,13 @@ components:
         pageNumber:
           type: integer
           format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        paged:
+          type: boolean
         pageSize:
           type: integer
           format: int32
-        paged:
-          type: boolean
-        sort:
-          $ref: '#/components/schemas/SortObject'
         unpaged:
           type: boolean
     SortObject:

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -10,6 +10,8 @@ servers:
 - url: http://api-gateway.local/v1/catalog
   description: API Gateway
 tags:
+- name: Substitution Group API
+  description: Groups of mutually interchangeable products; a product belongs to at most one group
 - name: UOM Conversion API
   description: Unit of measure conversion API
 - name: Catalog Bulk Ingest API
@@ -26,6 +28,8 @@ tags:
   description: API for managing catalogs
 - name: Price Book API
   description: Manage price books, pricing rules, and resolution
+- name: Product UoM API
+  description: Per-product unit-of-measure conversion set (purchase/pack UoMs with factor to base UoM)
 - name: Catalog Items API
   description: API for managing catalog items by type
 - name: Supplier Item Cost List API
@@ -105,6 +109,135 @@ paths:
                 $ref: '#/components/schemas/ProductDto'
         '409':
           description: Business conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_EDIT
+  /v1/products/{productId}/uoms/{uomId}:
+    put:
+      tags:
+      - Product UoM API
+      summary: Update product UoM conversion
+      description: Updates factor, precision scale, and optionally the UoM role. The UoM code is immutable. Re-emits the product contract event.
+      operationId: updateProductUom
+      parameters:
+      - name: productId
+        in: path
+        description: Product ID
+        required: true
+        schema:
+          type: string
+      - name: uomId
+        in: path
+        description: Product UoM ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductUomUpdateRequestDto'
+        required: true
+      responses:
+        '200':
+          description: Product UoM updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductUomDto'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductUomDto'
+        '404':
+          description: Product or UoM not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductUomDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_EDIT
+    delete:
+      tags:
+      - Product UoM API
+      summary: Delete product UoM conversion
+      description: Removes a UoM from the product's conversion set and re-emits the product contract event.
+      operationId: deleteProductUom
+      parameters:
+      - name: productId
+        in: path
+        description: Product ID
+        required: true
+        schema:
+          type: string
+      - name: uomId
+        in: path
+        description: Product UoM ID
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Product UoM deleted
+        '404':
+          description: Product or UoM not found
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_EDIT
+  /v1/products/{productId}/tracking-level:
+    put:
+      tags:
+      - Products API
+      summary: Set product tracking level
+      description: Sets the product's stock tracking level (NONE, LOT, or SERIAL; default NONE) and re-emits the product contract event for downstream replicas.
+      operationId: updateTrackingLevel
+      parameters:
+      - name: productId
+        in: path
+        description: ID of the product
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductTrackingLevelUpdateRequestDto'
+        required: true
+      responses:
+        '200':
+          description: Tracking level updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductDto'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductDto'
+        '404':
+          description: Product not found
           content:
             application/json:
               schema:
@@ -868,6 +1001,98 @@ paths:
       x-required-permissions:
       - ADMIN
       - CATALOG_VIEW
+  /v1/products/{productId}/uoms:
+    get:
+      tags:
+      - Product UoM API
+      summary: List product UoM conversions
+      description: Returns the product's UoM conversion set ordered by UoM code.
+      operationId: listProductUoms
+      parameters:
+      - name: productId
+        in: path
+        description: Product ID
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Product UoMs listed
+          content:
+            application/json:
+              schema:
+                type: array
+                additionalProperties: {}
+                contains: {}
+                items:
+                  $ref: '#/components/schemas/ProductUomDto'
+                unevaluatedItems: {}
+        '404':
+          description: Product not found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductUomDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_VIEW
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_VIEW
+    post:
+      tags:
+      - Product UoM API
+      summary: Add product UoM conversion
+      description: Adds a purchase/pack (or base) UoM with its conversion factor to the product's base UoM and a precision scale. Re-emits the product contract event.
+      operationId: addProductUom
+      parameters:
+      - name: productId
+        in: path
+        description: Product ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductUomCreateRequestDto'
+        required: true
+      responses:
+        '201':
+          description: Product UoM created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductUomDto'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductUomDto'
+        '404':
+          description: Product not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductUomDto'
+        '409':
+          description: UoM code already defined for product
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductUomDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_EDIT
   /v1/products/{productId}/replacements:
     get:
       tags:
@@ -1034,8 +1259,11 @@ paths:
             application/json:
               schema:
                 type: array
+                additionalProperties: {}
+                contains: {}
                 items:
                   $ref: '#/components/schemas/UomConversionDto'
+                unevaluatedItems: {}
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -1112,6 +1340,116 @@ paths:
         - catalog:supplier_cost:write
       x-required-permissions:
       - catalog:supplier_cost:write
+  /v1/products/substitution-groups:
+    get:
+      tags:
+      - Substitution Group API
+      summary: List substitution groups
+      description: Returns all substitution groups with their member product ids.
+      operationId: listSubstitutionGroups
+      responses:
+        '200':
+          description: Substitution groups listed
+          content:
+            application/json:
+              schema:
+                type: array
+                additionalProperties: {}
+                contains: {}
+                items:
+                  $ref: '#/components/schemas/SubstitutionGroupDto'
+                unevaluatedItems: {}
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_VIEW
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_VIEW
+    post:
+      tags:
+      - Substitution Group API
+      summary: Create substitution group
+      description: Creates an empty substitution group; add members afterwards.
+      operationId: createSubstitutionGroup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubstitutionGroupCreateRequestDto'
+        required: true
+      responses:
+        '201':
+          description: Substitution group created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_EDIT
+  /v1/products/substitution-groups/{groupId}/members:
+    post:
+      tags:
+      - Substitution Group API
+      summary: Add product to substitution group
+      description: Adds a product to the group (a product belongs to at most one group) and re-emits the product contract event for every member.
+      operationId: addSubstitutionGroupMember
+      parameters:
+      - name: groupId
+        in: path
+        description: Substitution group ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubstitutionGroupMemberRequestDto'
+        required: true
+      responses:
+        '200':
+          description: Member added
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+        '404':
+          description: Substitution group or product not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+        '409':
+          description: Product already belongs to a substitution group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_EDIT
   /v1/products/pricing/location-overrides:
     post:
       tags:
@@ -1635,6 +1973,65 @@ paths:
       x-required-permissions:
       - ADMIN
       - CATALOG_VIEW
+  /v1/products/substitution-groups/{groupId}:
+    get:
+      tags:
+      - Substitution Group API
+      summary: Get substitution group
+      description: Retrieves a substitution group with its member product ids.
+      operationId: getSubstitutionGroup
+      parameters:
+      - name: groupId
+        in: path
+        description: Substitution group ID
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Substitution group found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+        '404':
+          description: Substitution group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_VIEW
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_VIEW
+    delete:
+      tags:
+      - Substitution Group API
+      summary: Delete substitution group
+      description: Deletes a group and its memberships, re-emitting the product contract event for every former member.
+      operationId: deleteSubstitutionGroup
+      parameters:
+      - name: groupId
+        in: path
+        description: Substitution group ID
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Substitution group deleted
+        '404':
+          description: Substitution group not found
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_EDIT
   /v1/products/services/{serviceId}:
     get:
       tags:
@@ -1696,8 +2093,11 @@ paths:
             application/json:
               schema:
                 type: array
+                additionalProperties: {}
+                contains: {}
                 items:
                   $ref: '#/components/schemas/ServiceDto'
+                unevaluatedItems: {}
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -2080,6 +2480,46 @@ paths:
         - catalog:supplier_cost:read
       x-required-permissions:
       - catalog:supplier_cost:read
+  /v1/products/substitution-groups/{groupId}/members/{productId}:
+    delete:
+      tags:
+      - Substitution Group API
+      summary: Remove product from substitution group
+      description: Removes a product from the group and re-emits the product contract event for the removed product and every remaining member.
+      operationId: removeSubstitutionGroupMember
+      parameters:
+      - name: groupId
+        in: path
+        description: Substitution group ID
+        required: true
+        schema:
+          type: string
+      - name: productId
+        in: path
+        description: Product ID to remove
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Member removed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+        '404':
+          description: Substitution group or membership not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubstitutionGroupDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
+      x-required-permissions:
+      - ADMIN
+      - CATALOG_EDIT
 components:
   schemas:
     ProductUpdateRequestDto:
@@ -2281,6 +2721,14 @@ components:
           - ACTIVE
           - INACTIVE
           example: ACTIVE
+        trackingLevel:
+          type: string
+          description: Stock tracking level
+          enum:
+          - NONE
+          - LOT
+          - SERIAL
+          example: NONE
         productCode:
           type: string
           description: Product code
@@ -2376,6 +2824,101 @@ components:
           type: string
           description: Subcategory name
           example: Hand Tools
+    ProductUomUpdateRequestDto:
+      type: object
+      description: Request to update a product UoM conversion (the UoM code is immutable)
+      properties:
+        uomType:
+          type: string
+          description: New role of this UoM for the product; unchanged when omitted
+          enum:
+          - BASE
+          - PURCHASE
+          - PACK
+          - OTHER
+          example: PACK
+        factorToBase:
+          type: number
+          description: Multiplier converting one unit of this UoM into the product's base UoM
+          example: 12
+          minimum: 0
+        precisionScale:
+          type: integer
+          format: int32
+          description: Decimal precision scale for quantities expressed in this UoM (0-6)
+          example: 0
+          maximum: 6
+          minimum: 0
+      required:
+      - factorToBase
+      - precisionScale
+    ProductUomDto:
+      type: object
+      description: A per-product unit-of-measure conversion to the product's base UoM
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Identifier of the product UoM row
+          example: 0196cf6f-c8dd-7ee0-93e7-f48a5698a535
+        productId:
+          type: string
+          format: uuid
+          description: Identifier of the product
+          example: 018e1c9f-6b5a-7890-abcd-1234567890ab
+        uomCode:
+          type: string
+          description: Unit-of-measure code
+          example: CASE
+        uomType:
+          type: string
+          description: Role of this UoM for the product
+          enum:
+          - BASE
+          - PURCHASE
+          - PACK
+          - OTHER
+          example: PURCHASE
+        factorToBase:
+          type: number
+          description: Multiplier converting one unit of this UoM into the product's base UoM
+          example: 12
+        precisionScale:
+          type: integer
+          format: int32
+          description: Decimal precision scale for quantities expressed in this UoM
+          example: 0
+        createdAt:
+          type: string
+          format: date-time
+          description: Created timestamp
+          example: 2026-01-15 09:30:00+00:00
+        updatedAt:
+          type: string
+          format: date-time
+          description: Updated timestamp
+          example: 2026-01-16 11:00:00+00:00
+      required:
+      - factorToBase
+      - id
+      - precisionScale
+      - productId
+      - uomCode
+      - uomType
+    ProductTrackingLevelUpdateRequestDto:
+      type: object
+      description: Request to set a product's stock tracking level
+      properties:
+        trackingLevel:
+          type: string
+          description: Stock tracking level
+          enum:
+          - NONE
+          - LOT
+          - SERIAL
+          example: LOT
+      required:
+      - trackingLevel
     UpdateMsrpRequestDto:
       type: object
       description: Request to update the MSRP for a product
@@ -3219,6 +3762,41 @@ components:
       - name
       - sku
       - unitOfMeasure
+    ProductUomCreateRequestDto:
+      type: object
+      description: Request to add a UoM conversion to a product
+      properties:
+        uomCode:
+          type: string
+          description: Unit-of-measure code
+          example: CASE
+          minLength: 1
+        uomType:
+          type: string
+          description: Role of this UoM for the product
+          enum:
+          - BASE
+          - PURCHASE
+          - PACK
+          - OTHER
+          example: PURCHASE
+        factorToBase:
+          type: number
+          description: Multiplier converting one unit of this UoM into the product's base UoM
+          example: 12
+          minimum: 0
+        precisionScale:
+          type: integer
+          format: int32
+          description: Decimal precision scale for quantities expressed in this UoM (0-6)
+          example: 0
+          maximum: 6
+          minimum: 0
+      required:
+      - factorToBase
+      - precisionScale
+      - uomCode
+      - uomType
     ProductReplacementRequest:
       type: object
       description: Product replacement option request
@@ -3332,6 +3910,72 @@ components:
       - currencyCode
       - itemId
       - supplierId
+    SubstitutionGroupCreateRequestDto:
+      type: object
+      description: Request to create a substitution group
+      properties:
+        name:
+          type: string
+          description: Group name
+          example: 5W-30 full synthetic quarts
+          maxLength: 128
+          minLength: 0
+        notes:
+          type: string
+          description: Free-text notes
+          example: Any brand acceptable
+          maxLength: 512
+          minLength: 0
+      required:
+      - name
+    SubstitutionGroupDto:
+      type: object
+      description: 'A substitution group: a set of mutually interchangeable products'
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Identifier of the substitution group
+          example: 0196cf6f-c8dd-7ee0-93e7-f48a5698a535
+        name:
+          type: string
+          description: Group name
+          example: 5W-30 full synthetic quarts
+        notes:
+          type: string
+          description: Free-text notes
+          example: Any brand acceptable
+        productIds:
+          type: array
+          description: Product ids of all group members
+          items:
+            type: string
+            format: uuid
+        createdAt:
+          type: string
+          format: date-time
+          description: Created timestamp
+          example: 2026-01-15 09:30:00+00:00
+        updatedAt:
+          type: string
+          format: date-time
+          description: Updated timestamp
+          example: 2026-01-16 11:00:00+00:00
+      required:
+      - id
+      - name
+      - productIds
+    SubstitutionGroupMemberRequestDto:
+      type: object
+      description: Request to add a product to a substitution group
+      properties:
+        productId:
+          type: string
+          format: uuid
+          description: Identifier of the product to add
+          example: 018e1c9f-6b5a-7890-abcd-1234567890ab
+      required:
+      - productId
     LocationPriceOverrideCreateRequestDto:
       type: object
       description: Request payload for creating a location price override
@@ -4199,10 +4843,10 @@ components:
         number:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
         pageable:
           $ref: '#/components/schemas/PageableObject'
+        sort:
+          $ref: '#/components/schemas/SortObject'
         first:
           type: boolean
         last:
@@ -4218,16 +4862,16 @@ components:
         offset:
           type: integer
           format: int64
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        paged:
-          type: boolean
         pageNumber:
           type: integer
           format: int32
         pageSize:
           type: integer
           format: int32
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
         unpaged:
           type: boolean
     SortObject:
@@ -4258,10 +4902,10 @@ components:
         number:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
         pageable:
           $ref: '#/components/schemas/PageableObject'
+        sort:
+          $ref: '#/components/schemas/SortObject'
         first:
           type: boolean
         last:

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogEventTypes.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogEventTypes.java
@@ -48,6 +48,26 @@ public final class CatalogEventTypes {
                                 "CATALOG_PRODUCT_REPLACEMENT_ADD",
                                 "Add replacement recommendation for a discontinued product")
                         .build(),
+                EventTypeRegistration.write(
+                                "CATALOG_PRODUCT_TRACKING_LEVEL_UPDATE",
+                                "Set product stock tracking level (NONE, LOT, SERIAL)")
+                        .build(),
+                EventTypeRegistration.write("CATALOG_PRODUCT_UOM_CREATE", "Add per-product UOM conversion")
+                        .build(),
+                EventTypeRegistration.write("CATALOG_PRODUCT_UOM_UPDATE", "Update per-product UOM conversion")
+                        .build(),
+                EventTypeRegistration.write("CATALOG_PRODUCT_UOM_DELETE", "Delete per-product UOM conversion")
+                        .build(),
+                EventTypeRegistration.write("CATALOG_SUBSTITUTION_GROUP_CREATE", "Create substitution group")
+                        .build(),
+                EventTypeRegistration.write("CATALOG_SUBSTITUTION_GROUP_DELETE", "Delete substitution group")
+                        .build(),
+                EventTypeRegistration.write(
+                                "CATALOG_SUBSTITUTION_GROUP_MEMBER_ADD", "Add product to substitution group")
+                        .build(),
+                EventTypeRegistration.write(
+                                "CATALOG_SUBSTITUTION_GROUP_MEMBER_REMOVE", "Remove product from substitution group")
+                        .build(),
                 EventTypeRegistration.write("CATALOG_UOM_CONVERSION_CREATE", "Create UOM conversion")
                         .build(),
                 EventTypeRegistration.write("CATALOG_UOM_CONVERSION_UPDATE", "Update UOM conversion factor")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
@@ -3,12 +3,19 @@ package com.positivity.catalog.internal.config;
 import com.positivity.catalog.internal.entity.Category;
 import com.positivity.catalog.internal.entity.ProductEntity;
 import com.positivity.catalog.internal.entity.ProductStatus;
+import com.positivity.catalog.internal.entity.ProductTrackingLevel;
+import com.positivity.catalog.internal.entity.SubstitutionGroupMemberEntity;
+import com.positivity.catalog.internal.repository.ProductUomRepository;
+import com.positivity.catalog.internal.repository.SubstitutionGroupMemberRepository;
 import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.DomainTopics;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
 import java.time.Clock;
+import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 
@@ -20,9 +27,16 @@ import org.springframework.stereotype.Component;
  * {@link OutboxEventWriter} bean is conditional, so this publisher degrades gracefully. Must be
  * called inside the mutating transaction (the writer requires {@code MANDATORY} propagation).
  *
+ * <p>Since #1023 (inventory Odoo-parity Story X1, schema version 2) the payload additionally
+ * carries the product's base UoM, tracking level, per-product UoM conversion set, and
+ * substitution-group membership, read from the current persisted state at publish time. Because
+ * the payload is always assembled here from entity state, any replay/re-emit path that goes
+ * through {@link #publishProductUpdated(ProductEntity)} automatically includes the full contract.
+ *
  * <p>pos-catalog's {@code ProductEntity} has no JPA {@code @Version}; the envelope's
  * {@code aggregateVersion} carries {@code updatedAt} as epoch millis (monotonic per product), which
- * consumers use as the stale-event guard.
+ * consumers use as the stale-event guard. Callers mutating only attribute tables (product_uom,
+ * substitution_group_member) must bump the product's {@code updatedAt} before publishing.
  */
 @Slf4j
 @Component
@@ -30,10 +44,18 @@ public class CatalogFactPublisher {
 
     private final Clock clock;
     private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+    private final ProductUomRepository productUomRepository;
+    private final SubstitutionGroupMemberRepository substitutionGroupMemberRepository;
 
-    public CatalogFactPublisher(Clock clock, ObjectProvider<OutboxEventWriter> outboxEventWriter) {
+    public CatalogFactPublisher(
+            Clock clock,
+            ObjectProvider<OutboxEventWriter> outboxEventWriter,
+            ProductUomRepository productUomRepository,
+            SubstitutionGroupMemberRepository substitutionGroupMemberRepository) {
         this.clock = clock;
         this.outboxEventWriter = outboxEventWriter;
+        this.productUomRepository = productUomRepository;
+        this.substitutionGroupMemberRepository = substitutionGroupMemberRepository;
     }
 
     public void publishProductUpdated(@NonNull ProductEntity product) {
@@ -44,6 +66,11 @@ public class CatalogFactPublisher {
         Category category = product.getCategory();
         long aggregateVersion =
                 product.getUpdatedAt() == null ? 0L : product.getUpdatedAt().toEpochMilli();
+        ProductTrackingLevel trackingLevel =
+                product.getTrackingLevel() == null ? ProductTrackingLevel.NONE : product.getTrackingLevel();
+        SubstitutionGroupMemberEntity membership = substitutionGroupMemberRepository
+                .findByProductId(product.getId())
+                .orElse(null);
         ProductUpdatedV1 payload = new ProductUpdatedV1(
                 product.getId(),
                 product.getSku(),
@@ -57,7 +84,12 @@ public class CatalogFactPublisher {
                 product.getManufacturerWarranty(),
                 product.getStatus() == ProductStatus.ACTIVE,
                 product.getCreatedAt(),
-                product.getUpdatedAt());
+                product.getUpdatedAt(),
+                product.getUnitOfMeasure(),
+                trackingLevel.name(),
+                uomConversionsOf(product.getId()),
+                membership == null ? null : membership.getGroup().getId(),
+                membership == null ? null : substitutionMemberIdsOf(membership));
         DomainEventEnvelope<ProductUpdatedV1> envelope = DomainEventEnvelope.of(
                 ProductUpdatedV1.EVENT_TYPE,
                 ProductUpdatedV1.SCHEMA_VERSION,
@@ -70,5 +102,27 @@ public class CatalogFactPublisher {
                 clock);
         writer.publish(DomainTopics.events("catalog"), envelope);
         log.debug("Queued catalog.product.updated productId={} sku={}", product.getId(), product.getSku());
+    }
+
+    private @Nullable List<ProductUpdatedV1.UomConversion> uomConversionsOf(UUID productId) {
+        List<ProductUpdatedV1.UomConversion> conversions =
+                productUomRepository.findByProductIdOrderByUomCodeAsc(productId).stream()
+                        .map(row -> new ProductUpdatedV1.UomConversion(
+                                row.getUomCode(),
+                                row.getUomType() == null
+                                        ? null
+                                        : row.getUomType().name(),
+                                row.getFactorToBase(),
+                                row.getPrecisionScale()))
+                        .toList();
+        return conversions.isEmpty() ? null : conversions;
+    }
+
+    private List<UUID> substitutionMemberIdsOf(SubstitutionGroupMemberEntity membership) {
+        return substitutionGroupMemberRepository
+                .findByGroupIdOrderByCreatedAtAsc(membership.getGroup().getId())
+                .stream()
+                .map(member -> member.getProduct().getId())
+                .toList();
     }
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
@@ -13,6 +13,7 @@ import com.positivity.catalog.internal.dto.ProductDto;
 import com.positivity.catalog.internal.dto.ProductLifecycleResponse;
 import com.positivity.catalog.internal.dto.ProductLifecycleUpdateRequest;
 import com.positivity.catalog.internal.dto.ProductReplacementRequest;
+import com.positivity.catalog.internal.dto.ProductTrackingLevelUpdateRequestDto;
 import com.positivity.catalog.internal.dto.ProductUpdateRequestDto;
 import com.positivity.catalog.internal.dto.ServiceDto;
 import com.positivity.catalog.service.CatalogService;
@@ -261,6 +262,28 @@ public class ProductController {
             @Parameter(description = "ID of the product to update", required = true) @PathVariable UUID productId,
             @Valid @RequestBody ProductUpdateRequestDto request) {
         return ResponseEntity.ok(productMasterDataService.updateProduct(productId, request));
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @PutMapping("/{productId}/tracking-level")
+    @Operation(
+            summary = "Set product tracking level",
+            description = "Sets the product's stock tracking level (NONE, LOT, or SERIAL; default NONE) and"
+                    + " re-emits the product contract event for downstream replicas.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Tracking level updated",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductDto.class)))
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "404", description = "Product not found")
+    @EmitEvent(id = "CATALOG_PRODUCT_TRACKING_LEVEL_UPDATE", apiVersion = "1")
+    public ResponseEntity<ProductDto> updateTrackingLevel(
+            @Parameter(description = "ID of the product", required = true) @PathVariable UUID productId,
+            @Valid @RequestBody ProductTrackingLevelUpdateRequestDto request) {
+        return ResponseEntity.ok(productMasterDataService.updateTrackingLevel(productId, request));
     }
 
     @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductUomController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductUomController.java
@@ -1,0 +1,129 @@
+package com.positivity.catalog.internal.controller;
+
+import com.positivity.catalog.internal.dto.ProductUomCreateRequestDto;
+import com.positivity.catalog.internal.dto.ProductUomDto;
+import com.positivity.catalog.internal.dto.ProductUomUpdateRequestDto;
+import com.positivity.catalog.service.ProductUomService;
+import com.positivity.events.EmitEvent;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/products/{productId}/uoms")
+@Tag(
+        name = "Product UoM API",
+        description = "Per-product unit-of-measure conversion set (purchase/pack UoMs with factor to base UoM)")
+public class ProductUomController {
+
+    private final ProductUomService productUomService;
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @PostMapping
+    @Operation(
+            summary = "Add product UoM conversion",
+            description = "Adds a purchase/pack (or base) UoM with its conversion factor to the product's base UoM"
+                    + " and a precision scale. Re-emits the product contract event.",
+            operationId = "addProductUom")
+    @ApiResponse(
+            responseCode = "201",
+            description = "Product UoM created",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductUomDto.class)))
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "404", description = "Product not found")
+    @ApiResponse(responseCode = "409", description = "UoM code already defined for product")
+    @EmitEvent(id = "CATALOG_PRODUCT_UOM_CREATE", apiVersion = "1")
+    public ResponseEntity<ProductUomDto> addProductUom(
+            @Parameter(description = "Product ID", required = true) @PathVariable UUID productId,
+            @Valid @RequestBody ProductUomCreateRequestDto request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(productUomService.addProductUom(productId, request));
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
+    @GetMapping
+    @Operation(
+            summary = "List product UoM conversions",
+            description = "Returns the product's UoM conversion set ordered by UoM code.",
+            operationId = "listProductUoms")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Product UoMs listed",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = ProductUomDto.class))))
+    @ApiResponse(responseCode = "404", description = "Product not found")
+    public ResponseEntity<List<ProductUomDto>> listProductUoms(
+            @Parameter(description = "Product ID", required = true) @PathVariable UUID productId) {
+        return ResponseEntity.ok(productUomService.listProductUoms(productId));
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @PutMapping("/{uomId}")
+    @Operation(
+            summary = "Update product UoM conversion",
+            description = "Updates factor, precision scale, and optionally the UoM role. The UoM code is immutable."
+                    + " Re-emits the product contract event.",
+            operationId = "updateProductUom")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Product UoM updated",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductUomDto.class)))
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "404", description = "Product or UoM not found")
+    @EmitEvent(id = "CATALOG_PRODUCT_UOM_UPDATE", apiVersion = "1")
+    public ResponseEntity<ProductUomDto> updateProductUom(
+            @Parameter(description = "Product ID", required = true) @PathVariable UUID productId,
+            @Parameter(description = "Product UoM ID", required = true) @PathVariable UUID uomId,
+            @Valid @RequestBody ProductUomUpdateRequestDto request) {
+        return ResponseEntity.ok(productUomService.updateProductUom(productId, uomId, request));
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @DeleteMapping("/{uomId}")
+    @Operation(
+            summary = "Delete product UoM conversion",
+            description = "Removes a UoM from the product's conversion set and re-emits the product contract event.",
+            operationId = "deleteProductUom")
+    @ApiResponse(responseCode = "204", description = "Product UoM deleted")
+    @ApiResponse(responseCode = "404", description = "Product or UoM not found")
+    @EmitEvent(id = "CATALOG_PRODUCT_UOM_DELETE", apiVersion = "1")
+    public ResponseEntity<Void> deleteProductUom(
+            @Parameter(description = "Product ID", required = true) @PathVariable UUID productId,
+            @Parameter(description = "Product UoM ID", required = true) @PathVariable UUID uomId) {
+        productUomService.deleteProductUom(productId, uomId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SubstitutionGroupController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SubstitutionGroupController.java
@@ -1,0 +1,175 @@
+package com.positivity.catalog.internal.controller;
+
+import com.positivity.catalog.internal.dto.SubstitutionGroupCreateRequestDto;
+import com.positivity.catalog.internal.dto.SubstitutionGroupDto;
+import com.positivity.catalog.internal.dto.SubstitutionGroupMemberRequestDto;
+import com.positivity.catalog.service.SubstitutionGroupService;
+import com.positivity.events.EmitEvent;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/products/substitution-groups")
+@Tag(
+        name = "Substitution Group API",
+        description = "Groups of mutually interchangeable products; a product belongs to at most one group")
+public class SubstitutionGroupController {
+
+    private final SubstitutionGroupService substitutionGroupService;
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @PostMapping
+    @Operation(
+            summary = "Create substitution group",
+            description = "Creates an empty substitution group; add members afterwards.",
+            operationId = "createSubstitutionGroup")
+    @ApiResponse(
+            responseCode = "201",
+            description = "Substitution group created",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SubstitutionGroupDto.class)))
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @EmitEvent(id = "CATALOG_SUBSTITUTION_GROUP_CREATE", apiVersion = "1")
+    public ResponseEntity<SubstitutionGroupDto> createGroup(
+            @Valid @RequestBody SubstitutionGroupCreateRequestDto request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(substitutionGroupService.createGroup(request));
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
+    @GetMapping
+    @Operation(
+            summary = "List substitution groups",
+            description = "Returns all substitution groups with their member product ids.",
+            operationId = "listSubstitutionGroups")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Substitution groups listed",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = SubstitutionGroupDto.class))))
+    public ResponseEntity<List<SubstitutionGroupDto>> listGroups() {
+        return ResponseEntity.ok(substitutionGroupService.listGroups());
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
+    @GetMapping("/{groupId}")
+    @Operation(
+            summary = "Get substitution group",
+            description = "Retrieves a substitution group with its member product ids.",
+            operationId = "getSubstitutionGroup")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Substitution group found",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SubstitutionGroupDto.class)))
+    @ApiResponse(responseCode = "404", description = "Substitution group not found")
+    public ResponseEntity<SubstitutionGroupDto> getGroup(
+            @Parameter(description = "Substitution group ID", required = true) @PathVariable UUID groupId) {
+        return ResponseEntity.ok(substitutionGroupService.getGroup(groupId));
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @DeleteMapping("/{groupId}")
+    @Operation(
+            summary = "Delete substitution group",
+            description = "Deletes a group and its memberships, re-emitting the product contract event"
+                    + " for every former member.",
+            operationId = "deleteSubstitutionGroup")
+    @ApiResponse(responseCode = "204", description = "Substitution group deleted")
+    @ApiResponse(responseCode = "404", description = "Substitution group not found")
+    @EmitEvent(id = "CATALOG_SUBSTITUTION_GROUP_DELETE", apiVersion = "1")
+    public ResponseEntity<Void> deleteGroup(
+            @Parameter(description = "Substitution group ID", required = true) @PathVariable UUID groupId) {
+        substitutionGroupService.deleteGroup(groupId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @PostMapping("/{groupId}/members")
+    @Operation(
+            summary = "Add product to substitution group",
+            description = "Adds a product to the group (a product belongs to at most one group) and re-emits the"
+                    + " product contract event for every member.",
+            operationId = "addSubstitutionGroupMember")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Member added",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SubstitutionGroupDto.class)))
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "404", description = "Substitution group or product not found")
+    @ApiResponse(responseCode = "409", description = "Product already belongs to a substitution group")
+    @EmitEvent(id = "CATALOG_SUBSTITUTION_GROUP_MEMBER_ADD", apiVersion = "1")
+    public ResponseEntity<SubstitutionGroupDto> addMember(
+            @Parameter(description = "Substitution group ID", required = true) @PathVariable UUID groupId,
+            @Valid @RequestBody SubstitutionGroupMemberRequestDto request) {
+        return ResponseEntity.ok(substitutionGroupService.addMember(groupId, request));
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @DeleteMapping("/{groupId}/members/{productId}")
+    @Operation(
+            summary = "Remove product from substitution group",
+            description = "Removes a product from the group and re-emits the product contract event for the removed"
+                    + " product and every remaining member.",
+            operationId = "removeSubstitutionGroupMember")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Member removed",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SubstitutionGroupDto.class)))
+    @ApiResponse(responseCode = "404", description = "Substitution group or membership not found")
+    @EmitEvent(id = "CATALOG_SUBSTITUTION_GROUP_MEMBER_REMOVE", apiVersion = "1")
+    public ResponseEntity<SubstitutionGroupDto> removeMember(
+            @Parameter(description = "Substitution group ID", required = true) @PathVariable UUID groupId,
+            @Parameter(description = "Product ID to remove", required = true) @PathVariable UUID productId) {
+        return ResponseEntity.ok(substitutionGroupService.removeMember(groupId, productId));
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductDto.java
@@ -6,6 +6,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import com.positivity.catalog.internal.entity.ProductCodeType;
 import com.positivity.catalog.internal.entity.ProductLifecycleState;
 import com.positivity.catalog.internal.entity.ProductStatus;
+import com.positivity.catalog.internal.entity.ProductTrackingLevel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.List;
@@ -85,6 +86,13 @@ public class ProductDto {
             implementation = ProductStatus.class,
             requiredMode = NOT_REQUIRED)
     private ProductStatus status;
+
+    @Schema(
+            description = "Stock tracking level",
+            example = "NONE",
+            implementation = ProductTrackingLevel.class,
+            requiredMode = NOT_REQUIRED)
+    private ProductTrackingLevel trackingLevel;
 
     @Schema(description = "Product code", example = "012345678905", requiredMode = NOT_REQUIRED)
     private String productCode;

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductTrackingLevelUpdateRequestDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductTrackingLevelUpdateRequestDto.java
@@ -1,0 +1,25 @@
+package com.positivity.catalog.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.catalog.internal.entity.ProductTrackingLevel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Request to set a product's stock tracking level")
+public class ProductTrackingLevelUpdateRequestDto {
+
+    @NotNull
+    @Schema(
+            description = "Stock tracking level",
+            example = "LOT",
+            implementation = ProductTrackingLevel.class,
+            requiredMode = REQUIRED)
+    private ProductTrackingLevel trackingLevel;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductUomCreateRequestDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductUomCreateRequestDto.java
@@ -1,0 +1,51 @@
+package com.positivity.catalog.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.catalog.internal.entity.ProductUomType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Request to add a UoM conversion to a product")
+public class ProductUomCreateRequestDto {
+
+    @NotBlank
+    @Schema(description = "Unit-of-measure code", example = "CASE", requiredMode = REQUIRED)
+    private String uomCode;
+
+    @NotNull
+    @Schema(
+            description = "Role of this UoM for the product",
+            example = "PURCHASE",
+            implementation = ProductUomType.class,
+            requiredMode = REQUIRED)
+    private ProductUomType uomType;
+
+    @NotNull
+    @DecimalMin(value = "0", inclusive = false)
+    @Schema(
+            description = "Multiplier converting one unit of this UoM into the product's base UoM",
+            example = "12",
+            requiredMode = REQUIRED)
+    private BigDecimal factorToBase;
+
+    @NotNull
+    @Min(0)
+    @Max(6)
+    @Schema(
+            description = "Decimal precision scale for quantities expressed in this UoM (0-6)",
+            example = "0",
+            requiredMode = REQUIRED)
+    private Integer precisionScale;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductUomDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductUomDto.java
@@ -1,0 +1,58 @@
+package com.positivity.catalog.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.catalog.internal.entity.ProductUomType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "A per-product unit-of-measure conversion to the product's base UoM")
+public class ProductUomDto {
+
+    @Schema(
+            description = "Identifier of the product UoM row",
+            example = "0196cf6f-c8dd-7ee0-93e7-f48a5698a535",
+            requiredMode = REQUIRED)
+    private UUID id;
+
+    @Schema(
+            description = "Identifier of the product",
+            example = "018e1c9f-6b5a-7890-abcd-1234567890ab",
+            requiredMode = REQUIRED)
+    private UUID productId;
+
+    @Schema(description = "Unit-of-measure code", example = "CASE", requiredMode = REQUIRED)
+    private String uomCode;
+
+    @Schema(
+            description = "Role of this UoM for the product",
+            example = "PURCHASE",
+            implementation = ProductUomType.class,
+            requiredMode = REQUIRED)
+    private ProductUomType uomType;
+
+    @Schema(
+            description = "Multiplier converting one unit of this UoM into the product's base UoM",
+            example = "12",
+            requiredMode = REQUIRED)
+    private BigDecimal factorToBase;
+
+    @Schema(
+            description = "Decimal precision scale for quantities expressed in this UoM",
+            example = "0",
+            requiredMode = REQUIRED)
+    private int precisionScale;
+
+    @Schema(description = "Created timestamp", example = "2026-01-15T09:30:00Z", requiredMode = NOT_REQUIRED)
+    private Instant createdAt;
+
+    @Schema(description = "Updated timestamp", example = "2026-01-16T11:00:00Z", requiredMode = NOT_REQUIRED)
+    private Instant updatedAt;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductUomUpdateRequestDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductUomUpdateRequestDto.java
@@ -1,0 +1,46 @@
+package com.positivity.catalog.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.catalog.internal.entity.ProductUomType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Request to update a product UoM conversion (the UoM code is immutable)")
+public class ProductUomUpdateRequestDto {
+
+    @Schema(
+            description = "New role of this UoM for the product; unchanged when omitted",
+            example = "PACK",
+            implementation = ProductUomType.class,
+            requiredMode = NOT_REQUIRED)
+    private ProductUomType uomType;
+
+    @NotNull
+    @DecimalMin(value = "0", inclusive = false)
+    @Schema(
+            description = "Multiplier converting one unit of this UoM into the product's base UoM",
+            example = "12",
+            requiredMode = REQUIRED)
+    private BigDecimal factorToBase;
+
+    @NotNull
+    @Min(0)
+    @Max(6)
+    @Schema(
+            description = "Decimal precision scale for quantities expressed in this UoM (0-6)",
+            example = "0",
+            requiredMode = REQUIRED)
+    private Integer precisionScale;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/SubstitutionGroupCreateRequestDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/SubstitutionGroupCreateRequestDto.java
@@ -1,0 +1,27 @@
+package com.positivity.catalog.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Request to create a substitution group")
+public class SubstitutionGroupCreateRequestDto {
+
+    @NotBlank
+    @Size(max = 128)
+    @Schema(description = "Group name", example = "5W-30 full synthetic quarts", requiredMode = REQUIRED)
+    private String name;
+
+    @Size(max = 512)
+    @Schema(description = "Free-text notes", example = "Any brand acceptable", requiredMode = NOT_REQUIRED)
+    private String notes;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/SubstitutionGroupDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/SubstitutionGroupDto.java
@@ -1,0 +1,38 @@
+package com.positivity.catalog.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "A substitution group: a set of mutually interchangeable products")
+public class SubstitutionGroupDto {
+
+    @Schema(
+            description = "Identifier of the substitution group",
+            example = "0196cf6f-c8dd-7ee0-93e7-f48a5698a535",
+            requiredMode = REQUIRED)
+    private UUID id;
+
+    @Schema(description = "Group name", example = "5W-30 full synthetic quarts", requiredMode = REQUIRED)
+    private String name;
+
+    @Schema(description = "Free-text notes", example = "Any brand acceptable", requiredMode = NOT_REQUIRED)
+    private String notes;
+
+    @Schema(description = "Product ids of all group members", requiredMode = REQUIRED)
+    private List<UUID> productIds;
+
+    @Schema(description = "Created timestamp", example = "2026-01-15T09:30:00Z", requiredMode = NOT_REQUIRED)
+    private Instant createdAt;
+
+    @Schema(description = "Updated timestamp", example = "2026-01-16T11:00:00Z", requiredMode = NOT_REQUIRED)
+    private Instant updatedAt;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/SubstitutionGroupMemberRequestDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/SubstitutionGroupMemberRequestDto.java
@@ -1,0 +1,24 @@
+package com.positivity.catalog.internal.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Request to add a product to a substitution group")
+public class SubstitutionGroupMemberRequestDto {
+
+    @NotNull
+    @Schema(
+            description = "Identifier of the product to add",
+            example = "018e1c9f-6b5a-7890-abcd-1234567890ab",
+            requiredMode = REQUIRED)
+    private UUID productId;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
@@ -44,6 +44,9 @@ public class ProductEntity implements CatalogItem {
         if (lifecycleState == null) {
             lifecycleState = ProductLifecycleState.ACTIVE;
         }
+        if (trackingLevel == null) {
+            trackingLevel = ProductTrackingLevel.NONE;
+        }
     }
 
     @Schema(description = "Name of the product", example = "Heavy Duty Wrench")
@@ -58,6 +61,11 @@ public class ProductEntity implements CatalogItem {
 
     @Schema(description = "Unit of measure", example = "EA")
     private String unitOfMeasure;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tracking_level", nullable = false, length = 16)
+    @Schema(description = "Stock tracking level", implementation = ProductTrackingLevel.class)
+    private ProductTrackingLevel trackingLevel = ProductTrackingLevel.NONE;
 
     @Schema(
             description = "Short description of the product",

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductTrackingLevel.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductTrackingLevel.java
@@ -1,0 +1,16 @@
+package com.positivity.catalog.internal.entity;
+
+/**
+ * Stock tracking level of a product (#1023, inventory Odoo-parity Story X1).
+ *
+ * <p>Owned by pos-catalog and replicated to pos-inventory via {@code catalog.product.updated}
+ * events; inventory enforces lot/serial capture on receipts and issues based on this flag.
+ */
+public enum ProductTrackingLevel {
+    /** No lot or serial tracking (default). */
+    NONE,
+    /** Stock is tracked per lot/batch number. */
+    LOT,
+    /** Stock is tracked per individual serial number. */
+    SERIAL
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductUomEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductUomEntity.java
@@ -1,0 +1,77 @@
+package com.positivity.catalog.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Per-product UoM conversion: one purchase/pack (or base) unit of measure with its factor to the
+ * product's base UoM and a precision scale (#1023, inventory Odoo-parity Story X1). Distinct from
+ * the global {@link UomConversionEntity} pair table — these rows are product-scoped and travel on
+ * the {@code catalog.product.updated} event for the pos-inventory {@code ext_product_uom} replica.
+ */
+@Getter
+@Setter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "product_uom",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uk_product_uom_product_code",
+                        columnNames = {"product_id", "uom_code"}),
+        indexes = @Index(name = "idx_product_uom_product", columnList = "product_id"))
+public class ProductUomEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private ProductEntity product;
+
+    @Column(name = "uom_code", nullable = false, length = 32)
+    private String uomCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "uom_type", nullable = false, length = 16)
+    private ProductUomType uomType;
+
+    /** Multiplier converting one unit of this UoM into the product's base UoM. */
+    @Column(name = "factor_to_base", nullable = false, precision = 20, scale = 6)
+    private BigDecimal factorToBase;
+
+    /** Decimal precision scale for quantities expressed in this UoM. */
+    @Column(name = "precision_scale", nullable = false)
+    private int precisionScale;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductUomType.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductUomType.java
@@ -1,0 +1,18 @@
+package com.positivity.catalog.internal.entity;
+
+/**
+ * Role of a per-product unit of measure (#1023, inventory Odoo-parity Story X1).
+ */
+public enum ProductUomType {
+    /**
+     * Declares the product's base (stocking) UoM precision; factor must be 1 and the code should
+     * match the product's {@code unitOfMeasure}.
+     */
+    BASE,
+    /** UoM the product is purchased in (e.g. CASE). */
+    PURCHASE,
+    /** Pack/bundle UoM (e.g. BOX, PALLET). */
+    PACK,
+    /** Any other conversion relevant to the product. */
+    OTHER
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SubstitutionGroupEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SubstitutionGroupEntity.java
@@ -1,0 +1,50 @@
+package com.positivity.catalog.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * A group of mutually interchangeable products (#1023, inventory Odoo-parity Story X1). Membership
+ * lives in {@link SubstitutionGroupMemberEntity}; a product belongs to at most one group. Distinct
+ * from {@link ProductReplacementEntity}, which models directional successor recommendations for
+ * discontinued products.
+ */
+@Getter
+@Setter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "substitution_group")
+public class SubstitutionGroupEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(nullable = false, length = 128)
+    private String name;
+
+    @Column(length = 512)
+    private String notes;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SubstitutionGroupMemberEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SubstitutionGroupMemberEntity.java
@@ -1,0 +1,60 @@
+package com.positivity.catalog.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Membership of a product in a {@link SubstitutionGroupEntity} (#1023). A product belongs to at
+ * most one substitution group (unique constraint on {@code product_id}), which keeps the
+ * {@code catalog.product.updated} payload shape a single {@code substitutionGroupId} + member list.
+ */
+@Getter
+@Setter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "substitution_group_member",
+        uniqueConstraints =
+                @UniqueConstraint(name = "uk_substitution_group_member_product", columnNames = "product_id"),
+        indexes = @Index(name = "idx_substitution_group_member_group", columnList = "group_id"))
+public class SubstitutionGroupMemberEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(columnDefinition = "UUID")
+    private UUID id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private SubstitutionGroupEntity group;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private ProductEntity product;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ProductUomRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ProductUomRepository.java
@@ -1,0 +1,18 @@
+package com.positivity.catalog.internal.repository;
+
+import com.positivity.catalog.internal.entity.ProductUomEntity;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductUomRepository extends JpaRepository<ProductUomEntity, UUID> {
+
+    List<ProductUomEntity> findByProductIdOrderByUomCodeAsc(UUID productId);
+
+    Optional<ProductUomEntity> findByProductIdAndUomCode(UUID productId, String uomCode);
+
+    boolean existsByProductIdAndUomCode(UUID productId, String uomCode);
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SubstitutionGroupMemberRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SubstitutionGroupMemberRepository.java
@@ -1,0 +1,18 @@
+package com.positivity.catalog.internal.repository;
+
+import com.positivity.catalog.internal.entity.SubstitutionGroupMemberEntity;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubstitutionGroupMemberRepository extends JpaRepository<SubstitutionGroupMemberEntity, UUID> {
+
+    Optional<SubstitutionGroupMemberEntity> findByProductId(UUID productId);
+
+    Optional<SubstitutionGroupMemberEntity> findByGroupIdAndProductId(UUID groupId, UUID productId);
+
+    List<SubstitutionGroupMemberEntity> findByGroupIdOrderByCreatedAtAsc(UUID groupId);
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SubstitutionGroupRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SubstitutionGroupRepository.java
@@ -1,0 +1,9 @@
+package com.positivity.catalog.internal.repository;
+
+import com.positivity.catalog.internal.entity.SubstitutionGroupEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubstitutionGroupRepository extends JpaRepository<SubstitutionGroupEntity, UUID> {}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
@@ -339,6 +339,7 @@ public class CatalogServiceImpl implements CatalogService {
         dto.setDescription(entity.getDescription());
         dto.setUnitOfMeasure(entity.getUnitOfMeasure());
         dto.setStatus(entity.getStatus());
+        dto.setTrackingLevel(entity.getTrackingLevel());
         dto.setLifecycleState(entity.getLifecycleState());
         dto.setLifecycleStateEffectiveAt(entity.getLifecycleStateEffectiveAt());
         dto.setLastStateChangedBy(entity.getLastStateChangedBy());

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductMasterDataServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductMasterDataServiceImpl.java
@@ -5,6 +5,7 @@ import com.positivity.catalog.internal.dto.CategoryDto;
 import com.positivity.catalog.internal.dto.ProductCreateRequestDto;
 import com.positivity.catalog.internal.dto.ProductDto;
 import com.positivity.catalog.internal.dto.ProductSearchResultDto;
+import com.positivity.catalog.internal.dto.ProductTrackingLevelUpdateRequestDto;
 import com.positivity.catalog.internal.dto.ProductUpdateRequestDto;
 import com.positivity.catalog.internal.entity.Category;
 import com.positivity.catalog.internal.entity.ProductCodeType;
@@ -110,6 +111,18 @@ public class ProductMasterDataServiceImpl implements ProductMasterDataService {
     }
 
     @Override
+    @Transactional
+    public ProductDto updateTrackingLevel(
+            @NonNull UUID productId, @NonNull ProductTrackingLevelUpdateRequestDto request) {
+        ProductEntity entity = findProduct(productId);
+        entity.setTrackingLevel(request.getTrackingLevel());
+        ProductEntity saved = productRepository.save(entity);
+        productDetailCacheInvalidationPublisher.invalidateProduct(saved.getId());
+        catalogFactPublisher.publishProductUpdated(saved);
+        return toDto(saved);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public ProductSearchResultDto searchProducts(String q, String sku, String mpn, @NonNull Pageable pageable) {
         Page<ProductEntity> page = productRepository.searchProducts(q, sku, mpn, pageable);
@@ -160,6 +173,7 @@ public class ProductMasterDataServiceImpl implements ProductMasterDataService {
         dto.setUpc(entity.getUpc());
         dto.setAttributes(entity.getAttributes());
         dto.setStatus(entity.getStatus());
+        dto.setTrackingLevel(entity.getTrackingLevel());
         dto.setLifecycleState(entity.getLifecycleState());
         dto.setLifecycleStateEffectiveAt(entity.getLifecycleStateEffectiveAt());
         dto.setLastStateChangedBy(entity.getLastStateChangedBy());

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductUomServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductUomServiceImpl.java
@@ -1,0 +1,151 @@
+package com.positivity.catalog.internal.service;
+
+import com.positivity.catalog.internal.config.CatalogFactPublisher;
+import com.positivity.catalog.internal.dto.ProductUomCreateRequestDto;
+import com.positivity.catalog.internal.dto.ProductUomDto;
+import com.positivity.catalog.internal.dto.ProductUomUpdateRequestDto;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.ProductUomEntity;
+import com.positivity.catalog.internal.entity.ProductUomType;
+import com.positivity.catalog.internal.exception.CatalogBusinessRuleException;
+import com.positivity.catalog.internal.exception.CatalogNotFoundException;
+import com.positivity.catalog.internal.exception.CatalogValidationException;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.catalog.internal.repository.ProductUomRepository;
+import com.positivity.catalog.service.ProductUomService;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductUomServiceImpl implements ProductUomService {
+
+    private final ProductUomRepository productUomRepository;
+    private final ProductRepository productRepository;
+    private final CatalogFactPublisher catalogFactPublisher;
+    private final Clock clock;
+
+    @Override
+    @Transactional
+    public ProductUomDto addProductUom(@NonNull UUID productId, @NonNull ProductUomCreateRequestDto request) {
+        ProductEntity product = findProduct(productId);
+        String uomCode = normalize(request.getUomCode());
+        if (productUomRepository.existsByProductIdAndUomCode(productId, uomCode)) {
+            throw new CatalogBusinessRuleException("Product UoM already exists for code " + uomCode);
+        }
+        validateFactor(request.getUomType(), request.getFactorToBase());
+
+        ProductUomEntity entity = new ProductUomEntity();
+        entity.setProduct(product);
+        entity.setUomCode(uomCode);
+        entity.setUomType(request.getUomType());
+        entity.setFactorToBase(request.getFactorToBase().setScale(6, RoundingMode.HALF_UP));
+        entity.setPrecisionScale(request.getPrecisionScale());
+        ProductUomEntity saved = productUomRepository.save(entity);
+
+        touchAndPublish(product);
+        return toDto(saved, productId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ProductUomDto> listProductUoms(@NonNull UUID productId) {
+        findProduct(productId);
+        return productUomRepository.findByProductIdOrderByUomCodeAsc(productId).stream()
+                .map(entity -> toDto(entity, productId))
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public ProductUomDto updateProductUom(
+            @NonNull UUID productId, @NonNull UUID uomId, @NonNull ProductUomUpdateRequestDto request) {
+        ProductEntity product = findProduct(productId);
+        ProductUomEntity entity = findProductUom(productId, uomId);
+        ProductUomType uomType = request.getUomType() == null ? entity.getUomType() : request.getUomType();
+        validateFactor(uomType, request.getFactorToBase());
+
+        entity.setUomType(uomType);
+        entity.setFactorToBase(request.getFactorToBase().setScale(6, RoundingMode.HALF_UP));
+        entity.setPrecisionScale(request.getPrecisionScale());
+        ProductUomEntity saved = productUomRepository.save(entity);
+
+        touchAndPublish(product);
+        return toDto(saved, productId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteProductUom(@NonNull UUID productId, @NonNull UUID uomId) {
+        ProductEntity product = findProduct(productId);
+        ProductUomEntity entity = findProductUom(productId, uomId);
+        productUomRepository.delete(entity);
+        productUomRepository.flush();
+        touchAndPublish(product);
+    }
+
+    private void validateFactor(ProductUomType uomType, BigDecimal factor) {
+        if (factor == null || factor.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new CatalogValidationException("factorToBase must be greater than zero");
+        }
+        if (uomType == ProductUomType.BASE && factor.compareTo(BigDecimal.ONE) != 0) {
+            throw new CatalogValidationException("BASE UoM requires factorToBase 1");
+        }
+    }
+
+    /**
+     * Bump the product row's {@code updatedAt} before re-emitting its fact: the envelope's
+     * {@code aggregateVersion} is {@code updatedAt} epoch millis, so attribute-only changes must
+     * advance it for consumers' stale-event guards.
+     */
+    private void touchAndPublish(ProductEntity product) {
+        product.setUpdatedAt(Instant.now(clock));
+        productRepository.saveAndFlush(product);
+        catalogFactPublisher.publishProductUpdated(product);
+    }
+
+    private ProductEntity findProduct(UUID productId) {
+        return productRepository
+                .findById(productId)
+                .orElseThrow(() -> new CatalogNotFoundException("Product not found: " + productId));
+    }
+
+    private ProductUomEntity findProductUom(UUID productId, UUID uomId) {
+        ProductUomEntity entity = productUomRepository
+                .findById(uomId)
+                .orElseThrow(() -> new CatalogNotFoundException("Product UoM not found: " + uomId));
+        if (!productId.equals(entity.getProduct().getId())) {
+            throw new CatalogNotFoundException("Product UoM " + uomId + " does not belong to product " + productId);
+        }
+        return entity;
+    }
+
+    private String normalize(String code) {
+        if (code == null || code.isBlank()) {
+            throw new CatalogValidationException("uomCode is required");
+        }
+        return code.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private ProductUomDto toDto(ProductUomEntity entity, UUID productId) {
+        return ProductUomDto.builder()
+                .id(entity.getId())
+                .productId(productId)
+                .uomCode(entity.getUomCode())
+                .uomType(entity.getUomType())
+                .factorToBase(entity.getFactorToBase())
+                .precisionScale(entity.getPrecisionScale())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SubstitutionGroupServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SubstitutionGroupServiceImpl.java
@@ -1,0 +1,145 @@
+package com.positivity.catalog.internal.service;
+
+import com.positivity.catalog.internal.config.CatalogFactPublisher;
+import com.positivity.catalog.internal.dto.SubstitutionGroupCreateRequestDto;
+import com.positivity.catalog.internal.dto.SubstitutionGroupDto;
+import com.positivity.catalog.internal.dto.SubstitutionGroupMemberRequestDto;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.SubstitutionGroupEntity;
+import com.positivity.catalog.internal.entity.SubstitutionGroupMemberEntity;
+import com.positivity.catalog.internal.exception.CatalogBusinessRuleException;
+import com.positivity.catalog.internal.exception.CatalogNotFoundException;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.catalog.internal.repository.SubstitutionGroupMemberRepository;
+import com.positivity.catalog.internal.repository.SubstitutionGroupRepository;
+import com.positivity.catalog.service.SubstitutionGroupService;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SubstitutionGroupServiceImpl implements SubstitutionGroupService {
+
+    private final SubstitutionGroupRepository groupRepository;
+    private final SubstitutionGroupMemberRepository memberRepository;
+    private final ProductRepository productRepository;
+    private final CatalogFactPublisher catalogFactPublisher;
+    private final Clock clock;
+
+    @Override
+    @Transactional
+    public SubstitutionGroupDto createGroup(@NonNull SubstitutionGroupCreateRequestDto request) {
+        SubstitutionGroupEntity entity = new SubstitutionGroupEntity();
+        entity.setName(request.getName().trim());
+        entity.setNotes(request.getNotes());
+        return toDto(groupRepository.save(entity), List.of());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SubstitutionGroupDto getGroup(@NonNull UUID groupId) {
+        SubstitutionGroupEntity group = findGroup(groupId);
+        return toDto(group, membersOf(groupId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SubstitutionGroupDto> listGroups() {
+        return groupRepository.findAll().stream()
+                .map(group -> toDto(group, membersOf(group.getId())))
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public void deleteGroup(@NonNull UUID groupId) {
+        SubstitutionGroupEntity group = findGroup(groupId);
+        List<SubstitutionGroupMemberEntity> members = memberRepository.findByGroupIdOrderByCreatedAtAsc(groupId);
+        List<ProductEntity> affected =
+                members.stream().map(SubstitutionGroupMemberEntity::getProduct).toList();
+        memberRepository.deleteAll(members);
+        groupRepository.delete(group);
+        memberRepository.flush();
+        affected.forEach(this::touchAndPublish);
+    }
+
+    @Override
+    @Transactional
+    public SubstitutionGroupDto addMember(@NonNull UUID groupId, @NonNull SubstitutionGroupMemberRequestDto request) {
+        SubstitutionGroupEntity group = findGroup(groupId);
+        ProductEntity product = productRepository
+                .findById(request.getProductId())
+                .orElseThrow(() -> new CatalogNotFoundException("Product not found: " + request.getProductId()));
+        if (memberRepository.findByProductId(product.getId()).isPresent()) {
+            throw new CatalogBusinessRuleException(
+                    "Product " + product.getId() + " already belongs to a substitution group");
+        }
+
+        SubstitutionGroupMemberEntity member = new SubstitutionGroupMemberEntity();
+        member.setGroup(group);
+        member.setProduct(product);
+        memberRepository.saveAndFlush(member);
+
+        List<SubstitutionGroupMemberEntity> members = memberRepository.findByGroupIdOrderByCreatedAtAsc(groupId);
+        members.forEach(m -> touchAndPublish(m.getProduct()));
+        return toDto(group, members);
+    }
+
+    @Override
+    @Transactional
+    public SubstitutionGroupDto removeMember(@NonNull UUID groupId, @NonNull UUID productId) {
+        SubstitutionGroupEntity group = findGroup(groupId);
+        SubstitutionGroupMemberEntity member = memberRepository
+                .findByGroupIdAndProductId(groupId, productId)
+                .orElseThrow(() -> new CatalogNotFoundException(
+                        "Product " + productId + " is not a member of substitution group " + groupId));
+        ProductEntity removedProduct = member.getProduct();
+        memberRepository.delete(member);
+        memberRepository.flush();
+
+        touchAndPublish(removedProduct);
+        List<SubstitutionGroupMemberEntity> remaining = memberRepository.findByGroupIdOrderByCreatedAtAsc(groupId);
+        remaining.forEach(m -> touchAndPublish(m.getProduct()));
+        return toDto(group, remaining);
+    }
+
+    /**
+     * Bump the product row's {@code updatedAt} before re-emitting its fact: the envelope's
+     * {@code aggregateVersion} is {@code updatedAt} epoch millis, so membership-only changes must
+     * advance it for consumers' stale-event guards.
+     */
+    private void touchAndPublish(ProductEntity product) {
+        product.setUpdatedAt(Instant.now(clock));
+        productRepository.saveAndFlush(product);
+        catalogFactPublisher.publishProductUpdated(product);
+    }
+
+    private SubstitutionGroupEntity findGroup(UUID groupId) {
+        return groupRepository
+                .findById(groupId)
+                .orElseThrow(() -> new CatalogNotFoundException("Substitution group not found: " + groupId));
+    }
+
+    private List<SubstitutionGroupMemberEntity> membersOf(UUID groupId) {
+        return memberRepository.findByGroupIdOrderByCreatedAtAsc(groupId);
+    }
+
+    private SubstitutionGroupDto toDto(SubstitutionGroupEntity group, List<SubstitutionGroupMemberEntity> members) {
+        return SubstitutionGroupDto.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .notes(group.getNotes())
+                .productIds(members.stream()
+                        .map(member -> member.getProduct().getId())
+                        .toList())
+                .createdAt(group.getCreatedAt())
+                .updatedAt(group.getUpdatedAt())
+                .build();
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/ProductMasterDataService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/ProductMasterDataService.java
@@ -3,6 +3,7 @@ package com.positivity.catalog.service;
 import com.positivity.catalog.internal.dto.ProductCreateRequestDto;
 import com.positivity.catalog.internal.dto.ProductDto;
 import com.positivity.catalog.internal.dto.ProductSearchResultDto;
+import com.positivity.catalog.internal.dto.ProductTrackingLevelUpdateRequestDto;
 import com.positivity.catalog.internal.dto.ProductUpdateRequestDto;
 import com.positivity.catalog.internal.entity.ProductStatus;
 import java.util.UUID;
@@ -16,6 +17,8 @@ public interface ProductMasterDataService {
     ProductDto updateProduct(@NonNull UUID productId, @NonNull ProductUpdateRequestDto request);
 
     ProductDto changeProductStatus(@NonNull UUID productId, @NonNull ProductStatus newStatus);
+
+    ProductDto updateTrackingLevel(@NonNull UUID productId, @NonNull ProductTrackingLevelUpdateRequestDto request);
 
     ProductSearchResultDto searchProducts(String q, String sku, String mpn, @NonNull Pageable pageable);
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/ProductUomService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/ProductUomService.java
@@ -1,0 +1,25 @@
+package com.positivity.catalog.service;
+
+import com.positivity.catalog.internal.dto.ProductUomCreateRequestDto;
+import com.positivity.catalog.internal.dto.ProductUomDto;
+import com.positivity.catalog.internal.dto.ProductUomUpdateRequestDto;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Manages a product's UoM conversion set (#1023, inventory Odoo-parity Story X1): purchase/pack
+ * UoMs with conversion factor to the product's base UoM and a precision scale. Every mutation
+ * re-emits the product's {@code catalog.product.updated} fact so downstream replicas stay in sync.
+ */
+public interface ProductUomService {
+
+    ProductUomDto addProductUom(@NonNull UUID productId, @NonNull ProductUomCreateRequestDto request);
+
+    List<ProductUomDto> listProductUoms(@NonNull UUID productId);
+
+    ProductUomDto updateProductUom(
+            @NonNull UUID productId, @NonNull UUID uomId, @NonNull ProductUomUpdateRequestDto request);
+
+    void deleteProductUom(@NonNull UUID productId, @NonNull UUID uomId);
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/SubstitutionGroupService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/SubstitutionGroupService.java
@@ -1,0 +1,28 @@
+package com.positivity.catalog.service;
+
+import com.positivity.catalog.internal.dto.SubstitutionGroupCreateRequestDto;
+import com.positivity.catalog.internal.dto.SubstitutionGroupDto;
+import com.positivity.catalog.internal.dto.SubstitutionGroupMemberRequestDto;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Manages substitution groups of mutually interchangeable products (#1023, inventory Odoo-parity
+ * Story X1). A product belongs to at most one group. Membership mutations re-emit
+ * {@code catalog.product.updated} for every affected member so downstream replicas stay in sync.
+ */
+public interface SubstitutionGroupService {
+
+    SubstitutionGroupDto createGroup(@NonNull SubstitutionGroupCreateRequestDto request);
+
+    SubstitutionGroupDto getGroup(@NonNull UUID groupId);
+
+    List<SubstitutionGroupDto> listGroups();
+
+    void deleteGroup(@NonNull UUID groupId);
+
+    SubstitutionGroupDto addMember(@NonNull UUID groupId, @NonNull SubstitutionGroupMemberRequestDto request);
+
+    SubstitutionGroupDto removeMember(@NonNull UUID groupId, @NonNull UUID productId);
+}

--- a/pos-catalog/src/main/resources/db/migration/V7__add_product_uom_tracking_substitution.sql
+++ b/pos-catalog/src/main/resources/db/migration/V7__add_product_uom_tracking_substitution.sql
@@ -1,0 +1,49 @@
+-- #1023 (inventory Odoo-parity Story X1): product contract additions owned by pos-catalog and
+-- replicated to pos-inventory via catalog.product.updated events (ADR-0044):
+--   1. tracking_level on product (NONE | LOT | SERIAL, default NONE)
+--   2. product_uom — per-product purchase/pack UoMs with factor to the base UoM + precision scale
+--   3. substitution_group / substitution_group_member — interchangeable-product groups
+--      (a product belongs to at most one group)
+
+ALTER TABLE product ADD COLUMN tracking_level character varying(16) DEFAULT 'NONE' NOT NULL;
+ALTER TABLE product ADD CONSTRAINT product_tracking_level_check
+    CHECK (((tracking_level)::text = ANY ((ARRAY['NONE'::character varying, 'LOT'::character varying, 'SERIAL'::character varying])::text[])));
+
+CREATE TABLE product_uom (
+    id uuid NOT NULL,
+    product_id uuid NOT NULL,
+    uom_code character varying(32) NOT NULL,
+    uom_type character varying(16) NOT NULL,
+    factor_to_base numeric(20,6) NOT NULL,
+    precision_scale integer NOT NULL,
+    created_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT product_uom_pkey PRIMARY KEY (id),
+    CONSTRAINT uk_product_uom_product_code UNIQUE (product_id, uom_code),
+    CONSTRAINT product_uom_uom_type_check
+        CHECK (((uom_type)::text = ANY ((ARRAY['BASE'::character varying, 'PURCHASE'::character varying, 'PACK'::character varying, 'OTHER'::character varying])::text[]))),
+    CONSTRAINT fk_product_uom_product FOREIGN KEY (product_id) REFERENCES product(id)
+);
+CREATE INDEX idx_product_uom_product ON product_uom (product_id);
+
+CREATE TABLE substitution_group (
+    id uuid NOT NULL,
+    name character varying(128) NOT NULL,
+    notes character varying(512),
+    created_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT substitution_group_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE substitution_group_member (
+    id uuid NOT NULL,
+    group_id uuid NOT NULL,
+    product_id uuid NOT NULL,
+    created_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT substitution_group_member_pkey PRIMARY KEY (id),
+    CONSTRAINT uk_substitution_group_member_product UNIQUE (product_id),
+    CONSTRAINT fk_substitution_group_member_group FOREIGN KEY (group_id) REFERENCES substitution_group(id),
+    CONSTRAINT fk_substitution_group_member_product FOREIGN KEY (product_id) REFERENCES product(id)
+);
+CREATE INDEX idx_substitution_group_member_group ON substitution_group_member (group_id);

--- a/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductContractAttributesContractTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductContractAttributesContractTest.java
@@ -1,0 +1,244 @@
+package com.positivity.catalog.contract;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.catalog.BaseContractIntegrationTest;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Contract behavioral tests for the #1023 (Story X1) product contract attributes: per-product UoM
+ * conversions, tracking level, and substitution groups.
+ */
+@DisplayName("Product Contract Attributes (UoM / tracking level / substitution groups) Behavioral Tests")
+class ProductContractAttributesContractTest extends BaseContractIntegrationTest {
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    // ─── Tracking level ──────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("X1-010: New product defaults to trackingLevel NONE")
+    void newProduct_defaultsToTrackingLevelNone() throws Exception {
+        String productId = createProduct();
+        mockMvc.perform(withAuth(get("/v1/products/{id}", productId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.trackingLevel").value("NONE"));
+    }
+
+    @Test
+    @DisplayName("X1-011: PUT tracking-level sets LOT and returns updated product")
+    void updateTrackingLevel_returnsUpdatedProduct() throws Exception {
+        String productId = createProduct();
+        mockMvc.perform(withAuth(put("/v1/products/{id}/tracking-level", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("trackingLevel", "LOT")))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.trackingLevel").value("LOT"));
+    }
+
+    @Test
+    @DisplayName("X1-012: PUT tracking-level with unknown value returns 400")
+    void updateTrackingLevel_invalidValue_returnsBadRequest() throws Exception {
+        String productId = createProduct();
+        mockMvc.perform(withAuth(put("/v1/products/{id}/tracking-level", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"trackingLevel\":\"PALLET\"}")))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ─── Product UoM conversions ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("X1-020: Add purchase UoM returns 201 with normalized code and factor")
+    void addProductUom_returnsCreated() throws Exception {
+        String productId = createProduct();
+        mockMvc.perform(withAuth(post("/v1/products/{id}/uoms", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "uomCode", "case", "uomType", "PURCHASE", "factorToBase", 12, "precisionScale", 0)))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.productId").value(productId))
+                .andExpect(jsonPath("$.uomCode").value("CASE"))
+                .andExpect(jsonPath("$.uomType").value("PURCHASE"))
+                .andExpect(jsonPath("$.precisionScale").value(0));
+    }
+
+    @Test
+    @DisplayName("X1-021: Duplicate UoM code for same product returns 409")
+    void addProductUom_duplicateCode_returnsConflict() throws Exception {
+        String productId = createProduct();
+        Map<String, Object> payload =
+                Map.of("uomCode", "CASE", "uomType", "PURCHASE", "factorToBase", 12, "precisionScale", 0);
+        mockMvc.perform(withAuth(post("/v1/products/{id}/uoms", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload))))
+                .andExpect(status().isCreated());
+        mockMvc.perform(withAuth(post("/v1/products/{id}/uoms", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("X1-022: Zero factor returns 400; BASE UoM with factor != 1 returns 400")
+    void addProductUom_invalidFactor_returnsBadRequest() throws Exception {
+        String productId = createProduct();
+        mockMvc.perform(withAuth(post("/v1/products/{id}/uoms", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "uomCode", "CASE", "uomType", "PURCHASE", "factorToBase", 0, "precisionScale", 0)))))
+                .andExpect(status().isBadRequest());
+        mockMvc.perform(withAuth(post("/v1/products/{id}/uoms", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("uomCode", "EA", "uomType", "BASE", "factorToBase", 2, "precisionScale", 0)))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("X1-023: Update and delete product UoM round-trip")
+    void updateAndDeleteProductUom_roundTrip() throws Exception {
+        String productId = createProduct();
+        MvcResult created = mockMvc.perform(withAuth(post("/v1/products/{id}/uoms", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("uomCode", "BOX", "uomType", "PACK", "factorToBase", 6, "precisionScale", 0)))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        String uomId = readId(created);
+
+        mockMvc.perform(withAuth(put("/v1/products/{id}/uoms/{uomId}", productId, uomId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("factorToBase", 8, "precisionScale", 2)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.precisionScale").value(2));
+
+        mockMvc.perform(withAuth(delete("/v1/products/{id}/uoms/{uomId}", productId, uomId)))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(withAuth(get("/v1/products/{id}/uoms", productId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    @DisplayName("X1-024: UoM operations on unknown product return 404")
+    void productUom_unknownProduct_returnsNotFound() throws Exception {
+        mockMvc.perform(withAuth(get("/v1/products/{id}/uoms", UUID.randomUUID())))
+                .andExpect(status().isNotFound());
+    }
+
+    // ─── Substitution groups ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("X1-030: Create group, add members, read membership")
+    void substitutionGroup_membershipRoundTrip() throws Exception {
+        String productA = createProduct();
+        String productB = createProduct();
+        String groupId = createGroup("Interchangeable filters");
+
+        mockMvc.perform(withAuth(post("/v1/products/substitution-groups/{id}/members", groupId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("productId", productA)))))
+                .andExpect(status().isOk());
+        mockMvc.perform(withAuth(post("/v1/products/substitution-groups/{id}/members", groupId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("productId", productB)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.productIds.length()").value(2));
+
+        mockMvc.perform(withAuth(get("/v1/products/substitution-groups/{id}", groupId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Interchangeable filters"))
+                .andExpect(jsonPath("$.productIds.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("X1-031: A product can belong to only one substitution group (409 on second add)")
+    void substitutionGroup_singleMembershipEnforced() throws Exception {
+        String product = createProduct();
+        String groupA = createGroup("Group A");
+        String groupB = createGroup("Group B");
+
+        mockMvc.perform(withAuth(post("/v1/products/substitution-groups/{id}/members", groupA)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("productId", product)))))
+                .andExpect(status().isOk());
+        mockMvc.perform(withAuth(post("/v1/products/substitution-groups/{id}/members", groupB)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("productId", product)))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("X1-032: Remove member and delete group")
+    void substitutionGroup_removeAndDelete() throws Exception {
+        String product = createProduct();
+        String groupId = createGroup("Short-lived group");
+
+        mockMvc.perform(withAuth(post("/v1/products/substitution-groups/{id}/members", groupId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("productId", product)))))
+                .andExpect(status().isOk());
+        mockMvc.perform(withAuth(delete("/v1/products/substitution-groups/{id}/members/{productId}", groupId, product)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.productIds").isEmpty());
+        mockMvc.perform(withAuth(delete("/v1/products/substitution-groups/{id}", groupId)))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(withAuth(get("/v1/products/substitution-groups/{id}", groupId)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("X1-033: Blank group name returns 400")
+    void substitutionGroup_blankName_returnsBadRequest() throws Exception {
+        mockMvc.perform(withAuth(post("/v1/products/substitution-groups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("name", " ")))))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private String createProduct() throws Exception {
+        int seq = SEQ.incrementAndGet();
+        MvcResult result = mockMvc.perform(withAuth(post("/v1/products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "name", "Contract Product " + seq,
+                                "description", "Contract test product",
+                                "unitOfMeasure", "EA",
+                                "sku", "X1-SKU-" + seq,
+                                "mpn", "X1-MPN-" + seq)))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readId(result);
+    }
+
+    private String createGroup(String name) throws Exception {
+        MvcResult result = mockMvc.perform(withAuth(post("/v1/products/substitution-groups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("name", name)))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return readId(result);
+    }
+
+    private String readId(MvcResult result) throws Exception {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> response =
+                objectMapper.readValue(result.getResponse().getContentAsString(), Map.class);
+        return (String) response.get("id");
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/config/CatalogFactPublisherTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/config/CatalogFactPublisherTest.java
@@ -1,0 +1,202 @@
+package com.positivity.catalog.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.entity.Category;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.ProductStatus;
+import com.positivity.catalog.internal.entity.ProductTrackingLevel;
+import com.positivity.catalog.internal.entity.ProductUomEntity;
+import com.positivity.catalog.internal.entity.ProductUomType;
+import com.positivity.catalog.internal.entity.SubstitutionGroupEntity;
+import com.positivity.catalog.internal.entity.SubstitutionGroupMemberEntity;
+import com.positivity.catalog.internal.repository.ProductUomRepository;
+import com.positivity.catalog.internal.repository.SubstitutionGroupMemberRepository;
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.catalog.ProductUpdatedV1;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Contract test for the {@code catalog.product.updated} payload shape (#1023, Story X1).
+ *
+ * <p>Proves that schema version 2 is additive: every version-1 field keeps its name and position in
+ * the serialized JSON, and the new UoM / tracking-level / substitution fields appear alongside them.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CatalogFactPublisher product contract payload")
+class CatalogFactPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-22T10:15:30Z");
+
+    @Mock
+    private ObjectProvider<OutboxEventWriter> outboxEventWriterProvider;
+
+    @Mock
+    private OutboxEventWriter outboxEventWriter;
+
+    @Mock
+    private ProductUomRepository productUomRepository;
+
+    @Mock
+    private SubstitutionGroupMemberRepository substitutionGroupMemberRepository;
+
+    private CatalogFactPublisher publisher;
+
+    private final ObjectMapper objectMapper = JsonMapper.builder().build();
+
+    @BeforeEach
+    void setUp() {
+        when(outboxEventWriterProvider.getIfAvailable()).thenReturn(outboxEventWriter);
+        publisher = new CatalogFactPublisher(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                outboxEventWriterProvider,
+                productUomRepository,
+                substitutionGroupMemberRepository);
+    }
+
+    @Test
+    @DisplayName("payload carries UoM conversions, tracking level, and substitution membership (schema v2)")
+    void payloadCarriesNewContractFields() {
+        ProductEntity product = product();
+        UUID siblingId = UUID.fromString("00000000-0000-0000-0000-000000000bbb");
+        UUID groupId = UUID.fromString("00000000-0000-0000-0000-000000000ccc");
+
+        ProductUomEntity caseUom = new ProductUomEntity();
+        caseUom.setUomCode("CASE");
+        caseUom.setUomType(ProductUomType.PURCHASE);
+        caseUom.setFactorToBase(new BigDecimal("12.000000"));
+        caseUom.setPrecisionScale(0);
+        when(productUomRepository.findByProductIdOrderByUomCodeAsc(product.getId()))
+                .thenReturn(List.of(caseUom));
+
+        SubstitutionGroupEntity group = new SubstitutionGroupEntity();
+        group.setId(groupId);
+        SubstitutionGroupMemberEntity self = member(group, product);
+        ProductEntity sibling = new ProductEntity();
+        sibling.setId(siblingId);
+        SubstitutionGroupMemberEntity other = member(group, sibling);
+        when(substitutionGroupMemberRepository.findByProductId(product.getId())).thenReturn(Optional.of(self));
+        when(substitutionGroupMemberRepository.findByGroupIdOrderByCreatedAtAsc(groupId))
+                .thenReturn(List.of(self, other));
+
+        publisher.publishProductUpdated(product);
+
+        DomainEventEnvelope<?> envelope = capturedEnvelope();
+        assertThat(envelope.eventType()).isEqualTo("catalog.product.updated");
+        assertThat(envelope.schemaVersion()).isEqualTo(2);
+        assertThat(envelope.aggregateId()).isEqualTo(product.getId());
+        assertThat(envelope.aggregateVersion()).isEqualTo(product.getUpdatedAt().toEpochMilli());
+
+        JsonNode payload =
+                objectMapper.readTree(objectMapper.writeValueAsString(envelope)).path("payload");
+        assertThat(payload.path("baseUom").stringValue(null)).isEqualTo("EA");
+        assertThat(payload.path("trackingLevel").stringValue(null)).isEqualTo("LOT");
+        assertThat(payload.path("uomConversions")).hasSize(1);
+        JsonNode conversion = payload.path("uomConversions").get(0);
+        assertThat(conversion.path("uomCode").stringValue(null)).isEqualTo("CASE");
+        assertThat(conversion.path("uomType").stringValue(null)).isEqualTo("PURCHASE");
+        assertThat(conversion.path("factorToBase").decimalValue()).isEqualByComparingTo("12");
+        assertThat(conversion.path("precisionScale").intValue()).isZero();
+        assertThat(payload.path("substitutionGroupId").stringValue(null)).isEqualTo(groupId.toString());
+        assertThat(payload.path("substitutionProductIds"))
+                .extracting(node -> node.stringValue(null))
+                .containsExactly(product.getId().toString(), siblingId.toString());
+    }
+
+    @Test
+    @DisplayName("regression: every schema-v1 field survives with its original name (additive-only change)")
+    void v1FieldsAreUnchanged() {
+        ProductEntity product = product();
+        when(productUomRepository.findByProductIdOrderByUomCodeAsc(product.getId()))
+                .thenReturn(List.of());
+        when(substitutionGroupMemberRepository.findByProductId(product.getId())).thenReturn(Optional.empty());
+
+        publisher.publishProductUpdated(product);
+
+        JsonNode payload = objectMapper
+                .readTree(objectMapper.writeValueAsString(capturedEnvelope()))
+                .path("payload");
+        List<String> v1Fields = List.of(
+                "productId",
+                "sku",
+                "name",
+                "manufacturerId",
+                "manufacturerName",
+                "manufacturerBrand",
+                "categoryId",
+                "category",
+                "warranty",
+                "manufacturerWarranty",
+                "active",
+                "createdAt",
+                "updatedAt");
+        for (String field : v1Fields) {
+            assertThat(payload.has(field))
+                    .as("schema-v1 field '%s' must keep its name", field)
+                    .isTrue();
+        }
+        assertThat(payload.path("productId").stringValue(null))
+                .isEqualTo(product.getId().toString());
+        assertThat(payload.path("sku").stringValue(null)).isEqualTo("SKU-1");
+        assertThat(payload.path("active").booleanValue()).isTrue();
+        // Products without UoM/substitution data keep the new fields null so consumers can
+        // distinguish "no data" from an empty set.
+        assertThat(payload.path("trackingLevel").stringValue(null)).isEqualTo("LOT");
+        assertThat(payload.path("uomConversions").isNull()).isTrue();
+        assertThat(payload.path("substitutionGroupId").isNull()).isTrue();
+        assertThat(payload.path("substitutionProductIds").isNull()).isTrue();
+    }
+
+    private DomainEventEnvelope<?> capturedEnvelope() {
+        @SuppressWarnings("rawtypes")
+        ArgumentCaptor<DomainEventEnvelope> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(outboxEventWriter).publish(eq("catalog.events.v1"), any());
+        verify(outboxEventWriter).publish(any(), captor.capture());
+        DomainEventEnvelope<?> envelope = captor.getValue();
+        assertThat(envelope.payload()).isInstanceOf(ProductUpdatedV1.class);
+        return envelope;
+    }
+
+    private ProductEntity product() {
+        ProductEntity product = new ProductEntity();
+        product.setId(UUID.fromString("00000000-0000-0000-0000-000000000aaa"));
+        product.setSku("SKU-1");
+        product.setName("Heavy Duty Wrench");
+        product.setUnitOfMeasure("EA");
+        product.setStatus(ProductStatus.ACTIVE);
+        product.setTrackingLevel(ProductTrackingLevel.LOT);
+        product.setCreatedAt(NOW.minusSeconds(3600));
+        product.setUpdatedAt(NOW);
+        Category category = new Category();
+        product.setCategory(category);
+        return product;
+    }
+
+    private SubstitutionGroupMemberEntity member(SubstitutionGroupEntity group, ProductEntity product) {
+        SubstitutionGroupMemberEntity member = new SubstitutionGroupMemberEntity();
+        member.setGroup(group);
+        member.setProduct(product);
+        return member;
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/catalog/ProductUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/catalog/ProductUpdatedV1.java
@@ -1,21 +1,32 @@
 package com.positivity.domainevents.catalog;
 
+import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Payload for {@code catalog.product.updated} v1 on {@code catalog.events.v1} (ADR-0044 §6, #924).
+ * Payload for {@code catalog.product.updated} on {@code catalog.events.v1} (ADR-0044 §6, #924).
  *
- * <p>Published by pos-catalog after every product master-data or lifecycle mutation. Carries the
- * product facts consumers replicate — pos-warranty maintains an {@code ext_catalog} replica for
- * candidate-line product lookup and eligibility (manufacturer / warranty terms), replacing the
- * retired synchronous {@code CatalogClient}.
+ * <p>Published by pos-catalog after every product master-data, lifecycle, UoM, tracking-level, or
+ * substitution-group mutation. Carries the product facts consumers replicate — pos-warranty
+ * maintains an {@code ext_catalog} replica for candidate-line product lookup and eligibility
+ * (manufacturer / warranty terms); pos-inventory replicates the UoM conversion set
+ * ({@code ext_product_uom}), tracking level, and substitution-group membership for the Odoo-parity
+ * program (#1023, spec workstreams B1/E1/G2).
+ *
+ * <p>Schema version 2 (#1023) added {@code baseUom}, {@code trackingLevel}, {@code uomConversions},
+ * {@code substitutionGroupId}, and {@code substitutionProductIds} — additive only; version-1
+ * consumers are unaffected and version-2 consumers must treat the new fields as absent on old
+ * events ({@code trackingLevel} null ⇒ {@code NONE}).
  *
  * <p>pos-catalog's {@code ProductEntity} has no JPA optimistic-lock {@code @Version}; the envelope's
  * {@code aggregateVersion} therefore carries {@code updatedAt} as epoch millis, which increases per
- * mutation and gives consumers a monotonic stale-event guard.
+ * mutation and gives consumers a monotonic stale-event guard. Attribute mutations that do not touch
+ * the product row itself (UoM rows, substitution membership) bump {@code updatedAt} on every
+ * affected product before publishing so the guard keeps working.
  *
  * @param productId product identifier (also the envelope aggregateId)
  * @param sku stock-keeping unit (null until assigned)
@@ -30,6 +41,14 @@ import org.jspecify.annotations.Nullable;
  * @param active whether the product is active (soft-delete flag)
  * @param createdAt owner row creation timestamp
  * @param updatedAt owner row last-update timestamp
+ * @param baseUom the product's base (stocking) unit of measure code
+ * @param trackingLevel stock tracking level: {@code NONE}, {@code LOT}, or {@code SERIAL}; null on
+ *     pre-v2 events means {@code NONE}
+ * @param uomConversions per-product UoM conversion set (purchase/pack UoMs with factor to base UoM
+ *     and precision scale); null or empty when the product has none
+ * @param substitutionGroupId substitution group this product belongs to, if any
+ * @param substitutionProductIds product ids of all members of the substitution group (including
+ *     this product); null when the product is not in a group
  */
 public record ProductUpdatedV1(
         @NonNull UUID productId,
@@ -44,14 +63,45 @@ public record ProductUpdatedV1(
         @Nullable String manufacturerWarranty,
         boolean active,
         @Nullable Instant createdAt,
-        @Nullable Instant updatedAt) {
+        @Nullable Instant updatedAt,
+        @Nullable String baseUom,
+        @Nullable String trackingLevel,
+        @Nullable List<UomConversion> uomConversions,
+        @Nullable UUID substitutionGroupId,
+        @Nullable List<UUID> substitutionProductIds) {
 
     public static final String EVENT_TYPE = "catalog.product.updated";
-    public static final int SCHEMA_VERSION = 1;
+    public static final int SCHEMA_VERSION = 2;
 
     public ProductUpdatedV1 {
         if (productId == null) {
             throw new IllegalArgumentException("productId must not be null");
+        }
+    }
+
+    /**
+     * One entry of a product's UoM conversion set (#1023).
+     *
+     * @param uomCode unit-of-measure code, e.g. {@code CASE}
+     * @param uomType role of this UoM for the product: {@code BASE}, {@code PURCHASE}, {@code PACK},
+     *     or {@code OTHER}
+     * @param factorToBase multiplier converting one unit of this UoM into the product's base UoM
+     *     ({@code 1 CASE = factorToBase × baseUom}); {@code 1} for {@code BASE} rows
+     * @param precisionScale decimal precision scale for quantities expressed in this UoM
+     */
+    public record UomConversion(
+            @NonNull String uomCode,
+            @Nullable String uomType,
+            @NonNull BigDecimal factorToBase,
+            int precisionScale) {
+
+        public UomConversion {
+            if (uomCode == null) {
+                throw new IllegalArgumentException("uomCode must not be null");
+            }
+            if (factorToBase == null) {
+                throw new IllegalArgumentException("factorToBase must not be null");
+            }
         }
     }
 }

--- a/pos-inventory/docs/inventory-ledger-atp.md
+++ b/pos-inventory/docs/inventory-ledger-atp.md
@@ -53,6 +53,11 @@ ATP = On-Hand - Allocations
 - `BACKORDER_CREATED` / `BACKORDER_RESOLVED`
 - `PICK_TASK_CREATED` / `PICK_TASK_COMPLETED` (unless posting GOODS_ISSUE)
 
+#### Negative-Stock Policy
+
+Whether a posting may take on-hand below zero is governed per event type by the
+negative-stock policy matrix — see [negative-stock-policy.md](negative-stock-policy.md) (odoo-parity K1, #1027).
+
 ## API Contract (Proposed)
 
 ### GET /api/inventory/availability

--- a/pos-inventory/docs/negative-stock-policy.md
+++ b/pos-inventory/docs/negative-stock-policy.md
@@ -1,0 +1,51 @@
+# Negative-Stock Policy Matrix
+
+Story: odoo-parity K1 (issue #1027). Spec: `durion/domains/inventory/SPEC-pos-inventory-odoo-parity.md` §11.
+
+## Where it is enforced
+
+All `inventory_ledger_entry` appends funnel through `LedgerPostingService` /
+`LedgerPostingServiceImpl` (odoo-parity A1, issue #1024). That funnel is the
+**single enforcement point** of this matrix: before the batch's summary deltas
+are applied, the entries are replayed in order per `(stockItemId, locationId)`
+key against the row-locked `inventory_stock_summary` balances, and every
+on-hand-affecting entry is checked against the matrix. A violation aborts the
+whole posting transaction — ledger entries and summary rows roll back together.
+
+A DB-level check is impractical against an append-only ledger, so the funnel is
+asserted architecturally: the `ArchitectureTest` rule
+`ledger_entry_writes_must_go_through_posting_funnel` forbids any class other
+than `LedgerPostingServiceImpl` from calling
+`InventoryLedgerEntryRepository.save/saveAll`.
+
+## The matrix
+
+| Event type(s) | Policy | Error code (422 `ApiError`) | Rationale |
+| --- | --- | --- | --- |
+| `GOODS_ISSUE`, `WORKORDER_CONSUMPTION` (PICK/ISSUE flows) | **Blocked** below zero | `INSUFFICIENT_STOCK` (`InsufficientStockException`) | You cannot physically pick, issue, or consume more stock than exists. Pre-K1 behavior for PICK/ISSUE, kept and generalized to the funnel. |
+| `TRANSFER_OUT` (transfer dispatch) | **Blocked** below zero | `INSUFFICIENT_STOCK` (`InsufficientStockException`) | A dispatch is a physical outbound movement; shipping stock you do not have would silently fabricate in-transit inventory. |
+| `SCRAP_OUT` | **Blocked, overridable** | `NEGATIVE_STOCK_OVERRIDE_REQUIRED` (`NegativeStockPolicyViolationException`) | Scrap records physical loss that the ledger may not know about yet (shrinkage found on the floor). A supervisor holding `inventory:adjustment:override` may force the write; the caller checks the permission and passes an explicit override flag — the funnel never reads the security context. |
+| `ADJUSTMENT_OUT`, `COUNT_VARIANCE_OUT`, `ADJUST_CYCLE_COUNT` | **Floor at zero** (never overridable) | `NEGATIVE_STOCK_FLOOR_VIOLATION` (`NegativeStockPolicyViolationException`) | Counts and manual adjustments set reality: they may zero a balance, but a count can never observe *negative* physical stock, so driving the ledger below zero is by definition a data error. |
+| `GOODS_RECEIPT`, `TRANSFER_IN`, `PUTAWAY`, `RETURN_TO_STOCK`, `ADJUSTMENT_IN`, `COUNT_VARIANCE_IN` | **Unconstrained** | — | Inbound flows only add stock. `PUTAWAY` writes paired entries (source decrement + destination increment) under one event type; the putaway services already validate source on-hand (`NoOnHandAtSourceLocationException`), so the matrix leaves the paired move unconstrained. |
+| `RESERVATION_*`, `ALLOCATION_*`, `BACKORDER_*`, `PICK_TASK_*` | **Untouched** (not part of the matrix) | — | Neutral/ATP-only types never move physical on-hand; over-promising is an ATP concern (`INSUFFICIENT_ATP`), not a negative-stock one. |
+
+Notes:
+
+- "Below zero" is evaluated per `(stockItemId, locationId)` key — the same key
+  the funnel uses for `inventory_stock_summary` deltas — with entries in a
+  batch replayed sequentially, so a receipt earlier in the batch covers a later
+  issue of the same key.
+- Exactly-to-zero postings are always allowed, for every row of the matrix.
+- `ADJUST_CYCLE_COUNT` is grouped with the count-variance types: it is the
+  posted form of an approved cycle-count adjustment, and counts set reality.
+- The override flag applies only to `BLOCKED_OVERRIDABLE` rows; passing it does
+  not weaken `BLOCKED` or `FLOOR_AT_ZERO` rows.
+
+## Code pointers
+
+- Matrix: `com.positivity.inventory.internal.enums.NegativeStockPolicy`
+- Enforcement: `LedgerPostingServiceImpl#enforceNegativeStockPolicy`
+- Error mapping: `InventoryGlobalExceptionHandler` (422 with the codes above)
+- Funnel assertion: `ArchitectureTest#ledger_entry_writes_must_go_through_posting_funnel`
+- Tests: `NegativeStockPolicyEnforcementTest` (per-row coverage),
+  `StockMovementContractBehaviorIT` (HTTP `ApiError` surface)

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -351,6 +351,25 @@ paths:
         - inventory:adjustment:create
       x-required-permissions:
       - inventory:adjustment:create
+  /v1/inventory/replenishment/scan:
+    post:
+      tags:
+      - Replenishment
+      summary: Run the batch replenishment scan
+      description: 'Evaluates every replenishment policy against current on-hand and creates or refreshes batch-triggered replenishment tasks for below-minimum pick faces. Idempotent per (policy, day): repeated runs on the same day never create duplicate open tasks. Returns a summary of the scan run.'
+      operationId: runReplenishmentScan
+      responses:
+        '200':
+          description: Scan completed; summary returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplenishmentScanResultResponse'
+      security:
+      - bearerAuth:
+        - inventory:replenishment:manage
+      x-required-permissions:
+      - inventory:replenishment:manage
   /v1/inventory/replenishment/policies:
     get:
       tags:
@@ -411,9 +430,9 @@ paths:
                 $ref: '#/components/schemas/ReplenishmentPolicyResponse'
       security:
       - bearerAuth:
-        - inventory:adjustment:create
+        - inventory:replenishment:manage
       x-required-permissions:
-      - inventory:adjustment:create
+      - inventory:replenishment:manage
   /v1/inventory/receiving/sessions:
     post:
       tags:
@@ -3225,6 +3244,42 @@ paths:
         - inventory:cycle_count:view
       x-required-permissions:
       - inventory:cycle_count:view
+  /v1/inventory/cycleCount/task/{taskId}/interfering-movements:
+    get:
+      tags:
+      - Cycle Count Query
+      - Cycle Count API
+      summary: List interfering movements for a cycle count task
+      description: 'Returns the on-hand-affecting ledger entries for the task''s SKU/location recorded between task creation and now — the movements that make the task''s expected-quantity snapshot stale (CONFLICT). Design note: freezing stock movements during counts was rejected as it contradicts continuous shop operation; conflict detection with this listing replaces freezing.'
+      operationId: getInterferingMovements
+      parameters:
+      - name: taskId
+        in: path
+        description: Task ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Interfering movements retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterferingMovementResponse'
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InterferingMovementResponse'
+      security:
+      - bearerAuth:
+        - inventory:cycle_count:view
+      x-required-permissions:
+      - inventory:cycle_count:view
   /v1/inventory/cycleCount/task/{taskId}/history:
     get:
       tags:
@@ -3919,6 +3974,40 @@ components:
           example: Reserved for scheduled workorder pick
       required:
       - storageLocationId
+    ReplenishmentScanResultResponse:
+      type: object
+      description: Summary of a batch replenishment scan run over all replenishment policies
+      properties:
+        policiesEvaluated:
+          type: integer
+          format: int32
+          description: Number of replenishment policies evaluated by the scan
+          example: 42
+        policiesBelowMinimum:
+          type: integer
+          format: int32
+          description: Number of policies whose on-hand quantity was below the configured minimum
+          example: 5
+        tasksCreated:
+          type: integer
+          format: int32
+          description: Number of new replenishment tasks created by the scan
+          example: 3
+        tasksRefreshed:
+          type: integer
+          format: int32
+          description: Number of already-open replenishment tasks whose quantity was refreshed to the current need
+          example: 2
+        scanAt:
+          type: string
+          description: Timestamp at which the scan ran
+          example: 2026-01-15 09:30:00+00:00
+      required:
+      - policiesBelowMinimum
+      - policiesEvaluated
+      - scanAt
+      - tasksCreated
+      - tasksRefreshed
     CreateReplenishmentPolicyRequest:
       type: object
       description: Request to create a replenishment policy defining min/max stock thresholds for an item at a location
@@ -5424,6 +5513,11 @@ components:
           format: uuid
           description: Identifier of the stock item being adjusted
           example: 01960003-0000-7000-8000-000000000001
+        taskId:
+          type: string
+          format: uuid
+          description: Cycle count task this adjustment settles, if created from a task. Enables approval-time conflict detection and variance recomputation against current on-hand.
+          example: 01960003-0000-7000-8000-000000000009
         reasonCode:
           type: string
           description: Reason code explaining why the adjustment is being made
@@ -5461,6 +5555,11 @@ components:
       type: object
       description: Result of a cycle count inventory adjustment, including approval state and posting outcome
       properties:
+        taskId:
+          type: string
+          format: uuid
+          description: Cycle count task this adjustment settles, if created from a task
+          example: 01960003-0000-7000-8000-000000000009
         adjustmentId:
           type: string
           format: uuid
@@ -5674,6 +5773,7 @@ components:
           enum:
           - ASSIGNED
           - COUNTED_PENDING_REVIEW
+          - CONFLICT
           - REQUIRES_INVESTIGATION
           - APPROVED
           - REJECTED
@@ -6968,6 +7068,7 @@ components:
           enum:
           - ASSIGNED
           - COUNTED_PENDING_REVIEW
+          - CONFLICT
           - REQUIRES_INVESTIGATION
           - APPROVED
           - REJECTED
@@ -7001,6 +7102,73 @@ components:
       - status
       - taskId
       - updatedAt
+    InterferingMovementResponse:
+      type: object
+      description: Ledger movement recorded between cycle-count task creation and now for the task's SKU/location
+      properties:
+        ledgerEntryId:
+          type: string
+          format: uuid
+          description: Unique identifier of the ledger entry
+          example: 01960003-0000-7000-8000-000000000001
+        eventType:
+          type: string
+          description: Type of inventory ledger event recorded
+          enum:
+          - GOODS_RECEIPT
+          - TRANSFER_IN
+          - PUTAWAY
+          - RETURN_TO_STOCK
+          - ADJUSTMENT_IN
+          - COUNT_VARIANCE_IN
+          - GOODS_ISSUE
+          - WORKORDER_CONSUMPTION
+          - TRANSFER_OUT
+          - SCRAP_OUT
+          - ADJUSTMENT_OUT
+          - COUNT_VARIANCE_OUT
+          - ADJUST_CYCLE_COUNT
+          - RESERVATION_CREATED
+          - RESERVATION_RELEASED
+          - ALLOCATION_CREATED
+          - ALLOCATION_RELEASED
+          - BACKORDER_CREATED
+          - BACKORDER_RESOLVED
+          - PICK_TASK_CREATED
+          - PICK_TASK_COMPLETED
+          example: GOODS_ISSUE
+        changeInQuantity:
+          type: integer
+          format: int32
+          description: Signed change in quantity applied by this entry (positive inbound, negative outbound)
+          example: -3
+        quantityAfter:
+          type: integer
+          format: int32
+          description: Running quantity after this entry was applied
+          example: 7
+        locationId:
+          type: string
+          format: uuid
+          description: Location the entry applies to
+          example: 01960003-0000-7000-8000-000000000004
+        timestamp:
+          type: string
+          format: date-time
+          description: Business timestamp of the inventory event
+          example: 2026-01-15 09:30:00+00:00
+        transactionUserId:
+          type: string
+          description: Identifier of the user who initiated the transaction
+          example: user-10042
+        notes:
+          type: string
+          description: Free-text notes recorded with the entry
+      required:
+      - changeInQuantity
+      - eventType
+      - ledgerEntryId
+      - timestamp
     CountEntryResponse:
       type: object
       description: A single recorded count entry in a cycle count task's history

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -3266,15 +3266,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InterferingMovementResponse'
+                type: array
+                items:
+                  $ref: '#/components/schemas/InterferingMovementResponse'
         '404':
           description: Task not found
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/InterferingMovementResponse'
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - inventory:cycle_count:view
@@ -6892,12 +6892,12 @@ components:
           description: Storage location identifier
         onHandQuantity:
           type: integer
-          format: int32
+          format: int64
           description: Current on-hand quantity across all stock items at the location
           example: 12
         availableToPromiseQuantity:
           type: integer
-          format: int32
+          format: int64
           description: 'Quantity available to promise after pending allocations. Note: reservation events are not yet factored in.'
           example: 8
       required:

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
@@ -81,10 +81,14 @@ public final class EventTypes {
                 EventTypeRegistration.write("INVENTORY_PUTAWAY_TASK_CLAIM", "Claim a putaway task for execution")
                         .build(),
 
-                // ReplenishmentController - 1 event
+                // ReplenishmentController - 2 events
                 EventTypeRegistration.write(
                                 "INVENTORY_REPLENISHMENT_POLICY_CREATE",
                                 "Create replenishment policy used for task generation")
+                        .build(),
+                EventTypeRegistration.write(
+                                "INVENTORY_REPLENISHMENT_SCAN_RUN",
+                                "Run the batch replenishment scan over all replenishment policies")
                         .build(),
 
                 // StockMovementController - 3 events

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountController.java
@@ -185,8 +185,16 @@ public class CycleCountController {
             content =
                     @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = InterferingMovementResponse.class)))
-    @ApiResponse(responseCode = "404", description = "Task not found")
+                            array =
+                                    @io.swagger.v3.oas.annotations.media.ArraySchema(
+                                            schema = @Schema(implementation = InterferingMovementResponse.class))))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Task not found",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = com.positivity.shared.error.ApiError.class)))
     public ResponseEntity<List<InterferingMovementResponse>> getInterferingMovements(
             @Parameter(description = "Task ID") @PathVariable UUID taskId) {
         return ResponseEntity.ok(cycleCountService.getInterferingMovements(taskId));

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/CycleCountController.java
@@ -4,6 +4,7 @@ import com.positivity.events.EmitEvent;
 import com.positivity.inventory.internal.dto.cyclecount.CountEntryResponse;
 import com.positivity.inventory.internal.dto.cyclecount.CountResponse;
 import com.positivity.inventory.internal.dto.cyclecount.CycleCountTaskResponse;
+import com.positivity.inventory.internal.dto.cyclecount.InterferingMovementResponse;
 import com.positivity.inventory.internal.dto.cyclecount.SubmitCountRequest;
 import com.positivity.inventory.internal.dto.cyclecount.SubmitRecountRequest;
 import com.positivity.inventory.service.CycleCountService;
@@ -151,6 +152,44 @@ public class CycleCountController {
             @Parameter(description = "Task ID") @PathVariable UUID taskId) {
         List<CountEntryResponse> history = cycleCountService.getCountHistory(taskId);
         return ResponseEntity.ok(history);
+    }
+
+    /**
+     * List ledger movements interfering with a task's count window
+     * (odoo-parity I2, issue #1026).
+     *
+     * <p>Design note (I3): the alternative of freezing stock movements for the
+     * duration of a count was explicitly REJECTED — blocking movements
+     * contradicts continuous shop operation. Conflict detection replaces
+     * freezing: movements stay allowed, the ledger makes them listable here,
+     * and a detected conflict forces an explicit reviewer choice (recount, or
+     * approve with the variance recomputed against current on-hand).
+     */
+    @GetMapping("/task/{taskId}/interfering-movements")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:cycle_count:view"})
+    @PreAuthorize("hasAuthority('inventory:cycle_count:view')")
+    @Tag(name = "Cycle Count Query")
+    @Operation(
+            summary = "List interfering movements for a cycle count task",
+            description = "Returns the on-hand-affecting ledger entries for the task's SKU/location recorded"
+                    + " between task creation and now — the movements that make the task's expected-quantity"
+                    + " snapshot stale (CONFLICT). Design note: freezing stock movements during counts was"
+                    + " rejected as it contradicts continuous shop operation; conflict detection with this"
+                    + " listing replaces freezing.",
+            tags = {"Cycle Count Query"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Interfering movements retrieved successfully",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = InterferingMovementResponse.class)))
+    @ApiResponse(responseCode = "404", description = "Task not found")
+    public ResponseEntity<List<InterferingMovementResponse>> getInterferingMovements(
+            @Parameter(description = "Task ID") @PathVariable UUID taskId) {
+        return ResponseEntity.ok(cycleCountService.getInterferingMovements(taskId));
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.controller;
 
 import com.positivity.inventory.internal.exception.AdjustmentLedgerPostingException;
+import com.positivity.inventory.internal.exception.CycleCountConflictException;
 import com.positivity.inventory.internal.exception.CycleCountPlanNotFoundException;
 import com.positivity.inventory.internal.exception.DuplicateAsnException;
 import com.positivity.inventory.internal.exception.InsufficientAtpException;
@@ -153,6 +154,13 @@ public class InventoryGlobalExceptionHandler {
         // odoo-parity K1 (#1027): deterministic per-case code from the exception
         // (NEGATIVE_STOCK_OVERRIDE_REQUIRED / NEGATIVE_STOCK_FLOOR_VIOLATION).
         return build(HttpStatus.valueOf(422), ex.getErrorCode(), ex.getMessage());
+    }
+
+    @ExceptionHandler(CycleCountConflictException.class)
+    public ResponseEntity<ApiError> handleCycleCountConflict(CycleCountConflictException ex) {
+        // odoo-parity I2 (#1026): approval rejected — task flagged CONFLICT,
+        // reviewer must explicitly choose recount or recomputed approval.
+        return build(HttpStatus.CONFLICT, "CYCLE_COUNT_CONFLICT", ex.getMessage());
     }
 
     @ExceptionHandler(RecountLimitExceededException.class)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import com.positivity.inventory.internal.exception.LocationAtCapacityException;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.LocationNotValidForSkuException;
 import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
+import com.positivity.inventory.internal.exception.NegativeStockPolicyViolationException;
 import com.positivity.inventory.internal.exception.NoOnHandAtSourceLocationException;
 import com.positivity.inventory.internal.exception.OverReceiptNotPermittedException;
 import com.positivity.inventory.internal.exception.PartMatchPermissionException;
@@ -145,6 +146,13 @@ public class InventoryGlobalExceptionHandler {
     @ExceptionHandler(InsufficientStockException.class)
     public ResponseEntity<ApiError> handleInsufficientStock(InsufficientStockException ex) {
         return build(HttpStatus.valueOf(422), "INSUFFICIENT_STOCK", ex.getMessage());
+    }
+
+    @ExceptionHandler(NegativeStockPolicyViolationException.class)
+    public ResponseEntity<ApiError> handleNegativeStockPolicyViolation(NegativeStockPolicyViolationException ex) {
+        // odoo-parity K1 (#1027): deterministic per-case code from the exception
+        // (NEGATIVE_STOCK_OVERRIDE_REQUIRED / NEGATIVE_STOCK_FLOOR_VIOLATION).
+        return build(HttpStatus.valueOf(422), ex.getErrorCode(), ex.getMessage());
     }
 
     @ExceptionHandler(RecountLimitExceededException.class)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
@@ -3,7 +3,9 @@ package com.positivity.inventory.internal.controller;
 import com.positivity.events.EmitEvent;
 import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
+import com.positivity.inventory.internal.security.InventoryPermissionRegistry;
 import com.positivity.inventory.service.ReplenishmentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -86,8 +88,8 @@ public class ReplenishmentController {
     @EmitEvent(id = "INVENTORY_REPLENISHMENT_POLICY_CREATE", apiVersion = "1")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
-            scopes = {"inventory:adjustment:create"})
-    @PreAuthorize("hasAuthority('inventory:adjustment:create')")
+            scopes = {"inventory:replenishment:manage"})
+    @PreAuthorize("hasAuthority('" + InventoryPermissionRegistry.REPLENISHMENT_MANAGE + "')")
     @Operation(
             operationId = "createReplenishmentPolicy",
             summary = "Create replenishment policy",
@@ -104,5 +106,30 @@ public class ReplenishmentController {
     public ResponseEntity<ReplenishmentPolicyResponse> createReplenishmentPolicy(
             @Valid @RequestBody CreateReplenishmentPolicyRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(replenishmentService.createReplenishmentPolicy(request));
+    }
+
+    @PostMapping("/scan")
+    @EmitEvent(id = "INVENTORY_REPLENISHMENT_SCAN_RUN", apiVersion = "1")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:replenishment:manage"})
+    @PreAuthorize("hasAuthority('" + InventoryPermissionRegistry.REPLENISHMENT_MANAGE + "')")
+    @Operation(
+            operationId = "runReplenishmentScan",
+            summary = "Run the batch replenishment scan",
+            description = "Evaluates every replenishment policy against current on-hand and creates or refreshes"
+                    + " batch-triggered replenishment tasks for below-minimum pick faces. Idempotent per"
+                    + " (policy, day): repeated runs on the same day never create duplicate open tasks."
+                    + " Returns a summary of the scan run.",
+            tags = {"Replenishment"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Scan completed; summary returned",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ReplenishmentScanResultResponse.class)))
+    public ResponseEntity<ReplenishmentScanResultResponse> runReplenishmentScan() {
+        return ResponseEntity.ok(replenishmentService.runBatchReplenishmentScan());
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryInquiryResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryInquiryResponse.java
@@ -24,12 +24,12 @@ public class LocationInventoryInquiryResponse {
             description = "Current on-hand quantity across all stock items at the location",
             example = "12",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private int onHandQuantity;
+    private long onHandQuantity;
 
     @Schema(
             description =
                     "Quantity available to promise after pending allocations. Note: reservation events are not yet factored in.",
             example = "8",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private int availableToPromiseQuantity;
+    private long availableToPromiseQuantity;
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/AdjustmentResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/AdjustmentResponse.java
@@ -26,6 +26,12 @@ import lombok.NoArgsConstructor;
 public class AdjustmentResponse {
 
     @Schema(
+            description = "Cycle count task this adjustment settles, if created from a task",
+            example = "01960003-0000-7000-8000-000000000009",
+            requiredMode = NOT_REQUIRED)
+    private UUID taskId;
+
+    @Schema(
             description = "Unique identifier of the adjustment record",
             example = "01960003-0000-7000-8000-000000000001",
             requiredMode = REQUIRED)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/CreateAdjustmentRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/CreateAdjustmentRequest.java
@@ -29,6 +29,13 @@ public class CreateAdjustmentRequest {
     private UUID stockItemId;
 
     @Schema(
+            description = "Cycle count task this adjustment settles, if created from a task. Enables"
+                    + " approval-time conflict detection and variance recomputation against current on-hand.",
+            example = "01960003-0000-7000-8000-000000000009",
+            requiredMode = io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED)
+    private UUID taskId;
+
+    @Schema(
             description = "Reason code explaining why the adjustment is being made",
             example = "CYCLE_COUNT_VARIANCE",
             requiredMode = REQUIRED)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/InterferingMovementResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/InterferingMovementResponse.java
@@ -1,0 +1,66 @@
+package com.positivity.inventory.internal.dto.cyclecount;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * One ledger movement that interfered with a cycle-count window: an
+ * on-hand-affecting entry for the task's SKU/location recorded between task
+ * creation and now (odoo-parity I2, issue #1026).
+ */
+@Schema(description = "Ledger movement recorded between cycle-count task creation and now for the task's SKU/location")
+@Value
+@Builder
+public class InterferingMovementResponse {
+
+    @Schema(
+            description = "Unique identifier of the ledger entry",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
+    UUID ledgerEntryId;
+
+    @Schema(description = "Type of inventory ledger event recorded", example = "GOODS_ISSUE", requiredMode = REQUIRED)
+    @NotNull
+    InventoryLedgerEventType eventType;
+
+    @Schema(
+            description = "Signed change in quantity applied by this entry (positive inbound, negative outbound)",
+            example = "-3",
+            requiredMode = REQUIRED)
+    @NotNull
+    Integer changeInQuantity;
+
+    @Schema(description = "Running quantity after this entry was applied", example = "7", requiredMode = NOT_REQUIRED)
+    Integer quantityAfter;
+
+    @Schema(
+            description = "Location the entry applies to",
+            example = "01960003-0000-7000-8000-000000000004",
+            requiredMode = NOT_REQUIRED)
+    UUID locationId;
+
+    @Schema(
+            description = "Business timestamp of the inventory event",
+            example = "2026-01-15T09:30:00Z",
+            requiredMode = REQUIRED)
+    @NotNull
+    Instant timestamp;
+
+    @Schema(
+            description = "Identifier of the user who initiated the transaction",
+            example = "user-10042",
+            requiredMode = NOT_REQUIRED)
+    String transactionUserId;
+
+    @Schema(description = "Free-text notes recorded with the entry", requiredMode = NOT_REQUIRED)
+    String notes;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentScanResultResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentScanResultResponse.java
@@ -1,0 +1,49 @@
+package com.positivity.inventory.internal.dto.replenishment;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Summary of one batch replenishment scan run (CAP-217 / odoo-parity F1).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Summary of a batch replenishment scan run over all replenishment policies")
+public class ReplenishmentScanResultResponse {
+
+    @Schema(
+            description = "Number of replenishment policies evaluated by the scan",
+            example = "42",
+            requiredMode = REQUIRED)
+    private int policiesEvaluated;
+
+    @Schema(
+            description = "Number of policies whose on-hand quantity was below the configured minimum",
+            example = "5",
+            requiredMode = REQUIRED)
+    private int policiesBelowMinimum;
+
+    @Schema(
+            description = "Number of new replenishment tasks created by the scan",
+            example = "3",
+            requiredMode = REQUIRED)
+    private int tasksCreated;
+
+    @Schema(
+            description = "Number of already-open replenishment tasks whose quantity was refreshed to the current need",
+            example = "2",
+            requiredMode = REQUIRED)
+    private int tasksRefreshed;
+
+    @Schema(description = "Timestamp at which the scan ran", example = "2026-01-15T09:30:00Z", requiredMode = REQUIRED)
+    @NotNull
+    private String scanAt;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/CycleCountAdjustment.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/CycleCountAdjustment.java
@@ -44,6 +44,15 @@ public class CycleCountAdjustment {
     private UUID stockItemId;
 
     /**
+     * Cycle count task this adjustment settles, when created from a task
+     * (odoo-parity I2, issue #1026). Enables approval-time conflict detection
+     * and variance recomputation against current on-hand. Nullable — legacy
+     * adjustments have no task reference.
+     */
+    @Column(name = "task_id")
+    private UUID taskId;
+
+    /**
      * Reason code for the adjustment (e.g., 'CYCLE_COUNT_SHRINK',
      * 'CYCLE_COUNT_OVERAGE').
      */

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryStockSummary.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryStockSummary.java
@@ -1,0 +1,93 @@
+package com.positivity.inventory.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Stored on-hand snapshot (issue #1024, odoo-parity A1): one row per
+ * (stockItemId, locationId) derived from the append-only inventory ledger.
+ *
+ * <p>Maintained transactionally with each ledger append by
+ * {@code LedgerPostingService}; never written by any other path. The ledger
+ * remains the source of truth — {@code StockSummaryRebuildService} rebuilds
+ * this table from scratch and {@code StockSummaryDriftVerifier} reports drift.
+ *
+ * <p>{@code locationId} is nullable: ledger entries posted without a location
+ * (e.g. workorder consumption) aggregate on a NULL-location row. Later stories
+ * add a nullable {@code lotId} to the uniqueness and an {@code inTransitQty}
+ * column without reshaping the table.
+ */
+@Entity
+@Table(
+        name = "inventory_stock_summary",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uq_inventory_stock_summary_key",
+                        columnNames = {"stock_item_id", "location_id"}),
+        indexes = @Index(name = "idx_inventory_stock_summary_location", columnList = "location_id"))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class InventoryStockSummary {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    private UUID summaryId;
+
+    @Column(name = "stock_item_id", nullable = false)
+    private String stockItemId;
+
+    @Column(name = "location_id")
+    private UUID locationId;
+
+    /** Net physical stock: sum of on-hand-affecting ledger deltas. */
+    @Column(name = "on_hand", nullable = false)
+    private long onHand;
+
+    /** Outstanding hard allocations: ALLOCATION_CREATED - ALLOCATION_RELEASED. */
+    @Column(name = "allocated", nullable = false)
+    private long allocated;
+
+    /** Outstanding soft reservations: RESERVATION_CREATED - RESERVATION_RELEASED. */
+    @Column(name = "reserved", nullable = false)
+    private long reserved;
+
+    /** Available to promise: onHand - allocated (ADR-0001). */
+    @Column(name = "atp", nullable = false)
+    private long atp;
+
+    /** Ledger entry that last touched this row. */
+    @Column(name = "last_ledger_entry_id")
+    private UUID lastLedgerEntryId;
+
+    /** Timestamp of the ledger entry that last touched this row. */
+    @Column(name = "last_event_at")
+    private Instant lastEventAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/NegativeStockPolicy.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/NegativeStockPolicy.java
@@ -1,0 +1,62 @@
+package com.positivity.inventory.internal.enums;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Per-event-type negative-stock policy matrix (odoo-parity K1, issue #1027).
+ *
+ * <p>Classifies every {@link InventoryLedgerEventType} by what happens when a
+ * posting would take the {@code (stockItemId, locationId)} on-hand balance
+ * below zero. The matrix is enforced exclusively inside the single ledger
+ * posting funnel ({@code LedgerPostingServiceImpl}); a DB-level check is
+ * impractical against an append-only ledger.
+ *
+ * <p>See {@code pos-inventory/docs/negative-stock-policy.md} for the full
+ * matrix table with per-row rationale.
+ */
+public enum NegativeStockPolicy {
+
+    /**
+     * Posting below zero is always rejected ({@code InsufficientStockException},
+     * {@code INSUFFICIENT_STOCK}). Physical outbound flows cannot take more
+     * stock than exists.
+     */
+    BLOCKED,
+
+    /**
+     * Posting below zero is rejected unless the caller passes an explicit
+     * negative-stock override flag after its own
+     * {@code inventory:adjustment:override} permission check
+     * ({@code NEGATIVE_STOCK_OVERRIDE_REQUIRED} otherwise).
+     */
+    BLOCKED_OVERRIDABLE,
+
+    /**
+     * Posting may drive on-hand to exactly zero but never below
+     * ({@code NEGATIVE_STOCK_FLOOR_VIOLATION}); counts set reality, so they
+     * can zero stock but not invent negative stock. Not overridable.
+     */
+    FLOOR_AT_ZERO,
+
+    /**
+     * No negative-stock constraint. Inbound flows and paired-location moves
+     * (e.g. the PUTAWAY source decrement) post freely; neutral/ATP-only types
+     * never touch on-hand and are equally unconstrained.
+     */
+    UNCONSTRAINED;
+
+    /**
+     * Returns the negative-stock policy for the given ledger event type.
+     *
+     * @param eventType the ledger event type being posted
+     * @return the policy row of the matrix that applies to the event type
+     */
+    public static @NonNull NegativeStockPolicy forEventType(@NonNull InventoryLedgerEventType eventType) {
+        return switch (eventType) {
+            case GOODS_ISSUE, WORKORDER_CONSUMPTION, TRANSFER_OUT -> BLOCKED;
+            case SCRAP_OUT -> BLOCKED_OVERRIDABLE;
+            case ADJUSTMENT_OUT, COUNT_VARIANCE_OUT, ADJUST_CYCLE_COUNT -> FLOOR_AT_ZERO;
+            default -> UNCONSTRAINED;
+        };
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/TaskStatus.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/TaskStatus.java
@@ -9,6 +9,7 @@ package com.positivity.inventory.internal.enums;
  * <ul>
  * <li>ASSIGNED → Auditor has been assigned the count task</li>
  * <li>COUNTED_PENDING_REVIEW → Count submitted, awaiting manager review</li>
+ * <li>CONFLICT → Stock moved between task creation and count/approval; reviewer must choose</li>
  * <li>REQUIRES_INVESTIGATION → Max recounts exceeded or threshold breach</li>
  * <li>APPROVED → Variance accepted, ready for inventory adjustment</li>
  * <li>REJECTED → Count rejected, may require new task assignment</li>
@@ -24,6 +25,15 @@ public enum TaskStatus {
      * Count has been submitted and is awaiting manager review.
      */
     COUNTED_PENDING_REVIEW,
+
+    /**
+     * Interfering stock movements were detected between task creation and
+     * count submission (or adjustment approval), so the task's expected-quantity
+     * snapshot is stale (odoo-parity I2, issue #1026 — Odoo's {@code is_outdated}).
+     * Requires an explicit reviewer choice: request a recount, or approve the
+     * adjustment with the variance recomputed against CURRENT on-hand.
+     */
+    CONFLICT,
 
     /**
      * Task requires investigation due to exceeding recount limits or high variance.

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/CycleCountConflictException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/CycleCountConflictException.java
@@ -1,0 +1,20 @@
+package com.positivity.inventory.internal.exception;
+
+import java.util.UUID;
+
+/**
+ * Raised when a cycle-count adjustment approval detects interfering stock
+ * movements in the count window (odoo-parity I2, issue #1026): the task's
+ * expected-quantity snapshot is stale, the task has been flagged
+ * {@code CONFLICT}, and the approval is rejected until the reviewer makes an
+ * explicit choice — request a recount, or re-approve the adjustment (approving
+ * a {@code CONFLICT} task recomputes the variance against current on-hand).
+ */
+public class CycleCountConflictException extends RuntimeException {
+
+    public CycleCountConflictException(UUID taskId, int movementDelta) {
+        super("Cycle count task " + taskId + " has interfering stock movements (net on-hand delta " + movementDelta
+                + ") since the count snapshot; task flagged CONFLICT. Request a recount, or approve again to accept"
+                + " the variance recomputed against current on-hand.");
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/NegativeStockPolicyViolationException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/NegativeStockPolicyViolationException.java
@@ -1,0 +1,39 @@
+package com.positivity.inventory.internal.exception;
+
+/**
+ * Thrown by the ledger posting funnel when a posting violates the
+ * per-event-type negative-stock policy matrix (odoo-parity K1, issue #1027).
+ *
+ * <p>Carries a deterministic per-case error code surfaced in the
+ * {@code ApiError} envelope:
+ * <ul>
+ *   <li>{@link #OVERRIDE_REQUIRED} — a {@code BLOCKED_OVERRIDABLE} event type
+ *       (SCRAP_OUT) would take on-hand below zero and no override flag was
+ *       passed;</li>
+ *   <li>{@link #FLOOR_VIOLATION} — a {@code FLOOR_AT_ZERO} event type
+ *       (ADJUSTMENT_OUT, COUNT_VARIANCE_OUT, ADJUST_CYCLE_COUNT) would take
+ *       on-hand below zero; never overridable.</li>
+ * </ul>
+ *
+ * <p>{@code BLOCKED} event types keep surfacing the pre-existing
+ * {@link InsufficientStockException} ({@code INSUFFICIENT_STOCK}).
+ */
+public class NegativeStockPolicyViolationException extends RuntimeException {
+
+    /** SCRAP_OUT below zero without the caller-approved override flag. */
+    public static final String OVERRIDE_REQUIRED = "NEGATIVE_STOCK_OVERRIDE_REQUIRED";
+
+    /** Floor-at-zero event type would drive on-hand negative. */
+    public static final String FLOOR_VIOLATION = "NEGATIVE_STOCK_FLOOR_VIOLATION";
+
+    private final String errorCode;
+
+    public NegativeStockPolicyViolationException(String errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
@@ -43,6 +43,53 @@ public interface InventoryLedgerEntryRepository
 
     Optional<InventoryLedgerEntry> findByAdjustmentId(UUID adjustmentId);
 
+    // ─── Cycle-count conflict window queries (odoo-parity I2, issue #1026) ────
+
+    /**
+     * Interfering movements for a cycle-count task: on-hand-affecting entries
+     * for the task's SKU recorded after the task snapshot was taken.
+     */
+    List<InventoryLedgerEntry> findByStockItemIdAndEventTypeInAndTimestampGreaterThanOrderByTimestampAsc(
+            String stockItemId, Collection<InventoryLedgerEventType> eventTypes, java.time.Instant after);
+
+    /** Location-scoped variant of the interfering-movement listing. */
+    List<InventoryLedgerEntry> findByStockItemIdAndLocationIdAndEventTypeInAndTimestampGreaterThanOrderByTimestampAsc(
+            String stockItemId,
+            UUID locationId,
+            Collection<InventoryLedgerEventType> eventTypes,
+            java.time.Instant after);
+
+    /**
+     * Net on-hand delta for one SKU since a point in time — non-zero means
+     * movements interfered with a count window (odoo-parity I2).
+     */
+    @Query("""
+                        SELECT COALESCE(SUM(e.changeInQuantity), 0)
+                        FROM InventoryLedgerEntry e
+                        WHERE e.stockItemId = :stockItemId
+                          AND e.eventType IN :eventTypes
+                          AND e.timestamp > :after
+                        """)
+    Integer sumChangeForStockItemSince(
+            @Param("stockItemId") String stockItemId,
+            @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes,
+            @Param("after") java.time.Instant after);
+
+    /** Location-scoped variant of {@link #sumChangeForStockItemSince}. */
+    @Query("""
+                        SELECT COALESCE(SUM(e.changeInQuantity), 0)
+                        FROM InventoryLedgerEntry e
+                        WHERE e.stockItemId = :stockItemId
+                          AND e.locationId = :locationId
+                          AND e.eventType IN :eventTypes
+                          AND e.timestamp > :after
+                        """)
+    Integer sumChangeForStockItemAtLocationSince(
+            @Param("stockItemId") String stockItemId,
+            @Param("locationId") UUID locationId,
+            @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes,
+            @Param("after") java.time.Instant after);
+
     default Integer calculateOnHandQuantity(UUID stockItemId) {
         return calculateOnHandQuantityForEventTypes(
                 stockItemId.toString(), InventoryLedgerEventType.onHandAffectingTypes());

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,14 @@ import org.springframework.data.repository.query.Param;
 
 /**
  * Repository for {@link InventoryLedgerEntry} entities.
+ *
+ * <p>Since issue #1024 (A1) the availability/inquiry/rollup read paths are
+ * served by the {@code inventory_stock_summary} read model, not by the
+ * aggregate queries below. The {@code calculateOnHand*}/{@code sumQuantity*}
+ * aggregations remain for (a) posting-path {@code quantityAfter} and
+ * validation computations and (b) the summary rebuild/drift-verifier jobs,
+ * for which the ledger is the source of truth. Do not reintroduce them on
+ * hot read endpoints.
  */
 public interface InventoryLedgerEntryRepository
         extends JpaRepository<InventoryLedgerEntry, UUID>, JpaSpecificationExecutor<InventoryLedgerEntry> {
@@ -219,4 +228,83 @@ public interface InventoryLedgerEntryRepository
 
         long getQuantity();
     }
+
+    /**
+     * Ledger-truth aggregation per (stockItemId, locationId) for every key with
+     * summary-relevant events (issue #1024, A1). Used by the summary rebuild
+     * job and the drift verifier — not by read endpoints.
+     */
+    @Query("""
+                        SELECT e.stockItemId AS stockItemId, e.locationId AS locationId,
+                               COALESCE(SUM(CASE WHEN e.eventType IN :onHandTypes THEN e.changeInQuantity ELSE 0 END), 0) AS onHand,
+                               COALESCE(SUM(CASE WHEN e.eventType = :allocationCreated THEN e.changeInQuantity
+                                                 WHEN e.eventType = :allocationReleased THEN -e.changeInQuantity
+                                                 ELSE 0 END), 0) AS allocated,
+                               COALESCE(SUM(CASE WHEN e.eventType = :reservationCreated THEN e.changeInQuantity
+                                                 WHEN e.eventType = :reservationReleased THEN -e.changeInQuantity
+                                                 ELSE 0 END), 0) AS reserved
+                        FROM InventoryLedgerEntry e
+                        WHERE e.eventType IN :summaryTypes
+                        GROUP BY e.stockItemId, e.locationId
+                        """)
+    List<SummaryAggregate> aggregateForStockSummary(
+            @Param("onHandTypes") Collection<InventoryLedgerEventType> onHandTypes,
+            @Param("allocationCreated") InventoryLedgerEventType allocationCreated,
+            @Param("allocationReleased") InventoryLedgerEventType allocationReleased,
+            @Param("reservationCreated") InventoryLedgerEventType reservationCreated,
+            @Param("reservationReleased") InventoryLedgerEventType reservationReleased,
+            @Param("summaryTypes") Collection<InventoryLedgerEventType> summaryTypes);
+
+    interface SummaryAggregate {
+        String getStockItemId();
+
+        UUID getLocationId();
+
+        long getOnHand();
+
+        long getAllocated();
+
+        long getReserved();
+    }
+
+    /** Latest summary-relevant entries for one key; pass a page of size 1. Rebuild use only. */
+    @Query("""
+                        SELECT e
+                        FROM InventoryLedgerEntry e
+                        WHERE e.stockItemId = :stockItemId
+                          AND ((:locationId IS NULL AND e.locationId IS NULL) OR e.locationId = :locationId)
+                          AND e.eventType IN :summaryTypes
+                        ORDER BY e.timestamp DESC, e.ledgerEntryId DESC
+                        """)
+    List<InventoryLedgerEntry> findLatestSummaryEntries(
+            @Param("stockItemId") String stockItemId,
+            @Param("locationId") UUID locationId,
+            @Param("summaryTypes") Collection<InventoryLedgerEventType> summaryTypes,
+            Pageable pageable);
+
+    /**
+     * First non-blank unit of measure recorded for a stock item (oldest entry
+     * first); pass a page of size 1. Preserves the pre-#1024 availability
+     * response's derived UoM without scanning the full ledger.
+     */
+    @Query("""
+                        SELECT e.unitOfMeasure
+                        FROM InventoryLedgerEntry e
+                        WHERE e.stockItemId = :stockItemId
+                          AND e.unitOfMeasure IS NOT NULL AND TRIM(e.unitOfMeasure) <> ''
+                        ORDER BY e.timestamp ASC, e.ledgerEntryId ASC
+                        """)
+    List<String> findUnitsOfMeasureByStockItem(@Param("stockItemId") String stockItemId, Pageable pageable);
+
+    /** Location-scoped variant of {@link #findUnitsOfMeasureByStockItem}. */
+    @Query("""
+                        SELECT e.unitOfMeasure
+                        FROM InventoryLedgerEntry e
+                        WHERE e.stockItemId = :stockItemId
+                          AND e.locationId = :locationId
+                          AND e.unitOfMeasure IS NOT NULL AND TRIM(e.unitOfMeasure) <> ''
+                        ORDER BY e.timestamp ASC, e.ledgerEntryId ASC
+                        """)
+    List<String> findUnitsOfMeasureByStockItemAtLocation(
+            @Param("stockItemId") String stockItemId, @Param("locationId") UUID locationId, Pageable pageable);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryStockSummaryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryStockSummaryRepository.java
@@ -1,0 +1,115 @@
+package com.positivity.inventory.internal.repository;
+
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import jakarta.persistence.LockModeType;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Repository for {@link InventoryStockSummary} rows (issue #1024, A1).
+ *
+ * <p>Writes go exclusively through {@code LedgerPostingService} (row-locked
+ * upsert) and {@code StockSummaryRebuildService}; everything else is read-only.
+ */
+public interface InventoryStockSummaryRepository extends JpaRepository<InventoryStockSummary, UUID> {
+
+    /** Maximum number of location ids passed to a single {@code IN} clause. */
+    int LOCATION_ID_CHUNK_SIZE = 1000;
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM InventoryStockSummary s WHERE s.stockItemId = :stockItemId AND s.locationId = :locationId")
+    Optional<InventoryStockSummary> findWithLockByStockItemIdAndLocationId(
+            @Param("stockItemId") String stockItemId, @Param("locationId") UUID locationId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM InventoryStockSummary s WHERE s.stockItemId = :stockItemId AND s.locationId IS NULL")
+    Optional<InventoryStockSummary> findWithLockByStockItemIdAndLocationIdIsNull(
+            @Param("stockItemId") String stockItemId);
+
+    Optional<InventoryStockSummary> findByStockItemIdAndLocationId(String stockItemId, UUID locationId);
+
+    Optional<InventoryStockSummary> findByStockItemIdAndLocationIdIsNull(String stockItemId);
+
+    List<InventoryStockSummary> findByStockItemId(String stockItemId);
+
+    boolean existsByStockItemId(String stockItemId);
+
+    List<InventoryStockSummary> findByLocationIdAndOnHandGreaterThan(UUID locationId, long onHand);
+
+    @Query("""
+                        SELECT COALESCE(SUM(s.onHand), 0)
+                        FROM InventoryStockSummary s
+                        WHERE s.locationId = :locationId
+                        """)
+    long sumOnHandAtLocation(@Param("locationId") UUID locationId);
+
+    @Query("""
+                        SELECT COALESCE(SUM(s.allocated), 0)
+                        FROM InventoryStockSummary s
+                        WHERE s.locationId = :locationId
+                        """)
+    long sumAllocatedAtLocation(@Param("locationId") UUID locationId);
+
+    @Query("""
+                        SELECT s.locationId AS locationId, COALESCE(SUM(s.onHand), 0) AS onHand,
+                               COALESCE(SUM(s.allocated), 0) AS allocated
+                        FROM InventoryStockSummary s
+                        WHERE s.locationId IN :locationIds
+                        GROUP BY s.locationId
+                        """)
+    List<LocationSummary> sumByLocation(@Param("locationIds") Collection<UUID> locationIds);
+
+    @Query("""
+                        SELECT s.locationId AS locationId, COALESCE(SUM(s.onHand), 0) AS onHand,
+                               COALESCE(SUM(s.allocated), 0) AS allocated
+                        FROM InventoryStockSummary s
+                        WHERE s.stockItemId = :stockItemId
+                          AND s.locationId IN :locationIds
+                        GROUP BY s.locationId
+                        """)
+    List<LocationSummary> sumByLocationForSku(
+            @Param("stockItemId") String stockItemId, @Param("locationIds") Collection<UUID> locationIds);
+
+    interface LocationSummary {
+        UUID getLocationId();
+
+        long getOnHand();
+
+        long getAllocated();
+    }
+
+    /**
+     * Chunk-safe per-location on-hand and allocated sums for the given
+     * locations, optionally restricted to one stock item. Locations without
+     * summary rows are absent from the maps (treat as 0).
+     */
+    default LocationQuantityMaps sumByLocationChunked(Collection<UUID> locationIds, String stockItemIdOrNull) {
+        Map<UUID, Long> onHand = new HashMap<>();
+        Map<UUID, Long> allocated = new HashMap<>();
+        if (locationIds != null && !locationIds.isEmpty()) {
+            List<UUID> distinctIds = locationIds.stream().distinct().toList();
+            for (int start = 0; start < distinctIds.size(); start += LOCATION_ID_CHUNK_SIZE) {
+                List<UUID> chunk =
+                        distinctIds.subList(start, Math.min(start + LOCATION_ID_CHUNK_SIZE, distinctIds.size()));
+                List<LocationSummary> rows = stockItemIdOrNull == null
+                        ? sumByLocation(chunk)
+                        : sumByLocationForSku(stockItemIdOrNull, chunk);
+                for (LocationSummary row : rows) {
+                    onHand.merge(row.getLocationId(), row.getOnHand(), Long::sum);
+                    allocated.merge(row.getLocationId(), row.getAllocated(), Long::sum);
+                }
+            }
+        }
+        return new LocationQuantityMaps(Map.copyOf(onHand), Map.copyOf(allocated));
+    }
+
+    record LocationQuantityMaps(Map<UUID, Long> onHand, Map<UUID, Long> allocated) {}
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryStockSummaryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryStockSummaryRepository.java
@@ -87,6 +87,90 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
     }
 
     /**
+     * Set-based drift diff between ledger truth and the summary table (issue
+     * #1024 drift verifier): returns ONLY mismatching keys, so the scheduled
+     * job never materializes either table in application memory. Emulates a
+     * full outer join as a UNION of two left joins (H2-compatible). Event
+     * types are passed as enum names ({@code event_type} is stored as text).
+     */
+    @Query(value = """
+                        WITH ledger AS (
+                            SELECT stock_item_id,
+                                   location_id,
+                                   COALESCE(SUM(CASE WHEN event_type IN (:onHandTypes) THEN change_in_quantity ELSE 0 END), 0) AS on_hand,
+                                   COALESCE(SUM(CASE WHEN event_type = :allocationCreated THEN change_in_quantity
+                                                     WHEN event_type = :allocationReleased THEN -change_in_quantity
+                                                     ELSE 0 END), 0) AS allocated,
+                                   COALESCE(SUM(CASE WHEN event_type = :reservationCreated THEN change_in_quantity
+                                                     WHEN event_type = :reservationReleased THEN -change_in_quantity
+                                                     ELSE 0 END), 0) AS reserved
+                            FROM inventory_ledger_entry
+                            WHERE event_type IN (:summaryTypes)
+                            GROUP BY stock_item_id, location_id
+                        )
+                        SELECT l.stock_item_id AS stockItemId,
+                               CAST(l.location_id AS VARCHAR) AS locationId,
+                               l.on_hand AS ledgerOnHand,
+                               l.allocated AS ledgerAllocated,
+                               l.reserved AS ledgerReserved,
+                               s.on_hand AS summaryOnHand,
+                               s.allocated AS summaryAllocated,
+                               s.reserved AS summaryReserved
+                        FROM ledger l
+                        LEFT JOIN inventory_stock_summary s
+                          ON s.stock_item_id = l.stock_item_id
+                         AND s.location_id IS NOT DISTINCT FROM l.location_id
+                        WHERE (s.summary_id IS NULL
+                               AND (l.on_hand <> 0 OR l.allocated <> 0 OR l.reserved <> 0))
+                           OR (s.summary_id IS NOT NULL
+                               AND (s.on_hand <> l.on_hand
+                                    OR s.allocated <> l.allocated
+                                    OR s.reserved <> l.reserved
+                                    OR s.atp <> l.on_hand - l.allocated))
+                        UNION ALL
+                        SELECT s.stock_item_id AS stockItemId,
+                               CAST(s.location_id AS VARCHAR) AS locationId,
+                               CAST(0 AS BIGINT) AS ledgerOnHand,
+                               CAST(0 AS BIGINT) AS ledgerAllocated,
+                               CAST(0 AS BIGINT) AS ledgerReserved,
+                               s.on_hand AS summaryOnHand,
+                               s.allocated AS summaryAllocated,
+                               s.reserved AS summaryReserved
+                        FROM inventory_stock_summary s
+                        LEFT JOIN ledger l
+                          ON l.stock_item_id = s.stock_item_id
+                         AND l.location_id IS NOT DISTINCT FROM s.location_id
+                        WHERE l.stock_item_id IS NULL
+                          AND (s.on_hand <> 0 OR s.allocated <> 0 OR s.reserved <> 0 OR s.atp <> 0)
+                        """, nativeQuery = true)
+    List<DriftRow> findDriftRows(
+            @Param("onHandTypes") Collection<String> onHandTypes,
+            @Param("allocationCreated") String allocationCreated,
+            @Param("allocationReleased") String allocationReleased,
+            @Param("reservationCreated") String reservationCreated,
+            @Param("reservationReleased") String reservationReleased,
+            @Param("summaryTypes") Collection<String> summaryTypes);
+
+    interface DriftRow {
+        String getStockItemId();
+
+        /** Rendered as text in SQL (log-only field; H2 returns raw UUID columns as byte[] in native projections). */
+        String getLocationId();
+
+        long getLedgerOnHand();
+
+        long getLedgerAllocated();
+
+        long getLedgerReserved();
+
+        Long getSummaryOnHand();
+
+        Long getSummaryAllocated();
+
+        Long getSummaryReserved();
+    }
+
+    /**
      * Chunk-safe per-location on-hand and allocated sums for the given
      * locations, optionally restricted to one stock item. Locations without
      * summary rows are absent from the maps (treat as 0).

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReplenishmentTaskRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReplenishmentTaskRepository.java
@@ -2,7 +2,10 @@ package com.positivity.inventory.internal.repository;
 
 import com.positivity.inventory.internal.entity.ReplenishmentTask;
 import com.positivity.inventory.internal.enums.ReplenishmentStatus;
+import com.positivity.inventory.internal.enums.ReplenishmentTriggerType;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -14,4 +17,16 @@ public interface ReplenishmentTaskRepository extends JpaRepository<Replenishment
 
     boolean existsByItemSKUAndDestinationLocationIdAndStatusIn(
             String itemSKU, UUID destinationLocationId, List<ReplenishmentStatus> statuses);
+
+    /** Open task lookup used by the batch scan to refresh instead of duplicate (odoo-parity F1). */
+    Optional<ReplenishmentTask> findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
+            String itemSKU, UUID destinationLocationId, List<ReplenishmentStatus> statuses);
+
+    /**
+     * Per-(policy, day) idempotency guard for the batch scan (odoo-parity F1):
+     * true when a batch-triggered task for this SKU/destination was already
+     * created on or after the given day boundary, regardless of its status.
+     */
+    boolean existsByItemSKUAndDestinationLocationIdAndTriggerTypeAndCreatedAtGreaterThanEqual(
+            String itemSKU, UUID destinationLocationId, ReplenishmentTriggerType triggerType, Instant createdAtFrom);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/security/InventoryPermissionRegistry.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/security/InventoryPermissionRegistry.java
@@ -136,6 +136,14 @@ public class InventoryPermissionRegistry {
      */
     public static final String CYCLE_COUNT_COMPLETE = "inventory:cycle_count:complete";
 
+    // ==================== REPLENISHMENT PERMISSIONS ====================
+
+    /**
+     * Manage replenishment: create/maintain replenishment policies and run the
+     * batch replenishment scan (CAP-217 / odoo-parity F1, issue #1025).
+     */
+    public static final String REPLENISHMENT_MANAGE = "inventory:replenishment:manage";
+
     // ==================== INVENTORY VIEW PERMISSIONS ====================
 
     /**
@@ -234,6 +242,13 @@ public class InventoryPermissionRegistry {
                 permission(CYCLE_COUNT_VIEW, "View cycle count tasks and results", "LOW"),
                 permission(CYCLE_COUNT_COMPLETE, "Complete and submit cycle count results", "MEDIUM"),
 
+                // Replenishment permissions (1)
+                permission(
+                        REPLENISHMENT_MANAGE,
+                        "Manage replenishment policies and run the batch replenishment scan",
+                        "MEDIUM",
+                        "Issue #1025"),
+
                 // Inventory view permissions (2)
                 permission(INVENTORY_VIEW, "View on-hand inventory levels at locations", "LOW"),
                 permission(INVENTORY_SEARCH, "Search inventory across multiple locations", "LOW"));
@@ -316,5 +331,12 @@ public class InventoryPermissionRegistry {
      */
     public static List<String> inventoryViewPermissions() {
         return Arrays.asList(INVENTORY_VIEW, INVENTORY_SEARCH);
+    }
+
+    /**
+     * Replenishment permissions
+     */
+    public static List<String> replenishmentPermissions() {
+        return Arrays.asList(REPLENISHMENT_MANAGE);
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
@@ -55,6 +55,7 @@ public class AsnServiceImpl implements AsnService {
     private final PurchaseOrderRepository purchaseOrderRepository;
     private final PurchaseOrderLineRepository purchaseOrderLineRepository;
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+    private final LedgerPostingService ledgerPostingService;
     private final InventoryFactPublisher inventoryFactPublisher;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -240,7 +241,7 @@ public class AsnServiceImpl implements AsnService {
                     .sourceTransactionId(persistedReceipt.getReceiptId().toString())
                     .notes("Goods receipt " + persistedReceipt.getReceiptNumber())
                     .build();
-            inventoryLedgerEntryRepository.save(entry);
+            ledgerPostingService.post(entry);
             inventoryFactPublisher.markEntry(entry);
         }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
@@ -57,6 +57,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
     private final ReservationRepository reservationRepository;
     private final AllocationRepository allocationRepository;
+    private final LedgerPostingService ledgerPostingService;
     private final InventoryFactPublisher inventoryFactPublisher;
 
     public ConsumptionServiceImpl(
@@ -64,6 +65,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
             InventoryLedgerEntryRepository inventoryLedgerEntryRepository,
             ReservationRepository reservationRepository,
             AllocationRepository allocationRepository,
+            LedgerPostingService ledgerPostingService,
             InventoryFactPublisher inventoryFactPublisher,
             Clock clock) {
         this.clock = clock;
@@ -72,6 +74,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
         this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
         this.reservationRepository = reservationRepository;
         this.allocationRepository = allocationRepository;
+        this.ledgerPostingService = ledgerPostingService;
     }
 
     @Override
@@ -106,7 +109,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
             entriesToSave.addAll(closeAllocations(request, item, task, releasedInBatch));
         }
 
-        List<InventoryLedgerEntry> savedEntries = inventoryLedgerEntryRepository.saveAll(entriesToSave);
+        List<InventoryLedgerEntry> savedEntries = ledgerPostingService.postAll(entriesToSave);
         inventoryFactPublisher.markEntries(savedEntries);
         List<UUID> ledgerEntryIds = savedEntries.stream()
                 .map(InventoryLedgerEntry::getLedgerEntryId)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImpl.java
@@ -45,6 +45,7 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
 
     private final CycleCountAdjustmentRepository adjustmentRepository;
     private final InventoryLedgerEntryRepository ledgerRepository;
+    private final LedgerPostingService ledgerPostingService;
     private final ApprovalThresholdEvaluator thresholdEvaluator;
     private final ApplicationEventPublisher eventPublisher;
     private final Clock clock;
@@ -202,7 +203,7 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
                     .notes(String.format("Cycle count adjustment: %s", adjustment.getReasonCode()))
                     .build();
 
-            ledgerEntry = ledgerRepository.save(ledgerEntry);
+            ledgerEntry = ledgerPostingService.post(ledgerEntry);
             adjustment.setLedgerEntryId(ledgerEntry.getLedgerEntryId());
             adjustment.setStatus(AdjustmentStatus.POSTED);
             adjustment.setPostedAt(Instant.now(clock));

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImpl.java
@@ -5,15 +5,20 @@ import com.positivity.inventory.internal.dto.cyclecount.ApproveAdjustmentRequest
 import com.positivity.inventory.internal.dto.cyclecount.CreateAdjustmentRequest;
 import com.positivity.inventory.internal.dto.cyclecount.RejectAdjustmentRequest;
 import com.positivity.inventory.internal.entity.CycleCountAdjustment;
+import com.positivity.inventory.internal.entity.CycleCountTask;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.AdjustmentStatus;
 import com.positivity.inventory.internal.enums.ApprovalTier;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.TaskStatus;
 import com.positivity.inventory.internal.event.AuditActorRef;
 import com.positivity.inventory.internal.event.AuditAggregateRef;
 import com.positivity.inventory.internal.event.InventoryAuditEvent;
 import com.positivity.inventory.internal.exception.AdjustmentLedgerPostingException;
+import com.positivity.inventory.internal.exception.CycleCountConflictException;
+import com.positivity.inventory.internal.exception.TaskNotFoundException;
 import com.positivity.inventory.internal.repository.CycleCountAdjustmentRepository;
+import com.positivity.inventory.internal.repository.CycleCountTaskRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.service.ApprovalThresholdEvaluator;
 import com.positivity.inventory.service.CycleCountAdjustmentService;
@@ -49,6 +54,8 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
     private final ApprovalThresholdEvaluator thresholdEvaluator;
     private final ApplicationEventPublisher eventPublisher;
     private final Clock clock;
+    private final CycleCountTaskRepository taskRepository;
+    private final CycleCountConflictDetector conflictDetector;
 
     @Override
     @Transactional
@@ -64,8 +71,13 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
             throw new IllegalArgumentException("No adjustment needed - counted quantity matches system quantity");
         }
 
+        if (request.getTaskId() != null && !taskRepository.existsById(request.getTaskId())) {
+            throw new TaskNotFoundException(request.getTaskId());
+        }
+
         CycleCountAdjustment adjustment = CycleCountAdjustment.builder()
                 .stockItemId(request.getStockItemId())
+                .taskId(request.getTaskId())
                 .reasonCode(request.getReasonCode())
                 .quantityChange(quantityChange)
                 .costAtTimeOfAdjustment(request.getCostAtTimeOfAdjustment())
@@ -92,7 +104,10 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
             adjustment = adjustmentRepository.save(adjustment);
 
             log.info("Adjustment {} auto-approved (below thresholds)", adjustment.getAdjustmentId());
-            postAdjustmentToLedger(adjustment);
+            // Auto-approval is still an approval: the conflict gate applies
+            // (odoo-parity I2, #1026) before anything posts to the ledger.
+            guardConflictAndRecompute(adjustment);
+            postApprovedAdjustment(adjustment);
         }
 
         return toResponse(adjustment);
@@ -115,6 +130,12 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
             throw new IllegalStateException("Cannot approve adjustment in status: " + adjustment.getStatus());
         }
 
+        // Conflict gate (odoo-parity I2, #1026): a first approval attempt that
+        // detects in-window movements flags the task CONFLICT and aborts;
+        // approving a CONFLICT task recomputes the variance against CURRENT
+        // on-hand — never the stale snapshot.
+        guardConflictAndRecompute(adjustment);
+
         Instant occurredAt = Instant.now(clock);
         adjustment.setStatus(AdjustmentStatus.APPROVED);
         adjustment.setApprovedByUserId(actorUserId);
@@ -122,7 +143,7 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
         adjustment = adjustmentRepository.save(adjustment);
 
         log.info("Adjustment {} approved by {} ({})", adjustmentId, actorUsername, actorUserId);
-        postAdjustmentToLedger(adjustment);
+        postApprovedAdjustment(adjustment);
         publishMovementAdjustedEvent(adjustment, occurredAt, actorUserId, actorUsername, correlationId);
 
         return toResponse(adjustment);
@@ -176,6 +197,88 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
     @Transactional(readOnly = true)
     public long countAdjustmentsByStatus(AdjustmentStatus status) {
         return adjustmentRepository.countByStatus(status);
+    }
+
+    /**
+     * Conflict gate applied at every approval (odoo-parity I2, #1026), for
+     * adjustments linked to a cycle-count task:
+     * <ul>
+     *   <li>task already {@code CONFLICT} — the reviewer's approval IS the
+     *       explicit "accept" choice, so the variance is recomputed against
+     *       CURRENT on-hand (never the stale snapshot) before posting;</li>
+     *   <li>task not yet flagged but in-window movements exist — the task is
+     *       flagged {@code CONFLICT} (in its own transaction, surviving this
+     *       rollback) and the approval is rejected so the reviewer must choose
+     *       explicitly: recount, or re-approve with recomputation.</li>
+     * </ul>
+     */
+    private void guardConflictAndRecompute(CycleCountAdjustment adjustment) {
+        if (adjustment.getTaskId() == null) {
+            return;
+        }
+        CycleCountTask task = taskRepository
+                .findById(adjustment.getTaskId())
+                .orElseThrow(() -> new TaskNotFoundException(adjustment.getTaskId()));
+
+        if (task.getStatus() == TaskStatus.CONFLICT) {
+            recomputeVarianceAgainstCurrentOnHand(adjustment);
+            return;
+        }
+
+        int movementDelta = conflictDetector.movementDeltaSinceSnapshot(task);
+        if (movementDelta != 0) {
+            conflictDetector.flagConflict(task.getTaskId());
+            throw new CycleCountConflictException(task.getTaskId(), movementDelta);
+        }
+    }
+
+    /**
+     * Replaces the stale snapshot math with current-on-hand math: quantityChange
+     * becomes countedQuantity - currentOnHand, using the same global on-hand
+     * aggregation the posting path uses for quantityAfter. The funnel's
+     * floor-at-zero matrix still applies when the recomputed variance posts.
+     */
+    private void recomputeVarianceAgainstCurrentOnHand(CycleCountAdjustment adjustment) {
+        Integer currentOnHand = ledgerRepository.calculateOnHandQuantity(adjustment.getStockItemId());
+        int recomputedChange = adjustment.getCountedQuantity() - currentOnHand;
+        log.info(
+                "Adjustment {} approved on CONFLICT task {}: variance recomputed against current on-hand"
+                        + " {} (stale snapshot {}): quantityChange {} -> {}",
+                adjustment.getAdjustmentId(),
+                adjustment.getTaskId(),
+                currentOnHand,
+                adjustment.getQuantityOnHandBefore(),
+                adjustment.getQuantityChange(),
+                recomputedChange);
+        adjustment.setQuantityOnHandBefore(currentOnHand);
+        adjustment.setQuantityChange(recomputedChange);
+    }
+
+    /**
+     * Posts an approved adjustment and closes out its linked task. A recomputed
+     * zero variance (count matches current on-hand — the movements fully explain
+     * the original delta) has nothing to post: the adjustment stays approved
+     * without a ledger entry.
+     */
+    private void postApprovedAdjustment(CycleCountAdjustment adjustment) {
+        if (adjustment.getQuantityChange() != 0) {
+            postAdjustmentToLedger(adjustment);
+        } else {
+            log.info(
+                    "Adjustment {} has zero recomputed variance; nothing to post to the ledger",
+                    adjustment.getAdjustmentId());
+        }
+        markLinkedTaskApproved(adjustment);
+    }
+
+    private void markLinkedTaskApproved(CycleCountAdjustment adjustment) {
+        if (adjustment.getTaskId() == null) {
+            return;
+        }
+        taskRepository.findById(adjustment.getTaskId()).ifPresent(task -> {
+            task.setStatus(TaskStatus.APPROVED);
+            taskRepository.save(task);
+        });
     }
 
     private void postAdjustmentToLedger(CycleCountAdjustment adjustment) {
@@ -259,6 +362,7 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
         return AdjustmentResponse.builder()
                 .adjustmentId(adjustment.getAdjustmentId())
                 .stockItemId(adjustment.getStockItemId())
+                .taskId(adjustment.getTaskId())
                 .reasonCode(adjustment.getReasonCode())
                 .quantityChange(adjustment.getQuantityChange())
                 .costAtTimeOfAdjustment(adjustment.getCostAtTimeOfAdjustment())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountConflictDetector.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountConflictDetector.java
@@ -1,0 +1,108 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.CycleCountTask;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.TaskStatus;
+import com.positivity.inventory.internal.repository.CycleCountTaskRepository;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Detects interfering stock movements in a cycle-count window (odoo-parity I2,
+ * issue #1026 — Odoo's {@code is_outdated} conflict flag).
+ *
+ * <p>The task's {@code expectedQuantity} is snapshotted at task creation
+ * (tasks are seeded with the system quantity of the moment; there is no
+ * task-creation service that derives it from the ledger), so a like-for-like
+ * absolute comparison of snapshot vs current on-hand is not possible. The
+ * honest equivalent is the <em>window delta</em>: the net sum of
+ * on-hand-affecting ledger entries for the task's SKU (location-scoped when
+ * the task's {@code binLocation} is a location UUID) recorded after
+ * {@code createdAt}. A non-zero delta means movements occurred while the count
+ * was in flight and the snapshot no longer matches what the auditor counted
+ * against.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CycleCountConflictDetector {
+
+    private final InventoryLedgerEntryRepository ledgerRepository;
+    private final CycleCountTaskRepository taskRepository;
+
+    /**
+     * Net on-hand delta from ledger movements recorded after the task snapshot
+     * was taken. Non-zero ⇒ the count window was interfered with.
+     */
+    @Transactional(readOnly = true)
+    public int movementDeltaSinceSnapshot(@NonNull CycleCountTask task) {
+        Optional<UUID> locationId = locationIdOf(task);
+        Integer delta = locationId
+                .map(location -> ledgerRepository.sumChangeForStockItemAtLocationSince(
+                        task.getItemSku(),
+                        location,
+                        InventoryLedgerEventType.onHandAffectingTypes(),
+                        task.getCreatedAt()))
+                .orElseGet(() -> ledgerRepository.sumChangeForStockItemSince(
+                        task.getItemSku(), InventoryLedgerEventType.onHandAffectingTypes(), task.getCreatedAt()));
+        return delta == null ? 0 : delta;
+    }
+
+    /**
+     * The ledger entries interfering with the task's count window, oldest
+     * first: on-hand-affecting entries for the task's SKU/location between
+     * task creation and now.
+     */
+    @Transactional(readOnly = true)
+    public @NonNull List<InventoryLedgerEntry> interferingMovements(@NonNull CycleCountTask task) {
+        return locationIdOf(task)
+                .map(location ->
+                        ledgerRepository
+                                .findByStockItemIdAndLocationIdAndEventTypeInAndTimestampGreaterThanOrderByTimestampAsc(
+                                        task.getItemSku(),
+                                        location,
+                                        InventoryLedgerEventType.onHandAffectingTypes(),
+                                        task.getCreatedAt()))
+                .orElseGet(() ->
+                        ledgerRepository.findByStockItemIdAndEventTypeInAndTimestampGreaterThanOrderByTimestampAsc(
+                                task.getItemSku(),
+                                InventoryLedgerEventType.onHandAffectingTypes(),
+                                task.getCreatedAt()));
+    }
+
+    /**
+     * Flags a task {@code CONFLICT} in its own transaction so the flag survives
+     * the rollback of a rejected approval attempt.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void flagConflict(@NonNull UUID taskId) {
+        taskRepository.findById(taskId).ifPresent(task -> {
+            task.setStatus(TaskStatus.CONFLICT);
+            taskRepository.save(task);
+            log.warn("Cycle count task {} flagged CONFLICT: interfering movements detected in count window", taskId);
+        });
+    }
+
+    /**
+     * Tasks store the bin as free text; when it holds a storage-location UUID
+     * the window queries are location-scoped, otherwise they fall back to the
+     * SKU across all locations (consistent with the global on-hand math used
+     * by the adjustment posting path).
+     */
+    private Optional<UUID> locationIdOf(CycleCountTask task) {
+        try {
+            return Optional.of(UUID.fromString(task.getBinLocation()));
+        } catch (RuntimeException ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountServiceImpl.java
@@ -3,10 +3,12 @@ package com.positivity.inventory.internal.service;
 import com.positivity.inventory.internal.dto.cyclecount.CountEntryResponse;
 import com.positivity.inventory.internal.dto.cyclecount.CountResponse;
 import com.positivity.inventory.internal.dto.cyclecount.CycleCountTaskResponse;
+import com.positivity.inventory.internal.dto.cyclecount.InterferingMovementResponse;
 import com.positivity.inventory.internal.dto.cyclecount.SubmitCountRequest;
 import com.positivity.inventory.internal.dto.cyclecount.SubmitRecountRequest;
 import com.positivity.inventory.internal.entity.CountEntry;
 import com.positivity.inventory.internal.entity.CycleCountTask;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.TaskStatus;
 import com.positivity.inventory.internal.exception.InsufficientPermissionException;
 import com.positivity.inventory.internal.exception.InvalidCountQuantityException;
@@ -51,12 +53,17 @@ public class CycleCountServiceImpl implements CycleCountService {
     private final Clock clock;
     private final CycleCountTaskRepository taskRepository;
     private final CountEntryRepository countEntryRepository;
+    private final CycleCountConflictDetector conflictDetector;
 
     public CycleCountServiceImpl(
-            CycleCountTaskRepository taskRepository, CountEntryRepository countEntryRepository, Clock clock) {
+            CycleCountTaskRepository taskRepository,
+            CountEntryRepository countEntryRepository,
+            Clock clock,
+            CycleCountConflictDetector conflictDetector) {
         this.taskRepository = taskRepository;
         this.countEntryRepository = countEntryRepository;
         this.clock = clock;
+        this.conflictDetector = conflictDetector;
     }
 
     @Override
@@ -100,13 +107,21 @@ public class CycleCountServiceImpl implements CycleCountService {
             log.info("Created count entry: {}, variance: {}", maskForLog(countEntry.getCountEntryId()), variance);
         }
 
-        // Update task
+        // Update task; conflict detection (odoo-parity I2, #1026) decides
+        // whether the count goes to review or needs a reviewer choice first.
         task.setLatestCountEntryId(countEntry.getCountEntryId());
         task.setCountEntriesCount(1);
-        task.setStatus(TaskStatus.COUNTED_PENDING_REVIEW);
+        boolean conflict = applyConflictStatus(task);
         taskRepository.save(task);
 
-        return buildCountResponse(countEntry, task, false, "Count submitted successfully");
+        return buildCountResponse(
+                countEntry,
+                task,
+                false,
+                conflict
+                        ? "Count submitted, but stock moved during the count window; task flagged CONFLICT —"
+                                + " request a recount or approve with the variance recomputed against current on-hand"
+                        : "Count submitted successfully");
     }
 
     @Override
@@ -173,10 +188,12 @@ public class CycleCountServiceImpl implements CycleCountService {
                     variance);
         }
 
-        // Update task
+        // Update task; recounts re-run conflict detection (odoo-parity I2) —
+        // a recount from CONFLICT stays CONFLICT while movements remain in
+        // the window, because the snapshot is still stale.
         task.setLatestCountEntryId(recountEntry.getCountEntryId());
         task.setCountEntriesCount(task.getCountEntriesCount() + 1);
-        task.setStatus(TaskStatus.COUNTED_PENDING_REVIEW);
+        applyConflictStatus(task);
 
         // Check if this was the last allowed recount
         boolean limitReached = task.getCountEntriesCount() >= MAX_TOTAL_COUNTS;
@@ -221,8 +238,51 @@ public class CycleCountServiceImpl implements CycleCountService {
                 .toList();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<InterferingMovementResponse> getInterferingMovements(UUID taskId) {
+        CycleCountTask task = getTaskEntity(taskId);
+        return conflictDetector.interferingMovements(task).stream()
+                .map(this::toInterferingMovementResponse)
+                .toList();
+    }
+
     private CycleCountTask getTaskEntity(UUID taskId) {
         return taskRepository.findById(taskId).orElseThrow(() -> new TaskNotFoundException(taskId));
+    }
+
+    /**
+     * Sets the task status from conflict detection (odoo-parity I2, #1026):
+     * CONFLICT when the count window has a non-zero net movement delta,
+     * COUNTED_PENDING_REVIEW otherwise. Returns whether a conflict was found.
+     */
+    private boolean applyConflictStatus(CycleCountTask task) {
+        int movementDelta = conflictDetector.movementDeltaSinceSnapshot(task);
+        if (movementDelta != 0) {
+            if (log.isWarnEnabled()) {
+                log.warn(
+                        "Cycle count conflict detected at submission for task {}: in-window movement delta {}",
+                        maskForLog(task.getTaskId()),
+                        movementDelta);
+            }
+            task.setStatus(TaskStatus.CONFLICT);
+            return true;
+        }
+        task.setStatus(TaskStatus.COUNTED_PENDING_REVIEW);
+        return false;
+    }
+
+    private InterferingMovementResponse toInterferingMovementResponse(InventoryLedgerEntry entry) {
+        return InterferingMovementResponse.builder()
+                .ledgerEntryId(entry.getLedgerEntryId())
+                .eventType(entry.getEventType())
+                .changeInQuantity(entry.getChangeInQuantity())
+                .quantityAfter(entry.getQuantityAfter())
+                .locationId(entry.getLocationId())
+                .timestamp(entry.getTimestamp())
+                .transactionUserId(entry.getTransactionUserId())
+                .notes(entry.getNotes())
+                .build();
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
@@ -2,27 +2,30 @@ package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.dto.AvailabilityView;
 import com.positivity.inventory.internal.dto.LocationAvailabilityDto;
-import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
-import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.enums.InventorySourceType;
 import com.positivity.inventory.internal.exception.InvalidInventoryAvailabilityRequestException;
 import com.positivity.inventory.internal.exception.ProductNotFoundException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.service.InventoryAvailabilityService;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Inventory availability service implementation backed by inventory ledger
- * entries.
+ * Inventory availability service implementation backed by the
+ * {@code inventory_stock_summary} read model (issue #1024, A1). Quantities
+ * come from the stored summary maintained by {@code LedgerPostingService};
+ * only the derived unit of measure still consults the ledger (single-row
+ * lookup). Response shapes are unchanged from the ledger-aggregation era.
  *
  * Issue: CAP-170 (#48)
  */
@@ -30,9 +33,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class InventoryAvailabilityServiceImpl implements InventoryAvailabilityService {
 
+    private static final Pageable FIRST_ONLY = PageRequest.of(0, 1);
+    private static final String DEFAULT_UOM = "EACH";
+
+    private final InventoryStockSummaryRepository stockSummaryRepository;
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
-    public InventoryAvailabilityServiceImpl(InventoryLedgerEntryRepository inventoryLedgerEntryRepository) {
+    public InventoryAvailabilityServiceImpl(
+            InventoryStockSummaryRepository stockSummaryRepository,
+            InventoryLedgerEntryRepository inventoryLedgerEntryRepository) {
+        this.stockSummaryRepository = stockSummaryRepository;
         this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
     }
 
@@ -43,27 +53,18 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
             throw new InvalidInventoryAvailabilityRequestException("Product ID is required");
         }
 
-        // Issue #48: Resolve per-location on-hand and ATP from ledger entries.
-        List<InventoryLedgerEntry> ledgerEntries;
+        List<InventoryStockSummary> summaryRows;
         try {
-            ledgerEntries = inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString());
+            summaryRows = stockSummaryRepository.findByStockItemId(productId.toString());
         } catch (Exception ex) {
-            log.error("Failed retrieving inventory availability ledger entries for product {}", productId, ex);
+            log.error("Failed retrieving inventory availability summary for product {}", productId, ex);
             throw new IllegalStateException("Unable to retrieve inventory availability at this time", ex);
         }
 
-        if (ledgerEntries.isEmpty()) {
-            return List.of();
-        }
-
-        Map<UUID, List<InventoryLedgerEntry>> entriesByLocation = ledgerEntries.stream()
-                .filter(this::isProcessableEntry)
-                .filter(ledgerEntry -> ledgerEntry.getLocationId() != null)
-                .collect(Collectors.groupingBy(this::resolveLocationId));
-
-        return entriesByLocation.entrySet().stream()
-                .map(entry -> toLocationAvailability(entry.getKey(), entry.getValue()))
-                .sorted(Comparator.comparing(LocationAvailabilityDto::getLocationId))
+        return summaryRows.stream()
+                .filter(row -> row.getLocationId() != null)
+                .sorted(Comparator.comparing(InventoryStockSummary::getLocationId))
+                .map(this::toLocationAvailability)
                 .toList();
     }
 
@@ -74,106 +75,59 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
             @Nullable UUID locationId,
             @Nullable UUID storageLocationId,
             @Nullable InventorySourceType sourceType) {
-        List<InventoryLedgerEntry> allProductEntries =
-                inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku);
-        if (allProductEntries.isEmpty()) {
+        List<InventoryStockSummary> productRows = stockSummaryRepository.findByStockItemId(productSku);
+        if (productRows.isEmpty()) {
             throw new ProductNotFoundException(productSku);
         }
 
         UUID scopeLocationId = storageLocationId != null ? storageLocationId : locationId;
-        List<InventoryLedgerEntry> scopedEntries = scopeLocationId == null
-                ? allProductEntries
-                : inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(
-                        productSku, scopeLocationId);
-
-        int onHand = scopedEntries.stream()
-                .filter(e -> e.getEventType() != null && e.getEventType().affectsOnHand())
-                .mapToInt(e -> e.getChangeInQuantity() != null ? e.getChangeInQuantity() : 0)
-                .sum();
-
-        int allocationCreated = scopedEntries.stream()
-                .filter(e -> e.getEventType() == InventoryLedgerEventType.ALLOCATION_CREATED)
-                .mapToInt(e -> e.getChangeInQuantity() != null ? e.getChangeInQuantity() : 0)
-                .sum();
-        int allocationReleased = scopedEntries.stream()
-                .filter(e -> e.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
-                .mapToInt(e -> e.getChangeInQuantity() != null ? e.getChangeInQuantity() : 0)
-                .sum();
-        int allocatedQty = allocationCreated - allocationReleased;
-
-        String derivedUom = scopedEntries.stream()
-                .map(InventoryLedgerEntry::getUnitOfMeasure)
-                .filter(uom -> uom != null && !uom.isBlank())
-                .findFirst()
-                .orElse("EACH");
+        long onHand;
+        long allocated;
+        if (scopeLocationId == null) {
+            onHand = productRows.stream()
+                    .mapToLong(InventoryStockSummary::getOnHand)
+                    .sum();
+            allocated = productRows.stream()
+                    .mapToLong(InventoryStockSummary::getAllocated)
+                    .sum();
+        } else {
+            InventoryStockSummary scoped = productRows.stream()
+                    .filter(row -> scopeLocationId.equals(row.getLocationId()))
+                    .findFirst()
+                    .orElse(null);
+            onHand = scoped == null ? 0L : scoped.getOnHand();
+            allocated = scoped == null ? 0L : scoped.getAllocated();
+        }
 
         return AvailabilityView.builder()
                 .productSku(productSku)
                 .locationId(locationId)
                 .storageLocationId(storageLocationId)
-                .onHandQuantity(onHand)
-                .allocatedQuantity(allocatedQty)
-                .availableToPromiseQuantity(onHand - allocatedQty)
-                .unitOfMeasure(derivedUom)
+                .onHandQuantity(Math.toIntExact(onHand))
+                .allocatedQuantity(Math.toIntExact(allocated))
+                .availableToPromiseQuantity(Math.toIntExact(onHand - allocated))
+                .unitOfMeasure(deriveUnitOfMeasure(productSku, scopeLocationId))
                 .build();
     }
 
-    private boolean isProcessableEntry(InventoryLedgerEntry ledgerEntry) {
-        if (ledgerEntry == null) {
-            log.warn("Skipping null inventory ledger entry while computing availability");
-            return false;
-        }
-        if (ledgerEntry.getChangeInQuantity() == null) {
-            log.warn("Skipping inventory ledger entry {} with null changeInQuantity", ledgerEntry.getLedgerEntryId());
-            return false;
-        }
-        return true;
+    private String deriveUnitOfMeasure(String productSku, @Nullable UUID scopeLocationId) {
+        List<String> units = scopeLocationId == null
+                ? inventoryLedgerEntryRepository.findUnitsOfMeasureByStockItem(productSku, FIRST_ONLY)
+                : inventoryLedgerEntryRepository.findUnitsOfMeasureByStockItemAtLocation(
+                        productSku, scopeLocationId, FIRST_ONLY);
+        return units.isEmpty() ? DEFAULT_UOM : units.getFirst();
     }
 
-    private UUID resolveLocationId(InventoryLedgerEntry ledgerEntry) {
-        return ledgerEntry.getLocationId();
-    }
-
-    private LocationAvailabilityDto toLocationAvailability(UUID locationId, List<InventoryLedgerEntry> entries) {
-        int onHandQuantity = entries.stream()
-                .filter(ledgerEntry -> ledgerEntry.getEventType() != null
-                        && ledgerEntry.getEventType().affectsOnHand())
-                .mapToInt(ledgerEntry ->
-                        ledgerEntry.getChangeInQuantity() != null ? ledgerEntry.getChangeInQuantity() : 0)
-                .sum();
-
-        int activeReservations =
-                entries.stream().mapToInt(this::reservationDelta).sum();
-
-        int atpQuantity = onHandQuantity - activeReservations;
-
+    private LocationAvailabilityDto toLocationAvailability(InventoryStockSummary row) {
+        // Pre-#1024 behavior: this per-location list subtracts BOTH hard
+        // allocations and soft reservations from ATP (unlike queryAvailability,
+        // which per ADR-0001 subtracts allocations only).
+        long atpWithReservations = row.getOnHand() - row.getAllocated() - row.getReserved();
         return LocationAvailabilityDto.builder()
-                .locationId(locationId)
-                .locationName(locationId.toString())
-                .onHandQuantity(onHandQuantity)
-                .availableToPromiseQuantity(atpQuantity)
+                .locationId(row.getLocationId())
+                .locationName(row.getLocationId().toString())
+                .onHandQuantity(Math.toIntExact(row.getOnHand()))
+                .availableToPromiseQuantity(Math.toIntExact(atpWithReservations))
                 .build();
-    }
-
-    private int reservationDelta(InventoryLedgerEntry ledgerEntry) {
-        InventoryLedgerEventType eventType = ledgerEntry.getEventType();
-        if (eventType == null) {
-            return 0;
-        }
-
-        return switch (eventType) {
-            case RESERVATION_CREATED, ALLOCATION_CREATED -> safeQuantity(ledgerEntry);
-            case RESERVATION_RELEASED, ALLOCATION_RELEASED -> -safeQuantity(ledgerEntry);
-            default -> 0;
-        };
-    }
-
-    private int safeQuantity(InventoryLedgerEntry ledgerEntry) {
-        Integer quantity = ledgerEntry.getChangeInQuantity();
-        if (quantity == null) {
-            log.warn("Ledger entry {} has null changeInQuantity; treating as 0", ledgerEntry.getLedgerEntryId());
-            return 0;
-        }
-        return quantity;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
@@ -201,7 +201,8 @@ public class InventoryFactPublisher {
                         writer,
                         StorageLocationOnHandUpdatedV1.EVENT_TYPE,
                         storageLocationId,
-                        new StorageLocationOnHandUpdatedV1(storageLocationId, inquiry.getOnHandQuantity()));
+                        new StorageLocationOnHandUpdatedV1(
+                                storageLocationId, Math.toIntExact(inquiry.getOnHandQuantity())));
             } catch (Exception e) {
                 log.warn("Skipping storage-location on-hand fact for {}: {}", storageLocationId, e.getMessage());
             }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLocationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLocationServiceImpl.java
@@ -27,6 +27,7 @@ public class InventoryLocationServiceImpl implements InventoryLocationService {
     private static final String LOCATION_TRANSFER_REASON = "LOCATION_DEACTIVATION_TRANSFER";
 
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+    private final LedgerPostingService ledgerPostingService;
     private final StorageLocationValidationService storageLocationValidationService;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final MeterRegistry meterRegistry;
@@ -35,12 +36,14 @@ public class InventoryLocationServiceImpl implements InventoryLocationService {
 
     public InventoryLocationServiceImpl(
             InventoryLedgerEntryRepository inventoryLedgerEntryRepository,
+            LedgerPostingService ledgerPostingService,
             StorageLocationValidationService storageLocationValidationService,
             ApplicationEventPublisher applicationEventPublisher,
             MeterRegistry meterRegistry,
             InventoryFactPublisher inventoryFactPublisher,
             Clock clock) {
         this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
+        this.ledgerPostingService = ledgerPostingService;
         this.inventoryFactPublisher = inventoryFactPublisher;
         this.storageLocationValidationService = storageLocationValidationService;
         this.applicationEventPublisher = applicationEventPublisher;
@@ -185,7 +188,7 @@ public class InventoryLocationServiceImpl implements InventoryLocationService {
         }
 
         if (!transferEntries.isEmpty()) {
-            inventoryLedgerEntryRepository.saveAll(transferEntries);
+            ledgerPostingService.postAll(transferEntries);
             inventoryFactPublisher.markEntries(transferEntries);
         }
         return movedItems;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingService.java
@@ -1,0 +1,33 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Single posting path for the inventory ledger (issue #1024, odoo-parity A1).
+ *
+ * <p>Every {@link InventoryLedgerEntry} append MUST flow through this service:
+ * it persists the entry and maintains the {@code inventory_stock_summary}
+ * derived balance row for the entry's (stockItemId, locationId) key in the
+ * same transaction. Writing ledger entries directly through
+ * {@code InventoryLedgerEntryRepository} bypasses the summary and causes
+ * drift (caught by {@code StockSummaryDriftVerifier}, but still a bug).
+ *
+ * <p>This service only appends and maintains the summary — validation,
+ * {@code quantityAfter} computation, and fact publishing remain the caller's
+ * responsibility, exactly as before the funnel refactor.
+ */
+public interface LedgerPostingService {
+
+    /** Appends one ledger entry and upserts its summary row transactionally. */
+    @NonNull
+    InventoryLedgerEntry post(@NonNull InventoryLedgerEntry entry);
+
+    /**
+     * Appends the entries in order and upserts the affected summary rows
+     * transactionally. Returns the saved entries in input order.
+     */
+    @NonNull
+    List<InventoryLedgerEntry> postAll(@NonNull List<InventoryLedgerEntry> entries);
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingService.java
@@ -12,11 +12,20 @@ import org.jspecify.annotations.NonNull;
  * derived balance row for the entry's (stockItemId, locationId) key in the
  * same transaction. Writing ledger entries directly through
  * {@code InventoryLedgerEntryRepository} bypasses the summary and causes
- * drift (caught by {@code StockSummaryDriftVerifier}, but still a bug).
+ * drift (caught by {@code StockSummaryDriftVerifier} and forbidden by the
+ * {@code ArchitectureTest} funnel rule).
  *
- * <p>This service only appends and maintains the summary — validation,
- * {@code quantityAfter} computation, and fact publishing remain the caller's
- * responsibility, exactly as before the funnel refactor.
+ * <p>Since odoo-parity K1 (issue #1027) the funnel is also the single
+ * enforcement point of the per-event-type negative-stock policy matrix (see
+ * {@code NegativeStockPolicy} and {@code docs/negative-stock-policy.md}): a
+ * posting that would take a key's on-hand below zero is rejected for blocked
+ * and floor-at-zero event types. Other validation, {@code quantityAfter}
+ * computation, and fact publishing remain the caller's responsibility.
+ *
+ * <p>The {@code negativeStockOverride} variants exist for the single
+ * overridable row of the matrix (SCRAP_OUT): the caller performs its own
+ * {@code inventory:adjustment:override} permission check and passes the
+ * explicit flag — the funnel itself never consults the security context.
  */
 public interface LedgerPostingService {
 
@@ -25,9 +34,27 @@ public interface LedgerPostingService {
     InventoryLedgerEntry post(@NonNull InventoryLedgerEntry entry);
 
     /**
+     * Same as {@link #post(InventoryLedgerEntry)} but with an explicit
+     * negative-stock override flag for {@code BLOCKED_OVERRIDABLE} event
+     * types. Callers must only pass {@code true} after verifying the actor
+     * holds {@code inventory:adjustment:override}.
+     */
+    @NonNull
+    InventoryLedgerEntry post(@NonNull InventoryLedgerEntry entry, boolean negativeStockOverride);
+
+    /**
      * Appends the entries in order and upserts the affected summary rows
      * transactionally. Returns the saved entries in input order.
      */
     @NonNull
     List<InventoryLedgerEntry> postAll(@NonNull List<InventoryLedgerEntry> entries);
+
+    /**
+     * Same as {@link #postAll(List)} but with an explicit negative-stock
+     * override flag applying to every {@code BLOCKED_OVERRIDABLE} entry in
+     * the batch. Callers must only pass {@code true} after verifying the
+     * actor holds {@code inventory:adjustment:override}.
+     */
+    @NonNull
+    List<InventoryLedgerEntry> postAll(@NonNull List<InventoryLedgerEntry> entries, boolean negativeStockOverride);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingServiceImpl.java
@@ -3,13 +3,18 @@ package com.positivity.inventory.internal.service;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.NegativeStockPolicy;
+import com.positivity.inventory.internal.exception.InsufficientStockException;
+import com.positivity.inventory.internal.exception.NegativeStockPolicyViolationException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -33,11 +38,18 @@ import org.springframework.transaction.annotation.Transactional;
  * </ul>
  * {@code atp} is maintained as {@code onHand - allocated} (ADR-0001).
  *
+ * <p>Negative-stock policy (odoo-parity K1, issue #1027): before the summary
+ * deltas are applied, the batch is replayed per (stockItemId, locationId) key
+ * against the locked summary rows and every on-hand-affecting entry is checked
+ * against the {@link NegativeStockPolicy} matrix. A violation aborts the whole
+ * posting transaction — ledger entries and summary rows roll back together.
+ *
  * <p>Concurrency: the affected summary rows are locked with
- * {@code SELECT ... FOR UPDATE} before applying deltas, in deterministic key
- * order to avoid deadlocks between concurrent batches. First-time row
- * creation happens in a nested transaction ({@link StockSummaryRowInitializer})
- * so a lost creation race cannot poison the posting transaction.
+ * {@code SELECT ... FOR UPDATE} before validating and applying deltas, in
+ * deterministic key order to avoid deadlocks between concurrent batches.
+ * First-time row creation happens in a nested transaction
+ * ({@link StockSummaryRowInitializer}) so a lost creation race cannot poison
+ * the posting transaction.
  */
 @Service
 @Slf4j
@@ -59,12 +71,25 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
     @Override
     @Transactional
     public @NonNull InventoryLedgerEntry post(@NonNull InventoryLedgerEntry entry) {
-        return postAll(List.of(entry)).getFirst();
+        return postAll(List.of(entry), false).getFirst();
+    }
+
+    @Override
+    @Transactional
+    public @NonNull InventoryLedgerEntry post(@NonNull InventoryLedgerEntry entry, boolean negativeStockOverride) {
+        return postAll(List.of(entry), negativeStockOverride).getFirst();
     }
 
     @Override
     @Transactional
     public @NonNull List<InventoryLedgerEntry> postAll(@NonNull List<InventoryLedgerEntry> entries) {
+        return postAll(entries, false);
+    }
+
+    @Override
+    @Transactional
+    public @NonNull List<InventoryLedgerEntry> postAll(
+            @NonNull List<InventoryLedgerEntry> entries, boolean negativeStockOverride) {
         List<InventoryLedgerEntry> saved = ledgerRepository.saveAll(entries);
 
         Map<SummaryKey, SummaryDelta> deltas = new LinkedHashMap<>();
@@ -76,11 +101,84 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
             deltas.merge(new SummaryKey(entry.getStockItemId(), entry.getLocationId()), delta, SummaryDelta::plus);
         }
 
-        deltas.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey(SummaryKey.ORDER))
-                .forEach(keyed -> applyDelta(keyed.getKey(), keyed.getValue()));
+        Map<SummaryKey, InventoryStockSummary> lockedRows = new LinkedHashMap<>();
+        deltas.keySet().stream()
+                .sorted(SummaryKey.ORDER)
+                .forEach(key -> lockedRows.put(key, lockRow(key).orElseGet(() -> createAndLockRow(key))));
+
+        enforceNegativeStockPolicy(saved, lockedRows, negativeStockOverride);
+
+        deltas.forEach((key, delta) -> applyDelta(lockedRows.get(key), delta));
 
         return saved;
+    }
+
+    /**
+     * Replays the batch per (stockItemId, locationId) key over the locked
+     * summary balances and rejects any on-hand-affecting entry whose
+     * {@link NegativeStockPolicy} forbids the projected below-zero balance
+     * (odoo-parity K1, issue #1027). Enforcement lives here — the single
+     * posting path — because a DB-level check is impractical against an
+     * append-only ledger.
+     */
+    private void enforceNegativeStockPolicy(
+            List<InventoryLedgerEntry> entries,
+            Map<SummaryKey, InventoryStockSummary> lockedRows,
+            boolean negativeStockOverride) {
+        Map<SummaryKey, Long> projectedOnHand = new HashMap<>();
+        for (InventoryLedgerEntry entry : entries) {
+            InventoryLedgerEventType eventType = entry.getEventType();
+            if (eventType == null || !eventType.affectsOnHand()) {
+                continue;
+            }
+            SummaryKey key = new SummaryKey(entry.getStockItemId(), entry.getLocationId());
+            long projected = projectedOnHand.computeIfAbsent(
+                    key,
+                    missing -> Objects.requireNonNull(
+                                    lockedRows.get(missing), "summary row must be locked for on-hand entry " + missing)
+                            .getOnHand());
+            projected += entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+            projectedOnHand.put(key, projected);
+            if (projected < 0) {
+                rejectNegativeProjection(eventType, entry, projected, negativeStockOverride);
+            }
+        }
+    }
+
+    private void rejectNegativeProjection(
+            InventoryLedgerEventType eventType,
+            InventoryLedgerEntry entry,
+            long projectedOnHand,
+            boolean negativeStockOverride) {
+        switch (NegativeStockPolicy.forEventType(eventType)) {
+            case BLOCKED ->
+                // Keep the pre-K1 error contract for physical outbound flows.
+                throw new InsufficientStockException(entry.getStockItemId(), entry.getLocationId());
+            case BLOCKED_OVERRIDABLE -> {
+                if (!negativeStockOverride) {
+                    throw new NegativeStockPolicyViolationException(
+                            NegativeStockPolicyViolationException.OVERRIDE_REQUIRED,
+                            eventType + " for stock item " + entry.getStockItemId() + " at location "
+                                    + entry.getLocationId() + " would take on-hand to " + projectedOnHand
+                                    + "; requires inventory:adjustment:override");
+                }
+                log.warn(
+                        "Negative-stock override accepted: eventType={} stockItemId={} locationId={} projectedOnHand={}",
+                        eventType,
+                        entry.getStockItemId(),
+                        entry.getLocationId(),
+                        projectedOnHand);
+            }
+            case FLOOR_AT_ZERO ->
+                throw new NegativeStockPolicyViolationException(
+                        NegativeStockPolicyViolationException.FLOOR_VIOLATION,
+                        eventType + " for stock item " + entry.getStockItemId() + " at location "
+                                + entry.getLocationId() + " would take on-hand to " + projectedOnHand
+                                + "; counts and adjustments may zero stock but never drive it negative");
+            case UNCONSTRAINED -> {
+                // Inbound/paired-move types post freely.
+            }
+        }
     }
 
     private @Nullable SummaryDelta deltaFor(InventoryLedgerEntry entry) {
@@ -105,8 +203,7 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
         return new SummaryDelta(onHand, allocated, reserved, entry.getLedgerEntryId(), entry.getTimestamp());
     }
 
-    private void applyDelta(SummaryKey key, SummaryDelta delta) {
-        InventoryStockSummary row = lockRow(key).orElseGet(() -> createAndLockRow(key));
+    private void applyDelta(InventoryStockSummary row, SummaryDelta delta) {
         row.setOnHand(row.getOnHand() + delta.onHand());
         row.setAllocated(row.getAllocated() + delta.allocated());
         row.setReserved(row.getReserved() + delta.reserved());

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingServiceImpl.java
@@ -1,0 +1,165 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Single ledger posting path (issue #1024, A1): appends entries and applies
+ * their deltas to {@code inventory_stock_summary} in the same transaction.
+ *
+ * <p>Summary impact per event type:
+ * <ul>
+ *   <li>{@link InventoryLedgerEventType#affectsOnHand() on-hand-affecting} — {@code onHand}</li>
+ *   <li>{@code ALLOCATION_CREATED}/{@code ALLOCATION_RELEASED} — {@code allocated}</li>
+ *   <li>{@code RESERVATION_CREATED}/{@code RESERVATION_RELEASED} — {@code reserved}</li>
+ *   <li>anything else (backorders, pick-task markers) — no summary touch</li>
+ * </ul>
+ * {@code atp} is maintained as {@code onHand - allocated} (ADR-0001).
+ *
+ * <p>Concurrency: the affected summary rows are locked with
+ * {@code SELECT ... FOR UPDATE} before applying deltas, in deterministic key
+ * order to avoid deadlocks between concurrent batches. First-time row
+ * creation happens in a nested transaction ({@link StockSummaryRowInitializer})
+ * so a lost creation race cannot poison the posting transaction.
+ */
+@Service
+@Slf4j
+public class LedgerPostingServiceImpl implements LedgerPostingService {
+
+    private final InventoryLedgerEntryRepository ledgerRepository;
+    private final InventoryStockSummaryRepository summaryRepository;
+    private final StockSummaryRowInitializer rowInitializer;
+
+    public LedgerPostingServiceImpl(
+            InventoryLedgerEntryRepository ledgerRepository,
+            InventoryStockSummaryRepository summaryRepository,
+            StockSummaryRowInitializer rowInitializer) {
+        this.ledgerRepository = ledgerRepository;
+        this.summaryRepository = summaryRepository;
+        this.rowInitializer = rowInitializer;
+    }
+
+    @Override
+    @Transactional
+    public @NonNull InventoryLedgerEntry post(@NonNull InventoryLedgerEntry entry) {
+        return postAll(List.of(entry)).getFirst();
+    }
+
+    @Override
+    @Transactional
+    public @NonNull List<InventoryLedgerEntry> postAll(@NonNull List<InventoryLedgerEntry> entries) {
+        List<InventoryLedgerEntry> saved = ledgerRepository.saveAll(entries);
+
+        Map<SummaryKey, SummaryDelta> deltas = new LinkedHashMap<>();
+        for (InventoryLedgerEntry entry : saved) {
+            SummaryDelta delta = deltaFor(entry);
+            if (delta == null) {
+                continue;
+            }
+            deltas.merge(new SummaryKey(entry.getStockItemId(), entry.getLocationId()), delta, SummaryDelta::plus);
+        }
+
+        deltas.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey(SummaryKey.ORDER))
+                .forEach(keyed -> applyDelta(keyed.getKey(), keyed.getValue()));
+
+        return saved;
+    }
+
+    private @Nullable SummaryDelta deltaFor(InventoryLedgerEntry entry) {
+        InventoryLedgerEventType eventType = entry.getEventType();
+        int change = entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+        long onHand = 0;
+        long allocated = 0;
+        long reserved = 0;
+        if (eventType != null && eventType.affectsOnHand()) {
+            onHand = change;
+        } else if (eventType == InventoryLedgerEventType.ALLOCATION_CREATED) {
+            allocated = change;
+        } else if (eventType == InventoryLedgerEventType.ALLOCATION_RELEASED) {
+            allocated = -change;
+        } else if (eventType == InventoryLedgerEventType.RESERVATION_CREATED) {
+            reserved = change;
+        } else if (eventType == InventoryLedgerEventType.RESERVATION_RELEASED) {
+            reserved = -change;
+        } else {
+            return null;
+        }
+        return new SummaryDelta(onHand, allocated, reserved, entry.getLedgerEntryId(), entry.getTimestamp());
+    }
+
+    private void applyDelta(SummaryKey key, SummaryDelta delta) {
+        InventoryStockSummary row = lockRow(key).orElseGet(() -> createAndLockRow(key));
+        row.setOnHand(row.getOnHand() + delta.onHand());
+        row.setAllocated(row.getAllocated() + delta.allocated());
+        row.setReserved(row.getReserved() + delta.reserved());
+        row.setAtp(row.getOnHand() - row.getAllocated());
+        row.setLastLedgerEntryId(delta.lastLedgerEntryId());
+        row.setLastEventAt(delta.lastEventAt());
+        summaryRepository.save(row);
+    }
+
+    private InventoryStockSummary createAndLockRow(SummaryKey key) {
+        try {
+            rowInitializer.createRowIfAbsent(key.stockItemId(), key.locationId());
+        } catch (DataIntegrityViolationException | UnexpectedRollbackException ex) {
+            // Lost the creation race to a concurrent posting; the row exists now.
+            log.debug(
+                    "Lost stock summary creation race for stockItemId={} locationId={}",
+                    key.stockItemId(),
+                    key.locationId());
+        }
+        return lockRow(key)
+                .orElseThrow(() ->
+                        new IllegalStateException("Stock summary row missing after initialization for stockItemId="
+                                + key.stockItemId() + " locationId=" + key.locationId()));
+    }
+
+    private Optional<InventoryStockSummary> lockRow(SummaryKey key) {
+        return key.locationId() == null
+                ? summaryRepository.findWithLockByStockItemIdAndLocationIdIsNull(key.stockItemId())
+                : summaryRepository.findWithLockByStockItemIdAndLocationId(key.stockItemId(), key.locationId());
+    }
+
+    private record SummaryKey(String stockItemId, @Nullable UUID locationId) {
+
+        /** Deterministic lock-acquisition order to avoid deadlocks between concurrent batches. */
+        private static final Comparator<SummaryKey> ORDER = Comparator.comparing(SummaryKey::stockItemId)
+                .thenComparing(
+                        key -> key.locationId() == null ? "" : key.locationId().toString());
+    }
+
+    private record SummaryDelta(
+            long onHand,
+            long allocated,
+            long reserved,
+            @Nullable UUID lastLedgerEntryId,
+            @Nullable Instant lastEventAt) {
+
+        private SummaryDelta plus(SummaryDelta other) {
+            return new SummaryDelta(
+                    onHand + other.onHand,
+                    allocated + other.allocated,
+                    reserved + other.reserved,
+                    other.lastLedgerEntryId() != null ? other.lastLedgerEntryId() : lastLedgerEntryId,
+                    other.lastEventAt() != null ? other.lastEventAt() : lastEventAt);
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
@@ -2,11 +2,9 @@ package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
 import com.positivity.inventory.internal.dto.LocationInventoryItemsResponse;
-import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
-import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
-import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.service.LocationInventoryInquiryService;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -15,42 +13,39 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Aggregates on-hand inventory at the location level from inventory ledger
- * entries.
+ * Location-level on-hand inquiry served from the {@code inventory_stock_summary}
+ * read model (issue #1024, A1) instead of aggregating the ledger per request.
  */
 @Service
 public class LocationInventoryInquiryServiceImpl implements LocationInventoryInquiryService {
 
-    private static final List<InventoryLedgerEventType> ON_HAND_EVENT_TYPES = Arrays.stream(
-                    InventoryLedgerEventType.values())
-            .filter(InventoryLedgerEventType::affectsOnHand)
-            .toList();
+    private final InventoryStockSummaryRepository stockSummaryRepository;
 
-    private static final List<InventoryLedgerEventType> ALLOCATION_EVENT_TYPES =
-            List.of(InventoryLedgerEventType.ALLOCATION_CREATED, InventoryLedgerEventType.ALLOCATION_RELEASED);
-
-    private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
-
-    public LocationInventoryInquiryServiceImpl(InventoryLedgerEntryRepository inventoryLedgerEntryRepository) {
-        this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
+    public LocationInventoryInquiryServiceImpl(InventoryStockSummaryRepository stockSummaryRepository) {
+        this.stockSummaryRepository = stockSummaryRepository;
     }
 
     @Override
     @Transactional(readOnly = true)
     @NonNull
     public LocationInventoryInquiryResponse getLocationInventory(@NonNull UUID locationId, @Nullable String sku) {
-        Integer onHandQuantity = sku == null || sku.isBlank()
-                ? inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(locationId, ON_HAND_EVENT_TYPES)
-                : inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
-                        sku, locationId, ON_HAND_EVENT_TYPES);
-
-        int resolvedOnHandQuantity = onHandQuantity == null ? 0 : onHandQuantity;
-        int outstandingAllocations = calculateOutstandingAllocations(locationId, sku);
+        long onHandQuantity;
+        long outstandingAllocations;
+        if (sku == null || sku.isBlank()) {
+            onHandQuantity = stockSummaryRepository.sumOnHandAtLocation(locationId);
+            outstandingAllocations = stockSummaryRepository.sumAllocatedAtLocation(locationId);
+        } else {
+            InventoryStockSummary row = stockSummaryRepository
+                    .findByStockItemIdAndLocationId(sku, locationId)
+                    .orElse(null);
+            onHandQuantity = row == null ? 0L : row.getOnHand();
+            outstandingAllocations = row == null ? 0L : row.getAllocated();
+        }
 
         return LocationInventoryInquiryResponse.builder()
                 .locationId(locationId)
-                .onHandQuantity(resolvedOnHandQuantity)
-                .availableToPromiseQuantity(resolvedOnHandQuantity - outstandingAllocations)
+                .onHandQuantity(Math.toIntExact(onHandQuantity))
+                .availableToPromiseQuantity(Math.toIntExact(onHandQuantity - outstandingAllocations))
                 .build();
     }
 
@@ -59,10 +54,10 @@ public class LocationInventoryInquiryServiceImpl implements LocationInventoryInq
     @NonNull
     public LocationInventoryItemsResponse listLocationInventoryItems(@NonNull UUID locationId) {
         List<LocationInventoryItemsResponse.Item> items =
-                inventoryLedgerEntryRepository.findPositiveOnHandByLocation(locationId, ON_HAND_EVENT_TYPES).stream()
+                stockSummaryRepository.findByLocationIdAndOnHandGreaterThan(locationId, 0L).stream()
                         .map(row -> LocationInventoryItemsResponse.Item.builder()
                                 .stockItemId(row.getStockItemId())
-                                .onHandQuantity(row.getOnHandQuantity() == null ? 0L : row.getOnHandQuantity())
+                                .onHandQuantity(row.getOnHand())
                                 .build())
                         .toList();
 
@@ -70,28 +65,5 @@ public class LocationInventoryInquiryServiceImpl implements LocationInventoryInq
                 .locationId(locationId)
                 .items(items)
                 .build();
-    }
-
-    private int calculateOutstandingAllocations(UUID locationId, @Nullable String sku) {
-        List<InventoryLedgerEntry> allocationEntries = sku == null || sku.isBlank()
-                ? inventoryLedgerEntryRepository.findByLocationIdAndEventTypeIn(locationId, ALLOCATION_EVENT_TYPES)
-                : inventoryLedgerEntryRepository
-                        .findByStockItemIdAndLocationIdOrderByTimestampAsc(sku, locationId)
-                        .stream()
-                        .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_CREATED
-                                || entry.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
-                        .toList();
-
-        int allocationCreated = allocationEntries.stream()
-                .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_CREATED)
-                .mapToInt(entry -> entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity())
-                .sum();
-
-        int allocationReleased = allocationEntries.stream()
-                .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
-                .mapToInt(entry -> entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity())
-                .sum();
-
-        return allocationCreated - allocationReleased;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
@@ -44,8 +44,8 @@ public class LocationInventoryInquiryServiceImpl implements LocationInventoryInq
 
         return LocationInventoryInquiryResponse.builder()
                 .locationId(locationId)
-                .onHandQuantity(Math.toIntExact(onHandQuantity))
-                .availableToPromiseQuantity(Math.toIntExact(onHandQuantity - outstandingAllocations))
+                .onHandQuantity(onHandQuantity)
+                .availableToPromiseQuantity(onHandQuantity - outstandingAllocations)
                 .build();
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayExecuteServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayExecuteServiceImpl.java
@@ -28,6 +28,7 @@ public class PutawayExecuteServiceImpl implements PutawayExecuteService {
 
     private final PutawayTaskRepository putawayTaskRepository;
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+    private final LedgerPostingService ledgerPostingService;
     private final InventoryFactPublisher inventoryFactPublisher;
     private final PutawayValidationService putawayValidationService;
     private final Clock clock;
@@ -68,7 +69,7 @@ public class PutawayExecuteServiceImpl implements PutawayExecuteService {
                 .timestamp(now)
                 .build();
 
-        InventoryLedgerEntry savedSourceLedgerEntry = inventoryLedgerEntryRepository.save(sourceLedgerEntry);
+        InventoryLedgerEntry savedSourceLedgerEntry = ledgerPostingService.post(sourceLedgerEntry);
         inventoryFactPublisher.markEntry(savedSourceLedgerEntry);
 
         InventoryLedgerEntry destinationLedgerEntry = InventoryLedgerEntry.builder()
@@ -82,7 +83,7 @@ public class PutawayExecuteServiceImpl implements PutawayExecuteService {
                         + request.getDestinationLocationId())
                 .timestamp(now)
                 .build();
-        inventoryLedgerEntryRepository.save(destinationLedgerEntry);
+        ledgerPostingService.post(destinationLedgerEntry);
         inventoryFactPublisher.markEntry(destinationLedgerEntry);
 
         task.setStatus(PutawayTaskStatus.COMPLETED);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
@@ -61,6 +61,7 @@ public class ReceivingServiceImpl implements ReceivingService {
     private final ReceivingSessionRepository receivingSessionRepository;
     private final InventoryVarianceRepository inventoryVarianceRepository;
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+    private final LedgerPostingService ledgerPostingService;
     private final InventoryFactPublisher inventoryFactPublisher;
     private final SourceDocumentStubClient sourceDocumentStubClient;
     private final SiteDefaultsService siteDefaultsService;
@@ -245,7 +246,7 @@ public class ReceivingServiceImpl implements ReceivingService {
                 .notes("Cross-dock GOODS_RECEIPT for workorder " + workorderId)
                 .build();
 
-        InventoryLedgerEntry savedReceiptEntry = inventoryLedgerEntryRepository.save(receiptEntry);
+        InventoryLedgerEntry savedReceiptEntry = ledgerPostingService.post(receiptEntry);
         inventoryFactPublisher.markEntry(savedReceiptEntry);
         int issueQuantityAfter = calculateQuantityAfter(line.getProductId(), crossDockLocationId, -quantityDelta);
 
@@ -261,7 +262,7 @@ public class ReceivingServiceImpl implements ReceivingService {
                 .notes("Cross-dock GOODS_ISSUE to workorder " + workorderId)
                 .build();
 
-        InventoryLedgerEntry savedIssueEntry = inventoryLedgerEntryRepository.save(issueEntry);
+        InventoryLedgerEntry savedIssueEntry = ledgerPostingService.post(issueEntry);
         inventoryFactPublisher.markEntry(savedIssueEntry);
 
         line.setWorkorderId(workorderId);
@@ -334,7 +335,7 @@ public class ReceivingServiceImpl implements ReceivingService {
                 .notes("Receiving session " + sessionId + " line " + lineId)
                 .build();
 
-        inventoryLedgerEntryRepository.save(entry);
+        ledgerPostingService.post(entry);
         inventoryFactPublisher.markEntry(entry);
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentScanScheduler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentScanScheduler.java
@@ -1,0 +1,45 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
+import com.positivity.inventory.service.ReplenishmentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduled driver for the batch replenishment scan (CAP-217 / odoo-parity F1,
+ * issue #1025), mirroring the {@code pos.inventory.stock-summary.*} scheduling
+ * convention used by {@link StockSummaryDriftVerifier}.
+ *
+ * <p>Disabled by default; enable per environment with
+ * {@code pos.inventory.replenishment.scan.enabled=true}. The scan itself is
+ * idempotent per (policy, day), so an aggressive interval cannot create
+ * duplicate open tasks.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(prefix = "pos.inventory.replenishment.scan", name = "enabled", havingValue = "true")
+public class ReplenishmentScanScheduler {
+
+    private final ReplenishmentService replenishmentService;
+
+    @Scheduled(
+            fixedDelayString = "${pos.inventory.replenishment.scan.interval-ms:3600000}",
+            initialDelayString = "${pos.inventory.replenishment.scan.initial-delay-ms:600000}")
+    public void runScheduledScan() {
+        try {
+            ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+            log.info(
+                    "Scheduled replenishment scan: policiesEvaluated={} tasksCreated={} tasksRefreshed={}",
+                    result.getPoliciesEvaluated(),
+                    result.getTasksCreated(),
+                    result.getTasksRefreshed());
+        } catch (Exception ex) {
+            // Scheduled job: never let one failed pass escalate; the next pass retries.
+            log.error("Scheduled replenishment scan failed", ex);
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
@@ -2,16 +2,26 @@ package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
 import com.positivity.inventory.internal.entity.ReplenishmentPolicy;
 import com.positivity.inventory.internal.entity.ReplenishmentTask;
+import com.positivity.inventory.internal.enums.ReplenishmentDecisionReason;
 import com.positivity.inventory.internal.enums.ReplenishmentStatus;
+import com.positivity.inventory.internal.enums.ReplenishmentTriggerType;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentTaskRepository;
 import com.positivity.inventory.service.ReplenishmentService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
@@ -22,17 +32,21 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ReplenishmentServiceImpl implements ReplenishmentService {
+
+    private static final List<ReplenishmentStatus> OPEN_STATUSES =
+            List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS);
 
     private final ReplenishmentTaskRepository replenishmentTaskRepository;
     private final ReplenishmentPolicyRepository replenishmentPolicyRepository;
+    private final InventoryStockSummaryRepository stockSummaryRepository;
+    private final Clock clock;
 
     @Override
     @Transactional(readOnly = true)
     public @NonNull List<ReplenishmentTaskResponse> getReplenishmentTasks() {
-        return replenishmentTaskRepository
-                .findByStatusIn(List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS))
-                .stream()
+        return replenishmentTaskRepository.findByStatusIn(OPEN_STATUSES).stream()
                 .map(this::toTaskResponse)
                 .toList();
     }
@@ -78,17 +92,11 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                 .findFirst()
                 .isPresent();
 
-        if (policyExists) {
-            boolean taskAlreadyOpen = replenishmentTaskRepository.existsByItemSKUAndDestinationLocationIdAndStatusIn(
-                    productId,
-                    pickFaceLocationId,
-                    List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS));
-            if (taskAlreadyOpen) {
-                return ReplenishmentTaskResponse.builder()
-                        .taskId(null)
-                        .status("TASK_ALREADY_QUEUED")
-                        .build();
-            }
+        if (policyExists && hasOpenTask(productId, pickFaceLocationId)) {
+            return ReplenishmentTaskResponse.builder()
+                    .taskId(null)
+                    .status("TASK_ALREADY_QUEUED")
+                    .build();
         }
 
         return ReplenishmentTaskResponse.builder()
@@ -97,13 +105,142 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                 .build();
     }
 
+    /**
+     * Batch replenishment scan (CAP-217 / odoo-parity F1, issue #1025).
+     *
+     * <p>Iterates every {@link ReplenishmentPolicy} and applies the same
+     * below-minimum trigger evaluation the event path uses ({@link
+     * #isBelowMinimum(ReplenishmentPolicy, long)} / {@link #hasOpenTask(String,
+     * UUID)}), against the current on-hand from the {@code
+     * inventory_stock_summary} read model (issue #1024). F2 upgrades this to
+     * forecast-aware math.
+     *
+     * <p>Idempotency per (policy, day): a still-open task for the policy's
+     * SKU/location is refreshed (quantity re-derived) instead of duplicated, and
+     * if a batch-triggered task was already created today (UTC) no new task is
+     * created even if the earlier one has since closed.
+     */
     @Override
-    @Transactional(readOnly = true)
-    public @NonNull List<ReplenishmentTaskResponse> runBatchReplenishmentScan() {
-        // TODO(CAP-217): batch replenishment scan deferred to follow-on story
-        // Full implementation will query pick faces below minimumQuantity threshold
-        // and generate replenishment tasks for each violation found.
-        return List.of();
+    @Transactional
+    public @NonNull ReplenishmentScanResultResponse runBatchReplenishmentScan() {
+        Instant now = Instant.now(clock);
+        Instant startOfDayUtc = LocalDate.ofInstant(now, ZoneOffset.UTC)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant();
+
+        int policiesEvaluated = 0;
+        int belowMinimum = 0;
+        int tasksCreated = 0;
+        int tasksRefreshed = 0;
+
+        for (ReplenishmentPolicy policy : replenishmentPolicyRepository.findAll()) {
+            policiesEvaluated++;
+            long onHand = currentOnHand(policy.getItemSKU(), policy.getLocationId());
+            if (!isBelowMinimum(policy, onHand)) {
+                continue;
+            }
+            belowMinimum++;
+
+            int quantityNeeded = (int) Math.max(1, policy.getMaximumQuantity() - onHand);
+            Optional<ReplenishmentTask> openTask =
+                    replenishmentTaskRepository
+                            .findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
+                                    policy.getItemSKU(), policy.getLocationId(), OPEN_STATUSES);
+            if (openTask.isPresent()) {
+                if (refreshOpenTask(openTask.get(), quantityNeeded)) {
+                    tasksRefreshed++;
+                }
+                continue;
+            }
+
+            boolean alreadyScannedToday =
+                    replenishmentTaskRepository
+                            .existsByItemSKUAndDestinationLocationIdAndTriggerTypeAndCreatedAtGreaterThanEqual(
+                                    policy.getItemSKU(),
+                                    policy.getLocationId(),
+                                    ReplenishmentTriggerType.BATCH,
+                                    startOfDayUtc);
+            if (alreadyScannedToday) {
+                log.debug(
+                        "Batch scan skip (already created today): sku={} locationId={}",
+                        policy.getItemSKU(),
+                        policy.getLocationId());
+                continue;
+            }
+
+            createBatchTask(policy, quantityNeeded);
+            tasksCreated++;
+        }
+
+        log.info(
+                "Batch replenishment scan complete: policiesEvaluated={} belowMinimum={} tasksCreated={}"
+                        + " tasksRefreshed={}",
+                policiesEvaluated,
+                belowMinimum,
+                tasksCreated,
+                tasksRefreshed);
+
+        return ReplenishmentScanResultResponse.builder()
+                .policiesEvaluated(policiesEvaluated)
+                .policiesBelowMinimum(belowMinimum)
+                .tasksCreated(tasksCreated)
+                .tasksRefreshed(tasksRefreshed)
+                .scanAt(now.toString())
+                .build();
+    }
+
+    /**
+     * Shared below-minimum trigger evaluation (event path and batch scan must
+     * not diverge — odoo-parity F1). Current math: plain on-hand vs policy
+     * minimum; forecast-aware projection replaces this in F2.
+     */
+    private boolean isBelowMinimum(ReplenishmentPolicy policy, long onHand) {
+        return onHand < policy.getMinimumQuantity();
+    }
+
+    /** Duplicate-open-task guard shared by the event path and the batch scan. */
+    private boolean hasOpenTask(String itemSKU, UUID destinationLocationId) {
+        return replenishmentTaskRepository.existsByItemSKUAndDestinationLocationIdAndStatusIn(
+                itemSKU, destinationLocationId, OPEN_STATUSES);
+    }
+
+    /**
+     * Current on-hand for one SKU/location from the stock summary read model
+     * (single sanctioned read path since issue #1024); absent row means no
+     * postings yet, i.e. zero on-hand.
+     */
+    private long currentOnHand(String itemSKU, UUID locationId) {
+        return stockSummaryRepository
+                .findByStockItemIdAndLocationId(itemSKU, locationId)
+                .map(summary -> summary.getOnHand())
+                .orElse(0L);
+    }
+
+    /** Refreshes a still-open PENDING task's quantity to the currently computed need. */
+    private boolean refreshOpenTask(ReplenishmentTask task, int quantityNeeded) {
+        if (task.getStatus() != ReplenishmentStatus.PENDING
+                || (task.getQuantity() != null && task.getQuantity() == quantityNeeded)) {
+            return false;
+        }
+        task.setQuantity(quantityNeeded);
+        replenishmentTaskRepository.save(task);
+        return true;
+    }
+
+    private void createBatchTask(ReplenishmentPolicy policy, int quantityNeeded) {
+        // Source selection is a placeholder until odoo-parity F5 (internal
+        // sourcing): the policy's own location stands in for the backstock
+        // source because the column is non-null and no sourcing engine exists yet.
+        ReplenishmentTask task = ReplenishmentTask.builder()
+                .itemSKU(policy.getItemSKU())
+                .quantity(quantityNeeded)
+                .sourceLocationId(policy.getLocationId())
+                .destinationLocationId(policy.getLocationId())
+                .status(ReplenishmentStatus.PENDING)
+                .triggerType(ReplenishmentTriggerType.BATCH)
+                .decisionReason(ReplenishmentDecisionReason.BELOW_MIN)
+                .build();
+        replenishmentTaskRepository.save(task);
     }
 
     private ReplenishmentTaskResponse toTaskResponse(ReplenishmentTask task) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
@@ -36,6 +36,7 @@ public class ReservationServiceImpl implements ReservationService {
     private final ReservationRepository reservationRepository;
     private final AllocationRepository allocationRepository;
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+    private final LedgerPostingService ledgerPostingService;
     private final InventoryFactPublisher inventoryFactPublisher;
     private final StorageLocationValidationService storageLocationValidationService;
 
@@ -204,7 +205,7 @@ public class ReservationServiceImpl implements ReservationService {
                                 : allocation.getAllocationId().toString())
                 .timestamp(Instant.now(clock))
                 .build();
-        inventoryLedgerEntryRepository.save(entry);
+        ledgerPostingService.post(entry);
         inventoryFactPublisher.markEntry(entry);
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReturnServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReturnServiceImpl.java
@@ -36,6 +36,7 @@ public class ReturnServiceImpl implements ReturnService {
 
     private final InventoryReturnRepository inventoryReturnRepository;
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+    private final LedgerPostingService ledgerPostingService;
     private final InventoryFactPublisher inventoryFactPublisher;
     private final Clock clock;
 
@@ -112,7 +113,7 @@ public class ReturnServiceImpl implements ReturnService {
             ledgerEntries.add(buildReturnLedgerEntry(request, item));
         }
 
-        List<InventoryLedgerEntry> savedLedgerEntries = inventoryLedgerEntryRepository.saveAll(ledgerEntries);
+        List<InventoryLedgerEntry> savedLedgerEntries = ledgerPostingService.postAll(ledgerEntries);
         inventoryFactPublisher.markEntries(savedLedgerEntries);
         List<UUID> ledgerEntryIds = savedLedgerEntries.stream()
                 .map(InventoryLedgerEntry::getLedgerEntryId)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryQuantityLoader.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryQuantityLoader.java
@@ -1,10 +1,7 @@
 package com.positivity.inventory.internal.service;
 
-import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
-import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -16,19 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
  * Loads bulk per-location quantity maps inside a single read-only
  * transaction, keeping the remote topology fetch outside transactional
  * scope (CAP-218 #658; see #657 handoff note on non-atomic grouped sums).
+ *
+ * <p>Since issue #1024 (A1) quantities come from the
+ * {@code inventory_stock_summary} read model rather than ledger aggregation.
  */
 @Component
 public class SiteInventoryQuantityLoader {
 
-    private static final List<InventoryLedgerEventType> ALLOCATION_CREATED_TYPES =
-            List.of(InventoryLedgerEventType.ALLOCATION_CREATED);
-    private static final List<InventoryLedgerEventType> ALLOCATION_RELEASED_TYPES =
-            List.of(InventoryLedgerEventType.ALLOCATION_RELEASED);
+    private final InventoryStockSummaryRepository stockSummaryRepository;
 
-    private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
-
-    public SiteInventoryQuantityLoader(InventoryLedgerEntryRepository inventoryLedgerEntryRepository) {
-        this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
+    public SiteInventoryQuantityLoader(InventoryStockSummaryRepository stockSummaryRepository) {
+        this.stockSummaryRepository = stockSummaryRepository;
     }
 
     /**
@@ -39,29 +34,10 @@ public class SiteInventoryQuantityLoader {
     @Transactional(readOnly = true)
     @NonNull
     public QuantitySnapshot load(@NonNull Collection<UUID> locationIds, @Nullable String sku) {
-        Collection<InventoryLedgerEventType> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes();
-
-        Map<UUID, Long> onHand;
-        Map<UUID, Long> allocated;
-        if (sku == null || sku.isBlank()) {
-            onHand = inventoryLedgerEntryRepository.sumQuantityByLocationChunked(locationIds, onHandTypes);
-            allocated = inventoryLedgerEntryRepository.calculateOutstandingAllocationsByLocation(locationIds);
-        } else {
-            onHand = inventoryLedgerEntryRepository.sumQuantityByLocationForSkuChunked(sku, locationIds, onHandTypes);
-            allocated = outstandingForSku(sku, locationIds);
-        }
-        return new QuantitySnapshot(onHand, allocated);
-    }
-
-    private Map<UUID, Long> outstandingForSku(String sku, Collection<UUID> locationIds) {
-        Map<UUID, Long> created = inventoryLedgerEntryRepository.sumQuantityByLocationForSkuChunked(
-                sku, locationIds, ALLOCATION_CREATED_TYPES);
-        Map<UUID, Long> released = inventoryLedgerEntryRepository.sumQuantityByLocationForSkuChunked(
-                sku, locationIds, ALLOCATION_RELEASED_TYPES);
-
-        Map<UUID, Long> outstanding = new HashMap<>(created);
-        released.forEach((locationId, quantity) -> outstanding.merge(locationId, -quantity, Long::sum));
-        return Map.copyOf(outstanding);
+        String skuFilter = sku == null || sku.isBlank() ? null : sku;
+        InventoryStockSummaryRepository.LocationQuantityMaps maps =
+                stockSummaryRepository.sumByLocationChunked(locationIds, skuFilter);
+        return new QuantitySnapshot(maps.onHand(), maps.allocated());
     }
 
     public record QuantitySnapshot(Map<UUID, Long> onHand, Map<UUID, Long> allocated) {}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockMovementServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockMovementServiceImpl.java
@@ -32,14 +32,17 @@ public class StockMovementServiceImpl implements StockMovementService {
 
     private final InventoryLedgerEntryRepository ledgerRepository;
     private final InventoryAdjustmentRequestRepository adjustmentRepository;
+    private final LedgerPostingService ledgerPostingService;
     private final Clock clock;
 
     public StockMovementServiceImpl(
             InventoryLedgerEntryRepository ledgerRepository,
             InventoryAdjustmentRequestRepository adjustmentRepository,
+            LedgerPostingService ledgerPostingService,
             Clock clock) {
         this.ledgerRepository = ledgerRepository;
         this.adjustmentRepository = adjustmentRepository;
+        this.ledgerPostingService = ledgerPostingService;
         this.clock = clock;
     }
 
@@ -77,7 +80,7 @@ public class StockMovementServiceImpl implements StockMovementService {
                     .transactionUserId(actorUserId)
                     .timestamp(Instant.now(clock))
                     .build();
-            ledgerRepository.save(transferInEntry);
+            ledgerPostingService.post(transferInEntry);
         }
 
         InventoryLedgerEventType eventType = mapMovementTypeToEventType(movementType);
@@ -106,7 +109,7 @@ public class StockMovementServiceImpl implements StockMovementService {
 
         log.debug(
                 "Recorded stock movement type={} sku={} actor={}", movementType, request.getProductSku(), actorUserId);
-        InventoryLedgerEntry savedEntry = ledgerRepository.save(entry);
+        InventoryLedgerEntry savedEntry = ledgerPostingService.post(entry);
         return toResponse(savedEntry);
     }
 
@@ -172,7 +175,7 @@ public class StockMovementServiceImpl implements StockMovementService {
         adjustmentRequest.setApprovedAt(Instant.now(clock));
         adjustmentRepository.save(adjustmentRequest);
 
-        return ledgerRepository.save(entry);
+        return ledgerPostingService.post(entry);
     }
 
     private InventoryLedgerEventType mapMovementTypeToEventType(MovementType movementType) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryDriftVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryDriftVerifier.java
@@ -1,0 +1,152 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Scheduled report-only drift check for the stock summary read model (issue
+ * #1024, A1): compares every {@code inventory_stock_summary} row against
+ * {@code SUM(ledger)} per (stockItemId, locationId) and logs/counts
+ * mismatches. NEVER mutates either table — repair is a manual
+ * {@link StockSummaryRebuildService#rebuildFromLedger()}.
+ */
+@Component
+@Slf4j
+public class StockSummaryDriftVerifier {
+
+    private final InventoryLedgerEntryRepository ledgerRepository;
+    private final InventoryStockSummaryRepository summaryRepository;
+    private final Counter driftCounter;
+
+    public StockSummaryDriftVerifier(
+            InventoryLedgerEntryRepository ledgerRepository,
+            InventoryStockSummaryRepository summaryRepository,
+            MeterRegistry meterRegistry) {
+        this.ledgerRepository = ledgerRepository;
+        this.summaryRepository = summaryRepository;
+        this.driftCounter = meterRegistry.counter("inventory.stock_summary.drift.total");
+    }
+
+    @Scheduled(
+            fixedDelayString = "${pos.inventory.stock-summary.verify-interval-ms:3600000}",
+            initialDelayString = "${pos.inventory.stock-summary.verify-initial-delay-ms:600000}")
+    public void verifyScheduled() {
+        try {
+            verify();
+        } catch (Exception ex) {
+            // Report-only job: never let a verification failure escalate.
+            log.error("Stock summary drift verification failed", ex);
+        }
+    }
+
+    /**
+     * Runs one full comparison pass and returns the number of drifted keys.
+     */
+    @Transactional(readOnly = true)
+    public int verify() {
+        Map<Key, InventoryLedgerEntryRepository.SummaryAggregate> ledgerTruth = new HashMap<>();
+        for (InventoryLedgerEntryRepository.SummaryAggregate aggregate : ledgerRepository.aggregateForStockSummary(
+                InventoryLedgerEventType.onHandAffectingTypes(),
+                InventoryLedgerEventType.ALLOCATION_CREATED,
+                InventoryLedgerEventType.ALLOCATION_RELEASED,
+                InventoryLedgerEventType.RESERVATION_CREATED,
+                InventoryLedgerEventType.RESERVATION_RELEASED,
+                StockSummaryEventSets.SUMMARY_TYPES)) {
+            ledgerTruth.put(new Key(aggregate.getStockItemId(), aggregate.getLocationId()), aggregate);
+        }
+
+        int driftedKeys = 0;
+        List<InventoryStockSummary> summaryRows = summaryRepository.findAll();
+        for (InventoryStockSummary row : summaryRows) {
+            Key key = new Key(row.getStockItemId(), row.getLocationId());
+            InventoryLedgerEntryRepository.SummaryAggregate truth = ledgerTruth.remove(key);
+            long expectedOnHand = truth == null ? 0L : truth.getOnHand();
+            long expectedAllocated = truth == null ? 0L : truth.getAllocated();
+            long expectedReserved = truth == null ? 0L : truth.getReserved();
+            if (row.getOnHand() != expectedOnHand
+                    || row.getAllocated() != expectedAllocated
+                    || row.getReserved() != expectedReserved
+                    || row.getAtp() != expectedOnHand - expectedAllocated) {
+                driftedKeys++;
+                logDrift(
+                        key,
+                        expectedOnHand,
+                        expectedAllocated,
+                        expectedReserved,
+                        row.getOnHand(),
+                        row.getAllocated(),
+                        row.getReserved());
+            }
+        }
+
+        // Remaining ledger keys have no summary row at all: drift unless they net to zero.
+        for (Map.Entry<Key, InventoryLedgerEntryRepository.SummaryAggregate> missing : ledgerTruth.entrySet()) {
+            InventoryLedgerEntryRepository.SummaryAggregate truth = missing.getValue();
+            if (truth.getOnHand() != 0 || truth.getAllocated() != 0 || truth.getReserved() != 0) {
+                driftedKeys++;
+                logDrift(
+                        missing.getKey(),
+                        truth.getOnHand(),
+                        truth.getAllocated(),
+                        truth.getReserved(),
+                        null,
+                        null,
+                        null);
+            }
+        }
+
+        if (driftedKeys > 0) {
+            driftCounter.increment(driftedKeys);
+            log.error(
+                    "Stock summary drift detected: driftedKeys={} summaryRows={} — summary is stale;"
+                            + " run StockSummaryRebuildService.rebuildFromLedger() in a quiet window",
+                    driftedKeys,
+                    summaryRows.size());
+        } else {
+            log.debug("Stock summary drift verification clean: summaryRows={}", summaryRows.size());
+        }
+        return driftedKeys;
+    }
+
+    @SuppressWarnings("java:S107")
+    private void logDrift(
+            Key key,
+            long expectedOnHand,
+            long expectedAllocated,
+            long expectedReserved,
+            @Nullable Long actualOnHand,
+            @Nullable Long actualAllocated,
+            @Nullable Long actualReserved) {
+        log.warn(
+                "Stock summary drift: stockItemId={} locationId={} ledgerOnHand={} ledgerAllocated={}"
+                        + " ledgerReserved={} summaryOnHand={} summaryAllocated={} summaryReserved={}",
+                key.stockItemId(),
+                key.locationId(),
+                expectedOnHand,
+                expectedAllocated,
+                expectedReserved,
+                actualOnHand,
+                actualAllocated,
+                actualReserved);
+    }
+
+    private record Key(String stockItemId, @Nullable UUID locationId) {
+        private Key {
+            Objects.requireNonNull(stockItemId, "stockItemId");
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryDriftVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryDriftVerifier.java
@@ -1,18 +1,11 @@
 package com.positivity.inventory.internal.service;
 
-import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
-import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.jspecify.annotations.Nullable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,15 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class StockSummaryDriftVerifier {
 
-    private final InventoryLedgerEntryRepository ledgerRepository;
     private final InventoryStockSummaryRepository summaryRepository;
     private final Counter driftCounter;
 
-    public StockSummaryDriftVerifier(
-            InventoryLedgerEntryRepository ledgerRepository,
-            InventoryStockSummaryRepository summaryRepository,
-            MeterRegistry meterRegistry) {
-        this.ledgerRepository = ledgerRepository;
+    public StockSummaryDriftVerifier(InventoryStockSummaryRepository summaryRepository, MeterRegistry meterRegistry) {
         this.summaryRepository = summaryRepository;
         this.driftCounter = meterRegistry.counter("inventory.stock_summary.drift.total");
     }
@@ -53,100 +41,62 @@ public class StockSummaryDriftVerifier {
         }
     }
 
+    /** Cap on per-key WARN lines per pass; the total always lands in the summary ERROR + counter. */
+    private static final int MAX_DETAILED_DRIFT_LOGS = 50;
+
     /**
      * Runs one full comparison pass and returns the number of drifted keys.
+     *
+     * <p>The diff is computed set-based in the database
+     * ({@link InventoryStockSummaryRepository#findDriftRows}) and returns only
+     * mismatching keys, so this job holds no table-sized state in application
+     * memory regardless of catalog × location cardinality.
      */
     @Transactional(readOnly = true)
     public int verify() {
-        Map<Key, InventoryLedgerEntryRepository.SummaryAggregate> ledgerTruth = new HashMap<>();
-        for (InventoryLedgerEntryRepository.SummaryAggregate aggregate : ledgerRepository.aggregateForStockSummary(
-                InventoryLedgerEventType.onHandAffectingTypes(),
-                InventoryLedgerEventType.ALLOCATION_CREATED,
-                InventoryLedgerEventType.ALLOCATION_RELEASED,
-                InventoryLedgerEventType.RESERVATION_CREATED,
-                InventoryLedgerEventType.RESERVATION_RELEASED,
-                StockSummaryEventSets.SUMMARY_TYPES)) {
-            ledgerTruth.put(new Key(aggregate.getStockItemId(), aggregate.getLocationId()), aggregate);
-        }
+        List<String> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes().stream()
+                .map(Enum::name)
+                .toList();
+        List<String> summaryTypes =
+                StockSummaryEventSets.SUMMARY_TYPES.stream().map(Enum::name).toList();
 
-        int driftedKeys = 0;
-        List<InventoryStockSummary> summaryRows = summaryRepository.findAll();
-        for (InventoryStockSummary row : summaryRows) {
-            Key key = new Key(row.getStockItemId(), row.getLocationId());
-            InventoryLedgerEntryRepository.SummaryAggregate truth = ledgerTruth.remove(key);
-            long expectedOnHand = truth == null ? 0L : truth.getOnHand();
-            long expectedAllocated = truth == null ? 0L : truth.getAllocated();
-            long expectedReserved = truth == null ? 0L : truth.getReserved();
-            if (row.getOnHand() != expectedOnHand
-                    || row.getAllocated() != expectedAllocated
-                    || row.getReserved() != expectedReserved
-                    || row.getAtp() != expectedOnHand - expectedAllocated) {
-                driftedKeys++;
-                logDrift(
-                        key,
-                        expectedOnHand,
-                        expectedAllocated,
-                        expectedReserved,
-                        row.getOnHand(),
-                        row.getAllocated(),
-                        row.getReserved());
-            }
-        }
+        List<InventoryStockSummaryRepository.DriftRow> drifted = summaryRepository.findDriftRows(
+                onHandTypes,
+                InventoryLedgerEventType.ALLOCATION_CREATED.name(),
+                InventoryLedgerEventType.ALLOCATION_RELEASED.name(),
+                InventoryLedgerEventType.RESERVATION_CREATED.name(),
+                InventoryLedgerEventType.RESERVATION_RELEASED.name(),
+                summaryTypes);
 
-        // Remaining ledger keys have no summary row at all: drift unless they net to zero.
-        for (Map.Entry<Key, InventoryLedgerEntryRepository.SummaryAggregate> missing : ledgerTruth.entrySet()) {
-            InventoryLedgerEntryRepository.SummaryAggregate truth = missing.getValue();
-            if (truth.getOnHand() != 0 || truth.getAllocated() != 0 || truth.getReserved() != 0) {
-                driftedKeys++;
-                logDrift(
-                        missing.getKey(),
-                        truth.getOnHand(),
-                        truth.getAllocated(),
-                        truth.getReserved(),
-                        null,
-                        null,
-                        null);
-            }
+        int driftedKeys = drifted.size();
+        for (int i = 0; i < driftedKeys && i < MAX_DETAILED_DRIFT_LOGS; i++) {
+            logDrift(drifted.get(i));
         }
 
         if (driftedKeys > 0) {
             driftCounter.increment(driftedKeys);
             log.error(
-                    "Stock summary drift detected: driftedKeys={} summaryRows={} — summary is stale;"
-                            + " run StockSummaryRebuildService.rebuildFromLedger() in a quiet window",
+                    "Stock summary drift detected: driftedKeys={} (detailed above, capped at {}) — summary is"
+                            + " stale; run StockSummaryRebuildService.rebuildFromLedger() in a quiet window",
                     driftedKeys,
-                    summaryRows.size());
+                    MAX_DETAILED_DRIFT_LOGS);
         } else {
-            log.debug("Stock summary drift verification clean: summaryRows={}", summaryRows.size());
+            log.debug("Stock summary drift verification clean");
         }
         return driftedKeys;
     }
 
-    @SuppressWarnings("java:S107")
-    private void logDrift(
-            Key key,
-            long expectedOnHand,
-            long expectedAllocated,
-            long expectedReserved,
-            @Nullable Long actualOnHand,
-            @Nullable Long actualAllocated,
-            @Nullable Long actualReserved) {
+    private void logDrift(InventoryStockSummaryRepository.DriftRow row) {
         log.warn(
                 "Stock summary drift: stockItemId={} locationId={} ledgerOnHand={} ledgerAllocated={}"
                         + " ledgerReserved={} summaryOnHand={} summaryAllocated={} summaryReserved={}",
-                key.stockItemId(),
-                key.locationId(),
-                expectedOnHand,
-                expectedAllocated,
-                expectedReserved,
-                actualOnHand,
-                actualAllocated,
-                actualReserved);
-    }
-
-    private record Key(String stockItemId, @Nullable UUID locationId) {
-        private Key {
-            Objects.requireNonNull(stockItemId, "stockItemId");
-        }
+                row.getStockItemId(),
+                row.getLocationId(),
+                row.getLedgerOnHand(),
+                row.getLedgerAllocated(),
+                row.getLedgerReserved(),
+                row.getSummaryOnHand(),
+                row.getSummaryAllocated(),
+                row.getSummaryReserved());
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryEventSets.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryEventSets.java
@@ -1,0 +1,27 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Ledger event types that contribute to the {@code inventory_stock_summary}
+ * read model (issue #1024, A1). Shared by the posting funnel, rebuild job,
+ * and drift verifier so all three stay aligned.
+ */
+final class StockSummaryEventSets {
+
+    /** Every event type that touches a summary column. */
+    static final Set<InventoryLedgerEventType> SUMMARY_TYPES;
+
+    static {
+        EnumSet<InventoryLedgerEventType> types = EnumSet.copyOf(InventoryLedgerEventType.onHandAffectingTypes());
+        types.add(InventoryLedgerEventType.ALLOCATION_CREATED);
+        types.add(InventoryLedgerEventType.ALLOCATION_RELEASED);
+        types.add(InventoryLedgerEventType.RESERVATION_CREATED);
+        types.add(InventoryLedgerEventType.RESERVATION_RELEASED);
+        SUMMARY_TYPES = Set.copyOf(types);
+    }
+
+    private StockSummaryEventSets() {}
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRebuildService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRebuildService.java
@@ -1,0 +1,20 @@
+package com.positivity.inventory.internal.service;
+
+/**
+ * Rebuilds the {@code inventory_stock_summary} read model from the ledger
+ * (issue #1024, A1). The ledger is the source of truth; the summary is
+ * disposable and fully reconstructible.
+ */
+public interface StockSummaryRebuildService {
+
+    /**
+     * Truncates the summary table and reconstructs every row from the ledger
+     * in one transaction. Intended for backfill and disaster recovery; run it
+     * in a quiet window — a posting that commits between truncate and
+     * reinsert of the same key aborts the rebuild on the unique key (safe to
+     * retry).
+     *
+     * @return number of summary rows written
+     */
+    int rebuildFromLedger();
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRebuildServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRebuildServiceImpl.java
@@ -1,0 +1,80 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Rebuilds {@code inventory_stock_summary} from the ledger: one grouped
+ * aggregation over all summary-relevant entries, then a per-key lookup of the
+ * latest contributing entry to restore {@code lastLedgerEntryId}/{@code
+ * lastEventAt}. Applies the same delta rules as {@code LedgerPostingServiceImpl}
+ * so a rebuild reproduces exactly what live posting maintains.
+ */
+@Service
+@Slf4j
+public class StockSummaryRebuildServiceImpl implements StockSummaryRebuildService {
+
+    private static final Pageable LATEST_ONLY = PageRequest.of(0, 1);
+
+    private final InventoryLedgerEntryRepository ledgerRepository;
+    private final InventoryStockSummaryRepository summaryRepository;
+
+    public StockSummaryRebuildServiceImpl(
+            InventoryLedgerEntryRepository ledgerRepository, InventoryStockSummaryRepository summaryRepository) {
+        this.ledgerRepository = ledgerRepository;
+        this.summaryRepository = summaryRepository;
+    }
+
+    @Override
+    @Transactional
+    public int rebuildFromLedger() {
+        summaryRepository.deleteAllInBatch();
+
+        List<InventoryLedgerEntryRepository.SummaryAggregate> aggregates = ledgerRepository.aggregateForStockSummary(
+                InventoryLedgerEventType.onHandAffectingTypes(),
+                InventoryLedgerEventType.ALLOCATION_CREATED,
+                InventoryLedgerEventType.ALLOCATION_RELEASED,
+                InventoryLedgerEventType.RESERVATION_CREATED,
+                InventoryLedgerEventType.RESERVATION_RELEASED,
+                StockSummaryEventSets.SUMMARY_TYPES);
+
+        List<InventoryStockSummary> rows =
+                aggregates.stream().map(this::toSummaryRow).toList();
+        summaryRepository.saveAll(rows);
+
+        log.info("Rebuilt inventory_stock_summary from ledger: {} rows", rows.size());
+        return rows.size();
+    }
+
+    private InventoryStockSummary toSummaryRow(InventoryLedgerEntryRepository.SummaryAggregate aggregate) {
+        InventoryLedgerEntry latest = ledgerRepository
+                .findLatestSummaryEntries(
+                        aggregate.getStockItemId(),
+                        aggregate.getLocationId(),
+                        StockSummaryEventSets.SUMMARY_TYPES,
+                        LATEST_ONLY)
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        return InventoryStockSummary.builder()
+                .stockItemId(aggregate.getStockItemId())
+                .locationId(aggregate.getLocationId())
+                .onHand(aggregate.getOnHand())
+                .allocated(aggregate.getAllocated())
+                .reserved(aggregate.getReserved())
+                .atp(aggregate.getOnHand() - aggregate.getAllocated())
+                .lastLedgerEntryId(latest == null ? null : latest.getLedgerEntryId())
+                .lastEventAt(latest == null ? null : latest.getTimestamp())
+                .build();
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRowInitializer.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRowInitializer.java
@@ -1,0 +1,54 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Creates missing {@code inventory_stock_summary} rows in a separate
+ * transaction so a lost creation race (unique-key violation from a concurrent
+ * posting) aborts only the inner transaction, never the caller's posting
+ * transaction. {@code LedgerPostingServiceImpl} catches the violation,
+ * re-acquires the row lock, and proceeds.
+ */
+@Component
+public class StockSummaryRowInitializer {
+
+    private final InventoryStockSummaryRepository summaryRepository;
+
+    public StockSummaryRowInitializer(InventoryStockSummaryRepository summaryRepository) {
+        this.summaryRepository = summaryRepository;
+    }
+
+    /**
+     * Inserts a zero-quantity summary row for the key unless one already
+     * exists. May throw a duplicate-key exception when racing another
+     * posting; callers must treat that as "row now exists".
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createRowIfAbsent(@NonNull String stockItemId, @Nullable UUID locationId) {
+        boolean exists = locationId == null
+                ? summaryRepository
+                        .findByStockItemIdAndLocationIdIsNull(stockItemId)
+                        .isPresent()
+                : summaryRepository
+                        .findByStockItemIdAndLocationId(stockItemId, locationId)
+                        .isPresent();
+        if (exists) {
+            return;
+        }
+        summaryRepository.saveAndFlush(InventoryStockSummary.builder()
+                .stockItemId(stockItemId)
+                .locationId(locationId)
+                .onHand(0L)
+                .allocated(0L)
+                .reserved(0L)
+                .atp(0L)
+                .build());
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/CycleCountService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/CycleCountService.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.service;
 import com.positivity.inventory.internal.dto.cyclecount.CountEntryResponse;
 import com.positivity.inventory.internal.dto.cyclecount.CountResponse;
 import com.positivity.inventory.internal.dto.cyclecount.CycleCountTaskResponse;
+import com.positivity.inventory.internal.dto.cyclecount.InterferingMovementResponse;
 import com.positivity.inventory.internal.dto.cyclecount.SubmitCountRequest;
 import com.positivity.inventory.internal.dto.cyclecount.SubmitRecountRequest;
 import java.util.List;
@@ -63,4 +64,14 @@ public interface CycleCountService {
      * @return list of assigned tasks
      */
     List<CycleCountTaskResponse> getTasksByAuditor(String auditorId);
+
+    /**
+     * Ledger movements interfering with a task's count window: every
+     * on-hand-affecting entry for the task's SKU/location recorded between task
+     * creation and now (odoo-parity I2, issue #1026).
+     *
+     * @param taskId the task ID
+     * @return in-window ledger movements, oldest first
+     */
+    List<InterferingMovementResponse> getInterferingMovements(UUID taskId);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ReplenishmentService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ReplenishmentService.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.service;
 
 import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
 import java.util.List;
 import java.util.UUID;
@@ -16,8 +17,13 @@ public interface ReplenishmentService {
     ReplenishmentTaskResponse evaluatePickFaceForReplenishment(
             @NonNull String productId, @NonNull UUID pickFaceLocationId);
 
+    /**
+     * Runs the batch replenishment scan over all policies (CAP-217 / odoo-parity
+     * F1): below-minimum policies get a batch-triggered replenishment task,
+     * idempotent per (policy, day).
+     */
     @NonNull
-    List<ReplenishmentTaskResponse> runBatchReplenishmentScan();
+    ReplenishmentScanResultResponse runBatchReplenishmentScan();
 
     @NonNull
     List<ReplenishmentTaskResponse> getReplenishmentTasks();

--- a/pos-inventory/src/main/resources/application.yml
+++ b/pos-inventory/src/main/resources/application.yml
@@ -140,5 +140,13 @@ pos:
     location:
       # Window the manual sync endpoint asks pos-location to re-emit (owner caps lookback).
       replay-lookback: ${POS_INVENTORY_LOCATION_REPLAY_LOOKBACK:P30D}
+    replenishment:
+      scan:
+        # Scheduled batch replenishment scan (CAP-217 / odoo-parity F1, #1025).
+        # Off by default; flip per environment. The scan is idempotent per
+        # (policy, day) so the interval only controls freshness, not duplication.
+        enabled: ${POS_INVENTORY_REPLENISHMENT_SCAN_ENABLED:false}
+        interval-ms: ${POS_INVENTORY_REPLENISHMENT_SCAN_INTERVAL_MS:3600000}
+        initial-delay-ms: ${POS_INVENTORY_REPLENISHMENT_SCAN_INITIAL_DELAY_MS:600000}
   workorder:
     service-id: ${POS_WORKORDER_SERVICE_ID:workorder}

--- a/pos-inventory/src/main/resources/db/migration/V10__cycle_count_conflict_detection.sql
+++ b/pos-inventory/src/main/resources/db/migration/V10__cycle_count_conflict_detection.sql
@@ -1,0 +1,20 @@
+-- Cycle-count conflict detection (odoo-parity I2, issue #1026).
+--
+-- 1. cycle_count_task.status gains the CONFLICT state: interfering stock
+--    movements were detected between task creation and count submission (or
+--    adjustment approval), so the expected-quantity snapshot is stale and an
+--    explicit reviewer choice (recount, or approve with the variance
+--    recomputed against current on-hand) is required.
+ALTER TABLE cycle_count_task DROP CONSTRAINT cycle_count_task_status_check;
+
+ALTER TABLE cycle_count_task ADD CONSTRAINT cycle_count_task_status_check CHECK (((status)::text = ANY ((ARRAY['ASSIGNED'::character varying, 'COUNTED_PENDING_REVIEW'::character varying, 'CONFLICT'::character varying, 'REQUIRES_INVESTIGATION'::character varying, 'APPROVED'::character varying, 'REJECTED'::character varying])::text[])));
+
+-- 2. cycle_count_adjustment can now reference the cycle-count task it settles,
+--    so approval can consult the task's conflict state and recompute the
+--    variance against current on-hand. Nullable: adjustments may still be
+--    created without a task reference.
+ALTER TABLE cycle_count_adjustment ADD COLUMN task_id uuid;
+
+ALTER TABLE cycle_count_adjustment ADD CONSTRAINT fk_cycle_count_adjustment_task FOREIGN KEY (task_id) REFERENCES cycle_count_task(task_id);
+
+CREATE INDEX idx_cycle_count_adjustment_task_id ON cycle_count_adjustment (task_id);

--- a/pos-inventory/src/main/resources/db/migration/V9__create_inventory_stock_summary.sql
+++ b/pos-inventory/src/main/resources/db/migration/V9__create_inventory_stock_summary.sql
@@ -1,0 +1,36 @@
+-- Issue #1024 (odoo-parity A1): stored on-hand snapshot.
+-- Derived balance read model: one row per (stock_item_id, location_id), maintained
+-- transactionally with every ledger append through LedgerPostingService. The ledger
+-- remains the source of truth; StockSummaryRebuildService reconstructs this table from
+-- scratch and StockSummaryDriftVerifier compares it against SUM(ledger) (report-only).
+--
+-- Forward-compatibility (do not reshape later):
+--   * WS-E per-lot rows: add a nullable lot_id column and extend the unique index to
+--     (stock_item_id, location_id, lot_id) NULLS NOT DISTINCT.
+--   * WS-C in-transit: add an in_transit_qty column.
+CREATE TABLE inventory_stock_summary (
+    summary_id uuid NOT NULL,
+    stock_item_id varchar(255) NOT NULL,
+    -- Nullable: ledger entries may be posted without a location (e.g. workorder
+    -- consumption, cycle-count variances); their balances aggregate on a NULL-location row.
+    location_id uuid,
+    on_hand bigint NOT NULL DEFAULT 0,
+    allocated bigint NOT NULL DEFAULT 0,
+    -- Reservation events (RESERVATION_CREATED/RELEASED) are tracked separately from hard
+    -- allocations because the availability endpoints expose different ATP semantics
+    -- (ADR-0001: allocations only) vs the per-location availability list (reservations too).
+    reserved bigint NOT NULL DEFAULT 0,
+    -- atp = on_hand - allocated (ADR-0001 definition; maintained by LedgerPostingService).
+    atp bigint NOT NULL DEFAULT 0,
+    last_ledger_entry_id uuid,
+    last_event_at timestamp(6) with time zone,
+    created_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT inventory_stock_summary_pkey PRIMARY KEY (summary_id)
+);
+
+-- NULLS NOT DISTINCT so at most one NULL-location row can exist per stock item.
+CREATE UNIQUE INDEX uq_inventory_stock_summary_key
+    ON inventory_stock_summary (stock_item_id, location_id) NULLS NOT DISTINCT;
+
+CREATE INDEX idx_inventory_stock_summary_location ON inventory_stock_summary (location_id);

--- a/pos-inventory/src/main/resources/permissions.yaml
+++ b/pos-inventory/src/main/resources/permissions.yaml
@@ -89,3 +89,5 @@ permissions:
     description: "Submit inventory returns to stock"
   - name: "inventory:shortage:view"
     description: "View shortage resolution options"
+  - name: "inventory:replenishment:manage"
+    description: "Manage replenishment policies and run the batch replenishment scan"

--- a/pos-inventory/src/test/java/com/positivity/inventory/ArchitectureTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/ArchitectureTest.java
@@ -33,6 +33,16 @@ public class ArchitectureTest {
                 }
             };
 
+    private static final DescribedPredicate<JavaCall<?>> LEDGER_REPOSITORY_SAVE_CALL =
+            new DescribedPredicate<>("call InventoryLedgerEntryRepository.save/saveAll") {
+
+                public boolean test(JavaCall<?> input) {
+                    return "com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository"
+                                    .equals(input.getTargetOwner().getFullName())
+                            && ("save".equals(input.getName()) || "saveAll".equals(input.getName()));
+                }
+            };
+
     @ArchTest
     static final ArchRule inventory_should_not_depend_on_pos_location_classes = noClasses()
             .that()
@@ -167,6 +177,17 @@ public class ArchitectureTest {
             .haveFullyQualifiedName("com.positivity.shared.id.UUIDv7Id")
             .allowEmptyShould(true)
             .because("ADR-0013 mandates UUID v7 generation for all entity identifiers");
+
+    @ArchTest
+    static final ArchRule ledger_entry_writes_must_go_through_posting_funnel = noClasses()
+            .that()
+            .doNotHaveFullyQualifiedName("com.positivity.inventory.internal.service.LedgerPostingServiceImpl")
+            .should()
+            .callMethodWhere(LEDGER_REPOSITORY_SAVE_CALL)
+            .allowEmptyShould(true)
+            .because("all inventory_ledger_entry appends must flow through LedgerPostingService so the"
+                    + " stock summary read model stays consistent (#1024, A1) and the negative-stock"
+                    + " policy matrix has a single enforcement point (#1027, K1)");
 
     @ArchTest
     static final ArchRule entities_should_not_call_uuid_randomUUID = noClasses()

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/BaseContractIntegrationTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/BaseContractIntegrationTest.java
@@ -53,7 +53,8 @@ public abstract class BaseContractIntegrationTest {
                                 "inventory:allocations:reallocate",
                                 "inventory:shortage:resolve",
                                 "inventory:return:write",
-                                "inventory:return:view"));
+                                "inventory:return:view",
+                                "inventory:replenishment:manage"));
     }
 
     protected MockHttpServletRequestBuilder withApproveOnlyAuth(MockHttpServletRequestBuilder requestBuilder) {

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/CycleCountAdjustmentContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/CycleCountAdjustmentContractBehaviorIT.java
@@ -11,6 +11,7 @@ import com.positivity.inventory.internal.enums.ApprovalTier;
 import com.positivity.inventory.internal.repository.ApprovalThresholdConfigRepository;
 import com.positivity.inventory.internal.repository.CycleCountAdjustmentRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,11 +53,15 @@ class CycleCountAdjustmentContractBehaviorIT extends BaseContractIntegrationTest
     @Autowired
     private InventoryLedgerEntryRepository ledgerEntryRepository;
 
+    @Autowired
+    private InventoryStockSummaryRepository stockSummaryRepository;
+
     @BeforeEach
     void setUp() {
         // Issue #26: delete ledger entries before adjustments (ledger refs adjustment
         // ID)
         ledgerEntryRepository.deleteAll();
+        stockSummaryRepository.deleteAll();
         adjustmentRepository.deleteAll();
         thresholdConfigRepository.deleteAll();
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/CycleCountContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/CycleCountContractBehaviorIT.java
@@ -434,6 +434,37 @@ class CycleCountContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(jsonPath("$[0].auditorId").value("auditor-target"));
     }
 
+    // ─── I2 (#1026): interfering movements listing ───────────────────────────
+
+    @Test
+    @DisplayName("I2: GET /cycleCount/task/{id}/interfering-movements returns 200 with an array for a clean window")
+    void getInterferingMovements_cleanWindow_returns200WithEmptyArray() throws Exception {
+        CycleCountTask task = cycleCountTaskRepository.save(CycleCountTask.builder()
+                .binLocation("BIN-I2-CONTRACT")
+                .itemSku("SKU-I2-CONTRACT")
+                .itemDescription("I2 contract test item")
+                .expectedQuantity(10)
+                .auditorId("auditor-i2")
+                .status(TaskStatus.ASSIGNED)
+                .countEntriesCount(0)
+                .build());
+
+        mockMvc.perform(withGatewayAuth(
+                        get("/v1/inventory/cycleCount/task/{taskId}/interfering-movements", task.getTaskId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    @DisplayName("I2: GET /cycleCount/task/{id}/interfering-movements for unknown task returns 404")
+    void getInterferingMovements_unknownTask_returns404() throws Exception {
+        mockMvc.perform(withGatewayAuth(get(
+                        "/v1/inventory/cycleCount/task/{taskId}/interfering-movements",
+                        UUID.fromString("00000000-0000-0000-0000-00000000dead"))))
+                .andExpect(status().isNotFound());
+    }
+
     // ─── Private request body records (inline serialization) ────────────────
 
     private record SubmitCountBody(UUID taskId, String auditorId, Integer actualQuantity) {}

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityContractBehaviorIT.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -36,9 +38,16 @@ class InventoryAvailabilityContractBehaviorIT extends BaseContractIntegrationTes
     @Autowired
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
+    @Autowired
+    private InventoryStockSummaryRepository inventoryStockSummaryRepository;
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
     @BeforeEach
     void setUp() {
         inventoryLedgerEntryRepository.deleteAll();
+        inventoryStockSummaryRepository.deleteAll();
     }
 
     @Test
@@ -113,7 +122,7 @@ class InventoryAvailabilityContractBehaviorIT extends BaseContractIntegrationTes
     }
 
     private void seedOnHand(UUID productId, UUID locationId, int quantity) {
-        inventoryLedgerEntryRepository.save(InventoryLedgerEntry.builder()
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productId.toString())
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
@@ -126,7 +135,7 @@ class InventoryAvailabilityContractBehaviorIT extends BaseContractIntegrationTes
     }
 
     private void seedReservationCreated(UUID productId, UUID locationId, int quantity) {
-        inventoryLedgerEntryRepository.save(InventoryLedgerEntry.builder()
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productId.toString())
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.RESERVATION_CREATED)
@@ -139,7 +148,7 @@ class InventoryAvailabilityContractBehaviorIT extends BaseContractIntegrationTes
     }
 
     private void seedReservationReleased(UUID productId, UUID locationId, int quantity) {
-        inventoryLedgerEntryRepository.save(InventoryLedgerEntry.builder()
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productId.toString())
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.RESERVATION_RELEASED)

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityQueryContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityQueryContractBehaviorIT.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -49,9 +51,16 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     @Autowired
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
+    @Autowired
+    private InventoryStockSummaryRepository inventoryStockSummaryRepository;
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
     @BeforeEach
     void setUp() {
         inventoryLedgerEntryRepository.deleteAll();
+        inventoryStockSummaryRepository.deleteAll();
     }
 
     // Issue CAP-215: AC-1 — on-hand and ATP returned correctly when stock exists
@@ -187,7 +196,7 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     // -------------------------------------------------------------------------
 
     private void seedGoodsReceipt(String productSku, UUID locationId, int quantity) {
-        inventoryLedgerEntryRepository.save(InventoryLedgerEntry.builder()
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productSku)
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
@@ -200,7 +209,7 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     }
 
     private void seedAllocationCreated(String productSku, UUID locationId, int quantity) {
-        inventoryLedgerEntryRepository.save(InventoryLedgerEntry.builder()
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productSku)
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.ALLOCATION_CREATED)
@@ -213,7 +222,7 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     }
 
     private void seedAllocationReleased(String productSku, UUID locationId, int quantity) {
-        inventoryLedgerEntryRepository.save(InventoryLedgerEntry.builder()
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productSku)
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.ALLOCATION_RELEASED)
@@ -226,7 +235,7 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     }
 
     private void seedReservationCreated(String productSku, UUID locationId, int quantity) {
-        inventoryLedgerEntryRepository.save(InventoryLedgerEntry.builder()
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productSku)
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.RESERVATION_CREATED)

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReplenishmentContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReplenishmentContractBehaviorIT.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
 import com.positivity.inventory.service.ReplenishmentService;
 import java.time.Clock;
@@ -202,6 +203,64 @@ class ReplenishmentContractBehaviorIT extends BaseContractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(status().isBadRequest());
+    }
+
+    // ─── F1 (#1025): POST /replenishment/scan + inventory:replenishment:manage ─
+
+    /**
+     * Verifies that the manual batch scan endpoint returns 200 with the scan
+     * summary when the caller holds {@code inventory:replenishment:manage}.
+     *
+     * Issue: #1025
+     */
+    @Test
+    @DisplayName("F1: POST /replenishment/scan with manage permission returns 200 with scan summary")
+    void runReplenishmentScan_withManagePermission_returns200WithSummary() throws Exception {
+        when(replenishmentService.runBatchReplenishmentScan())
+                .thenReturn(ReplenishmentScanResultResponse.builder()
+                        .policiesEvaluated(4)
+                        .policiesBelowMinimum(2)
+                        .tasksCreated(1)
+                        .tasksRefreshed(1)
+                        .scanAt(Instant.now(TEST_CLOCK).toString())
+                        .build());
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/replenishment/scan")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.policiesEvaluated").value(4))
+                .andExpect(jsonPath("$.tasksCreated").value(1));
+    }
+
+    /**
+     * Verifies that the scan endpoint is denied (403) without
+     * {@code inventory:replenishment:manage} — even for a caller holding the
+     * legacy {@code inventory:adjustment:create} authority.
+     *
+     * Issue: #1025
+     */
+    @Test
+    @DisplayName("F1: POST /replenishment/scan without manage permission returns 403")
+    void runReplenishmentScan_withoutManagePermission_returns403() throws Exception {
+        mockMvc.perform(withCreateOnlyAuth(post("/v1/inventory/replenishment/scan")))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Verifies that policy creation migrated off {@code inventory:adjustment:create}
+     * onto {@code inventory:replenishment:manage}: the legacy authority alone is
+     * now rejected with 403.
+     *
+     * Issue: #1025
+     */
+    @Test
+    @DisplayName("F1: POST /replenishment/policies with only legacy adjustment:create returns 403")
+    void createReplenishmentPolicy_withLegacyAdjustmentCreateOnly_returns403() throws Exception {
+        String requestBody = buildCreatePolicyRequestBody("00000000-0000-0000-0000-000000000001", "SKU-NUT-M5", 10, 50);
+
+        mockMvc.perform(withCreateOnlyAuth(post("/v1/inventory/replenishment/policies"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isForbidden());
     }
 
     // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/StockMovementContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/StockMovementContractBehaviorIT.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.repository.InventoryAdjustmentRequestRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -60,6 +61,9 @@ class StockMovementContractBehaviorIT extends BaseContractIntegrationTest {
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
     @Autowired
+    private InventoryStockSummaryRepository inventoryStockSummaryRepository;
+
+    @Autowired
     private InventoryAdjustmentRequestRepository inventoryAdjustmentRequestRepository;
 
     @Autowired
@@ -69,6 +73,7 @@ class StockMovementContractBehaviorIT extends BaseContractIntegrationTest {
     void setUp() {
         inventoryAdjustmentRequestRepository.deleteAll();
         inventoryLedgerEntryRepository.deleteAll();
+        inventoryStockSummaryRepository.deleteAll();
     }
 
     // Issue CAP-215: AC-1 — RECEIVE movement records a GOODS_RECEIPT ledger entry

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/StockMovementContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/StockMovementContractBehaviorIT.java
@@ -92,6 +92,14 @@ class StockMovementContractBehaviorIT extends BaseContractIntegrationTest {
     @Test
     @DisplayName("AC-2: recordMovement_TRANSFER_createsTwoLedgerEntries")
     void recordMovement_TRANSFER_createsTwoLedgerEntries() throws Exception {
+        // K1 (#1027): TRANSFER dispatch is blocked below zero on-hand, so seed
+        // the source location before transferring from it.
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/stock-movements")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"productSku\":\"SKU-XFER-1\",\"fromLocationId\":\"" + LOC_SRC + "\","
+                                + "\"movementType\":\"RECEIVE\",\"quantity\":25,\"unitOfMeasure\":\"EACH\"}")))
+                .andExpect(status().isCreated());
+
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/stock-movements")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"productSku\":\"SKU-XFER-1\",\"fromLocationId\":\"" + LOC_SRC + "\","
@@ -99,8 +107,27 @@ class StockMovementContractBehaviorIT extends BaseContractIntegrationTest {
                                 + "\"quantity\":25,\"unitOfMeasure\":\"EACH\"}")))
                 .andExpect(status().isCreated());
 
+        // 1 seed GOODS_RECEIPT + TRANSFER_IN/TRANSFER_OUT pair
         List<InventoryLedgerEntry> entries = inventoryLedgerEntryRepository.findAll();
-        assertThat(entries).hasSize(2);
+        assertThat(entries).hasSize(3);
+    }
+
+    // Issue #1027 (odoo-parity K1): TRANSFER dispatch below zero on-hand is
+    // blocked by the negative-stock policy matrix in the posting funnel and the
+    // whole movement (both paired entries) rolls back.
+    @Test
+    @DisplayName("K1: recordMovement_TRANSFER_returns422_whenInsufficientStock")
+    void recordMovement_TRANSFER_returns422_whenInsufficientStock() throws Exception {
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/stock-movements")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"productSku\":\"SKU-XFER-NEG\",\"fromLocationId\":\"" + LOC_SRC + "\","
+                                + "\"toLocationId\":\"" + LOC_DST + "\",\"movementType\":\"TRANSFER\","
+                                + "\"quantity\":25,\"unitOfMeasure\":\"EACH\"}")))
+                .andExpect(status().is(422))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value("INSUFFICIENT_STOCK"));
+
+        assertThat(inventoryLedgerEntryRepository.findAll()).isEmpty();
     }
 
     @Test
@@ -144,6 +171,14 @@ class StockMovementContractBehaviorIT extends BaseContractIntegrationTest {
     @Test
     @DisplayName("AC-4: approveAdjustment_postsLedgerEntry")
     void approveAdjustment_postsLedgerEntry() throws Exception {
+        // K1 (#1027): ADJUSTMENT_OUT floors at zero, so seed on-hand at the
+        // adjustment location before approving a negative adjustment.
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/stock-movements")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"productSku\":\"SKU-ADJ2\",\"fromLocationId\":\"" + LOC_2 + "\","
+                                + "\"movementType\":\"RECEIVE\",\"quantity\":5,\"unitOfMeasure\":\"EACH\"}")))
+                .andExpect(status().isCreated());
+
         MvcResult createResult = mockMvc.perform(withGatewayAuth(post("/v1/inventory/adjustments")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"productSku\":\"SKU-ADJ2\",\"locationId\":\"" + LOC_2 + "\","
@@ -159,6 +194,31 @@ class StockMovementContractBehaviorIT extends BaseContractIntegrationTest {
         mockMvc.perform(withGatewayAuth(
                         post("/v1/inventory/adjustments/{adjustmentRequestId}/approve", adjustmentRequestId)))
                 .andExpect(status().isOk());
+    }
+
+    // Issue #1027 (odoo-parity K1): ADJUSTMENT_OUT may zero stock but never
+    // drive it negative — approval of an over-sized negative adjustment is
+    // rejected with the deterministic floor-violation code.
+    @Test
+    @DisplayName("K1: approveAdjustment_drivingOnHandNegative_returns422FloorViolation")
+    void approveAdjustment_drivingOnHandNegative_returns422FloorViolation() throws Exception {
+        MvcResult createResult = mockMvc.perform(withGatewayAuth(post("/v1/inventory/adjustments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"productSku\":\"SKU-ADJ-NEG\",\"locationId\":\"" + LOC_2 + "\","
+                                + "\"quantity\":-3,\"reasonCode\":\"DAMAGE\",\"unitOfMeasure\":\"EACH\"}")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode responseJson = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        String adjustmentRequestId = responseJson.get("adjustmentRequestId").asString();
+
+        mockMvc.perform(withGatewayAuth(
+                        post("/v1/inventory/adjustments/{adjustmentRequestId}/approve", adjustmentRequestId)))
+                .andExpect(status().is(422))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value("NEGATIVE_STOCK_FLOOR_VIOLATION"));
+
+        assertThat(inventoryLedgerEntryRepository.findAll()).isEmpty();
     }
 
     // Issue CAP-215: AC-5 — PICK with no prior stock present returns 422

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BatchReplenishmentScanTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BatchReplenishmentScanTest.java
@@ -1,0 +1,158 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.ReplenishmentPolicy;
+import com.positivity.inventory.internal.entity.ReplenishmentTask;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.ReplenishmentStatus;
+import com.positivity.inventory.internal.enums.ReplenishmentTriggerType;
+import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
+import com.positivity.inventory.internal.repository.ReplenishmentTaskRepository;
+import com.positivity.inventory.service.ReplenishmentService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * End-to-end tests for the batch replenishment scan (CAP-217 / odoo-parity F1,
+ * issue #1025) against the real repositories and the {@code
+ * inventory_stock_summary} read model maintained by the ledger posting funnel.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("Batch replenishment scan (F1)")
+class BatchReplenishmentScanTest {
+
+    @Autowired
+    private ReplenishmentService replenishmentService;
+
+    @Autowired
+    private ReplenishmentPolicyRepository policyRepository;
+
+    @Autowired
+    private ReplenishmentTaskRepository taskRepository;
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
+    private static String uniqueSku() {
+        return "SKU-F1-" + UUID.randomUUID();
+    }
+
+    private void receive(String sku, UUID locationId, int quantity) {
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(locationId)
+                .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
+                .changeInQuantity(quantity)
+                .quantityAfter(quantity)
+                .transactionUserId("f1-test")
+                .build());
+    }
+
+    private ReplenishmentPolicy seedPolicy(String sku, UUID locationId, int min, int max) {
+        return policyRepository.save(ReplenishmentPolicy.builder()
+                .locationId(locationId)
+                .itemSKU(sku)
+                .minimumQuantity(min)
+                .maximumQuantity(max)
+                .build());
+    }
+
+    private List<ReplenishmentTask> openTasksFor(String sku) {
+        return taskRepository
+                .findByStatusIn(List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS))
+                .stream()
+                .filter(task -> task.getItemSKU().equals(sku))
+                .toList();
+    }
+
+    @Test
+    @DisplayName("below-minimum policy yields exactly one open task across repeated same-day scans")
+    void repeatedScans_sameDay_createExactlyOneOpenTask() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seedPolicy(sku, location, 5, 20);
+        receive(sku, location, 3); // on-hand 3 < min 5
+
+        replenishmentService.runBatchReplenishmentScan();
+        replenishmentService.runBatchReplenishmentScan();
+        replenishmentService.runBatchReplenishmentScan();
+
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        ReplenishmentTask task = tasks.getFirst();
+        assertThat(task.getTriggerType()).isEqualTo(ReplenishmentTriggerType.BATCH);
+        assertThat(task.getStatus()).isEqualTo(ReplenishmentStatus.PENDING);
+        assertThat(task.getQuantity()).isEqualTo(17); // max 20 - onHand 3
+        assertThat(task.getDestinationLocationId()).isEqualTo(location);
+    }
+
+    @Test
+    @DisplayName("policy at or above minimum triggers nothing")
+    void policyAtOrAboveMinimum_createsNoTask() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seedPolicy(sku, location, 5, 20);
+        receive(sku, location, 5); // exactly at minimum
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertThat(openTasksFor(sku)).isEmpty();
+        assertThat(result.getPoliciesEvaluated()).isPositive();
+    }
+
+    @Test
+    @DisplayName("open task quantity is refreshed when on-hand drops further")
+    void openTask_refreshedWhenNeedGrows() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seedPolicy(sku, location, 5, 20);
+        receive(sku, location, 4); // on-hand 4 < min 5 → need 16
+
+        replenishmentService.runBatchReplenishmentScan();
+        assertThat(openTasksFor(sku).getFirst().getQuantity()).isEqualTo(16);
+
+        // Stock drops further between scans.
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(location)
+                .eventType(InventoryLedgerEventType.GOODS_ISSUE)
+                .changeInQuantity(-2)
+                .quantityAfter(2)
+                .transactionUserId("f1-test")
+                .build());
+
+        ReplenishmentScanResultResponse second = replenishmentService.runBatchReplenishmentScan();
+
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getQuantity()).isEqualTo(18); // max 20 - onHand 2
+        assertThat(second.getTasksRefreshed()).isPositive();
+        assertThat(second.getTasksCreated()).isZero();
+    }
+
+    @Test
+    @DisplayName("scan summary counts evaluated policies and created tasks")
+    void scanSummary_reflectsActivity() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seedPolicy(sku, location, 10, 30);
+        // No receipts → summary row absent → on-hand 0 (below min).
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertThat(result.getPoliciesEvaluated()).isPositive();
+        assertThat(result.getScanAt()).isNotBlank();
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getQuantity()).isEqualTo(30);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImplTest.java
@@ -49,6 +49,9 @@ class CycleCountAdjustmentServiceImplTest {
     private InventoryLedgerEntryRepository ledgerRepository;
 
     @Mock
+    private LedgerPostingService ledgerPostingService;
+
+    @Mock
     private ApprovalThresholdEvaluator thresholdEvaluator;
 
     @Mock
@@ -60,7 +63,12 @@ class CycleCountAdjustmentServiceImplTest {
     @BeforeEach
     void setUp() {
         service = new CycleCountAdjustmentServiceImpl(
-                adjustmentRepository, ledgerRepository, thresholdEvaluator, eventPublisher, fixedClock);
+                adjustmentRepository,
+                ledgerRepository,
+                ledgerPostingService,
+                thresholdEvaluator,
+                eventPublisher,
+                fixedClock);
     }
 
     @AfterEach
@@ -109,7 +117,7 @@ class CycleCountAdjustmentServiceImplTest {
 
             assertThat(savedAdjustment.getStatus()).isEqualTo(AdjustmentStatus.PENDING_APPROVAL);
             assertThat(savedAdjustment.getRequiredApprovalTier()).isEqualTo(ApprovalTier.TIER_1_MANAGER);
-            verify(ledgerRepository, never()).save(any());
+            verify(ledgerPostingService, never()).post(any());
         }
 
         @Test
@@ -135,7 +143,7 @@ class CycleCountAdjustmentServiceImplTest {
             });
 
             when(ledgerRepository.calculateOnHandQuantity(stockItemId)).thenReturn(10);
-            when(ledgerRepository.save(any(InventoryLedgerEntry.class))).thenAnswer(invocation -> {
+            when(ledgerPostingService.post(any(InventoryLedgerEntry.class))).thenAnswer(invocation -> {
                 InventoryLedgerEntry entry = invocation.getArgument(0);
                 entry.setLedgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
                 return entry;
@@ -146,7 +154,7 @@ class CycleCountAdjustmentServiceImplTest {
             ArgumentCaptor<CycleCountAdjustment> adjustmentCaptor = ArgumentCaptor.forClass(CycleCountAdjustment.class);
             verify(adjustmentRepository, org.mockito.Mockito.times(2)).save(adjustmentCaptor.capture());
 
-            verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+            verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
 
             CycleCountAdjustment finalSave = adjustmentCaptor.getAllValues().get(1);
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImplTest.java
@@ -57,6 +57,12 @@ class CycleCountAdjustmentServiceImplTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private com.positivity.inventory.internal.repository.CycleCountTaskRepository taskRepository;
+
+    @Mock
+    private CycleCountConflictDetector conflictDetector;
+
     private CycleCountAdjustmentServiceImpl service;
     private Clock fixedClock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
@@ -68,7 +74,9 @@ class CycleCountAdjustmentServiceImplTest {
                 ledgerPostingService,
                 thresholdEvaluator,
                 eventPublisher,
-                fixedClock);
+                fixedClock,
+                taskRepository,
+                conflictDetector);
     }
 
     @AfterEach

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountConflictDetectionTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountConflictDetectionTest.java
@@ -1,0 +1,335 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.positivity.inventory.internal.dto.cyclecount.AdjustmentResponse;
+import com.positivity.inventory.internal.dto.cyclecount.ApproveAdjustmentRequest;
+import com.positivity.inventory.internal.dto.cyclecount.CountResponse;
+import com.positivity.inventory.internal.dto.cyclecount.CreateAdjustmentRequest;
+import com.positivity.inventory.internal.dto.cyclecount.InterferingMovementResponse;
+import com.positivity.inventory.internal.dto.cyclecount.SubmitCountRequest;
+import com.positivity.inventory.internal.dto.cyclecount.SubmitRecountRequest;
+import com.positivity.inventory.internal.entity.ApprovalThresholdConfig;
+import com.positivity.inventory.internal.entity.CycleCountTask;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.enums.AdjustmentStatus;
+import com.positivity.inventory.internal.enums.ApprovalTier;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.TaskStatus;
+import com.positivity.inventory.internal.exception.CycleCountConflictException;
+import com.positivity.inventory.internal.repository.ApprovalThresholdConfigRepository;
+import com.positivity.inventory.internal.repository.CycleCountTaskRepository;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.service.CycleCountAdjustmentService;
+import com.positivity.inventory.service.CycleCountService;
+import com.positivity.security.common.GatewaySecurityConstants;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * End-to-end tests for cycle-count conflict detection (odoo-parity I2, issue
+ * #1026): movements between task creation and count submission / adjustment
+ * approval flag the task CONFLICT, approval on a CONFLICT task recomputes the
+ * variance against CURRENT on-hand, and the interfering movements are listable.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("Cycle count conflict detection (I2)")
+class CycleCountConflictDetectionTest {
+
+    private static final String AUDITOR = "auditor-i2";
+
+    @Autowired
+    private CycleCountService cycleCountService;
+
+    @Autowired
+    private CycleCountAdjustmentService adjustmentService;
+
+    @Autowired
+    private CycleCountTaskRepository taskRepository;
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
+    @Autowired
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    @Autowired
+    private ApprovalThresholdConfigRepository thresholdConfigRepository;
+
+    @BeforeEach
+    void authenticateApprover() {
+        TestingAuthenticationToken authentication =
+                new TestingAuthenticationToken("manager-i2", "password", "ROLE_MANAGER");
+        authentication.setDetails(Map.of(
+                GatewaySecurityConstants.DETAIL_USER_ID, "manager-i2-id",
+                GatewaySecurityConstants.DETAIL_USERNAME, "manager-i2"));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void post(String sku, UUID locationId, InventoryLedgerEventType type, int change, int after) {
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(locationId)
+                .eventType(type)
+                .changeInQuantity(change)
+                .quantityAfter(after)
+                .transactionUserId("i2-test")
+                .build());
+    }
+
+    private CycleCountTask task(String binLocation, String sku, int expectedQuantity) {
+        return taskRepository.save(CycleCountTask.builder()
+                .binLocation(binLocation)
+                .itemSku(sku)
+                .itemDescription("I2 test item")
+                .expectedQuantity(expectedQuantity)
+                .auditorId(AUDITOR)
+                .status(TaskStatus.ASSIGNED)
+                .countEntriesCount(0)
+                .build());
+    }
+
+    /** Forces adjustments into PENDING_APPROVAL (approval_tier is unique — seed once). */
+    private void ensureTier1ApprovalThreshold() {
+        boolean present = thresholdConfigRepository.findAll().stream()
+                .anyMatch(config -> config.getApprovalTier() == ApprovalTier.TIER_1_MANAGER);
+        if (!present) {
+            thresholdConfigRepository.save(ApprovalThresholdConfig.builder()
+                    .approvalTier(ApprovalTier.TIER_1_MANAGER)
+                    .unitVarianceThreshold(1)
+                    .valueVarianceThreshold(new BigDecimal("0.01"))
+                    .percentageVarianceThreshold(new BigDecimal("0.01"))
+                    .active(true)
+                    .build());
+        }
+    }
+
+    /** Movement timestamps must be strictly after the task snapshot. */
+    private static void tick() {
+        try {
+            Thread.sleep(10);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Test
+    @DisplayName("movement posted mid-count flags the task CONFLICT at submission")
+    void movementMidCount_flagsConflictAtSubmission() {
+        String sku = "SKU-I2-" + UUID.randomUUID();
+        UUID location = UUID.randomUUID();
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        CycleCountTask task = task(location.toString(), sku, 10);
+        tick();
+        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -3, 7);
+
+        CountResponse response = cycleCountService.submitCount(SubmitCountRequest.builder()
+                .taskId(task.getTaskId())
+                .auditorId(AUDITOR)
+                .actualQuantity(7)
+                .build());
+
+        assertThat(response.getTaskStatus()).isEqualTo(TaskStatus.CONFLICT);
+        assertThat(taskRepository.findById(task.getTaskId()).orElseThrow().getStatus())
+                .isEqualTo(TaskStatus.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("no movement in the window keeps the pre-I2 COUNTED_PENDING_REVIEW flow (regression)")
+    void noMovement_staysPendingReview() {
+        String sku = "SKU-I2-" + UUID.randomUUID();
+        UUID location = UUID.randomUUID();
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        CycleCountTask task = task(location.toString(), sku, 10);
+
+        CountResponse response = cycleCountService.submitCount(SubmitCountRequest.builder()
+                .taskId(task.getTaskId())
+                .auditorId(AUDITOR)
+                .actualQuantity(8)
+                .build());
+
+        assertThat(response.getTaskStatus()).isEqualTo(TaskStatus.COUNTED_PENDING_REVIEW);
+        assertThat(response.getVariance()).isEqualTo(-2);
+    }
+
+    @Test
+    @DisplayName("recount path from CONFLICT works and stays CONFLICT while movements remain in the window")
+    void recountFromConflict_works() {
+        String sku = "SKU-I2-" + UUID.randomUUID();
+        UUID location = UUID.randomUUID();
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        CycleCountTask task = task(location.toString(), sku, 10);
+        tick();
+        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -3, 7);
+
+        cycleCountService.submitCount(SubmitCountRequest.builder()
+                .taskId(task.getTaskId())
+                .auditorId(AUDITOR)
+                .actualQuantity(7)
+                .build());
+        assertThat(taskRepository.findById(task.getTaskId()).orElseThrow().getStatus())
+                .isEqualTo(TaskStatus.CONFLICT);
+
+        CountResponse recount = cycleCountService.submitRecount(SubmitRecountRequest.builder()
+                .taskId(task.getTaskId())
+                .auditorId(AUDITOR)
+                .actualQuantity(7)
+                .permission("TRIGGER_RECOUNT_SELF")
+                .build());
+
+        assertThat(recount.getRecountSequenceNumber()).isEqualTo(1);
+        // The snapshot is still stale — the movement remains in the window.
+        assertThat(recount.getTaskStatus()).isEqualTo(TaskStatus.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("approval on a CONFLICT task recomputes the variance against current on-hand before posting")
+    void approvalOnConflict_recomputesVarianceAgainstCurrentOnHand() {
+        ensureTier1ApprovalThreshold();
+
+        UUID stockItemId = UUID.randomUUID();
+        String sku = stockItemId.toString();
+        // Non-UUID bin ⇒ detection and recomputation both use the global
+        // (SKU-wide) on-hand math, like the adjustment posting path itself.
+        post(sku, null, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        CycleCountTask task = task("BIN-I2-APPROVE", sku, 10);
+        tick();
+        post(sku, null, InventoryLedgerEventType.GOODS_ISSUE, -3, 7);
+
+        CountResponse count = cycleCountService.submitCount(SubmitCountRequest.builder()
+                .taskId(task.getTaskId())
+                .auditorId(AUDITOR)
+                .actualQuantity(5)
+                .build());
+        assertThat(count.getTaskStatus()).isEqualTo(TaskStatus.CONFLICT);
+
+        AdjustmentResponse created = adjustmentService.createAdjustment(CreateAdjustmentRequest.builder()
+                .stockItemId(stockItemId)
+                .taskId(task.getTaskId())
+                .reasonCode("CYCLE_COUNT_VARIANCE")
+                .countedQuantity(5)
+                .quantityOnHandBefore(10) // stale snapshot: would imply -5
+                .costAtTimeOfAdjustment(new BigDecimal("10.00"))
+                .createdByUserId(AUDITOR)
+                .build());
+        assertThat(created.getStatus()).isEqualTo(AdjustmentStatus.PENDING_APPROVAL);
+
+        AdjustmentResponse approved = adjustmentService.approveAdjustment(
+                created.getAdjustmentId(), ApproveAdjustmentRequest.builder().build(), null);
+
+        // Recomputed against CURRENT on-hand (7), never the stale snapshot (10):
+        // counted 5 - current 7 = -2, not -5.
+        assertThat(approved.getStatus()).isEqualTo(AdjustmentStatus.POSTED);
+        assertThat(approved.getQuantityChange()).isEqualTo(-2);
+        assertThat(approved.getQuantityOnHandBefore()).isEqualTo(7);
+
+        InventoryLedgerEntry posted =
+                ledgerRepository.findByAdjustmentId(created.getAdjustmentId()).orElseThrow();
+        assertThat(posted.getEventType()).isEqualTo(InventoryLedgerEventType.COUNT_VARIANCE_OUT);
+        assertThat(posted.getChangeInQuantity()).isEqualTo(-2);
+
+        assertThat(taskRepository.findById(task.getTaskId()).orElseThrow().getStatus())
+                .isEqualTo(TaskStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("movements after a clean count are detected at approval: task flagged CONFLICT, approval rejected")
+    void approvalDetectsLateConflict_flagsTaskAndRejects() {
+        ensureTier1ApprovalThreshold();
+
+        UUID stockItemId = UUID.randomUUID();
+        String sku = stockItemId.toString();
+        post(sku, null, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        CycleCountTask task = task("BIN-I2-LATE", sku, 10);
+
+        CountResponse count = cycleCountService.submitCount(SubmitCountRequest.builder()
+                .taskId(task.getTaskId())
+                .auditorId(AUDITOR)
+                .actualQuantity(8)
+                .build());
+        assertThat(count.getTaskStatus()).isEqualTo(TaskStatus.COUNTED_PENDING_REVIEW);
+
+        AdjustmentResponse created = adjustmentService.createAdjustment(CreateAdjustmentRequest.builder()
+                .stockItemId(stockItemId)
+                .taskId(task.getTaskId())
+                .reasonCode("CYCLE_COUNT_VARIANCE")
+                .countedQuantity(8)
+                .quantityOnHandBefore(10)
+                .costAtTimeOfAdjustment(new BigDecimal("10.00"))
+                .createdByUserId(AUDITOR)
+                .build());
+        assertThat(created.getStatus()).isEqualTo(AdjustmentStatus.PENDING_APPROVAL);
+
+        // Movement lands between count and approval.
+        tick();
+        post(sku, null, InventoryLedgerEventType.GOODS_ISSUE, -4, 6);
+
+        assertThatExceptionOfType(CycleCountConflictException.class)
+                .isThrownBy(() -> adjustmentService.approveAdjustment(
+                        created.getAdjustmentId(),
+                        ApproveAdjustmentRequest.builder().build(),
+                        null));
+
+        // Task flagged in its own transaction; adjustment untouched.
+        assertThat(taskRepository.findById(task.getTaskId()).orElseThrow().getStatus())
+                .isEqualTo(TaskStatus.CONFLICT);
+        assertThat(adjustmentService.getAdjustment(created.getAdjustmentId()).getStatus())
+                .isEqualTo(AdjustmentStatus.PENDING_APPROVAL);
+
+        // Second approval is the explicit reviewer choice: recompute and post.
+        AdjustmentResponse approved = adjustmentService.approveAdjustment(
+                created.getAdjustmentId(), ApproveAdjustmentRequest.builder().build(), null);
+
+        // counted 8 - current 6 = +2 → COUNT_VARIANCE_IN.
+        assertThat(approved.getQuantityChange()).isEqualTo(2);
+        InventoryLedgerEntry posted =
+                ledgerRepository.findByAdjustmentId(created.getAdjustmentId()).orElseThrow();
+        assertThat(posted.getEventType()).isEqualTo(InventoryLedgerEventType.COUNT_VARIANCE_IN);
+        assertThat(posted.getChangeInQuantity()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("interfering-movements listing contains exactly the in-window entries for the task's SKU/location")
+    void interferingMovements_listsExactlyInWindowEntries() {
+        String sku = "SKU-I2-" + UUID.randomUUID();
+        UUID location = UUID.randomUUID();
+        UUID otherLocation = UUID.randomUUID();
+        // Before the task snapshot — must NOT be listed.
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 5, 5);
+        CycleCountTask task = task(location.toString(), sku, 5);
+        tick();
+        // In-window entries at the task's location — must be listed, in order.
+        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -2, 3);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 3, 6);
+        // In-window but other location — must NOT be listed.
+        post(sku, otherLocation, InventoryLedgerEventType.GOODS_RECEIPT, 7, 7);
+
+        List<InterferingMovementResponse> movements = cycleCountService.getInterferingMovements(task.getTaskId());
+
+        assertThat(movements).hasSize(2);
+        assertThat(movements.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_ISSUE);
+        assertThat(movements.get(0).getChangeInQuantity()).isEqualTo(-2);
+        assertThat(movements.get(1).getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_RECEIPT);
+        assertThat(movements.get(1).getChangeInQuantity()).isEqualTo(3);
+        assertThat(movements)
+                .allSatisfy(movement -> assertThat(movement.getLocationId()).isEqualTo(location));
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingConcurrencyTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingConcurrencyTest.java
@@ -1,0 +1,101 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Concurrency IT for the stock summary upsert (issue #1024, A1 acceptance):
+ * parallel postings to the same (SKU, location) key must not lose updates —
+ * the final summary must equal {@code SUM(ledger)}. The row-level
+ * {@code SELECT ... FOR UPDATE} in {@code LedgerPostingServiceImpl}
+ * serializes the read-modify-write.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("LedgerPostingService concurrency — no lost summary updates")
+class LedgerPostingConcurrencyTest {
+
+    private static final int THREADS = 6;
+    private static final int POSTS_PER_THREAD = 20;
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
+    @Autowired
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    @Autowired
+    private InventoryStockSummaryRepository summaryRepository;
+
+    @Test
+    void concurrentPostingsToSameKey_finalSummaryEqualsLedgerSum() throws Exception {
+        String sku = "SKU-CONC-" + UUID.randomUUID();
+        UUID location = UUID.randomUUID();
+
+        CountDownLatch startGate = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(THREADS);
+        try {
+            List<Callable<Void>> workers = new ArrayList<>();
+            for (int workerIndex = 0; workerIndex < THREADS; workerIndex++) {
+                int delta = workerIndex + 1;
+                workers.add(() -> {
+                    startGate.await();
+                    for (int post = 0; post < POSTS_PER_THREAD; post++) {
+                        InventoryLedgerEventType type = post % 3 == 2
+                                ? InventoryLedgerEventType.GOODS_ISSUE
+                                : InventoryLedgerEventType.GOODS_RECEIPT;
+                        int change = type == InventoryLedgerEventType.GOODS_ISSUE ? -delta : delta;
+                        ledgerPostingService.post(InventoryLedgerEntry.builder()
+                                .stockItemId(sku)
+                                .locationId(location)
+                                .eventType(type)
+                                .changeInQuantity(change)
+                                .quantityAfter(0)
+                                .transactionUserId("concurrency-test")
+                                .build());
+                    }
+                    return null;
+                });
+            }
+
+            List<Future<Void>> futures = workers.stream().map(executor::submit).toList();
+            startGate.countDown();
+            for (Future<Void> future : futures) {
+                future.get(120, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        long ledgerSum = ledgerRepository
+                .calculateOnHandQuantityAtLocation(sku, location)
+                .longValue();
+        InventoryStockSummary summary =
+                summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
+
+        assertThat(summary.getOnHand())
+                .as("summary on-hand must equal SUM(ledger) — no lost updates")
+                .isEqualTo(ledgerSum);
+        // Exactly one summary row despite the first-post creation race.
+        assertThat(summaryRepository.findByStockItemId(sku)).hasSize(1);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingServiceImplTest.java
@@ -113,12 +113,15 @@ class LedgerPostingServiceImplTest {
     void post_nullLocationEntry_aggregatesOnNullLocationRow() {
         String sku = uniqueSku();
 
+        // K1 (#1027): consumption may no longer drive on-hand negative, so seed
+        // the null-location row before consuming from it.
+        ledgerPostingService.post(entry(sku, null, InventoryLedgerEventType.GOODS_RECEIPT, 5));
         ledgerPostingService.post(entry(sku, null, InventoryLedgerEventType.WORKORDER_CONSUMPTION, -3));
         ledgerPostingService.post(entry(sku, null, InventoryLedgerEventType.RETURN_TO_STOCK, 1));
 
         InventoryStockSummary summary =
                 summaryRepository.findByStockItemIdAndLocationIdIsNull(sku).orElseThrow();
-        assertThat(summary.getOnHand()).isEqualTo(-2);
+        assertThat(summary.getOnHand()).isEqualTo(3);
     }
 
     @Test
@@ -127,18 +130,21 @@ class LedgerPostingServiceImplTest {
         UUID locationA = UUID.randomUUID();
         UUID locationB = UUID.randomUUID();
 
+        // K1 (#1027): TRANSFER_OUT is blocked below zero, so the batch seeds
+        // location A before dispatching from it (exactly-to-zero is allowed).
         List<InventoryLedgerEntry> saved = ledgerPostingService.postAll(List.of(
+                entry(sku, locationA, InventoryLedgerEventType.GOODS_RECEIPT, 5),
                 entry(sku, locationA, InventoryLedgerEventType.TRANSFER_OUT, -5),
                 entry(sku, locationB, InventoryLedgerEventType.TRANSFER_IN, 5),
                 entry(sku, locationB, InventoryLedgerEventType.GOODS_RECEIPT, 2)));
 
-        assertThat(saved).hasSize(3);
+        assertThat(saved).hasSize(4);
         assertThat(saved.getFirst().getLedgerEntryId()).isNotNull();
         assertThat(summaryRepository
                         .findByStockItemIdAndLocationId(sku, locationA)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(-5);
+                .isZero();
         assertThat(summaryRepository
                         .findByStockItemIdAndLocationId(sku, locationB)
                         .orElseThrow()

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingServiceImplTest.java
@@ -1,0 +1,148 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Integration tests for the single ledger posting path and its
+ * same-transaction stock summary maintenance (issue #1024, A1).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("LedgerPostingService stock summary maintenance")
+class LedgerPostingServiceImplTest {
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
+    @Autowired
+    private InventoryStockSummaryRepository summaryRepository;
+
+    private static String uniqueSku() {
+        return "SKU-" + UUID.randomUUID();
+    }
+
+    private InventoryLedgerEntry entry(String sku, UUID locationId, InventoryLedgerEventType type, int change) {
+        return InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(locationId)
+                .eventType(type)
+                .changeInQuantity(change)
+                .quantityAfter(0)
+                .transactionUserId("posting-test")
+                .build();
+    }
+
+    @Test
+    void post_onHandEvent_createsAndUpdatesSummaryRow() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+
+        InventoryLedgerEntry first =
+                ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 10));
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -4));
+
+        InventoryStockSummary summary =
+                summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
+        assertThat(summary.getOnHand()).isEqualTo(6);
+        assertThat(summary.getAllocated()).isZero();
+        assertThat(summary.getAtp()).isEqualTo(6);
+        assertThat(summary.getLastLedgerEntryId()).isNotNull();
+        assertThat(summary.getLastLedgerEntryId()).isNotEqualTo(first.getLedgerEntryId());
+        assertThat(summary.getLastEventAt()).isNotNull();
+    }
+
+    @Test
+    void post_allocationEvents_updateAllocatedAndAtp() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 100));
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.ALLOCATION_CREATED, 30));
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.ALLOCATION_RELEASED, 10));
+
+        InventoryStockSummary summary =
+                summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
+        assertThat(summary.getOnHand()).isEqualTo(100);
+        assertThat(summary.getAllocated()).isEqualTo(20);
+        assertThat(summary.getAtp()).isEqualTo(80);
+    }
+
+    @Test
+    void post_reservationEvents_updateReservedOnly() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 50));
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.RESERVATION_CREATED, 20));
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.RESERVATION_RELEASED, 5));
+
+        InventoryStockSummary summary =
+                summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
+        assertThat(summary.getOnHand()).isEqualTo(50);
+        assertThat(summary.getAllocated()).isZero();
+        assertThat(summary.getReserved()).isEqualTo(15);
+        // ATP per ADR-0001 subtracts allocations only.
+        assertThat(summary.getAtp()).isEqualTo(50);
+    }
+
+    @Test
+    void post_trackingOnlyEvent_createsNoSummaryRow() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.BACKORDER_CREATED, 5));
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.PICK_TASK_CREATED, 5));
+
+        assertThat(summaryRepository.findByStockItemIdAndLocationId(sku, location))
+                .isEmpty();
+    }
+
+    @Test
+    void post_nullLocationEntry_aggregatesOnNullLocationRow() {
+        String sku = uniqueSku();
+
+        ledgerPostingService.post(entry(sku, null, InventoryLedgerEventType.WORKORDER_CONSUMPTION, -3));
+        ledgerPostingService.post(entry(sku, null, InventoryLedgerEventType.RETURN_TO_STOCK, 1));
+
+        InventoryStockSummary summary =
+                summaryRepository.findByStockItemIdAndLocationIdIsNull(sku).orElseThrow();
+        assertThat(summary.getOnHand()).isEqualTo(-2);
+    }
+
+    @Test
+    void postAll_appliesBatchDeltasPerKey_andReturnsEntriesInOrder() {
+        String sku = uniqueSku();
+        UUID locationA = UUID.randomUUID();
+        UUID locationB = UUID.randomUUID();
+
+        List<InventoryLedgerEntry> saved = ledgerPostingService.postAll(List.of(
+                entry(sku, locationA, InventoryLedgerEventType.TRANSFER_OUT, -5),
+                entry(sku, locationB, InventoryLedgerEventType.TRANSFER_IN, 5),
+                entry(sku, locationB, InventoryLedgerEventType.GOODS_RECEIPT, 2)));
+
+        assertThat(saved).hasSize(3);
+        assertThat(saved.getFirst().getLedgerEntryId()).isNotNull();
+        assertThat(summaryRepository
+                        .findByStockItemIdAndLocationId(sku, locationA)
+                        .orElseThrow()
+                        .getOnHand())
+                .isEqualTo(-5);
+        assertThat(summaryRepository
+                        .findByStockItemIdAndLocationId(sku, locationB)
+                        .orElseThrow()
+                        .getOnHand())
+                .isEqualTo(7);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/NegativeStockPolicyEnforcementTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/NegativeStockPolicyEnforcementTest.java
@@ -1,0 +1,305 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.exception.InsufficientStockException;
+import com.positivity.inventory.internal.exception.NegativeStockPolicyViolationException;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Per-event-type integration tests for the negative-stock policy matrix
+ * enforced inside the ledger posting funnel (odoo-parity K1, issue #1027).
+ *
+ * <p>Matrix under test (see {@code docs/negative-stock-policy.md}):
+ * <ul>
+ *   <li>GOODS_ISSUE / WORKORDER_CONSUMPTION / TRANSFER_OUT — blocked below zero
+ *       ({@link InsufficientStockException}, pre-K1 error contract);</li>
+ *   <li>SCRAP_OUT — blocked below zero unless the caller passes the explicit
+ *       negative-stock override flag;</li>
+ *   <li>ADJUSTMENT_OUT / COUNT_VARIANCE_OUT / ADJUST_CYCLE_COUNT — floor at
+ *       zero, never overridable;</li>
+ *   <li>GOODS_RECEIPT / TRANSFER_IN / PUTAWAY / RETURN_TO_STOCK /
+ *       ADJUSTMENT_IN / COUNT_VARIANCE_IN — unconstrained;</li>
+ *   <li>neutral/ATP-only types — untouched by the matrix.</li>
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("Negative-stock policy matrix enforcement in the ledger posting funnel (K1)")
+class NegativeStockPolicyEnforcementTest {
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
+    @Autowired
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    @Autowired
+    private InventoryStockSummaryRepository summaryRepository;
+
+    private static String uniqueSku() {
+        return "SKU-K1-" + UUID.randomUUID();
+    }
+
+    private InventoryLedgerEntry entry(String sku, UUID locationId, InventoryLedgerEventType type, int change) {
+        return InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(locationId)
+                .eventType(type)
+                .changeInQuantity(change)
+                .quantityAfter(0)
+                .transactionUserId("k1-policy-test")
+                .build();
+    }
+
+    private void seed(String sku, UUID location, int quantity) {
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, quantity));
+    }
+
+    private long onHand(String sku, UUID location) {
+        return summaryRepository
+                .findByStockItemIdAndLocationId(sku, location)
+                .orElseThrow()
+                .getOnHand();
+    }
+
+    // ─── BLOCKED: GOODS_ISSUE / WORKORDER_CONSUMPTION / TRANSFER_OUT ─────────
+
+    @Test
+    void goodsIssue_belowZero_isBlockedWithInsufficientStock() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 5);
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() ->
+                        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -8)));
+
+        assertThat(onHand(sku, location)).isEqualTo(5);
+        assertThat(ledgerRepository.findByStockItemIdOrderByTimestampAsc(sku)).hasSize(1);
+    }
+
+    @Test
+    void workorderConsumption_belowZero_isBlockedWithInsufficientStock() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 2);
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() -> ledgerPostingService.post(
+                        entry(sku, location, InventoryLedgerEventType.WORKORDER_CONSUMPTION, -3)));
+
+        assertThat(onHand(sku, location)).isEqualTo(2);
+    }
+
+    @Test
+    void transferOut_belowZero_isBlockedWithInsufficientStock() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 1);
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() ->
+                        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.TRANSFER_OUT, -2)));
+
+        assertThat(onHand(sku, location)).isEqualTo(1);
+    }
+
+    @Test
+    void goodsIssue_exactlyToZero_isAllowed() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 5);
+
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -5));
+
+        assertThat(onHand(sku, location)).isZero();
+    }
+
+    // ─── BLOCKED_OVERRIDABLE: SCRAP_OUT ──────────────────────────────────────
+
+    @Test
+    void scrapOut_belowZero_withoutOverride_isRejectedWithOverrideRequiredCode() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 3);
+
+        assertThatExceptionOfType(NegativeStockPolicyViolationException.class)
+                .isThrownBy(
+                        () -> ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.SCRAP_OUT, -4)))
+                .satisfies(ex -> assertThat(ex.getErrorCode())
+                        .isEqualTo(NegativeStockPolicyViolationException.OVERRIDE_REQUIRED));
+
+        assertThat(onHand(sku, location)).isEqualTo(3);
+    }
+
+    @Test
+    void scrapOut_belowZero_withOverride_isAllowed() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 3);
+
+        // Caller has already verified inventory:adjustment:override and passes
+        // the explicit flag — the funnel never reads the security context.
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.SCRAP_OUT, -5), true);
+
+        assertThat(onHand(sku, location)).isEqualTo(-2);
+    }
+
+    @Test
+    void scrapOut_exactlyToZero_withoutOverride_isAllowed() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 3);
+
+        assertThatCode(() -> ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.SCRAP_OUT, -3)))
+                .doesNotThrowAnyException();
+
+        assertThat(onHand(sku, location)).isZero();
+    }
+
+    // ─── FLOOR_AT_ZERO: ADJUSTMENT_OUT / COUNT_VARIANCE_OUT ──────────────────
+
+    @Test
+    void adjustmentOut_belowZero_isRejectedEvenWithOverride() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 2);
+
+        assertThatExceptionOfType(NegativeStockPolicyViolationException.class)
+                .isThrownBy(() -> ledgerPostingService.post(
+                        entry(sku, location, InventoryLedgerEventType.ADJUSTMENT_OUT, -3), true))
+                .satisfies(ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(NegativeStockPolicyViolationException.FLOOR_VIOLATION));
+
+        assertThat(onHand(sku, location)).isEqualTo(2);
+    }
+
+    @Test
+    void adjustmentOut_exactlyToZero_isAllowed() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 2);
+
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.ADJUSTMENT_OUT, -2));
+
+        assertThat(onHand(sku, location)).isZero();
+    }
+
+    @Test
+    void countVarianceOut_belowZero_isRejected_andExactlyToZeroAllowed() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 4);
+
+        assertThatExceptionOfType(NegativeStockPolicyViolationException.class)
+                .isThrownBy(() -> ledgerPostingService.post(
+                        entry(sku, location, InventoryLedgerEventType.COUNT_VARIANCE_OUT, -5)))
+                .satisfies(ex ->
+                        assertThat(ex.getErrorCode()).isEqualTo(NegativeStockPolicyViolationException.FLOOR_VIOLATION));
+
+        // Counts set reality: zeroing the balance is legitimate.
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.COUNT_VARIANCE_OUT, -4));
+
+        assertThat(onHand(sku, location)).isZero();
+    }
+
+    // ─── UNCONSTRAINED: inbound + paired-move types ──────────────────────────
+
+    @Test
+    void putawaySourceDecrement_belowZero_isUnconstrained() {
+        String sku = uniqueSku();
+        UUID stagingLocation = UUID.randomUUID();
+
+        // Paired putaway moves decrement the source location with the same
+        // PUTAWAY event type; the matrix leaves them unconstrained (the putaway
+        // services validate source on-hand themselves).
+        ledgerPostingService.post(entry(sku, stagingLocation, InventoryLedgerEventType.PUTAWAY, -4));
+
+        assertThat(onHand(sku, stagingLocation)).isEqualTo(-4);
+    }
+
+    @Test
+    void inboundTypes_areUnconstrained() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+
+        assertThatCode(() -> ledgerPostingService.postAll(List.of(
+                        entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 1),
+                        entry(sku, location, InventoryLedgerEventType.TRANSFER_IN, 1),
+                        entry(sku, location, InventoryLedgerEventType.RETURN_TO_STOCK, 1),
+                        entry(sku, location, InventoryLedgerEventType.ADJUSTMENT_IN, 1),
+                        entry(sku, location, InventoryLedgerEventType.COUNT_VARIANCE_IN, 1))))
+                .doesNotThrowAnyException();
+
+        assertThat(onHand(sku, location)).isEqualTo(5);
+    }
+
+    // ─── Neutral/ATP-only types: untouched by the matrix ─────────────────────
+
+    @Test
+    void neutralAtpOnlyTypes_areUntouchedByTheMatrix() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seed(sku, location, 1);
+
+        // Reservations/allocations far beyond on-hand are an ATP concern
+        // (InsufficientAtpException at the caller), never a negative-stock one.
+        assertThatCode(() -> ledgerPostingService.postAll(List.of(
+                        entry(sku, location, InventoryLedgerEventType.RESERVATION_CREATED, 100),
+                        entry(sku, location, InventoryLedgerEventType.ALLOCATION_CREATED, 100),
+                        entry(sku, location, InventoryLedgerEventType.BACKORDER_CREATED, 100),
+                        entry(sku, location, InventoryLedgerEventType.PICK_TASK_CREATED, 100))))
+                .doesNotThrowAnyException();
+
+        assertThat(onHand(sku, location)).isEqualTo(1);
+    }
+
+    // ─── Batch semantics ─────────────────────────────────────────────────────
+
+    @Test
+    void batchViolation_rollsBackWholePosting() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+
+        assertThatExceptionOfType(InsufficientStockException.class)
+                .isThrownBy(() -> ledgerPostingService.postAll(List.of(
+                        entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 5),
+                        entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -8))));
+
+        // Single enforcement point inside the posting transaction: the valid
+        // receipt rolls back together with the rejected issue. (The summary row
+        // itself is created in a REQUIRES_NEW nested transaction and may remain
+        // as an empty zero-balance row.)
+        assertThat(ledgerRepository.findByStockItemIdOrderByTimestampAsc(sku)).isEmpty();
+        assertThat(summaryRepository
+                        .findByStockItemIdAndLocationId(sku, location)
+                        .map(row -> row.getOnHand())
+                        .orElse(0L))
+                .isZero();
+    }
+
+    @Test
+    void batchReplay_isSequential_receiptBeforeIssueInSameBatchIsAllowed() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+
+        ledgerPostingService.postAll(List.of(
+                entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 5),
+                entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -5)));
+
+        assertThat(onHand(sku, location)).isZero();
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryReadBenchmarkTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryReadBenchmarkTest.java
@@ -1,0 +1,122 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import com.positivity.inventory.service.InventoryAvailabilityService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Benchmark harness for the stock summary read model (issue #1024, A1
+ * acceptance: availability P95 &lt; 200 ms with a large ledger). NOT part of
+ * the regular suite — {@code @Disabled}; remove the annotation (or run with
+ * {@code -Dtest=StockSummaryReadBenchmarkTest} after enabling) to execute
+ * manually. Sizing knobs:
+ *
+ * <ul>
+ *   <li>{@code -Dbenchmark.ledger-rows} (default 100000) — ledger entries to seed</li>
+ *   <li>{@code -Dbenchmark.skus} (default 200) — distinct stock items</li>
+ *   <li>{@code -Dbenchmark.locations} (default 50) — distinct locations</li>
+ *   <li>{@code -Dbenchmark.reads} (default 500) — measured availability reads</li>
+ * </ul>
+ *
+ * <p>Note: the test profile runs H2 in-memory; representative numbers require
+ * pointing the datasource at a production-shaped PostgreSQL instance.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Tag("benchmark")
+@Disabled("benchmark harness — run manually, never in CI")
+class StockSummaryReadBenchmarkTest {
+
+    @Autowired
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    @Autowired
+    private InventoryStockSummaryRepository summaryRepository;
+
+    @Autowired
+    private StockSummaryRebuildService rebuildService;
+
+    @Autowired
+    private InventoryAvailabilityService availabilityService;
+
+    @Test
+    void measureSummaryReadLatencyOverLargeLedger() {
+        int ledgerRows = Integer.getInteger("benchmark.ledger-rows", 100_000);
+        int skuCount = Integer.getInteger("benchmark.skus", 200);
+        int locationCount = Integer.getInteger("benchmark.locations", 50);
+        int reads = Integer.getInteger("benchmark.reads", 500);
+
+        Random random = new Random(42);
+        List<UUID> skus = new ArrayList<>(skuCount);
+        for (int i = 0; i < skuCount; i++) {
+            skus.add(UUID.randomUUID());
+        }
+        List<UUID> locations = new ArrayList<>(locationCount);
+        for (int i = 0; i < locationCount; i++) {
+            locations.add(UUID.randomUUID());
+        }
+
+        // Seed the ledger directly in batches (bulk load, not the posting
+        // funnel), then rebuild the summary from it — mirroring a backfill.
+        List<InventoryLedgerEntry> batch = new ArrayList<>(1000);
+        for (int i = 0; i < ledgerRows; i++) {
+            boolean issue = random.nextInt(4) == 0;
+            batch.add(InventoryLedgerEntry.builder()
+                    .stockItemId(skus.get(random.nextInt(skuCount)).toString())
+                    .locationId(locations.get(random.nextInt(locationCount)))
+                    .eventType(issue ? InventoryLedgerEventType.GOODS_ISSUE : InventoryLedgerEventType.GOODS_RECEIPT)
+                    .changeInQuantity(issue ? -random.nextInt(3) : 1 + random.nextInt(10))
+                    .quantityAfter(0)
+                    .transactionUserId("benchmark")
+                    .build());
+            if (batch.size() == 1000) {
+                ledgerRepository.saveAll(batch);
+                batch.clear();
+            }
+        }
+        if (!batch.isEmpty()) {
+            ledgerRepository.saveAll(batch);
+        }
+
+        long rebuildStart = System.nanoTime();
+        int summaryRows = rebuildService.rebuildFromLedger();
+        long rebuildMillis = (System.nanoTime() - rebuildStart) / 1_000_000;
+
+        long[] latenciesMicros = new long[reads];
+        for (int i = 0; i < reads; i++) {
+            UUID sku = skus.get(random.nextInt(skuCount));
+            long start = System.nanoTime();
+            availabilityService.getAvailabilityByProduct(sku);
+            latenciesMicros[i] = (System.nanoTime() - start) / 1_000;
+        }
+        Arrays.sort(latenciesMicros);
+        long p50 = latenciesMicros[reads / 2];
+        long p95 = latenciesMicros[(int) (reads * 0.95)];
+        long p99 = latenciesMicros[(int) (reads * 0.99)];
+
+        // Plain stdout on purpose: benchmark output, not application logging.
+        System.out.printf(
+                "stock-summary benchmark: ledgerRows=%d summaryRows=%d rebuildMs=%d readP50us=%d readP95us=%d readP99us=%d%n",
+                ledgerRows, summaryRows, rebuildMillis, p50, p95, p99);
+
+        assertThat(summaryRepository.count()).isEqualTo(summaryRows);
+        assertThat(p95)
+                .as("availability P95 must stay under 200ms (A1 acceptance)")
+                .isLessThan(200_000L);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryRebuildAndDriftTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryRebuildAndDriftTest.java
@@ -69,6 +69,9 @@ class StockSummaryRebuildAndDriftTest {
         post(skuA, loc1, InventoryLedgerEventType.ALLOCATION_CREATED, 15);
         post(skuA, loc2, InventoryLedgerEventType.TRANSFER_IN, 7);
         post(skuB, loc1, InventoryLedgerEventType.GOODS_RECEIPT, 3);
+        // K1 (#1027): consumption may not drive on-hand negative — seed the
+        // null-location key before consuming from it.
+        post(skuB, null, InventoryLedgerEventType.GOODS_RECEIPT, 6);
         post(skuB, null, InventoryLedgerEventType.WORKORDER_CONSUMPTION, -2);
         post(skuB, loc1, InventoryLedgerEventType.RESERVATION_CREATED, 1);
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryRebuildAndDriftTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryRebuildAndDriftTest.java
@@ -1,0 +1,140 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Rebuild + drift-verifier tests (issue #1024, A1): the ledger is the source
+ * of truth; a rebuild reconstructs the summary exactly and the verifier
+ * reports (but never repairs) mismatches.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("Stock summary rebuild and drift verification")
+class StockSummaryRebuildAndDriftTest {
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
+    @Autowired
+    private StockSummaryRebuildService rebuildService;
+
+    @Autowired
+    private StockSummaryDriftVerifier driftVerifier;
+
+    @Autowired
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    @Autowired
+    private InventoryStockSummaryRepository summaryRepository;
+
+    @BeforeEach
+    void cleanSlate() {
+        // These tests assert whole-table invariants; start from empty tables.
+        summaryRepository.deleteAll();
+        ledgerRepository.deleteAll();
+    }
+
+    private void post(String sku, UUID location, InventoryLedgerEventType type, int change) {
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(location)
+                .eventType(type)
+                .changeInQuantity(change)
+                .quantityAfter(0)
+                .transactionUserId("rebuild-test")
+                .build());
+    }
+
+    @Test
+    void rebuild_reconstructsSummaryIdenticallyFromLedger() {
+        String skuA = "SKU-A-" + UUID.randomUUID();
+        String skuB = "SKU-B-" + UUID.randomUUID();
+        UUID loc1 = UUID.randomUUID();
+        UUID loc2 = UUID.randomUUID();
+
+        post(skuA, loc1, InventoryLedgerEventType.GOODS_RECEIPT, 40);
+        post(skuA, loc1, InventoryLedgerEventType.ALLOCATION_CREATED, 15);
+        post(skuA, loc2, InventoryLedgerEventType.TRANSFER_IN, 7);
+        post(skuB, loc1, InventoryLedgerEventType.GOODS_RECEIPT, 3);
+        post(skuB, null, InventoryLedgerEventType.WORKORDER_CONSUMPTION, -2);
+        post(skuB, loc1, InventoryLedgerEventType.RESERVATION_CREATED, 1);
+
+        var liveRows = summaryRepository.findAll();
+
+        int rebuilt = rebuildService.rebuildFromLedger();
+
+        assertThat(rebuilt).isEqualTo(liveRows.size());
+        for (InventoryStockSummary live : liveRows) {
+            InventoryStockSummary rebuiltRow = (live.getLocationId() == null
+                            ? summaryRepository.findByStockItemIdAndLocationIdIsNull(live.getStockItemId())
+                            : summaryRepository.findByStockItemIdAndLocationId(
+                                    live.getStockItemId(), live.getLocationId()))
+                    .orElseThrow();
+            assertThat(rebuiltRow.getOnHand()).isEqualTo(live.getOnHand());
+            assertThat(rebuiltRow.getAllocated()).isEqualTo(live.getAllocated());
+            assertThat(rebuiltRow.getReserved()).isEqualTo(live.getReserved());
+            assertThat(rebuiltRow.getAtp()).isEqualTo(live.getAtp());
+            assertThat(rebuiltRow.getLastLedgerEntryId()).isEqualTo(live.getLastLedgerEntryId());
+        }
+
+        assertThat(driftVerifier.verify()).isZero();
+    }
+
+    @Test
+    void verifier_reportsDriftWithoutMutating() {
+        String sku = "SKU-DRIFT-" + UUID.randomUUID();
+        UUID location = UUID.randomUUID();
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 25);
+
+        assertThat(driftVerifier.verify()).isZero();
+
+        // Corrupt the summary out-of-band (simulating a bypassing write).
+        InventoryStockSummary row =
+                summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
+        row.setOnHand(999);
+        summaryRepository.save(row);
+
+        int drifted = driftVerifier.verify();
+        assertThat(drifted).isEqualTo(1);
+
+        // Report-only: the corrupted value must still be there.
+        assertThat(summaryRepository
+                        .findByStockItemIdAndLocationId(sku, location)
+                        .orElseThrow()
+                        .getOnHand())
+                .isEqualTo(999);
+
+        // Repair path is the rebuild.
+        rebuildService.rebuildFromLedger();
+        assertThat(summaryRepository
+                        .findByStockItemIdAndLocationId(sku, location)
+                        .orElseThrow()
+                        .getOnHand())
+                .isEqualTo(25);
+        assertThat(driftVerifier.verify()).isZero();
+    }
+
+    @Test
+    void verifier_reportsMissingSummaryRowForLedgerBalance() {
+        String sku = "SKU-MISSING-" + UUID.randomUUID();
+        UUID location = UUID.randomUUID();
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 5);
+
+        summaryRepository.deleteAll();
+
+        assertThat(driftVerifier.verify()).isEqualTo(1);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/AsnServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/AsnServiceImplTest.java
@@ -36,6 +36,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.PurchaseOrderLineRepository;
 import com.positivity.inventory.internal.repository.PurchaseOrderRepository;
 import com.positivity.inventory.internal.service.AsnServiceImpl;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.security.common.GatewaySecurityConstants;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -84,6 +85,9 @@ class AsnServiceImplTest {
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
     @Mock
+    private LedgerPostingService ledgerPostingService;
+
+    @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
     private AsnServiceImpl asnService;
@@ -98,6 +102,7 @@ class AsnServiceImplTest {
                 purchaseOrderRepository,
                 purchaseOrderLineRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 applicationEventPublisher);
         authenticateAs("asn-test-user");

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
@@ -18,6 +18,7 @@ import com.positivity.inventory.internal.exception.WorkorderConsumptionException
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.PickTaskRepository;
 import com.positivity.inventory.internal.service.ConsumptionServiceImpl;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +45,9 @@ class ConsumptionServiceImplTest {
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
     @Mock
+    private LedgerPostingService ledgerPostingService;
+
+    @Mock
     private com.positivity.inventory.internal.repository.ReservationRepository reservationRepository;
 
     @Mock
@@ -62,6 +66,7 @@ class ConsumptionServiceImplTest {
                 inventoryLedgerEntryRepository,
                 reservationRepository,
                 allocationRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 FIXED_CLOCK);
     }
@@ -92,7 +97,7 @@ class ConsumptionServiceImplTest {
                         .status(PickTaskStatus.PICKED)
                         .quantityPicked(4)
                         .build()));
-        when(inventoryLedgerEntryRepository.saveAll(any()))
+        when(ledgerPostingService.postAll(any()))
                 .thenReturn(List.of(
                         InventoryLedgerEntry.builder()
                                 .ledgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
@@ -120,7 +125,7 @@ class ConsumptionServiceImplTest {
         ConsumeItemsRequest request =
                 new ConsumeItemsRequest(workorderId, UUID.fromString("00000000-0000-0000-0000-000000000001"), null);
 
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenReturn(List.of());
+        when(ledgerPostingService.postAll(any())).thenReturn(List.of());
 
         ConsumptionResponse result = inMemoryService().consumePickedItems(request);
 
@@ -222,11 +227,11 @@ class ConsumptionServiceImplTest {
                 InventoryLedgerEntry.builder().ledgerEntryId(savedId).build();
         InventoryLedgerEntry savedTwo =
                 InventoryLedgerEntry.builder().ledgerEntryId(null).build();
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenReturn(List.of(savedOne, savedTwo));
+        when(ledgerPostingService.postAll(any())).thenReturn(List.of(savedOne, savedTwo));
 
         ConsumptionResponse response = service.consumePickedItems(request);
 
-        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        verify(ledgerPostingService).postAll(entriesCaptor.capture());
         assertThat(entriesCaptor.getValue()).hasSize(2);
         InventoryLedgerEntry firstEntry = entriesCaptor.getValue().getFirst();
         InventoryLedgerEntry secondEntry = entriesCaptor.getValue().get(1);
@@ -364,7 +369,7 @@ class ConsumptionServiceImplTest {
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
                 .thenReturn(0);
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
         ConsumeItemsRequest request = new ConsumeItemsRequest(
@@ -374,7 +379,7 @@ class ConsumptionServiceImplTest {
 
         service.consumePickedItems(request);
 
-        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        verify(ledgerPostingService).postAll(entriesCaptor.capture());
         List<InventoryLedgerEntry> entries = entriesCaptor.getValue();
         assertThat(entries).hasSize(2);
         InventoryLedgerEntry released = entries.get(1);
@@ -403,7 +408,7 @@ class ConsumptionServiceImplTest {
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
                 .thenReturn(0);
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
 
         ConsumeItemsRequest request = new ConsumeItemsRequest(
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
@@ -412,7 +417,7 @@ class ConsumptionServiceImplTest {
 
         service.consumePickedItems(request);
 
-        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        verify(ledgerPostingService).postAll(entriesCaptor.capture());
         InventoryLedgerEntry released = entriesCaptor.getValue().get(1);
         assertThat(released.getChangeInQuantity()).isEqualTo(2);
         assertThat(allocation.getStatus())
@@ -428,7 +433,7 @@ class ConsumptionServiceImplTest {
 
         when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(pickedTaskWithLine(pickTaskId)));
         when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.empty());
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
 
         ConsumeItemsRequest request = new ConsumeItemsRequest(
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
@@ -437,7 +442,7 @@ class ConsumptionServiceImplTest {
 
         service.consumePickedItems(request);
 
-        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        verify(ledgerPostingService).postAll(entriesCaptor.capture());
         assertThat(entriesCaptor.getValue()).hasSize(1);
         assertThat(entriesCaptor.getValue().getFirst().getEventType())
                 .isEqualTo(InventoryLedgerEventType.WORKORDER_CONSUMPTION);
@@ -459,7 +464,7 @@ class ConsumptionServiceImplTest {
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
                 .thenReturn(3);
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
         ConsumeItemsRequest request = new ConsumeItemsRequest(
@@ -469,7 +474,7 @@ class ConsumptionServiceImplTest {
 
         service.consumePickedItems(request);
 
-        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        verify(ledgerPostingService).postAll(entriesCaptor.capture());
         InventoryLedgerEntry released = entriesCaptor.getValue().get(1);
         // invariant: total RELEASED never exceeds allocatedQuantity (3 + 2 = 5)
         assertThat(released.getChangeInQuantity()).isEqualTo(2);
@@ -512,7 +517,7 @@ class ConsumptionServiceImplTest {
                         any(String.class),
                         org.mockito.ArgumentMatchers.eq(InventoryLedgerEventType.ALLOCATION_RELEASED)))
                 .thenReturn(0);
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
         when(reservationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -523,7 +528,7 @@ class ConsumptionServiceImplTest {
 
         service.consumePickedItems(request);
 
-        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        verify(ledgerPostingService).postAll(entriesCaptor.capture());
         List<InventoryLedgerEntry> entries = entriesCaptor.getValue();
         assertThat(entries).hasSize(3); // 1 consumption + 2 releases
         InventoryLedgerEntry first = entries.get(1);
@@ -560,7 +565,7 @@ class ConsumptionServiceImplTest {
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
                 .thenReturn(0);
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
         when(reservationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -573,7 +578,7 @@ class ConsumptionServiceImplTest {
 
         service.consumePickedItems(request);
 
-        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        verify(ledgerPostingService).postAll(entriesCaptor.capture());
         int totalReleased = entriesCaptor.getValue().stream()
                 .filter(e -> e.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
                 .mapToInt(InventoryLedgerEntry::getChangeInQuantity)
@@ -594,14 +599,14 @@ class ConsumptionServiceImplTest {
                 .quantityPicked(5)
                 .build();
         when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(task));
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
 
         service.consumePickedItems(new ConsumeItemsRequest(
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 List.of(new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 2))));
 
-        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        verify(ledgerPostingService).postAll(entriesCaptor.capture());
         assertThat(entriesCaptor.getValue()).hasSize(1);
     }
 
@@ -623,14 +628,14 @@ class ConsumptionServiceImplTest {
         when(pickTaskRepository.findById(pickTaskId)).thenReturn(Optional.of(pickedTaskWithLine(pickTaskId)));
         when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
         when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(soft));
-        when(inventoryLedgerEntryRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+        when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
 
         service.consumePickedItems(new ConsumeItemsRequest(
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 List.of(new ConsumeItemLine(pickTaskId, STOCK_ITEM_ID, 2))));
 
-        verify(inventoryLedgerEntryRepository).saveAll(entriesCaptor.capture());
+        verify(ledgerPostingService).postAll(entriesCaptor.capture());
         assertThat(entriesCaptor.getValue()).hasSize(1);
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/CycleCountAdjustmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/CycleCountAdjustmentServiceImplTest.java
@@ -18,6 +18,7 @@ import com.positivity.inventory.internal.enums.ApprovalTier;
 import com.positivity.inventory.internal.repository.CycleCountAdjustmentRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.service.CycleCountAdjustmentServiceImpl;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.security.common.GatewaySecurityConstants;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -55,6 +56,9 @@ class CycleCountAdjustmentServiceImplTest {
     private InventoryLedgerEntryRepository ledgerRepository;
 
     @Mock
+    private LedgerPostingService ledgerPostingService;
+
+    @Mock
     private ApprovalThresholdEvaluator thresholdEvaluator;
 
     @Mock
@@ -70,7 +74,12 @@ class CycleCountAdjustmentServiceImplTest {
     @BeforeEach
     void setUp() {
         service = new CycleCountAdjustmentServiceImpl(
-                adjustmentRepository, ledgerRepository, thresholdEvaluator, eventPublisher, clock);
+                adjustmentRepository,
+                ledgerRepository,
+                ledgerPostingService,
+                thresholdEvaluator,
+                eventPublisher,
+                clock);
     }
 
     @AfterEach
@@ -111,7 +120,7 @@ class CycleCountAdjustmentServiceImplTest {
             return adj;
         });
         when(ledgerRepository.calculateOnHandQuantity(STOCK_ITEM_ID)).thenReturn(10);
-        when(ledgerRepository.save(any(InventoryLedgerEntry.class))).thenAnswer(inv -> {
+        when(ledgerPostingService.post(any(InventoryLedgerEntry.class))).thenAnswer(inv -> {
             InventoryLedgerEntry entry = inv.getArgument(0);
             entry.setLedgerEntryId(ledgerId);
             return entry;
@@ -122,7 +131,7 @@ class CycleCountAdjustmentServiceImplTest {
         assertThat(response.getStatus()).isEqualTo(AdjustmentStatus.POSTED);
         assertThat(response.getApprovedByUserId()).isEqualTo("SYSTEM");
         assertThat(response.getLedgerEntryId()).isEqualTo(ledgerId);
-        verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -144,7 +153,7 @@ class CycleCountAdjustmentServiceImplTest {
 
         assertThat(response.getStatus()).isEqualTo(AdjustmentStatus.PENDING_APPROVAL);
         assertThat(response.getRequiredApprovalTier()).isEqualTo(ApprovalTier.TIER_1_MANAGER);
-        verify(ledgerRepository, never()).save(any());
+        verify(ledgerPostingService, never()).post(any());
         verify(ledgerRepository, never()).calculateOnHandQuantity(any(UUID.class));
     }
 
@@ -162,7 +171,7 @@ class CycleCountAdjustmentServiceImplTest {
         when(adjustmentRepository.findById(adjustmentId)).thenReturn(Optional.of(adjustment));
         when(adjustmentRepository.save(any(CycleCountAdjustment.class))).thenAnswer(inv -> inv.getArgument(0));
         when(ledgerRepository.calculateOnHandQuantity(STOCK_ITEM_ID)).thenReturn(10);
-        when(ledgerRepository.save(any(InventoryLedgerEntry.class))).thenAnswer(inv -> {
+        when(ledgerPostingService.post(any(InventoryLedgerEntry.class))).thenAnswer(inv -> {
             InventoryLedgerEntry entry = inv.getArgument(0);
             entry.setLedgerEntryId(ledgerId);
             return entry;
@@ -174,7 +183,7 @@ class CycleCountAdjustmentServiceImplTest {
 
         assertThat(response.getStatus()).isEqualTo(AdjustmentStatus.POSTED);
         assertThat(response.getApprovedByUserId()).isEqualTo(ACTOR_USERNAME);
-        verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
         verify(eventPublisher).publishEvent(any(Object.class));
     }
 
@@ -214,7 +223,7 @@ class CycleCountAdjustmentServiceImplTest {
         assertThat(response.getStatus()).isEqualTo(AdjustmentStatus.REJECTED);
         assertThat(response.getRejectedByUserId()).isEqualTo("mgr-001");
         assertThat(response.getRejectionReason()).isEqualTo("Count value seems incorrect");
-        verify(ledgerRepository, never()).save(any());
+        verify(ledgerPostingService, never()).post(any());
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/CycleCountAdjustmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/CycleCountAdjustmentServiceImplTest.java
@@ -64,6 +64,12 @@ class CycleCountAdjustmentServiceImplTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private com.positivity.inventory.internal.repository.CycleCountTaskRepository taskRepository;
+
+    @Mock
+    private com.positivity.inventory.internal.service.CycleCountConflictDetector conflictDetector;
+
     private CycleCountAdjustmentServiceImpl service;
 
     private static final String ACTOR_USER_ID = "actor-person-id-001";
@@ -79,7 +85,9 @@ class CycleCountAdjustmentServiceImplTest {
                 ledgerPostingService,
                 thresholdEvaluator,
                 eventPublisher,
-                clock);
+                clock,
+                taskRepository,
+                conflictDetector);
     }
 
     @AfterEach

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/CycleCountServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/CycleCountServiceImplTest.java
@@ -51,11 +51,15 @@ class CycleCountServiceImplTest {
     @Mock
     private CountEntryRepository countEntryRepository;
 
+    @Mock
+    private com.positivity.inventory.internal.service.CycleCountConflictDetector conflictDetector;
+
     private CycleCountServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        service = new CycleCountServiceImpl(taskRepository, countEntryRepository, Clock.systemDefaultZone());
+        service = new CycleCountServiceImpl(
+                taskRepository, countEntryRepository, Clock.systemDefaultZone(), conflictDetector);
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryAvailabilityServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryAvailabilityServiceImplTest.java
@@ -2,20 +2,19 @@ package com.positivity.inventory.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.inventory.internal.dto.AvailabilityView;
 import com.positivity.inventory.internal.dto.LocationAvailabilityDto;
-import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
-import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.exception.InvalidInventoryAvailabilityRequestException;
 import com.positivity.inventory.internal.exception.ProductNotFoundException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.service.InventoryAvailabilityServiceImpl;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,13 +22,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class InventoryAvailabilityServiceImplTest {
-    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
 
     private static final UUID LOC_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID LOC_2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
     private static final UUID SLOC_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    @Mock
+    private InventoryStockSummaryRepository stockSummaryRepository;
 
     @Mock
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
@@ -38,29 +41,25 @@ class InventoryAvailabilityServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new InventoryAvailabilityServiceImpl(inventoryLedgerEntryRepository);
+        service = new InventoryAvailabilityServiceImpl(stockSummaryRepository, inventoryLedgerEntryRepository);
     }
 
     @Test
-    void getAvailabilityByProduct_returnsEmptyWhenNoEntriesExist() {
+    void getAvailabilityByProduct_returnsEmptyWhenNoSummaryRowsExist() {
         UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of());
+        when(stockSummaryRepository.findByStockItemId(productId.toString())).thenReturn(List.of());
 
         List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
         assertThat(result).isEmpty();
-        verify(inventoryLedgerEntryRepository).findByStockItemIdOrderByTimestampAsc(productId.toString());
+        verify(stockSummaryRepository).findByStockItemId(productId.toString());
     }
 
     @Test
-    void getAvailabilityByProduct_skipsEntryWhenLocationIsMissing() {
+    void getAvailabilityByProduct_skipsNullLocationRow() {
         UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry onHandEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.GOODS_RECEIPT, 5, null);
-
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(onHandEntry));
+        when(stockSummaryRepository.findByStockItemId(productId.toString()))
+                .thenReturn(List.of(summary(productId.toString(), null, 5, 0, 0)));
 
         List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
@@ -70,13 +69,8 @@ class InventoryAvailabilityServiceImplTest {
     @Test
     void getAvailabilityByProduct_allowsNegativeAtpWhenReservationsExceedOnHand() {
         UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry onHandEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.GOODS_RECEIPT, 2, LOC_1);
-        InventoryLedgerEntry reservationEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.RESERVATION_CREATED, 5, LOC_1);
-
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(onHandEntry, reservationEntry));
+        when(stockSummaryRepository.findByStockItemId(productId.toString()))
+                .thenReturn(List.of(summary(productId.toString(), LOC_1, 2, 0, 5)));
 
         List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
@@ -84,6 +78,23 @@ class InventoryAvailabilityServiceImplTest {
         assertThat(result.getFirst().getLocationId()).isEqualTo(LOC_1);
         assertThat(result.getFirst().getOnHandQuantity()).isEqualTo(2);
         assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(-3);
+    }
+
+    @Test
+    void getAvailabilityByProduct_sortsRowsByLocationId() {
+        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        when(stockSummaryRepository.findByStockItemId(productId.toString()))
+                .thenReturn(List.of(
+                        summary(productId.toString(), LOC_2, 60, 0, 0),
+                        summary(productId.toString(), LOC_1, 40, 0, 0)));
+
+        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getLocationId()).isEqualTo(LOC_1);
+        assertThat(result.get(0).getOnHandQuantity()).isEqualTo(40);
+        assertThat(result.get(1).getLocationId()).isEqualTo(LOC_2);
+        assertThat(result.get(1).getOnHandQuantity()).isEqualTo(60);
     }
 
     @Test
@@ -96,8 +107,7 @@ class InventoryAvailabilityServiceImplTest {
     @Test
     void getAvailabilityByProduct_wrapsRepositoryErrors() {
         UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenThrow(new RuntimeException("db down"));
+        when(stockSummaryRepository.findByStockItemId(productId.toString())).thenThrow(new RuntimeException("db down"));
 
         assertThatThrownBy(() -> service.getAvailabilityByProduct(productId))
                 .isInstanceOf(IllegalStateException.class)
@@ -105,97 +115,21 @@ class InventoryAvailabilityServiceImplTest {
     }
 
     @Test
-    void getAvailabilityByProduct_skipsNullQuantityEntries() {
+    void getAvailabilityByProduct_subtractsAllocationsAndReservationsFromAtp() {
         UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry invalidEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.GOODS_RECEIPT, 1, LOC_1);
-        invalidEntry.setChangeInQuantity(null);
-
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(invalidEntry));
-
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    void getAvailabilityByProduct_skipsNullLedgerEntry() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(java.util.Arrays.asList(
-                        ledgerEntry(productId.toString(), InventoryLedgerEventType.GOODS_RECEIPT, 1, LOC_1), null));
-
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getOnHandQuantity()).isEqualTo(1);
-    }
-
-    @Test
-    void getAvailabilityByProduct_handlesNullEventType() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry entry = ledgerEntry(productId.toString(), null, 5, LOC_1);
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(entry));
+        when(stockSummaryRepository.findByStockItemId(productId.toString()))
+                .thenReturn(List.of(summary(productId.toString(), LOC_1, 100, 20, 30)));
 
         List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getOnHandQuantity()).isZero();
-        assertThat(result.get(0).getAvailableToPromiseQuantity()).isZero();
+        assertThat(result.getFirst().getOnHandQuantity()).isEqualTo(100);
+        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(50);
     }
 
     @Test
-    void queryAvailability_handlesNullChangeInQuantity() {
-        String productSku = "SKU-123";
-        UUID locationId = LOC_1;
-        InventoryLedgerEntry entry = ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId);
-        entry.setChangeInQuantity(null);
-
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku))
-                .thenReturn(List.of(entry));
-        when(inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(productSku, locationId))
-                .thenReturn(List.of(entry));
-
-        AvailabilityView result = service.queryAvailability(productSku, locationId, null, null);
-
-        assertThat(result.getOnHandQuantity()).isZero();
-        assertThat(result.getAllocatedQuantity()).isZero();
-        assertThat(result.getAvailableToPromiseQuantity()).isZero();
-    }
-
-    @Test
-    void getAvailabilityByProduct_handlesReservationReleased() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry reservationEntry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.RESERVATION_RELEASED, 5, LOC_1);
-
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(reservationEntry));
-
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
-
-        assertThat(result).hasSize(1);
-        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(5);
-    }
-
-    @Test
-    void getAvailabilityByProduct_handlesNullQuantityInSafeQuantity() {
-        UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        InventoryLedgerEntry entry =
-                ledgerEntry(productId.toString(), InventoryLedgerEventType.RESERVATION_CREATED, 1, LOC_1);
-        entry.setChangeInQuantity(null);
-
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString()))
-                .thenReturn(List.of(entry));
-
-        List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    void queryAvailability_throwsProductNotFoundException_whenNoEntriesExist() {
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc("SKU-123"))
-                .thenReturn(List.of());
+    void queryAvailability_throwsProductNotFoundException_whenNoSummaryRowsExist() {
+        when(stockSummaryRepository.findByStockItemId("SKU-123")).thenReturn(List.of());
 
         assertThatThrownBy(() -> service.queryAvailability("SKU-123", LOC_1, null, null))
                 .isInstanceOf(ProductNotFoundException.class)
@@ -205,64 +139,83 @@ class InventoryAvailabilityServiceImplTest {
     @Test
     void queryAvailability_calculatesCorrectly_withLocationAndStorageLocation() {
         String productSku = "SKU-123";
-        UUID locationId = LOC_1;
-        UUID storageLocationId = SLOC_A;
+        when(stockSummaryRepository.findByStockItemId(productSku))
+                .thenReturn(List.of(summary(productSku, LOC_1, 10, 0, 0), summary(productSku, SLOC_A, 5, 2, 0)));
+        when(inventoryLedgerEntryRepository.findUnitsOfMeasureByStockItemAtLocation(
+                        eq(productSku), eq(SLOC_A), any(Pageable.class)))
+                .thenReturn(List.of());
 
-        List<InventoryLedgerEntry> productEntries =
-                List.of(ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId));
-        List<InventoryLedgerEntry> locationEntries = List.of(
-                ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 5, storageLocationId),
-                ledgerEntry(productSku, InventoryLedgerEventType.ALLOCATION_CREATED, 2, storageLocationId));
-
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku))
-                .thenReturn(productEntries);
-        when(inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(
-                        productSku, storageLocationId))
-                .thenReturn(locationEntries);
-
-        AvailabilityView result = service.queryAvailability(productSku, locationId, storageLocationId, null);
+        AvailabilityView result = service.queryAvailability(productSku, LOC_1, SLOC_A, null);
 
         assertThat(result.getOnHandQuantity()).isEqualTo(5);
         assertThat(result.getAllocatedQuantity()).isEqualTo(2);
         assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(3);
-        assertThat(result.getStorageLocationId()).isEqualTo(storageLocationId);
+        assertThat(result.getStorageLocationId()).isEqualTo(SLOC_A);
+        assertThat(result.getUnitOfMeasure()).isEqualTo("EACH");
     }
 
     @Test
     void queryAvailability_calculatesCorrectly_withOnlyLocationId() {
         String productSku = "SKU-123";
-        UUID locationId = LOC_1;
+        when(stockSummaryRepository.findByStockItemId(productSku))
+                .thenReturn(List.of(summary(productSku, LOC_1, 10, 2, 7)));
+        when(inventoryLedgerEntryRepository.findUnitsOfMeasureByStockItemAtLocation(
+                        eq(productSku), eq(LOC_1), any(Pageable.class)))
+                .thenReturn(List.of("EA"));
 
-        List<InventoryLedgerEntry> productEntries =
-                List.of(ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId));
-        List<InventoryLedgerEntry> locationEntries = List.of(
-                ledgerEntry(productSku, InventoryLedgerEventType.GOODS_RECEIPT, 10, locationId),
-                ledgerEntry(productSku, InventoryLedgerEventType.ALLOCATION_CREATED, 3, locationId),
-                ledgerEntry(productSku, InventoryLedgerEventType.ALLOCATION_RELEASED, 1, locationId));
-
-        when(inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productSku))
-                .thenReturn(productEntries);
-        when(inventoryLedgerEntryRepository.findByStockItemIdAndLocationIdOrderByTimestampAsc(productSku, locationId))
-                .thenReturn(locationEntries);
-
-        AvailabilityView result = service.queryAvailability(productSku, locationId, null, null);
+        AvailabilityView result = service.queryAvailability(productSku, LOC_1, null, null);
 
         assertThat(result.getOnHandQuantity()).isEqualTo(10);
-        assertThat(result.getAllocatedQuantity()).isEqualTo(2); // 3 created - 1 released
+        // Per ADR-0001, allocatedQuantity counts hard allocations only, never reservations.
+        assertThat(result.getAllocatedQuantity()).isEqualTo(2);
         assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(8);
         assertThat(result.getStorageLocationId()).isNull();
+        assertThat(result.getUnitOfMeasure()).isEqualTo("EA");
     }
 
-    private InventoryLedgerEntry ledgerEntry(
-            String stockItemId, InventoryLedgerEventType eventType, int changeInQuantity, UUID locationId) {
-        return InventoryLedgerEntry.builder()
+    @Test
+    void queryAvailability_sumsAllRowsIncludingNullLocation_whenUnscoped() {
+        String productSku = "SKU-123";
+        when(stockSummaryRepository.findByStockItemId(productSku))
+                .thenReturn(List.of(
+                        summary(productSku, LOC_1, 10, 1, 0),
+                        summary(productSku, LOC_2, 5, 2, 0),
+                        summary(productSku, null, -3, 0, 0)));
+        when(inventoryLedgerEntryRepository.findUnitsOfMeasureByStockItem(eq(productSku), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        AvailabilityView result = service.queryAvailability(productSku, null, null, null);
+
+        assertThat(result.getOnHandQuantity()).isEqualTo(12);
+        assertThat(result.getAllocatedQuantity()).isEqualTo(3);
+        assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(9);
+    }
+
+    @Test
+    void queryAvailability_returnsZeroes_whenScopedLocationHasNoRow() {
+        String productSku = "SKU-123";
+        when(stockSummaryRepository.findByStockItemId(productSku))
+                .thenReturn(List.of(summary(productSku, LOC_1, 10, 0, 0)));
+        when(inventoryLedgerEntryRepository.findUnitsOfMeasureByStockItemAtLocation(
+                        eq(productSku), eq(LOC_2), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        AvailabilityView result = service.queryAvailability(productSku, LOC_2, null, null);
+
+        assertThat(result.getOnHandQuantity()).isZero();
+        assertThat(result.getAllocatedQuantity()).isZero();
+        assertThat(result.getAvailableToPromiseQuantity()).isZero();
+    }
+
+    private InventoryStockSummary summary(
+            String stockItemId, UUID locationId, long onHand, long allocated, long reserved) {
+        return InventoryStockSummary.builder()
                 .stockItemId(stockItemId)
-                .eventType(eventType)
-                .changeInQuantity(changeInQuantity)
-                .quantityAfter(0)
-                .transactionUserId("test-user")
-                .timestamp(Instant.now(TEST_CLOCK))
                 .locationId(locationId)
+                .onHand(onHand)
+                .allocated(allocated)
+                .reserved(reserved)
+                .atp(onHand - allocated)
                 .build();
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryLocationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryLocationServiceImplTest.java
@@ -120,12 +120,23 @@ class InventoryLocationServiceImplTest {
         return new LedgerPostingService() {
             @Override
             public InventoryLedgerEntry post(InventoryLedgerEntry entry) {
+                return post(entry, false);
+            }
+
+            @Override
+            public InventoryLedgerEntry post(InventoryLedgerEntry entry, boolean negativeStockOverride) {
                 persistedEntries.add(entry);
                 return entry;
             }
 
             @Override
             public List<InventoryLedgerEntry> postAll(List<InventoryLedgerEntry> entries) {
+                return postAll(entries, false);
+            }
+
+            @Override
+            public List<InventoryLedgerEntry> postAll(
+                    List<InventoryLedgerEntry> entries, boolean negativeStockOverride) {
                 persistedEntries.addAll(entries);
                 return entries;
             }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryLocationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryLocationServiceImplTest.java
@@ -7,6 +7,7 @@ import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.service.InventoryLocationServiceImpl;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import com.positivity.security.common.GatewaySecurityConstants;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -43,7 +44,8 @@ class InventoryLocationServiceImplTest {
         validations.put(sourceLocationId.toString(), validation(sourceLocationId, siteId, true, true));
 
         InventoryLocationServiceImpl service = new InventoryLocationServiceImpl(
-                stubLedgerRepository(List.of(), Map.of(), persistedEntries),
+                stubLedgerRepository(List.of(), Map.of()),
+                stubLedgerPostingService(persistedEntries),
                 new StubStorageLocationValidationService(validations),
                 eventPublisher(publishedEvents),
                 new SimpleMeterRegistry(),
@@ -76,9 +78,8 @@ class InventoryLocationServiceImplTest {
             validations.put(destinationLocationId.toString(), validation(destinationLocationId, siteId, true, true));
             InventoryLocationServiceImpl service = new InventoryLocationServiceImpl(
                     stubLedgerRepository(
-                            List.of(onHand("SKU-001", 5L)),
-                            Map.of(stockKey("SKU-001", destinationLocationId), 3),
-                            persistedEntries),
+                            List.of(onHand("SKU-001", 5L)), Map.of(stockKey("SKU-001", destinationLocationId), 3)),
+                    stubLedgerPostingService(persistedEntries),
                     new StubStorageLocationValidationService(validations),
                     eventPublisher(new ArrayList<>()),
                     new SimpleMeterRegistry(),
@@ -102,9 +103,7 @@ class InventoryLocationServiceImplTest {
     }
 
     private InventoryLedgerEntryRepository stubLedgerRepository(
-            List<InventoryLedgerEntryRepository.LocationOnHand> sourceRows,
-            Map<String, Integer> destinationOnHand,
-            List<InventoryLedgerEntry> persistedEntries) {
+            List<InventoryLedgerEntryRepository.LocationOnHand> sourceRows, Map<String, Integer> destinationOnHand) {
         return (InventoryLedgerEntryRepository) Proxy.newProxyInstance(
                 InventoryLedgerEntryRepository.class.getClassLoader(),
                 new Class[] {InventoryLedgerEntryRepository.class},
@@ -112,15 +111,25 @@ class InventoryLocationServiceImplTest {
                     case "findPositiveOnHandByLocation" -> sourceRows;
                     case "calculateOnHandQuantityAtLocation" ->
                         destinationOnHand.getOrDefault(stockKey((String) args[0], (UUID) args[1]), 0);
-                    case "saveAll" -> {
-                        for (Object entry : (Iterable<?>) args[0]) {
-                            persistedEntries.add((InventoryLedgerEntry) entry);
-                        }
-                        yield args[0];
-                    }
                     case "toString" -> "InventoryLedgerEntryRepositoryStub";
                     default -> defaultValue(method.getReturnType());
                 });
+    }
+
+    private LedgerPostingService stubLedgerPostingService(List<InventoryLedgerEntry> persistedEntries) {
+        return new LedgerPostingService() {
+            @Override
+            public InventoryLedgerEntry post(InventoryLedgerEntry entry) {
+                persistedEntries.add(entry);
+                return entry;
+            }
+
+            @Override
+            public List<InventoryLedgerEntry> postAll(List<InventoryLedgerEntry> entries) {
+                persistedEntries.addAll(entries);
+                return entries;
+            }
+        };
     }
 
     private ApplicationEventPublisher eventPublisher(List<Object> events) {

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryInquiryServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryInquiryServiceImplTest.java
@@ -1,15 +1,15 @@
 package com.positivity.inventory.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
 import com.positivity.inventory.internal.dto.LocationInventoryItemsResponse;
-import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
-import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository.LocationOnHand;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.service.LocationInventoryInquiryServiceImpl;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,7 +17,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * Unit tests for {@link LocationInventoryInquiryServiceImpl#listLocationInventoryItems}.
+ * Unit tests for {@link LocationInventoryInquiryServiceImpl} backed by the
+ * stock summary read model (issue #1024, A1).
  */
 @ExtendWith(MockitoExtension.class)
 class LocationInventoryInquiryServiceImplTest {
@@ -25,27 +26,23 @@ class LocationInventoryInquiryServiceImplTest {
     private static final UUID LOCATION_ID = UUID.fromString("01960004-0001-7000-8000-000000000047");
 
     @Mock
-    private InventoryLedgerEntryRepository ledgerRepository;
+    private InventoryStockSummaryRepository stockSummaryRepository;
 
-    private LocationOnHand onHand(String sku, Long qty) {
-        return new LocationOnHand() {
-            @Override
-            public String getStockItemId() {
-                return sku;
-            }
-
-            @Override
-            public Long getOnHandQuantity() {
-                return qty;
-            }
-        };
+    private InventoryStockSummary summary(String sku, long onHand, long allocated) {
+        return InventoryStockSummary.builder()
+                .stockItemId(sku)
+                .locationId(LOCATION_ID)
+                .onHand(onHand)
+                .allocated(allocated)
+                .atp(onHand - allocated)
+                .build();
     }
 
     @Test
     void listLocationInventoryItems_mapsPositiveOnHandRowsToItems() {
-        var service = new LocationInventoryInquiryServiceImpl(ledgerRepository);
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(LOCATION_ID), any()))
-                .thenReturn(List.of(onHand("MICH-XC2-0001", 24L), onHand("MICH-DEF-0002", 8L)));
+        var service = new LocationInventoryInquiryServiceImpl(stockSummaryRepository);
+        when(stockSummaryRepository.findByLocationIdAndOnHandGreaterThan(LOCATION_ID, 0L))
+                .thenReturn(List.of(summary("MICH-XC2-0001", 24L, 0L), summary("MICH-DEF-0002", 8L, 0L)));
 
         LocationInventoryItemsResponse response = service.listLocationInventoryItems(LOCATION_ID);
 
@@ -60,8 +57,8 @@ class LocationInventoryInquiryServiceImplTest {
 
     @Test
     void listLocationInventoryItems_returnsEmptyListForLocationWithoutStock() {
-        var service = new LocationInventoryInquiryServiceImpl(ledgerRepository);
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(LOCATION_ID), any()))
+        var service = new LocationInventoryInquiryServiceImpl(stockSummaryRepository);
+        when(stockSummaryRepository.findByLocationIdAndOnHandGreaterThan(LOCATION_ID, 0L))
                 .thenReturn(List.of());
 
         LocationInventoryItemsResponse response = service.listLocationInventoryItems(LOCATION_ID);
@@ -71,14 +68,39 @@ class LocationInventoryInquiryServiceImplTest {
     }
 
     @Test
-    void listLocationInventoryItems_treatsNullQuantityAsZero() {
-        var service = new LocationInventoryInquiryServiceImpl(ledgerRepository);
-        when(ledgerRepository.findPositiveOnHandByLocation(eq(LOCATION_ID), any()))
-                .thenReturn(List.of(onHand("WIXF-XP57356", null)));
+    void getLocationInventory_withoutSku_sumsAcrossStockItems() {
+        var service = new LocationInventoryInquiryServiceImpl(stockSummaryRepository);
+        when(stockSummaryRepository.sumOnHandAtLocation(LOCATION_ID)).thenReturn(32L);
+        when(stockSummaryRepository.sumAllocatedAtLocation(LOCATION_ID)).thenReturn(5L);
 
-        LocationInventoryItemsResponse response = service.listLocationInventoryItems(LOCATION_ID);
+        LocationInventoryInquiryResponse response = service.getLocationInventory(LOCATION_ID, null);
 
-        assertThat(response.getItems()).hasSize(1);
-        assertThat(response.getItems().get(0).getOnHandQuantity()).isZero();
+        assertThat(response.getLocationId()).isEqualTo(LOCATION_ID);
+        assertThat(response.getOnHandQuantity()).isEqualTo(32);
+        assertThat(response.getAvailableToPromiseQuantity()).isEqualTo(27);
+    }
+
+    @Test
+    void getLocationInventory_withSku_usesSingleSummaryRow() {
+        var service = new LocationInventoryInquiryServiceImpl(stockSummaryRepository);
+        when(stockSummaryRepository.findByStockItemIdAndLocationId("MICH-XC2-0001", LOCATION_ID))
+                .thenReturn(Optional.of(summary("MICH-XC2-0001", 24L, 4L)));
+
+        LocationInventoryInquiryResponse response = service.getLocationInventory(LOCATION_ID, "MICH-XC2-0001");
+
+        assertThat(response.getOnHandQuantity()).isEqualTo(24);
+        assertThat(response.getAvailableToPromiseQuantity()).isEqualTo(20);
+    }
+
+    @Test
+    void getLocationInventory_withUnknownSku_returnsZeroes() {
+        var service = new LocationInventoryInquiryServiceImpl(stockSummaryRepository);
+        when(stockSummaryRepository.findByStockItemIdAndLocationId("NOPE", LOCATION_ID))
+                .thenReturn(Optional.empty());
+
+        LocationInventoryInquiryResponse response = service.getLocationInventory(LOCATION_ID, "NOPE");
+
+        assertThat(response.getOnHandQuantity()).isZero();
+        assertThat(response.getAvailableToPromiseQuantity()).isZero();
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayExecuteServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayExecuteServiceImplTest.java
@@ -22,6 +22,7 @@ import com.positivity.inventory.internal.exception.PutawayValidationException;
 import com.positivity.inventory.internal.exception.TaskNotFoundException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.PutawayTaskRepository;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.PutawayExecuteServiceImpl;
 import java.time.Clock;
 import java.time.Instant;
@@ -46,6 +47,9 @@ class PutawayExecuteServiceImplTest {
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
     @Mock
+    private LedgerPostingService ledgerPostingService;
+
+    @Mock
     private PutawayValidationService putawayValidationService;
 
     private PutawayExecuteServiceImpl putawayExecuteService;
@@ -64,6 +68,7 @@ class PutawayExecuteServiceImplTest {
         putawayExecuteService = new PutawayExecuteServiceImpl(
                 putawayTaskRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 putawayValidationService,
                 fixedClock);
@@ -88,17 +93,16 @@ class PutawayExecuteServiceImplTest {
                 .thenReturn(50);
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("sku-abc", destinationLocationId))
                 .thenReturn(5);
-        when(inventoryLedgerEntryRepository.save(any(InventoryLedgerEntry.class)))
-                .thenAnswer(invocation -> {
-                    InventoryLedgerEntry entry = invocation.getArgument(0);
-                    entry.setLedgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
-                    return entry;
-                });
+        when(ledgerPostingService.post(any(InventoryLedgerEntry.class))).thenAnswer(invocation -> {
+            InventoryLedgerEntry entry = invocation.getArgument(0);
+            entry.setLedgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+            return entry;
+        });
 
         PutawayExecutionResponse response = putawayExecuteService.executePutaway(taskId.toString(), request);
 
         ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
-        verify(inventoryLedgerEntryRepository, times(2)).save(ledgerCaptor.capture());
+        verify(ledgerPostingService, times(2)).post(ledgerCaptor.capture());
         List<InventoryLedgerEntry> allCaptured = ledgerCaptor.getAllValues();
 
         InventoryLedgerEntry sourceEntry = allCaptured.stream()
@@ -193,7 +197,7 @@ class PutawayExecuteServiceImplTest {
         assertThrows(
                 PutawayValidationException.class,
                 () -> putawayExecuteService.executePutaway(taskId.toString(), request));
-        verify(inventoryLedgerEntryRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
         verify(putawayTaskRepository, never()).save(any(PutawayTask.class));
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReceivingServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReceivingServiceImplTest.java
@@ -29,6 +29,7 @@ import com.positivity.inventory.internal.exception.WorkorderClosedException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryVarianceRepository;
 import com.positivity.inventory.internal.repository.ReceivingSessionRepository;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.ReceivingServiceImpl;
 import com.positivity.inventory.internal.service.SiteDefaultsService;
 import com.positivity.inventory.internal.service.WorkorderValidationService;
@@ -74,6 +75,9 @@ class ReceivingServiceImplTest {
 
     @Mock
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+
+    @Mock
+    private LedgerPostingService ledgerPostingService;
 
     @Mock
     private SourceDocumentStubClient sourceDocumentStubClient;
@@ -569,7 +573,7 @@ class ReceivingServiceImplTest {
         line.setSession(session);
         when(receivingSessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
         when(receivingSessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-        when(inventoryLedgerEntryRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(ledgerPostingService.post(any())).thenAnswer(inv -> inv.getArgument(0));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("PROD-001", STAGING_LOCATION_ID))
                 .thenReturn(7);
 
@@ -579,7 +583,7 @@ class ReceivingServiceImplTest {
         receivingService.receiveItemsIntoStaging(sessionId, request, "test-user");
 
         ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
-        verify(inventoryLedgerEntryRepository).save(ledgerCaptor.capture());
+        verify(ledgerPostingService).post(ledgerCaptor.capture());
         InventoryLedgerEntry savedLedgerEntry = ledgerCaptor.getValue();
 
         assertThat(savedLedgerEntry.getLocationId()).isEqualTo(STAGING_LOCATION_ID);
@@ -615,7 +619,7 @@ class ReceivingServiceImplTest {
         when(receivingSessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(siteDefaultsService.getDefaultStagingLocationId(siteId))
                 .thenReturn(Optional.of(siteDefaultStagingLocationId));
-        when(inventoryLedgerEntryRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(ledgerPostingService.post(any())).thenAnswer(inv -> inv.getArgument(0));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("PROD-001", siteDefaultStagingLocationId))
                 .thenReturn(7);
 
@@ -625,7 +629,7 @@ class ReceivingServiceImplTest {
         receivingService.receiveItemsIntoStaging(sessionId, request, "test-user");
 
         ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
-        verify(inventoryLedgerEntryRepository).save(ledgerCaptor.capture());
+        verify(ledgerPostingService).post(ledgerCaptor.capture());
         InventoryLedgerEntry savedLedgerEntry = ledgerCaptor.getValue();
 
         assertThat(savedLedgerEntry.getLocationId()).isEqualTo(siteDefaultStagingLocationId);
@@ -900,7 +904,7 @@ class ReceivingServiceImplTest {
                 () -> receivingService.crossDockLineToWorkorder(sessionId, lineId, request, "actor-user"));
 
         assertThat(exception.getMessage()).contains("exceeds expected quantity");
-        verify(inventoryLedgerEntryRepository, never()).save(any());
+        verify(ledgerPostingService, never()).post(any());
         verify(receivingSessionRepository, never()).save(any(ReceivingSession.class));
     }
 
@@ -1109,7 +1113,7 @@ class ReceivingServiceImplTest {
 
         when(receivingSessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
         when(receivingSessionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-        when(inventoryLedgerEntryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(ledgerPostingService.post(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(workorderValidationService.getWorkorderLineValidation("WO-001", workorderLineId.toString()))
                 .thenReturn(new WorkorderValidationService.WorkorderLineValidation("WORK_IN_PROGRESS", "PROD-001"));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("PROD-001", CROSS_DOCK_LOCATION_ID))
@@ -1121,7 +1125,7 @@ class ReceivingServiceImplTest {
         receivingService.crossDockLineToWorkorder(sessionId, lineId, request, "actor-user");
 
         ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
-        verify(inventoryLedgerEntryRepository, times(2)).save(ledgerCaptor.capture());
+        verify(ledgerPostingService, times(2)).post(ledgerCaptor.capture());
         List<InventoryLedgerEntry> savedEntries = ledgerCaptor.getAllValues();
 
         InventoryLedgerEntry receiptEntry = savedEntries.get(0);

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
@@ -8,10 +8,15 @@ import static org.mockito.Mockito.when;
 
 import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.entity.ReplenishmentPolicy;
 import com.positivity.inventory.internal.entity.ReplenishmentTask;
+import com.positivity.inventory.internal.enums.ReplenishmentDecisionReason;
 import com.positivity.inventory.internal.enums.ReplenishmentStatus;
+import com.positivity.inventory.internal.enums.ReplenishmentTriggerType;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentTaskRepository;
 import com.positivity.inventory.internal.service.ReplenishmentServiceImpl;
@@ -53,6 +58,9 @@ class ReplenishmentServiceImplTest {
 
     @Mock
     private ReplenishmentPolicyRepository replenishmentPolicyRepository;
+
+    @Mock
+    private InventoryStockSummaryRepository stockSummaryRepository;
 
     @Test
     void getReplenishmentTasks_shouldReturnMappedTasks() {
@@ -216,12 +224,151 @@ class ReplenishmentServiceImplTest {
         assertEquals("TASK_ALREADY_QUEUED", response.getStatus());
     }
 
-    @Test
-    void runBatchReplenishmentScan_shouldReturnEmptyList() {
-        // When
-        List<ReplenishmentTaskResponse> responses = replenishmentService.runBatchReplenishmentScan();
+    // ─── runBatchReplenishmentScan (CAP-217 / odoo-parity F1, issue #1025) ────
 
-        // Then
-        assertTrue(responses.isEmpty());
+    private ReplenishmentPolicy policy(UUID locationId, String sku, int min, int max) {
+        return ReplenishmentPolicy.builder()
+                .policyId(UUID.fromString("00000000-0000-0000-0000-00000000000f"))
+                .locationId(locationId)
+                .itemSKU(sku)
+                .minimumQuantity(min)
+                .maximumQuantity(max)
+                .build();
+    }
+
+    private void givenOnHand(String sku, UUID locationId, long onHand) {
+        when(stockSummaryRepository.findByStockItemIdAndLocationId(sku, locationId))
+                .thenReturn(java.util.Optional.of(InventoryStockSummary.builder()
+                        .stockItemId(sku)
+                        .locationId(locationId)
+                        .onHand(onHand)
+                        .build()));
+    }
+
+    @Test
+    void runBatchReplenishmentScan_withNoPolicies_reportsZeroActivity() {
+        when(replenishmentPolicyRepository.findAll()).thenReturn(Collections.emptyList());
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(0, result.getPoliciesEvaluated());
+        assertEquals(0, result.getTasksCreated());
+        assertEquals(0, result.getTasksRefreshed());
+    }
+
+    @Test
+    void runBatchReplenishmentScan_belowMinimum_createsBatchTaskToMaximum() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-LOW", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        givenOnHand("SKU-LOW", LOC_01, 3);
+        when(replenishmentTaskRepository.findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .thenReturn(java.util.Optional.empty());
+        when(replenishmentTaskRepository
+                        .existsByItemSKUAndDestinationLocationIdAndTriggerTypeAndCreatedAtGreaterThanEqual(
+                                any(), any(), any(), any()))
+                .thenReturn(false);
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(1, result.getPoliciesEvaluated());
+        assertEquals(1, result.getPoliciesBelowMinimum());
+        assertEquals(1, result.getTasksCreated());
+
+        org.mockito.ArgumentCaptor<ReplenishmentTask> captor =
+                org.mockito.ArgumentCaptor.forClass(ReplenishmentTask.class);
+        org.mockito.Mockito.verify(replenishmentTaskRepository).save(captor.capture());
+        ReplenishmentTask saved = captor.getValue();
+        assertEquals("SKU-LOW", saved.getItemSKU());
+        assertEquals(17, saved.getQuantity()); // max 20 - onHand 3
+        assertEquals(LOC_01, saved.getDestinationLocationId());
+        assertEquals(ReplenishmentStatus.PENDING, saved.getStatus());
+        assertEquals(ReplenishmentTriggerType.BATCH, saved.getTriggerType());
+        assertEquals(ReplenishmentDecisionReason.BELOW_MIN, saved.getDecisionReason());
+    }
+
+    @Test
+    void runBatchReplenishmentScan_atOrAboveMinimum_createsNothing() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-OK", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        givenOnHand("SKU-OK", LOC_01, 5); // exactly at minimum → not below
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(1, result.getPoliciesEvaluated());
+        assertEquals(0, result.getPoliciesBelowMinimum());
+        assertEquals(0, result.getTasksCreated());
+        org.mockito.Mockito.verify(replenishmentTaskRepository, org.mockito.Mockito.never())
+                .save(any());
+    }
+
+    @Test
+    void runBatchReplenishmentScan_missingSummaryRow_treatedAsZeroOnHand() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-NEW", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        when(stockSummaryRepository.findByStockItemIdAndLocationId("SKU-NEW", LOC_01))
+                .thenReturn(java.util.Optional.empty());
+        when(replenishmentTaskRepository.findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .thenReturn(java.util.Optional.empty());
+        when(replenishmentTaskRepository
+                        .existsByItemSKUAndDestinationLocationIdAndTriggerTypeAndCreatedAtGreaterThanEqual(
+                                any(), any(), any(), any()))
+                .thenReturn(false);
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(1, result.getTasksCreated());
+        org.mockito.ArgumentCaptor<ReplenishmentTask> captor =
+                org.mockito.ArgumentCaptor.forClass(ReplenishmentTask.class);
+        org.mockito.Mockito.verify(replenishmentTaskRepository).save(captor.capture());
+        assertEquals(20, captor.getValue().getQuantity()); // max 20 - onHand 0
+    }
+
+    @Test
+    void runBatchReplenishmentScan_openTaskExists_refreshesQuantityInsteadOfDuplicating() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-LOW", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        givenOnHand("SKU-LOW", LOC_01, 2);
+        ReplenishmentTask openTask = ReplenishmentTask.builder()
+                .taskId(UUID.fromString("00000000-0000-0000-0000-0000000000aa"))
+                .itemSKU("SKU-LOW")
+                .quantity(15)
+                .sourceLocationId(LOC_01)
+                .destinationLocationId(LOC_01)
+                .status(ReplenishmentStatus.PENDING)
+                .triggerType(ReplenishmentTriggerType.BATCH)
+                .build();
+        when(replenishmentTaskRepository.findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .thenReturn(java.util.Optional.of(openTask));
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(0, result.getTasksCreated());
+        assertEquals(1, result.getTasksRefreshed());
+        assertEquals(18, openTask.getQuantity()); // refreshed to max 20 - onHand 2
+        org.mockito.Mockito.verify(replenishmentTaskRepository).save(openTask);
+    }
+
+    @Test
+    void runBatchReplenishmentScan_taskAlreadyCreatedToday_skipsCreation() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-LOW", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        givenOnHand("SKU-LOW", LOC_01, 2);
+        when(replenishmentTaskRepository.findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .thenReturn(java.util.Optional.empty());
+        when(replenishmentTaskRepository
+                        .existsByItemSKUAndDestinationLocationIdAndTriggerTypeAndCreatedAtGreaterThanEqual(
+                                any(), any(), any(), any()))
+                .thenReturn(true);
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(1, result.getPoliciesBelowMinimum());
+        assertEquals(0, result.getTasksCreated());
+        org.mockito.Mockito.verify(replenishmentTaskRepository, org.mockito.Mockito.never())
+                .save(any());
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
@@ -25,6 +25,7 @@ import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.repository.AllocationRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.ReservationRepository;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.ReservationServiceImpl;
 import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import java.time.Clock;
@@ -79,6 +80,9 @@ class ReservationServiceImplTest {
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
     @Mock
+    private LedgerPostingService ledgerPostingService;
+
+    @Mock
     private StorageLocationValidationService storageLocationValidationService;
 
     private ReservationServiceImpl service;
@@ -100,6 +104,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
         // Default lenient stubs for the SC1–SC7 scaffold tests
@@ -136,7 +141,7 @@ class ReservationServiceImplTest {
                 .when(storageLocationValidationService.getStorageLocationValidation(any(String.class)))
                 .thenReturn(validation(true, true));
         lenient()
-                .when(inventoryLedgerEntryRepository.save(any(InventoryLedgerEntry.class)))
+                .when(ledgerPostingService.post(any(InventoryLedgerEntry.class)))
                 .thenAnswer(i -> i.getArgument(0));
     }
 
@@ -294,7 +299,7 @@ class ReservationServiceImplTest {
         // No on-hand change expected for SOFT cancel — no additional
         // repository calls beyond the standard cancel flow.
         assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
-        verify(inventoryLedgerEntryRepository, never()).save(any());
+        verify(ledgerPostingService, never()).post(any());
     }
 
     // ─── SC6: Cancel HARD allocation — ATP restored ─────────────────────────────
@@ -378,6 +383,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
 
@@ -410,6 +416,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
 
@@ -448,6 +455,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
 
@@ -468,6 +476,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
 
@@ -515,6 +524,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
 
@@ -565,6 +575,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
 
@@ -618,6 +629,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
 
@@ -637,6 +649,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
 
@@ -671,6 +684,7 @@ class ReservationServiceImplTest {
                 reservationRepository,
                 allocationRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 storageLocationValidationService);
 
@@ -753,7 +767,7 @@ class ReservationServiceImplTest {
         assertThat(allocation.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);
 
         ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
-        verify(inventoryLedgerEntryRepository).save(ledgerCaptor.capture());
+        verify(ledgerPostingService).post(ledgerCaptor.capture());
         InventoryLedgerEntry entry = ledgerCaptor.getValue();
         assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.ALLOCATION_CREATED);
         assertThat(entry.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);
@@ -798,7 +812,7 @@ class ReservationServiceImplTest {
                 allocation.getAllocationId(), new PromoteAllocationRequest(STORAGE_LOCATION_ID, "re-promote"));
 
         assertThat(allocation.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);
-        verify(inventoryLedgerEntryRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -839,7 +853,7 @@ class ReservationServiceImplTest {
 
         assertThat(allocation.getLocationId()).isEqualTo(originalLocation);
         verify(allocationRepository, never()).save(any(AllocationEntity.class));
-        verify(inventoryLedgerEntryRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -889,7 +903,7 @@ class ReservationServiceImplTest {
         assertThatThrownBy(() -> service.promoteToHard(allocationId, request))
                 .isInstanceOf(LocationNotFoundException.class);
         verify(allocationRepository, never()).save(any(AllocationEntity.class));
-        verify(inventoryLedgerEntryRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -942,7 +956,7 @@ class ReservationServiceImplTest {
         service.cancelReservation(workorderLineId);
 
         ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
-        verify(inventoryLedgerEntryRepository).save(ledgerCaptor.capture());
+        verify(ledgerPostingService).post(ledgerCaptor.capture());
         assertThat(ledgerCaptor.getValue().getChangeInQuantity()).isEqualTo(2);
     }
 
@@ -994,7 +1008,7 @@ class ReservationServiceImplTest {
         service.cancelReservation(workorderLineId);
 
         ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
-        verify(inventoryLedgerEntryRepository).save(ledgerCaptor.capture());
+        verify(ledgerPostingService).post(ledgerCaptor.capture());
         InventoryLedgerEntry entry = ledgerCaptor.getValue();
         assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.ALLOCATION_RELEASED);
         assertThat(entry.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReturnServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReturnServiceImplTest.java
@@ -19,6 +19,7 @@ import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.exception.ReturnQuantityExceededException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryReturnRepository;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.ReturnServiceImpl;
 import java.time.Clock;
 import java.time.Instant;
@@ -68,6 +69,9 @@ class ReturnServiceImplTest {
     @Mock
     private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
 
+    @Mock
+    private LedgerPostingService ledgerPostingService;
+
     @Captor
     private ArgumentCaptor<InventoryReturnEntity> entityCaptor;
 
@@ -84,6 +88,7 @@ class ReturnServiceImplTest {
         return new ReturnServiceImpl(
                 inventoryReturnRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 clock);
     }
@@ -92,6 +97,7 @@ class ReturnServiceImplTest {
         return new ReturnServiceImpl(
                 inventoryReturnRepository,
                 inventoryLedgerEntryRepository,
+                ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 clock);
     }
@@ -125,7 +131,7 @@ class ReturnServiceImplTest {
                         eq(workorderId.toString())))
                 .thenReturn(List.of(
                         InventoryLedgerEntry.builder().changeInQuantity(-100).build()));
-        when(inventoryLedgerEntryRepository.saveAll(anyList()))
+        when(ledgerPostingService.postAll(anyList()))
                 .thenReturn(List.of(InventoryLedgerEntry.builder()
                         .ledgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                         .build()));
@@ -211,7 +217,7 @@ class ReturnServiceImplTest {
                         anyString(), any(), anyString()))
                 .thenReturn(List.of(
                         InventoryLedgerEntry.builder().changeInQuantity(-100).build()));
-        when(inventoryLedgerEntryRepository.saveAll(anyList()))
+        when(ledgerPostingService.postAll(anyList()))
                 .thenReturn(List.of(
                         InventoryLedgerEntry.builder()
                                 .ledgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
@@ -317,7 +323,7 @@ class ReturnServiceImplTest {
                 InventoryLedgerEntry.builder().ledgerEntryId(firstLedgerId).build();
         InventoryLedgerEntry savedLedgerTwo =
                 InventoryLedgerEntry.builder().ledgerEntryId(null).build();
-        when(inventoryLedgerEntryRepository.saveAll(anyList())).thenReturn(List.of(savedLedgerOne, savedLedgerTwo));
+        when(ledgerPostingService.postAll(anyList())).thenReturn(List.of(savedLedgerOne, savedLedgerTwo));
 
         ReturnResponse result = serviceWithLedgerRepository().returnItemsToStock(request);
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/SiteInventoryRollupServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/SiteInventoryRollupServiceImplTest.java
@@ -4,19 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
 import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
-import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
-import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository.LocationQuantityMaps;
 import com.positivity.inventory.internal.service.SiteInventoryQuantityLoader;
 import com.positivity.inventory.internal.service.SiteInventoryRollupServiceImpl;
 import com.positivity.inventory.internal.service.StorageLocationTopologyService;
 import com.positivity.inventory.internal.service.StorageLocationTopologyService.StorageLocationNode;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -31,8 +31,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * Unit tests for {@link SiteInventoryRollupServiceImpl} — CAP-218 #658.
  *
  * <p>Topology client is mocked; quantities come through a real
- * {@link SiteInventoryQuantityLoader} backed by a mocked repository so the
- * loader's sku/no-sku branching is exercised too.
+ * {@link SiteInventoryQuantityLoader} backed by a mocked stock-summary
+ * repository (issue #1024, A1) so the loader's sku/no-sku branching is
+ * exercised too.
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SiteInventoryRollupServiceImpl — CAP-218 #658 unit tests")
@@ -47,14 +48,14 @@ class SiteInventoryRollupServiceImplTest {
     private StorageLocationTopologyService topologyService;
 
     @Mock
-    private InventoryLedgerEntryRepository ledgerRepository;
+    private InventoryStockSummaryRepository stockSummaryRepository;
 
     private SiteInventoryRollupServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        service =
-                new SiteInventoryRollupServiceImpl(topologyService, new SiteInventoryQuantityLoader(ledgerRepository));
+        service = new SiteInventoryRollupServiceImpl(
+                topologyService, new SiteInventoryQuantityLoader(stockSummaryRepository));
     }
 
     private static List<StorageLocationNode> threeLevelTopology() {
@@ -69,10 +70,9 @@ class SiteInventoryRollupServiceImplTest {
     void rollup_threeLevelTree_correctOwnAndRolledUp() {
         // Issue #658: rolledUp = own + sum of descendants' own, depth-first
         when(topologyService.fetchSiteTopology(SITE_ID)).thenReturn(threeLevelTopology());
-        when(ledgerRepository.sumQuantityByLocationChunked(any(), any()))
-                .thenReturn(Map.of(SHELF_ID, 120L, BIN_ID, 360L));
-        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any()))
-                .thenReturn(Map.of(SHELF_ID, 10L, BIN_ID, 20L));
+        when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
+                .thenReturn(new LocationQuantityMaps(
+                        Map.of(SHELF_ID, 120L, BIN_ID, 360L), Map.of(SHELF_ID, 10L, BIN_ID, 20L)));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, true);
 
@@ -102,17 +102,8 @@ class SiteInventoryRollupServiceImplTest {
     void rollup_skuFilter_usesSkuScopedQueries() {
         // Issue #658: when sku given, all quantities are for that SKU only
         when(topologyService.fetchSiteTopology(SITE_ID)).thenReturn(threeLevelTopology());
-        when(ledgerRepository.sumQuantityByLocationForSkuChunked(eq("SKU-1"), any(), any()))
-                .thenAnswer(invocation -> {
-                    Collection<InventoryLedgerEventType> types = invocation.getArgument(2);
-                    if (types.contains(InventoryLedgerEventType.ALLOCATION_CREATED)) {
-                        return Map.of(BIN_ID, 7L);
-                    }
-                    if (types.contains(InventoryLedgerEventType.ALLOCATION_RELEASED)) {
-                        return Map.of(BIN_ID, 2L);
-                    }
-                    return Map.of(BIN_ID, 50L); // on-hand types
-                });
+        when(stockSummaryRepository.sumByLocationChunked(any(), eq("SKU-1")))
+                .thenReturn(new LocationQuantityMaps(Map.of(BIN_ID, 50L), Map.of(BIN_ID, 5L)));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, "SKU-1", null, true);
 
@@ -130,8 +121,8 @@ class SiteInventoryRollupServiceImplTest {
                 .thenReturn(List.of(
                         new StorageLocationNode(FLOOR_ID, "Floor A", "FLOOR", "ACTIVE", null),
                         new StorageLocationNode(SHELF_ID, "Orphan Shelf", "SHELF", "ACTIVE", ghostParent)));
-        when(ledgerRepository.sumQuantityByLocationChunked(any(), any())).thenReturn(Map.of(SHELF_ID, 5L));
-        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any())).thenReturn(Map.of());
+        when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
+                .thenReturn(new LocationQuantityMaps(Map.of(SHELF_ID, 5L), Map.of()));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, true);
 
@@ -145,8 +136,8 @@ class SiteInventoryRollupServiceImplTest {
         // Issue #658: available may be negative — real over-allocation signal
         when(topologyService.fetchSiteTopology(SITE_ID))
                 .thenReturn(List.of(new StorageLocationNode(BIN_ID, "Bin", "BIN", "ACTIVE", null)));
-        when(ledgerRepository.sumQuantityByLocationChunked(any(), any())).thenReturn(Map.of(BIN_ID, 3L));
-        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any())).thenReturn(Map.of(BIN_ID, 8L));
+        when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
+                .thenReturn(new LocationQuantityMaps(Map.of(BIN_ID, 3L), Map.of(BIN_ID, 8L)));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, true);
 
@@ -163,8 +154,8 @@ class SiteInventoryRollupServiceImplTest {
                         new StorageLocationNode(FLOOR_ID, "Floor A", "FLOOR", "ACTIVE", null),
                         new StorageLocationNode(SHELF_ID, "Shelf A-1", "SHELF", "ACTIVE", FLOOR_ID),
                         new StorageLocationNode(emptyBin, "Empty Bin", "BIN", "ACTIVE", FLOOR_ID)));
-        when(ledgerRepository.sumQuantityByLocationChunked(any(), any())).thenReturn(Map.of(SHELF_ID, 9L));
-        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any())).thenReturn(Map.of());
+        when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
+                .thenReturn(new LocationQuantityMaps(Map.of(SHELF_ID, 9L), Map.of()));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, false);
 
@@ -179,8 +170,8 @@ class SiteInventoryRollupServiceImplTest {
     void rollup_depthOne_truncatesChildrenButKeepsFullTotals() {
         // Issue #658: depth truncates the returned tree, not the math
         when(topologyService.fetchSiteTopology(SITE_ID)).thenReturn(threeLevelTopology());
-        when(ledgerRepository.sumQuantityByLocationChunked(any(), any())).thenReturn(Map.of(BIN_ID, 360L));
-        when(ledgerRepository.calculateOutstandingAllocationsByLocation(any())).thenReturn(Map.of());
+        when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
+                .thenReturn(new LocationQuantityMaps(Map.of(BIN_ID, 360L), Map.of()));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, 1, true);
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/StockMovementServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/StockMovementServiceImplTest.java
@@ -20,6 +20,7 @@ import com.positivity.inventory.internal.enums.MovementType;
 import com.positivity.inventory.internal.exception.InsufficientStockException;
 import com.positivity.inventory.internal.repository.InventoryAdjustmentRequestRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.StockMovementServiceImpl;
 import java.time.Clock;
 import java.time.Instant;
@@ -44,6 +45,9 @@ class StockMovementServiceImplTest {
     private InventoryLedgerEntryRepository ledgerRepository;
 
     @Mock
+    private LedgerPostingService ledgerPostingService;
+
+    @Mock
     private InventoryAdjustmentRequestRepository adjustmentRepository;
 
     @Mock
@@ -53,7 +57,7 @@ class StockMovementServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new StockMovementServiceImpl(ledgerRepository, adjustmentRepository, clock);
+        service = new StockMovementServiceImpl(ledgerRepository, adjustmentRepository, ledgerPostingService, clock);
     }
 
     private void setupClock() {
@@ -72,7 +76,7 @@ class StockMovementServiceImplTest {
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_RECEIPT);
         assertThat(result.getChangeInQuantity()).isEqualTo(5);
-        verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -87,7 +91,7 @@ class StockMovementServiceImplTest {
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_ISSUE);
         assertThat(result.getChangeInQuantity()).isEqualTo(-4);
-        verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -99,7 +103,7 @@ class StockMovementServiceImplTest {
         Throwable exception = catchThrowable(() -> service.recordMovement(request, "actor-1"));
 
         assertThat(exception).isInstanceOf(InsufficientStockException.class);
-        verify(ledgerRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -111,7 +115,7 @@ class StockMovementServiceImplTest {
         Throwable exception = catchThrowable(() -> service.recordMovement(request, "actor-1"));
 
         assertThat(exception).isInstanceOf(InsufficientStockException.class);
-        verify(ledgerRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -123,7 +127,7 @@ class StockMovementServiceImplTest {
         assertThat(exception)
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("ADJUST must use adjustment workflow");
-        verify(ledgerRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -141,7 +145,7 @@ class StockMovementServiceImplTest {
         assertThat(result.getChangeInQuantity()).isEqualTo(-5);
         verify(ledgerRepository, times(2)).calculateOnHandQuantityAtLocation(request.getProductSku(), LOC_2);
         verify(ledgerRepository, never()).calculateOnHandQuantityAtLocation(request.getProductSku(), LOC_1);
-        verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -158,7 +162,7 @@ class StockMovementServiceImplTest {
         service.recordMovement(request, "actor-1");
 
         ArgumentCaptor<InventoryLedgerEntry> captor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
-        verify(ledgerRepository, times(2)).save(captor.capture());
+        verify(ledgerPostingService, times(2)).post(captor.capture());
         List<InventoryLedgerEntry> savedEntries = captor.getAllValues();
 
         InventoryLedgerEntry transferIn = savedEntries.get(0);
@@ -188,7 +192,7 @@ class StockMovementServiceImplTest {
         assertThat(exception)
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("toLocationId is required for TRANSFER movements");
-        verify(ledgerRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -203,7 +207,7 @@ class StockMovementServiceImplTest {
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.PUTAWAY);
         assertThat(result.getChangeInQuantity()).isEqualTo(3);
-        verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -218,7 +222,7 @@ class StockMovementServiceImplTest {
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.RETURN_TO_STOCK);
         assertThat(result.getChangeInQuantity()).isEqualTo(2);
-        verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -232,7 +236,7 @@ class StockMovementServiceImplTest {
         service.recordMovement(request, "actor-xyz");
 
         ArgumentCaptor<InventoryLedgerEntry> captor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
-        verify(ledgerRepository).save(captor.capture());
+        verify(ledgerPostingService).post(captor.capture());
         assertThat(captor.getValue().getTransactionUserId()).isEqualTo("actor-xyz");
     }
 
@@ -280,7 +284,7 @@ class StockMovementServiceImplTest {
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.ADJUSTMENT_IN);
         assertThat(result.getChangeInQuantity()).isEqualTo(4);
-        verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -297,7 +301,7 @@ class StockMovementServiceImplTest {
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.ADJUSTMENT_OUT);
         assertThat(result.getChangeInQuantity()).isEqualTo(-3);
-        verify(ledgerRepository).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -308,7 +312,7 @@ class StockMovementServiceImplTest {
         Throwable exception = catchThrowable(() -> service.approveAdjustmentRequest(requestId, "approver-1"));
 
         assertThat(exception).isInstanceOf(IllegalArgumentException.class);
-        verify(ledgerRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -321,7 +325,7 @@ class StockMovementServiceImplTest {
                 catchThrowable(() -> service.approveAdjustmentRequest(request.getAdjustmentRequestId(), "approver-1"));
 
         assertThat(exception).isInstanceOf(IllegalStateException.class);
-        verify(ledgerRepository, never()).save(any(InventoryLedgerEntry.class));
+        verify(ledgerPostingService, never()).post(any(InventoryLedgerEntry.class));
     }
 
     @Test
@@ -381,7 +385,7 @@ class StockMovementServiceImplTest {
     }
 
     private void stubLedgerSaveReturnsEntry() {
-        when(ledgerRepository.save(any(InventoryLedgerEntry.class)))
+        when(ledgerPostingService.post(any(InventoryLedgerEntry.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
     }
 

--- a/pos-warranty/openapi.yaml
+++ b/pos-warranty/openapi.yaml
@@ -3039,16 +3039,16 @@ components:
         offset:
           type: integer
           format: int64
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        paged:
+          type: boolean
         pageNumber:
           type: integer
           format: int32
         pageSize:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        paged:
-          type: boolean
         unpaged:
           type: boolean
     SortObject:


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-inventory` — Wave 1 of the inventory Odoo-parity program (plan: durion `domains/inventory/plan-odoo-parity-pos-inventory.md`; spec: `domains/inventory/SPEC-pos-inventory-odoo-parity.md`)
- Parent STORY (durion): louisburroughs/durion#365 (J0 valuation ADR — delivered as ADR-0048 on the durion branch of the same name)
- Child issues: louisburroughs/durion-positivity-backend#1023 (X1), #1024 (A1), #1025 (F1), #1026 (I2), #1027 (K1)
- Domain: `domain:inventory` (plus `domain:product` for the pos-catalog contract story X1)

## Contract References (REQUIRED for backend PRs touching API/event behavior)

- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` → CAP-217 (replenishment scan) and CAP-219 (count conflict) sections need extension for the new endpoints — follow-up on the durion branch; permission taxonomy already updated there (`inventory:replenishment:manage`)
- Durion contract PR (if applicable): none yet — plan/ADR/taxonomy changes are on durion branch `claude/odoo-pos-inventory-comparison-ywp0ev` (ADR-0048 PROPOSED, pending accounting sign-off; gates Wave-5 J1 only, not this PR)

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controllers (catalog: product UoM/tracking/substitution endpoints; inventory: `POST /v1/inventory/replenishment/scan`, `GET /v1/inventory/cycleCount/task/{taskId}/interfering-movements`)
- [x] `openapi.yaml` regenerated (pos-catalog via `-Popenapi` profile; pos-inventory/pos-warranty + `docs/permissions-report.yaml` in 891e53ed) — gateway `openapi-aggregate.yaml` not yet refreshed
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — frontend-repo follow-up, rides the next SDK refresh

## Scope
- What changed:
  - **X1 (#1023, pos-catalog + pos-domain-events)**: `catalog.product.updated` schema v2 (additive): `baseUom`, `trackingLevel` (NONE/LOT/SERIAL), per-product `uomConversions[]`, substitution groups with member fan-out; new `product_uom` + substitution-group tables (catalog V7); admin endpoints under existing role guards.
  - **A1 (#1024, pos-inventory)**: `inventory_stock_summary` read model (V9) maintained transactionally by a new `LedgerPostingService` funnel that ALL 9 ledger writers now use; availability/inquiry/rollup reads switched off `SUM(ledger)` onto the summary; rebuild job + scheduled drift verifier (report-only); disabled-by-default benchmark harness. Ledger stays append-only truth.
  - **K1 (#1027, pos-inventory)**: negative-stock policy matrix enforced in the funnel (issue/consumption/transfer-out blocked below zero; scrap blocked-with-override; adjustment/count-variance floored at zero; receipts unconstrained), deterministic 422 codes, ArchUnit rule pinning all ledger writes to the funnel, `docs/negative-stock-policy.md`.
  - **F1 (#1025, pos-inventory)**: CAP-217 batch replenishment scan implemented (idempotent per policy/day, open-task refresh), `@Scheduled` driver gated by `pos.inventory.replenishment.scan.enabled` (default off), manual scan endpoint, new `inventory:replenishment:manage` permission (policy-create migrated off `inventory:adjustment:create`).
  - **I2 (#1026, pos-inventory)**: cycle-count conflict detection via in-window ledger delta at submission/recount/approval; new `CONFLICT` task status (V10); approving a CONFLICT task recomputes variance against current on-hand (never the stale snapshot); interfering-movements endpoint; 409 `CYCLE_COUNT_CONFLICT`.
- Why: first wave of the Odoo-parity plan — the summary/funnel is the foundation four later workstreams consume (forecast quantities, in-transit, per-lot balances, valuation); the rest are the plan's independent quick wins closing gaps G2, G4-enabler, G10, G14/G15, G18 evidence in the comparison docs.

## Tests
- [x] Unit tests added/updated (pos-inventory 379 green; pos-catalog 42 green)
- [x] Integration tests added/updated (pos-inventory failsafe 169 green, incl. funnel concurrency, matrix rows, scan idempotency, conflict flows)
- [x] Provider behavioral contract tests added/updated (catalog payload-shape + additive-regression test; inventory contract ITs extended; response contracts of existing availability endpoints unchanged)
- How to run:
  - `./mvnw -pl pos-inventory test` and `./mvnw -pl pos-inventory verify` (Java 25)
  - `./mvnw -pl pos-catalog -am test`
  - `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests -Dsurefire.failIfNoSpecifiedTests=false test` (cross-module, 12/12 green on this branch)

## Risk & Rollback
- Risk level: Medium — mechanical-but-wide funnel refactor across all ledger writers (behavior preserved, proven by the unchanged contract suites), plus two deliberate behavioral changes: (1) `POST /v1/inventory/replenishment/policies` now requires `inventory:replenishment:manage` — callers holding only `inventory:adjustment:create` get 403; (2) postings that previously could drive on-hand negative are now rejected per the policy matrix.
- Rollback plan: revert the branch commits; all migrations are additive (catalog V7, inventory V9/V10 — new tables/column-with-default/status-value), so a code rollback is safe without down-migrations. The summary table is derived state and can be rebuilt or ignored after rollback.
- Known edge (documented in plan/docs): workorder consumption posts at a null location, so its negative-stock guard evaluates the (SKU, null-location) key — revisit with the C-workstream location semantics.

## Checklist
- [ ] Branch name matches `cap/` (session-designated branch `claude/odoo-pos-inventory-comparison-ywp0ev`)
- [x] PR title starts with `[CAP:]`
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (CAP-217/CAP-219 endpoint additions — durion-side follow-up noted above)
- [ ] Required CI checks passing (verify on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145oPegbQy1DY4DXPmnj6x3