### PR TITLE
[CAP:odoo-parity-inventory] Wave 4: transfer short-close, forecast replenishment math, policy enrichment, lot-aware outbound, shrinkage GL

### DIFF
--- a/pos-accounting/README.md
+++ b/pos-accounting/README.md
@@ -12,6 +12,7 @@ General-ledger accounting service for the Durion Positivity ETSMS platform. Mana
 - Apply payments to invoices and record AP payments
 - Issue credit memos with configurable GL account targets, freezing their per-jurisdiction tax reversal
 - Apply or refund AR customer credits, relieving the customer-credit liability recognized at issuance
+- Post inventory shrinkage (Dr Inventory Shrinkage 5100 / Cr Inventory 1300) from `inventory.scrap.posted` facts on `inventory.events.v1`, exactly once per scrap; uncosted scraps (ADR-0048 interim `costSource=NONE`) are logged and skipped, never posted
 - Manage monthly accounting periods (list, close, reopen)
 - Produce financial reports (income statement, balance sheet)
 - Ingest domain events from Kafka via the event ingestion pipeline
@@ -196,6 +197,7 @@ preserved); a second conflict returns `409 Conflict` and the client should retry
 | `pos.accounting.credit-memo.ar-account-id`          | required             | GL account for AR reductions             |
 | `pos.accounting.kafka.enabled`                      | `false`              | Enable Kafka consumer for payment events |
 | `pos.accounting.kafka.payments-topic`               | `payment.cleared.v1` | Kafka topic for cleared payments         |
+| `pos.accounting.kafka.inventory-events-topic`       | `inventory.events.v1` | Inventory scrap facts for shrinkage GL posting (#1043) |
 | `stripe.api-key`                                    | required             | Stripe API key for payment processing    |
 
 ## Dependencies

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
@@ -416,10 +416,12 @@ public class GLPostingServiceImpl implements GLPostingService {
             @Nullable String overrideJustification) {
 
         log.info(
-                "Posting inventory shrinkage GL entry {}: debit shrinkage expense {}, credit inventory {}",
+                "Posting inventory shrinkage GL entry {}: amount {}, debit shrinkage expense account {},"
+                        + " credit inventory account {}",
                 sourceEventId,
                 amount,
-                amount);
+                shrinkageAccountId,
+                inventoryAccountId);
 
         JournalEntry entry = new JournalEntry();
         entry.setTransactionDate(transactionDate);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/GLPostingServiceImpl.java
@@ -405,6 +405,45 @@ public class GLPostingServiceImpl implements GLPostingService {
     }
 
     @Override
+    public JournalEntry postInventoryShrinkage(
+            @NonNull UUID sourceEventId,
+            @NonNull UUID scrapId,
+            @NonNull UUID shrinkageAccountId,
+            @NonNull UUID inventoryAccountId,
+            @NonNull BigDecimal amount,
+            @NonNull LocalDateTime transactionDate,
+            @NonNull String description,
+            @Nullable String overrideJustification) {
+
+        log.info(
+                "Posting inventory shrinkage GL entry {}: debit shrinkage expense {}, credit inventory {}",
+                sourceEventId,
+                amount,
+                amount);
+
+        JournalEntry entry = new JournalEntry();
+        entry.setTransactionDate(transactionDate);
+        entry.setDescription(description);
+        entry.setSourceEventId(sourceEventId);
+
+        List<JournalEntryLine> lines = new ArrayList<>();
+
+        // Debit: Inventory Shrinkage expense (the write-off cost recognized).
+        addDebit(lines, shrinkageAccountId, amount, "Shrinkage Expense - Scrap#" + scrapId);
+        // Credit: Inventory asset (the stock value leaving the balance sheet).
+        addCredit(lines, inventoryAccountId, amount, "Inventory Relief - Scrap#" + scrapId);
+
+        entry.setLines(lines);
+
+        JournalEntry created = journalEntryService.createJournalEntry(entry);
+        JournalEntry posted = journalEntryService.postJournalEntry(created.getJournalEntryId(), overrideJustification);
+
+        log.info("Posted inventory shrinkage GL entry: journal entry ID {}", posted.getJournalEntryId());
+
+        return posted;
+    }
+
+    @Override
     public JournalEntry postSettlement(@NonNull SettlementPostingCommand command) {
         log.info(
                 "Posting settlement GL entry {}: Dr Cash {}, Dr Fees {}, Cr Undeposited {}, Cr Suspense {}",

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InventoryEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InventoryEventsListener.java
@@ -1,0 +1,122 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.entity.ProcessedEvent;
+import com.positivity.accounting.internal.repository.ProcessedEventRepository;
+import com.positivity.domainevents.inventory.ScrapPostedV1;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Consumes {@code inventory.events.v1} scrap facts into shrinkage GL postings (odoo-parity D2,
+ * issue #1043).
+ *
+ * <p>Same reliability contract as {@link SettlementEventsListener}: idempotent via {@code
+ * processed_events} in the ingest transaction, transient DB errors and posting failures propagate
+ * unwrapped for container retry / DLQ (ADR-0044 §4), malformed payloads logged and marked
+ * processed so a poison record never blocks the partition. Only {@code inventory.scrap.posted}
+ * events are handled; the topic's other (high-volume) fact types are ignored without recording
+ * their eventIds.
+ *
+ * <p><b>Null/zero-cost skip (spec D4 scope 4):</b> the fact's {@code unitCost} is the ADR-0048
+ * interim latest-receipt snapshot and is {@code null} when no receipt cost exists
+ * ({@code costSource = NONE}). A scrap without a positive cost has no determinate GL value, so no
+ * journal entry is posted: the event is logged at WARN (observable skip, greppable as
+ * {@code "Skipping uncosted scrap fact"}) and marked processed — record-and-skip, the module's
+ * established convention for unpostable payloads (mirrors the malformed-payload path here and in
+ * {@link SettlementEventsListener}). Odoo-parity J3 upgrades the cost source; recovery for skipped
+ * scraps is a manual journal entry, exactly like any other unpostable event in this module.
+ *
+ * <p>Posting itself (idempotent on scrapId via posting key, period-gated, accounts resolved
+ * through the {@code INVENTORY_SHRINKAGE} posting category) lives in
+ * {@link InventoryShrinkagePostingService}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.accounting.kafka", name = "enabled", havingValue = "true")
+public class InventoryEventsListener {
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final InventoryShrinkagePostingService shrinkagePostingService;
+
+    @KafkaListener(
+            topics = "${pos.accounting.kafka.inventory-events-topic:inventory.events.v1}",
+            groupId = "pos-accounting-inventory-events")
+    @Transactional
+    public void onInventoryEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable inventory event: {}", message, e);
+            return;
+        }
+        String eventType = envelope.path("eventType").stringValue(null);
+        if (!ScrapPostedV1.EVENT_TYPE.equals(eventType)) {
+            log.debug("Ignoring inventory event type={}", eventType);
+            return;
+        }
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping scrap event without eventId: {}", message);
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            log.debug("Skipping duplicate scrap event eventId={}", eventId);
+            return;
+        }
+
+        // Only deserialization/validation failures are terminal for this record — skip and mark
+        // processed so a malformed payload does not poison the partition. Anything thrown by
+        // posting (transient DB errors, period gate, unexpected failures) propagates unwrapped
+        // for container retry / DLQ.
+        ScrapPostedV1 fact;
+        try {
+            fact = objectMapper.treeToValue(envelope.path("payload"), ScrapPostedV1.class);
+        } catch (Exception e) {
+            log.warn("Skipping malformed scrap event eventId={}", eventId, e);
+            markProcessed(eventId);
+            return;
+        }
+
+        // ADR-0048 interim cost is nullable (costSource NONE) — record-and-skip, never post a
+        // zero/indeterminate JE. Marked processed so the record never poison-loops.
+        BigDecimal unitCost = fact.unitCost();
+        if (unitCost == null || unitCost.signum() <= 0) {
+            log.warn(
+                    "Skipping uncosted scrap fact — no shrinkage JE posted | eventId={} | scrapId={} | sku={} "
+                            + "| quantity={} | reasonCode={} | costSource={} | unitCost={}",
+                    eventId,
+                    fact.scrapId(),
+                    fact.sku(),
+                    fact.quantity(),
+                    fact.reasonCode(),
+                    fact.costSource(),
+                    unitCost);
+            markProcessed(eventId);
+            return;
+        }
+
+        shrinkagePostingService.postShrinkage(fact);
+        markProcessed(eventId);
+    }
+
+    private void markProcessed(@NonNull String eventId) {
+        processedEventRepository.save(ProcessedEvent.builder()
+                .eventId(eventId)
+                .processedAt(Instant.now(clock))
+                .build());
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InventoryShrinkagePostingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InventoryShrinkagePostingService.java
@@ -1,0 +1,126 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.service.GLMappingResolver;
+import com.positivity.accounting.service.GLPostingService;
+import com.positivity.accounting.service.IdempotencyService;
+import com.positivity.domainevents.inventory.ScrapPostedV1;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Posts the shrinkage journal entry for a consumed {@code inventory.scrap.posted} fact
+ * (odoo-parity D2, issue #1043): {@code Dr Inventory Shrinkage (expense) / Cr Inventory (asset)}
+ * for {@code quantity x unitCost}.
+ *
+ * <p>Accounts are never hardcoded: both sides resolve through the {@code INVENTORY_SHRINKAGE}
+ * posting category and its {@code SHRINKAGE_EXPENSE} / {@code INVENTORY_ASSET} mapping keys
+ * (seeded by {@code R__seed_reference_accounting.sql} as 5100 Inventory Shrinkage and
+ * 1300 Inventory).
+ *
+ * <p>Idempotency (mirrors {@code CustomerCreditIssuanceGLPostingEventHandler}): the posting key is
+ * the scrap id, namespaced with {@code INVENTORY_SHRINKAGE_GL_POSTING:}, registered in the same
+ * transaction as the posted journal entry — so a shrinkage posts exactly once per scrapId even if
+ * the fact is redelivered under a fresh Kafka {@code eventId} (which would slip past the
+ * {@code processed_events} guard in {@link InventoryEventsListener}).
+ *
+ * <p>The journal entry's transaction date is the fact's {@code occurredAt} (business time), never
+ * processing/clock time, so redeliveries post into the same accounting period and resolve the same
+ * effective-dated GL mapping. The Wave 2 period gate applies inside
+ * {@link com.positivity.accounting.service.JournalEntryService#postJournalEntry}; a CLOSED or
+ * hard-locked period propagates unwrapped to the listener for container retry / DLQ.
+ *
+ * <p>The scrap {@code reasonCode} rides into the entry description verbatim — unknown reason codes
+ * never block posting (spec D4 scope 4).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InventoryShrinkagePostingService {
+
+    static final String POSTING_CATEGORY_NAME = "INVENTORY_SHRINKAGE";
+    static final String DEBIT_MAPPING_KEY = "SHRINKAGE_EXPENSE";
+    static final String CREDIT_MAPPING_KEY = "INVENTORY_ASSET";
+    static final String IDEMPOTENCY_KEY_PREFIX = "INVENTORY_SHRINKAGE_GL_POSTING:";
+    static final String SOURCE_EVENT_NAMESPACE = "INVENTORY_SHRINKAGE:";
+
+    private final Clock clock;
+    private final IdempotencyService idempotencyService;
+    private final GLMappingResolver glMappingResolver;
+    private final GLPostingService glPostingService;
+
+    /**
+     * Post the balanced shrinkage journal entry for a scrap fact, exactly once per scrapId.
+     *
+     * <p>The caller must have already routed away unpostable facts ({@code unitCost} null or
+     * non-positive) — this method assumes a costed scrap.
+     *
+     * @param fact the consumed scrap fact (with a non-null, positive {@code unitCost})
+     */
+    @Transactional
+    public void postShrinkage(@NonNull ScrapPostedV1 fact) {
+        String idempotencyKey = IDEMPOTENCY_KEY_PREFIX + fact.scrapId();
+        if (idempotencyService.isKeyProcessed(idempotencyKey)) {
+            log.info("Inventory shrinkage GL posting already processed, skipping | scrapId={}", fact.scrapId());
+            return;
+        }
+
+        BigDecimal unitCost = fact.unitCost();
+        if (unitCost == null || unitCost.signum() <= 0) {
+            throw new IllegalArgumentException(
+                    "Unpostable scrap fact reached posting (unitCost=" + unitCost + "): " + fact.scrapId());
+        }
+        BigDecimal amount = unitCost.multiply(BigDecimal.valueOf(fact.quantity()));
+
+        // Business time, not processing time: redeliveries land in the same period.
+        LocalDateTime transactionDate = LocalDateTime.ofInstant(fact.occurredAt(), clock.getZone());
+
+        // Account resolution via posting category / mapping key configuration — never hardcoded.
+        UUID shrinkageAccountId =
+                glMappingResolver.resolveGLAccount(POSTING_CATEGORY_NAME, DEBIT_MAPPING_KEY, transactionDate);
+        UUID inventoryAccountId =
+                glMappingResolver.resolveGLAccount(POSTING_CATEGORY_NAME, CREDIT_MAPPING_KEY, transactionDate);
+
+        String description = "Inventory shrinkage for scrap " + fact.scrapId() + " (reason " + fact.reasonCode()
+                + ", sku " + fact.sku() + ", qty " + fact.quantity() + " @ " + unitCost + ")"
+                + (fact.workorderId() != null ? " [workorder " + fact.workorderId() + "]" : "");
+
+        JournalEntry posted = glPostingService.postInventoryShrinkage(
+                toSourceEventId(fact.scrapId()),
+                fact.scrapId(),
+                shrinkageAccountId,
+                inventoryAccountId,
+                amount,
+                transactionDate,
+                description,
+                null);
+
+        idempotencyService.registerKey(idempotencyKey, posted.getJournalEntryId());
+
+        log.info(
+                "Inventory shrinkage GL posting completed | scrapId={} | sku={} | reasonCode={} | amount={} "
+                        + "| journalEntryId={}",
+                fact.scrapId(),
+                fact.sku(),
+                fact.reasonCode(),
+                amount,
+                posted.getJournalEntryId());
+    }
+
+    /**
+     * Derive the journal entry {@code sourceEventId} deterministically from the scrap id,
+     * namespaced so it never collides with another entry deriving from the same id. Replays of
+     * the same scrap always produce the same source event id.
+     */
+    static @NonNull UUID toSourceEventId(@NonNull UUID scrapId) {
+        return UUID.nameUUIDFromBytes((SOURCE_EVENT_NAMESPACE + scrapId).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/GLPostingService.java
@@ -226,6 +226,41 @@ public interface GLPostingService {
             @Nullable String overrideJustification);
 
     /**
+     * Post an inventory shrinkage write-off to GL (odoo-parity D2, issue #1043):
+     * {@code Dr Inventory Shrinkage (expense) / Cr Inventory (asset)} for
+     * {@code quantity x unitCost} of a posted scrap document. Consumed from the
+     * {@code inventory.scrap.posted} fact on {@code inventory.events.v1}; both
+     * accounts are resolved by the caller through the {@code INVENTORY_SHRINKAGE}
+     * posting category's mapping keys, never hardcoded.
+     *
+     * @param sourceEventId         deterministic JE source id derived from the
+     *                              scrap id (namespaced so it never collides with
+     *                              another entry deriving from the same id)
+     * @param scrapId               the scrap document being expensed (audit label
+     *                              on the entry lines)
+     * @param shrinkageAccountId    GL account for Inventory Shrinkage expense (debit)
+     * @param inventoryAccountId    GL account for the Inventory asset (credit)
+     * @param amount                write-off amount ({@code quantity x unitCost})
+     * @param transactionDate       business transaction date (the scrap's
+     *                              {@code occurredAt}) used as the journal entry
+     *                              date; must not be derived from processing/clock
+     *                              time so Kafka redeliveries post into the correct
+     *                              period
+     * @param description           entry description (carries the scrap reason code)
+     * @param overrideJustification optional CLOSED-period override justification
+     * @return posted journal entry
+     */
+    JournalEntry postInventoryShrinkage(
+            @NonNull UUID sourceEventId,
+            @NonNull UUID scrapId,
+            @NonNull UUID shrinkageAccountId,
+            @NonNull UUID inventoryAccountId,
+            @NonNull BigDecimal amount,
+            @NonNull LocalDateTime transactionDate,
+            @NonNull String description,
+            @Nullable String overrideJustification);
+
+    /**
      * Post the batched settlement journal entry (story F1c, issue #963, decision
      * D-13): {@code Dr Cash (net) / Dr Processor Fees (fee) / Cr Undeposited
      * Funds (matched gross) / Cr Settlement Suspense (unmatched gross)}. Zero

--- a/pos-accounting/src/main/resources/application.yml
+++ b/pos-accounting/src/main/resources/application.yml
@@ -65,6 +65,8 @@ pos:
       invoice-events-topic: ${POS_ACCOUNTING_KAFKA_INVOICE_EVENTS_TOPIC:invoice.events.v1}
       # Warranty reimbursement expected-credit feed (#927)
       warranty-events-topic: ${POS_ACCOUNTING_KAFKA_WARRANTY_EVENTS_TOPIC:warranty.events.v1}
+      # Inventory scrap fact feed for shrinkage GL posting (#1043)
+      inventory-events-topic: ${POS_ACCOUNTING_KAFKA_INVENTORY_EVENTS_TOPIC:inventory.events.v1}
       workorder-commands-topic: ${POS_ACCOUNTING_KAFKA_WORKORDER_COMMANDS_TOPIC:workorder.commands.v1}
       consumer-group: ${POS_ACCOUNTING_KAFKA_CONSUMER_GROUP:${spring.application.name}-payments}
 

--- a/pos-accounting/src/main/resources/db/migration/R__seed_reference_accounting.sql
+++ b/pos-accounting/src/main/resources/db/migration/R__seed_reference_accounting.sql
@@ -444,3 +444,51 @@ ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system
 INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
 VALUES ('5eed0acc-0000-4000-8000-00000000cc24'::uuid, 'ACCOUNTING', 'CUSTOMER_CREDIT_REFUND_UNDEPOSITED_FUNDS', '5eed0acc-0000-4000-8000-00000000cc20'::uuid, '5eed0acc-0000-4000-8000-00000000cc22'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '1090'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
 ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';
+
+-- ============================================================================
+-- Parity-D2 (Issue #1043): inventory shrinkage GL posting.
+-- pos-accounting consumes the inventory.scrap.posted fact (ScrapPostedV1 on
+-- inventory.events.v1) and posts Dr Inventory Shrinkage (5100) / Cr Inventory
+-- (1300) for quantity x unitCost. Accounts resolve through the
+-- INVENTORY_SHRINKAGE posting category's SHRINKAGE_EXPENSE / INVENTORY_ASSET
+-- mapping keys — never hardcoded. gl_mapping.gl_account_id is resolved by
+-- account_code SELECT (not a hardcoded UUID) so the FK always binds to
+-- whichever id won the ON CONFLICT (account_code) upsert, matching the
+-- customer-credit / bank-rec pattern (accounting plan D-13).
+-- ============================================================================
+
+-- GL accounts: 1300 Inventory (asset relieved by the write-off) and
+-- 5100 Inventory Shrinkage (the recognized write-off cost).
+INSERT INTO gl_account (gl_account_id, account_code, account_name, account_type, account_subtype, reconcilable, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-000000001300'::uuid, '1300', 'Inventory', 'ASSET', 'CURRENT_ASSET', FALSE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (account_code) DO UPDATE SET
+    account_name = EXCLUDED.account_name, account_type = EXCLUDED.account_type, account_subtype = EXCLUDED.account_subtype,
+    reconcilable = EXCLUDED.reconcilable, modified_at = NOW(), modified_by = 'seed-generator';
+INSERT INTO gl_account (gl_account_id, account_code, account_name, account_type, account_subtype, reconcilable, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-000000005100'::uuid, '5100', 'Inventory Shrinkage', 'EXPENSE', 'COST_OF_SALES', FALSE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (account_code) DO UPDATE SET
+    account_name = EXCLUDED.account_name, account_type = EXCLUDED.account_type, account_subtype = EXCLUDED.account_subtype,
+    reconcilable = EXCLUDED.reconcilable, modified_at = NOW(), modified_by = 'seed-generator';
+
+-- Posting category.
+INSERT INTO posting_category (posting_category_id, category_name, description, is_active, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000d201'::uuid, 'INVENTORY_SHRINKAGE', 'Inventory scrap write-off GL posting (Dr Inventory Shrinkage / Cr Inventory, issue #1043)', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (posting_category_id) DO UPDATE SET
+    category_name = EXCLUDED.category_name, description = EXCLUDED.description, is_active = EXCLUDED.is_active,
+    modified_at = NOW(), modified_by = 'seed-generator';
+
+-- Mapping keys: SHRINKAGE_EXPENSE (debit) + INVENTORY_ASSET (credit).
+INSERT INTO mapping_key (mapping_key_id, posting_category_id, key_name, description, is_active, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000d202'::uuid, '5eed0acc-0000-4000-8000-00000000d201'::uuid, 'SHRINKAGE_EXPENSE', 'Debit side of a scrap write-off (shrinkage cost recognized)', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (mapping_key_id) DO UPDATE SET posting_category_id = EXCLUDED.posting_category_id, key_name = EXCLUDED.key_name, description = EXCLUDED.description, is_active = EXCLUDED.is_active, modified_at = NOW(), modified_by = 'seed-generator';
+INSERT INTO mapping_key (mapping_key_id, posting_category_id, key_name, description, is_active, created_at, created_by, modified_at, modified_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000d203'::uuid, '5eed0acc-0000-4000-8000-00000000d201'::uuid, 'INVENTORY_ASSET', 'Credit side of a scrap write-off (stock value relieved)', TRUE, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (mapping_key_id) DO UPDATE SET posting_category_id = EXCLUDED.posting_category_id, key_name = EXCLUDED.key_name, description = EXCLUDED.description, is_active = EXCLUDED.is_active, modified_at = NOW(), modified_by = 'seed-generator';
+
+-- GL mappings (fixed effective_start_date for idempotent re-runs; FK by account_code).
+INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000d204'::uuid, 'ACCOUNTING', 'INVENTORY_SHRINKAGE_SHRINKAGE_EXPENSE', '5eed0acc-0000-4000-8000-00000000d201'::uuid, '5eed0acc-0000-4000-8000-00000000d202'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '5100'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
+ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';
+INSERT INTO gl_mapping (gl_mapping_id, source_system, external_code, posting_category_id, mapping_key_id, gl_account_id, effective_start_date, created_at, created_by)
+VALUES ('5eed0acc-0000-4000-8000-00000000d205'::uuid, 'ACCOUNTING', 'INVENTORY_SHRINKAGE_INVENTORY_ASSET', '5eed0acc-0000-4000-8000-00000000d201'::uuid, '5eed0acc-0000-4000-8000-00000000d203'::uuid, (SELECT gl_account_id FROM gl_account WHERE account_code = '1300'), TIMESTAMP '2020-01-01 00:00:00', NOW(), 'seed-generator')
+ON CONFLICT (gl_mapping_id) DO UPDATE SET source_system = EXCLUDED.source_system, external_code = EXCLUDED.external_code, posting_category_id = EXCLUDED.posting_category_id, mapping_key_id = EXCLUDED.mapping_key_id, gl_account_id = EXCLUDED.gl_account_id, effective_start_date = EXCLUDED.effective_start_date, created_by = 'seed-generator';

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InventoryEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InventoryEventsListenerTest.java
@@ -1,0 +1,197 @@
+package com.positivity.accounting.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.accounting.internal.entity.ProcessedEvent;
+import com.positivity.accounting.internal.repository.ProcessedEventRepository;
+import com.positivity.domainevents.inventory.ScrapPostedV1;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Consumer-side contract test for {@code inventory.scrap.posted} ingestion (odoo-parity D2, issue
+ * #1043). The envelope JSON literals pin the {@link ScrapPostedV1} fact schema — including the
+ * ADR-0048 nullable-cost variant ({@code unitCost: null}, {@code costSource: NONE}) — so a
+ * producer-side field rename or type change fails here, not in production.
+ */
+class InventoryEventsListenerTest {
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-22T12:00:00Z"), ZoneOffset.UTC);
+    private static final UUID SCRAP_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID STORAGE_LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private static final UUID WORKORDER_ID = UUID.fromString("00000000-0000-0000-0000-000000000004");
+
+    private final ProcessedEventRepository processedEvents = mock(ProcessedEventRepository.class);
+    private final InventoryShrinkagePostingService postingService = mock(InventoryShrinkagePostingService.class);
+
+    private InventoryEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new InventoryEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, postingService);
+    }
+
+    /** Representative costed scrap fact as published by pos-inventory (Wave-2 D1, #1030). */
+    private String costedScrap(String eventId) {
+        return """
+                {"eventId":"%s","eventType":"inventory.scrap.posted","schemaVersion":1,
+                 "aggregateId":"%s","aggregateVersion":0,
+                 "occurredAtUtc":"2026-07-21T09:15:00Z","sourceService":"pos-inventory",
+                 "payload":{"scrapId":"%s","sku":"BRAKE-PAD-22","locationId":"%s",
+                            "storageLocationId":"%s","quantity":3,"reasonCode":"DAMAGED",
+                            "unitCost":12.50,"costSource":"LATEST_RECEIPT","workorderId":"%s",
+                            "occurredAt":"2026-07-21T09:15:00Z"}}
+                """.formatted(eventId, SCRAP_ID, SCRAP_ID, LOCATION_ID, STORAGE_LOCATION_ID, WORKORDER_ID);
+    }
+
+    /** ADR-0048 interim uncosted variant: unitCost null, costSource NONE, nullable ids absent. */
+    private String uncostedScrap(String eventId) {
+        return """
+                {"eventId":"%s","eventType":"inventory.scrap.posted","schemaVersion":1,
+                 "aggregateId":"%s","aggregateVersion":0,
+                 "occurredAtUtc":"2026-07-21T09:15:00Z","sourceService":"pos-inventory",
+                 "payload":{"scrapId":"%s","sku":"BRAKE-PAD-22","locationId":null,
+                            "storageLocationId":null,"quantity":3,"reasonCode":"LOST",
+                            "unitCost":null,"costSource":"NONE","workorderId":null,
+                            "occurredAt":"2026-07-21T09:15:00Z"}}
+                """.formatted(eventId, SCRAP_ID, SCRAP_ID);
+    }
+
+    @Test
+    @DisplayName("Costed scrap fact deserializes per the pinned schema and is handed to posting")
+    void costedScrapPostsShrinkage() {
+        when(processedEvents.existsById("e-1")).thenReturn(false);
+
+        listener.onInventoryEvent(costedScrap("e-1"));
+
+        ArgumentCaptor<ScrapPostedV1> fact = ArgumentCaptor.forClass(ScrapPostedV1.class);
+        verify(postingService).postShrinkage(fact.capture());
+        assertThat(fact.getValue().scrapId()).isEqualTo(SCRAP_ID);
+        assertThat(fact.getValue().sku()).isEqualTo("BRAKE-PAD-22");
+        assertThat(fact.getValue().locationId()).isEqualTo(LOCATION_ID);
+        assertThat(fact.getValue().storageLocationId()).isEqualTo(STORAGE_LOCATION_ID);
+        assertThat(fact.getValue().quantity()).isEqualTo(3);
+        assertThat(fact.getValue().reasonCode()).isEqualTo("DAMAGED");
+        assertThat(fact.getValue().unitCost()).isEqualByComparingTo(new BigDecimal("12.50"));
+        assertThat(fact.getValue().costSource()).isEqualTo("LATEST_RECEIPT");
+        assertThat(fact.getValue().workorderId()).isEqualTo(WORKORDER_ID);
+        assertThat(fact.getValue().occurredAt()).isEqualTo(Instant.parse("2026-07-21T09:15:00Z"));
+
+        ArgumentCaptor<ProcessedEvent> processed = ArgumentCaptor.forClass(ProcessedEvent.class);
+        verify(processedEvents).save(processed.capture());
+        assertThat(processed.getValue().getEventId()).isEqualTo("e-1");
+        assertThat(processed.getValue().getProcessedAt()).isEqualTo(Instant.now(TEST_CLOCK));
+    }
+
+    @Test
+    @DisplayName("Unknown reason codes do not block posting — they ride into the fact untouched")
+    void unknownReasonCodeStillPosts() {
+        when(processedEvents.existsById("e-2")).thenReturn(false);
+        String message = costedScrap("e-2").replace("\"DAMAGED\"", "\"GREMLINS\"");
+
+        listener.onInventoryEvent(message);
+
+        ArgumentCaptor<ScrapPostedV1> fact = ArgumentCaptor.forClass(ScrapPostedV1.class);
+        verify(postingService).postShrinkage(fact.capture());
+        assertThat(fact.getValue().reasonCode()).isEqualTo("GREMLINS");
+        verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Uncosted fact (unitCost null, costSource NONE) is skipped but marked processed")
+    void uncostedScrapIsSkippedAndMarkedProcessed() {
+        when(processedEvents.existsById("e-3")).thenReturn(false);
+
+        listener.onInventoryEvent(uncostedScrap("e-3"));
+
+        verify(postingService, never()).postShrinkage(any());
+        ArgumentCaptor<ProcessedEvent> processed = ArgumentCaptor.forClass(ProcessedEvent.class);
+        verify(processedEvents).save(processed.capture());
+        assertThat(processed.getValue().getEventId()).isEqualTo("e-3");
+    }
+
+    @Test
+    @DisplayName("Zero unit cost is skipped like a null cost — no zero-value journal entry")
+    void zeroCostScrapIsSkippedAndMarkedProcessed() {
+        when(processedEvents.existsById("e-4")).thenReturn(false);
+        String message = costedScrap("e-4").replace("12.50", "0.00");
+
+        listener.onInventoryEvent(message);
+
+        verify(postingService, never()).postShrinkage(any());
+        verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Duplicate eventId is skipped without touching posting")
+    void duplicateEventIdSkipped() {
+        when(processedEvents.existsById("e-5")).thenReturn(true);
+
+        listener.onInventoryEvent(costedScrap("e-5"));
+
+        verifyNoInteractions(postingService);
+        verify(processedEvents, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Other inventory fact types are ignored without recording their eventIds")
+    void otherEventTypesIgnored() {
+        listener.onInventoryEvent("""
+                {"eventId":"e-6","eventType":"inventory.availability.changed","payload":{}}
+                """);
+
+        verifyNoInteractions(postingService);
+        verifyNoInteractions(processedEvents);
+    }
+
+    @Test
+    @DisplayName("Malformed payload is skipped but marked processed so the partition is not poisoned")
+    void malformedPayloadSkippedAndMarkedProcessed() {
+        when(processedEvents.existsById("e-7")).thenReturn(false);
+        // quantity <= 0 violates the ScrapPostedV1 compact-constructor contract.
+        String message = costedScrap("e-7").replace("\"quantity\":3", "\"quantity\":0");
+
+        listener.onInventoryEvent(message);
+
+        verify(postingService, never()).postShrinkage(any());
+        verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Unparsable message is skipped without recording anything")
+    void unparsableMessageSkipped() {
+        listener.onInventoryEvent("this is not json");
+
+        verifyNoInteractions(postingService);
+        verifyNoInteractions(processedEvents);
+    }
+
+    @Test
+    @DisplayName("Posting failures propagate unwrapped for container retry / DLQ; nothing marked processed")
+    void postingFailurePropagates() {
+        when(processedEvents.existsById("e-8")).thenReturn(false);
+        doThrow(new QueryTimeoutException("db down")).when(postingService).postShrinkage(any());
+
+        assertThatExceptionOfType(QueryTimeoutException.class)
+                .isThrownBy(() -> listener.onInventoryEvent(costedScrap("e-8")));
+
+        verify(processedEvents, never()).save(any());
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InventoryShrinkagePostingServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InventoryShrinkagePostingServiceTest.java
@@ -1,0 +1,113 @@
+package com.positivity.accounting.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.service.GLMappingResolver;
+import com.positivity.accounting.service.GLPostingService;
+import com.positivity.accounting.service.IdempotencyService;
+import com.positivity.domainevents.inventory.ScrapPostedV1;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link InventoryShrinkagePostingService} (odoo-parity D2, issue #1043): account
+ * resolution through the {@code INVENTORY_SHRINKAGE} posting category, {@code quantity x unitCost}
+ * amount, business-time transaction date, and scrapId-keyed posting idempotency.
+ */
+class InventoryShrinkagePostingServiceTest {
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-22T12:00:00Z"), ZoneOffset.UTC);
+    private static final UUID SCRAP_ID = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+    private static final UUID SHRINKAGE_ACCOUNT = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+    private static final UUID INVENTORY_ACCOUNT = UUID.fromString("00000000-0000-0000-0000-00000000000c");
+    private static final UUID JOURNAL_ENTRY_ID = UUID.fromString("00000000-0000-0000-0000-00000000000d");
+    private static final Instant OCCURRED_AT = Instant.parse("2026-07-21T09:15:00Z");
+
+    private final IdempotencyService idempotencyService = mock(IdempotencyService.class);
+    private final GLMappingResolver glMappingResolver = mock(GLMappingResolver.class);
+    private final GLPostingService glPostingService = mock(GLPostingService.class);
+
+    private InventoryShrinkagePostingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new InventoryShrinkagePostingService(
+                TEST_CLOCK, idempotencyService, glMappingResolver, glPostingService);
+    }
+
+    private ScrapPostedV1 fact(BigDecimal unitCost) {
+        return new ScrapPostedV1(
+                SCRAP_ID, "BRAKE-PAD-22", null, null, 3, "EXPIRED", unitCost, "LATEST_RECEIPT", null, OCCURRED_AT);
+    }
+
+    @Test
+    @DisplayName("Posts Dr shrinkage / Cr inventory for quantity x unitCost at business time")
+    void postsBalancedShrinkageEntry() {
+        LocalDateTime expectedDate = LocalDateTime.ofInstant(OCCURRED_AT, ZoneOffset.UTC);
+        when(idempotencyService.isKeyProcessed("INVENTORY_SHRINKAGE_GL_POSTING:" + SCRAP_ID))
+                .thenReturn(false);
+        when(glMappingResolver.resolveGLAccount("INVENTORY_SHRINKAGE", "SHRINKAGE_EXPENSE", expectedDate))
+                .thenReturn(SHRINKAGE_ACCOUNT);
+        when(glMappingResolver.resolveGLAccount("INVENTORY_SHRINKAGE", "INVENTORY_ASSET", expectedDate))
+                .thenReturn(INVENTORY_ACCOUNT);
+        JournalEntry posted = new JournalEntry();
+        posted.setJournalEntryId(JOURNAL_ENTRY_ID);
+        when(glPostingService.postInventoryShrinkage(any(), any(), any(), any(), any(), any(), anyString(), any()))
+                .thenReturn(posted);
+
+        service.postShrinkage(fact(new BigDecimal("12.50")));
+
+        ArgumentCaptor<BigDecimal> amount = ArgumentCaptor.forClass(BigDecimal.class);
+        ArgumentCaptor<String> description = ArgumentCaptor.forClass(String.class);
+        verify(glPostingService)
+                .postInventoryShrinkage(
+                        eq(InventoryShrinkagePostingService.toSourceEventId(SCRAP_ID)),
+                        eq(SCRAP_ID),
+                        eq(SHRINKAGE_ACCOUNT),
+                        eq(INVENTORY_ACCOUNT),
+                        amount.capture(),
+                        eq(expectedDate),
+                        description.capture(),
+                        eq(null));
+        assertThat(amount.getValue()).isEqualByComparingTo(new BigDecimal("37.50"));
+        // The reason code rides into the JE memo (spec D4 scope 4).
+        assertThat(description.getValue()).contains("EXPIRED").contains(SCRAP_ID.toString());
+        verify(idempotencyService).registerKey("INVENTORY_SHRINKAGE_GL_POSTING:" + SCRAP_ID, JOURNAL_ENTRY_ID);
+    }
+
+    @Test
+    @DisplayName("Already-processed posting key is a no-op — exactly once per scrapId")
+    void replayedScrapIdIsNoOp() {
+        when(idempotencyService.isKeyProcessed("INVENTORY_SHRINKAGE_GL_POSTING:" + SCRAP_ID))
+                .thenReturn(true);
+
+        service.postShrinkage(fact(new BigDecimal("12.50")));
+
+        verify(glPostingService, never())
+                .postInventoryShrinkage(any(), any(), any(), any(), any(), any(), anyString(), any());
+        verify(idempotencyService, never()).registerKey(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("Source event id derivation is deterministic and namespaced")
+    void sourceEventIdIsDeterministic() {
+        assertThat(InventoryShrinkagePostingService.toSourceEventId(SCRAP_ID))
+                .isEqualTo(InventoryShrinkagePostingService.toSourceEventId(SCRAP_ID))
+                .isNotEqualTo(SCRAP_ID);
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/InventoryShrinkageGLPostingIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/InventoryShrinkageGLPostingIT.java
@@ -1,0 +1,219 @@
+package com.positivity.accounting.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.accounting.internal.config.TestSecurityConfig;
+import com.positivity.accounting.internal.entity.JournalEntry;
+import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.enums.JournalEntryStatus;
+import com.positivity.accounting.internal.repository.AccountingSequenceRepository;
+import com.positivity.accounting.internal.repository.GLAccountRepository;
+import com.positivity.accounting.internal.repository.IdempotencyKeyRepository;
+import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.ProcessedEventRepository;
+import com.positivity.accounting.internal.service.InventoryEventsListener;
+import com.positivity.accounting.internal.service.InventoryShrinkagePostingService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Real-Postgres IT for inventory shrinkage GL posting (odoo-parity D2, issue #1043). Runs the full
+ * Flyway chain + repeatable seed (which now carries the {@code INVENTORY_SHRINKAGE} posting
+ * category, its two mapping keys, and the 1300 Inventory / 5100 Inventory Shrinkage accounts) on a
+ * Testcontainers Postgres, so seed correctness and
+ * {@link com.positivity.accounting.service.GLMappingResolver} account resolution are exercised
+ * end-to-end.
+ *
+ * <p>Drives the {@code inventory.scrap.posted} envelope through
+ * {@link InventoryEventsListener} exactly as Kafka would deliver it and asserts:
+ * fact &rarr; one balanced POSTED entry (Dr 5100 / Cr 1300, quantity x unitCost); replay of the
+ * same record and redelivery under a fresh eventId are both no-ops (eventId dedup + scrapId
+ * posting key); an uncosted fact (ADR-0048 {@code costSource=NONE}) posts nothing but is marked
+ * processed.
+ *
+ * <p>Skipped cleanly when Docker is unavailable ({@code disabledWithoutDocker}).
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
+@DisplayName("Inventory shrinkage GL posting (parity-D2 #1043, real Postgres)")
+class InventoryShrinkageGLPostingIT {
+
+    @Container
+    static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+        // Schema + seed come from the real Flyway chain, not Hibernate DDL.
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    @Autowired
+    private Clock clock;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private InventoryShrinkagePostingService shrinkagePostingService;
+
+    @Autowired
+    private ProcessedEventRepository processedEventRepository;
+
+    @Autowired
+    private IdempotencyKeyRepository idempotencyKeyRepository;
+
+    @Autowired
+    private JournalEntryRepository journalEntryRepository;
+
+    @Autowired
+    private AccountingSequenceRepository sequenceRepository;
+
+    @Autowired
+    private GLAccountRepository glAccountRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    /**
+     * The listener under test, wired with the real Spring collaborators. Constructed manually
+     * because the Kafka rails ({@code pos.accounting.kafka.enabled}) stay off in tests — the
+     * message path from envelope JSON to posting is identical.
+     */
+    private InventoryEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new InventoryEventsListener(clock, objectMapper, processedEventRepository, shrinkagePostingService);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        journalEntryRepository.deleteAll();
+        sequenceRepository.deleteAll();
+        idempotencyKeyRepository.deleteAll();
+        processedEventRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Scrap fact posts one balanced Dr 5100 / Cr 1300 entry; replays and redeliveries are no-ops")
+    void scrapFactPostsBalancedEntryExactlyOnce() {
+        UUID scrapId = UUID.randomUUID();
+        // 3 x 12.50 = 37.50
+        String message = envelope("evt-1", scrapId, "\"DAMAGED\"", "12.50", "LATEST_RECEIPT");
+
+        listener.onInventoryEvent(message);
+
+        UUID shrinkage = accountId("5100");
+        UUID inventory = accountId("1300");
+        BigDecimal expected = new BigDecimal("37.50");
+
+        assertThat(journalEntryRepository.count()).isEqualTo(1);
+        Map<UUID, BigDecimal> debits = new HashMap<>();
+        Map<UUID, BigDecimal> credits = new HashMap<>();
+        sumLines(debits, credits);
+        assertThat(debits.getOrDefault(shrinkage, BigDecimal.ZERO)).isEqualByComparingTo(expected);
+        assertThat(credits.getOrDefault(inventory, BigDecimal.ZERO)).isEqualByComparingTo(expected);
+
+        inTransaction(() -> {
+            JournalEntry entry = journalEntryRepository.findAll().getFirst();
+            assertThat(entry.getStatus()).isEqualTo(JournalEntryStatus.POSTED);
+            // Reason code rides into the memo; unknown codes never block posting.
+            assertThat(entry.getDescription()).contains("DAMAGED").contains(scrapId.toString());
+            assertThat(entry.getLines()).hasSize(2);
+        });
+
+        // Replay of the exact same record: eventId dedup, no second entry.
+        listener.onInventoryEvent(message);
+        assertThat(journalEntryRepository.count()).isEqualTo(1);
+
+        // Redelivery under a fresh eventId (outbox re-publish): scrapId posting key, no second entry.
+        listener.onInventoryEvent(envelope("evt-2", scrapId, "\"DAMAGED\"", "12.50", "LATEST_RECEIPT"));
+        assertThat(journalEntryRepository.count()).isEqualTo(1);
+        assertThat(processedEventRepository.existsById("evt-1")).isTrue();
+        assertThat(processedEventRepository.existsById("evt-2")).isTrue();
+
+        Map<UUID, BigDecimal> debitsAfter = new HashMap<>();
+        sumLines(debitsAfter, new HashMap<>());
+        assertThat(debitsAfter.getOrDefault(shrinkage, BigDecimal.ZERO)).isEqualByComparingTo(expected);
+    }
+
+    @Test
+    @DisplayName("Uncosted fact (costSource NONE) posts nothing but is marked processed")
+    void uncostedFactIsSkippedButProcessed() {
+        UUID scrapId = UUID.randomUUID();
+
+        listener.onInventoryEvent(envelope("evt-3", scrapId, "\"LOST\"", "null", "NONE"));
+
+        assertThat(journalEntryRepository.count()).isZero();
+        assertThat(processedEventRepository.existsById("evt-3")).isTrue();
+    }
+
+    // ===== helpers =====
+
+    private String envelope(String eventId, UUID scrapId, String reasonCode, String unitCost, String costSource) {
+        Instant occurredAt = Instant.now(clock);
+        return """
+                {"eventId":"%s","eventType":"inventory.scrap.posted","schemaVersion":1,
+                 "aggregateId":"%s","aggregateVersion":0,
+                 "occurredAtUtc":"%s","sourceService":"pos-inventory",
+                 "payload":{"scrapId":"%s","sku":"BRAKE-PAD-22","locationId":null,
+                            "storageLocationId":null,"quantity":3,"reasonCode":%s,
+                            "unitCost":%s,"costSource":"%s","workorderId":null,
+                            "occurredAt":"%s"}}
+                """.formatted(eventId, scrapId, occurredAt, scrapId, reasonCode, unitCost, costSource, occurredAt);
+    }
+
+    private UUID accountId(String accountCode) {
+        return glAccountRepository
+                .findByAccountCode(accountCode)
+                .orElseThrow(() -> new IllegalStateException("Seed missing GL account " + accountCode))
+                .getGlAccountId();
+    }
+
+    /** Sum debit and credit amounts per GL account across all journal entries (lazy assoc loaded in-tx). */
+    private void sumLines(Map<UUID, BigDecimal> debits, Map<UUID, BigDecimal> credits) {
+        inTransaction(() -> {
+            for (JournalEntry entry : journalEntryRepository.findAll()) {
+                for (JournalEntryLine line : entry.getLines()) {
+                    BigDecimal debit = line.getDebitAmount() == null ? BigDecimal.ZERO : line.getDebitAmount();
+                    BigDecimal credit = line.getCreditAmount() == null ? BigDecimal.ZERO : line.getCreditAmount();
+                    debits.merge(line.getGlAccountId(), debit, BigDecimal::add);
+                    credits.merge(line.getGlAccountId(), credit, BigDecimal::add);
+                }
+            }
+        });
+    }
+
+    private void inTransaction(Runnable work) {
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> work.run());
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/TransferOrderUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/TransferOrderUpdatedV1.java
@@ -63,6 +63,20 @@ public record TransferOrderUpdatedV1(
         if (occurredAt == null) {
             throw new IllegalArgumentException("occurredAt must not be null");
         }
+        if (shortCloseDisposition != null) {
+            if (!"SHORT_CLOSED".equals(status)) {
+                throw new IllegalArgumentException("shortCloseDisposition is only valid for status SHORT_CLOSED");
+            }
+            if (!"LOST_IN_TRANSIT".equals(shortCloseDisposition)
+                    && !"RETURNED_TO_SOURCE".equals(shortCloseDisposition)) {
+                throw new IllegalArgumentException(
+                        "shortCloseDisposition must be LOST_IN_TRANSIT or RETURNED_TO_SOURCE, got: "
+                                + shortCloseDisposition);
+            }
+        }
+        if ("SHORT_CLOSED".equals(status) && shortCloseDisposition == null) {
+            throw new IllegalArgumentException("status SHORT_CLOSED requires a shortCloseDisposition");
+        }
         lines = List.copyOf(lines);
     }
 

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/TransferOrderUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/TransferOrderUpdatedV1.java
@@ -23,6 +23,11 @@ import org.jspecify.annotations.Nullable;
  * @param destinationLocationId destination site the transfer ships to
  * @param destinationStorageLocationId bin-level destination storage location, when bin-scoped
  * @param lines per-line quantity summary as of this transition
+ * @param shortCloseDisposition disposition chosen when the order was short-closed
+ *     ({@code LOST_IN_TRANSIT} or {@code RETURNED_TO_SOURCE}, odoo-parity C3 issue #1039);
+ *     null on every other transition. Transit losses carry NO {@code ScrapPostedV1} fact —
+ *     no scrap document exists for them — so accounting consumers derive the shrinkage from
+ *     this disposition plus the line remainders ({@code dispatchedQty - receivedQty})
  * @param occurredAt when the transition was recorded
  */
 public record TransferOrderUpdatedV1(
@@ -33,6 +38,7 @@ public record TransferOrderUpdatedV1(
         @NonNull UUID destinationLocationId,
         @Nullable UUID destinationStorageLocationId,
         @NonNull List<LineSummary> lines,
+        @Nullable String shortCloseDisposition,
         @NonNull Instant occurredAt) {
 
     public static final String EVENT_TYPE = "inventory.transfer-order.updated";

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -487,6 +487,69 @@ paths:
         - inventory:transfer:create
       x-required-permissions:
       - inventory:transfer:create
+  /v1/inventory/transfer-orders/{transferOrderId}/short-close:
+    post:
+      tags:
+      - Transfer Orders
+      summary: Short-close transfer order
+      description: 'Short-closes a DISPATCHED or PARTIALLY_RECEIVED order whose in-transit remainder will never be received normally (parity-C3). One whole-order disposition resolves every line''s remainder (dispatched minus received): LOST_IN_TRANSIT writes it off through the ledger funnel (paired constructive TRANSFER_IN + SCRAP_OUT with reason LOST at the destination — global on-hand drops, no scrap document is created); RETURNED_TO_SOURCE restores it to source on-hand (constructive TRANSFER_IN, TRANSFER_OUT back, TRANSFER_IN at source). Either way the destination in-transit quantity zeroes atomically and the order reaches the terminal SHORT_CLOSED status; reason and notes are mandatory. The terminal TransferOrderUpdatedV1 fact carries the disposition.'
+      operationId: shortCloseTransferOrder
+      parameters:
+      - name: transferOrderId
+        in: path
+        description: Transfer order ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShortCloseTransferOrderRequest'
+        required: true
+      responses:
+        '200':
+          description: Transfer order short-closed (terminal)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferOrderResponse'
+        '400':
+          description: Missing disposition, reason, or notes
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '403':
+          description: Missing inventory:transfer:short_close
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '404':
+          description: Transfer order not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Order is not short-closable (not DISPATCHED/PARTIALLY_RECEIVED, or no outstanding in-transit remainder)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '422':
+          description: 'RETURNED_TO_SOURCE only: the source site is not movement-eligible (TRANSFER_LOCATION_NOT_ELIGIBLE per DECISION-INVENTORY-009)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - inventory:transfer:short_close
+      x-required-permissions:
+      - inventory:transfer:short_close
   /v1/inventory/transfer-orders/{transferOrderId}/receive:
     post:
       tags:
@@ -5233,6 +5296,25 @@ components:
         dispatchedBy:
           type: string
           description: User who dispatched the order
+        shortCloseDisposition:
+          type: string
+          description: Disposition of the undelivered remainder; set only when SHORT_CLOSED
+          enum:
+          - LOST_IN_TRANSIT
+          - RETURNED_TO_SOURCE
+        shortCloseReason:
+          type: string
+          description: Short-close reason; set only when SHORT_CLOSED
+        shortCloseNotes:
+          type: string
+          description: Short-close notes; set only when SHORT_CLOSED
+        shortClosedBy:
+          type: string
+          description: User who short-closed the order; set only when SHORT_CLOSED
+        shortClosedAt:
+          type: string
+          format: date-time
+          description: When the order was short-closed; set only when SHORT_CLOSED
         createdAt:
           type: string
           format: date-time
@@ -5241,6 +5323,30 @@ components:
           type: string
           format: date-time
           description: Last update timestamp
+    ShortCloseTransferOrderRequest:
+      type: object
+      description: Request to short-close a transfer order, resolving the undelivered remainder with a whole-order disposition
+      properties:
+        disposition:
+          type: string
+          description: 'Disposition of the undelivered remainder: LOST_IN_TRANSIT writes it off (SCRAP_OUT, reason LOST); RETURNED_TO_SOURCE restores it to source on-hand'
+          enum:
+          - LOST_IN_TRANSIT
+          - RETURNED_TO_SOURCE
+        reason:
+          type: string
+          description: Reason for the short-close (mandatory)
+          maxLength: 100
+          minLength: 0
+        notes:
+          type: string
+          description: Free-text notes explaining the short-close (mandatory)
+          maxLength: 2000
+          minLength: 0
+      required:
+      - disposition
+      - notes
+      - reason
     ReceiveTransferOrderRequest:
       type: object
       description: Request to receive a transfer order; omitted lines receive their full remainder

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -5454,6 +5454,13 @@ components:
           type: integer
           format: int32
           description: Quantity received at the destination so far
+        lotId:
+          type: string
+          format: uuid
+          description: Lot the dispatched units were drawn from (LOT-tracked SKUs, pinned at dispatch)
+        lotNumber:
+          type: string
+          description: Lot number matching lotId, kept for audit/display
         createdAt:
           type: string
           format: date-time
@@ -5586,6 +5593,12 @@ components:
           type: integer
           format: int32
           description: Quantity to dispatch/receive on this line; must be positive
+        lotNumber:
+          type: string
+          description: Lot number the dispatched units are drawn from (dispatch only; receive and short-close reuse the lot recorded at dispatch). Required (422 LOT_NUMBER_REQUIRED) when the SKU is LOT-tracked; must reference an existing (422 LOT_UNKNOWN) ACTIVE (422 LOT_NOT_AVAILABLE) lot. Ignored for untracked SKUs
+          example: LOT-2026-A
+          maxLength: 128
+          minLength: 0
       required:
       - lineId
       - quantity
@@ -5750,6 +5763,12 @@ components:
           format: uuid
           description: Workorder the scrapped part belonged to, when linked
           example: 01960005-0000-7000-8000-000000000001
+        lotNumber:
+          type: string
+          description: Lot number the scrapped units belong to. Required (422 LOT_NUMBER_REQUIRED) when the SKU is LOT-tracked; must reference an existing (422 LOT_UNKNOWN) ACTIVE (422 LOT_NOT_AVAILABLE) lot. Ignored for untracked SKUs
+          example: LOT-2026-A
+          maxLength: 128
+          minLength: 0
         attachmentReference:
           type: string
           description: Photo/attachment reference (storage out of scope)
@@ -5810,6 +5829,10 @@ components:
           type: string
           format: uuid
           description: Linked workorder, when the part was damaged during a job
+        lotId:
+          type: string
+          format: uuid
+          description: Lot the scrapped units belong to (LOT-tracked SKUs)
         attachmentReference:
           type: string
           description: Photo/attachment reference
@@ -6419,6 +6442,12 @@ components:
           type: string
           description: Optional free-text note describing the cross-dock action
           example: Cross-docked at dock door 3 for urgent workorder
+        lotNumber:
+          type: string
+          description: Lot or batch number of the cross-docked stock. Required (422 LOT_NUMBER_REQUIRED) when the product is LOT-tracked (falls back to the lot number already keyed on the receiving line); the lot is found-or-created like any receipt and stamped on BOTH paired ledger entries. Ignored for untracked products
+          example: LOT-2026-A
+          maxLength: 128
+          minLength: 0
       required:
       - quantity
       - workorderId
@@ -7238,6 +7267,12 @@ components:
           format: int32
           description: Quantity of units actually picked at the scanned location
           example: 12
+        lotNumber:
+          type: string
+          description: Lot number the units were picked from. Required (422 LOT_NUMBER_REQUIRED) when the SKU is LOT-tracked; must reference an existing (422 LOT_UNKNOWN) ACTIVE (422 LOT_NOT_AVAILABLE) lot. May differ from the task's advisory suggestedLotNumber. Ignored for untracked SKUs
+          example: LOT-2026-A
+          maxLength: 128
+          minLength: 0
       required:
       - quantityPicked
       - scannedLocationId
@@ -7290,6 +7325,15 @@ components:
           format: int32
           description: Ordinal position of this task in the pick sequence
           example: 1
+        suggestedLotNumber:
+          type: string
+          description: Advisory lot suggestion for LOT-tracked SKUs (FIFO by lot receivedAt at the suggested location; FEFO once expiry data exists). Null for untracked SKUs or when no lot has stock
+          example: LOT-2026-A
+        pickedLotId:
+          type: string
+          format: uuid
+          description: Identifier of the lot actually keyed at pick confirmation for LOT-tracked SKUs; null for untracked SKUs and before confirmation
+          example: 01960003-0000-7000-8000-000000000044
       required:
       - locationId
       - pickListId
@@ -7998,6 +8042,12 @@ components:
           format: int32
           description: Quantity of the SKU to consume
           example: 4
+        lotNumber:
+          type: string
+          description: 'Optional lot override for LOT-tracked SKUs: must reference an existing (422 LOT_UNKNOWN) ACTIVE (422 LOT_NOT_AVAILABLE) lot. When absent, the lot recorded at pick confirmation is used; a LOT-tracked SKU with neither is rejected (422 LOT_NUMBER_REQUIRED). Ignored for untracked SKUs'
+          example: LOT-2026-A
+          maxLength: 128
+          minLength: 0
       required:
       - pickTaskId
       - quantity

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -211,6 +211,51 @@ paths:
         - inventory:location:admin
       x-required-permissions:
       - inventory:location:admin
+  /v1/inventory/replenishment/policies/{policyId}:
+    put:
+      tags:
+      - Replenishment
+      summary: Update replenishment policy
+      description: Full-replace update of a policy's min/max thresholds and tuning fields (order multiple, lead-time override, preferred source type, active flag). Omitted optional fields are cleared or reset to defaults. Location, SKU, and snooze state are not updatable here; snooze is managed by the snooze endpoint.
+      operationId: updateReplenishmentPolicy
+      parameters:
+      - name: policyId
+        in: path
+        description: Replenishment policy identifier
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateReplenishmentPolicyRequest'
+        required: true
+      responses:
+        '200':
+          description: Replenishment policy updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplenishmentPolicyResponse'
+        '400':
+          description: Validation failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplenishmentPolicyResponse'
+        '404':
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplenishmentPolicyResponse'
+      security:
+      - bearerAuth:
+        - inventory:replenishment:manage
+      x-required-permissions:
+      - inventory:replenishment:manage
   /v1/inventory/cycleCountSchedules/{scheduleId}:
     get:
       tags:
@@ -1266,6 +1311,51 @@ paths:
                 $ref: '#/components/schemas/ReplenishmentPolicyResponse'
         '400':
           description: Validation failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplenishmentPolicyResponse'
+      security:
+      - bearerAuth:
+        - inventory:replenishment:manage
+      x-required-permissions:
+      - inventory:replenishment:manage
+  /v1/inventory/replenishment/policies/{policyId}/snooze:
+    post:
+      tags:
+      - Replenishment
+      summary: Snooze or unsnooze a replenishment policy
+      description: Excludes the policy from scan, event, and needs evaluation until the given future instant (Odoo orderpoint snooze). A null snoozedUntil clears an existing snooze — there is no separate unsnooze endpoint. A non-null instant that is not in the future is rejected with 422.
+      operationId: snoozeReplenishmentPolicy
+      parameters:
+      - name: policyId
+        in: path
+        description: Replenishment policy identifier
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SnoozeReplenishmentPolicyRequest'
+        required: true
+      responses:
+        '200':
+          description: Snooze state updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplenishmentPolicyResponse'
+        '404':
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplenishmentPolicyResponse'
+        '422':
+          description: snoozedUntil is not in the future
           content:
             application/json:
               schema:
@@ -3444,6 +3534,27 @@ paths:
         - inventory:on_hand:view
       x-required-permissions:
       - inventory:on_hand:view
+  /v1/inventory/replenishment/needs:
+    get:
+      tags:
+      - Replenishment
+      summary: Replenishment needs report
+      description: 'Side-effect-free orderpoint evaluation of every active, non-snoozed replenishment policy: projected availability at the lead-time horizon, whether a scan would trigger, the multiple-rounded suggested quantity, and the projected stock-out deadline. Never creates or refreshes tasks — ops review before running the scan.'
+      operationId: listReplenishmentNeeds
+      responses:
+        '200':
+          description: Replenishment needs returned
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ReplenishmentNeedResponse'
+      security:
+      - bearerAuth:
+        - inventory:on_hand:view
+      x-required-permissions:
+      - inventory:on_hand:view
   /v1/inventory/receiving/sessions/{sessionId}:
     get:
       tags:
@@ -4969,6 +5080,113 @@ components:
       required:
       - field
       - message
+    UpdateReplenishmentPolicyRequest:
+      type: object
+      description: Full-replace update of a replenishment policy's thresholds and tuning fields. Omitted optional fields are cleared or reset to defaults; location, SKU, and snooze state are not updatable here.
+      properties:
+        minimumQuantity:
+          type: integer
+          format: int32
+          description: Minimum on-hand quantity that triggers replenishment when reached
+          example: 5
+          minimum: 0
+        maximumQuantity:
+          type: integer
+          format: int32
+          description: Maximum on-hand quantity replenishment aims to restock up to
+          example: 50
+          minimum: 1
+        orderMultiple:
+          type: integer
+          format: int32
+          description: Round the computed replenishment quantity up to the nearest multiple of this value; omit to clear (no rounding)
+          example: 6
+          minimum: 1
+        leadTimeDaysOverride:
+          type: integer
+          format: int32
+          description: Per-policy lead-time override in days; omit to clear (vendor-feed/default lead time applies)
+          example: 3
+          minimum: 0
+        preferredSourceType:
+          type: string
+          description: Preferred sourcing channel for replenishing this policy's pick face; omit to reset to EITHER
+          enum:
+          - INTERNAL_TRANSFER
+          - PURCHASE
+          - EITHER
+          example: EITHER
+        active:
+          type: boolean
+          description: Whether the policy participates in replenishment evaluation; omit to reset to true
+          example: true
+        minimumLessThanMaximum:
+          type: boolean
+      required:
+      - maximumQuantity
+      - minimumQuantity
+    ReplenishmentPolicyResponse:
+      type: object
+      description: Representation of a replenishment policy defining min/max stock thresholds for an item at a location
+      properties:
+        policyId:
+          type: string
+          description: Unique identifier of the replenishment policy
+          example: 01960003-0000-7000-8000-000000000001
+        locationId:
+          type: string
+          format: uuid
+          description: Identifier of the location the replenishment policy applies to
+          example: 01960003-0000-7000-8000-000000000002
+        itemSKU:
+          type: string
+          description: SKU of the item the replenishment policy applies to
+          example: SKU-10042
+        minimumQuantity:
+          type: integer
+          format: int32
+          description: Minimum on-hand quantity that triggers replenishment when reached
+          example: 5
+        maximumQuantity:
+          type: integer
+          format: int32
+          description: Maximum on-hand quantity replenishment aims to restock up to
+          example: 50
+        orderMultiple:
+          type: integer
+          format: int32
+          description: Round the computed replenishment quantity up to the nearest multiple of this value; absent means no rounding
+          example: 6
+        leadTimeDaysOverride:
+          type: integer
+          format: int32
+          description: Per-policy lead-time override in days; absent means vendor-feed/default lead time applies
+          example: 3
+        preferredSourceType:
+          type: string
+          description: Preferred sourcing channel for replenishing this policy's pick face
+          example: EITHER
+        snoozedUntil:
+          type: string
+          description: Instant until which the policy is snoozed (excluded from replenishment evaluation); absent or past means the policy is evaluated normally
+          example: 2026-02-01 00:00:00+00:00
+        active:
+          type: boolean
+          description: Whether the policy participates in replenishment evaluation
+          example: true
+        createdAt:
+          type: string
+          description: Timestamp at which the replenishment policy was created
+          example: 2026-01-15 09:30:00+00:00
+      required:
+      - active
+      - createdAt
+      - itemSKU
+      - locationId
+      - maximumQuantity
+      - minimumQuantity
+      - policyId
+      - preferredSourceType
     UpdateCycleCountScheduleRequest:
       type: object
       description: Partial update of a recurring cycle-count schedule; null fields are left unchanged
@@ -5873,6 +6091,11 @@ components:
           format: int32
           description: Number of already-open replenishment tasks whose quantity was refreshed to the current need
           example: 2
+        policiesSkipped:
+          type: integer
+          format: int32
+          description: Number of policies skipped without evaluation because they are inactive or snoozed
+          example: 1
         scanAt:
           type: string
           description: Timestamp at which the scan ran
@@ -5880,6 +6103,7 @@ components:
       required:
       - policiesBelowMinimum
       - policiesEvaluated
+      - policiesSkipped
       - scanAt
       - tasksCreated
       - tasksRefreshed
@@ -5909,6 +6133,30 @@ components:
           description: Maximum on-hand quantity replenishment aims to restock up to
           example: 50
           minimum: 1
+        orderMultiple:
+          type: integer
+          format: int32
+          description: Round the computed replenishment quantity up to the nearest multiple of this value. When omitted, defaults to the vendor-feed pack size for the SKU when one is known (greater than 1); otherwise no rounding is applied.
+          example: 6
+          minimum: 1
+        leadTimeDaysOverride:
+          type: integer
+          format: int32
+          description: Per-policy lead-time override in days; takes precedence over vendor-feed lead-time estimates and the configured default
+          example: 3
+          minimum: 0
+        preferredSourceType:
+          type: string
+          description: Preferred sourcing channel for replenishing this policy's pick face; defaults to EITHER
+          enum:
+          - INTERNAL_TRANSFER
+          - PURCHASE
+          - EITHER
+          example: EITHER
+        active:
+          type: boolean
+          description: Whether the policy participates in replenishment evaluation; defaults to true
+          example: true
         minimumLessThanMaximum:
           type: boolean
       required:
@@ -5916,44 +6164,15 @@ components:
       - locationId
       - maximumQuantity
       - minimumQuantity
-    ReplenishmentPolicyResponse:
+    SnoozeReplenishmentPolicyRequest:
       type: object
-      description: Representation of a replenishment policy defining min/max stock thresholds for an item at a location
+      description: Request to snooze a replenishment policy until a future instant, or clear an existing snooze by sending a null snoozedUntil
       properties:
-        policyId:
+        snoozedUntil:
           type: string
-          description: Unique identifier of the replenishment policy
-          example: 01960003-0000-7000-8000-000000000001
-        locationId:
-          type: string
-          format: uuid
-          description: Identifier of the location the replenishment policy applies to
-          example: 01960003-0000-7000-8000-000000000002
-        itemSKU:
-          type: string
-          description: SKU of the item the replenishment policy applies to
-          example: SKU-10042
-        minimumQuantity:
-          type: integer
-          format: int32
-          description: Minimum on-hand quantity that triggers replenishment when reached
-          example: 5
-        maximumQuantity:
-          type: integer
-          format: int32
-          description: Maximum on-hand quantity replenishment aims to restock up to
-          example: 50
-        createdAt:
-          type: string
-          description: Timestamp at which the replenishment policy was created
-          example: 2026-01-15 09:30:00+00:00
-      required:
-      - createdAt
-      - itemSKU
-      - locationId
-      - maximumQuantity
-      - minimumQuantity
-      - policyId
+          format: date-time
+          description: Future instant until which the policy is excluded from replenishment evaluation; null clears an existing snooze
+          example: 2026-02-01 00:00:00+00:00
     CreateReceivingSessionRequest:
       type: object
       description: Request to open a new inventory receiving session against a source document
@@ -8653,6 +8872,10 @@ components:
           type: string
           description: Identifier or name of the user the replenishment task is assigned to
           example: user-jdoe
+        deadlineDate:
+          type: string
+          description: Earliest date at which the projected available quantity goes below zero (stock-out deadline used for prioritization); absent when no stock-out is projected within the lead-time horizon
+          example: 2026-01-20
         createdAt:
           type: string
           description: Timestamp at which the replenishment task was created
@@ -8664,6 +8887,85 @@ components:
       - quantity
       - status
       - taskId
+    ReplenishmentNeedResponse:
+      type: object
+      description: 'Current computed replenishment state of one active, non-snoozed policy: the same orderpoint evaluation the batch scan applies, with no side effects'
+      properties:
+        policyId:
+          type: string
+          description: Unique identifier of the replenishment policy
+          example: 01960003-0000-7000-8000-000000000001
+        itemSKU:
+          type: string
+          description: SKU of the item the policy applies to
+          example: SKU-10042
+        locationId:
+          type: string
+          format: uuid
+          description: Identifier of the location the policy applies to
+          example: 01960003-0000-7000-8000-000000000002
+        onHand:
+          type: integer
+          format: int64
+          description: Current on-hand quantity at the policy's location
+          example: 3
+        projectedAvailable:
+          type: integer
+          format: int64
+          description: Projected available quantity at the lead-time horizon (on-hand + expected supply - open demand)
+          example: 3
+        leadHorizonDate:
+          type: string
+          description: UTC date of the lead-time horizon the projection was evaluated at
+          example: 2026-01-20
+        leadTimeSource:
+          type: string
+          description: Where the resolved lead time came from
+          enum:
+          - POLICY_OVERRIDE
+          - FEED
+          - DEFAULT
+          example: POLICY_OVERRIDE
+        minimumQuantity:
+          type: integer
+          format: int32
+          description: Minimum on-hand quantity that triggers replenishment when reached
+          example: 5
+        maximumQuantity:
+          type: integer
+          format: int32
+          description: Maximum on-hand quantity replenishment aims to restock up to
+          example: 50
+        wouldTrigger:
+          type: boolean
+          description: Whether a batch scan run now would consider this policy triggered (projected available below minimum)
+          example: true
+        suggestedQuantity:
+          type: integer
+          format: int32
+          description: 'Quantity a scan would replenish now: replenish-to-max after in-progress netting, rounded up to the policy''s order multiple; zero when in-progress supply already covers the need or the policy is not triggered'
+          example: 12
+        deadlineDate:
+          type: string
+          description: Earliest date at which the projected available quantity goes below zero; absent when the policy is not triggered or no stock-out is projected within the lead-time horizon
+          example: 2026-01-20
+        preferredSourceType:
+          type: string
+          description: Preferred sourcing channel configured on the policy
+          example: EITHER
+      required:
+      - itemSKU
+      - leadHorizonDate
+      - leadTimeSource
+      - locationId
+      - maximumQuantity
+      - minimumQuantity
+      - onHand
+      - policyId
+      - preferredSourceType
+      - projectedAvailable
+      - suggestedQuantity
+      - wouldTrigger
     ListPurchaseOrdersRequest:
       type: object
       description: Optional filter criteria for listing purchase orders

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
@@ -38,7 +38,7 @@ public final class EventTypes {
                 EventTypeRegistration.approval("INVENTORY_SCRAP_REJECT", "Reject a pending scrap document")
                         .build(),
 
-                // TransferOrderController - 5 events (odoo-parity C1/C2, #1035/#1036)
+                // TransferOrderController - 6 events (odoo-parity C1/C2/C3, #1035/#1036/#1039)
                 EventTypeRegistration.write("INVENTORY_TRANSFER_ORDER_CREATE", "Create a cross-site transfer order")
                         .build(),
                 EventTypeRegistration.approval("INVENTORY_TRANSFER_ORDER_APPROVE", "Approve a DRAFT transfer order")
@@ -53,6 +53,13 @@ public final class EventTypes {
                 EventTypeRegistration.write(
                                 "INVENTORY_TRANSFER_ORDER_RECEIVE",
                                 "Receive dispatched transfer quantities at the destination (posts TRANSFER_IN)")
+                        .build(),
+                // Approval preset: short-close accepts a stock loss or reverses a movement
+                // (odoo-parity C3, #1039).
+                EventTypeRegistration.approval(
+                                "INVENTORY_TRANSFER_ORDER_SHORT_CLOSE",
+                                "Short-close a transfer order's undelivered remainder with a loss or return"
+                                        + " disposition")
                         .build(),
 
                 // SourcingStrategyController - 3 events (odoo-parity H1, #1037)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
@@ -144,10 +144,21 @@ public final class EventTypes {
                 EventTypeRegistration.write("INVENTORY_PUTAWAY_TASK_CLAIM", "Claim a putaway task for execution")
                         .build(),
 
-                // ReplenishmentController - 2 events
+                // ReplenishmentController - 5 events
                 EventTypeRegistration.write(
                                 "INVENTORY_REPLENISHMENT_POLICY_CREATE",
                                 "Create replenishment policy used for task generation")
+                        .build(),
+                EventTypeRegistration.write(
+                                "INVENTORY_REPLENISHMENT_POLICY_UPDATE",
+                                "Update a replenishment policy's thresholds and tuning fields")
+                        .build(),
+                EventTypeRegistration.write(
+                                "INVENTORY_REPLENISHMENT_POLICY_SNOOZE", "Snooze or unsnooze a replenishment policy")
+                        .build(),
+                EventTypeRegistration.fastRead(
+                                "INVENTORY_REPLENISHMENT_NEEDS_LIST",
+                                "List the side-effect-free replenishment needs report")
                         .build(),
                 EventTypeRegistration.write(
                                 "INVENTORY_REPLENISHMENT_SCAN_RUN",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -17,7 +17,10 @@ import com.positivity.inventory.internal.exception.LocationAtCapacityException;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.LocationNotValidForSkuException;
 import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
+import com.positivity.inventory.internal.exception.LotInsufficientStockException;
+import com.positivity.inventory.internal.exception.LotNotAvailableException;
 import com.positivity.inventory.internal.exception.LotNumberRequiredException;
+import com.positivity.inventory.internal.exception.LotUnknownException;
 import com.positivity.inventory.internal.exception.NegativeStockPolicyViolationException;
 import com.positivity.inventory.internal.exception.NoOnHandAtSourceLocationException;
 import com.positivity.inventory.internal.exception.OverReceiptNotPermittedException;
@@ -308,8 +311,28 @@ public class InventoryGlobalExceptionHandler {
     @ExceptionHandler(LotNumberRequiredException.class)
     public ResponseEntity<ApiError> handleLotNumberRequired(LotNumberRequiredException ex) {
         // odoo-parity E1 (#1038): a receipt of a LOT-tracked product without a lot number is a
-        // deterministic 422, never a silently untracked posting.
+        // deterministic 422, never a silently untracked posting. Since E2 (#1042) the same
+        // code gates the outbound flows (pick confirm, consumption, transfer dispatch, scrap).
         return build(HttpStatus.valueOf(422), LotNumberRequiredException.ERROR_CODE, ex.getMessage());
+    }
+
+    @ExceptionHandler(LotUnknownException.class)
+    public ResponseEntity<ApiError> handleLotUnknown(LotUnknownException ex) {
+        // odoo-parity E2 (#1042): outbound flows never create lots — an unknown lot number is
+        // a deterministic 422.
+        return build(HttpStatus.valueOf(422), LotUnknownException.ERROR_CODE, ex.getMessage());
+    }
+
+    @ExceptionHandler(LotNotAvailableException.class)
+    public ResponseEntity<ApiError> handleLotNotAvailable(LotNotAvailableException ex) {
+        // odoo-parity E2 (#1042): QUARANTINED/RECALLED/CONSUMED lots cannot leave stock.
+        return build(HttpStatus.valueOf(422), LotNotAvailableException.ERROR_CODE, ex.getMessage());
+    }
+
+    @ExceptionHandler(LotInsufficientStockException.class)
+    public ResponseEntity<ApiError> handleLotInsufficientStock(LotInsufficientStockException ex) {
+        // odoo-parity E2 (#1042): the per-lot negative floor is absolute — no override.
+        return build(HttpStatus.valueOf(422), LotInsufficientStockException.ERROR_CODE, ex.getMessage());
     }
 
     @ExceptionHandler(InvalidParamCombinationException.class)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -34,6 +34,7 @@ import com.positivity.inventory.internal.exception.RollupExpansionTooLargeExcept
 import com.positivity.inventory.internal.exception.ScrapInsufficientStockException;
 import com.positivity.inventory.internal.exception.ScrapLedgerPostingException;
 import com.positivity.inventory.internal.exception.ScrapNotFoundException;
+import com.positivity.inventory.internal.exception.SnoozeUntilNotInFutureException;
 import com.positivity.inventory.internal.exception.SourceDocumentAlreadyReceivedException;
 import com.positivity.inventory.internal.exception.SourceDocumentNotFoundException;
 import com.positivity.inventory.internal.exception.TaskNotFoundException;
@@ -182,6 +183,12 @@ public class InventoryGlobalExceptionHandler {
     public ResponseEntity<ApiError> handleAsOfInFuture(AsOfInFutureException ex) {
         // odoo-parity A3 (#1029): deterministic 422 for future-dated point-in-time queries.
         return build(HttpStatus.valueOf(422), "AS_OF_IN_FUTURE", ex.getMessage());
+    }
+
+    @ExceptionHandler(SnoozeUntilNotInFutureException.class)
+    public ResponseEntity<ApiError> handleSnoozeUntilNotInFuture(SnoozeUntilNotInFutureException ex) {
+        // odoo-parity F3 (#1041): deterministic 422 for non-future snooze instants.
+        return build(HttpStatus.valueOf(422), SnoozeUntilNotInFutureException.ERROR_CODE, ex.getMessage());
     }
 
     @ExceptionHandler(InsufficientPermissionException.class)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/PickListController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/PickListController.java
@@ -200,7 +200,8 @@ public class PickListController {
                 taskId,
                 request.getScannedSkuId(),
                 request.getScannedLocationId(),
-                request.getQuantityPicked()));
+                request.getQuantityPicked(),
+                request.getLotNumber()));
     }
 
     @GetMapping("/{pickListId}/tasks")

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReplenishmentController.java
@@ -2,9 +2,12 @@ package com.positivity.inventory.internal.controller;
 
 import com.positivity.events.EmitEvent;
 import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentNeedResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
+import com.positivity.inventory.internal.dto.replenishment.SnoozeReplenishmentPolicyRequest;
+import com.positivity.inventory.internal.dto.replenishment.UpdateReplenishmentPolicyRequest;
 import com.positivity.inventory.internal.security.InventoryPermissionRegistry;
 import com.positivity.inventory.service.ReplenishmentService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,7 +27,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -106,6 +111,91 @@ public class ReplenishmentController {
     public ResponseEntity<ReplenishmentPolicyResponse> createReplenishmentPolicy(
             @Valid @RequestBody CreateReplenishmentPolicyRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(replenishmentService.createReplenishmentPolicy(request));
+    }
+
+    @PutMapping("/policies/{policyId}")
+    @EmitEvent(id = "INVENTORY_REPLENISHMENT_POLICY_UPDATE", apiVersion = "1")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:replenishment:manage"})
+    @PreAuthorize("hasAuthority('" + InventoryPermissionRegistry.REPLENISHMENT_MANAGE + "')")
+    @Operation(
+            operationId = "updateReplenishmentPolicy",
+            summary = "Update replenishment policy",
+            description = "Full-replace update of a policy's min/max thresholds and tuning fields (order multiple,"
+                    + " lead-time override, preferred source type, active flag). Omitted optional fields are"
+                    + " cleared or reset to defaults. Location, SKU, and snooze state are not updatable here;"
+                    + " snooze is managed by the snooze endpoint.",
+            tags = {"Replenishment"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Replenishment policy updated",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ReplenishmentPolicyResponse.class)))
+    @ApiResponse(responseCode = "400", description = "Validation failure")
+    @ApiResponse(responseCode = "404", description = "Policy not found")
+    public ResponseEntity<ReplenishmentPolicyResponse> updateReplenishmentPolicy(
+            @io.swagger.v3.oas.annotations.Parameter(description = "Replenishment policy identifier") @PathVariable
+                    UUID policyId,
+            @Valid @RequestBody UpdateReplenishmentPolicyRequest request) {
+        return ResponseEntity.ok(replenishmentService.updateReplenishmentPolicy(policyId, request));
+    }
+
+    @PostMapping("/policies/{policyId}/snooze")
+    @EmitEvent(id = "INVENTORY_REPLENISHMENT_POLICY_SNOOZE", apiVersion = "1")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:replenishment:manage"})
+    @PreAuthorize("hasAuthority('" + InventoryPermissionRegistry.REPLENISHMENT_MANAGE + "')")
+    @Operation(
+            operationId = "snoozeReplenishmentPolicy",
+            summary = "Snooze or unsnooze a replenishment policy",
+            description = "Excludes the policy from scan, event, and needs evaluation until the given future"
+                    + " instant (Odoo orderpoint snooze). A null snoozedUntil clears an existing snooze —"
+                    + " there is no separate unsnooze endpoint. A non-null instant that is not in the future"
+                    + " is rejected with 422.",
+            tags = {"Replenishment"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Snooze state updated",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ReplenishmentPolicyResponse.class)))
+    @ApiResponse(responseCode = "404", description = "Policy not found")
+    @ApiResponse(responseCode = "422", description = "snoozedUntil is not in the future")
+    public ResponseEntity<ReplenishmentPolicyResponse> snoozeReplenishmentPolicy(
+            @io.swagger.v3.oas.annotations.Parameter(description = "Replenishment policy identifier") @PathVariable
+                    UUID policyId,
+            @Valid @RequestBody SnoozeReplenishmentPolicyRequest request) {
+        return ResponseEntity.ok(replenishmentService.snoozeReplenishmentPolicy(policyId, request.getSnoozedUntil()));
+    }
+
+    @GetMapping("/needs")
+    @EmitEvent(id = "INVENTORY_REPLENISHMENT_NEEDS_LIST", apiVersion = "1")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:on_hand:view"})
+    @PreAuthorize("hasAuthority('inventory:on_hand:view')")
+    @Operation(
+            operationId = "listReplenishmentNeeds",
+            summary = "Replenishment needs report",
+            description = "Side-effect-free orderpoint evaluation of every active, non-snoozed replenishment"
+                    + " policy: projected availability at the lead-time horizon, whether a scan would trigger,"
+                    + " the multiple-rounded suggested quantity, and the projected stock-out deadline. Never"
+                    + " creates or refreshes tasks — ops review before running the scan.",
+            tags = {"Replenishment"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Replenishment needs returned",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = ReplenishmentNeedResponse.class))))
+    public ResponseEntity<List<ReplenishmentNeedResponse>> getReplenishmentNeeds() {
+        return ResponseEntity.ok(replenishmentService.getReplenishmentNeeds());
     }
 
     @PostMapping("/scan")

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/TransferOrderController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/TransferOrderController.java
@@ -4,6 +4,7 @@ import com.positivity.events.EmitEvent;
 import com.positivity.inventory.internal.dto.transfer.CreateTransferOrderRequest;
 import com.positivity.inventory.internal.dto.transfer.DispatchTransferOrderRequest;
 import com.positivity.inventory.internal.dto.transfer.ReceiveTransferOrderRequest;
+import com.positivity.inventory.internal.dto.transfer.ShortCloseTransferOrderRequest;
 import com.positivity.inventory.internal.dto.transfer.TransferOrderResponse;
 import com.positivity.inventory.internal.enums.TransferOrderStatus;
 import com.positivity.inventory.service.TransferOrderService;
@@ -348,6 +349,79 @@ public class TransferOrderController {
         log.info("Received request to receive transfer order {}", transferOrderId);
         return ResponseEntity.ok(transferOrderService.receiveTransferOrder(
                 transferOrderId, request != null ? request : new ReceiveTransferOrderRequest()));
+    }
+
+    /**
+     * Short-closes a transfer order with an undelivered in-transit remainder.
+     *
+     * @param transferOrderId the order id
+     * @param request the mandatory disposition, reason, and notes
+     * @return the short-closed order
+     */
+    @PostMapping("/{transferOrderId}/short-close")
+    @EmitEvent(id = "INVENTORY_TRANSFER_ORDER_SHORT_CLOSE", apiVersion = "1")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:transfer:short_close"})
+    @PreAuthorize("hasAuthority('inventory:transfer:short_close')")
+    @Operation(
+            summary = "Short-close transfer order",
+            description = "Short-closes a DISPATCHED or PARTIALLY_RECEIVED order whose in-transit remainder will"
+                    + " never be received normally (parity-C3). One whole-order disposition resolves every line's"
+                    + " remainder (dispatched minus received): LOST_IN_TRANSIT writes it off through the ledger"
+                    + " funnel (paired constructive TRANSFER_IN + SCRAP_OUT with reason LOST at the destination —"
+                    + " global on-hand drops, no scrap document is created); RETURNED_TO_SOURCE restores it to"
+                    + " source on-hand (constructive TRANSFER_IN, TRANSFER_OUT back, TRANSFER_IN at source)."
+                    + " Either way the destination in-transit quantity zeroes atomically and the order reaches"
+                    + " the terminal SHORT_CLOSED status; reason and notes are mandatory. The terminal"
+                    + " TransferOrderUpdatedV1 fact carries the disposition.",
+            tags = {"Transfer Orders"})
+    @ApiResponse(responseCode = "200", description = "Transfer order short-closed (terminal)")
+    @ApiResponse(
+            responseCode = "400",
+            description = "Missing disposition, reason, or notes",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Missing inventory:transfer:short_close",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Transfer order not found",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Order is not short-closable (not DISPATCHED/PARTIALLY_RECEIVED, or no outstanding"
+                    + " in-transit remainder)",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "RETURNED_TO_SOURCE only: the source site is not movement-eligible"
+                    + " (TRANSFER_LOCATION_NOT_ELIGIBLE per DECISION-INVENTORY-009)",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<TransferOrderResponse> shortCloseTransferOrder(
+            @Parameter(description = "Transfer order ID", required = true) @PathVariable UUID transferOrderId,
+            @Valid @RequestBody ShortCloseTransferOrderRequest request) {
+        log.info(
+                "Received request to short-close transfer order {} with disposition {}",
+                transferOrderId,
+                request.getDisposition());
+        return ResponseEntity.ok(transferOrderService.shortCloseTransferOrder(transferOrderId, request));
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/consumption/ConsumeItemLine.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/consumption/ConsumeItemLine.java
@@ -1,10 +1,12 @@
 package com.positivity.inventory.internal.dto.consumption;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -35,4 +37,19 @@ public class ConsumeItemLine {
     @Schema(description = "Quantity of the SKU to consume", example = "4", requiredMode = REQUIRED)
     @Positive
     private int quantity;
+
+    @Schema(
+            description = "Optional lot override for LOT-tracked SKUs: must reference an existing"
+                    + " (422 LOT_UNKNOWN) ACTIVE (422 LOT_NOT_AVAILABLE) lot. When absent, the lot recorded at pick"
+                    + " confirmation is used; a LOT-tracked SKU with neither is rejected (422 LOT_NUMBER_REQUIRED)."
+                    + " Ignored for untracked SKUs",
+            example = "LOT-2026-A",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 128)
+    private String lotNumber;
+
+    /** Pre-E2 arity kept for existing callers/tests: no lot override keyed. */
+    public ConsumeItemLine(UUID pickTaskId, UUID skuId, int quantity) {
+        this(pickTaskId, skuId, quantity, null);
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/picklist/ConfirmPickTaskRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/picklist/ConfirmPickTaskRequest.java
@@ -1,10 +1,12 @@
 package com.positivity.inventory.internal.dto.picklist;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -39,4 +41,18 @@ public class ConfirmPickTaskRequest {
     @NotNull
     @Positive
     private Integer quantityPicked;
+
+    @Schema(
+            description = "Lot number the units were picked from. Required (422 LOT_NUMBER_REQUIRED) when the SKU"
+                    + " is LOT-tracked; must reference an existing (422 LOT_UNKNOWN) ACTIVE (422 LOT_NOT_AVAILABLE)"
+                    + " lot. May differ from the task's advisory suggestedLotNumber. Ignored for untracked SKUs",
+            example = "LOT-2026-A",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 128)
+    private String lotNumber;
+
+    /** Pre-E2 arity kept for existing callers/tests: no lot number keyed. */
+    public ConfirmPickTaskRequest(UUID scannedSkuId, UUID scannedLocationId, Integer quantityPicked) {
+        this(scannedSkuId, scannedLocationId, quantityPicked, null);
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/picklist/PickTaskResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/picklist/PickTaskResponse.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.dto.picklist;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.positivity.inventory.internal.enums.PickTaskStatus;
@@ -56,4 +57,44 @@ public class PickTaskResponse {
 
     @Schema(description = "Ordinal position of this task in the pick sequence", example = "1", requiredMode = REQUIRED)
     private int sortOrder;
+
+    @Schema(
+            description = "Advisory lot suggestion for LOT-tracked SKUs (FIFO by lot receivedAt at the suggested"
+                    + " location; FEFO once expiry data exists). Null for untracked SKUs or when no lot has stock",
+            example = "LOT-2026-A",
+            requiredMode = NOT_REQUIRED)
+    private String suggestedLotNumber;
+
+    @Schema(
+            description = "Identifier of the lot actually keyed at pick confirmation for LOT-tracked SKUs;"
+                    + " null for untracked SKUs and before confirmation",
+            example = "01960003-0000-7000-8000-000000000044",
+            requiredMode = NOT_REQUIRED)
+    private UUID pickedLotId;
+
+    /**
+     * Pre-E2 arity kept for existing callers/tests: lot fields default to null (odoo-parity
+     * E2, issue #1042).
+     */
+    public PickTaskResponse(
+            UUID pickTaskId,
+            UUID pickListId,
+            UUID skuId,
+            UUID locationId,
+            int quantityRequired,
+            int quantityPicked,
+            PickTaskStatus status,
+            int sortOrder) {
+        this(
+                pickTaskId,
+                pickListId,
+                skuId,
+                locationId,
+                quantityRequired,
+                quantityPicked,
+                status,
+                sortOrder,
+                null,
+                null);
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/receiving/CrossDockRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/receiving/CrossDockRequest.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -45,4 +46,19 @@ public class CrossDockRequest {
             example = "Cross-docked at dock door 3 for urgent workorder",
             requiredMode = NOT_REQUIRED)
     private String notes;
+
+    @Schema(
+            description = "Lot or batch number of the cross-docked stock. Required (422 LOT_NUMBER_REQUIRED) when"
+                    + " the product is LOT-tracked (falls back to the lot number already keyed on the receiving"
+                    + " line); the lot is found-or-created like any receipt and stamped on BOTH paired ledger"
+                    + " entries. Ignored for untracked products",
+            example = "LOT-2026-A",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 128)
+    private String lotNumber;
+
+    /** Pre-E2 arity kept for existing callers/tests: no lot number keyed. */
+    public CrossDockRequest(String workorderId, String workorderLineId, BigDecimal quantity, String notes) {
+        this(workorderId, workorderLineId, quantity, notes, null);
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentNeedResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentNeedResponse.java
@@ -1,0 +1,112 @@
+package com.positivity.inventory.internal.dto.replenishment;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * One row of the side-effect-free replenishment needs report (odoo-parity F3/F6, issue
+ * #1041): the current orderpoint evaluation of an active, non-snoozed policy — exactly the
+ * math the batch scan would apply, without creating or refreshing any task.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(
+        description = "Current computed replenishment state of one active, non-snoozed policy: the same orderpoint"
+                + " evaluation the batch scan applies, with no side effects")
+public class ReplenishmentNeedResponse {
+
+    @Schema(
+            description = "Unique identifier of the replenishment policy",
+            example = "01960003-0000-7000-8000-000000000001",
+            requiredMode = REQUIRED)
+    @NotNull
+    private String policyId;
+
+    @Schema(description = "SKU of the item the policy applies to", example = "SKU-10042", requiredMode = REQUIRED)
+    @NotNull
+    private String itemSKU;
+
+    @Schema(
+            description = "Identifier of the location the policy applies to",
+            example = "01960003-0000-7000-8000-000000000002",
+            requiredMode = REQUIRED)
+    @NotNull
+    private UUID locationId;
+
+    @Schema(description = "Current on-hand quantity at the policy's location", example = "3", requiredMode = REQUIRED)
+    private long onHand;
+
+    @Schema(
+            description = "Projected available quantity at the lead-time horizon"
+                    + " (on-hand + expected supply - open demand)",
+            example = "3",
+            requiredMode = REQUIRED)
+    private long projectedAvailable;
+
+    @Schema(
+            description = "UTC date of the lead-time horizon the projection was evaluated at",
+            example = "2026-01-20",
+            requiredMode = REQUIRED)
+    @NotNull
+    private String leadHorizonDate;
+
+    @Schema(
+            description = "Where the resolved lead time came from",
+            example = "POLICY_OVERRIDE",
+            allowableValues = {"POLICY_OVERRIDE", "FEED", "DEFAULT"},
+            requiredMode = REQUIRED)
+    @NotNull
+    private String leadTimeSource;
+
+    @Schema(
+            description = "Minimum on-hand quantity that triggers replenishment when reached",
+            example = "5",
+            requiredMode = REQUIRED)
+    private int minimumQuantity;
+
+    @Schema(
+            description = "Maximum on-hand quantity replenishment aims to restock up to",
+            example = "50",
+            requiredMode = REQUIRED)
+    private int maximumQuantity;
+
+    @Schema(
+            description = "Whether a batch scan run now would consider this policy triggered"
+                    + " (projected available below minimum)",
+            example = "true",
+            requiredMode = REQUIRED)
+    private boolean wouldTrigger;
+
+    @Schema(
+            description = "Quantity a scan would replenish now: replenish-to-max after in-progress netting,"
+                    + " rounded up to the policy's order multiple; zero when in-progress supply already covers"
+                    + " the need or the policy is not triggered",
+            example = "12",
+            requiredMode = REQUIRED)
+    private int suggestedQuantity;
+
+    @Schema(
+            description = "Earliest date at which the projected available quantity goes below zero;"
+                    + " absent when the policy is not triggered or no stock-out is projected within"
+                    + " the lead-time horizon",
+            example = "2026-01-20",
+            requiredMode = NOT_REQUIRED)
+    private String deadlineDate;
+
+    @Schema(
+            description = "Preferred sourcing channel configured on the policy",
+            example = "EITHER",
+            requiredMode = REQUIRED)
+    @NotNull
+    private String preferredSourceType;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentPolicyResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentPolicyResponse.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.dto.replenishment;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -51,6 +52,38 @@ public class ReplenishmentPolicyResponse {
             example = "50",
             requiredMode = REQUIRED)
     private int maximumQuantity;
+
+    @Schema(
+            description = "Round the computed replenishment quantity up to the nearest multiple of this value;"
+                    + " absent means no rounding",
+            example = "6",
+            requiredMode = NOT_REQUIRED)
+    private Integer orderMultiple;
+
+    @Schema(
+            description = "Per-policy lead-time override in days; absent means vendor-feed/default lead time applies",
+            example = "3",
+            requiredMode = NOT_REQUIRED)
+    private Integer leadTimeDaysOverride;
+
+    @Schema(
+            description = "Preferred sourcing channel for replenishing this policy's pick face",
+            example = "EITHER",
+            requiredMode = REQUIRED)
+    private String preferredSourceType;
+
+    @Schema(
+            description = "Instant until which the policy is snoozed (excluded from replenishment evaluation);"
+                    + " absent or past means the policy is evaluated normally",
+            example = "2026-02-01T00:00:00Z",
+            requiredMode = NOT_REQUIRED)
+    private String snoozedUntil;
+
+    @Schema(
+            description = "Whether the policy participates in replenishment evaluation",
+            example = "true",
+            requiredMode = REQUIRED)
+    private boolean active;
 
     @Schema(
             description = "Timestamp at which the replenishment policy was created",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentScanResultResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentScanResultResponse.java
@@ -43,6 +43,12 @@ public class ReplenishmentScanResultResponse {
             requiredMode = REQUIRED)
     private int tasksRefreshed;
 
+    @Schema(
+            description = "Number of policies skipped without evaluation because they are inactive or snoozed",
+            example = "1",
+            requiredMode = REQUIRED)
+    private int policiesSkipped;
+
     @Schema(description = "Timestamp at which the scan ran", example = "2026-01-15T09:30:00Z", requiredMode = REQUIRED)
     @NotNull
     private String scanAt;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentTaskResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentTaskResponse.java
@@ -77,6 +77,14 @@ public class ReplenishmentTaskResponse {
     private String assignedTo;
 
     @Schema(
+            description = "Earliest date at which the projected available quantity goes below zero"
+                    + " (stock-out deadline used for prioritization); absent when no stock-out is"
+                    + " projected within the lead-time horizon",
+            example = "2026-01-20",
+            requiredMode = NOT_REQUIRED)
+    private String deadlineDate;
+
+    @Schema(
             description = "Timestamp at which the replenishment task was created",
             example = "2026-01-15T09:30:00Z",
             requiredMode = REQUIRED)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/SnoozeReplenishmentPolicyRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/SnoozeReplenishmentPolicyRequest.java
@@ -1,0 +1,33 @@
+package com.positivity.inventory.internal.dto.replenishment;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Snooze (or unsnooze) a replenishment policy (odoo-parity F3, issue #1041 — Odoo
+ * orderpoint snooze). A non-null {@code snoozedUntil} must be in the future (422
+ * otherwise); {@code null} clears an existing snooze — there is no separate unsnooze
+ * endpoint.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(
+        description = "Request to snooze a replenishment policy until a future instant, or clear an existing snooze"
+                + " by sending a null snoozedUntil")
+public class SnoozeReplenishmentPolicyRequest {
+
+    @Schema(
+            description = "Future instant until which the policy is excluded from replenishment evaluation;"
+                    + " null clears an existing snooze",
+            example = "2026-02-01T00:00:00Z",
+            requiredMode = NOT_REQUIRED)
+    private Instant snoozedUntil;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/UpdateReplenishmentPolicyRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/UpdateReplenishmentPolicyRequest.java
@@ -7,34 +7,28 @@ import com.positivity.inventory.internal.enums.ReplenishmentSourceType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Full-replace update of a replenishment policy's tunable fields (odoo-parity F3, issue
+ * #1041). PUT semantics: omitted optional fields are cleared / reset to their defaults
+ * ({@code orderMultiple} and {@code leadTimeDaysOverride} to none, {@code
+ * preferredSourceType} to EITHER, {@code active} to true). The policy's identity
+ * (location, SKU) and its snooze state are not updatable here — snooze is managed by the
+ * dedicated snooze endpoint.
+ */
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Schema(
-        description =
-                "Request to create a replenishment policy defining min/max stock thresholds for an item at a location")
-public class CreateReplenishmentPolicyRequest {
-
-    @Schema(
-            description = "Identifier of the location the replenishment policy applies to",
-            example = "01960003-0000-7000-8000-000000000001",
-            requiredMode = REQUIRED)
-    @NotNull
-    private UUID locationId;
-
-    @Schema(
-            description = "SKU of the item the replenishment policy applies to",
-            example = "SKU-10042",
-            requiredMode = REQUIRED)
-    @NotBlank
-    private String itemSKU;
+        description = "Full-replace update of a replenishment policy's thresholds and tuning fields. Omitted optional"
+                + " fields are cleared or reset to defaults; location, SKU, and snooze state are not updatable here.")
+public class UpdateReplenishmentPolicyRequest {
 
     @Schema(
             description = "Minimum on-hand quantity that triggers replenishment when reached",
@@ -53,17 +47,16 @@ public class CreateReplenishmentPolicyRequest {
     private Integer maximumQuantity;
 
     @Schema(
-            description = "Round the computed replenishment quantity up to the nearest multiple of this value."
-                    + " When omitted, defaults to the vendor-feed pack size for the SKU when one is known"
-                    + " (greater than 1); otherwise no rounding is applied.",
+            description = "Round the computed replenishment quantity up to the nearest multiple of this value;"
+                    + " omit to clear (no rounding)",
             example = "6",
             requiredMode = NOT_REQUIRED)
     @Min(1)
     private Integer orderMultiple;
 
     @Schema(
-            description = "Per-policy lead-time override in days; takes precedence over vendor-feed lead-time"
-                    + " estimates and the configured default",
+            description =
+                    "Per-policy lead-time override in days; omit to clear (vendor-feed/default lead time" + " applies)",
             example = "3",
             requiredMode = NOT_REQUIRED)
     @Min(0)
@@ -71,13 +64,13 @@ public class CreateReplenishmentPolicyRequest {
 
     @Schema(
             description =
-                    "Preferred sourcing channel for replenishing this policy's pick face;" + " defaults to EITHER",
+                    "Preferred sourcing channel for replenishing this policy's pick face;" + " omit to reset to EITHER",
             example = "EITHER",
             requiredMode = NOT_REQUIRED)
     private ReplenishmentSourceType preferredSourceType;
 
     @Schema(
-            description = "Whether the policy participates in replenishment evaluation; defaults to true",
+            description = "Whether the policy participates in replenishment evaluation; omit to reset to true",
             example = "true",
             requiredMode = NOT_REQUIRED)
     private Boolean active;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnItemLine.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnItemLine.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -49,6 +50,20 @@ public class ReturnItemLine {
             requiredMode = NOT_REQUIRED)
     @Positive
     private BigDecimal documentQuantity;
+
+    @Schema(
+            description = "Lot number the returned units belong to. Required (422 LOT_NUMBER_REQUIRED) when the SKU"
+                    + " is LOT-tracked and must reference an existing lot (422 LOT_UNKNOWN) — a CONSUMED lot is"
+                    + " legitimate (returning stock flips it back to ACTIVE). Ignored for untracked SKUs",
+            example = "LOT-2026-A",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 128)
+    private String lotNumber;
+
+    /** Pre-E2 arity kept for existing callers/tests: no lot number keyed. */
+    public ReturnItemLine(UUID skuId, int quantityReturned, String documentUom, BigDecimal documentQuantity) {
+        this(skuId, quantityReturned, documentUom, documentQuantity, null);
+    }
 
     @JsonIgnore
     @AssertTrue(message = "quantityReturned must be positive when documentUom/documentQuantity are absent")

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/scrap/CreateScrapRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/scrap/CreateScrapRequest.java
@@ -68,6 +68,15 @@ public class CreateScrapRequest {
     private UUID workorderId;
 
     @Schema(
+            description = "Lot number the scrapped units belong to. Required (422 LOT_NUMBER_REQUIRED) when the SKU"
+                    + " is LOT-tracked; must reference an existing (422 LOT_UNKNOWN) ACTIVE (422 LOT_NOT_AVAILABLE)"
+                    + " lot. Ignored for untracked SKUs",
+            example = "LOT-2026-A",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 128, message = "Lot number must not exceed 128 characters")
+    private String lotNumber;
+
+    @Schema(
             description = "Photo/attachment reference (storage out of scope)",
             example = "s3://scrap-evidence/2026/07/scrap-123.jpg",
             requiredMode = NOT_REQUIRED)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/scrap/ScrapResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/scrap/ScrapResponse.java
@@ -47,6 +47,9 @@ public class ScrapResponse {
     @Schema(description = "Linked workorder, when the part was damaged during a job")
     private UUID workorderId;
 
+    @Schema(description = "Lot the scrapped units belong to (LOT-tracked SKUs)")
+    private UUID lotId;
+
     @Schema(description = "Photo/attachment reference")
     private String attachmentReference;
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/transfer/ShortCloseTransferOrderRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/transfer/ShortCloseTransferOrderRequest.java
@@ -1,0 +1,48 @@
+package com.positivity.inventory.internal.dto.transfer;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.positivity.inventory.internal.enums.TransferShortCloseDisposition;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request DTO for short-closing a transfer order (odoo-parity C3, issue #1039; spec C4).
+ *
+ * <p>The disposition applies to every line's undelivered remainder
+ * ({@code dispatchedQty - receivedQty}) — one disposition per order, no per-line mix (v1
+ * simplification). Reason and notes are mandatory: short-close accepts a loss or reverses a
+ * movement, so the audit trail must say why.
+ */
+@Schema(
+        description = "Request to short-close a transfer order, resolving the undelivered remainder"
+                + " with a whole-order disposition")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ShortCloseTransferOrderRequest {
+
+    @Schema(
+            description = "Disposition of the undelivered remainder: LOST_IN_TRANSIT writes it off"
+                    + " (SCRAP_OUT, reason LOST); RETURNED_TO_SOURCE restores it to source on-hand",
+            requiredMode = REQUIRED)
+    @NotNull(message = "Disposition is required")
+    private TransferShortCloseDisposition disposition;
+
+    @Schema(description = "Reason for the short-close (mandatory)", requiredMode = REQUIRED)
+    @NotBlank(message = "Reason is required")
+    @Size(max = 100, message = "Reason must not exceed 100 characters")
+    private String reason;
+
+    @Schema(description = "Free-text notes explaining the short-close (mandatory)", requiredMode = REQUIRED)
+    @NotBlank(message = "Notes are required")
+    @Size(max = 2000, message = "Notes must not exceed 2000 characters")
+    private String notes;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/transfer/TransferOrderLineResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/transfer/TransferOrderLineResponse.java
@@ -36,6 +36,12 @@ public class TransferOrderLineResponse {
     @Schema(description = "Quantity received at the destination so far")
     private Integer receivedQty;
 
+    @Schema(description = "Lot the dispatched units were drawn from (LOT-tracked SKUs, pinned at dispatch)")
+    private UUID lotId;
+
+    @Schema(description = "Lot number matching lotId, kept for audit/display")
+    private String lotNumber;
+
     @Schema(description = "Creation timestamp")
     private Instant createdAt;
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/transfer/TransferOrderResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/transfer/TransferOrderResponse.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.dto.transfer;
 
 import com.positivity.inventory.internal.enums.TransferOrderStatus;
+import com.positivity.inventory.internal.enums.TransferShortCloseDisposition;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.List;
@@ -52,6 +53,21 @@ public class TransferOrderResponse {
 
     @Schema(description = "User who dispatched the order")
     private String dispatchedBy;
+
+    @Schema(description = "Disposition of the undelivered remainder; set only when SHORT_CLOSED")
+    private TransferShortCloseDisposition shortCloseDisposition;
+
+    @Schema(description = "Short-close reason; set only when SHORT_CLOSED")
+    private String shortCloseReason;
+
+    @Schema(description = "Short-close notes; set only when SHORT_CLOSED")
+    private String shortCloseNotes;
+
+    @Schema(description = "User who short-closed the order; set only when SHORT_CLOSED")
+    private String shortClosedBy;
+
+    @Schema(description = "When the order was short-closed; set only when SHORT_CLOSED")
+    private Instant shortClosedAt;
 
     @Schema(description = "Creation timestamp")
     private Instant createdAt;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/transfer/TransferQuantityLineRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/transfer/TransferQuantityLineRequest.java
@@ -1,10 +1,12 @@
 package com.positivity.inventory.internal.dto.transfer;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,4 +32,19 @@ public class TransferQuantityLineRequest {
     @NotNull(message = "Quantity is required")
     @Positive(message = "Quantity must be positive")
     private Integer quantity;
+
+    @Schema(
+            description = "Lot number the dispatched units are drawn from (dispatch only; receive and short-close"
+                    + " reuse the lot recorded at dispatch). Required (422 LOT_NUMBER_REQUIRED) when the SKU is"
+                    + " LOT-tracked; must reference an existing (422 LOT_UNKNOWN) ACTIVE (422 LOT_NOT_AVAILABLE)"
+                    + " lot. Ignored for untracked SKUs",
+            example = "LOT-2026-A",
+            requiredMode = NOT_REQUIRED)
+    @Size(max = 128)
+    private String lotNumber;
+
+    /** Pre-E2 arity kept for existing callers/tests: no lot number keyed. */
+    public TransferQuantityLineRequest(UUID lineId, Integer quantity) {
+        this(lineId, quantity, null);
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/PickTaskEntity.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/PickTaskEntity.java
@@ -69,6 +69,25 @@ public class PickTaskEntity {
     @Column(name = "sourcing_reason", length = 32)
     private SourcingStrategy sourcingReason;
 
+    /**
+     * Advisory lot suggestion for LOT-tracked SKUs (odoo-parity E2, issue #1042): FIFO by lot
+     * {@code receivedAt} over the ACTIVE lots with positive per-lot on-hand at
+     * {@code suggestedLocationId}, stamped at generation. Confirm may override with any valid
+     * ACTIVE lot — {@code pickedLotId} records what was actually keyed. Null for untracked
+     * SKUs and when no lot has stock at the suggested location. E3 upgrades the ordering to
+     * FEFO via the {@code LotExpiryProvider} SPI.
+     */
+    @Column(name = "suggested_lot_number", length = 128)
+    private String suggestedLotNumber;
+
+    /**
+     * Lot actually keyed at pick confirmation for LOT-tracked SKUs (odoo-parity E2, issue
+     * #1042); the consumption flow stamps this lot on its {@code WORKORDER_CONSUMPTION}
+     * posting. Null for untracked SKUs and on tasks confirmed before E2.
+     */
+    @Column(name = "picked_lot_id")
+    private UUID pickedLotId;
+
     @Column(name = "sort_order", nullable = false)
     @Builder.Default
     private int sortOrder = 0;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ReplenishmentPolicy.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ReplenishmentPolicy.java
@@ -1,11 +1,15 @@
 package com.positivity.inventory.internal.entity;
 
+import com.positivity.inventory.internal.enums.ReplenishmentSourceType;
 import com.positivity.shared.id.UUIDv7Id;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
@@ -42,6 +46,47 @@ public class ReplenishmentPolicy {
 
     @Column(nullable = false)
     private Integer maximumQuantity;
+
+    /**
+     * Round the computed replenishment quantity UP to the nearest multiple (odoo-parity F3,
+     * issue #1041 — Odoo {@code qty_multiple}); {@code null} means no rounding. Seeded from
+     * the vendor-feed pack size at creation when the caller supplies none.
+     */
+    private Integer orderMultiple;
+
+    /**
+     * Highest-precedence lead time in days (plan D-4: override → vendor feed → configured
+     * default); {@code null} falls through to the feed lookup.
+     */
+    private Integer leadTimeDaysOverride;
+
+    /** Sourcing preference consumed by parity-F5; stored only in F3. */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private ReplenishmentSourceType preferredSourceType = ReplenishmentSourceType.EITHER;
+
+    /**
+     * Policy suppressed from scan/event/needs evaluation while this instant is in the
+     * future (Odoo orderpoint snooze); {@code null} or a past instant means active
+     * evaluation.
+     */
+    private Instant snoozedUntil;
+
+    /** Hard on/off switch; inactive policies are never evaluated. */
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean active = Boolean.TRUE;
+
+    @PrePersist
+    void applyDefaults() {
+        if (preferredSourceType == null) {
+            preferredSourceType = ReplenishmentSourceType.EITHER;
+        }
+        if (active == null) {
+            active = Boolean.TRUE;
+        }
+    }
 
     @CreatedDate
     @Column(nullable = false, updatable = false)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ReplenishmentTask.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ReplenishmentTask.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -64,6 +65,14 @@ public class ReplenishmentTask {
     private ReplenishmentSourcingReason sourcingReason;
 
     private String assignedTo;
+
+    /**
+     * Earliest date the horizon-bounded stock-out projection goes negative (odoo-parity F3,
+     * issue #1041 — Odoo orderpoint deadline analogue), computed at task creation/refresh
+     * for prioritization; {@code null} when the projection never dips below zero within the
+     * lead horizon (or for pre-F3 tasks).
+     */
+    private LocalDate deadlineDate;
 
     @CreatedDate
     @Column(nullable = false, updatable = false)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/TransferOrder.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/TransferOrder.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.entity;
 
 import com.positivity.inventory.internal.enums.TransferOrderStatus;
+import com.positivity.inventory.internal.enums.TransferShortCloseDisposition;
 import com.positivity.shared.id.UUIDv7Id;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -93,6 +94,29 @@ public class TransferOrder {
 
     @Column(name = "dispatched_by")
     private String dispatchedBy;
+
+    /**
+     * Disposition of the undelivered remainder when short-closed (parity-C3, issue #1039):
+     * LOST_IN_TRANSIT or RETURNED_TO_SOURCE. One disposition covers the whole order (v1
+     * simplification). Null unless status is SHORT_CLOSED.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "short_close_disposition", length = 30)
+    private TransferShortCloseDisposition shortCloseDisposition;
+
+    /** Mandatory short-close reason (spec C4); null unless status is SHORT_CLOSED. */
+    @Column(name = "short_close_reason", length = 100)
+    private String shortCloseReason;
+
+    /** Mandatory short-close notes (spec C4); null unless status is SHORT_CLOSED. */
+    @Column(name = "short_close_notes", length = 2000)
+    private String shortCloseNotes;
+
+    @Column(name = "short_closed_by")
+    private String shortClosedBy;
+
+    @Column(name = "short_closed_at")
+    private Instant shortClosedAt;
 
     @Builder.Default
     @OneToMany(mappedBy = "transferOrder", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/TransferOrderLine.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/TransferOrderLine.java
@@ -69,6 +69,19 @@ public class TransferOrderLine {
     @Column(name = "received_qty", nullable = false)
     private Integer receivedQty = 0;
 
+    /**
+     * Lot the dispatched units were drawn from, resolved and pinned at dispatch for
+     * LOT-tracked SKUs (odoo-parity E2, issue #1042). Receive and short-close reuse this lot
+     * on every posting of the line, so the per-lot rows conserve across sites exactly like
+     * the lot-agnostic balances. Null for untracked SKUs and lines dispatched before E2.
+     */
+    @Column(name = "lot_id")
+    private UUID lotId;
+
+    /** Lot number matching {@link #lotId}, kept on the document for audit/display. */
+    @Column(name = "lot_number", length = 128)
+    private String lotNumber;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/ReplenishmentSourceType.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/ReplenishmentSourceType.java
@@ -1,0 +1,16 @@
+package com.positivity.inventory.internal.enums;
+
+/**
+ * Preferred sourcing channel for replenishing a policy's pick face (odoo-parity F3, issue
+ * #1041; spec F3).
+ *
+ * <p><b>Stored only in F3</b> — no evaluation path reads it yet. Parity-F5 (internal
+ * sourcing) consumes it: {@code INTERNAL_TRANSFER} restricts sourcing to backstock/transfer
+ * moves, {@code PURCHASE} routes straight to a purchase suggestion (F4), and {@code EITHER}
+ * lets the sourcing engine decide (internal surplus first, purchase as fallback).
+ */
+public enum ReplenishmentSourceType {
+    INTERNAL_TRANSFER,
+    PURCHASE,
+    EITHER
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/TransferShortCloseDisposition.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/TransferShortCloseDisposition.java
@@ -1,0 +1,27 @@
+package com.positivity.inventory.internal.enums;
+
+/**
+ * Disposition of the undelivered in-transit remainder when a transfer order is short-closed
+ * (odoo-parity C3, issue #1039; spec C4).
+ *
+ * <p>One disposition applies to the whole order (v1 simplification — per-line dispositions can
+ * be layered on later without schema changes to the ledger). Either way every remaining unit
+ * leaves transit atomically; the two dispositions differ only in where the stock ends up.
+ */
+public enum TransferShortCloseDisposition {
+
+    /**
+     * The remainder never arrived and is written off: a constructive {@code TRANSFER_IN} at the
+     * destination clears the in-transit balance and a paired {@code SCRAP_OUT}
+     * ({@code reasonCode = LOST}) removes it from on-hand — global on-hand drops by the
+     * remainder.
+     */
+    LOST_IN_TRANSIT,
+
+    /**
+     * The remainder came back to the source site: a constructive receive at the destination,
+     * an immediate {@code TRANSFER_OUT} back, and a {@code TRANSFER_IN} at the source restore
+     * source on-hand — global on-hand is unchanged.
+     */
+    RETURNED_TO_SOURCE
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotInsufficientStockException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotInsufficientStockException.java
@@ -1,0 +1,38 @@
+package com.positivity.inventory.internal.exception;
+
+import java.util.UUID;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Thrown when a lot-tagged posting would drive a per-lot summary row negative (odoo-parity E2,
+ * issue #1042; spec §6 E2 — "negative lot balances rejected").
+ *
+ * <p>Maps to a deterministic 422 with code {@code LOT_INSUFFICIENT_STOCK}. The per-lot floor is
+ * absolute: unlike the lot-agnostic {@code NegativeStockPolicy} matrix it has no override —
+ * a physical lot can never hold negative stock, and an "override" would silently misattribute
+ * stock between lots.
+ */
+public class LotInsufficientStockException extends RuntimeException {
+
+    public static final String ERROR_CODE = "LOT_INSUFFICIENT_STOCK";
+
+    private final String stockItemId;
+    private final UUID lotId;
+
+    public LotInsufficientStockException(
+            String stockItemId, UUID lotId, @Nullable UUID locationId, long projectedOnHand) {
+        super("LOT_INSUFFICIENT_STOCK: posting would take lot " + lotId + " of stock item " + stockItemId
+                + " at location " + locationId + " to " + projectedOnHand
+                + "; a lot cannot be drawn below its per-lot on-hand");
+        this.stockItemId = stockItemId;
+        this.lotId = lotId;
+    }
+
+    public String getStockItemId() {
+        return stockItemId;
+    }
+
+    public UUID getLotId() {
+        return lotId;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotNotAvailableException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotNotAvailableException.java
@@ -1,0 +1,38 @@
+package com.positivity.inventory.internal.exception;
+
+/**
+ * Thrown when an outbound posting for a LOT-tracked product references a lot whose status
+ * blocks it from leaving stock (odoo-parity E2, issue #1042; spec §6 E2): outbound flows
+ * require an {@code ACTIVE} lot — {@code QUARANTINED}, {@code RECALLED}, and {@code CONSUMED}
+ * lots are all rejected.
+ *
+ * <p>Maps to a deterministic 422 with code {@code LOT_NOT_AVAILABLE}.
+ */
+public class LotNotAvailableException extends RuntimeException {
+
+    public static final String ERROR_CODE = "LOT_NOT_AVAILABLE";
+
+    private final String stockItemId;
+    private final String lotNumber;
+    private final String lotStatus;
+
+    public LotNotAvailableException(String stockItemId, String lotNumber, String lotStatus) {
+        super("LOT_NOT_AVAILABLE: lot '" + lotNumber + "' of stock item " + stockItemId + " is " + lotStatus
+                + "; only ACTIVE lots may be picked, consumed, transferred, or scrapped");
+        this.stockItemId = stockItemId;
+        this.lotNumber = lotNumber;
+        this.lotStatus = lotStatus;
+    }
+
+    public String getStockItemId() {
+        return stockItemId;
+    }
+
+    public String getLotNumber() {
+        return lotNumber;
+    }
+
+    public String getLotStatus() {
+        return lotStatus;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotNumberRequiredException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotNumberRequiredException.java
@@ -1,8 +1,9 @@
 package com.positivity.inventory.internal.exception;
 
 /**
- * Thrown when a receipt posting for a LOT-tracked product carries no lot number
- * (odoo-parity E1, issue #1038; spec §6 E1).
+ * Thrown when a stock movement for a LOT-tracked product carries no lot number: receipts since
+ * odoo-parity E1 (issue #1038; spec §6 E1), outbound flows — pick confirmation, consumption,
+ * transfer dispatch, scrap, cross-dock, returns — since E2 (issue #1042; spec §6 E2).
  *
  * <p>Maps to a deterministic 422 with code {@code LOT_NUMBER_REQUIRED}; a missing lot on a
  * tracked product must never degrade to an untracked posting.
@@ -15,7 +16,7 @@ public class LotNumberRequiredException extends RuntimeException {
 
     public LotNumberRequiredException(String stockItemId) {
         super("LOT_NUMBER_REQUIRED: stock item " + stockItemId
-                + " is LOT-tracked; receipt lines must carry a lotNumber");
+                + " is LOT-tracked; this movement must carry a lotNumber");
         this.stockItemId = stockItemId;
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotUnknownException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotUnknownException.java
@@ -1,0 +1,31 @@
+package com.positivity.inventory.internal.exception;
+
+/**
+ * Thrown when an outbound posting for a LOT-tracked product references a lot number that does
+ * not exist in the lot master (odoo-parity E2, issue #1042; spec §6 E2).
+ *
+ * <p>Maps to a deterministic 422 with code {@code LOT_UNKNOWN}. Outbound flows never
+ * find-or-create lots — stock can only leave a lot that inbound capture (E1) registered.
+ */
+public class LotUnknownException extends RuntimeException {
+
+    public static final String ERROR_CODE = "LOT_UNKNOWN";
+
+    private final String stockItemId;
+    private final String lotNumber;
+
+    public LotUnknownException(String stockItemId, String lotNumber) {
+        super("LOT_UNKNOWN: no lot '" + lotNumber + "' exists for stock item " + stockItemId
+                + "; outbound postings may only reference lots registered by inbound receipt");
+        this.stockItemId = stockItemId;
+        this.lotNumber = lotNumber;
+    }
+
+    public String getStockItemId() {
+        return stockItemId;
+    }
+
+    public String getLotNumber() {
+        return lotNumber;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/SnoozeUntilNotInFutureException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/SnoozeUntilNotInFutureException.java
@@ -1,0 +1,19 @@
+package com.positivity.inventory.internal.exception;
+
+import java.time.Instant;
+
+/**
+ * Thrown when a replenishment-policy snooze request carries a {@code snoozedUntil} that is
+ * not in the future (odoo-parity F3, issue #1041): snoozing until the past or the present
+ * instant would be a silent no-op, so it is rejected with a deterministic 422 instead.
+ * Clearing a snooze is expressed with a {@code null} {@code snoozedUntil}, never with a
+ * past instant.
+ */
+public class SnoozeUntilNotInFutureException extends RuntimeException {
+
+    public static final String ERROR_CODE = "REPLENISHMENT_SNOOZE_NOT_IN_FUTURE";
+
+    public SnoozeUntilNotInFutureException(Instant snoozedUntil) {
+        super("snoozedUntil must be in the future: " + snoozedUntil);
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/AsnLineRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/AsnLineRepository.java
@@ -5,6 +5,7 @@ import com.positivity.inventory.internal.enums.AsnStatus;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -40,5 +41,26 @@ public interface AsnLineRepository extends JpaRepository<AsnLineEntity, UUID> {
             @Param("statuses") Collection<AsnStatus> statuses,
             @Param("siteId") UUID siteId,
             @Param("boundByExpectedArrival") boolean boundByExpectedArrival,
+            @Param("horizonDate") LocalDate horizonDate);
+
+    /**
+     * Distinct expected arrival dates of open ASN supply for one SKU within a horizon
+     * (odoo-parity F3, issue #1041): candidate cutoff dates for the stock-out deadline
+     * approximation. Undated ASNs are excluded, matching the bounded variant of
+     * {@link #sumUnreceivedRemainderForSku}.
+     */
+    @Query("""
+                        SELECT DISTINCT al.asn.expectedArrivalDate
+                        FROM AsnLineEntity al
+                        WHERE al.sku = :sku
+                          AND al.asn.status IN :statuses
+                          AND (:siteId IS NULL OR al.purchaseOrder.shipToLocationId = :siteId)
+                          AND al.asn.expectedArrivalDate IS NOT NULL
+                          AND al.asn.expectedArrivalDate <= :horizonDate
+                        """)
+    List<LocalDate> findDistinctExpectedArrivalDatesForSku(
+            @Param("sku") String sku,
+            @Param("statuses") Collection<AsnStatus> statuses,
+            @Param("siteId") UUID siteId,
             @Param("horizonDate") LocalDate horizonDate);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryStockSummaryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryStockSummaryRepository.java
@@ -80,6 +80,33 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
     /** Per-lot rows of one lot across locations (odoo-parity E1, issue #1038 lot read API). */
     List<InventoryStockSummary> findByLotId(UUID lotId);
 
+    /**
+     * Per-lot rows with positive on-hand for one (stockItemId, locationId) — the FIFO lot
+     * suggestion candidates of odoo-parity E2 (issue #1042).
+     */
+    @Query("""
+                        SELECT s FROM InventoryStockSummary s
+                        WHERE s.stockItemId = :stockItemId
+                          AND s.locationId = :locationId
+                          AND s.lotId IS NOT NULL
+                          AND s.onHand > 0
+                        """)
+    List<InventoryStockSummary> findPositivePerLotRows(
+            @Param("stockItemId") String stockItemId, @Param("locationId") UUID locationId);
+
+    /**
+     * Total stock attributed to one lot across all per-lot rows: on-hand everywhere plus
+     * in-transit toward anywhere (odoo-parity E2, issue #1042). Including in-transit keeps the
+     * total conserved across transfer dispatch → receive, so a fully-dispatched-but-unreceived
+     * lot does not spuriously read as empty for the CONSUMED status transition.
+     */
+    @Query("""
+                        SELECT COALESCE(SUM(s.onHand + s.inTransitQty), 0)
+                        FROM InventoryStockSummary s
+                        WHERE s.lotId = :lotId
+                        """)
+    long sumLotStockAcrossLocations(@Param("lotId") UUID lotId);
+
     /** Lot-agnostic rows with positive on-hand at one location. */
     @Query("""
                         SELECT s FROM InventoryStockSummary s

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/NormalizedAvailabilityRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/NormalizedAvailabilityRepository.java
@@ -18,6 +18,13 @@ public interface NormalizedAvailabilityRepository extends JpaRepository<Normaliz
     Optional<NormalizedAvailability> findByProductIdAndManufacturerIdAndAsOf(
             UUID productId, UUID manufacturerId, Instant asOf);
 
+    /**
+     * Most recent availability snapshot for a product across manufacturers (odoo-parity F3,
+     * issue #1041): the pack-size seed source for a newly created replenishment policy's
+     * {@code orderMultiple} default.
+     */
+    Optional<NormalizedAvailability> findFirstByProductIdOrderByAsOfDesc(UUID productId);
+
     @Query("""
             SELECT MIN(n.leadTimeDaysMin) AS minDays,
                    MAX(n.leadTimeDaysMax) AS maxDays,

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/PurchaseOrderLineRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/PurchaseOrderLineRepository.java
@@ -5,6 +5,7 @@ import com.positivity.inventory.internal.enums.PurchaseOrderStatus;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -37,5 +38,27 @@ public interface PurchaseOrderLineRepository extends JpaRepository<PurchaseOrder
             @Param("statuses") Collection<PurchaseOrderStatus> statuses,
             @Param("siteId") UUID siteId,
             @Param("boundByExpectedDelivery") boolean boundByExpectedDelivery,
+            @Param("horizonDate") LocalDate horizonDate);
+
+    /**
+     * Distinct expected delivery dates of open PO supply for one SKU within a horizon
+     * (odoo-parity F3, issue #1041): the candidate cutoff dates at which the
+     * horizon-bounded forecast projection can change — used by the stock-out deadline
+     * approximation. Undated orders are excluded, matching the bounded variant of
+     * {@link #sumOpenQuantityForSku}.
+     */
+    @Query("""
+                        SELECT DISTINCT l.purchaseOrder.expectedDeliveryDate
+                        FROM PurchaseOrderLineEntity l
+                        WHERE l.skuId = :skuId
+                          AND l.purchaseOrder.status IN :statuses
+                          AND (:siteId IS NULL OR l.purchaseOrder.shipToLocationId = :siteId)
+                          AND l.purchaseOrder.expectedDeliveryDate IS NOT NULL
+                          AND l.purchaseOrder.expectedDeliveryDate <= :horizonDate
+                        """)
+    List<LocalDate> findDistinctExpectedDeliveryDatesForSku(
+            @Param("skuId") UUID skuId,
+            @Param("statuses") Collection<PurchaseOrderStatus> statuses,
+            @Param("siteId") UUID siteId,
             @Param("horizonDate") LocalDate horizonDate);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReplenishmentTaskRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReplenishmentTaskRepository.java
@@ -23,6 +23,13 @@ public interface ReplenishmentTaskRepository extends JpaRepository<Replenishment
             String itemSKU, UUID destinationLocationId, List<ReplenishmentStatus> statuses);
 
     /**
+     * Open tasks for one SKU/destination — the in-progress supply netted out of the
+     * forecast-aware replenish quantity (odoo-parity F2, issue #1040).
+     */
+    List<ReplenishmentTask> findByItemSKUAndDestinationLocationIdAndStatusIn(
+            String itemSKU, UUID destinationLocationId, List<ReplenishmentStatus> statuses);
+
+    /**
      * Per-(policy, day) idempotency guard for the batch scan (odoo-parity F1):
      * true when a batch-triggered task for this SKU/destination was already
      * created on or after the given day boundary, regardless of its status.

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReservationRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReservationRepository.java
@@ -45,4 +45,23 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
             @Param("statuses") Collection<ReservationStatus> statuses,
             @Param("boundByDueDate") boolean boundByDueDate,
             @Param("horizon") Instant horizon);
+
+    /**
+     * Distinct due instants of open reservation demand for one SKU within a horizon
+     * (odoo-parity F3, issue #1041): candidate cutoff instants for the stock-out deadline
+     * approximation. Undated reservations are excluded, matching the bounded variant of
+     * {@link #sumOpenRemainderForSku}.
+     */
+    @Query("""
+                        SELECT DISTINCT r.dueDateTime
+                        FROM ReservationEntity r
+                        WHERE r.stockItemId = :stockItemId
+                          AND r.status IN :statuses
+                          AND r.dueDateTime IS NOT NULL
+                          AND r.dueDateTime <= :horizon
+                        """)
+    List<Instant> findDistinctDueInstantsForSku(
+            @Param("stockItemId") UUID stockItemId,
+            @Param("statuses") Collection<ReservationStatus> statuses,
+            @Param("horizon") Instant horizon);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
@@ -13,6 +13,7 @@ import com.positivity.inventory.internal.enums.AllocationStatus;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.enums.PickTaskStatus;
 import com.positivity.inventory.internal.enums.SourcingStrategy;
+import com.positivity.inventory.internal.exception.LotNumberRequiredException;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.exception.WorkorderConsumptionException;
 import com.positivity.inventory.internal.repository.AllocationRepository;
@@ -72,6 +73,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
     private final LedgerPostingService ledgerPostingService;
     private final InventoryFactPublisher inventoryFactPublisher;
     private final @Nullable SourcingStrategyService sourcingStrategyService;
+    private final @Nullable InventoryLotOutboundService lotOutboundService;
 
     @Autowired
     public ConsumptionServiceImpl(
@@ -82,7 +84,8 @@ public class ConsumptionServiceImpl implements ConsumptionService {
             LedgerPostingService ledgerPostingService,
             InventoryFactPublisher inventoryFactPublisher,
             Clock clock,
-            SourcingStrategyService sourcingStrategyService) {
+            SourcingStrategyService sourcingStrategyService,
+            InventoryLotOutboundService lotOutboundService) {
         this.clock = clock;
         this.inventoryFactPublisher = inventoryFactPublisher;
         this.pickTaskRepository = pickTaskRepository;
@@ -91,14 +94,41 @@ public class ConsumptionServiceImpl implements ConsumptionService {
         this.allocationRepository = allocationRepository;
         this.ledgerPostingService = ledgerPostingService;
         this.sourcingStrategyService = sourcingStrategyService;
+        this.lotOutboundService = lotOutboundService;
     }
 
     /**
-     * Engine-less constructor kept for the pre-H1 unit-test fixtures: without
-     * a {@link SourcingStrategyService} the allocation-close order is the
-     * platform-default FIFO (oldest-first) — identical to the engine's
-     * default-config decision, which the H1 regression tests prove.
+     * Engine-less constructor kept for the pre-H1 unit-test fixtures: without a
+     * {@link SourcingStrategyService} the allocation-close order is the platform-default FIFO
+     * (oldest-first) — identical to the engine's default-config decision, which the H1
+     * regression tests prove. The absent {@link InventoryLotOutboundService} likewise means
+     * every SKU behaves untracked (odoo-parity E2, #1042) — a task-recorded
+     * {@code pickedLotId} is still stamped, but no lot gating applies.
      */
+    public ConsumptionServiceImpl(
+            PickTaskRepository pickTaskRepository,
+            InventoryLedgerEntryRepository inventoryLedgerEntryRepository,
+            ReservationRepository reservationRepository,
+            AllocationRepository allocationRepository,
+            LedgerPostingService ledgerPostingService,
+            InventoryFactPublisher inventoryFactPublisher,
+            Clock clock,
+            @Nullable SourcingStrategyService sourcingStrategyService) {
+        this(
+                pickTaskRepository,
+                inventoryLedgerEntryRepository,
+                reservationRepository,
+                allocationRepository,
+                ledgerPostingService,
+                inventoryFactPublisher,
+                clock,
+                sourcingStrategyService,
+                null);
+    }
+
+    /** See {@link #ConsumptionServiceImpl(PickTaskRepository, InventoryLedgerEntryRepository,
+     * ReservationRepository, AllocationRepository, LedgerPostingService, InventoryFactPublisher,
+     * Clock, SourcingStrategyService)}. */
     public ConsumptionServiceImpl(
             PickTaskRepository pickTaskRepository,
             InventoryLedgerEntryRepository inventoryLedgerEntryRepository,
@@ -115,6 +145,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                 ledgerPostingService,
                 inventoryFactPublisher,
                 clock,
+                null,
                 null);
     }
 
@@ -146,7 +177,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                         "Requested quantity exceeds picked quantity for task: " + item.getPickTaskId());
             }
 
-            entriesToSave.add(buildConsumptionEntry(request, item));
+            entriesToSave.add(buildConsumptionEntry(request, item, resolveConsumptionLot(item, task)));
             entriesToSave.addAll(closeAllocations(request, item, task, releasedInBatch));
         }
 
@@ -310,12 +341,42 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                 .toList();
     }
 
-    private InventoryLedgerEntry buildConsumptionEntry(ConsumeItemsRequest request, ConsumeItemLine item) {
+    /**
+     * Lot the {@code WORKORDER_CONSUMPTION} entry draws from (odoo-parity E2, issue #1042).
+     * Source order for LOT-tracked SKUs: an explicit {@code lotNumber} on the request line
+     * (validated: must exist and be ACTIVE) overrides; otherwise the lot recorded at pick
+     * confirmation ({@code PickTaskEntity.pickedLotId} — the pick→consumption linkage);
+     * neither present is a 422 {@code LOT_NUMBER_REQUIRED}. Untracked SKUs return the task's
+     * recorded lot (always null pre-E2) with no validation — byte-identical behavior.
+     *
+     * <p>The {@code ALLOCATION_RELEASED} entries this flow also writes stay lot-null by
+     * design: allocations are location-level and never pin lots (spec §6 E2 decision).
+     */
+    private @Nullable UUID resolveConsumptionLot(ConsumeItemLine item, PickTaskEntity task) {
+        if (lotOutboundService == null) {
+            return task.getPickedLotId();
+        }
+        String stockItemId = item.getSkuId() == null ? "" : item.getSkuId().toString();
+        if (!lotOutboundService.isLotTracked(stockItemId)) {
+            return task.getPickedLotId();
+        }
+        if (item.getLotNumber() != null && !item.getLotNumber().isBlank()) {
+            return lotOutboundService.resolveOutboundLot(stockItemId, item.getLotNumber());
+        }
+        if (task.getPickedLotId() != null) {
+            return task.getPickedLotId();
+        }
+        throw new LotNumberRequiredException(stockItemId);
+    }
+
+    private InventoryLedgerEntry buildConsumptionEntry(
+            ConsumeItemsRequest request, ConsumeItemLine item, @Nullable UUID lotId) {
         return InventoryLedgerEntry.builder()
                 .stockItemId(item.getSkuId() == null ? "" : item.getSkuId().toString())
                 .eventType(InventoryLedgerEventType.WORKORDER_CONSUMPTION)
                 .changeInQuantity(-Math.abs(item.getQuantity()))
                 .quantityAfter(0)
+                .lotId(lotId)
                 .transactionUserId(SecurityContextHelper.getCurrentUsernameOrDefault("system"))
                 .notes("Consumed from pick task " + item.getPickTaskId() + " for workorder " + request.getWorkorderId())
                 .build();

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ForecastSiteResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ForecastSiteResolver.java
@@ -1,0 +1,35 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves a possibly bin-level location id to the SITE scope used by forecast supply
+ * queries (odoo-parity A2, issue #1028; extracted for reuse by the replenishment
+ * orderpoint math in F2, issue #1040).
+ *
+ * <p>Forecast supply is keyed by ship-to SITE ({@code PurchaseOrderEntity.shipToLocationId},
+ * transfer destination site); summary/scope/policy ids are frequently bin-level. A bin is
+ * resolved to its parent site via the storage-location replica; ids not present in the
+ * replica are assumed to already be site ids and pass through unchanged.
+ */
+@Component
+@RequiredArgsConstructor
+public class ForecastSiteResolver {
+
+    private final ExtStorageLocationReplicaRepository storageLocationReplicaRepository;
+
+    public @Nullable UUID resolveForecastSite(@Nullable UUID locationOrStorageLocationId) {
+        if (locationOrStorageLocationId == null) {
+            return null;
+        }
+        return storageLocationReplicaRepository
+                .findById(locationOrStorageLocationId)
+                .map(ExtStorageLocationReplica::getSiteId)
+                .orElse(locationOrStorageLocationId);
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
@@ -2,13 +2,11 @@ package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.dto.AvailabilityView;
 import com.positivity.inventory.internal.dto.LocationAvailabilityDto;
-import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
 import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.enums.InventorySourceType;
 import com.positivity.inventory.internal.exception.InvalidInventoryAvailabilityRequestException;
 import com.positivity.inventory.internal.exception.ProductNotFoundException;
-import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.service.InventoryAvailabilityService;
@@ -44,35 +42,24 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
     private final ForecastQuantityService forecastQuantityService;
     private final AsOfQueryGuard asOfQueryGuard;
-    private final ExtStorageLocationReplicaRepository storageLocationReplicaRepository;
+    private final ForecastSiteResolver forecastSiteResolver;
 
     public InventoryAvailabilityServiceImpl(
             InventoryStockSummaryRepository stockSummaryRepository,
             InventoryLedgerEntryRepository inventoryLedgerEntryRepository,
             ForecastQuantityService forecastQuantityService,
             AsOfQueryGuard asOfQueryGuard,
-            ExtStorageLocationReplicaRepository storageLocationReplicaRepository) {
+            ForecastSiteResolver forecastSiteResolver) {
         this.stockSummaryRepository = stockSummaryRepository;
         this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
         this.forecastQuantityService = forecastQuantityService;
         this.asOfQueryGuard = asOfQueryGuard;
-        this.storageLocationReplicaRepository = storageLocationReplicaRepository;
+        this.forecastSiteResolver = forecastSiteResolver;
     }
 
-    /**
-     * Forecast supply is keyed by ship-to SITE ({@code PurchaseOrderEntity.shipToLocationId});
-     * summary/scope ids are frequently bin-level. Resolve a bin to its parent site via the
-     * storage-location replica; ids not present in the replica are assumed to already be
-     * site ids and pass through unchanged.
-     */
+    /** Bin → parent-site resolution shared with the replenishment orderpoint math (F2). */
     private @Nullable UUID resolveForecastSite(@Nullable UUID locationOrStorageLocationId) {
-        if (locationOrStorageLocationId == null) {
-            return null;
-        }
-        return storageLocationReplicaRepository
-                .findById(locationOrStorageLocationId)
-                .map(ExtStorageLocationReplica::getSiteId)
-                .orElse(locationOrStorageLocationId);
+        return forecastSiteResolver.resolveForecastSite(locationOrStorageLocationId);
     }
 
     @Override

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLeadTimeServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLeadTimeServiceImpl.java
@@ -8,6 +8,7 @@ import com.positivity.inventory.internal.repository.NormalizedAvailabilityReposi
 import com.positivity.inventory.service.InventoryLeadTimeService;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -41,7 +42,14 @@ public class InventoryLeadTimeServiceImpl implements InventoryLeadTimeService {
         if (productId == null) {
             throw new InvalidInventoryAvailabilityRequestException("productId is required");
         }
+        return findLeadTime(productId, locationId, storageLocationId)
+                .orElseThrow(() -> new ResourceNotFoundException("LeadTime", productId.toString()));
+    }
 
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<LeadTimeView> findLeadTime(
+            @NonNull UUID productId, @Nullable UUID locationId, @Nullable UUID storageLocationId) {
         UUID resolvedLocationId = storageLocationId != null ? storageLocationId : locationId;
 
         LeadTimeCandidate distributorCandidate = toCandidate(
@@ -53,10 +61,10 @@ public class InventoryLeadTimeServiceImpl implements InventoryLeadTimeService {
 
         LeadTimeCandidate selected = distributorCandidate != null ? distributorCandidate : manufacturerCandidate;
         if (selected == null) {
-            throw new ResourceNotFoundException("LeadTime", productId.toString());
+            return Optional.empty();
         }
 
-        return LeadTimeView.builder()
+        return Optional.of(LeadTimeView.builder()
                 .productId(productId)
                 .locationId(resolvedLocationId)
                 .source(selected.source())
@@ -65,7 +73,7 @@ public class InventoryLeadTimeServiceImpl implements InventoryLeadTimeService {
                 .displayText(formatDisplayText(selected.minDays(), selected.maxDays()))
                 .confidence(selected.confidence())
                 .asOf(selected.asOf())
-                .build();
+                .build());
     }
 
     private LeadTimeCandidate toCandidate(

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLotOutboundService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLotOutboundService.java
@@ -1,0 +1,137 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.InventoryLot;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.enums.InventoryLotStatus;
+import com.positivity.inventory.internal.enums.ProductTrackingLevel;
+import com.positivity.inventory.internal.exception.LotNotAvailableException;
+import com.positivity.inventory.internal.exception.LotNumberRequiredException;
+import com.positivity.inventory.internal.exception.LotUnknownException;
+import com.positivity.inventory.internal.repository.InventoryLotRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Outbound lot resolution and FIFO lot suggestion (odoo-parity E2, issue #1042; spec §6 E2).
+ *
+ * <p>Counterpart of the inbound {@link InventoryLotCaptureService}: where inbound receipt
+ * find-or-creates lots, outbound flows (pick confirmation, consumption, transfers, scrap) may
+ * only draw from lots that already exist and are {@code ACTIVE}:
+ * <ul>
+ *   <li>untracked products (tracking level {@code NONE}, incl. non-UUID SKUs, no-replica
+ *       products, and {@code SERIAL} until E4) — resolution returns null and never validates;
+ *       a keyed lot number stays document-only free text, byte-identical to pre-E2</li>
+ *   <li>LOT-tracked, no lot number keyed — 422 {@code LOT_NUMBER_REQUIRED} (the E1 code,
+ *       reused: a tracked movement must never degrade to an untracked posting)</li>
+ *   <li>LOT-tracked, unknown lot number — 422 {@code LOT_UNKNOWN} (outbound never creates
+ *       lots)</li>
+ *   <li>LOT-tracked, lot exists but is not {@code ACTIVE} — 422 {@code LOT_NOT_AVAILABLE}
+ *       ({@code QUARANTINED}/{@code RECALLED} block outbound movement; {@code CONSUMED} lots
+ *       hold no stock to move)</li>
+ * </ul>
+ *
+ * <p>Returns are the one deliberate exception ({@link #resolveReturnLot}): a return
+ * legitimately references a lot that was fully consumed, so only existence is validated —
+ * the lot's status is left untouched here and the funnel-level
+ * {@link InventoryLotStatusReconciler} flips {@code CONSUMED → ACTIVE} once the returned
+ * quantity lands on the per-lot rows.
+ *
+ * <p>Lot suggestion ({@link #suggestFifoLotNumber}) is FIFO by lot {@code receivedAt} over the
+ * ACTIVE lots with positive per-lot on-hand at the pick location (spec E2: "FEFO when expiry
+ * present, else FIFO by receivedAt" — expiry data does not exist until E3, so this is plain
+ * FIFO for now; E3 upgrades the ordering to FEFO automatically through the
+ * {@link LotExpiryProvider} SPI without touching the callers). The suggestion is advisory:
+ * pick confirmation may override it with any valid ACTIVE lot, and the lot actually keyed at
+ * confirm is what the postings carry.
+ */
+@Component
+@RequiredArgsConstructor
+public class InventoryLotOutboundService {
+
+    private final InventoryLotRepository lotRepository;
+    private final InventoryStockSummaryRepository summaryRepository;
+    private final ProductTrackingLevelService trackingLevelService;
+
+    /** Whether the stock item is LOT-tracked per the catalog replica gate. */
+    public boolean isLotTracked(@NonNull String stockItemId) {
+        return trackingLevelService.trackingLevelFor(stockItemId) == ProductTrackingLevel.LOT;
+    }
+
+    /**
+     * Resolves the lot an outbound posting draws from; null for untracked stock items.
+     *
+     * @param stockItemId the ledger stock-item string of the product leaving stock
+     * @param lotNumber the lot number keyed on the outbound document line, if any
+     * @return the lot id to stamp on the outbound ledger entries, or null for untracked items
+     * @throws LotNumberRequiredException LOT-tracked and no lot number keyed
+     * @throws LotUnknownException LOT-tracked and the lot number is not in the lot master
+     * @throws LotNotAvailableException LOT-tracked and the lot is not ACTIVE
+     */
+    public @Nullable UUID resolveOutboundLot(@NonNull String stockItemId, @Nullable String lotNumber) {
+        if (!isLotTracked(stockItemId)) {
+            return null;
+        }
+        InventoryLot lot = requireExistingLot(stockItemId, lotNumber);
+        if (lot.getStatus() != InventoryLotStatus.ACTIVE) {
+            throw new LotNotAvailableException(
+                    stockItemId, lot.getLotNumber(), lot.getStatus().name());
+        }
+        return lot.getLotId();
+    }
+
+    /**
+     * Resolves the lot a return re-increments; null for untracked stock items. Unlike
+     * {@link #resolveOutboundLot} the lot's status is NOT gated — returns may reference a
+     * {@code CONSUMED} lot (the reconciler flips it back to ACTIVE once stock lands) and even
+     * a {@code QUARANTINED}/{@code RECALLED} one (returned units of a blocked lot belong on
+     * that lot's balance, where the block keeps applying). Existence is still mandatory:
+     * returns never create lots.
+     */
+    public @Nullable UUID resolveReturnLot(@NonNull String stockItemId, @Nullable String lotNumber) {
+        if (!isLotTracked(stockItemId)) {
+            return null;
+        }
+        return requireExistingLot(stockItemId, lotNumber).getLotId();
+    }
+
+    /**
+     * FIFO lot suggestion for a pick task (spec E2): among the per-lot summary rows with
+     * positive on-hand at the given location, the ACTIVE lot with the earliest
+     * {@code receivedAt} (lot id as deterministic tie-breaker). Null when the product is
+     * untracked, the location is unknown, or no ACTIVE lot has stock there.
+     */
+    public @Nullable String suggestFifoLotNumber(@NonNull String stockItemId, @Nullable UUID locationId) {
+        if (locationId == null || !isLotTracked(stockItemId)) {
+            return null;
+        }
+        Map<UUID, InventoryStockSummary> rowsByLotId =
+                summaryRepository.findPositivePerLotRows(stockItemId, locationId).stream()
+                        .collect(Collectors.toMap(InventoryStockSummary::getLotId, Function.identity()));
+        if (rowsByLotId.isEmpty()) {
+            return null;
+        }
+        return lotRepository.findAllById(rowsByLotId.keySet()).stream()
+                .filter(lot -> lot.getStatus() == InventoryLotStatus.ACTIVE)
+                .min(Comparator.comparing(InventoryLot::getReceivedAt).thenComparing(InventoryLot::getLotId))
+                .map(InventoryLot::getLotNumber)
+                .orElse(null);
+    }
+
+    private @NonNull InventoryLot requireExistingLot(@NonNull String stockItemId, @Nullable String lotNumber) {
+        if (lotNumber == null || lotNumber.isBlank()) {
+            throw new LotNumberRequiredException(stockItemId);
+        }
+        String normalized = lotNumber.trim();
+        return lotRepository
+                .findByStockItemIdAndLotNumber(stockItemId, normalized)
+                .orElseThrow(() -> new LotUnknownException(stockItemId, normalized));
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLotStatusReconciler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLotStatusReconciler.java
@@ -1,0 +1,65 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.InventoryLot;
+import com.positivity.inventory.internal.enums.InventoryLotStatus;
+import com.positivity.inventory.internal.repository.InventoryLotRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.util.Collection;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * CONSUMED status transition for lots (odoo-parity E2, issue #1042; spec §6 E2): invoked by
+ * the ledger posting funnel — in the posting transaction, after the summary deltas are
+ * applied — for every lot an on-hand-affecting entry touched.
+ *
+ * <p>Rule (exact-zero, in-transaction): a lot whose total attributed stock across ALL per-lot
+ * summary rows — on-hand everywhere plus in-transit toward anywhere, so dispatched-but-
+ * unreceived transfers keep counting — reaches exactly zero flips {@code ACTIVE → CONSUMED};
+ * a lot that regains stock (e.g. a return re-increments it) flips {@code CONSUMED → ACTIVE}.
+ * {@code QUARANTINED}/{@code RECALLED} are operator-owned states and are never touched here.
+ *
+ * <p>Race tolerance: the posting transaction holds row locks on the per-lot rows it changed,
+ * but not on the lot's rows at other locations. Two concurrent postings against different
+ * locations of the same lot can therefore each compute a total the other is about to change —
+ * whichever commits last wins, and since every posting that moves lot stock re-runs this
+ * reconciliation, the status converges to the correct value with the next posting. The status
+ * is a derived convenience flag (per-lot balances remain the source of truth), so a transient
+ * stale value between postings is acceptable by design; the summary rebuild path does not
+ * touch lot statuses for the same reason.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InventoryLotStatusReconciler {
+
+    private final InventoryLotRepository lotRepository;
+    private final InventoryStockSummaryRepository summaryRepository;
+
+    /** Reconciles ACTIVE/CONSUMED for each lot; call inside the posting transaction. */
+    public void reconcile(@NonNull Collection<UUID> lotIds) {
+        for (UUID lotId : lotIds) {
+            InventoryLot lot = lotRepository.findById(lotId).orElse(null);
+            if (lot == null) {
+                continue;
+            }
+            long totalStock = summaryRepository.sumLotStockAcrossLocations(lotId);
+            if (totalStock == 0 && lot.getStatus() == InventoryLotStatus.ACTIVE) {
+                lot.setStatus(InventoryLotStatus.CONSUMED);
+                lotRepository.save(lot);
+                log.info("Lot {} ({}) fully consumed; status ACTIVE -> CONSUMED", lotId, lot.getLotNumber());
+            } else if (totalStock > 0 && lot.getStatus() == InventoryLotStatus.CONSUMED) {
+                lot.setStatus(InventoryLotStatus.ACTIVE);
+                lotRepository.save(lot);
+                log.info(
+                        "Lot {} ({}) regained stock ({}); status CONSUMED -> ACTIVE",
+                        lotId,
+                        lot.getLotNumber(),
+                        totalStock);
+            }
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LeadTimeResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LeadTimeResolver.java
@@ -1,0 +1,90 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.entity.ReplenishmentPolicy;
+import com.positivity.inventory.service.InventoryLeadTimeService;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the replenishment lead time (in days) for one policy — the horizon the
+ * forecast-aware orderpoint trigger projects to (odoo-parity F2, issue #1040; decision D-4).
+ *
+ * <p><b>Precedence (D-4):</b> policy {@code leadTimeDaysOverride} → vendor-feed lead time →
+ * configurable default. The policy override column does not exist until parity-F3 enriches
+ * {@link ReplenishmentPolicy}; this component is the resolution seam — F3 only has to add
+ * the override check at the top of {@link #resolve(ReplenishmentPolicy)} (returning
+ * {@code LeadTimeSource.POLICY_OVERRIDE}) without touching any caller.
+ *
+ * <p><b>Feed lookup:</b> {@link InventoryLeadTimeService} aggregates MIN/MAX day estimates
+ * from normalized vendor feeds, keyed by product UUID. The MAX estimate is used —
+ * conservative on purpose: projecting to the worst-case arrival date means supply that might
+ * land later than the horizon never masks a breach, so we replenish early rather than
+ * stock out (Odoo equivalently projects to the orderpoint lead date, and under-estimating
+ * lead time is the failure mode that costs sales). Policies whose SKU is not a product UUID
+ * or that have no feed rows fall back to the default.
+ *
+ * <p><b>Default:</b> {@code pos.inventory.replenishment.default-lead-time-days} (0 when
+ * unset) — a horizon of "now", which makes the projection equal current on-hand plus
+ * already-due supply minus open demand.
+ */
+@Component
+public class LeadTimeResolver {
+
+    /** Where the resolved lead time came from; recorded in decision logs. */
+    public enum LeadTimeSource {
+        // POLICY_OVERRIDE joins here (highest precedence) when parity-F3 adds the column (D-4).
+        FEED,
+        DEFAULT
+    }
+
+    /** Resolved lead time in whole days plus its provenance. */
+    public record ResolvedLeadTime(int days, @NonNull LeadTimeSource source) {}
+
+    private final InventoryLeadTimeService inventoryLeadTimeService;
+    private final int defaultLeadTimeDays;
+
+    public LeadTimeResolver(
+            InventoryLeadTimeService inventoryLeadTimeService,
+            @Value("${pos.inventory.replenishment.default-lead-time-days:0}") int defaultLeadTimeDays) {
+        this.inventoryLeadTimeService = inventoryLeadTimeService;
+        this.defaultLeadTimeDays = Math.max(0, defaultLeadTimeDays);
+    }
+
+    /** Resolves the lead time for one policy per the D-4 precedence chain. */
+    public @NonNull ResolvedLeadTime resolve(@NonNull ReplenishmentPolicy policy) {
+        // F3 seam (D-4): check policy.getLeadTimeDaysOverride() first once the column exists.
+        Integer feedDays = feedLeadTimeDays(policy);
+        if (feedDays != null) {
+            return new ResolvedLeadTime(Math.max(0, feedDays), LeadTimeSource.FEED);
+        }
+        return new ResolvedLeadTime(defaultLeadTimeDays, LeadTimeSource.DEFAULT);
+    }
+
+    private @Nullable Integer feedLeadTimeDays(ReplenishmentPolicy policy) {
+        UUID productId = parseUuid(policy.getItemSKU());
+        if (productId == null) {
+            return null;
+        }
+        // Non-throwing lookup: absence is a normal outcome here, and an exception through
+        // the transactional proxy would mark the enclosing scan transaction rollback-only.
+        return inventoryLeadTimeService
+                .findLeadTime(productId, policy.getLocationId(), null)
+                // MAX estimate on purpose — see class javadoc (conservative horizon).
+                .map(view -> view.getMaxDays() != null ? view.getMaxDays() : view.getMinDays())
+                .orElse(null);
+    }
+
+    private static @Nullable UUID parseUuid(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LeadTimeResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LeadTimeResolver.java
@@ -12,11 +12,10 @@ import org.springframework.stereotype.Component;
  * Resolves the replenishment lead time (in days) for one policy — the horizon the
  * forecast-aware orderpoint trigger projects to (odoo-parity F2, issue #1040; decision D-4).
  *
- * <p><b>Precedence (D-4):</b> policy {@code leadTimeDaysOverride} → vendor-feed lead time →
- * configurable default. The policy override column does not exist until parity-F3 enriches
- * {@link ReplenishmentPolicy}; this component is the resolution seam — F3 only has to add
- * the override check at the top of {@link #resolve(ReplenishmentPolicy)} (returning
- * {@code LeadTimeSource.POLICY_OVERRIDE}) without touching any caller.
+ * <p><b>Precedence (D-4):</b> policy {@code leadTimeDaysOverride} (parity-F3, issue #1041)
+ * → vendor-feed lead time → configurable default. The override is an explicit operator
+ * decision on the policy and therefore beats any feed estimate; policies without one fall
+ * through to the feed chain unchanged.
  *
  * <p><b>Feed lookup:</b> {@link InventoryLeadTimeService} aggregates MIN/MAX day estimates
  * from normalized vendor feeds, keyed by product UUID. The MAX estimate is used —
@@ -35,7 +34,7 @@ public class LeadTimeResolver {
 
     /** Where the resolved lead time came from; recorded in decision logs. */
     public enum LeadTimeSource {
-        // POLICY_OVERRIDE joins here (highest precedence) when parity-F3 adds the column (D-4).
+        POLICY_OVERRIDE,
         FEED,
         DEFAULT
     }
@@ -55,7 +54,11 @@ public class LeadTimeResolver {
 
     /** Resolves the lead time for one policy per the D-4 precedence chain. */
     public @NonNull ResolvedLeadTime resolve(@NonNull ReplenishmentPolicy policy) {
-        // F3 seam (D-4): check policy.getLeadTimeDaysOverride() first once the column exists.
+        // D-4 highest precedence (parity-F3, #1041): an explicit per-policy override.
+        Integer overrideDays = policy.getLeadTimeDaysOverride();
+        if (overrideDays != null) {
+            return new ResolvedLeadTime(Math.max(0, overrideDays), LeadTimeSource.POLICY_OVERRIDE);
+        }
         Integer feedDays = feedLeadTimeDays(policy);
         if (feedDays != null) {
             return new ResolvedLeadTime(Math.max(0, feedDays), LeadTimeSource.FEED);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingServiceImpl.java
@@ -5,6 +5,7 @@ import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.enums.NegativeStockPolicy;
 import com.positivity.inventory.internal.exception.InsufficientStockException;
+import com.positivity.inventory.internal.exception.LotInsufficientStockException;
 import com.positivity.inventory.internal.exception.NegativeStockPolicyViolationException;
 import com.positivity.inventory.internal.exception.UomConversionUndefinedException;
 import com.positivity.inventory.internal.repository.ExtProductReplicaRepository;
@@ -14,10 +15,12 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -71,16 +74,19 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
     private final InventoryStockSummaryRepository summaryRepository;
     private final StockSummaryRowInitializer rowInitializer;
     private final ExtProductReplicaRepository extProductReplicaRepository;
+    private final InventoryLotStatusReconciler lotStatusReconciler;
 
     public LedgerPostingServiceImpl(
             InventoryLedgerEntryRepository ledgerRepository,
             InventoryStockSummaryRepository summaryRepository,
             StockSummaryRowInitializer rowInitializer,
-            ExtProductReplicaRepository extProductReplicaRepository) {
+            ExtProductReplicaRepository extProductReplicaRepository,
+            InventoryLotStatusReconciler lotStatusReconciler) {
         this.ledgerRepository = ledgerRepository;
         this.summaryRepository = summaryRepository;
         this.rowInitializer = rowInitializer;
         this.extProductReplicaRepository = extProductReplicaRepository;
+        this.lotStatusReconciler = lotStatusReconciler;
     }
 
     @Override
@@ -144,8 +150,23 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
                 .forEach(key -> lockedRows.put(key, lockRow(key).orElseGet(() -> createAndLockRow(key))));
 
         enforceNegativeStockPolicy(saved, lockedRows, negativeStockOverride);
+        enforcePerLotFloor(saved, lockedRows);
 
         deltas.forEach((key, delta) -> applyDelta(lockedRows.get(key), delta));
+
+        // odoo-parity E2 (#1042): after the per-lot rows are current, reconcile the
+        // ACTIVE <-> CONSUMED status of every lot this batch moved stock for.
+        Set<UUID> touchedLotIds = new LinkedHashSet<>();
+        for (InventoryLedgerEntry entry : saved) {
+            if (entry.getLotId() != null
+                    && entry.getEventType() != null
+                    && entry.getEventType().affectsOnHand()) {
+                touchedLotIds.add(entry.getLotId());
+            }
+        }
+        if (!touchedLotIds.isEmpty()) {
+            lotStatusReconciler.reconcile(touchedLotIds);
+        }
 
         return saved;
     }
@@ -213,8 +234,8 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
             if (eventType == null || !eventType.affectsOnHand()) {
                 continue;
             }
-            // The matrix evaluates the lot-agnostic key only: per-lot rows mirror a subset of
-            // the same postings and per-lot negative guards are the E2 story.
+            // The matrix evaluates the lot-agnostic key only; the per-lot floor is a separate,
+            // absolute check (enforcePerLotFloor — odoo-parity E2, #1042).
             SummaryKey key = new SummaryKey(entry.getStockItemId(), entry.getLocationId(), null);
             long projected = projectedOnHand.computeIfAbsent(
                     key,
@@ -225,6 +246,42 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
             projectedOnHand.put(key, projected);
             if (projected < 0) {
                 rejectNegativeProjection(eventType, entry, projected, negativeStockOverride);
+            }
+        }
+    }
+
+    /**
+     * Per-lot negative floor (odoo-parity E2, issue #1042; spec §6 E2 — "negative lot balances
+     * rejected"): replays the batch's lot-tagged on-hand-affecting entries over the locked
+     * per-lot rows and rejects any entry whose projected per-lot on-hand goes below zero
+     * (422 {@code LOT_INSUFFICIENT_STOCK}).
+     *
+     * <p>Unlike the lot-agnostic matrix above, the floor is absolute — no per-type policy, no
+     * override: a physical lot can never hold negative stock, and letting it would silently
+     * misattribute stock between lots (the whole point of lot tracking). The lot-agnostic
+     * matrix stays exactly as it was — the two checks are independent, and both must pass.
+     * Batch order is preserved, so a constructive {@code TRANSFER_IN} preceding its paired
+     * outbound entry (the C3 short-close shapes) projects correctly.
+     */
+    private void enforcePerLotFloor(
+            List<InventoryLedgerEntry> entries, Map<SummaryKey, InventoryStockSummary> lockedRows) {
+        Map<SummaryKey, Long> projectedOnHand = new HashMap<>();
+        for (InventoryLedgerEntry entry : entries) {
+            InventoryLedgerEventType eventType = entry.getEventType();
+            if (entry.getLotId() == null || eventType == null || !eventType.affectsOnHand()) {
+                continue;
+            }
+            SummaryKey key = new SummaryKey(entry.getStockItemId(), entry.getLocationId(), entry.getLotId());
+            long projected = projectedOnHand.computeIfAbsent(
+                    key,
+                    missing -> Objects.requireNonNull(
+                                    lockedRows.get(missing), "per-lot summary row must be locked for entry " + missing)
+                            .getOnHand());
+            projected += entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+            projectedOnHand.put(key, projected);
+            if (projected < 0) {
+                throw new LotInsufficientStockException(
+                        entry.getStockItemId(), entry.getLotId(), entry.getLocationId(), projected);
             }
         }
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PickListGenerationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PickListGenerationServiceImpl.java
@@ -18,9 +18,9 @@ import com.positivity.inventory.internal.service.SourcingStrategyService.Sourcin
 import com.positivity.inventory.service.PickListGenerationService;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,7 +43,6 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @Transactional
-@RequiredArgsConstructor
 public class PickListGenerationServiceImpl implements PickListGenerationService {
 
     private final PickListRepository pickListRepository;
@@ -52,6 +51,48 @@ public class PickListGenerationServiceImpl implements PickListGenerationService 
     private final InventoryStockSummaryRepository stockSummaryRepository;
     private final SourcingStrategyService sourcingStrategyService;
     private final InventoryFactPublisher inventoryFactPublisher;
+    private final @Nullable InventoryLotOutboundService lotOutboundService;
+
+    @Autowired
+    public PickListGenerationServiceImpl(
+            PickListRepository pickListRepository,
+            PickTaskRepository pickTaskRepository,
+            ReservationRepository reservationRepository,
+            InventoryStockSummaryRepository stockSummaryRepository,
+            SourcingStrategyService sourcingStrategyService,
+            InventoryFactPublisher inventoryFactPublisher,
+            InventoryLotOutboundService lotOutboundService) {
+        this.pickListRepository = pickListRepository;
+        this.pickTaskRepository = pickTaskRepository;
+        this.reservationRepository = reservationRepository;
+        this.stockSummaryRepository = stockSummaryRepository;
+        this.sourcingStrategyService = sourcingStrategyService;
+        this.inventoryFactPublisher = inventoryFactPublisher;
+        this.lotOutboundService = lotOutboundService;
+    }
+
+    /**
+     * Lot-suggestion-less constructor kept for the pre-E2 unit-test fixtures: without an
+     * {@link InventoryLotOutboundService} every SKU behaves untracked (no
+     * {@code suggestedLotNumber}) — identical to the service's behavior for NONE-tracked
+     * products.
+     */
+    public PickListGenerationServiceImpl(
+            PickListRepository pickListRepository,
+            PickTaskRepository pickTaskRepository,
+            ReservationRepository reservationRepository,
+            InventoryStockSummaryRepository stockSummaryRepository,
+            SourcingStrategyService sourcingStrategyService,
+            InventoryFactPublisher inventoryFactPublisher) {
+        this(
+                pickListRepository,
+                pickTaskRepository,
+                reservationRepository,
+                stockSummaryRepository,
+                sourcingStrategyService,
+                inventoryFactPublisher,
+                null);
+    }
 
     @Override
     public @NonNull PickListResponse generatePickList(@NonNull GeneratePickListRequest request) {
@@ -100,6 +141,14 @@ public class PickListGenerationServiceImpl implements PickListGenerationService 
                 ? null
                 : decision.orderedCandidates().getFirst().locationId();
 
+        // odoo-parity E2 (#1042): advisory FIFO lot suggestion for LOT-tracked SKUs at the
+        // suggested location (earliest lot receivedAt among ACTIVE lots with per-lot stock).
+        // Confirm may override with any valid ACTIVE lot. E3's LotExpiryProvider upgrades the
+        // ordering to FEFO without touching this call site.
+        String suggestedLotNumber = lotOutboundService == null
+                ? null
+                : lotOutboundService.suggestFifoLotNumber(line.getSku(), suggestedLocationId);
+
         return PickTaskEntity.builder()
                 .pickList(pickList)
                 .productId(resolveProductId(line))
@@ -112,6 +161,7 @@ public class PickListGenerationServiceImpl implements PickListGenerationService 
                 .status(PickTaskStatus.PENDING)
                 .suggestedLocationId(suggestedLocationId)
                 .sourcingReason(suggestedLocationId == null ? null : decision.effectiveStrategy())
+                .suggestedLotNumber(suggestedLotNumber)
                 .build();
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PickListServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PickListServiceImpl.java
@@ -16,6 +16,8 @@ import com.positivity.shared.id.UUIDv7Generator;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,14 +29,31 @@ public class PickListServiceImpl implements PickListService {
     private final PickListRepository pickListRepository;
     private final PickTaskRepository pickTaskRepository;
     private final InventoryFactPublisher inventoryFactPublisher;
+    private final @Nullable InventoryLotOutboundService lotOutboundService;
 
+    @Autowired
+    public PickListServiceImpl(
+            PickListRepository pickListRepository,
+            PickTaskRepository pickTaskRepository,
+            InventoryFactPublisher inventoryFactPublisher,
+            InventoryLotOutboundService lotOutboundService) {
+        this.pickListRepository = pickListRepository;
+        this.pickTaskRepository = pickTaskRepository;
+        this.inventoryFactPublisher = inventoryFactPublisher;
+        this.lotOutboundService = lotOutboundService;
+    }
+
+    /**
+     * Lot-gate-less constructor kept for the pre-E2 unit-test fixtures: without an
+     * {@link InventoryLotOutboundService} every SKU behaves untracked (no lot validation,
+     * null {@code pickedLotId}) — identical to the service's behavior for NONE-tracked
+     * products, which is all those fixtures exercise.
+     */
     public PickListServiceImpl(
             PickListRepository pickListRepository,
             PickTaskRepository pickTaskRepository,
             InventoryFactPublisher inventoryFactPublisher) {
-        this.pickListRepository = pickListRepository;
-        this.pickTaskRepository = pickTaskRepository;
-        this.inventoryFactPublisher = inventoryFactPublisher;
+        this(pickListRepository, pickTaskRepository, inventoryFactPublisher, null);
     }
 
     @Override
@@ -111,7 +130,8 @@ public class PickListServiceImpl implements PickListService {
             @NonNull UUID pickTaskId,
             @NonNull UUID scannedSkuId,
             @NonNull UUID scannedLocationId,
-            int quantityPicked) {
+            int quantityPicked,
+            @Nullable String lotNumber) {
         PickListEntity pickList = pickListRepository
                 .findById(pickListId)
                 .orElseThrow(() -> new ResourceNotFoundException(PICK_LIST, pickListId.toString()));
@@ -134,10 +154,20 @@ public class PickListServiceImpl implements PickListService {
                     "Quantity exceeds required: " + task.getQuantityRequired() + " (quantity)");
         }
 
+        // odoo-parity E2 (#1042): LOT-tracked SKUs must key the lot the units were taken from
+        // (422 LOT_NUMBER_REQUIRED / LOT_UNKNOWN / LOT_NOT_AVAILABLE); the suggestion recorded
+        // at generation is advisory only — the keyed lot wins and is what consumption posts.
+        // Untracked SKUs resolve to null, byte-identical to pre-E2. Pick confirmation itself
+        // posts no ledger entries; the pickedLotId travels to the consumption posting.
+        UUID pickedLotId = lotOutboundService == null
+                ? null
+                : lotOutboundService.resolveOutboundLot(task.getProductId().toString(), lotNumber);
+
         task.setStatus(PickTaskStatus.PICKED);
         task.setQuantityPicked(quantityPicked);
         UUID actualLocationId = scannedLocationId;
         task.setSuggestedLocationId(actualLocationId);
+        task.setPickedLotId(pickedLotId);
         PickTaskEntity savedTask = pickTaskRepository.save(task);
         inventoryFactPublisher.markPickTaskChanged(savedTask.getPickTaskId());
 
@@ -190,6 +220,8 @@ public class PickListServiceImpl implements PickListService {
                 entity.getQuantityRequired(),
                 entity.getQuantityPicked(),
                 entity.getStatus(),
-                entity.getSortOrder());
+                entity.getSortOrder(),
+                entity.getSuggestedLotNumber(),
+                entity.getPickedLotId());
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
@@ -261,10 +261,21 @@ public class ReceivingServiceImpl implements ReceivingService {
         UUID crossDockLocationId = resolveCrossDockLocationId();
         int receiptQuantityAfter = calculateQuantityAfter(line.getProductId(), crossDockLocationId, quantityDelta);
 
-        // odoo-parity E1 (#1038) deliberately does NOT lot-gate cross-dock: it posts a paired
-        // GOODS_RECEIPT + GOODS_ISSUE in one transaction, and lot-aware outbound postings are
-        // the E2 story — stamping only the receipt half would strand phantom per-lot on-hand.
-        // Cross-dock entries stay lot-null until E2 wires both halves.
+        // odoo-parity E2 (#1042): cross-dock is lot-gated like any other receipt of a
+        // LOT-tracked product (E1 deferred this because only the receipt half could have been
+        // stamped, stranding phantom per-lot on-hand). The lot number comes from the request,
+        // falling back to one already keyed on the receiving line, and the lot is
+        // found-or-created (inbound semantics — this receipt IS the lot's first sighting).
+        // BOTH paired entries carry the same lotId, so the per-lot row nets to zero and the
+        // funnel's status reconciler marks the lot CONSUMED — stock went straight to the
+        // workorder. Untracked products resolve to null, byte-identical to pre-E2.
+        String effectiveLotNumber =
+                request.getLotNumber() != null && !request.getLotNumber().isBlank()
+                        ? request.getLotNumber()
+                        : line.getLotNumber();
+        UUID lotId = lotCaptureService.resolveReceiptLot(
+                line.getProductId(), effectiveLotNumber, parseSupplierVendorId(session.getSupplierId()));
+
         InventoryLedgerEntry receiptEntry = InventoryLedgerEntry.builder()
                 .stockItemId(line.getProductId())
                 .locationId(crossDockLocationId)
@@ -272,6 +283,7 @@ public class ReceivingServiceImpl implements ReceivingService {
                 .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
                 .changeInQuantity(quantityDelta)
                 .quantityAfter(receiptQuantityAfter)
+                .lotId(lotId)
                 .transactionUserId(actorUserId)
                 .sourceTransactionId(sessionId.toString())
                 .notes("Cross-dock GOODS_RECEIPT for workorder " + workorderId)
@@ -288,6 +300,7 @@ public class ReceivingServiceImpl implements ReceivingService {
                 .eventType(InventoryLedgerEventType.GOODS_ISSUE)
                 .changeInQuantity(-quantityDelta)
                 .quantityAfter(issueQuantityAfter)
+                .lotId(lotId)
                 .transactionUserId(actorUserId)
                 .sourceTransactionId(sessionId.toString())
                 .notes("Cross-dock GOODS_ISSUE to workorder " + workorderId)
@@ -299,6 +312,9 @@ public class ReceivingServiceImpl implements ReceivingService {
         line.setWorkorderId(workorderId);
         line.setWorkorderLineId(request.getWorkorderLineId());
         line.setReceivedQuantity(cumulativeReceivedQuantity);
+        if (lotId != null && effectiveLotNumber != null) {
+            line.setLotNumber(effectiveLotNumber.trim());
+        }
 
         int quantityCompare = cumulativeReceivedQuantity.compareTo(expectedQuantity);
         if (quantityCompare == 0) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
@@ -1,15 +1,21 @@
 package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentNeedResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
+import com.positivity.inventory.internal.dto.replenishment.UpdateReplenishmentPolicyRequest;
 import com.positivity.inventory.internal.entity.ReplenishmentPolicy;
 import com.positivity.inventory.internal.entity.ReplenishmentTask;
 import com.positivity.inventory.internal.enums.ReplenishmentDecisionReason;
+import com.positivity.inventory.internal.enums.ReplenishmentSourceType;
 import com.positivity.inventory.internal.enums.ReplenishmentStatus;
 import com.positivity.inventory.internal.enums.ReplenishmentTriggerType;
+import com.positivity.inventory.internal.exception.ResourceNotFoundException;
+import com.positivity.inventory.internal.exception.SnoozeUntilNotInFutureException;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import com.positivity.inventory.internal.repository.NormalizedAvailabilityRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentTaskRepository;
 import com.positivity.inventory.service.ReplenishmentService;
@@ -18,6 +24,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -42,9 +49,11 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
     private final ReplenishmentTaskRepository replenishmentTaskRepository;
     private final ReplenishmentPolicyRepository replenishmentPolicyRepository;
     private final InventoryStockSummaryRepository stockSummaryRepository;
+    private final NormalizedAvailabilityRepository normalizedAvailabilityRepository;
     private final ForecastQuantityService forecastQuantityService;
     private final ForecastSiteResolver forecastSiteResolver;
     private final LeadTimeResolver leadTimeResolver;
+    private final StockoutDeadlineCalculator stockoutDeadlineCalculator;
     private final Clock clock;
 
     @Override
@@ -73,19 +82,102 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
         return new PageImpl<>(mapped.subList(fromIndex, toIndex), pageable, mapped.size());
     }
 
+    /**
+     * Creates a policy with the F3 tuning fields (odoo-parity F3, issue #1041).
+     *
+     * <p><b>Order-multiple seed:</b> when the caller supplies no {@code orderMultiple}, it
+     * defaults to the vendor-feed pack size for the SKU (spec F3: "pack-size default from
+     * feed data") — the most recent {@code NormalizedAvailability} snapshot's
+     * {@code packSize}, when the SKU is a product UUID with feed rows and the pack size is
+     * greater than 1 (a pack size of 1 is equivalent to no rounding and is not stored).
+     * The seed is a creation-time default, not a live link: later feed updates do not
+     * rewrite existing policies.
+     */
     @Override
     @Transactional
     public @NonNull ReplenishmentPolicyResponse createReplenishmentPolicy(
             @NonNull CreateReplenishmentPolicyRequest request) {
+        Integer orderMultiple = request.getOrderMultiple() != null
+                ? request.getOrderMultiple()
+                : feedPackSizeSeed(request.getItemSKU());
         ReplenishmentPolicy policy = ReplenishmentPolicy.builder()
                 .locationId(request.getLocationId())
                 .itemSKU(request.getItemSKU())
                 .minimumQuantity(request.getMinimumQuantity())
                 .maximumQuantity(request.getMaximumQuantity())
+                .orderMultiple(orderMultiple)
+                .leadTimeDaysOverride(request.getLeadTimeDaysOverride())
+                .preferredSourceType(
+                        request.getPreferredSourceType() != null
+                                ? request.getPreferredSourceType()
+                                : ReplenishmentSourceType.EITHER)
+                .active(request.getActive() != null ? request.getActive() : Boolean.TRUE)
                 .build();
 
         ReplenishmentPolicy saved = replenishmentPolicyRepository.save(policy);
         return toPolicyResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public @NonNull ReplenishmentPolicyResponse updateReplenishmentPolicy(
+            @NonNull UUID policyId, @NonNull UpdateReplenishmentPolicyRequest request) {
+        ReplenishmentPolicy policy = requirePolicy(policyId);
+        // Full-replace (PUT) semantics: omitted optional fields clear / reset to defaults.
+        policy.setMinimumQuantity(request.getMinimumQuantity());
+        policy.setMaximumQuantity(request.getMaximumQuantity());
+        policy.setOrderMultiple(request.getOrderMultiple());
+        policy.setLeadTimeDaysOverride(request.getLeadTimeDaysOverride());
+        policy.setPreferredSourceType(
+                request.getPreferredSourceType() != null
+                        ? request.getPreferredSourceType()
+                        : ReplenishmentSourceType.EITHER);
+        policy.setActive(request.getActive() != null ? request.getActive() : Boolean.TRUE);
+        return toPolicyResponse(replenishmentPolicyRepository.save(policy));
+    }
+
+    @Override
+    @Transactional
+    public @NonNull ReplenishmentPolicyResponse snoozeReplenishmentPolicy(
+            @NonNull UUID policyId, @Nullable Instant snoozedUntil) {
+        ReplenishmentPolicy policy = requirePolicy(policyId);
+        if (snoozedUntil != null && !snoozedUntil.isAfter(Instant.now(clock))) {
+            throw new SnoozeUntilNotInFutureException(snoozedUntil);
+        }
+        policy.setSnoozedUntil(snoozedUntil);
+        log.info(
+                "Replenishment policy {}: policyId={} sku={} locationId={} snoozedUntil={}",
+                snoozedUntil != null ? "snoozed" : "unsnoozed",
+                policy.getPolicyId(),
+                policy.getItemSKU(),
+                policy.getLocationId(),
+                snoozedUntil);
+        return toPolicyResponse(replenishmentPolicyRepository.save(policy));
+    }
+
+    private ReplenishmentPolicy requirePolicy(UUID policyId) {
+        return replenishmentPolicyRepository
+                .findById(policyId)
+                .orElseThrow(() -> new ResourceNotFoundException("ReplenishmentPolicy", policyId.toString()));
+    }
+
+    /**
+     * Vendor-feed pack size used as the {@code orderMultiple} creation default (spec F3);
+     * {@code null} when the SKU is not a product UUID, has no feed rows, or the pack size
+     * does not imply rounding.
+     */
+    private @Nullable Integer feedPackSizeSeed(String itemSKU) {
+        UUID productId;
+        try {
+            productId = UUID.fromString(itemSKU);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        return normalizedAvailabilityRepository
+                .findFirstByProductIdOrderByAsOfDesc(productId)
+                .map(snapshot -> snapshot.getPackSize())
+                .filter(packSize -> packSize > 1)
+                .orElse(null);
     }
 
     /**
@@ -107,6 +199,15 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                         .filter(candidate -> productId.equals(candidate.getItemSKU()))
                         .findFirst();
         if (policy.isEmpty()) {
+            return ReplenishmentTaskResponse.builder()
+                    .taskId(null)
+                    .status("NO_ACTION")
+                    .build();
+        }
+
+        String suspensionReason = suspensionReason(policy.get(), Instant.now(clock));
+        if (suspensionReason != null) {
+            logSkip("Event evaluation", policy.get(), suspensionReason);
             return ReplenishmentTaskResponse.builder()
                     .taskId(null)
                     .status("NO_ACTION")
@@ -136,8 +237,8 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                     .build();
         }
 
-        ReplenishmentTask saved =
-                replenishmentTaskRepository.save(newTask(policy.get(), quantityNeeded, ReplenishmentTriggerType.EVENT));
+        ReplenishmentTask saved = replenishmentTaskRepository.save(
+                newTask(policy.get(), quantityNeeded, ReplenishmentTriggerType.EVENT, deadlineFor(projection)));
         logDecision("created", ReplenishmentTriggerType.EVENT, policy.get(), projection, quantityNeeded);
         return toTaskResponse(saved);
     }
@@ -170,8 +271,15 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
         int belowMinimum = 0;
         int tasksCreated = 0;
         int tasksRefreshed = 0;
+        int policiesSkipped = 0;
 
         for (ReplenishmentPolicy policy : replenishmentPolicyRepository.findAll()) {
+            String suspensionReason = suspensionReason(policy, now);
+            if (suspensionReason != null) {
+                logSkip("Batch scan", policy, suspensionReason);
+                policiesSkipped++;
+                continue;
+            }
             policiesEvaluated++;
             Projection projection = project(policy);
             if (!projection.triggered()) {
@@ -189,7 +297,7 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                 // so its own quantity is replaced, not subtracted).
                 int quantityNeeded =
                         quantityToReplenish(policy, projection, openTask.get().getTaskId());
-                if (quantityNeeded > 0 && refreshOpenTask(openTask.get(), quantityNeeded)) {
+                if (quantityNeeded > 0 && refreshOpenTask(openTask.get(), quantityNeeded, deadlineFor(projection))) {
                     logDecision("refreshed", ReplenishmentTriggerType.BATCH, policy, projection, quantityNeeded);
                     tasksRefreshed++;
                 }
@@ -220,26 +328,72 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                 continue;
             }
 
-            replenishmentTaskRepository.save(newTask(policy, quantityNeeded, ReplenishmentTriggerType.BATCH));
+            replenishmentTaskRepository.save(
+                    newTask(policy, quantityNeeded, ReplenishmentTriggerType.BATCH, deadlineFor(projection)));
             logDecision("created", ReplenishmentTriggerType.BATCH, policy, projection, quantityNeeded);
             tasksCreated++;
         }
 
         log.info(
                 "Batch replenishment scan complete: policiesEvaluated={} belowMinimum={} tasksCreated={}"
-                        + " tasksRefreshed={}",
+                        + " tasksRefreshed={} policiesSkipped={}",
                 policiesEvaluated,
                 belowMinimum,
                 tasksCreated,
-                tasksRefreshed);
+                tasksRefreshed,
+                policiesSkipped);
 
         return ReplenishmentScanResultResponse.builder()
                 .policiesEvaluated(policiesEvaluated)
                 .policiesBelowMinimum(belowMinimum)
                 .tasksCreated(tasksCreated)
                 .tasksRefreshed(tasksRefreshed)
+                .policiesSkipped(policiesSkipped)
                 .scanAt(now.toString())
                 .build();
+    }
+
+    /**
+     * Side-effect-free needs report (odoo-parity F3/F6, issue #1041): evaluates every
+     * ACTIVE, non-snoozed policy with the SAME shared math the batch scan uses ({@link
+     * #project(ReplenishmentPolicy)} / {@link #quantityToReplenish(ReplenishmentPolicy,
+     * Projection, UUID)} / {@link #deadlineFor(Projection)}) so the report always matches
+     * what a scan run at the same instant would do — but never creates or refreshes tasks.
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public @NonNull List<ReplenishmentNeedResponse> getReplenishmentNeeds() {
+        Instant now = Instant.now(clock);
+        List<ReplenishmentNeedResponse> needs = new ArrayList<>();
+        for (ReplenishmentPolicy policy : replenishmentPolicyRepository.findAll()) {
+            if (suspensionReason(policy, now) != null) {
+                continue;
+            }
+            Projection projection = project(policy);
+            int suggestedQuantity = projection.triggered() ? quantityToReplenish(policy, projection, null) : 0;
+            LocalDate deadline = projection.triggered() ? deadlineFor(projection) : null;
+            needs.add(ReplenishmentNeedResponse.builder()
+                    .policyId(
+                            policy.getPolicyId() != null ? policy.getPolicyId().toString() : null)
+                    .itemSKU(policy.getItemSKU())
+                    .locationId(policy.getLocationId())
+                    .onHand(projection.onHand())
+                    .projectedAvailable(projection.projectedAvailable())
+                    .leadHorizonDate(LocalDate.ofInstant(projection.leadHorizon(), ZoneOffset.UTC)
+                            .toString())
+                    .leadTimeSource(projection.leadTime().source().name())
+                    .minimumQuantity(policy.getMinimumQuantity() != null ? policy.getMinimumQuantity() : 0)
+                    .maximumQuantity(policy.getMaximumQuantity() != null ? policy.getMaximumQuantity() : 0)
+                    .wouldTrigger(projection.triggered())
+                    .suggestedQuantity(suggestedQuantity)
+                    .deadlineDate(deadline != null ? deadline.toString() : null)
+                    .preferredSourceType(
+                            policy.getPreferredSourceType() != null
+                                    ? policy.getPreferredSourceType().name()
+                                    : ReplenishmentSourceType.EITHER.name())
+                    .build());
+        }
+        return needs;
     }
 
     /**
@@ -259,27 +413,91 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
      */
     private Projection project(ReplenishmentPolicy policy) {
         LeadTimeResolver.ResolvedLeadTime leadTime = leadTimeResolver.resolve(policy);
-        Instant leadHorizon = Instant.now(clock).plus(Duration.ofDays(leadTime.days()));
+        Instant evaluatedAt = Instant.now(clock);
+        Instant leadHorizon = evaluatedAt.plus(Duration.ofDays(leadTime.days()));
         long onHand = currentOnHand(policy.getItemSKU(), policy.getLocationId());
         UUID forecastSiteId = forecastSiteResolver.resolveForecastSite(policy.getLocationId());
         long projectedAvailable = forecastQuantityService
                 .forecast(policy.getItemSKU(), forecastSiteId, leadHorizon, onHand)
                 .projectedAvailable();
         boolean triggered = projectedAvailable < policy.getMinimumQuantity();
-        return new Projection(onHand, projectedAvailable, leadHorizon, leadTime, triggered);
+        return new Projection(
+                policy.getItemSKU(),
+                forecastSiteId,
+                onHand,
+                projectedAvailable,
+                evaluatedAt,
+                leadHorizon,
+                leadTime,
+                triggered);
     }
 
     /**
      * Odoo's replenish-to-max with in-progress netting ({@code qty_in_progress}):
-     * {@code max(0, maximumQuantity - projectedAvailable(leadHorizon) - inProgress)}.
-     * Zero means in-progress supply already covers the need — no task is created.
+     * {@code max(0, maximumQuantity - projectedAvailable(leadHorizon) - inProgress)},
+     * rounded UP to the policy's {@code orderMultiple} when one is set (odoo-parity F3,
+     * issue #1041 — Odoo {@code qty_multiple}; e.g. need 7 with multiple 6 orders 12).
+     * Rounding applies AFTER netting — an exact multiple stays as-is and zero stays zero
+     * (in-progress supply already covering the need never rounds up into a phantom order).
      *
      * @param excludeTaskId open task being refreshed, excluded from the in-progress sum so
      *     its own quantity is replaced rather than double-counted; {@code null} otherwise
      */
     private int quantityToReplenish(ReplenishmentPolicy policy, Projection projection, @Nullable UUID excludeTaskId) {
         long inProgress = inProgressQuantity(policy.getItemSKU(), policy.getLocationId(), excludeTaskId);
-        return (int) Math.max(0L, policy.getMaximumQuantity() - projection.projectedAvailable() - inProgress);
+        long raw = Math.max(0L, policy.getMaximumQuantity() - projection.projectedAvailable() - inProgress);
+        return (int) roundUpToMultiple(raw, policy.getOrderMultiple());
+    }
+
+    /** Rounds a positive quantity UP to the nearest multiple; zero and no-multiple pass through. */
+    private static long roundUpToMultiple(long quantity, @Nullable Integer multiple) {
+        if (quantity <= 0 || multiple == null || multiple <= 1) {
+            return quantity;
+        }
+        return ((quantity + multiple - 1) / multiple) * multiple;
+    }
+
+    /**
+     * Skip reason for a policy excluded from evaluation (odoo-parity F3, issue #1041):
+     * {@code INACTIVE} when the active flag is off, {@code SNOOZED} while
+     * {@code snoozedUntil} is in the future (a policy resumes automatically once the
+     * snooze instant passes — no unsnooze write is needed); {@code null} when the policy
+     * must be evaluated.
+     */
+    private @Nullable String suspensionReason(ReplenishmentPolicy policy, Instant now) {
+        if (Boolean.FALSE.equals(policy.getActive())) {
+            return "INACTIVE";
+        }
+        if (policy.getSnoozedUntil() != null && policy.getSnoozedUntil().isAfter(now)) {
+            return "SNOOZED";
+        }
+        return null;
+    }
+
+    private void logSkip(String path, ReplenishmentPolicy policy, String reason) {
+        log.info(
+                "{} skip: reason={} policyId={} sku={} locationId={} snoozedUntil={} active={}",
+                path,
+                reason,
+                policy.getPolicyId(),
+                policy.getItemSKU(),
+                policy.getLocationId(),
+                policy.getSnoozedUntil(),
+                policy.getActive());
+    }
+
+    /**
+     * Stock-out deadline for a triggered projection (odoo-parity F3, issue #1041): the
+     * earliest date the horizon-bounded projection goes negative — see
+     * {@link StockoutDeadlineCalculator} for the documented approximation.
+     */
+    private @Nullable LocalDate deadlineFor(Projection projection) {
+        return stockoutDeadlineCalculator.stockoutDeadline(
+                projection.stockItemId(),
+                projection.forecastSiteId(),
+                projection.onHand(),
+                projection.evaluatedAt(),
+                projection.leadHorizon());
     }
 
     /**
@@ -330,10 +548,13 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                 quantityNeeded);
     }
 
-    /** Forecast evaluation of one policy at its lead-time horizon (F2). */
+    /** Forecast evaluation of one policy at its lead-time horizon (F2; F3 added the deadline inputs). */
     private record Projection(
+            String stockItemId,
+            @Nullable UUID forecastSiteId,
             long onHand,
             long projectedAvailable,
+            Instant evaluatedAt,
             Instant leadHorizon,
             LeadTimeResolver.ResolvedLeadTime leadTime,
             boolean triggered) {}
@@ -356,19 +577,23 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                 .orElse(0L);
     }
 
-    /** Refreshes a still-open PENDING task's quantity to the currently computed need. */
-    private boolean refreshOpenTask(ReplenishmentTask task, int quantityNeeded) {
+    /** Refreshes a still-open PENDING task's quantity (and stock-out deadline) to the currently computed need. */
+    private boolean refreshOpenTask(ReplenishmentTask task, int quantityNeeded, @Nullable LocalDate deadlineDate) {
         if (task.getStatus() != ReplenishmentStatus.PENDING
                 || (task.getQuantity() != null && task.getQuantity() == quantityNeeded)) {
             return false;
         }
         task.setQuantity(quantityNeeded);
+        task.setDeadlineDate(deadlineDate);
         replenishmentTaskRepository.save(task);
         return true;
     }
 
     private ReplenishmentTask newTask(
-            ReplenishmentPolicy policy, int quantityNeeded, ReplenishmentTriggerType triggerType) {
+            ReplenishmentPolicy policy,
+            int quantityNeeded,
+            ReplenishmentTriggerType triggerType,
+            @Nullable LocalDate deadlineDate) {
         // Source selection is a placeholder until odoo-parity F5 (internal
         // sourcing): the policy's own location stands in for the backstock
         // source because the column is non-null and no sourcing engine exists yet.
@@ -380,6 +605,7 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                 .status(ReplenishmentStatus.PENDING)
                 .triggerType(triggerType)
                 .decisionReason(ReplenishmentDecisionReason.BELOW_MIN)
+                .deadlineDate(deadlineDate)
                 .build();
     }
 
@@ -402,6 +628,8 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                                 ? task.getSourcingReason().name()
                                 : null)
                 .assignedTo(task.getAssignedTo())
+                .deadlineDate(
+                        task.getDeadlineDate() != null ? task.getDeadlineDate().toString() : null)
                 .createdAt(task.getCreatedAt() != null ? task.getCreatedAt().toString() : null)
                 .build();
     }
@@ -413,6 +641,17 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                 .itemSKU(policy.getItemSKU())
                 .minimumQuantity(policy.getMinimumQuantity() != null ? policy.getMinimumQuantity() : 0)
                 .maximumQuantity(policy.getMaximumQuantity() != null ? policy.getMaximumQuantity() : 0)
+                .orderMultiple(policy.getOrderMultiple())
+                .leadTimeDaysOverride(policy.getLeadTimeDaysOverride())
+                .preferredSourceType(
+                        policy.getPreferredSourceType() != null
+                                ? policy.getPreferredSourceType().name()
+                                : ReplenishmentSourceType.EITHER.name())
+                .snoozedUntil(
+                        policy.getSnoozedUntil() != null
+                                ? policy.getSnoozedUntil().toString()
+                                : null)
+                .active(!Boolean.FALSE.equals(policy.getActive()))
                 .createdAt(policy.getCreatedAt() != null ? policy.getCreatedAt().toString() : null)
                 .build();
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
@@ -14,6 +14,7 @@ import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepositor
 import com.positivity.inventory.internal.repository.ReplenishmentTaskRepository;
 import com.positivity.inventory.service.ReplenishmentService;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -41,6 +42,9 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
     private final ReplenishmentTaskRepository replenishmentTaskRepository;
     private final ReplenishmentPolicyRepository replenishmentPolicyRepository;
     private final InventoryStockSummaryRepository stockSummaryRepository;
+    private final ForecastQuantityService forecastQuantityService;
+    private final ForecastSiteResolver forecastSiteResolver;
+    private final LeadTimeResolver leadTimeResolver;
     private final Clock clock;
 
     @Override
@@ -84,41 +88,75 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
         return toPolicyResponse(saved);
     }
 
+    /**
+     * Event-path orderpoint evaluation (odoo-parity F2, issue #1040). Uses the SAME
+     * forecast-aware trigger and quantity math as the batch scan ({@link
+     * #project(ReplenishmentPolicy)} / {@link #quantityToReplenish(ReplenishmentPolicy,
+     * Projection, UUID)}) — the two paths must not diverge.
+     *
+     * <p>An already-open task for the SKU/pick-face IS the in-progress supply for this
+     * breach: the evaluation short-circuits to {@code TASK_ALREADY_QUEUED} without adding
+     * quantity, which is what prevents double-ordering across the scan and event paths.
+     */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public @NonNull ReplenishmentTaskResponse evaluatePickFaceForReplenishment(
             @NonNull String productId, @NonNull UUID pickFaceLocationId) {
-        boolean policyExists = replenishmentPolicyRepository.findByLocationId(pickFaceLocationId).stream()
-                .findFirst()
-                .isPresent();
+        Optional<ReplenishmentPolicy> policy =
+                replenishmentPolicyRepository.findByLocationId(pickFaceLocationId).stream()
+                        .filter(candidate -> productId.equals(candidate.getItemSKU()))
+                        .findFirst();
+        if (policy.isEmpty()) {
+            return ReplenishmentTaskResponse.builder()
+                    .taskId(null)
+                    .status("NO_ACTION")
+                    .build();
+        }
 
-        if (policyExists && hasOpenTask(productId, pickFaceLocationId)) {
+        if (hasOpenTask(productId, pickFaceLocationId)) {
             return ReplenishmentTaskResponse.builder()
                     .taskId(null)
                     .status("TASK_ALREADY_QUEUED")
                     .build();
         }
 
-        return ReplenishmentTaskResponse.builder()
-                .taskId(null)
-                .status("NO_ACTION")
-                .build();
+        Projection projection = project(policy.get());
+        if (!projection.triggered()) {
+            return ReplenishmentTaskResponse.builder()
+                    .taskId(null)
+                    .status("NO_ACTION")
+                    .build();
+        }
+
+        int quantityNeeded = quantityToReplenish(policy.get(), projection, null);
+        if (quantityNeeded == 0) {
+            return ReplenishmentTaskResponse.builder()
+                    .taskId(null)
+                    .status("NO_ACTION")
+                    .build();
+        }
+
+        ReplenishmentTask saved =
+                replenishmentTaskRepository.save(newTask(policy.get(), quantityNeeded, ReplenishmentTriggerType.EVENT));
+        logDecision("created", ReplenishmentTriggerType.EVENT, policy.get(), projection, quantityNeeded);
+        return toTaskResponse(saved);
     }
 
     /**
-     * Batch replenishment scan (CAP-217 / odoo-parity F1, issue #1025).
+     * Batch replenishment scan (CAP-217 / odoo-parity F1, issue #1025; forecast-aware
+     * orderpoint math since F2, issue #1040).
      *
-     * <p>Iterates every {@link ReplenishmentPolicy} and applies the same
-     * below-minimum trigger evaluation the event path uses ({@link
-     * #isBelowMinimum(ReplenishmentPolicy, long)} / {@link #hasOpenTask(String,
-     * UUID)}), against the current on-hand from the {@code
-     * inventory_stock_summary} read model (issue #1024). F2 upgrades this to
-     * forecast-aware math.
+     * <p>Iterates every {@link ReplenishmentPolicy} and applies the same forecast-aware
+     * trigger evaluation the event path uses ({@link #project(ReplenishmentPolicy)} /
+     * {@link #quantityToReplenish(ReplenishmentPolicy, Projection, UUID)}): trigger when
+     * {@code projectedAvailable(leadHorizon) < minimumQuantity}, replenish {@code max(0,
+     * maximumQuantity - projectedAvailable(leadHorizon) - inProgress)}.
      *
      * <p>Idempotency per (policy, day): a still-open task for the policy's
-     * SKU/location is refreshed (quantity re-derived) instead of duplicated, and
-     * if a batch-triggered task was already created today (UTC) no new task is
-     * created even if the earlier one has since closed.
+     * SKU/location is refreshed (quantity re-derived, netting OTHER open tasks) instead of
+     * duplicated, and if a batch-triggered task was already created today (UTC) no new task
+     * is created even if the earlier one has since closed. A triggered policy whose
+     * computed quantity is zero (in-progress supply already covers to max) creates nothing.
      */
     @Override
     @Transactional
@@ -135,21 +173,35 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
 
         for (ReplenishmentPolicy policy : replenishmentPolicyRepository.findAll()) {
             policiesEvaluated++;
-            long onHand = currentOnHand(policy.getItemSKU(), policy.getLocationId());
-            if (!isBelowMinimum(policy, onHand)) {
+            Projection projection = project(policy);
+            if (!projection.triggered()) {
                 continue;
             }
             belowMinimum++;
 
-            int quantityNeeded = (int) Math.max(1, policy.getMaximumQuantity() - onHand);
             Optional<ReplenishmentTask> openTask =
                     replenishmentTaskRepository
                             .findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
                                     policy.getItemSKU(), policy.getLocationId(), OPEN_STATUSES);
             if (openTask.isPresent()) {
-                if (refreshOpenTask(openTask.get(), quantityNeeded)) {
+                // Re-derive the open task's quantity, netting any OTHER open tasks for the
+                // same SKU/location (the refreshed task itself is excluded from in-progress
+                // so its own quantity is replaced, not subtracted).
+                int quantityNeeded =
+                        quantityToReplenish(policy, projection, openTask.get().getTaskId());
+                if (quantityNeeded > 0 && refreshOpenTask(openTask.get(), quantityNeeded)) {
+                    logDecision("refreshed", ReplenishmentTriggerType.BATCH, policy, projection, quantityNeeded);
                     tasksRefreshed++;
                 }
+                continue;
+            }
+
+            int quantityNeeded = quantityToReplenish(policy, projection, null);
+            if (quantityNeeded == 0) {
+                log.debug(
+                        "Batch scan skip (in-progress supply covers to max): sku={} locationId={}",
+                        policy.getItemSKU(),
+                        policy.getLocationId());
                 continue;
             }
 
@@ -168,7 +220,8 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
                 continue;
             }
 
-            createBatchTask(policy, quantityNeeded);
+            replenishmentTaskRepository.save(newTask(policy, quantityNeeded, ReplenishmentTriggerType.BATCH));
+            logDecision("created", ReplenishmentTriggerType.BATCH, policy, projection, quantityNeeded);
             tasksCreated++;
         }
 
@@ -190,13 +243,100 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
     }
 
     /**
-     * Shared below-minimum trigger evaluation (event path and batch scan must
-     * not diverge — odoo-parity F1). Current math: plain on-hand vs policy
-     * minimum; forecast-aware projection replaces this in F2.
+     * Forecast projection for one policy at its lead-time horizon (odoo-parity F2, issue
+     * #1040 — Odoo orderpoint semantics; event path and batch scan must not diverge).
+     *
+     * <p>{@code leadHorizon = now + leadTimeDays} where lead time resolves per D-4
+     * ({@link LeadTimeResolver}: policy override [F3] → vendor feed MAX estimate →
+     * configured default). On-hand is read at the policy's own (possibly bin-level)
+     * location — the stock the pick face actually holds — while forecast supply/demand is
+     * scoped to the location's parent SITE via {@link ForecastSiteResolver}, because open
+     * POs/ASNs/transfers are keyed by ship-to site, never by bin.
+     *
+     * <p>Trigger: {@code projectedAvailable(leadHorizon) < minimumQuantity}. With no open
+     * supply/demand documents and no feed lead time, {@code projectedAvailable == onHand}
+     * at any horizon, so the trigger degrades exactly to the pre-F2 on-hand comparison.
      */
-    private boolean isBelowMinimum(ReplenishmentPolicy policy, long onHand) {
-        return onHand < policy.getMinimumQuantity();
+    private Projection project(ReplenishmentPolicy policy) {
+        LeadTimeResolver.ResolvedLeadTime leadTime = leadTimeResolver.resolve(policy);
+        Instant leadHorizon = Instant.now(clock).plus(Duration.ofDays(leadTime.days()));
+        long onHand = currentOnHand(policy.getItemSKU(), policy.getLocationId());
+        UUID forecastSiteId = forecastSiteResolver.resolveForecastSite(policy.getLocationId());
+        long projectedAvailable = forecastQuantityService
+                .forecast(policy.getItemSKU(), forecastSiteId, leadHorizon, onHand)
+                .projectedAvailable();
+        boolean triggered = projectedAvailable < policy.getMinimumQuantity();
+        return new Projection(onHand, projectedAvailable, leadHorizon, leadTime, triggered);
     }
+
+    /**
+     * Odoo's replenish-to-max with in-progress netting ({@code qty_in_progress}):
+     * {@code max(0, maximumQuantity - projectedAvailable(leadHorizon) - inProgress)}.
+     * Zero means in-progress supply already covers the need — no task is created.
+     *
+     * @param excludeTaskId open task being refreshed, excluded from the in-progress sum so
+     *     its own quantity is replaced rather than double-counted; {@code null} otherwise
+     */
+    private int quantityToReplenish(ReplenishmentPolicy policy, Projection projection, @Nullable UUID excludeTaskId) {
+        long inProgress = inProgressQuantity(policy.getItemSKU(), policy.getLocationId(), excludeTaskId);
+        return (int) Math.max(0L, policy.getMaximumQuantity() - projection.projectedAvailable() - inProgress);
+    }
+
+    /**
+     * Open replenishment-task quantity already in flight for one SKU/destination — the
+     * in-progress supply netted out of {@link #quantityToReplenish}.
+     *
+     * <p>F4 seam: open {@code PurchaseSuggestion} quantities (SUGGESTED/ACCEPTED, not yet
+     * CONVERTED) join this sum once purchase suggestions exist, so a suggested-but-unordered
+     * buy also prevents double-ordering.
+     */
+    private long inProgressQuantity(String itemSKU, UUID destinationLocationId, @Nullable UUID excludeTaskId) {
+        return replenishmentTaskRepository
+                .findByItemSKUAndDestinationLocationIdAndStatusIn(itemSKU, destinationLocationId, OPEN_STATUSES)
+                .stream()
+                .filter(task -> excludeTaskId == null || !excludeTaskId.equals(task.getTaskId()))
+                .mapToLong(task -> task.getQuantity() != null ? task.getQuantity() : 0L)
+                .sum();
+    }
+
+    /**
+     * Decision-input recording (F2 scope 3): {@link ReplenishmentTask} deliberately gains no
+     * columns — {@code decisionReason=BELOW_MIN} goes on the entity and the numeric inputs
+     * are logged at INFO with structured fields (projected, horizon, lead-time source,
+     * min/max) so every created/refreshed task's math is reconstructable from logs.
+     */
+    private void logDecision(
+            String action,
+            ReplenishmentTriggerType triggerType,
+            ReplenishmentPolicy policy,
+            Projection projection,
+            int quantityNeeded) {
+        log.info(
+                "Replenishment task {}: triggerType={} decisionReason={} sku={} locationId={} onHand={}"
+                        + " projectedAvailable={} leadHorizon={} leadTimeDays={} leadTimeSource={} min={} max={}"
+                        + " quantity={}",
+                action,
+                triggerType,
+                ReplenishmentDecisionReason.BELOW_MIN,
+                policy.getItemSKU(),
+                policy.getLocationId(),
+                projection.onHand(),
+                projection.projectedAvailable(),
+                projection.leadHorizon(),
+                projection.leadTime().days(),
+                projection.leadTime().source(),
+                policy.getMinimumQuantity(),
+                policy.getMaximumQuantity(),
+                quantityNeeded);
+    }
+
+    /** Forecast evaluation of one policy at its lead-time horizon (F2). */
+    private record Projection(
+            long onHand,
+            long projectedAvailable,
+            Instant leadHorizon,
+            LeadTimeResolver.ResolvedLeadTime leadTime,
+            boolean triggered) {}
 
     /** Duplicate-open-task guard shared by the event path and the batch scan. */
     private boolean hasOpenTask(String itemSKU, UUID destinationLocationId) {
@@ -227,20 +367,20 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
         return true;
     }
 
-    private void createBatchTask(ReplenishmentPolicy policy, int quantityNeeded) {
+    private ReplenishmentTask newTask(
+            ReplenishmentPolicy policy, int quantityNeeded, ReplenishmentTriggerType triggerType) {
         // Source selection is a placeholder until odoo-parity F5 (internal
         // sourcing): the policy's own location stands in for the backstock
         // source because the column is non-null and no sourcing engine exists yet.
-        ReplenishmentTask task = ReplenishmentTask.builder()
+        return ReplenishmentTask.builder()
                 .itemSKU(policy.getItemSKU())
                 .quantity(quantityNeeded)
                 .sourceLocationId(policy.getLocationId())
                 .destinationLocationId(policy.getLocationId())
                 .status(ReplenishmentStatus.PENDING)
-                .triggerType(ReplenishmentTriggerType.BATCH)
+                .triggerType(triggerType)
                 .decisionReason(ReplenishmentDecisionReason.BELOW_MIN)
                 .build();
-        replenishmentTaskRepository.save(task);
     }
 
     private ReplenishmentTaskResponse toTaskResponse(ReplenishmentTask task) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReturnServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReturnServiceImpl.java
@@ -24,14 +24,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
-@RequiredArgsConstructor
 public class ReturnServiceImpl implements ReturnService {
 
     private final InventoryReturnRepository inventoryReturnRepository;
@@ -40,6 +40,48 @@ public class ReturnServiceImpl implements ReturnService {
     private final InventoryFactPublisher inventoryFactPublisher;
     private final DocumentQuantityConverter documentQuantityConverter;
     private final Clock clock;
+    private final @Nullable InventoryLotOutboundService lotOutboundService;
+
+    @Autowired
+    public ReturnServiceImpl(
+            InventoryReturnRepository inventoryReturnRepository,
+            InventoryLedgerEntryRepository inventoryLedgerEntryRepository,
+            LedgerPostingService ledgerPostingService,
+            InventoryFactPublisher inventoryFactPublisher,
+            DocumentQuantityConverter documentQuantityConverter,
+            Clock clock,
+            InventoryLotOutboundService lotOutboundService) {
+        this.inventoryReturnRepository = inventoryReturnRepository;
+        this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
+        this.ledgerPostingService = ledgerPostingService;
+        this.inventoryFactPublisher = inventoryFactPublisher;
+        this.documentQuantityConverter = documentQuantityConverter;
+        this.clock = clock;
+        this.lotOutboundService = lotOutboundService;
+    }
+
+    /**
+     * Lot-gate-less constructor kept for the pre-E2 unit-test fixtures: without an
+     * {@link InventoryLotOutboundService} every SKU behaves untracked (no lot validation,
+     * lot-null postings) — identical to the service's behavior for NONE-tracked products
+     * (odoo-parity E2, issue #1042).
+     */
+    public ReturnServiceImpl(
+            InventoryReturnRepository inventoryReturnRepository,
+            InventoryLedgerEntryRepository inventoryLedgerEntryRepository,
+            LedgerPostingService ledgerPostingService,
+            InventoryFactPublisher inventoryFactPublisher,
+            DocumentQuantityConverter documentQuantityConverter,
+            Clock clock) {
+        this(
+                inventoryReturnRepository,
+                inventoryLedgerEntryRepository,
+                ledgerPostingService,
+                inventoryFactPublisher,
+                documentQuantityConverter,
+                clock,
+                null);
+    }
 
     @Override
     @Transactional(readOnly = true)
@@ -142,9 +184,18 @@ public class ReturnServiceImpl implements ReturnService {
     /**
      * Per-line return derivation (odoo-parity B2, #1034): the optional document-UoM conversion
      * plus the whole base quantity that validates against consumption and posts to the ledger.
+     * {@code lotId} (odoo-parity E2, #1042) is the resolved lot for LOT-tracked SKUs — a
+     * return must name an EXISTING lot ({@code LOT_NUMBER_REQUIRED}/{@code LOT_UNKNOWN}), but
+     * unlike the other outbound-flow validations its status is not gated: returning stock to a
+     * CONSUMED lot is the normal way it comes back to life (the funnel's status reconciler
+     * flips CONSUMED → ACTIVE once the quantity lands), and returned units of a
+     * QUARANTINED/RECALLED lot belong on that lot's balance where the block keeps applying.
      */
     private record ReturnLineComputation(
-            ReturnItemLine item, DocumentQuantityConverter.DocumentConversion conversion, int baseQuantity) {}
+            ReturnItemLine item,
+            DocumentQuantityConverter.DocumentConversion conversion,
+            int baseQuantity,
+            @Nullable UUID lotId) {}
 
     private ReturnLineComputation computeReturnLine(ReturnItemLine item) {
         DocumentQuantityConverter.DocumentConversion conversion = documentQuantityConverter
@@ -168,7 +219,10 @@ public class ReturnServiceImpl implements ReturnService {
         if (baseQuantity <= 0) {
             throw new IllegalArgumentException("quantityReturned must be positive");
         }
-        return new ReturnLineComputation(item, conversion, baseQuantity);
+        UUID lotId = lotOutboundService == null
+                ? null
+                : lotOutboundService.resolveReturnLot(item.getSkuId().toString(), item.getLotNumber());
+        return new ReturnLineComputation(item, conversion, baseQuantity, lotId);
     }
 
     private int calculateTotalItemsReturned(List<ReturnLineComputation> items) {
@@ -205,6 +259,7 @@ public class ReturnServiceImpl implements ReturnService {
                 .eventType(InventoryLedgerEventType.RETURN_TO_STOCK)
                 .changeInQuantity(Math.abs(computed.baseQuantity()))
                 .quantityAfter(0)
+                .lotId(computed.lotId())
                 .transactionUserId(SecurityContextHelper.getCurrentUsernameOrDefault("system"))
                 .notes("Returned to stock from workorder "
                         + request.getWorkorderId()

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ScrapServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ScrapServiceImpl.java
@@ -33,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
@@ -60,7 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
  * mirroring the putaway source-on-hand rule.
  */
 @Service
-@RequiredArgsConstructor
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
 @Slf4j
 public class ScrapServiceImpl implements ScrapService {
 
@@ -76,6 +77,32 @@ public class ScrapServiceImpl implements ScrapService {
     private final InventoryFactPublisher inventoryFactPublisher;
     private final ReplenishmentService replenishmentService;
     private final Clock clock;
+    private final @Nullable InventoryLotOutboundService lotOutboundService;
+
+    /**
+     * Lot-gate-less constructor kept for the pre-E2 unit-test fixtures: without an
+     * {@link InventoryLotOutboundService} every SKU behaves untracked (no lot validation,
+     * lot-null postings) — identical to the service's behavior for NONE-tracked products
+     * (odoo-parity E2, issue #1042).
+     */
+    public ScrapServiceImpl(
+            ScrapRecordRepository scrapRepository,
+            InventoryLedgerEntryRepository ledgerRepository,
+            LedgerPostingService ledgerPostingService,
+            ApprovalThresholdEvaluator thresholdEvaluator,
+            InventoryFactPublisher inventoryFactPublisher,
+            ReplenishmentService replenishmentService,
+            Clock clock) {
+        this(
+                scrapRepository,
+                ledgerRepository,
+                ledgerPostingService,
+                thresholdEvaluator,
+                inventoryFactPublisher,
+                replenishmentService,
+                clock,
+                null);
+    }
 
     @Override
     @Transactional
@@ -88,6 +115,15 @@ public class ScrapServiceImpl implements ScrapService {
         String actor = currentActor();
         CostSnapshot costSnapshot = snapshotCost(request.getStockItemId());
 
+        // odoo-parity E2 (#1042): LOT-tracked SKUs must key the lot being written off
+        // (422 LOT_NUMBER_REQUIRED / LOT_UNKNOWN / LOT_NOT_AVAILABLE); the resolved lot rides
+        // on the D1-reserved ScrapRecord.lotId column and stamps the SCRAP_OUT posting —
+        // including the approval path, which posts later from the stored record. Untracked
+        // SKUs resolve to null, byte-identical to pre-E2.
+        UUID lotId = lotOutboundService == null
+                ? null
+                : lotOutboundService.resolveOutboundLot(request.getStockItemId(), request.getLotNumber());
+
         ScrapRecord scrap = ScrapRecord.builder()
                 .stockItemId(request.getStockItemId())
                 .quantity(request.getQuantity())
@@ -96,6 +132,7 @@ public class ScrapServiceImpl implements ScrapService {
                 .reasonCode(request.getReasonCode())
                 .notes(request.getNotes())
                 .workorderId(request.getWorkorderId())
+                .lotId(lotId)
                 .attachmentReference(request.getAttachmentReference())
                 .unitCostSnapshot(costSnapshot.unitCost())
                 .costSource(costSnapshot.source())
@@ -264,6 +301,7 @@ public class ScrapServiceImpl implements ScrapService {
                 .quantityAfter(currentOnHand - scrap.getQuantity())
                 .unitCost(scrap.getUnitCostSnapshot())
                 .locationId(postingLocationId)
+                .lotId(scrap.getLotId())
                 .reasonCode(scrap.getReasonCode().name())
                 .sourceTransactionId(scrap.getScrapId().toString())
                 .transactionUserId(scrap.getApprovedBy() != null ? scrap.getApprovedBy() : scrap.getCreatedBy())
@@ -371,6 +409,7 @@ public class ScrapServiceImpl implements ScrapService {
                 .reasonCode(scrap.getReasonCode())
                 .notes(scrap.getNotes())
                 .workorderId(scrap.getWorkorderId())
+                .lotId(scrap.getLotId())
                 .attachmentReference(scrap.getAttachmentReference())
                 .unitCostSnapshot(scrap.getUnitCostSnapshot())
                 .costSource(scrap.getCostSource())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockoutDeadlineCalculator.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockoutDeadlineCalculator.java
@@ -1,0 +1,130 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.enums.AsnStatus;
+import com.positivity.inventory.internal.enums.PurchaseOrderStatus;
+import com.positivity.inventory.internal.enums.ReservationStatus;
+import com.positivity.inventory.internal.repository.AsnLineRepository;
+import com.positivity.inventory.internal.repository.PurchaseOrderLineRepository;
+import com.positivity.inventory.internal.repository.ReservationRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Approximates the stock-out deadline for a triggered replenishment policy (odoo-parity F3,
+ * issue #1041; spec F3 — Odoo orderpoint deadline analogue): the earliest date at which the
+ * horizon-bounded {@code projectedAvailable} goes below zero.
+ *
+ * <p><b>Approximation (documented, deliberate):</b> the projection is piecewise-constant in
+ * the horizon — it only changes at document date cutoffs (PO expected-delivery dates, ASN
+ * expected-arrival dates, reservation due instants). So instead of walking every day, the
+ * calculator evaluates {@link ForecastQuantityService#forecast} at exactly those candidate
+ * cutoffs within {@code (now, leadHorizon]}, ascending, and returns the UTC date of the
+ * first one whose projection is negative. If the projection is already negative at
+ * {@code now}, the deadline is today. Limitations inherited from the horizon rule: undated
+ * documents are excluded from every bounded evaluation (they can neither cause nor avert a
+ * dated stock-out), and released pick-task demand is horizon-independent, so it shifts the
+ * whole curve rather than creating a cutoff. Returns {@code null} when the projection never
+ * dips below zero within the lead horizon (a below-min breach without a projected
+ * stock-out has no deadline).
+ */
+@Component
+@RequiredArgsConstructor
+public class StockoutDeadlineCalculator {
+
+    // Mirrors the open-document status sets of ExpectedSupplyServiceImpl /
+    // ForecastQuantityServiceImpl: candidate cutoffs must come from exactly the documents
+    // the forecast counts, or the walk would evaluate at dates where nothing changes (or
+    // miss dates where something does).
+    private static final List<PurchaseOrderStatus> OPEN_PO_STATUSES =
+            List.of(PurchaseOrderStatus.APPROVED, PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    private static final List<AsnStatus> OPEN_ASN_STATUSES =
+            List.of(AsnStatus.LOADED, AsnStatus.READY_FOR_RECEIPT, AsnStatus.PARTIALLY_RECEIVED);
+    private static final List<ReservationStatus> OPEN_RESERVATION_STATUSES =
+            List.of(ReservationStatus.PENDING, ReservationStatus.PARTIALLY_FULFILLED);
+
+    private final ForecastQuantityService forecastQuantityService;
+    private final PurchaseOrderLineRepository purchaseOrderLineRepository;
+    private final AsnLineRepository asnLineRepository;
+    private final ReservationRepository reservationRepository;
+
+    /**
+     * Earliest UTC date within {@code (now, leadHorizon]} at which the projection for the
+     * SKU goes below zero, today when it is already negative at {@code now}, or
+     * {@code null} when it never does.
+     *
+     * @param stockItemId ledger stock-item identifier (product UUID string for PO lines)
+     * @param forecastSiteId site scope for supply documents (bin already resolved to site)
+     * @param onHand current on-hand at the policy's own location
+     * @param now evaluation instant
+     * @param leadHorizon the policy's resolved lead-time horizon (walk upper bound)
+     */
+    public @Nullable LocalDate stockoutDeadline(
+            @NonNull String stockItemId,
+            @Nullable UUID forecastSiteId,
+            long onHand,
+            @NonNull Instant now,
+            @NonNull Instant leadHorizon) {
+        if (projectedAt(stockItemId, forecastSiteId, onHand, now) < 0) {
+            return LocalDate.ofInstant(now, ZoneOffset.UTC);
+        }
+        for (Instant cutoff : candidateCutoffs(stockItemId, forecastSiteId, now, leadHorizon)) {
+            if (projectedAt(stockItemId, forecastSiteId, onHand, cutoff) < 0) {
+                return LocalDate.ofInstant(cutoff, ZoneOffset.UTC);
+            }
+        }
+        return null;
+    }
+
+    private long projectedAt(String stockItemId, @Nullable UUID forecastSiteId, long onHand, Instant horizon) {
+        return forecastQuantityService
+                .forecast(stockItemId, forecastSiteId, horizon, onHand)
+                .projectedAvailable();
+    }
+
+    /**
+     * Distinct document cutoff instants in {@code (now, leadHorizon]}, ascending. Date-only
+     * document dates (PO/ASN headers) become start-of-day UTC instants — the horizon rule
+     * compares by UTC date, so any instant on the day includes the day's documents;
+     * reservation due instants are used exactly.
+     */
+    private TreeSet<Instant> candidateCutoffs(
+            String stockItemId, @Nullable UUID forecastSiteId, Instant now, Instant leadHorizon) {
+        LocalDate horizonDate = LocalDate.ofInstant(leadHorizon, ZoneOffset.UTC);
+        TreeSet<Instant> cutoffs = new TreeSet<>();
+
+        UUID skuUuid = parseUuid(stockItemId);
+        if (skuUuid != null) {
+            purchaseOrderLineRepository
+                    .findDistinctExpectedDeliveryDatesForSku(skuUuid, OPEN_PO_STATUSES, forecastSiteId, horizonDate)
+                    .forEach(date ->
+                            cutoffs.add(date.atStartOfDay(ZoneOffset.UTC).toInstant()));
+            reservationRepository
+                    .findDistinctDueInstantsForSku(skuUuid, OPEN_RESERVATION_STATUSES, leadHorizon)
+                    .forEach(cutoffs::add);
+        }
+        asnLineRepository
+                .findDistinctExpectedArrivalDatesForSku(stockItemId, OPEN_ASN_STATUSES, forecastSiteId, horizonDate)
+                .forEach(date -> cutoffs.add(date.atStartOfDay(ZoneOffset.UTC).toInstant()));
+
+        // Keep only cutoffs strictly after "now" (the now-projection is evaluated first) and
+        // never beyond the lead horizon. Single subSet call: with a 0-day lead time
+        // now == leadHorizon and chained tailSet/headSet views would reject the bound.
+        return new TreeSet<>(cutoffs.subSet(now, false, leadHorizon, true));
+    }
+
+    private static @Nullable UUID parseUuid(String value) {
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/TransferOrderServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/TransferOrderServiceImpl.java
@@ -4,6 +4,7 @@ import com.positivity.domainevents.inventory.TransferOrderUpdatedV1;
 import com.positivity.inventory.internal.dto.transfer.CreateTransferOrderRequest;
 import com.positivity.inventory.internal.dto.transfer.DispatchTransferOrderRequest;
 import com.positivity.inventory.internal.dto.transfer.ReceiveTransferOrderRequest;
+import com.positivity.inventory.internal.dto.transfer.ShortCloseTransferOrderRequest;
 import com.positivity.inventory.internal.dto.transfer.TransferOrderLineRequest;
 import com.positivity.inventory.internal.dto.transfer.TransferOrderLineResponse;
 import com.positivity.inventory.internal.dto.transfer.TransferOrderResponse;
@@ -13,7 +14,9 @@ import com.positivity.inventory.internal.entity.LocationRefEntity;
 import com.positivity.inventory.internal.entity.TransferOrder;
 import com.positivity.inventory.internal.entity.TransferOrderLine;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.ScrapReasonCode;
 import com.positivity.inventory.internal.enums.TransferOrderStatus;
+import com.positivity.inventory.internal.enums.TransferShortCloseDisposition;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.TransferLocationNotEligibleException;
 import com.positivity.inventory.internal.exception.TransferOrderNotFoundException;
@@ -24,6 +27,7 @@ import com.positivity.inventory.internal.repository.LocationRefRepository;
 import com.positivity.inventory.internal.repository.TransferOrderRepository;
 import com.positivity.inventory.service.TransferOrderService;
 import com.positivity.security.common.SecurityContextHelper;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -36,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
@@ -56,6 +61,39 @@ import org.springframework.transaction.annotation.Transactional;
  * off (DRAFT dispatches directly, approve is a 409). When on, DRAFT must be approved before
  * dispatch. Approval authority rides on {@code inventory:transfer:dispatch} (the controller
  * gate): whoever may move the stock may authorize moving it.
+ *
+ * <p>Short-close ledger shape (parity-C3, issue #1039; spec C4). In-transit is derived purely
+ * from ledger shape: {@code TRANSFER_OUT} with a {@code toLocationId} contributes at the
+ * DESTINATION key, {@code TRANSFER_IN} cancels at its OWN key (C2 rule in
+ * {@code LedgerPostingServiceImpl}/{@code StockSummaryRebuildServiceImpl} and the drift SQL).
+ * Short-close therefore never needs new reconstruction rules — each line's remainder
+ * ({@code dispatched − received}) posts one of two same-batch shapes, both of which zero the
+ * destination in-transit through the existing rules:
+ * <ul>
+ *   <li>{@code LOST_IN_TRANSIT} — constructive {@code TRANSFER_IN} at the destination key
+ *       (cancels the outstanding in-transit, briefly raises destination on-hand) immediately
+ *       paired with {@code SCRAP_OUT} at the same key ({@code reasonCode = LOST}, WS-D
+ *       taxonomy, latest-receipt cost snapshot). Net: destination on-hand unchanged,
+ *       destination in-transit zero, GLOBAL on-hand down by the remainder. A direct
+ *       "SCRAP_OUT from transit" was rejected: {@code SCRAP_OUT} carries no in-transit
+ *       semantics anywhere (posting, rebuild, drift SQL), so it could only zero transit via a
+ *       special-case exemption in all three places — the paired shape needs none.</li>
+ *   <li>{@code RETURNED_TO_SOURCE} — constructive {@code TRANSFER_IN} at the destination,
+ *       {@code TRANSFER_OUT} destination→source, {@code TRANSFER_IN} at the source (the
+ *       intra-transaction OUT+IN pair self-cancels its own transit contribution at the source
+ *       key, exactly like intra-site bin moves). Net: destination unchanged, in-transit zero
+ *       at both keys, source on-hand restored by the remainder. A single {@code TRANSFER_IN}
+ *       at the source WITHOUT the pair was rejected: in-transit is keyed at the destination
+ *       via {@code TRANSFER_OUT.toLocationId}, so a source-keyed {@code TRANSFER_IN} would
+ *       leave destination transit standing and drive source transit negative.</li>
+ * </ul>
+ * All entries of a short-close post atomically through the funnel with
+ * {@code sourceTransactionId = transferOrderId}. Within each line the constructive
+ * {@code TRANSFER_IN} precedes the outbound entry, so the negative-stock projection at the
+ * destination never dips below its starting balance. No scrap document is created for transit
+ * losses (a document would re-gate an already-permissioned short-close behind the D1 approval
+ * flow) and consequently no {@code ScrapPostedV1} fact is emitted — the terminal
+ * {@link TransferOrderUpdatedV1} fact carries the disposition instead.
  *
  * <p>Facts: every state change queues a {@link TransferOrderUpdatedV1} occurrence fact through
  * {@link InventoryFactPublisher} (outbox at beforeCommit).
@@ -317,6 +355,155 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         return toResponse(order);
     }
 
+    @Override
+    @Transactional
+    public @NonNull TransferOrderResponse shortCloseTransferOrder(
+            @NonNull UUID transferOrderId, @NonNull ShortCloseTransferOrderRequest request) {
+        TransferOrder order = load(transferOrderId);
+        if (!order.getStatus().receivable()) {
+            throw new IllegalStateException("Cannot short-close transfer order in status: " + order.getStatus()
+                    + "; short-close resolves the in-transit remainder of a DISPATCHED or PARTIALLY_RECEIVED order");
+        }
+        int totalRemainder = order.getLines().stream()
+                .mapToInt(line -> line.getDispatchedQty() - line.getReceivedQty())
+                .sum();
+        if (totalRemainder <= 0) {
+            throw new IllegalStateException(
+                    "Cannot short-close transfer order " + transferOrderId + ": no outstanding in-transit remainder");
+        }
+        // RETURNED_TO_SOURCE physically lands stock back at the source site, so the source is
+        // re-validated for movement eligibility (DECISION-INVENTORY-009). LOST_IN_TRANSIT lands
+        // nothing anywhere — deliberately no eligibility check, so a transfer toward a
+        // since-deactivated destination can still be resolved as a loss.
+        if (request.getDisposition() == TransferShortCloseDisposition.RETURNED_TO_SOURCE) {
+            requireEligibleSite(order.getSourceLocationId(), "source");
+        }
+
+        UUID sourcePosting = sourcePostingLocation(order);
+        UUID destinationPosting = destinationPostingLocation(order);
+        String actor = currentActor();
+
+        List<InventoryLedgerEntry> entries = new ArrayList<>();
+        Map<String, Integer> runningDelta = new HashMap<>();
+        for (TransferOrderLine line : order.getLines()) {
+            int remainder = line.getDispatchedQty() - line.getReceivedQty();
+            if (remainder == 0) {
+                continue;
+            }
+            // Constructive arrival at the destination key: cancels this line's outstanding
+            // in-transit (see the short-close ledger-shape javadoc on this class).
+            entries.add(transferEntry(
+                    order,
+                    line.getSku(),
+                    InventoryLedgerEventType.TRANSFER_IN,
+                    remainder,
+                    destinationPosting,
+                    sourcePosting,
+                    destinationPosting,
+                    runningDelta,
+                    actor));
+            if (request.getDisposition() == TransferShortCloseDisposition.LOST_IN_TRANSIT) {
+                entries.add(lostRemainderEntry(
+                        order, line.getSku(), remainder, destinationPosting, request, runningDelta, actor));
+            } else {
+                entries.add(transferEntry(
+                        order,
+                        line.getSku(),
+                        InventoryLedgerEventType.TRANSFER_OUT,
+                        -remainder,
+                        destinationPosting,
+                        destinationPosting,
+                        sourcePosting,
+                        runningDelta,
+                        actor));
+                entries.add(transferEntry(
+                        order,
+                        line.getSku(),
+                        InventoryLedgerEventType.TRANSFER_IN,
+                        remainder,
+                        sourcePosting,
+                        destinationPosting,
+                        sourcePosting,
+                        runningDelta,
+                        actor));
+            }
+        }
+
+        List<InventoryLedgerEntry> saved = ledgerPostingService.postAll(entries);
+        inventoryFactPublisher.markEntries(saved);
+
+        order.setStatus(TransferOrderStatus.SHORT_CLOSED);
+        order.setShortCloseDisposition(request.getDisposition());
+        order.setShortCloseReason(request.getReason());
+        order.setShortCloseNotes(request.getNotes());
+        order.setShortClosedBy(actor);
+        order.setShortClosedAt(Instant.now(clock));
+        order = transferOrderRepository.save(order);
+
+        log.info(
+                "Transfer order {} short-closed by {} with disposition {}: remainder {} resolved in {} entries",
+                transferOrderId,
+                actor,
+                request.getDisposition(),
+                totalRemainder,
+                saved.size());
+        recordFact(order);
+        return toResponse(order);
+    }
+
+    /**
+     * Builds the {@code SCRAP_OUT} half of a LOST_IN_TRANSIT line (spec C4 via the WS-D reason
+     * taxonomy): posted at the destination key directly behind the constructive
+     * {@code TRANSFER_IN}, with {@code reasonCode = LOST},
+     * {@code sourceTransactionId = transferOrderId}, the request notes, and the D1 interim cost
+     * snapshot (latest {@code GOODS_RECEIPT} unit cost, falling back to the latest non-null
+     * unit cost of any entry — same rule as {@code ScrapServiceImpl}; WS-J refines the source).
+     * Deliberately NO {@code ScrapRecord} document: short-close is already permission-gated and
+     * loss-accepting, so a scrap document would only double-gate it behind the D1 approval
+     * tiers; accounting reads the disposition off the {@code TransferOrderUpdatedV1} fact.
+     */
+    private InventoryLedgerEntry lostRemainderEntry(
+            TransferOrder order,
+            String sku,
+            int remainder,
+            UUID destinationPosting,
+            ShortCloseTransferOrderRequest request,
+            Map<String, Integer> runningDelta,
+            String actor) {
+        Integer currentOnHand = ledgerRepository.calculateOnHandQuantityAtLocation(sku, destinationPosting);
+        String deltaKey = runningDeltaKey(sku, destinationPosting);
+        int before = (currentOnHand != null ? currentOnHand : 0) + runningDelta.getOrDefault(deltaKey, 0);
+        runningDelta.merge(deltaKey, -remainder, Integer::sum);
+        return InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(destinationPosting)
+                .eventType(InventoryLedgerEventType.SCRAP_OUT)
+                .changeInQuantity(-remainder)
+                .quantityAfter(before - remainder)
+                .unitCost(latestUnitCost(sku))
+                .reasonCode(ScrapReasonCode.LOST.name())
+                .sourceTransactionId(order.getTransferOrderId().toString())
+                .transactionUserId(actor)
+                .notes(request.getNotes())
+                .timestamp(Instant.now(clock))
+                .build();
+    }
+
+    /**
+     * D1's interim cost snapshot rule (ADR-0048 / plan D-6): most recent {@code GOODS_RECEIPT}
+     * unit cost for the SKU, falling back to the latest non-null unit cost of any entry, else
+     * null. odoo-parity J1 replaces this with the authoritative cost source.
+     */
+    private @Nullable BigDecimal latestUnitCost(String sku) {
+        List<BigDecimal> receiptCosts = ledgerRepository.findLatestUnitCostByStockItemAndEventType(
+                sku, InventoryLedgerEventType.GOODS_RECEIPT, PageRequest.of(0, 1));
+        if (!receiptCosts.isEmpty()) {
+            return receiptCosts.getFirst();
+        }
+        List<BigDecimal> anyCosts = ledgerRepository.findLatestUnitCostByStockItem(sku, PageRequest.of(0, 1));
+        return anyCosts.isEmpty() ? null : anyCosts.getFirst();
+    }
+
     /**
      * Decision D-8 status gate for dispatch: flag off — DRAFT dispatches directly (APPROVED is
      * unreachable); flag on — only APPROVED dispatches, a DRAFT must be approved first.
@@ -352,9 +539,11 @@ public class TransferOrderServiceImpl implements TransferOrderService {
     }
 
     /**
-     * Builds one transfer posting entry. {@code runningDelta} accumulates per-SKU deltas within
-     * the batch so {@code quantityAfter} stays correct when multiple lines share a SKU (the
-     * batch posts atomically, so each entry's after-quantity must include earlier lines).
+     * Builds one transfer posting entry. {@code runningDelta} accumulates per-(SKU, posting
+     * location) deltas within the batch so {@code quantityAfter} stays correct when multiple
+     * entries share a SKU — across lines (dispatch/receive) or across the two ends of a
+     * short-close return shape (the batch posts atomically, so each entry's after-quantity
+     * must include earlier entries at its own key).
      */
     private InventoryLedgerEntry transferEntry(
             TransferOrder order,
@@ -367,8 +556,9 @@ public class TransferOrderServiceImpl implements TransferOrderService {
             Map<String, Integer> runningDelta,
             String actor) {
         Integer currentOnHand = ledgerRepository.calculateOnHandQuantityAtLocation(sku, postingLocationId);
-        int before = (currentOnHand != null ? currentOnHand : 0) + runningDelta.getOrDefault(sku, 0);
-        runningDelta.merge(sku, changeInQuantity, Integer::sum);
+        String deltaKey = runningDeltaKey(sku, postingLocationId);
+        int before = (currentOnHand != null ? currentOnHand : 0) + runningDelta.getOrDefault(deltaKey, 0);
+        runningDelta.merge(deltaKey, changeInQuantity, Integer::sum);
         return InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(postingLocationId)
@@ -381,6 +571,11 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                 .transactionUserId(actor)
                 .timestamp(Instant.now(clock))
                 .build();
+    }
+
+    /** Within-batch quantity bookkeeping key: one running delta per (SKU, posting location). */
+    private static String runningDeltaKey(String sku, UUID postingLocationId) {
+        return sku + "@" + postingLocationId;
     }
 
     /** Bin-level source posting location when pinned on the order, else the source site key. */
@@ -445,6 +640,9 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                         .map(line -> new TransferOrderUpdatedV1.LineSummary(
                                 line.getSku(), line.getRequestedQty(), line.getDispatchedQty(), line.getReceivedQty()))
                         .toList(),
+                order.getShortCloseDisposition() != null
+                        ? order.getShortCloseDisposition().name()
+                        : null,
                 Instant.now(clock)));
     }
 
@@ -466,6 +664,11 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                 .createdBy(order.getCreatedBy())
                 .approvedBy(order.getApprovedBy())
                 .dispatchedBy(order.getDispatchedBy())
+                .shortCloseDisposition(order.getShortCloseDisposition())
+                .shortCloseReason(order.getShortCloseReason())
+                .shortCloseNotes(order.getShortCloseNotes())
+                .shortClosedBy(order.getShortClosedBy())
+                .shortClosedAt(order.getShortClosedAt())
                 .createdAt(order.getCreatedAt())
                 .updatedAt(order.getUpdatedAt())
                 .build();

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/TransferOrderServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/TransferOrderServiceImpl.java
@@ -110,6 +110,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
     private final LedgerPostingService ledgerPostingService;
     private final InventoryLedgerEntryRepository ledgerRepository;
     private final InventoryFactPublisher inventoryFactPublisher;
+    private final InventoryLotOutboundService lotOutboundService;
     private final Clock clock;
     private final boolean approvalRequired;
 
@@ -120,6 +121,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
             LedgerPostingService ledgerPostingService,
             InventoryLedgerEntryRepository ledgerRepository,
             InventoryFactPublisher inventoryFactPublisher,
+            InventoryLotOutboundService lotOutboundService,
             Clock clock,
             @Value("${pos.inventory.transfer.approval-required:false}") boolean approvalRequired) {
         this.transferOrderRepository = transferOrderRepository;
@@ -128,6 +130,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         this.ledgerPostingService = ledgerPostingService;
         this.ledgerRepository = ledgerRepository;
         this.inventoryFactPublisher = inventoryFactPublisher;
+        this.lotOutboundService = lotOutboundService;
         this.clock = clock;
         this.approvalRequired = approvalRequired;
     }
@@ -249,7 +252,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         requireEligibleSite(order.getSourceLocationId(), "source");
         requireEligibleSite(order.getDestinationLocationId(), "destination");
 
-        Map<UUID, Integer> explicit = explicitQuantities(request.getLines(), order);
+        Map<UUID, TransferQuantityLineRequest> explicit = explicitLines(request.getLines(), order);
         UUID sourcePosting = sourcePostingLocation(order);
         UUID destinationPosting = destinationPostingLocation(order);
         String actor = currentActor();
@@ -257,11 +260,21 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         List<InventoryLedgerEntry> entries = new ArrayList<>();
         Map<String, Integer> runningDelta = new HashMap<>();
         for (TransferOrderLine line : order.getLines()) {
-            int quantity = explicit.getOrDefault(line.getLineId(), line.getRequestedQty());
+            TransferQuantityLineRequest explicitLine = explicit.get(line.getLineId());
+            int quantity = explicitLine != null ? explicitLine.getQuantity() : line.getRequestedQty();
             if (quantity > line.getRequestedQty()) {
                 throw TransferQuantityExceededException.dispatchExceedsRequested(
                         line.getLineId(), line.getSku(), quantity, line.getRequestedQty());
             }
+            // odoo-parity E2 (#1042): LOT-tracked SKUs must key the lot being dispatched
+            // (422 LOT_NUMBER_REQUIRED / LOT_UNKNOWN / LOT_NOT_AVAILABLE); the resolved lot is
+            // pinned on the line so receive and short-close post the SAME lot on both sides —
+            // per-lot balances then conserve across sites exactly like the lot-agnostic ones.
+            // Untracked SKUs resolve to null, byte-identical to pre-E2.
+            UUID lotId = lotOutboundService.resolveOutboundLot(
+                    line.getSku(), explicitLine != null ? explicitLine.getLotNumber() : null);
+            line.setLotId(lotId);
+            line.setLotNumber(lotId == null || explicitLine == null ? null : explicitLine.getLotNumber());
             entries.add(transferEntry(
                     order,
                     line.getSku(),
@@ -270,6 +283,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                     sourcePosting,
                     sourcePosting,
                     destinationPosting,
+                    lotId,
                     runningDelta,
                     actor));
             line.setDispatchedQty(quantity);
@@ -306,7 +320,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         // Spec C5: the receiving end re-validated at posting time.
         requireEligibleSite(order.getDestinationLocationId(), "destination");
 
-        Map<UUID, Integer> explicit = explicitQuantities(request.getLines(), order);
+        Map<UUID, TransferQuantityLineRequest> explicit = explicitLines(request.getLines(), order);
         UUID sourcePosting = sourcePostingLocation(order);
         UUID destinationPosting = destinationPostingLocation(order);
         String actor = currentActor();
@@ -315,7 +329,8 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         Map<String, Integer> runningDelta = new HashMap<>();
         for (TransferOrderLine line : order.getLines()) {
             int remaining = line.getDispatchedQty() - line.getReceivedQty();
-            int quantity = explicit.getOrDefault(line.getLineId(), remaining);
+            TransferQuantityLineRequest explicitLine = explicit.get(line.getLineId());
+            int quantity = explicitLine != null ? explicitLine.getQuantity() : remaining;
             if (quantity > remaining) {
                 throw TransferQuantityExceededException.receiveExceedsDispatched(
                         line.getLineId(), line.getSku(), quantity, remaining);
@@ -323,6 +338,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
             if (quantity == 0) {
                 continue;
             }
+            // E2: the arrival carries the lot pinned at dispatch — never a request-keyed one.
             entries.add(transferEntry(
                     order,
                     line.getSku(),
@@ -331,6 +347,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                     destinationPosting,
                     sourcePosting,
                     destinationPosting,
+                    line.getLotId(),
                     runningDelta,
                     actor));
             line.setReceivedQty(line.getReceivedQty() + quantity);
@@ -391,7 +408,9 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                 continue;
             }
             // Constructive arrival at the destination key: cancels this line's outstanding
-            // in-transit (see the short-close ledger-shape javadoc on this class).
+            // in-transit (see the short-close ledger-shape javadoc on this class). Every entry
+            // of the shape carries the lot pinned at dispatch (E2), so the per-lot rows walk
+            // through the same conserving pairs as the lot-agnostic balances.
             entries.add(transferEntry(
                     order,
                     line.getSku(),
@@ -400,11 +419,12 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                     destinationPosting,
                     sourcePosting,
                     destinationPosting,
+                    line.getLotId(),
                     runningDelta,
                     actor));
             if (request.getDisposition() == TransferShortCloseDisposition.LOST_IN_TRANSIT) {
-                entries.add(lostRemainderEntry(
-                        order, line.getSku(), remainder, destinationPosting, request, runningDelta, actor));
+                entries.add(
+                        lostRemainderEntry(order, line, remainder, destinationPosting, request, runningDelta, actor));
             } else {
                 entries.add(transferEntry(
                         order,
@@ -414,6 +434,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                         destinationPosting,
                         destinationPosting,
                         sourcePosting,
+                        line.getLotId(),
                         runningDelta,
                         actor));
                 entries.add(transferEntry(
@@ -424,6 +445,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                         sourcePosting,
                         destinationPosting,
                         sourcePosting,
+                        line.getLotId(),
                         runningDelta,
                         actor));
             }
@@ -464,12 +486,13 @@ public class TransferOrderServiceImpl implements TransferOrderService {
      */
     private InventoryLedgerEntry lostRemainderEntry(
             TransferOrder order,
-            String sku,
+            TransferOrderLine line,
             int remainder,
             UUID destinationPosting,
             ShortCloseTransferOrderRequest request,
             Map<String, Integer> runningDelta,
             String actor) {
+        String sku = line.getSku();
         Integer currentOnHand = ledgerRepository.calculateOnHandQuantityAtLocation(sku, destinationPosting);
         String deltaKey = runningDeltaKey(sku, destinationPosting);
         int before = (currentOnHand != null ? currentOnHand : 0) + runningDelta.getOrDefault(deltaKey, 0);
@@ -482,6 +505,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                 .quantityAfter(before - remainder)
                 .unitCost(latestUnitCost(sku))
                 .reasonCode(ScrapReasonCode.LOST.name())
+                .lotId(line.getLotId())
                 .sourceTransactionId(order.getTransferOrderId().toString())
                 .transactionUserId(actor)
                 .notes(request.getNotes())
@@ -519,11 +543,11 @@ public class TransferOrderServiceImpl implements TransferOrderService {
     }
 
     /** Maps explicit request lines to their order lines; unknown line ids are a 400. */
-    private Map<UUID, Integer> explicitQuantities(
+    private Map<UUID, TransferQuantityLineRequest> explicitLines(
             @Nullable List<TransferQuantityLineRequest> requestLines, TransferOrder order) {
-        Map<UUID, Integer> quantities = new LinkedHashMap<>();
+        Map<UUID, TransferQuantityLineRequest> byLineId = new LinkedHashMap<>();
         if (requestLines == null) {
-            return quantities;
+            return byLineId;
         }
         for (TransferQuantityLineRequest requestLine : requestLines) {
             boolean known =
@@ -531,11 +555,11 @@ public class TransferOrderServiceImpl implements TransferOrderService {
             if (!known) {
                 throw new IllegalArgumentException("Unknown transfer order line: " + requestLine.getLineId());
             }
-            if (quantities.putIfAbsent(requestLine.getLineId(), requestLine.getQuantity()) != null) {
+            if (byLineId.putIfAbsent(requestLine.getLineId(), requestLine) != null) {
                 throw new IllegalArgumentException("Duplicate transfer order line: " + requestLine.getLineId());
             }
         }
-        return quantities;
+        return byLineId;
     }
 
     /**
@@ -553,6 +577,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
             UUID postingLocationId,
             UUID fromLocationId,
             UUID toLocationId,
+            @Nullable UUID lotId,
             Map<String, Integer> runningDelta,
             String actor) {
         Integer currentOnHand = ledgerRepository.calculateOnHandQuantityAtLocation(sku, postingLocationId);
@@ -567,6 +592,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                 .eventType(eventType)
                 .changeInQuantity(changeInQuantity)
                 .quantityAfter(before + changeInQuantity)
+                .lotId(lotId)
                 .sourceTransactionId(order.getTransferOrderId().toString())
                 .transactionUserId(actor)
                 .timestamp(Instant.now(clock))
@@ -682,6 +708,8 @@ public class TransferOrderServiceImpl implements TransferOrderService {
                 .requestedQty(line.getRequestedQty())
                 .dispatchedQty(line.getDispatchedQty())
                 .receivedQty(line.getReceivedQty())
+                .lotId(line.getLotId())
+                .lotNumber(line.getLotNumber())
                 .createdAt(line.getCreatedAt())
                 .updatedAt(line.getUpdatedAt())
                 .build();

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryLeadTimeService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/InventoryLeadTimeService.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.service;
 
 import com.positivity.inventory.internal.dto.LeadTimeView;
+import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -17,7 +18,20 @@ public interface InventoryLeadTimeService {
      * @param locationId        location identifier
      * @param storageLocationId optional storage location identifier
      * @return lead-time view
+     * @throws com.positivity.inventory.internal.exception.ResourceNotFoundException when no
+     *     feed source carries lead-time data for the product
      */
     @NonNull
     LeadTimeView queryLeadTime(@NonNull UUID productId, @Nullable UUID locationId, @Nullable UUID storageLocationId);
+
+    /**
+     * Non-throwing variant of {@link #queryLeadTime} for internal callers that treat absent
+     * feed data as a normal outcome (e.g. the replenishment lead-time resolution chain,
+     * odoo-parity F2 issue #1040): absence must not raise an exception through a
+     * transactional proxy, which would mark an enclosing transaction rollback-only.
+     *
+     * @return the lead-time view, or empty when no feed source carries data for the product
+     */
+    Optional<LeadTimeView> findLeadTime(
+            @NonNull UUID productId, @Nullable UUID locationId, @Nullable UUID storageLocationId);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/PickListService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/PickListService.java
@@ -7,6 +7,7 @@ import com.positivity.inventory.internal.enums.PickListStatus;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public interface PickListService {
 
@@ -25,13 +26,30 @@ public interface PickListService {
     @NonNull
     PickListResponse releasePickList(@NonNull UUID pickListId);
 
+    /** Pre-E2 arity: confirms without a lot number (LOT-tracked SKUs will reject — see below). */
+    @NonNull
+    default PickTaskResponse confirmPickTask(
+            @NonNull UUID pickListId,
+            @NonNull UUID pickTaskId,
+            @NonNull UUID scannedSkuId,
+            @NonNull UUID scannedLocationId,
+            int quantityPicked) {
+        return confirmPickTask(pickListId, pickTaskId, scannedSkuId, scannedLocationId, quantityPicked, null);
+    }
+
+    /**
+     * Confirms a pick task, optionally recording the lot the units were taken from
+     * (odoo-parity E2, issue #1042): LOT-tracked SKUs require a lot number referencing an
+     * existing ACTIVE lot; untracked SKUs ignore it.
+     */
     @NonNull
     PickTaskResponse confirmPickTask(
             @NonNull UUID pickListId,
             @NonNull UUID pickTaskId,
             @NonNull UUID scannedSkuId,
             @NonNull UUID scannedLocationId,
-            int quantityPicked);
+            int quantityPicked,
+            @Nullable String lotNumber);
 
     @NonNull
     List<PickTaskResponse> getPickTasksForPickList(@NonNull UUID pickListId);

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ReplenishmentService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ReplenishmentService.java
@@ -1,9 +1,12 @@
 package com.positivity.inventory.service;
 
 import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentNeedResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
+import com.positivity.inventory.internal.dto.replenishment.UpdateReplenishmentPolicyRequest;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -41,4 +44,30 @@ public interface ReplenishmentService {
 
     @NonNull
     ReplenishmentPolicyResponse createReplenishmentPolicy(@NonNull CreateReplenishmentPolicyRequest request);
+
+    /**
+     * Full-replace update of a policy's thresholds and F3 tuning fields (odoo-parity F3,
+     * issue #1041). PUT semantics: omitted optional fields are cleared / reset to their
+     * defaults; identity (location, SKU) and snooze state are not updatable here.
+     */
+    @NonNull
+    ReplenishmentPolicyResponse updateReplenishmentPolicy(
+            @NonNull UUID policyId, @NonNull UpdateReplenishmentPolicyRequest request);
+
+    /**
+     * Snoozes a policy until a future instant, or clears an existing snooze when
+     * {@code snoozedUntil} is {@code null} (odoo-parity F3, issue #1041 — Odoo orderpoint
+     * snooze). A non-null instant that is not in the future is rejected with
+     * {@link com.positivity.inventory.internal.exception.SnoozeUntilNotInFutureException}.
+     */
+    @NonNull
+    ReplenishmentPolicyResponse snoozeReplenishmentPolicy(@NonNull UUID policyId, @Nullable Instant snoozedUntil);
+
+    /**
+     * Side-effect-free replenishment needs report (odoo-parity F3/F6, issue #1041): the
+     * current orderpoint evaluation of every ACTIVE, non-snoozed policy — the same shared
+     * math the batch scan applies — without creating or refreshing any task.
+     */
+    @NonNull
+    List<ReplenishmentNeedResponse> getReplenishmentNeeds();
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ReplenishmentService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ReplenishmentService.java
@@ -13,14 +13,22 @@ import org.springframework.data.domain.Pageable;
 
 public interface ReplenishmentService {
 
+    /**
+     * Event-path orderpoint evaluation for one SKU/pick-face (odoo-parity F2, issue
+     * #1040): triggers when {@code projectedAvailable(leadHorizon) < minimumQuantity} and
+     * creates an EVENT-triggered task for {@code max(0, maximumQuantity -
+     * projectedAvailable(leadHorizon) - inProgress)}; an already-open task short-circuits
+     * to {@code TASK_ALREADY_QUEUED} (no double-ordering).
+     */
     @NonNull
     ReplenishmentTaskResponse evaluatePickFaceForReplenishment(
             @NonNull String productId, @NonNull UUID pickFaceLocationId);
 
     /**
      * Runs the batch replenishment scan over all policies (CAP-217 / odoo-parity
-     * F1): below-minimum policies get a batch-triggered replenishment task,
-     * idempotent per (policy, day).
+     * F1; forecast-aware orderpoint math since F2, issue #1040): policies whose
+     * projected available at the lead-time horizon is below minimum get a
+     * batch-triggered replenishment task, idempotent per (policy, day).
      */
     @NonNull
     ReplenishmentScanResultResponse runBatchReplenishmentScan();

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/TransferOrderService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/TransferOrderService.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.service;
 import com.positivity.inventory.internal.dto.transfer.CreateTransferOrderRequest;
 import com.positivity.inventory.internal.dto.transfer.DispatchTransferOrderRequest;
 import com.positivity.inventory.internal.dto.transfer.ReceiveTransferOrderRequest;
+import com.positivity.inventory.internal.dto.transfer.ShortCloseTransferOrderRequest;
 import com.positivity.inventory.internal.dto.transfer.TransferOrderResponse;
 import com.positivity.inventory.internal.enums.TransferOrderStatus;
 import java.util.List;
@@ -120,4 +121,29 @@ public interface TransferOrderService {
     @NonNull
     TransferOrderResponse receiveTransferOrder(
             @NonNull UUID transferOrderId, @NonNull ReceiveTransferOrderRequest request);
+
+    /**
+     * Short-closes an order with an undelivered in-transit remainder (odoo-parity C3, issue
+     * #1039; spec C4): resolves every line's {@code dispatched − received} remainder under ONE
+     * whole-order disposition and moves the order to the terminal SHORT_CLOSED status.
+     *
+     * <ul>
+     *   <li>{@code LOST_IN_TRANSIT} — the remainder is written off: destination in-transit
+     *       zeroes and global on-hand drops by the remainder ({@code SCRAP_OUT}, reason LOST,
+     *       {@code sourceTransactionId = transferOrderId}; no scrap document is created).</li>
+     *   <li>{@code RETURNED_TO_SOURCE} — the remainder is restored to source on-hand:
+     *       destination in-transit zeroes and global on-hand is unchanged.</li>
+     * </ul>
+     *
+     * <p>Allowed from DISPATCHED/PARTIALLY_RECEIVED with a positive total remainder; any other
+     * status — or a zero remainder — is a 409. Reason and notes are mandatory. Once
+     * SHORT_CLOSED, further dispatch/receive calls are 409s (terminal status).
+     *
+     * @param transferOrderId the order id
+     * @param request the disposition, reason, and notes
+     * @return the short-closed order
+     */
+    @NonNull
+    TransferOrderResponse shortCloseTransferOrder(
+            @NonNull UUID transferOrderId, @NonNull ShortCloseTransferOrderRequest request);
 }

--- a/pos-inventory/src/main/resources/application.yml
+++ b/pos-inventory/src/main/resources/application.yml
@@ -149,6 +149,11 @@ pos:
       # Window the manual sync endpoint asks pos-location to re-emit (owner caps lookback).
       replay-lookback: ${POS_INVENTORY_LOCATION_REPLAY_LOOKBACK:P30D}
     replenishment:
+      # Last-resort lead time for the forecast-aware orderpoint trigger (odoo-parity F2,
+      # #1040; decision D-4). Precedence: policy override (F3) -> vendor-feed MAX estimate
+      # -> this default. 0 projects to "now" (on-hand plus already-due supply minus open
+      # demand).
+      default-lead-time-days: ${POS_INVENTORY_REPLENISHMENT_DEFAULT_LEAD_TIME_DAYS:0}
       scan:
         # Scheduled batch replenishment scan (CAP-217 / odoo-parity F1, #1025).
         # Off by default; flip per environment. The scan is idempotent per

--- a/pos-inventory/src/main/resources/db/migration/V19__add_transfer_order_short_close.sql
+++ b/pos-inventory/src/main/resources/db/migration/V19__add_transfer_order_short_close.sql
@@ -1,0 +1,25 @@
+-- odoo-parity C3 (#1039, spec C4): short-close metadata on the transfer order.
+--
+-- Short-closing a DISPATCHED/PARTIALLY_RECEIVED order resolves the undelivered in-transit
+-- remainder with one whole-order disposition (v1 simplification — no per-line dispositions):
+--   LOST_IN_TRANSIT    — constructive TRANSFER_IN at the destination + paired SCRAP_OUT
+--                        (reason LOST); global on-hand drops by the remainder.
+--   RETURNED_TO_SOURCE — constructive TRANSFER_IN at the destination + TRANSFER_OUT back +
+--                        TRANSFER_IN at the source; source on-hand is restored.
+-- Both shapes zero the destination in-transit balance purely through existing ledger rules
+-- (TRANSFER_OUT.to_location_id contributes in-transit at the destination key; TRANSFER_IN
+-- cancels at its own key), so drift verification and rebuild need no changes. Reason and
+-- notes are mandatory on the API; the columns stay nullable because every pre-C3 row and
+-- every non-short-closed row carries none. The SHORT_CLOSED status value already exists in
+-- transfer_order_status_check (declared by V15).
+ALTER TABLE transfer_order
+    ADD COLUMN short_close_disposition character varying(30),
+    ADD COLUMN short_close_reason character varying(100),
+    ADD COLUMN short_close_notes character varying(2000),
+    ADD COLUMN short_closed_by character varying(255),
+    ADD COLUMN short_closed_at timestamp(6) with time zone;
+
+ALTER TABLE transfer_order
+    ADD CONSTRAINT transfer_order_short_close_disposition_check
+        CHECK (short_close_disposition IS NULL
+               OR short_close_disposition IN ('LOST_IN_TRANSIT', 'RETURNED_TO_SOURCE'));

--- a/pos-inventory/src/main/resources/db/migration/V20__enrich_replenishment_policy_and_task_deadline.sql
+++ b/pos-inventory/src/main/resources/db/migration/V20__enrich_replenishment_policy_and_task_deadline.sql
@@ -1,0 +1,35 @@
+-- odoo-parity F3 (#1041, spec F3/F6): replenishment policy enrichment + task deadline date.
+--
+-- Policy columns (all backward-safe — every pre-F3 row keeps its previous behaviour):
+--   order_multiple          — round the computed replenishment quantity UP to the nearest
+--                             multiple (Odoo qty_multiple); NULL means no rounding. Seeded
+--                             from the vendor-feed pack size on policy creation when the
+--                             caller supplies none and feed data exists for the SKU.
+--   lead_time_days_override — highest-precedence lead time (plan D-4: override → vendor
+--                             feed → configured default); NULL falls through to the feed.
+--   preferred_source_type   — sourcing preference for F5 (stored only in F3; no reader yet).
+--   snoozed_until           — policy suppressed from scan/event/needs evaluation while this
+--                             instant is in the future (Odoo orderpoint snooze); NULL or a
+--                             past instant means active evaluation.
+--   active                  — hard on/off switch; inactive policies are never evaluated.
+ALTER TABLE replenishment_policy
+    ADD COLUMN order_multiple integer,
+    ADD COLUMN lead_time_days_override integer,
+    ADD COLUMN preferred_source_type character varying(30) NOT NULL DEFAULT 'EITHER',
+    ADD COLUMN snoozed_until timestamp(6) with time zone,
+    ADD COLUMN active boolean NOT NULL DEFAULT true;
+
+ALTER TABLE replenishment_policy
+    ADD CONSTRAINT replenishment_policy_order_multiple_check
+        CHECK (order_multiple IS NULL OR order_multiple > 0),
+    ADD CONSTRAINT replenishment_policy_lead_time_days_override_check
+        CHECK (lead_time_days_override IS NULL OR lead_time_days_override >= 0),
+    ADD CONSTRAINT replenishment_policy_preferred_source_type_check
+        CHECK (preferred_source_type IN ('INTERNAL_TRANSFER', 'PURCHASE', 'EITHER'));
+
+-- Stock-out deadline (Odoo orderpoint lead_days_date analogue): the earliest date the
+-- horizon-bounded projection goes negative, computed at task creation/refresh for
+-- prioritization. Nullable: pre-F3 tasks carry none, and a triggered policy whose
+-- projection never dips below zero within the lead horizon has no deadline.
+ALTER TABLE replenishment_task
+    ADD COLUMN deadline_date date;

--- a/pos-inventory/src/main/resources/db/migration/V21__add_lot_outbound_columns.sql
+++ b/pos-inventory/src/main/resources/db/migration/V21__add_lot_outbound_columns.sql
@@ -1,0 +1,22 @@
+-- odoo-parity E2 (#1042, spec §6 E2): lot-aware outbound flows.
+--
+-- The ledger (lot_id, V18) and the dual-row summary bookkeeping already support lots — this
+-- migration only adds the document-side columns the outbound flows persist.
+
+-- 1) Pick tasks: advisory FIFO lot suggestion stamped at generation (earliest lot received_at
+--    among ACTIVE lots with positive per-lot on-hand at the suggested location; E3 upgrades
+--    the ordering to FEFO via the LotExpiryProvider SPI), plus the lot actually keyed at pick
+--    confirmation — the confirm may override the suggestion with any valid ACTIVE lot, and
+--    picked_lot_id is what the consumption posting carries.
+ALTER TABLE inventory_pick_task ADD COLUMN suggested_lot_number varchar(128);
+ALTER TABLE inventory_pick_task ADD COLUMN picked_lot_id uuid;
+
+-- 2) Transfer-order lines: the lot resolved at dispatch is pinned on the line so receive and
+--    short-close post the SAME lot on both sides — per-lot balances conserve across sites
+--    exactly like the lot-agnostic ones.
+ALTER TABLE transfer_order_line ADD COLUMN lot_id uuid;
+ALTER TABLE transfer_order_line ADD COLUMN lot_number varchar(128);
+
+-- scrap_record.lot_id already exists (V12, reserved by D1) and is now populated for
+-- LOT-tracked scraps. Returns and consumption stamp the ledger rows only — the ledger plus
+-- sourceTransactionId is the traceability source (E5).

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/BaseContractIntegrationTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/BaseContractIntegrationTest.java
@@ -61,7 +61,8 @@ public abstract class BaseContractIntegrationTest {
                                 "inventory:transfer:create",
                                 "inventory:transfer:view",
                                 "inventory:transfer:dispatch",
-                                "inventory:transfer:receive"));
+                                "inventory:transfer:receive",
+                                "inventory:transfer:short_close"));
     }
 
     protected MockHttpServletRequestBuilder withApproveOnlyAuth(MockHttpServletRequestBuilder requestBuilder) {

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/LotOutboundFlowsIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/LotOutboundFlowsIT.java
@@ -1,0 +1,585 @@
+package com.positivity.inventory.contract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.inventory.internal.dto.consumption.ConsumeItemLine;
+import com.positivity.inventory.internal.dto.consumption.ConsumeItemsRequest;
+import com.positivity.inventory.internal.dto.picklist.ConfirmPickTaskRequest;
+import com.positivity.inventory.internal.dto.picklist.GeneratePickListRequest;
+import com.positivity.inventory.internal.dto.picklist.PickListResponse;
+import com.positivity.inventory.internal.dto.receiving.CrossDockRequest;
+import com.positivity.inventory.internal.dto.returns.ReturnItemLine;
+import com.positivity.inventory.internal.dto.returns.ReturnItemsRequest;
+import com.positivity.inventory.internal.entity.ExtProductReplica;
+import com.positivity.inventory.internal.entity.ExtWorkorderPartReplica;
+import com.positivity.inventory.internal.entity.ExtWorkorderReplica;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.InventoryLot;
+import com.positivity.inventory.internal.entity.PickListEntity;
+import com.positivity.inventory.internal.entity.PickTaskEntity;
+import com.positivity.inventory.internal.entity.ReceivingLine;
+import com.positivity.inventory.internal.entity.ReceivingSession;
+import com.positivity.inventory.internal.enums.EntryMethod;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.InventoryLotStatus;
+import com.positivity.inventory.internal.enums.PickListStatus;
+import com.positivity.inventory.internal.enums.PickTaskStatus;
+import com.positivity.inventory.internal.enums.ReceivingLineStatus;
+import com.positivity.inventory.internal.enums.ReceivingSessionStatus;
+import com.positivity.inventory.internal.enums.ScrapReasonCode;
+import com.positivity.inventory.internal.enums.SourceDocumentType;
+import com.positivity.inventory.internal.exception.LotInsufficientStockException;
+import com.positivity.inventory.internal.exception.LotNumberRequiredException;
+import com.positivity.inventory.internal.exception.LotUnknownException;
+import com.positivity.inventory.internal.repository.ExtProductReplicaRepository;
+import com.positivity.inventory.internal.repository.ExtWorkorderPartReplicaRepository;
+import com.positivity.inventory.internal.repository.ExtWorkorderReplicaRepository;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryLotRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import com.positivity.inventory.internal.repository.PickListRepository;
+import com.positivity.inventory.internal.repository.PickTaskRepository;
+import com.positivity.inventory.internal.repository.ReceivingSessionRepository;
+import com.positivity.inventory.internal.service.LedgerPostingService;
+import com.positivity.inventory.internal.service.ReturnServiceImpl;
+import com.positivity.inventory.service.ConsumptionService;
+import com.positivity.inventory.service.PickListGenerationService;
+import com.positivity.inventory.service.ReceivingService;
+import com.positivity.security.common.GatewaySecurityConstants;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * IT for odoo-parity E2 (issue #1042, spec §6 E2): lot-aware outbound flows.
+ *
+ * <p>Covers the acceptance shape end-to-end against the real service + H2 stack:
+ * <ul>
+ *   <li>pick confirmation of a LOT-tracked SKU without a lot number → 422
+ *       {@code LOT_NUMBER_REQUIRED}; unknown lot → {@code LOT_UNKNOWN}; QUARANTINED lot →
+ *       {@code LOT_NOT_AVAILABLE}; a valid ACTIVE lot is recorded as {@code pickedLotId}</li>
+ *   <li>consumption decrements the EXACT per-lot row via the pick→consumption linkage
+ *       ({@code pickedLotId}); the per-lot floor blocks over-consumption of one lot while
+ *       another lot still has stock ({@code LOT_INSUFFICIENT_STOCK}); a lot drawn to exactly
+ *       zero flips ACTIVE → CONSUMED</li>
+ *   <li>returns re-increment the per-lot row and flip CONSUMED → ACTIVE; a missing/unknown
+ *       lot on a tracked return line is a 422</li>
+ *   <li>scrap requires and stamps the lot on its {@code SCRAP_OUT} posting (both over HTTP
+ *       and on the ledger row)</li>
+ *   <li>cross-dock is now lot-gated: both paired entries carry the same {@code lotId}, the
+ *       per-lot row nets to zero (no phantom per-lot on-hand), and the lot reads CONSUMED</li>
+ *   <li>FIFO lot suggestion ordering vector: earliest {@code receivedAt} ACTIVE lot with
+ *       stock at the suggested location wins; QUARANTINED lots are skipped</li>
+ * </ul>
+ * The lot-tracked transfer conservation walk lives in {@code TransferOrderDispatchReceiveIT}
+ * next to the lot-agnostic invariant it mirrors. Untracked SKUs are byte-identical to pre-E2 —
+ * the unmodified pre-E2 suites passing is the regression proof.
+ */
+@DisplayName("Lot-aware outbound flows (odoo-parity E2, #1042)")
+class LotOutboundFlowsIT extends BaseContractIntegrationTest {
+
+    private static final String ACTOR = "lot-e2-it";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private tools.jackson.databind.ObjectMapper objectMapper;
+
+    @Autowired
+    private ExtProductReplicaRepository extProductReplicaRepository;
+
+    @Autowired
+    private InventoryLotRepository lotRepository;
+
+    @Autowired
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    @Autowired
+    private InventoryStockSummaryRepository summaryRepository;
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
+    @Autowired
+    private PickListRepository pickListRepository;
+
+    @Autowired
+    private PickTaskRepository pickTaskRepository;
+
+    @Autowired
+    private PickListGenerationService pickListGenerationService;
+
+    @Autowired
+    private ConsumptionService consumptionService;
+
+    @Autowired
+    private ReturnServiceImpl returnService;
+
+    @Autowired
+    private ReceivingService receivingService;
+
+    @Autowired
+    private ReceivingSessionRepository receivingSessionRepository;
+
+    @Autowired
+    private ExtWorkorderReplicaRepository extWorkorderReplicaRepository;
+
+    @Autowired
+    private ExtWorkorderPartReplicaRepository extWorkorderPartReplicaRepository;
+
+    @BeforeEach
+    void setUp() {
+        var authentication = new UsernamePasswordAuthenticationToken(ACTOR, "N/A", List.of());
+        authentication.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, ACTOR));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ─── Pick confirmation ──────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("pick confirm: tracked without lot → 422 LOT_NUMBER_REQUIRED; unknown → LOT_UNKNOWN;"
+            + " quarantined → LOT_NOT_AVAILABLE; valid ACTIVE lot recorded as pickedLotId")
+    void pickConfirm_lotGates() throws Exception {
+        UUID productId = seedProduct("LOT");
+        UUID locationId = UUID.randomUUID();
+        InventoryLot active = seedLot(productId, "LOT-PICK-A", Instant.parse("2026-01-01T00:00:00Z"));
+        InventoryLot quarantined = seedLot(productId, "LOT-PICK-Q", Instant.parse("2026-01-02T00:00:00Z"));
+        quarantined.setStatus(InventoryLotStatus.QUARANTINED);
+        lotRepository.save(quarantined);
+
+        PickTaskEntity task = seedPickTask(productId, locationId, 5);
+        UUID pickListId = task.getPickList().getPickListId();
+        UUID taskId = task.getPickTaskId();
+
+        mockMvc.perform(confirmRequest(pickListId, taskId, productId, locationId, 5, null))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("LOT_NUMBER_REQUIRED"));
+
+        mockMvc.perform(confirmRequest(pickListId, taskId, productId, locationId, 5, "LOT-NOPE"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("LOT_UNKNOWN"));
+
+        mockMvc.perform(confirmRequest(pickListId, taskId, productId, locationId, 5, "LOT-PICK-Q"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("LOT_NOT_AVAILABLE"));
+
+        // Nothing stuck: task still PENDING after the rejections.
+        assertThat(pickTaskRepository.findById(taskId).orElseThrow().getStatus())
+                .isEqualTo(PickTaskStatus.PENDING);
+
+        mockMvc.perform(confirmRequest(pickListId, taskId, productId, locationId, 5, "LOT-PICK-A"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PICKED"))
+                .andExpect(jsonPath("$.pickedLotId").value(active.getLotId().toString()));
+
+        assertThat(pickTaskRepository.findById(taskId).orElseThrow().getPickedLotId())
+                .isEqualTo(active.getLotId());
+    }
+
+    @Test
+    @DisplayName("pick confirm: untracked SKU ignores a keyed lot number (byte-identical pre-E2 behavior)")
+    void pickConfirm_untracked_ignoresLotNumber() throws Exception {
+        UUID productId = seedProduct("NONE");
+        UUID locationId = UUID.randomUUID();
+        PickTaskEntity task = seedPickTask(productId, locationId, 3);
+
+        mockMvc.perform(confirmRequest(
+                        task.getPickList().getPickListId(),
+                        task.getPickTaskId(),
+                        productId,
+                        locationId,
+                        3,
+                        "FREE-TEXT"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PICKED"))
+                .andExpect(jsonPath("$.pickedLotId").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    // ─── Consumption: exact per-lot decrement, floor, CONSUMED flip ─────────────
+
+    @Test
+    @DisplayName("consumption decrements the exact per-lot row via the pick's lot; the per-lot floor blocks"
+            + " over-consumption of one lot while another has stock; exact zero flips the lot CONSUMED")
+    void consumption_perLotDecrementFloorAndConsumedFlip() {
+        UUID productId = seedProduct("LOT");
+        InventoryLot lotA = seedLot(productId, "LOT-CONS-A", Instant.parse("2026-02-01T00:00:00Z"));
+        InventoryLot lotB = seedLot(productId, "LOT-CONS-B", Instant.parse("2026-02-02T00:00:00Z"));
+        // Consumption posts at the NULL-location key (pre-E2 shape, unchanged) — seed the lot
+        // stock there so the walk exercises the exact rows consumption touches.
+        seedLotStock(productId, null, lotA.getLotId(), 5);
+        seedLotStock(productId, null, lotB.getLotId(), 5);
+
+        UUID workorderId = UUID.randomUUID();
+        PickTaskEntity task = seedPickedTask(productId, 5, lotA.getLotId());
+
+        consumptionService.consumePickedItems(new ConsumeItemsRequest(
+                workorderId, null, List.of(new ConsumeItemLine(task.getPickTaskId(), productId, 3))));
+
+        // Exact per-lot decrement: lot A 5 -> 2, lot B untouched, agnostic row 10 -> 7.
+        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isEqualTo(2);
+        assertThat(perLotOnHand(productId, null, lotB.getLotId())).isEqualTo(5);
+        assertThat(summaryRepository
+                        .findByStockItemIdAndLocationIdIsNull(productId.toString())
+                        .orElseThrow()
+                        .getOnHand())
+                .isEqualTo(7);
+        List<InventoryLedgerEntry> consumptionEntries =
+                entriesOf(productId, InventoryLedgerEventType.WORKORDER_CONSUMPTION);
+        assertThat(consumptionEntries).hasSize(1);
+        assertThat(consumptionEntries.getFirst().getLotId()).isEqualTo(lotA.getLotId());
+
+        // Per-lot floor: 3 more from lot A (only 2 left) is rejected even though lot B has 5.
+        PickTaskEntity overTask = seedPickedTask(productId, 5, lotA.getLotId());
+        ConsumeItemsRequest overRequest = new ConsumeItemsRequest(
+                workorderId, null, List.of(new ConsumeItemLine(overTask.getPickTaskId(), productId, 3)));
+        assertThatThrownBy(() -> consumptionService.consumePickedItems(overRequest))
+                .isInstanceOf(LotInsufficientStockException.class)
+                .hasMessageContaining("LOT_INSUFFICIENT_STOCK");
+        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isEqualTo(2);
+        assertThat(lotRepository.findById(lotA.getLotId()).orElseThrow().getStatus())
+                .isEqualTo(InventoryLotStatus.ACTIVE);
+
+        // Draw lot A to exactly zero: status flips ACTIVE -> CONSUMED; lot B stays ACTIVE.
+        consumptionService.consumePickedItems(new ConsumeItemsRequest(
+                workorderId, null, List.of(new ConsumeItemLine(overTask.getPickTaskId(), productId, 2))));
+        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isZero();
+        assertThat(lotRepository.findById(lotA.getLotId()).orElseThrow().getStatus())
+                .isEqualTo(InventoryLotStatus.CONSUMED);
+        assertThat(lotRepository.findById(lotB.getLotId()).orElseThrow().getStatus())
+                .isEqualTo(InventoryLotStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("consumption: tracked SKU whose pick recorded no lot and whose line keys none → LOT_NUMBER_REQUIRED;"
+            + " an explicit line lotNumber overrides the pick's lot")
+    void consumption_lotSourceRules() {
+        UUID productId = seedProduct("LOT");
+        InventoryLot lotA = seedLot(productId, "LOT-SRC-A", Instant.parse("2026-02-01T00:00:00Z"));
+        InventoryLot lotB = seedLot(productId, "LOT-SRC-B", Instant.parse("2026-02-02T00:00:00Z"));
+        seedLotStock(productId, null, lotA.getLotId(), 4);
+        seedLotStock(productId, null, lotB.getLotId(), 4);
+
+        UUID workorderId = UUID.randomUUID();
+        // Pre-E2 task shape: PICKED but no pickedLotId (e.g. confirmed before E2).
+        PickTaskEntity legacyTask = seedPickedTask(productId, 4, null);
+        ConsumeItemsRequest noLot = new ConsumeItemsRequest(
+                workorderId, null, List.of(new ConsumeItemLine(legacyTask.getPickTaskId(), productId, 2)));
+        assertThatThrownBy(() -> consumptionService.consumePickedItems(noLot))
+                .isInstanceOf(LotNumberRequiredException.class);
+
+        // Explicit line lotNumber fills the gap (same validation as everywhere else).
+        consumptionService.consumePickedItems(new ConsumeItemsRequest(
+                workorderId,
+                null,
+                List.of(new ConsumeItemLine(legacyTask.getPickTaskId(), productId, 2, "LOT-SRC-B"))));
+        assertThat(perLotOnHand(productId, null, lotB.getLotId())).isEqualTo(2);
+        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isEqualTo(4);
+    }
+
+    // ─── Returns: re-increment + CONSUMED → ACTIVE ──────────────────────────────
+
+    @Test
+    @DisplayName("return of a tracked SKU requires an existing lot; re-increments its per-lot row and flips"
+            + " CONSUMED → ACTIVE")
+    void returns_reincrementAndReactivate() {
+        UUID productId = seedProduct("LOT");
+        InventoryLot lot = seedLot(productId, "LOT-RET-A", Instant.parse("2026-03-01T00:00:00Z"));
+        seedLotStock(productId, null, lot.getLotId(), 3);
+
+        UUID workorderId = UUID.randomUUID();
+        PickTaskEntity task = seedPickedTask(productId, 3, lot.getLotId());
+        consumptionService.consumePickedItems(new ConsumeItemsRequest(
+                workorderId, null, List.of(new ConsumeItemLine(task.getPickTaskId(), productId, 3))));
+        assertThat(lotRepository.findById(lot.getLotId()).orElseThrow().getStatus())
+                .isEqualTo(InventoryLotStatus.CONSUMED);
+
+        // Tracked return without a lot number → 422 LOT_NUMBER_REQUIRED.
+        ReturnItemsRequest noLot =
+                new ReturnItemsRequest(workorderId, "DAMAGED", List.of(new ReturnItemLine(productId, 2, null, null)));
+        assertThatThrownBy(() -> returnService.returnItemsToStock(noLot))
+                .isInstanceOf(LotNumberRequiredException.class);
+
+        // Unknown lot → 422 LOT_UNKNOWN (returns never create lots).
+        ReturnItemsRequest unknownLot = new ReturnItemsRequest(
+                workorderId, "DAMAGED", List.of(new ReturnItemLine(productId, 2, null, null, "LOT-NOPE")));
+        assertThatThrownBy(() -> returnService.returnItemsToStock(unknownLot)).isInstanceOf(LotUnknownException.class);
+
+        // Valid return against the CONSUMED lot: per-lot row re-increments, lot reactivates.
+        returnService.returnItemsToStock(new ReturnItemsRequest(
+                workorderId, "DAMAGED", List.of(new ReturnItemLine(productId, 2, null, null, "LOT-RET-A"))));
+        assertThat(perLotOnHand(productId, null, lot.getLotId())).isEqualTo(2);
+        assertThat(lotRepository.findById(lot.getLotId()).orElseThrow().getStatus())
+                .isEqualTo(InventoryLotStatus.ACTIVE);
+        List<InventoryLedgerEntry> returnEntries = entriesOf(productId, InventoryLedgerEventType.RETURN_TO_STOCK);
+        assertThat(returnEntries).hasSize(1);
+        assertThat(returnEntries.getFirst().getLotId()).isEqualTo(lot.getLotId());
+    }
+
+    // ─── Scrap ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("scrap of a tracked SKU without lotNumber → 422 over HTTP; with a valid lot the SCRAP_OUT"
+            + " posting is stamped and the record carries the lot")
+    void scrap_lotGateAndStamp() throws Exception {
+        UUID productId = seedProduct("LOT");
+        UUID locationId = UUID.randomUUID();
+        InventoryLot lot = seedLot(productId, "LOT-SCRAP-A", Instant.parse("2026-04-01T00:00:00Z"));
+        seedLotStock(productId, locationId, lot.getLotId(), 6);
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(scrapBody(productId, locationId, 2, null)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("LOT_NUMBER_REQUIRED"));
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(scrapBody(productId, locationId, 2, "LOT-SCRAP-A")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("POSTED"))
+                .andExpect(jsonPath("$.lotId").value(lot.getLotId().toString()));
+
+        List<InventoryLedgerEntry> scrapEntries = entriesOf(productId, InventoryLedgerEventType.SCRAP_OUT);
+        assertThat(scrapEntries).hasSize(1);
+        assertThat(scrapEntries.getFirst().getLotId()).isEqualTo(lot.getLotId());
+        assertThat(perLotOnHand(productId, locationId, lot.getLotId())).isEqualTo(4);
+    }
+
+    // ─── Cross-dock ─────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("cross-dock of a tracked product is lot-gated; both paired entries carry the same lotId and the"
+            + " per-lot row nets to zero (no phantom per-lot on-hand)")
+    void crossDock_lotGatedBothEntriesStamped() {
+        UUID productId = seedProduct("LOT");
+        UUID workorderId = UUID.randomUUID();
+        UUID workorderLineId = seedWorkorderLine(workorderId, productId);
+        ReceivingSession session = seedReceivingSession(productId, new BigDecimal("4"));
+        UUID lineId = session.getLines().getFirst().getLineId();
+
+        CrossDockRequest withoutLot = new CrossDockRequest(
+                workorderId.toString(), workorderLineId.toString(), new BigDecimal("4"), "no lot keyed");
+        assertThatThrownBy(() ->
+                        receivingService.crossDockLineToWorkorder(session.getSessionId(), lineId, withoutLot, ACTOR))
+                .isInstanceOf(LotNumberRequiredException.class);
+
+        receivingService.crossDockLineToWorkorder(
+                session.getSessionId(),
+                lineId,
+                new CrossDockRequest(
+                        workorderId.toString(), workorderLineId.toString(), new BigDecimal("4"), null, "LOT-XD-1"),
+                ACTOR);
+
+        InventoryLot lot = lotRepository
+                .findByStockItemIdAndLotNumber(productId.toString(), "LOT-XD-1")
+                .orElseThrow();
+        List<InventoryLedgerEntry> entries = ledgerRepository.findAll().stream()
+                .filter(entry -> productId.toString().equals(entry.getStockItemId()))
+                .toList();
+        assertThat(entries).hasSize(2);
+        assertThat(entries).allMatch(entry -> lot.getLotId().equals(entry.getLotId()));
+        assertThat(entries)
+                .extracting(InventoryLedgerEntry::getEventType)
+                .containsExactlyInAnyOrder(
+                        InventoryLedgerEventType.GOODS_RECEIPT, InventoryLedgerEventType.GOODS_ISSUE);
+
+        // No phantom per-lot on-hand: the paired entries net the per-lot row to zero, and the
+        // reconciler marks the lot CONSUMED (its stock went straight to the workorder).
+        assertThat(summaryRepository.findByLotId(lot.getLotId()))
+                .allMatch(row -> row.getOnHand() == 0 && row.getInTransitQty() == 0);
+        assertThat(lotRepository.findById(lot.getLotId()).orElseThrow().getStatus())
+                .isEqualTo(InventoryLotStatus.CONSUMED);
+    }
+
+    // ─── FIFO lot suggestion ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("pick generation suggests the FIFO lot (earliest receivedAt, ACTIVE, with stock at the suggested"
+            + " location); QUARANTINED lots are skipped; untracked SKUs get no suggestion")
+    void pickGeneration_fifoLotSuggestion() {
+        UUID productId = seedProduct("LOT");
+        UUID locationId = UUID.randomUUID();
+        InventoryLot oldest = seedLot(productId, "LOT-FIFO-1", Instant.parse("2026-01-01T00:00:00Z"));
+        InventoryLot middle = seedLot(productId, "LOT-FIFO-2", Instant.parse("2026-02-01T00:00:00Z"));
+        InventoryLot newest = seedLot(productId, "LOT-FIFO-3", Instant.parse("2026-03-01T00:00:00Z"));
+        seedLotStock(productId, locationId, oldest.getLotId(), 4);
+        seedLotStock(productId, locationId, middle.getLotId(), 4);
+        seedLotStock(productId, locationId, newest.getLotId(), 4);
+
+        assertThat(taskFor(generate(productId)).getSuggestedLotNumber()).isEqualTo("LOT-FIFO-1");
+
+        // Quarantining the oldest lot moves the suggestion to the next-oldest ACTIVE lot.
+        oldest.setStatus(InventoryLotStatus.QUARANTINED);
+        lotRepository.save(oldest);
+        assertThat(taskFor(generate(productId)).getSuggestedLotNumber()).isEqualTo("LOT-FIFO-2");
+
+        // Untracked SKUs get no suggestion.
+        UUID untracked = seedProduct("NONE");
+        seedLotStock(untracked, locationId, null, 4);
+        assertThat(taskFor(generate(untracked)).getSuggestedLotNumber()).isNull();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    private UUID seedProduct(String trackingLevel) {
+        UUID productId = UUID.randomUUID();
+        extProductReplicaRepository.save(ExtProductReplica.builder()
+                .productId(productId)
+                .baseUom("EA")
+                .trackingLevel(trackingLevel)
+                .aggregateVersion(1L)
+                .build());
+        return productId;
+    }
+
+    private InventoryLot seedLot(UUID productId, String lotNumber, Instant receivedAt) {
+        return lotRepository.save(InventoryLot.builder()
+                .stockItemId(productId.toString())
+                .lotNumber(lotNumber)
+                .receivedAt(receivedAt)
+                .status(InventoryLotStatus.ACTIVE)
+                .build());
+    }
+
+    /** Posts a lot-tagged GOODS_RECEIPT through the funnel so both summary rows exist. */
+    private void seedLotStock(UUID productId, UUID locationId, UUID lotId, int quantity) {
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
+                .stockItemId(productId.toString())
+                .locationId(locationId)
+                .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
+                .changeInQuantity(quantity)
+                .quantityAfter(quantity)
+                .lotId(lotId)
+                .unitCost(new BigDecimal("3.0000"))
+                .transactionUserId(ACTOR)
+                .timestamp(Instant.now())
+                .build());
+    }
+
+    private PickTaskEntity seedPickTask(UUID productId, UUID locationId, int quantityRequired) {
+        PickListEntity pickList = pickListRepository.save(PickListEntity.builder()
+                .workorderId(UUID.randomUUID())
+                .status(PickListStatus.READY_TO_PICK)
+                .build());
+        return pickTaskRepository.save(PickTaskEntity.builder()
+                .pickList(pickList)
+                .productId(productId)
+                .sku(productId.toString())
+                .quantityRequired(quantityRequired)
+                .suggestedLocationId(locationId)
+                .status(PickTaskStatus.PENDING)
+                .build());
+    }
+
+    private PickTaskEntity seedPickedTask(UUID productId, int quantityPicked, UUID pickedLotId) {
+        PickTaskEntity task = seedPickTask(productId, UUID.randomUUID(), quantityPicked);
+        task.setStatus(PickTaskStatus.PICKED);
+        task.setQuantityPicked(quantityPicked);
+        task.setPickedLotId(pickedLotId);
+        return pickTaskRepository.save(task);
+    }
+
+    private UUID seedWorkorderLine(UUID workorderId, UUID productId) {
+        extWorkorderReplicaRepository.save(ExtWorkorderReplica.builder()
+                .workorderId(workorderId)
+                .workorderNumber("WO-E2")
+                .status("IN_PROGRESS")
+                .aggregateVersion(1L)
+                .build());
+        return extWorkorderPartReplicaRepository
+                .save(ExtWorkorderPartReplica.builder()
+                        .workorderLineId(UUID.randomUUID())
+                        .workorderId(workorderId)
+                        .productEntityId(productId)
+                        .quantity(new BigDecimal("4"))
+                        .build())
+                .getWorkorderLineId();
+    }
+
+    private ReceivingSession seedReceivingSession(UUID productId, BigDecimal expectedQuantity) {
+        ReceivingSession session = ReceivingSession.builder()
+                .sourceDocumentId("PO-E2-" + UUID.randomUUID())
+                .sourceDocumentType(SourceDocumentType.PO)
+                .status(ReceivingSessionStatus.OPEN)
+                .entryMethod(EntryMethod.MANUAL)
+                .createdByUserId(ACTOR)
+                .build();
+        ReceivingLine line = ReceivingLine.builder()
+                .session(session)
+                .productId(productId.toString())
+                .expectedQuantity(expectedQuantity)
+                .receivedQuantity(BigDecimal.ZERO)
+                .status(ReceivingLineStatus.EXPECTED)
+                .build();
+        session.setLines(new java.util.ArrayList<>(List.of(line)));
+        return receivingSessionRepository.save(session);
+    }
+
+    private PickListResponse generate(UUID productId) {
+        GeneratePickListRequest request = new GeneratePickListRequest();
+        request.setWorkorderId(UUID.randomUUID());
+        GeneratePickListRequest.PickLineItem line = new GeneratePickListRequest.PickLineItem();
+        line.setSku(productId.toString());
+        line.setQuantity(2);
+        request.setLineItems(List.of(line));
+        return pickListGenerationService.generatePickList(request);
+    }
+
+    private PickTaskEntity taskFor(PickListResponse pickList) {
+        return pickTaskRepository
+                .findByPickList_PickListId(pickList.getPickListId())
+                .getFirst();
+    }
+
+    private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder confirmRequest(
+            UUID pickListId, UUID taskId, UUID skuId, UUID locationId, int quantity, String lotNumber)
+            throws Exception {
+        ConfirmPickTaskRequest request = new ConfirmPickTaskRequest(skuId, locationId, quantity, lotNumber);
+        return withGatewayAuth(post("/v1/inventory/pick-lists/{pickListId}/tasks/{taskId}/confirm", pickListId, taskId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request));
+    }
+
+    private String scrapBody(UUID productId, UUID locationId, int quantity, String lotNumber) {
+        String lotPart = lotNumber == null ? "" : ",\"lotNumber\":\"" + lotNumber + "\"";
+        return "{\"stockItemId\":\"" + productId + "\",\"quantity\":" + quantity + ",\"locationId\":\"" + locationId
+                + "\",\"reasonCode\":\"" + ScrapReasonCode.DAMAGED.name() + "\"" + lotPart + "}";
+    }
+
+    private long perLotOnHand(UUID productId, UUID locationId, UUID lotId) {
+        return summaryRepository
+                .findByKey(productId.toString(), locationId, lotId)
+                .map(row -> row.getOnHand())
+                .orElse(0L);
+    }
+
+    private List<InventoryLedgerEntry> entriesOf(UUID productId, InventoryLedgerEventType eventType) {
+        return ledgerRepository.findAll().stream()
+                .filter(entry -> productId.toString().equals(entry.getStockItemId()))
+                .filter(entry -> entry.getEventType() == eventType)
+                .toList();
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/PickingContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/PickingContractBehaviorIT.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.contract;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -154,8 +155,10 @@ class PickingContractBehaviorIT extends BaseContractIntegrationTest {
         PickTaskResponse mockResponse =
                 new PickTaskResponse(taskId, pickListId, productId, locationId, 2, 2, PickTaskStatus.PICKED, 0);
 
-        // BLOCKED: confirmPickTask does not exist on PickListService
-        when(pickListService.confirmPickTask(eq(pickListId), eq(taskId), eq(productId), eq(locationId), eq(2)))
+        // odoo-parity E2 (#1042): the controller delegates to the lot-aware overload; no lot
+        // number keyed on this request → null.
+        when(pickListService.confirmPickTask(
+                        eq(pickListId), eq(taskId), eq(productId), eq(locationId), eq(2), isNull()))
                 .thenReturn(mockResponse);
 
         String requestBody = objectMapper.writeValueAsString(Map.of(
@@ -199,7 +202,8 @@ class PickingContractBehaviorIT extends BaseContractIntegrationTest {
         // BLOCKED: confirmPickTask and PickScanMismatchException do not exist
         // Issue #179: compile fix — constructor is (UUID expectedSkuId, UUID
         // scannedSkuId)
-        when(pickListService.confirmPickTask(eq(pickListId), eq(taskId), eq(wrongSkuId), eq(locationId), eq(1)))
+        when(pickListService.confirmPickTask(
+                        eq(pickListId), eq(taskId), eq(wrongSkuId), eq(locationId), eq(1), isNull()))
                 .thenThrow(new PickScanMismatchException(
                         UUID.fromString("00000000-0000-0000-0000-000000000001"), wrongSkuId));
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReplenishmentContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReplenishmentContractBehaviorIT.java
@@ -4,13 +4,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentNeedResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
+import com.positivity.inventory.internal.dto.replenishment.UpdateReplenishmentPolicyRequest;
+import com.positivity.inventory.internal.exception.SnoozeUntilNotInFutureException;
 import com.positivity.inventory.service.ReplenishmentService;
 import java.time.Clock;
 import java.time.Instant;
@@ -260,6 +264,172 @@ class ReplenishmentContractBehaviorIT extends BaseContractIntegrationTest {
         mockMvc.perform(withCreateOnlyAuth(post("/v1/inventory/replenishment/policies"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
+                .andExpect(status().isForbidden());
+    }
+
+    // ─── F3 (#1041): snooze / update / needs endpoints ───────────────────────
+
+    /**
+     * Verifies that snoozing a policy with a future instant returns 200 with the
+     * updated snooze state when the caller holds
+     * {@code inventory:replenishment:manage}.
+     *
+     * Issue: #1041
+     */
+    @Test
+    @DisplayName("F3: POST /replenishment/policies/{id}/snooze with manage permission returns 200")
+    void snoozeReplenishmentPolicy_withManagePermission_returns200() throws Exception {
+        UUID policyId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        Instant snoozedUntil = Instant.parse("2024-02-01T00:00:00Z");
+        when(replenishmentService.snoozeReplenishmentPolicy(any(UUID.class), any(Instant.class)))
+                .thenReturn(ReplenishmentPolicyResponse.builder()
+                        .policyId(policyId.toString())
+                        .locationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                        .itemSKU("SKU-BOLT-M5")
+                        .minimumQuantity(20)
+                        .maximumQuantity(100)
+                        .preferredSourceType("EITHER")
+                        .snoozedUntil(snoozedUntil.toString())
+                        .active(true)
+                        .createdAt(Instant.now(TEST_CLOCK).toString())
+                        .build());
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/replenishment/policies/" + policyId + "/snooze"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"snoozedUntil\":\"" + snoozedUntil + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.snoozedUntil").value(snoozedUntil.toString()));
+    }
+
+    /**
+     * Verifies that a non-future snooze instant is rejected with a deterministic
+     * 422 carrying the {@code REPLENISHMENT_SNOOZE_NOT_IN_FUTURE} error code.
+     *
+     * Issue: #1041
+     */
+    @Test
+    @DisplayName("F3: POST /replenishment/policies/{id}/snooze with past instant returns 422")
+    void snoozeReplenishmentPolicy_withPastInstant_returns422() throws Exception {
+        Instant past = Instant.parse("2020-01-01T00:00:00Z");
+        when(replenishmentService.snoozeReplenishmentPolicy(any(UUID.class), any(Instant.class)))
+                .thenThrow(new SnoozeUntilNotInFutureException(past));
+
+        mockMvc.perform(withGatewayAuth(post(
+                                "/v1/inventory/replenishment/policies/00000000-0000-0000-0000-000000000001/snooze"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"snoozedUntil\":\"" + past + "\"}"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("REPLENISHMENT_SNOOZE_NOT_IN_FUTURE"));
+    }
+
+    /**
+     * Verifies that the snooze endpoint is denied (403) without
+     * {@code inventory:replenishment:manage}.
+     *
+     * Issue: #1041
+     */
+    @Test
+    @DisplayName("F3: POST /replenishment/policies/{id}/snooze without manage permission returns 403")
+    void snoozeReplenishmentPolicy_withoutManagePermission_returns403() throws Exception {
+        mockMvc.perform(withCreateOnlyAuth(post(
+                                "/v1/inventory/replenishment/policies/00000000-0000-0000-0000-000000000001/snooze"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"snoozedUntil\":\"2024-02-01T00:00:00Z\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Verifies that the full-replace policy update returns 200 with the updated
+     * fields when the caller holds {@code inventory:replenishment:manage}.
+     *
+     * Issue: #1041
+     */
+    @Test
+    @DisplayName("F3: PUT /replenishment/policies/{id} with manage permission returns 200")
+    void updateReplenishmentPolicy_withManagePermission_returns200() throws Exception {
+        UUID policyId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        when(replenishmentService.updateReplenishmentPolicy(
+                        any(UUID.class), any(UpdateReplenishmentPolicyRequest.class)))
+                .thenReturn(ReplenishmentPolicyResponse.builder()
+                        .policyId(policyId.toString())
+                        .locationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                        .itemSKU("SKU-BOLT-M5")
+                        .minimumQuantity(8)
+                        .maximumQuantity(40)
+                        .orderMultiple(6)
+                        .preferredSourceType("PURCHASE")
+                        .active(true)
+                        .createdAt(Instant.now(TEST_CLOCK).toString())
+                        .build());
+
+        mockMvc.perform(withGatewayAuth(put("/v1/inventory/replenishment/policies/" + policyId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"minimumQuantity\":8,\"maximumQuantity\":40,\"orderMultiple\":6,"
+                                + "\"preferredSourceType\":\"PURCHASE\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.orderMultiple").value(6))
+                .andExpect(jsonPath("$.preferredSourceType").value("PURCHASE"));
+    }
+
+    /**
+     * Verifies that the policy update endpoint is denied (403) without
+     * {@code inventory:replenishment:manage}.
+     *
+     * Issue: #1041
+     */
+    @Test
+    @DisplayName("F3: PUT /replenishment/policies/{id} without manage permission returns 403")
+    void updateReplenishmentPolicy_withoutManagePermission_returns403() throws Exception {
+        mockMvc.perform(withCreateOnlyAuth(
+                                put("/v1/inventory/replenishment/policies/00000000-0000-0000-0000-000000000001"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"minimumQuantity\":8,\"maximumQuantity\":40}"))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Verifies that the side-effect-free needs report returns 200 with the per-policy
+     * evaluation rows for a caller holding {@code inventory:on_hand:view}.
+     *
+     * Issue: #1041
+     */
+    @Test
+    @DisplayName("F3/F6: GET /replenishment/needs returns 200 with needs rows")
+    void getReplenishmentNeeds_returns200WithNeeds() throws Exception {
+        when(replenishmentService.getReplenishmentNeeds())
+                .thenReturn(List.of(ReplenishmentNeedResponse.builder()
+                        .policyId("00000000-0000-0000-0000-000000000001")
+                        .itemSKU("SKU-BOLT-M5")
+                        .locationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                        .onHand(3)
+                        .projectedAvailable(3)
+                        .leadHorizonDate("2024-01-06")
+                        .leadTimeSource("POLICY_OVERRIDE")
+                        .minimumQuantity(5)
+                        .maximumQuantity(10)
+                        .wouldTrigger(true)
+                        .suggestedQuantity(12)
+                        .deadlineDate("2024-01-03")
+                        .preferredSourceType("EITHER")
+                        .build()));
+
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/replenishment/needs")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].wouldTrigger").value(true))
+                .andExpect(jsonPath("$[0].suggestedQuantity").value(12))
+                .andExpect(jsonPath("$[0].deadlineDate").value("2024-01-03"));
+    }
+
+    /**
+     * Verifies that the needs report is denied (403) without
+     * {@code inventory:on_hand:view}.
+     *
+     * Issue: #1041
+     */
+    @Test
+    @DisplayName("F3/F6: GET /replenishment/needs without view permission returns 403")
+    void getReplenishmentNeeds_withoutViewPermission_returns403() throws Exception {
+        mockMvc.perform(withCreateOnlyAuth(get("/v1/inventory/replenishment/needs")))
                 .andExpect(status().isForbidden());
     }
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderDispatchReceiveIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderDispatchReceiveIT.java
@@ -7,10 +7,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.positivity.domainevents.inventory.TransferOrderUpdatedV1;
 import com.positivity.inventory.internal.config.OutboxEventWriter;
+import com.positivity.inventory.internal.entity.ExtProductReplica;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.InventoryLot;
 import com.positivity.inventory.internal.entity.LocationRefEntity;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.InventoryLotStatus;
+import com.positivity.inventory.internal.repository.ExtProductReplicaRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryLotRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.LocationRefRepository;
 import com.positivity.inventory.internal.repository.OutboxEventRepository;
@@ -94,6 +99,12 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
     @Autowired
     private ExpectedSupplyService expectedSupplyService;
 
+    @Autowired
+    private ExtProductReplicaRepository extProductReplicaRepository;
+
+    @Autowired
+    private InventoryLotRepository lotRepository;
+
     @BeforeEach
     void setUp() {
         outboxEventRepository.deleteAll();
@@ -162,6 +173,82 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
         assertThat(outboxEventRepository.findAll())
                 .anyMatch(row -> row.getPayload().contains(TransferOrderUpdatedV1.EVENT_TYPE)
                         && row.getPayload().contains("\"RECEIVED\""));
+    }
+
+    // ─── Lot-tracked conservation walk (odoo-parity E2, #1042) ────────────────
+
+    @Test
+    @DisplayName("lot-tracked transfer: dispatch requires an ACTIVE lot; per-lot balances conserve across"
+            + " dispatch, partial receive, and final receive exactly like the lot-agnostic ones")
+    void lotTrackedTransfer_conservesPerLotBalances() throws Exception {
+        UUID productId = UUID.randomUUID();
+        extProductReplicaRepository.save(ExtProductReplica.builder()
+                .productId(productId)
+                .baseUom("EA")
+                .trackingLevel("LOT")
+                .aggregateVersion(1L)
+                .build());
+        String sku = productId.toString();
+        InventoryLot lot = lotRepository.save(InventoryLot.builder()
+                .stockItemId(sku)
+                .lotNumber("LOT-C2-A")
+                .receivedAt(Instant.parse("2026-01-01T00:00:00Z"))
+                .status(InventoryLotStatus.ACTIVE)
+                .build());
+        seedLotOnHand(sku, SOURCE_SITE, lot.getLotId(), 10);
+        String orderId = createOrder(sku, 6);
+        UUID lineId = singleLineId(orderId);
+
+        // LOT-tracked dispatch without a lot number → 422 LOT_NUMBER_REQUIRED (whole batch
+        // rolled back), unknown lot → 422 LOT_UNKNOWN.
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/dispatch", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(lineBody(lineId, 6)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("LOT_NUMBER_REQUIRED"));
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/dispatch", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(lotLineBody(lineId, 6, "LOT-NOPE")))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("LOT_UNKNOWN"));
+        assertPerLotBalances(sku, lot.getLotId(), 10, 0, 0);
+
+        // Valid dispatch: lot pinned on the line, per-lot balances mirror the agnostic walk.
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/dispatch", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(lotLineBody(lineId, 6, "LOT-C2-A")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lines[0].lotNumber").value("LOT-C2-A"))
+                .andExpect(jsonPath("$.lines[0].lotId").value(lot.getLotId().toString()));
+        assertBalances(sku, 4, 6, 0);
+        assertPerLotBalances(sku, lot.getLotId(), 4, 6, 0);
+
+        // Partial receive (2 of 6): the arrival reuses the lot pinned at dispatch.
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/receive", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(lineBody(lineId, 2)))
+                .andExpect(status().isOk());
+        assertBalances(sku, 4, 4, 2);
+        assertPerLotBalances(sku, lot.getLotId(), 4, 4, 2);
+
+        // Final receive: per-lot conservation completes; every transfer entry is lot-stamped.
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/receive", orderId)))
+                .andExpect(status().isOk());
+        assertBalances(sku, 4, 0, 6);
+        assertPerLotBalances(sku, lot.getLotId(), 4, 0, 6);
+        assertThat(entriesOf(sku, InventoryLedgerEventType.TRANSFER_OUT))
+                .allMatch(entry -> lot.getLotId().equals(entry.getLotId()));
+        assertThat(entriesOf(sku, InventoryLedgerEventType.TRANSFER_IN))
+                .hasSize(2)
+                .allMatch(entry -> lot.getLotId().equals(entry.getLotId()));
+        assertThat(lotRepository.findById(lot.getLotId()).orElseThrow().getStatus())
+                .isEqualTo(InventoryLotStatus.ACTIVE);
+
+        // Ledger truth reproduces the per-lot rows too: verifier clean, rebuild identical.
+        assertThat(driftVerifier.verify()).isZero();
+        rebuildService.rebuildFromLedger();
+        assertPerLotBalances(sku, lot.getLotId(), 4, 0, 6);
+        assertThat(driftVerifier.verify()).isZero();
     }
 
     // ─── Negative stock: TRANSFER_OUT is BLOCKED below zero ──────────────────
@@ -346,6 +433,52 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
 
     private String lineBody(UUID lineId, int quantity) {
         return "{\"lines\":[{\"lineId\":\"" + lineId + "\",\"quantity\":" + quantity + "}]}";
+    }
+
+    private String lotLineBody(UUID lineId, int quantity, String lotNumber) {
+        return "{\"lines\":[{\"lineId\":\"" + lineId + "\",\"quantity\":" + quantity + ",\"lotNumber\":\"" + lotNumber
+                + "\"}]}";
+    }
+
+    /** Lot-tagged variant of {@link #seedOnHand} (odoo-parity E2, #1042). */
+    private void seedLotOnHand(String sku, UUID locationId, UUID lotId, int quantity) {
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(locationId)
+                .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
+                .changeInQuantity(quantity)
+                .quantityAfter(quantity)
+                .lotId(lotId)
+                .unitCost(new BigDecimal("2.0000"))
+                .transactionUserId("contract-test-user")
+                .timestamp(Instant.now())
+                .build());
+    }
+
+    /**
+     * Asserts the same three conserved balances as {@link #assertBalances} but over the
+     * PER-LOT summary rows of one lot (odoo-parity E2, #1042): source per-lot on-hand,
+     * destination per-lot in-transit, destination per-lot on-hand.
+     */
+    private void assertPerLotBalances(
+            String sku, UUID lotId, long sourceOnHand, long destinationInTransit, long destinationOnHand) {
+        assertThat(perLotRow(sku, SOURCE_SITE, lotId)
+                        .map(row -> row.getOnHand())
+                        .orElse(0L))
+                .isEqualTo(sourceOnHand);
+        assertThat(perLotRow(sku, DESTINATION_SITE, lotId)
+                        .map(row -> row.getInTransitQty())
+                        .orElse(0L))
+                .isEqualTo(destinationInTransit);
+        assertThat(perLotRow(sku, DESTINATION_SITE, lotId)
+                        .map(row -> row.getOnHand())
+                        .orElse(0L))
+                .isEqualTo(destinationOnHand);
+    }
+
+    private java.util.Optional<com.positivity.inventory.internal.entity.InventoryStockSummary> perLotRow(
+            String sku, UUID locationId, UUID lotId) {
+        return summaryRepository.findByKey(sku, locationId, lotId);
     }
 
     /**

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderShortCloseIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderShortCloseIT.java
@@ -1,0 +1,489 @@
+package com.positivity.inventory.contract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.domainevents.inventory.ScrapPostedV1;
+import com.positivity.domainevents.inventory.TransferOrderUpdatedV1;
+import com.positivity.inventory.internal.config.OutboxEventWriter;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.LocationRefEntity;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import com.positivity.inventory.internal.repository.LocationRefRepository;
+import com.positivity.inventory.internal.repository.OutboxEventRepository;
+import com.positivity.inventory.internal.repository.ScrapRecordRepository;
+import com.positivity.inventory.internal.repository.TransferOrderRepository;
+import com.positivity.inventory.internal.service.ExpectedSupplyService;
+import com.positivity.inventory.internal.service.LedgerPostingService;
+import com.positivity.inventory.internal.service.StockSummaryDriftVerifier;
+import com.positivity.inventory.internal.service.StockSummaryRebuildService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Short-close ITs (odoo-parity C3, issue #1039; spec C4).
+ *
+ * <p>The centerpiece is the conservation extension: after short-close under EITHER disposition
+ * the destination in-transit balance for the order is exactly zero, LOST_IN_TRANSIT decreases
+ * GLOBAL on-hand by the remainder while RETURNED_TO_SOURCE restores source on-hand, and in both
+ * cases the drift verifier is clean and a full rebuild from the ledger reproduces identical
+ * summaries — proving the chosen ledger shapes need no special reconstruction rules. Also
+ * covers the terminal-status 409s, validation of the mandatory disposition/reason/notes, the
+ * no-scrap-document rule (no ScrapPostedV1 fact), and permission gating.
+ */
+@DisplayName("Transfer Order Short-Close Behavior")
+class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
+
+    @TestConfiguration
+    static class OutboxTestConfig {
+        @Bean
+        OutboxEventWriter outboxEventWriter(
+                Clock clock, ObjectMapper objectMapper, OutboxEventRepository outboxEventRepository) {
+            return new OutboxEventWriter(clock, objectMapper, outboxEventRepository);
+        }
+    }
+
+    private static final UUID SOURCE_SITE = UUID.fromString("01970003-0003-7000-8000-000000000001");
+    private static final UUID DESTINATION_SITE = UUID.fromString("01970003-0003-7000-8000-000000000002");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TransferOrderRepository transferOrderRepository;
+
+    @Autowired
+    private LocationRefRepository locationRefRepository;
+
+    @Autowired
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    @Autowired
+    private InventoryStockSummaryRepository summaryRepository;
+
+    @Autowired
+    private OutboxEventRepository outboxEventRepository;
+
+    @Autowired
+    private ScrapRecordRepository scrapRecordRepository;
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
+    @Autowired
+    private StockSummaryDriftVerifier driftVerifier;
+
+    @Autowired
+    private StockSummaryRebuildService rebuildService;
+
+    @Autowired
+    private ExpectedSupplyService expectedSupplyService;
+
+    @BeforeEach
+    void setUp() {
+        outboxEventRepository.deleteAll();
+        transferOrderRepository.deleteAll();
+        summaryRepository.deleteAll();
+        ledgerRepository.deleteAll();
+        locationRefRepository.deleteAll();
+        seedSite(SOURCE_SITE, "C3 Source Site");
+        seedSite(DESTINATION_SITE, "C3 Destination Site");
+    }
+
+    // ─── Conservation extension: LOST_IN_TRANSIT (spec C4 centerpiece) ────────
+
+    @Test
+    @DisplayName("LOST_IN_TRANSIT short-close zeroes the in-transit remainder, drops global on-hand by it,"
+            + " and ledger truth reproduces the balances (drift clean, rebuild identical)")
+    void shortClose_lost_zeroesTransitAndDropsGlobalOnHand() throws Exception {
+        String sku = uniqueSku();
+        seedOnHand(sku, SOURCE_SITE, 10);
+        String orderId = createOrder(sku, 6);
+        UUID lineId = singleLineId(orderId);
+        dispatch(orderId);
+        receive(orderId, lineId, 2); // remainder 4 stays in transit
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(shortCloseBody(
+                                "LOST_IN_TRANSIT", "Carrier lost the pallet", "Claim filed with carrier")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SHORT_CLOSED"))
+                .andExpect(jsonPath("$.shortCloseDisposition").value("LOST_IN_TRANSIT"))
+                .andExpect(jsonPath("$.shortCloseReason").value("Carrier lost the pallet"))
+                .andExpect(jsonPath("$.shortClosedBy").value("contract-test-user"))
+                .andExpect(jsonPath("$.lines[0].receivedQty").value(2));
+
+        // Source 4, transit zero, destination keeps only what physically arrived; the 4 lost
+        // units left global stock entirely: total 10 − 4 = 6.
+        assertBalances(sku, 4, 0, 2);
+        assertThat(expectedIncoming(sku)).isZero();
+
+        // Loss posted as SCRAP_OUT (reason LOST, joined to the order) behind a constructive
+        // TRANSFER_IN that cancels the outstanding transit at the destination key.
+        List<InventoryLedgerEntry> scrapEntries = entriesOf(sku, InventoryLedgerEventType.SCRAP_OUT);
+        assertThat(scrapEntries).hasSize(1);
+        InventoryLedgerEntry scrap = scrapEntries.getFirst();
+        assertThat(scrap.getChangeInQuantity()).isEqualTo(-4);
+        assertThat(scrap.getReasonCode()).isEqualTo("LOST");
+        assertThat(scrap.getSourceTransactionId()).isEqualTo(orderId);
+        assertThat(scrap.getLocationId()).isEqualTo(DESTINATION_SITE);
+        assertThat(scrap.getUnitCost()).isEqualByComparingTo(new BigDecimal("2.0000"));
+        assertThat(entriesOf(sku, InventoryLedgerEventType.TRANSFER_IN)).hasSize(2); // receive 2 + constructive 4
+
+        // Ledger truth reproduces the same balances: verifier clean, rebuild identical.
+        assertThat(driftVerifier.verify()).isZero();
+        rebuildService.rebuildFromLedger();
+        assertBalances(sku, 4, 0, 2);
+        assertThat(driftVerifier.verify()).isZero();
+
+        // No scrap document, no ScrapPostedV1 — the transfer fact carries the disposition.
+        assertThat(scrapRecordRepository.findAll()).isEmpty();
+        assertThat(outboxEventRepository.findAll())
+                .noneMatch(row -> row.getPayload().contains(ScrapPostedV1.EVENT_TYPE));
+        assertThat(outboxEventRepository.findAll())
+                .anyMatch(row -> row.getPayload().contains(TransferOrderUpdatedV1.EVENT_TYPE)
+                        && row.getPayload().contains("\"SHORT_CLOSED\"")
+                        && row.getPayload().contains("\"LOST_IN_TRANSIT\""));
+    }
+
+    // ─── Conservation extension: RETURNED_TO_SOURCE ───────────────────────────
+
+    @Test
+    @DisplayName("RETURNED_TO_SOURCE short-close zeroes the in-transit remainder and restores source on-hand,"
+            + " with drift clean and rebuild identical")
+    void shortClose_returned_zeroesTransitAndRestoresSource() throws Exception {
+        String sku = uniqueSku();
+        seedOnHand(sku, SOURCE_SITE, 10);
+        String orderId = createOrder(sku, 6);
+        UUID lineId = singleLineId(orderId);
+        dispatch(orderId);
+        receive(orderId, lineId, 2); // remainder 4 stays in transit
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(shortCloseBody(
+                                "RETURNED_TO_SOURCE", "Destination refused delivery", "Returned on truck 42")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SHORT_CLOSED"))
+                .andExpect(jsonPath("$.shortCloseDisposition").value("RETURNED_TO_SOURCE"));
+
+        // Source restored to 4 + 4 = 8, transit zero, destination keeps the received 2:
+        // nothing lost — global total is still 10.
+        assertBalances(sku, 8, 0, 2);
+        assertThat(expectedIncoming(sku)).isZero();
+
+        // Return shape: dispatch OUT + return OUT; receive IN + constructive IN + source IN.
+        assertThat(entriesOf(sku, InventoryLedgerEventType.TRANSFER_OUT)).hasSize(2);
+        List<InventoryLedgerEntry> inEntries = entriesOf(sku, InventoryLedgerEventType.TRANSFER_IN);
+        assertThat(inEntries).hasSize(3);
+        assertThat(inEntries).allMatch(entry -> orderId.equals(entry.getSourceTransactionId()));
+        // The source-keyed arrival lands on restored on-hand (running-delta bookkeeping).
+        assertThat(inEntries.stream()
+                        .filter(entry -> SOURCE_SITE.equals(entry.getLocationId()))
+                        .map(InventoryLedgerEntry::getQuantityAfter)
+                        .toList())
+                .containsExactly(8);
+        assertThat(entriesOf(sku, InventoryLedgerEventType.SCRAP_OUT)).isEmpty();
+
+        assertThat(driftVerifier.verify()).isZero();
+        rebuildService.rebuildFromLedger();
+        assertBalances(sku, 8, 0, 2);
+        assertThat(driftVerifier.verify()).isZero();
+
+        assertThat(outboxEventRepository.findAll())
+                .anyMatch(row -> row.getPayload().contains(TransferOrderUpdatedV1.EVENT_TYPE)
+                        && row.getPayload().contains("\"SHORT_CLOSED\"")
+                        && row.getPayload().contains("\"RETURNED_TO_SOURCE\""));
+    }
+
+    @Test
+    @DisplayName("short-close straight from DISPATCHED (no receipt at all) resolves the full dispatched quantity")
+    void shortClose_fromDispatched_resolvesFullQuantity() throws Exception {
+        String sku = uniqueSku();
+        seedOnHand(sku, SOURCE_SITE, 10);
+        String orderId = createOrder(sku, 6);
+        dispatch(orderId);
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(shortCloseBody("RETURNED_TO_SOURCE", "Truck turned back", "Road closure")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SHORT_CLOSED"));
+
+        assertBalances(sku, 10, 0, 0);
+        assertThat(driftVerifier.verify()).isZero();
+        rebuildService.rebuildFromLedger();
+        assertBalances(sku, 10, 0, 0);
+        assertThat(driftVerifier.verify()).isZero();
+    }
+
+    // ─── Terminal status: no further movement ─────────────────────────────────
+
+    @Test
+    @DisplayName("receive and dispatch on a SHORT_CLOSED order return 409")
+    void receiveAndDispatch_onShortClosed_return409() throws Exception {
+        String sku = uniqueSku();
+        seedOnHand(sku, SOURCE_SITE, 10);
+        String orderId = createOrder(sku, 6);
+        dispatch(orderId);
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(shortCloseBody("LOST_IN_TRANSIT", "Lost", "Whole shipment missing")))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/receive", orderId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CONFLICT"));
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/dispatch", orderId)))
+                .andExpect(status().isConflict());
+        // Balances untouched by the rejected calls: everything already written off.
+        assertBalances(sku, 4, 0, 0);
+    }
+
+    // ─── Status gates and validation ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("short-close before dispatch returns 409")
+    void shortClose_beforeDispatch_returns409() throws Exception {
+        String sku = uniqueSku();
+        seedOnHand(sku, SOURCE_SITE, 10);
+        String orderId = createOrder(sku, 6);
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(shortCloseBody("LOST_IN_TRANSIT", "Lost", "Notes")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CONFLICT"));
+    }
+
+    @Test
+    @DisplayName("short-close on a fully RECEIVED order returns 409 (terminal, no remainder)")
+    void shortClose_onFullyReceived_returns409() throws Exception {
+        String sku = uniqueSku();
+        seedOnHand(sku, SOURCE_SITE, 10);
+        String orderId = createOrder(sku, 6);
+        dispatch(orderId);
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/receive", orderId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("RECEIVED"));
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(shortCloseBody("LOST_IN_TRANSIT", "Lost", "Notes")))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("missing disposition, reason, or notes each return 400")
+    void shortClose_missingMandatoryFields_returns400() throws Exception {
+        String sku = uniqueSku();
+        seedOnHand(sku, SOURCE_SITE, 10);
+        String orderId = createOrder(sku, 6);
+        dispatch(orderId);
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"Lost\",\"notes\":\"Notes\"}"))
+                .andExpect(status().isBadRequest());
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"disposition\":\"LOST_IN_TRANSIT\",\"notes\":\"Notes\"}"))
+                .andExpect(status().isBadRequest());
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"disposition\":\"LOST_IN_TRANSIT\",\"reason\":\"Lost\"}"))
+                .andExpect(status().isBadRequest());
+
+        // Nothing changed: still fully in transit.
+        assertBalances(sku, 4, 6, 0);
+    }
+
+    @Test
+    @DisplayName("RETURNED_TO_SOURCE against a no-longer-eligible source returns 422 and rolls back")
+    void shortClose_returnedToIneligibleSource_returns422() throws Exception {
+        String sku = uniqueSku();
+        seedOnHand(sku, SOURCE_SITE, 10);
+        String orderId = createOrder(sku, 6);
+        dispatch(orderId);
+        LocationRefEntity source =
+                locationRefRepository.findByLocationId(SOURCE_SITE).orElseThrow();
+        source.setStatus("INACTIVE");
+        locationRefRepository.save(source);
+
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(shortCloseBody("RETURNED_TO_SOURCE", "Refused", "Notes")))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("TRANSFER_LOCATION_NOT_ELIGIBLE"));
+
+        // Rolled back: order still DISPATCHED with the remainder in transit.
+        mockMvc.perform(withGatewayAuth(get("/v1/inventory/transfer-orders/{id}", orderId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DISPATCHED"));
+        assertBalances(sku, 4, 6, 0);
+    }
+
+    // ─── Permission gating ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("short-close without inventory:transfer:short_close is rejected with 403")
+    void shortCloseWithoutPermission_returns403() throws Exception {
+        String sku = uniqueSku();
+        seedOnHand(sku, SOURCE_SITE, 10);
+        String orderId = createOrder(sku, 6);
+        dispatch(orderId);
+
+        mockMvc.perform(withDispatchOnly(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(shortCloseBody("LOST_IN_TRANSIT", "Lost", "Notes")))
+                .andExpect(status().isForbidden());
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private MockHttpServletRequestBuilder withDispatchOnly(MockHttpServletRequestBuilder requestBuilder) {
+        return requestBuilder
+                .header("X-User", "contract-test-user")
+                .header("X-Authorities", "inventory:transfer:view,inventory:transfer:dispatch");
+    }
+
+    private String uniqueSku() {
+        return "SKU-C3-" + UUID.randomUUID();
+    }
+
+    private void seedSite(UUID siteId, String name) {
+        locationRefRepository.save(LocationRefEntity.builder()
+                .locationId(siteId)
+                .name(name)
+                .status("ACTIVE")
+                .active(true)
+                .build());
+    }
+
+    private void seedOnHand(String sku, UUID locationId, int quantity) {
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(locationId)
+                .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
+                .changeInQuantity(quantity)
+                .quantityAfter(quantity)
+                .unitCost(new BigDecimal("2.0000"))
+                .transactionUserId("contract-test-user")
+                .timestamp(Instant.now())
+                .build());
+    }
+
+    private String createOrder(String sku, int quantity) throws Exception {
+        String body = "{\"sourceLocationId\":\"" + SOURCE_SITE + "\",\"destinationLocationId\":\"" + DESTINATION_SITE
+                + "\",\"lines\":[{\"sku\":\"" + sku + "\",\"requestedQty\":" + quantity + "}]}";
+        MvcResult result = mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper
+                .readTree(result.getResponse().getContentAsString())
+                .get("transferOrderId")
+                .asString();
+    }
+
+    private void dispatch(String orderId) throws Exception {
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/dispatch", orderId)))
+                .andExpect(status().isOk());
+    }
+
+    private void receive(String orderId, UUID lineId, int quantity) throws Exception {
+        mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/receive", orderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"lines\":[{\"lineId\":\"" + lineId + "\",\"quantity\":" + quantity + "}]}"))
+                .andExpect(status().isOk());
+    }
+
+    private UUID singleLineId(String orderId) throws Exception {
+        MvcResult result = mockMvc.perform(withGatewayAuth(get("/v1/inventory/transfer-orders/{id}", orderId)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return UUID.fromString(objectMapper
+                .readTree(result.getResponse().getContentAsString())
+                .get("lines")
+                .get(0)
+                .get("lineId")
+                .asString());
+    }
+
+    private String shortCloseBody(String disposition, String reason, String notes) {
+        return "{\"disposition\":\"" + disposition + "\",\"reason\":\"" + reason + "\",\"notes\":\"" + notes + "\"}";
+    }
+
+    /**
+     * Asserts the three conserved balances for the SKU (source on-hand, destination in-transit,
+     * destination on-hand) AND that total stock across ALL summary keys equals their sum —
+     * short-close under either disposition leaks nothing to any other key.
+     */
+    private void assertBalances(String sku, long sourceOnHand, long destinationInTransit, long destinationOnHand) {
+        assertThat(onHand(sku, SOURCE_SITE)).isEqualTo(sourceOnHand);
+        assertThat(inTransit(sku, DESTINATION_SITE)).isEqualTo(destinationInTransit);
+        assertThat(onHand(sku, DESTINATION_SITE)).isEqualTo(destinationOnHand);
+        assertThat(inTransit(sku, SOURCE_SITE))
+                .as("source key must carry no residual in-transit after any short-close shape")
+                .isZero();
+        assertThat(totalAcrossAllKeys(sku))
+                .as("conservation: no stock outside source on-hand + destination in-transit + destination on-hand")
+                .isEqualTo(sourceOnHand + destinationInTransit + destinationOnHand);
+    }
+
+    private long totalAcrossAllKeys(String sku) {
+        return summaryRepository.findByStockItemId(sku).stream()
+                .mapToLong(row -> row.getOnHand() + row.getInTransitQty())
+                .sum();
+    }
+
+    private long onHand(String sku, UUID locationId) {
+        return summaryRepository
+                .findByStockItemIdAndLocationId(sku, locationId)
+                .map(row -> row.getOnHand())
+                .orElse(0L);
+    }
+
+    private long inTransit(String sku, UUID locationId) {
+        return summaryRepository
+                .findByStockItemIdAndLocationId(sku, locationId)
+                .map(row -> row.getInTransitQty())
+                .orElse(0L);
+    }
+
+    private long expectedIncoming(String sku) {
+        return expectedSupplyService
+                .expectedIncomingQuantity(sku, DESTINATION_SITE, null)
+                .longValueExact();
+    }
+
+    private List<InventoryLedgerEntry> entriesOf(String sku, InventoryLedgerEventType eventType) {
+        return ledgerRepository.findByStockItemIdOrderByTimestampDesc(sku).stream()
+                .filter(entry -> entry.getEventType() == eventType)
+                .toList();
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BatchReplenishmentScanTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BatchReplenishmentScanTest.java
@@ -3,17 +3,27 @@ package com.positivity.inventory.internal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
+import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.PurchaseOrderEntity;
+import com.positivity.inventory.internal.entity.PurchaseOrderLineEntity;
 import com.positivity.inventory.internal.entity.ReplenishmentPolicy;
 import com.positivity.inventory.internal.entity.ReplenishmentTask;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.PurchaseOrderStatus;
 import com.positivity.inventory.internal.enums.ReplenishmentStatus;
 import com.positivity.inventory.internal.enums.ReplenishmentTriggerType;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
+import com.positivity.inventory.internal.repository.PurchaseOrderRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentTaskRepository;
 import com.positivity.inventory.service.ReplenishmentService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,13 +32,16 @@ import org.springframework.test.context.ActiveProfiles;
 
 /**
  * End-to-end tests for the batch replenishment scan (CAP-217 / odoo-parity F1,
- * issue #1025) against the real repositories and the {@code
- * inventory_stock_summary} read model maintained by the ledger posting funnel.
+ * issue #1025; forecast-aware orderpoint math since F2, issue #1040) against the
+ * real repositories, the {@code inventory_stock_summary} read model maintained by
+ * the ledger posting funnel, and real open-PO forecast supply.
  */
 @SpringBootTest
 @ActiveProfiles("test")
-@DisplayName("Batch replenishment scan (F1)")
+@DisplayName("Batch replenishment scan (F1/F2)")
 class BatchReplenishmentScanTest {
+
+    private static final AtomicInteger PO_SEQ = new AtomicInteger();
 
     @Autowired
     private ReplenishmentService replenishmentService;
@@ -41,6 +54,12 @@ class BatchReplenishmentScanTest {
 
     @Autowired
     private LedgerPostingService ledgerPostingService;
+
+    @Autowired
+    private PurchaseOrderRepository purchaseOrderRepository;
+
+    @Autowired
+    private ExtStorageLocationReplicaRepository storageLocationReplicaRepository;
 
     private static String uniqueSku() {
         return "SKU-F1-" + UUID.randomUUID();
@@ -154,5 +173,122 @@ class BatchReplenishmentScanTest {
         List<ReplenishmentTask> tasks = openTasksFor(sku);
         assertThat(tasks).hasSize(1);
         assertThat(tasks.getFirst().getQuantity()).isEqualTo(30);
+    }
+
+    // ─── F2 (#1040): forecast-aware orderpoint math against real open-PO supply ──────
+    // Default lead time is 0 days in the test profile, so leadHorizon == now and the
+    // horizon UTC date is TODAY: a PO expected today is inside the horizon (boundary
+    // date inclusive), a PO expected tomorrow is outside it.
+
+    @Test
+    @DisplayName("F2: below-min on-hand with inbound PO covering the gap within the horizon does not trigger")
+    void inboundPoWithinHorizon_coversGap_noTaskCreated() {
+        UUID skuId = UUID.randomUUID();
+        String sku = skuId.toString();
+        UUID location = UUID.randomUUID(); // not in the replica → treated as a site id
+        seedPolicy(sku, location, 5, 20);
+        receive(sku, location, 3); // on-hand 3 < min 5 — pre-F2 math would trigger
+        // Open APPROVED PO for 7 units expected TODAY (== horizon date, boundary inclusive):
+        // projected 3 + 7 = 10 >= min 5.
+        savePo(PurchaseOrderStatus.APPROVED, location, LocalDate.now(ZoneOffset.UTC), skuId, "7");
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        assertThat(openTasksFor(sku)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("F2: inbound PO beyond the horizon is excluded — trigger fires and replenishes off the projection")
+    void inboundPoBeyondHorizon_triggersOnProjection() {
+        UUID skuId = UUID.randomUUID();
+        String sku = skuId.toString();
+        UUID location = UUID.randomUUID();
+        seedPolicy(sku, location, 5, 20);
+        receive(sku, location, 3);
+        // Same PO but expected TOMORROW — outside the 0-day horizon, excluded from the
+        // projection: projected stays 3 < min 5.
+        savePo(
+                PurchaseOrderStatus.APPROVED,
+                location,
+                LocalDate.now(ZoneOffset.UTC).plusDays(1),
+                skuId,
+                "7");
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getQuantity()).isEqualTo(17); // max 20 - projected 3
+    }
+
+    @Test
+    @DisplayName("F2: bin-level policy resolves to its parent site for forecast supply")
+    void binLevelPolicy_countsSupplyShippedToParentSite() {
+        UUID skuId = UUID.randomUUID();
+        String sku = skuId.toString();
+        UUID bin = UUID.randomUUID();
+        UUID site = UUID.randomUUID();
+        storageLocationReplicaRepository.save(ExtStorageLocationReplica.builder()
+                .storageLocationId(bin)
+                .siteId(site)
+                .name("F2 pick face")
+                .build());
+        seedPolicy(sku, bin, 5, 20);
+        receive(sku, bin, 3); // on-hand at the BIN the policy governs
+        // PO ships to the SITE (POs are never keyed by bin) — bin→site resolution must
+        // credit it to the policy's projection: 3 + 7 = 10 >= 5 → no trigger.
+        savePo(PurchaseOrderStatus.APPROVED, site, LocalDate.now(ZoneOffset.UTC), skuId, "7");
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        assertThat(openTasksFor(sku)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("F2: event path after the scan queues no duplicate quantity for the same breach")
+    void eventPathAfterScan_noDuplicateQuantityForSameBreach() {
+        UUID skuId = UUID.randomUUID();
+        String sku = skuId.toString();
+        UUID location = UUID.randomUUID();
+        seedPolicy(sku, location, 5, 20);
+        receive(sku, location, 3);
+
+        replenishmentService.runBatchReplenishmentScan();
+        var eventResponse = replenishmentService.evaluatePickFaceForReplenishment(sku, location);
+
+        // The scan's open task is the in-progress supply for this breach: the event path
+        // must short-circuit instead of adding quantity.
+        assertThat(eventResponse.getStatus()).isEqualTo("TASK_ALREADY_QUEUED");
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getQuantity()).isEqualTo(17); // total open quantity unchanged
+    }
+
+    private void savePo(
+            PurchaseOrderStatus status, UUID shipToSiteId, LocalDate expectedDeliveryDate, UUID skuId, String openQty) {
+        BigDecimal open = new BigDecimal(openQty);
+        PurchaseOrderEntity po = PurchaseOrderEntity.builder()
+                .vendorId(UUID.randomUUID())
+                .poNumber("F2-" + PO_SEQ.incrementAndGet() + "-" + UUID.randomUUID())
+                .status(status)
+                .currency("USD")
+                .subtotalMinor(100L)
+                .taxMinor(0L)
+                .grandTotalMinor(100L)
+                .shipToLocationId(shipToSiteId)
+                .expectedDeliveryDate(expectedDeliveryDate)
+                .build();
+        PurchaseOrderLineEntity line = PurchaseOrderLineEntity.builder()
+                .lineNumber(1)
+                .skuId(skuId)
+                .description("F2 orderpoint test line")
+                .quantityDecimal(open.max(BigDecimal.ONE))
+                .unitCostMinor(100L)
+                .lineTotalMinor(100L)
+                .openQuantityDecimal(open)
+                .build();
+        line.setPurchaseOrder(po);
+        po.getLines().add(line);
+        purchaseOrderRepository.save(po);
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LeadTimeResolverTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LeadTimeResolverTest.java
@@ -1,0 +1,113 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.dto.LeadTimeView;
+import com.positivity.inventory.internal.entity.ReplenishmentPolicy;
+import com.positivity.inventory.service.InventoryLeadTimeService;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Lead-time resolution for the forecast-aware orderpoint trigger (odoo-parity F2, issue
+ * #1040; decision D-4 precedence: policy override [F3] → vendor feed → default).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LeadTimeResolver (F2, D-4 precedence)")
+class LeadTimeResolverTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("01960003-0000-7000-8000-000000000001");
+    private static final UUID LOCATION_ID = UUID.fromString("01960003-0000-7000-8000-000000000002");
+
+    @Mock
+    private InventoryLeadTimeService inventoryLeadTimeService;
+
+    private ReplenishmentPolicy policy(String sku) {
+        return ReplenishmentPolicy.builder()
+                .locationId(LOCATION_ID)
+                .itemSKU(sku)
+                .minimumQuantity(5)
+                .maximumQuantity(20)
+                .build();
+    }
+
+    @Test
+    @DisplayName("feed lead time wins over the default and uses the MAX day estimate (conservative)")
+    void feedLeadTime_usesMaxDays() {
+        LeadTimeResolver resolver = new LeadTimeResolver(inventoryLeadTimeService, 3);
+        when(inventoryLeadTimeService.findLeadTime(PRODUCT_ID, LOCATION_ID, null))
+                .thenReturn(Optional.of(LeadTimeView.builder()
+                        .productId(PRODUCT_ID)
+                        .locationId(LOCATION_ID)
+                        .minDays(2)
+                        .maxDays(5)
+                        .build()));
+
+        LeadTimeResolver.ResolvedLeadTime resolved = resolver.resolve(policy(PRODUCT_ID.toString()));
+
+        assertThat(resolved.days()).isEqualTo(5);
+        assertThat(resolved.source()).isEqualTo(LeadTimeResolver.LeadTimeSource.FEED);
+    }
+
+    @Test
+    @DisplayName("no feed rows falls back to the configured default")
+    void noFeedRows_fallsBackToDefault() {
+        LeadTimeResolver resolver = new LeadTimeResolver(inventoryLeadTimeService, 3);
+        when(inventoryLeadTimeService.findLeadTime(PRODUCT_ID, LOCATION_ID, null))
+                .thenReturn(Optional.empty());
+
+        LeadTimeResolver.ResolvedLeadTime resolved = resolver.resolve(policy(PRODUCT_ID.toString()));
+
+        assertThat(resolved.days()).isEqualTo(3);
+        assertThat(resolved.source()).isEqualTo(LeadTimeResolver.LeadTimeSource.DEFAULT);
+    }
+
+    @Test
+    @DisplayName("non-UUID SKU skips the feed lookup entirely (feeds key on product UUID)")
+    void nonUuidSku_skipsFeedLookup() {
+        LeadTimeResolver resolver = new LeadTimeResolver(inventoryLeadTimeService, 2);
+
+        LeadTimeResolver.ResolvedLeadTime resolved = resolver.resolve(policy("SKU-BOLT-M5"));
+
+        assertThat(resolved.days()).isEqualTo(2);
+        assertThat(resolved.source()).isEqualTo(LeadTimeResolver.LeadTimeSource.DEFAULT);
+        verify(inventoryLeadTimeService, never()).findLeadTime(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("feed view with only minDays still resolves from the feed")
+    void feedWithOnlyMinDays_resolvesMinDays() {
+        LeadTimeResolver resolver = new LeadTimeResolver(inventoryLeadTimeService, 0);
+        when(inventoryLeadTimeService.findLeadTime(PRODUCT_ID, LOCATION_ID, null))
+                .thenReturn(Optional.of(LeadTimeView.builder()
+                        .productId(PRODUCT_ID)
+                        .locationId(LOCATION_ID)
+                        .minDays(4)
+                        .build()));
+
+        LeadTimeResolver.ResolvedLeadTime resolved = resolver.resolve(policy(PRODUCT_ID.toString()));
+
+        assertThat(resolved.days()).isEqualTo(4);
+        assertThat(resolved.source()).isEqualTo(LeadTimeResolver.LeadTimeSource.FEED);
+    }
+
+    @Test
+    @DisplayName("negative configured default clamps to zero")
+    void negativeDefault_clampsToZero() {
+        LeadTimeResolver resolver = new LeadTimeResolver(inventoryLeadTimeService, -7);
+
+        LeadTimeResolver.ResolvedLeadTime resolved = resolver.resolve(policy("SKU-NOT-UUID"));
+
+        assertThat(resolved.days()).isZero();
+        assertThat(resolved.source()).isEqualTo(LeadTimeResolver.LeadTimeSource.DEFAULT);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReplenishmentPolicyEnrichmentTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReplenishmentPolicyEnrichmentTest.java
@@ -1,0 +1,513 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.positivity.inventory.internal.dto.replenishment.CreateReplenishmentPolicyRequest;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentNeedResponse;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyResponse;
+import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
+import com.positivity.inventory.internal.dto.replenishment.UpdateReplenishmentPolicyRequest;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.NormalizedAvailability;
+import com.positivity.inventory.internal.entity.PurchaseOrderEntity;
+import com.positivity.inventory.internal.entity.PurchaseOrderLineEntity;
+import com.positivity.inventory.internal.entity.ReplenishmentPolicy;
+import com.positivity.inventory.internal.entity.ReplenishmentTask;
+import com.positivity.inventory.internal.entity.ReservationEntity;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.PurchaseOrderStatus;
+import com.positivity.inventory.internal.enums.ReplenishmentSourceType;
+import com.positivity.inventory.internal.enums.ReplenishmentStatus;
+import com.positivity.inventory.internal.enums.ReservationStatus;
+import com.positivity.inventory.internal.exception.SnoozeUntilNotInFutureException;
+import com.positivity.inventory.internal.repository.NormalizedAvailabilityRepository;
+import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
+import com.positivity.inventory.internal.repository.ReplenishmentTaskRepository;
+import com.positivity.inventory.internal.repository.ReservationRepository;
+import com.positivity.inventory.service.ReplenishmentService;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * End-to-end tests for the F3 policy enrichment (odoo-parity F3/F6, issue #1041):
+ * order-multiple rounding, lead-time override precedence, snooze/active skips, the
+ * stock-out deadline approximation, the side-effect-free needs report, and the
+ * vendor-feed pack-size seed — against the real repositories and forecast math.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("Replenishment policy enrichment (F3)")
+class ReplenishmentPolicyEnrichmentTest {
+
+    private static final AtomicInteger PO_SEQ = new AtomicInteger();
+
+    @Autowired
+    private ReplenishmentService replenishmentService;
+
+    @Autowired
+    private ReplenishmentPolicyRepository policyRepository;
+
+    @Autowired
+    private ReplenishmentTaskRepository taskRepository;
+
+    @Autowired
+    private LedgerPostingService ledgerPostingService;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private NormalizedAvailabilityRepository normalizedAvailabilityRepository;
+
+    @Autowired
+    private com.positivity.inventory.internal.repository.PurchaseOrderRepository purchaseOrderRepository;
+
+    @Autowired
+    private LeadTimeResolver leadTimeResolver;
+
+    private static String uniqueSku() {
+        return "SKU-F3-" + UUID.randomUUID();
+    }
+
+    private void receive(String sku, UUID locationId, int quantity) {
+        ledgerPostingService.post(InventoryLedgerEntry.builder()
+                .stockItemId(sku)
+                .locationId(locationId)
+                .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
+                .changeInQuantity(quantity)
+                .quantityAfter(quantity)
+                .transactionUserId("f3-test")
+                .build());
+    }
+
+    private ReplenishmentPolicy seedPolicy(String sku, UUID locationId, int min, int max) {
+        return policyRepository.save(ReplenishmentPolicy.builder()
+                .locationId(locationId)
+                .itemSKU(sku)
+                .minimumQuantity(min)
+                .maximumQuantity(max)
+                .build());
+    }
+
+    private List<ReplenishmentTask> openTasksFor(String sku) {
+        return taskRepository
+                .findByStatusIn(List.of(ReplenishmentStatus.PENDING, ReplenishmentStatus.IN_PROGRESS))
+                .stream()
+                .filter(task -> task.getItemSKU().equals(sku))
+                .toList();
+    }
+
+    // ─── Order-multiple rounding ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("need 7 with orderMultiple 6 rounds up to 12")
+    void orderMultiple_roundsNeedUpToNearestMultiple() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 10);
+        policy.setOrderMultiple(6);
+        policyRepository.save(policy);
+        receive(sku, location, 3); // need = 10 - 3 = 7 → rounded to 12
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getQuantity()).isEqualTo(12);
+    }
+
+    @Test
+    @DisplayName("need that is already an exact multiple stays as-is")
+    void orderMultiple_exactMultipleStaysUnchanged() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        ReplenishmentPolicy policy = seedPolicy(sku, location, 10, 20);
+        policy.setOrderMultiple(6);
+        policyRepository.save(policy);
+        receive(sku, location, 8); // need = 20 - 8 = 12, exact multiple of 6
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getQuantity()).isEqualTo(12);
+    }
+
+    @Test
+    @DisplayName("zero need stays zero despite an order multiple (no phantom round-up)")
+    void orderMultiple_zeroNeedStaysZero() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 20);
+        policy.setOrderMultiple(6);
+        policyRepository.save(policy);
+        receive(sku, location, 3);
+
+        // Scan creates the open task (need 17 → rounded to 18); its quantity is now the
+        // in-progress supply covering the breach.
+        replenishmentService.runBatchReplenishmentScan();
+        assertThat(openTasksFor(sku).getFirst().getQuantity()).isEqualTo(18);
+
+        // Needs report nets that open task: 20 - 3 - 18 < 0 → suggested quantity is zero,
+        // NOT rounded up to 6.
+        ReplenishmentNeedResponse need = needFor(sku);
+        assertThat(need.isWouldTrigger()).isTrue();
+        assertThat(need.getSuggestedQuantity()).isZero();
+    }
+
+    // ─── Lead-time override precedence (D-4) ─────────────────────────────────
+
+    @Test
+    @DisplayName("policy leadTimeDaysOverride wins over vendor-feed lead time")
+    void leadTimeOverride_winsOverFeed() {
+        UUID skuId = UUID.randomUUID();
+        String sku = skuId.toString();
+        UUID location = UUID.randomUUID();
+        // Feed lead time of 5 days would pull tomorrow's PO inside the horizon.
+        seedFeedRow(skuId, 5, 1);
+        ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 20);
+        policy.setLeadTimeDaysOverride(0);
+        policyRepository.save(policy);
+        receive(sku, location, 3);
+        savePo(
+                PurchaseOrderStatus.APPROVED,
+                location,
+                LocalDate.now(ZoneOffset.UTC).plusDays(1),
+                skuId,
+                "7");
+
+        assertThat(leadTimeResolver.resolve(policy).source())
+                .isEqualTo(LeadTimeResolver.LeadTimeSource.POLICY_OVERRIDE);
+        assertThat(leadTimeResolver.resolve(policy).days()).isZero();
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        // Override 0 puts tomorrow's PO OUTSIDE the horizon: projection stays 3 < min 5 →
+        // task created off the projection. With the feed's 5 days it would not have fired.
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getQuantity()).isEqualTo(17);
+    }
+
+    // ─── Snooze / active skips ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("snoozed policy is skipped by scan and event path, and counted in the scan summary")
+    void snoozedPolicy_isSkipped() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 20);
+        policy.setSnoozedUntil(Instant.now().plus(Duration.ofHours(1)));
+        policyRepository.save(policy);
+        receive(sku, location, 3); // below min — would trigger if not snoozed
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertThat(openTasksFor(sku)).isEmpty();
+        assertThat(result.getPoliciesSkipped()).isPositive();
+        assertThat(replenishmentService
+                        .evaluatePickFaceForReplenishment(sku, location)
+                        .getStatus())
+                .isEqualTo("NO_ACTION");
+        assertThat(needFor(sku)).isNull(); // excluded from the needs report too
+    }
+
+    @Test
+    @DisplayName("policy resumes automatically once the snooze instant has passed")
+    void expiredSnooze_resumesEvaluation() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 20);
+        policy.setSnoozedUntil(Instant.now().minus(Duration.ofSeconds(1)));
+        policyRepository.save(policy);
+        receive(sku, location, 3);
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        assertThat(openTasksFor(sku)).hasSize(1); // past snooze instant = no suppression
+    }
+
+    @Test
+    @DisplayName("inactive policy is skipped even when below minimum")
+    void inactivePolicy_isSkipped() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 20);
+        policy.setActive(Boolean.FALSE);
+        policyRepository.save(policy);
+        receive(sku, location, 3);
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertThat(openTasksFor(sku)).isEmpty();
+        assertThat(result.getPoliciesSkipped()).isPositive();
+        assertThat(needFor(sku)).isNull();
+    }
+
+    // ─── Snooze endpoint semantics ───────────────────────────────────────────
+
+    @Test
+    @DisplayName("snooze requires a future instant (422 semantics) and null clears the snooze")
+    void snooze_validatesFutureAndNullClears() {
+        String sku = uniqueSku();
+        ReplenishmentPolicy policy = seedPolicy(sku, UUID.randomUUID(), 5, 20);
+        UUID policyId = policy.getPolicyId();
+        Instant future = Instant.now().plus(Duration.ofDays(1));
+
+        assertThatThrownBy(() -> replenishmentService.snoozeReplenishmentPolicy(
+                        policyId, Instant.now().minus(Duration.ofHours(1))))
+                .isInstanceOf(SnoozeUntilNotInFutureException.class);
+
+        ReplenishmentPolicyResponse snoozed = replenishmentService.snoozeReplenishmentPolicy(policyId, future);
+        assertThat(snoozed.getSnoozedUntil()).isEqualTo(future.toString());
+
+        ReplenishmentPolicyResponse cleared = replenishmentService.snoozeReplenishmentPolicy(policyId, null);
+        assertThat(cleared.getSnoozedUntil()).isNull();
+    }
+
+    // ─── Update endpoint semantics ───────────────────────────────────────────
+
+    @Test
+    @DisplayName("PUT update replaces thresholds and tuning fields; omitted optionals reset to defaults")
+    void update_fullReplaceSemantics() {
+        String sku = uniqueSku();
+        ReplenishmentPolicy policy = seedPolicy(sku, UUID.randomUUID(), 5, 20);
+        UUID policyId = policy.getPolicyId();
+
+        ReplenishmentPolicyResponse updated = replenishmentService.updateReplenishmentPolicy(
+                policyId,
+                UpdateReplenishmentPolicyRequest.builder()
+                        .minimumQuantity(8)
+                        .maximumQuantity(40)
+                        .orderMultiple(6)
+                        .leadTimeDaysOverride(3)
+                        .preferredSourceType(ReplenishmentSourceType.PURCHASE)
+                        .active(Boolean.FALSE)
+                        .build());
+        assertThat(updated.getMinimumQuantity()).isEqualTo(8);
+        assertThat(updated.getMaximumQuantity()).isEqualTo(40);
+        assertThat(updated.getOrderMultiple()).isEqualTo(6);
+        assertThat(updated.getLeadTimeDaysOverride()).isEqualTo(3);
+        assertThat(updated.getPreferredSourceType()).isEqualTo("PURCHASE");
+        assertThat(updated.isActive()).isFalse();
+
+        // PUT again with only the required fields: optionals clear / reset to defaults.
+        ReplenishmentPolicyResponse reset = replenishmentService.updateReplenishmentPolicy(
+                policyId,
+                UpdateReplenishmentPolicyRequest.builder()
+                        .minimumQuantity(8)
+                        .maximumQuantity(40)
+                        .build());
+        assertThat(reset.getOrderMultiple()).isNull();
+        assertThat(reset.getLeadTimeDaysOverride()).isNull();
+        assertThat(reset.getPreferredSourceType()).isEqualTo("EITHER");
+        assertThat(reset.isActive()).isTrue();
+    }
+
+    // ─── Pack-size seed on creation ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("orderMultiple defaults to the vendor-feed pack size when omitted at creation")
+    void create_seedsOrderMultipleFromFeedPackSize() {
+        UUID skuId = UUID.randomUUID();
+        seedFeedRow(skuId, null, 6);
+
+        ReplenishmentPolicyResponse seeded =
+                replenishmentService.createReplenishmentPolicy(createRequest(skuId.toString(), null));
+        assertThat(seeded.getOrderMultiple()).isEqualTo(6);
+
+        // An explicit orderMultiple always wins over the feed seed.
+        ReplenishmentPolicyResponse explicit =
+                replenishmentService.createReplenishmentPolicy(createRequest(skuId.toString(), 4));
+        assertThat(explicit.getOrderMultiple()).isEqualTo(4);
+
+        // Non-UUID SKUs have no feed identity: no seed, no rounding.
+        ReplenishmentPolicyResponse plain =
+                replenishmentService.createReplenishmentPolicy(createRequest(uniqueSku(), null));
+        assertThat(plain.getOrderMultiple()).isNull();
+    }
+
+    // ─── Needs report (F6) ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("needs report matches the subsequent scan's output and creates no tasks")
+    void needsReport_matchesScanAndMutatesNothing() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 10);
+        policy.setOrderMultiple(6);
+        policyRepository.save(policy);
+        receive(sku, location, 3); // need 7 → rounded 12
+
+        long tasksBefore = taskRepository.count();
+        ReplenishmentNeedResponse need = needFor(sku);
+        assertThat(taskRepository.count()).isEqualTo(tasksBefore); // side-effect free
+
+        assertThat(need.isWouldTrigger()).isTrue();
+        assertThat(need.getOnHand()).isEqualTo(3);
+        assertThat(need.getProjectedAvailable()).isEqualTo(3);
+        assertThat(need.getSuggestedQuantity()).isEqualTo(12);
+        assertThat(need.getMinimumQuantity()).isEqualTo(5);
+        assertThat(need.getMaximumQuantity()).isEqualTo(10);
+        assertThat(need.getPreferredSourceType()).isEqualTo("EITHER");
+        assertThat(need.getLeadTimeSource()).isEqualTo("DEFAULT");
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getQuantity()).isEqualTo(need.getSuggestedQuantity());
+    }
+
+    // ─── Stock-out deadline ──────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("deadline is the demand due date at which the projection first goes negative")
+    void deadline_isFirstNegativeCutoffDate() {
+        UUID skuId = UUID.randomUUID();
+        String sku = skuId.toString();
+        UUID location = UUID.randomUUID();
+        ReplenishmentPolicy policy = seedPolicy(sku, location, 10, 20);
+        policy.setLeadTimeDaysOverride(5);
+        policyRepository.save(policy);
+        receive(sku, location, 5);
+        // Open reservation remainder of 8 due in 2 days: projected(now) = 5 >= 0, but at
+        // the due-date cutoff the projection drops to 5 - 8 = -3 < 0 → deadline = due date.
+        Instant due = Instant.now().plus(Duration.ofDays(2));
+        reservationRepository.save(ReservationEntity.builder()
+                .workorderLineId(UUID.randomUUID())
+                .stockItemId(skuId)
+                .requiredQuantity(13)
+                .allocatedQuantity(5)
+                .status(ReservationStatus.PENDING)
+                .dueDateTime(due)
+                .build());
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getDeadlineDate()).isEqualTo(LocalDate.ofInstant(due, ZoneOffset.UTC));
+
+        ReplenishmentNeedResponse need = needFor(sku);
+        assertThat(need.getDeadlineDate())
+                .isEqualTo(LocalDate.ofInstant(due, ZoneOffset.UTC).toString());
+        assertThat(need.getLeadTimeSource()).isEqualTo("POLICY_OVERRIDE");
+    }
+
+    @Test
+    @DisplayName("deadline is today when the projection is already negative now")
+    void deadline_isTodayWhenAlreadyNegative() {
+        UUID skuId = UUID.randomUUID();
+        String sku = skuId.toString();
+        UUID location = UUID.randomUUID();
+        seedPolicy(sku, location, 5, 20);
+        receive(sku, location, 2);
+        // Overdue reservation remainder of 5: projected(now) = 2 - 5 = -3 < 0 → deadline today.
+        reservationRepository.save(ReservationEntity.builder()
+                .workorderLineId(UUID.randomUUID())
+                .stockItemId(skuId)
+                .requiredQuantity(5)
+                .allocatedQuantity(0)
+                .status(ReservationStatus.PENDING)
+                .dueDateTime(Instant.now().minus(Duration.ofHours(1)))
+                .build());
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getDeadlineDate()).isEqualTo(LocalDate.now(ZoneOffset.UTC));
+    }
+
+    @Test
+    @DisplayName("no deadline when the projection never goes below zero within the horizon")
+    void deadline_absentWhenNoProjectedStockout() {
+        String sku = uniqueSku();
+        UUID location = UUID.randomUUID();
+        seedPolicy(sku, location, 5, 20);
+        receive(sku, location, 3); // below min but never below zero
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        List<ReplenishmentTask> tasks = openTasksFor(sku);
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.getFirst().getDeadlineDate()).isNull();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private ReplenishmentNeedResponse needFor(String sku) {
+        return replenishmentService.getReplenishmentNeeds().stream()
+                .filter(need -> sku.equals(need.getItemSKU()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private CreateReplenishmentPolicyRequest createRequest(String sku, Integer orderMultiple) {
+        CreateReplenishmentPolicyRequest request = new CreateReplenishmentPolicyRequest();
+        request.setLocationId(UUID.randomUUID());
+        request.setItemSKU(sku);
+        request.setMinimumQuantity(5);
+        request.setMaximumQuantity(20);
+        request.setOrderMultiple(orderMultiple);
+        return request;
+    }
+
+    private void seedFeedRow(UUID productId, Integer leadTimeDaysMax, int packSize) {
+        normalizedAvailabilityRepository.save(NormalizedAvailability.builder()
+                .productId(productId)
+                .manufacturerId(UUID.randomUUID())
+                .manufacturerPartNumber("MPN-" + productId)
+                .availableQty(100)
+                .uom("EA")
+                .leadTimeDaysMin(leadTimeDaysMax)
+                .leadTimeDaysMax(leadTimeDaysMax)
+                .minOrderQty(1)
+                .packSize(packSize)
+                .asOf(Instant.now())
+                .receivedAt(Instant.now())
+                .schemaVersion(1)
+                .build());
+    }
+
+    private void savePo(
+            PurchaseOrderStatus status, UUID shipToSiteId, LocalDate expectedDeliveryDate, UUID skuId, String openQty) {
+        BigDecimal open = new BigDecimal(openQty);
+        PurchaseOrderEntity po = PurchaseOrderEntity.builder()
+                .vendorId(UUID.randomUUID())
+                .poNumber("F3-" + PO_SEQ.incrementAndGet() + "-" + UUID.randomUUID())
+                .status(status)
+                .currency("USD")
+                .subtotalMinor(100L)
+                .taxMinor(0L)
+                .grandTotalMinor(100L)
+                .shipToLocationId(shipToSiteId)
+                .expectedDeliveryDate(expectedDeliveryDate)
+                .build();
+        PurchaseOrderLineEntity line = PurchaseOrderLineEntity.builder()
+                .lineNumber(1)
+                .skuId(skuId)
+                .description("F3 enrichment test line")
+                .quantityDecimal(open.max(BigDecimal.ONE))
+                .unitCostMinor(100L)
+                .lineTotalMinor(100L)
+                .openQuantityDecimal(open)
+                .build();
+        line.setPurchaseOrder(po);
+        po.getLines().add(line);
+        purchaseOrderRepository.save(po);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryAvailabilityServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryAvailabilityServiceImplTest.java
@@ -68,7 +68,7 @@ class InventoryAvailabilityServiceImplTest {
                 inventoryLedgerEntryRepository,
                 forecastQuantityService,
                 asOfQueryGuard,
-                storageLocationReplicaRepository);
+                new com.positivity.inventory.internal.service.ForecastSiteResolver(storageLocationReplicaRepository));
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
@@ -77,6 +77,14 @@ class ReplenishmentServiceImplTest {
     @Mock
     private LeadTimeResolver leadTimeResolver;
 
+    @Mock
+    private com.positivity.inventory.internal.repository.NormalizedAvailabilityRepository
+            normalizedAvailabilityRepository;
+
+    /** F3 (#1041): deadline computation is mocked out — the unit vectors here don't exercise it. */
+    @Mock
+    private com.positivity.inventory.internal.service.StockoutDeadlineCalculator stockoutDeadlineCalculator;
+
     /**
      * F2 equivalence defaults: no feed lead time (DEFAULT source, 0 days), the policy
      * location is already a site, and no open supply/demand documents — so
@@ -202,7 +210,11 @@ class ReplenishmentServiceImplTest {
     @Test
     void createReplenishmentPolicy_shouldSaveAndReturnMappedPolicy() {
         // Given
-        CreateReplenishmentPolicyRequest request = new CreateReplenishmentPolicyRequest(LOC_02, "SKUABC", 10, 50);
+        CreateReplenishmentPolicyRequest request = new CreateReplenishmentPolicyRequest();
+        request.setLocationId(LOC_02);
+        request.setItemSKU("SKUABC");
+        request.setMinimumQuantity(10);
+        request.setMaximumQuantity(50);
         UUID policyId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         Instant now = Instant.now(TEST_CLOCK);
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
@@ -19,17 +19,23 @@ import com.positivity.inventory.internal.enums.ReplenishmentTriggerType;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentTaskRepository;
+import com.positivity.inventory.internal.service.ForecastQuantityService;
+import com.positivity.inventory.internal.service.ForecastSiteResolver;
+import com.positivity.inventory.internal.service.LeadTimeResolver;
 import com.positivity.inventory.internal.service.ReplenishmentServiceImpl;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -61,6 +67,39 @@ class ReplenishmentServiceImplTest {
 
     @Mock
     private InventoryStockSummaryRepository stockSummaryRepository;
+
+    @Mock
+    private ForecastQuantityService forecastQuantityService;
+
+    @Mock
+    private ForecastSiteResolver forecastSiteResolver;
+
+    @Mock
+    private LeadTimeResolver leadTimeResolver;
+
+    /**
+     * F2 equivalence defaults: no feed lead time (DEFAULT source, 0 days), the policy
+     * location is already a site, and no open supply/demand documents — so
+     * {@code projectedAvailable == onHand} at any horizon and the forecast-aware trigger
+     * and quantity math degrade exactly to the pre-F2 on-hand behavior. Individual tests
+     * override the forecast where the projection matters.
+     */
+    @BeforeEach
+    void defaultForecastEqualsOnHand() {
+        Mockito.lenient()
+                .when(leadTimeResolver.resolve(any()))
+                .thenReturn(new LeadTimeResolver.ResolvedLeadTime(0, LeadTimeResolver.LeadTimeSource.DEFAULT));
+        Mockito.lenient()
+                .when(forecastSiteResolver.resolveForecastSite(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        Mockito.lenient()
+                .when(forecastQuantityService.forecast(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong()))
+                .thenAnswer(invocation ->
+                        new ForecastQuantityService.ForecastQuantities(0L, 0L, invocation.getArgument(3, Long.class)));
+        Mockito.lenient()
+                .when(replenishmentTaskRepository.findByItemSKUAndDestinationLocationIdAndStatusIn(any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+    }
 
     @Test
     void getReplenishmentTasks_shouldReturnMappedTasks() {
@@ -206,10 +245,14 @@ class ReplenishmentServiceImplTest {
 
     @Test
     void evaluatePickFaceForReplenishment_shouldReturnTaskAlreadyQueued_whenTaskAlreadyExists() {
-        // Given - a policy exists for the location
+        // Given - a policy exists for the SKU at the location
         when(replenishmentPolicyRepository.findByLocationId(any()))
-                .thenReturn(List.of(
-                        ReplenishmentPolicy.builder().locationId(PICKFACE_01).build()));
+                .thenReturn(List.of(ReplenishmentPolicy.builder()
+                        .locationId(PICKFACE_01)
+                        .itemSKU("PROD123")
+                        .minimumQuantity(5)
+                        .maximumQuantity(20)
+                        .build()));
         // AND - a pending/in-progress replenishment task already exists for that
         // sku+location
         when(replenishmentTaskRepository.existsByItemSKUAndDestinationLocationIdAndStatusIn(any(), any(), any()))
@@ -219,9 +262,65 @@ class ReplenishmentServiceImplTest {
         ReplenishmentTaskResponse response =
                 replenishmentService.evaluatePickFaceForReplenishment("PROD123", PICKFACE_01);
 
-        // Then
+        // Then — the open task IS the in-progress supply for this breach: no new task, no
+        // added quantity (F2 no-double-ordering across scan and event paths).
         assertNotNull(response);
         assertEquals("TASK_ALREADY_QUEUED", response.getStatus());
+        org.mockito.Mockito.verify(replenishmentTaskRepository, org.mockito.Mockito.never())
+                .save(any());
+    }
+
+    @Test
+    void evaluatePickFaceForReplenishment_projectedAtOrAboveMinimum_returnsNoAction() {
+        when(replenishmentPolicyRepository.findByLocationId(PICKFACE_01))
+                .thenReturn(List.of(ReplenishmentPolicy.builder()
+                        .locationId(PICKFACE_01)
+                        .itemSKU("PROD123")
+                        .minimumQuantity(5)
+                        .maximumQuantity(20)
+                        .build()));
+        when(replenishmentTaskRepository.existsByItemSKUAndDestinationLocationIdAndStatusIn(any(), any(), any()))
+                .thenReturn(false);
+        givenOnHand("PROD123", PICKFACE_01, 3);
+        // Inbound supply within the horizon lifts the projection to the minimum.
+        when(forecastQuantityService.forecast(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong()))
+                .thenReturn(new ForecastQuantityService.ForecastQuantities(2L, 0L, 5L));
+
+        ReplenishmentTaskResponse response =
+                replenishmentService.evaluatePickFaceForReplenishment("PROD123", PICKFACE_01);
+
+        assertEquals("NO_ACTION", response.getStatus());
+        org.mockito.Mockito.verify(replenishmentTaskRepository, org.mockito.Mockito.never())
+                .save(any());
+    }
+
+    @Test
+    void evaluatePickFaceForReplenishment_projectedBelowMinimum_createsEventTaskToMax() {
+        when(replenishmentPolicyRepository.findByLocationId(PICKFACE_01))
+                .thenReturn(List.of(ReplenishmentPolicy.builder()
+                        .locationId(PICKFACE_01)
+                        .itemSKU("PROD123")
+                        .minimumQuantity(5)
+                        .maximumQuantity(20)
+                        .build()));
+        when(replenishmentTaskRepository.existsByItemSKUAndDestinationLocationIdAndStatusIn(any(), any(), any()))
+                .thenReturn(false);
+        givenOnHand("PROD123", PICKFACE_01, 3);
+        when(replenishmentTaskRepository.save(any(ReplenishmentTask.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ReplenishmentTaskResponse response =
+                replenishmentService.evaluatePickFaceForReplenishment("PROD123", PICKFACE_01);
+
+        assertEquals("PENDING", response.getStatus());
+        org.mockito.ArgumentCaptor<ReplenishmentTask> captor =
+                org.mockito.ArgumentCaptor.forClass(ReplenishmentTask.class);
+        org.mockito.Mockito.verify(replenishmentTaskRepository).save(captor.capture());
+        ReplenishmentTask saved = captor.getValue();
+        assertEquals("PROD123", saved.getItemSKU());
+        assertEquals(17, saved.getQuantity()); // max 20 - projected 3
+        assertEquals(ReplenishmentTriggerType.EVENT, saved.getTriggerType());
+        assertEquals(ReplenishmentDecisionReason.BELOW_MIN, saved.getDecisionReason());
     }
 
     // ─── runBatchReplenishmentScan (CAP-217 / odoo-parity F1, issue #1025) ────
@@ -368,6 +467,163 @@ class ReplenishmentServiceImplTest {
 
         assertEquals(1, result.getPoliciesBelowMinimum());
         assertEquals(0, result.getTasksCreated());
+        org.mockito.Mockito.verify(replenishmentTaskRepository, org.mockito.Mockito.never())
+                .save(any());
+    }
+
+    // ─── F2 (#1040): Odoo-derived orderpoint vectors — forecast-aware trigger math ────
+
+    /**
+     * Odoo vector: on-hand below minimum but an inbound PO inside the lead horizon lifts
+     * {@code projectedAvailable} to the minimum — NO trigger (the pre-F2 on-hand math
+     * would have fired).
+     */
+    @Test
+    void runBatchReplenishmentScan_inboundSupplyWithinHorizonCoversGap_noTrigger() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-INBOUND", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        givenOnHand("SKU-INBOUND", LOC_01, 3);
+        // Inbound 7 due within the horizon: projected 10 >= min 5.
+        when(forecastQuantityService.forecast(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong()))
+                .thenReturn(new ForecastQuantityService.ForecastQuantities(7L, 0L, 10L));
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(1, result.getPoliciesEvaluated());
+        assertEquals(0, result.getPoliciesBelowMinimum());
+        assertEquals(0, result.getTasksCreated());
+        org.mockito.Mockito.verify(replenishmentTaskRepository, org.mockito.Mockito.never())
+                .save(any());
+    }
+
+    /**
+     * Odoo vector: the same inbound supply arriving BEYOND the horizon is excluded from
+     * the horizon-bounded projection — trigger fires and the task replenishes to max off
+     * the projection (max − projected, not max − onHand).
+     */
+    @Test
+    void runBatchReplenishmentScan_inboundSupplyBeyondHorizon_triggersOnProjection() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-LATE-PO", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        givenOnHand("SKU-LATE-PO", LOC_01, 1);
+        // Horizon-bounded forecast: late PO excluded, but 3 units of due supply count →
+        // projected 4 < min 5.
+        when(forecastQuantityService.forecast(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong()))
+                .thenReturn(new ForecastQuantityService.ForecastQuantities(3L, 0L, 4L));
+        when(replenishmentTaskRepository.findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .thenReturn(java.util.Optional.empty());
+        when(replenishmentTaskRepository
+                        .existsByItemSKUAndDestinationLocationIdAndTriggerTypeAndCreatedAtGreaterThanEqual(
+                                any(), any(), any(), any()))
+                .thenReturn(false);
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(1, result.getPoliciesBelowMinimum());
+        assertEquals(1, result.getTasksCreated());
+        org.mockito.ArgumentCaptor<ReplenishmentTask> captor =
+                org.mockito.ArgumentCaptor.forClass(ReplenishmentTask.class);
+        org.mockito.Mockito.verify(replenishmentTaskRepository).save(captor.capture());
+        assertEquals(16, captor.getValue().getQuantity()); // max 20 - projected 4 (NOT max - onHand 1 = 19)
+    }
+
+    /**
+     * Horizon-boundary vector: {@code leadHorizon = now + leadTimeDays} exactly — the
+     * resolved (feed) lead time of 5 days against the fixed clock must produce a horizon
+     * of 2024-01-06T00:00:00Z, and the projection must be requested at that instant.
+     */
+    @Test
+    void runBatchReplenishmentScan_passesResolvedLeadTimeHorizonToForecast() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-HORIZON", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        givenOnHand("SKU-HORIZON", LOC_01, 9); // above min: trigger not fired, projection still requested
+        when(leadTimeResolver.resolve(policy))
+                .thenReturn(new LeadTimeResolver.ResolvedLeadTime(5, LeadTimeResolver.LeadTimeSource.FEED));
+
+        replenishmentService.runBatchReplenishmentScan();
+
+        org.mockito.ArgumentCaptor<Instant> horizonCaptor = org.mockito.ArgumentCaptor.forClass(Instant.class);
+        org.mockito.Mockito.verify(forecastQuantityService)
+                .forecast(
+                        org.mockito.ArgumentMatchers.eq("SKU-HORIZON"),
+                        org.mockito.ArgumentMatchers.eq(LOC_01),
+                        horizonCaptor.capture(),
+                        org.mockito.ArgumentMatchers.eq(9L));
+        assertEquals(Instant.now(TEST_CLOCK).plus(Duration.ofDays(5)), horizonCaptor.getValue());
+        assertEquals(Instant.parse("2024-01-06T00:00:00Z"), horizonCaptor.getValue());
+    }
+
+    /**
+     * In-progress netting vector: refreshing the oldest open task nets the quantities of
+     * OTHER open tasks for the same SKU/location (Odoo {@code qty_in_progress}) — the
+     * refreshed task's own quantity is replaced, not double-counted.
+     */
+    @Test
+    void runBatchReplenishmentScan_refreshNetsOtherOpenTaskQuantities() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-NET", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        givenOnHand("SKU-NET", LOC_01, 2);
+        ReplenishmentTask oldest = ReplenishmentTask.builder()
+                .taskId(UUID.fromString("00000000-0000-0000-0000-0000000000aa"))
+                .itemSKU("SKU-NET")
+                .quantity(5)
+                .sourceLocationId(LOC_01)
+                .destinationLocationId(LOC_01)
+                .status(ReplenishmentStatus.PENDING)
+                .triggerType(ReplenishmentTriggerType.BATCH)
+                .build();
+        ReplenishmentTask inProgress = ReplenishmentTask.builder()
+                .taskId(UUID.fromString("00000000-0000-0000-0000-0000000000bb"))
+                .itemSKU("SKU-NET")
+                .quantity(4)
+                .sourceLocationId(LOC_01)
+                .destinationLocationId(LOC_01)
+                .status(ReplenishmentStatus.IN_PROGRESS)
+                .triggerType(ReplenishmentTriggerType.EVENT)
+                .build();
+        when(replenishmentTaskRepository.findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .thenReturn(java.util.Optional.of(oldest));
+        when(replenishmentTaskRepository.findByItemSKUAndDestinationLocationIdAndStatusIn(any(), any(), any()))
+                .thenReturn(List.of(oldest, inProgress));
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(1, result.getTasksRefreshed());
+        assertEquals(0, result.getTasksCreated());
+        // max 20 - projected 2 - other-in-progress 4 = 14 (own quantity 5 excluded).
+        assertEquals(14, oldest.getQuantity());
+        org.mockito.Mockito.verify(replenishmentTaskRepository).save(oldest);
+    }
+
+    /**
+     * Zero-quantity vector: trigger fires (projected < min) but in-progress supply already
+     * covers to max — no task is created. In-progress here flows through the F4 seam
+     * (open supply not surfaced as the policy's own open task).
+     */
+    @Test
+    void runBatchReplenishmentScan_triggeredButInProgressCoversToMax_createsNoTask() {
+        ReplenishmentPolicy policy = policy(LOC_01, "SKU-COVERED", 5, 20);
+        when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
+        givenOnHand("SKU-COVERED", LOC_01, 3);
+        when(replenishmentTaskRepository.findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .thenReturn(java.util.Optional.empty());
+        // In-progress supply for the SKU/location already sums to 18: 20 - 3 - 18 < 0 → 0.
+        when(replenishmentTaskRepository.findByItemSKUAndDestinationLocationIdAndStatusIn(any(), any(), any()))
+                .thenReturn(List.of(ReplenishmentTask.builder()
+                        .taskId(UUID.fromString("00000000-0000-0000-0000-0000000000cc"))
+                        .itemSKU("SKU-COVERED")
+                        .quantity(18)
+                        .status(ReplenishmentStatus.IN_PROGRESS)
+                        .build()));
+
+        ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
+
+        assertEquals(1, result.getPoliciesBelowMinimum());
+        assertEquals(0, result.getTasksCreated());
+        assertEquals(0, result.getTasksRefreshed());
         org.mockito.Mockito.verify(replenishmentTaskRepository, org.mockito.Mockito.never())
                 .save(any());
     }


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-inventory` — Wave 4 of the inventory Odoo-parity program (plan: durion `domains/inventory/plan-odoo-parity-pos-inventory.md`; spec: `domains/inventory/SPEC-pos-inventory-odoo-parity.md`)
- Parent STORY (durion): louisburroughs/durion#365 (J0 ADR-0048, ACCEPTED/closed)
- Child issues: louisburroughs/durion-positivity-backend#1039 (C3), #1040 (F2), #1041 (F3), #1042 (E2), #1043 (D2)
- Domain: `domain:inventory` (plus `domain:accounting` for D2)

## Contract References (REQUIRED for backend PRs touching API/event behavior)

- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` → transfer/replenishment/lot sections still pending as durion-side follow-up (tracked in the plan)
- Durion contract PR (if applicable): none — plan status rides durion branch `claude/odoo-pos-inventory-comparison-ywp0ev`

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations on changed controllers (transfer short-close endpoint; replenishment PUT/snooze/needs; lot fields on pick/consume/return/transfer/scrap/cross-dock DTOs)
- [x] `pos-inventory/openapi.yaml` regenerated per story via the `-Popenapi` profile — gateway aggregate not refreshed
- [ ] Angular SDK regenerated — frontend-repo follow-up

## Scope
- What changed:
  - **C3 (#1039)**: `POST /transfer-orders/{id}/short-close` with dispositions LOST_IN_TRANSIT (constructive TRANSFER_IN + destination SCRAP_OUT, reason LOST) and RETURNED_TO_SOURCE (constructive TRANSFER_IN + return TRANSFER_OUT/IN pair) — both zero in-transit through the existing ledger-shape reconstruction rules (no drift-SQL changes); no ScrapRecord/ScrapPostedV1 for transit losses (the `TransferOrderUpdatedV1` fact carries the disposition, protecting D2's document assumption); V19 disposition/reason/notes columns.
  - **F2 (#1040)**: forecast-aware orderpoint math in both scan and event paths — trigger `projectedAvailable(leadHorizon) < min`, `qtyToReplenish = max(0, max − projected − inProgress)`; feed-based lead times (conservative MAX estimate) → configurable default with the plan D-4 override seam; bin→site resolution shared via `ForecastSiteResolver`. The event-path evaluation previously contained no math at all — it now runs the shared evaluation.
  - **F3 (#1041)**: policy `orderMultiple` (round-up, creation-seeded from vendor-feed pack size), `leadTimeDaysOverride` (completes the D-4 chain), `snoozedUntil`/`active` scan gates, `preferredSourceType` (stored for Wave-5 F5); task `deadlineDate` (stock-out projection at forecast change points); `GET /replenishment/needs` side-effect-free report; minimal policy `PUT` (policies were create-only); V20.
  - **E2 (#1042)**: lot-aware outbound across pick confirmation (validates + pins `pickedLotId`; picks post nothing — consumption is the first posting), consumption, returns (CONSUMED lots reactivate), transfers (lot pinned at dispatch, conserved through receive/short-close), scrap, and cross-dock (now lot-gated, both paired entries stamped); per-lot negative floor enforced in the posting funnel (absolute, batch-order-aware); FIFO lot suggestion by `receivedAt` (FEFO activates via the SPI in E3); CONSUMED↔ACTIVE reconciliation counting on-hand + in-transit; deterministic 422s `LOT_UNKNOWN`/`LOT_NOT_AVAILABLE`/`LOT_INSUFFICIENT_STOCK`; V21.
  - **D2 (#1043, pos-accounting)**: new `InventoryEventsListener` on `inventory.events.v1` (none existed) consuming `ScrapPostedV1` → balanced JE **Dr 5100 Inventory Shrinkage / Cr 1300 Inventory** (both accounts newly seeded, category `INVENTORY_SHRINKAGE`, account_code-FK mapping pattern); two-layer idempotency (`processed_events` eventId + scrapId posting key); uncosted facts (interim costSource NONE per ADR-0048) record-and-skip with greppable WARN; Testcontainers IT mirrors the customer-credit posting IT.
- Why: Wave 4 of the parity plan — completes the transfer lifecycle (G5), replaces stub replenishment math with real orderpoint logic (G10), finishes the E2 lot phase (G7), and lands the first inventory→accounting value posting (G6/D4).

## Tests
- [x] Unit tests added/updated (pos-inventory 547 green; pos-accounting 1,212 green)
- [x] Integration tests added/updated (pos-inventory failsafe 256 green — short-close conservation under both dispositions, orderpoint vectors, needs-report purity, per-lot floors/conservation, CONSUMED lifecycle; pos-accounting shrinkage IT is Docker-gated like its siblings)
- [x] Provider behavioral contract tests added/updated (`TransferOrderUpdatedV1` +disposition additive; `ScrapPostedV1` consumer contract pinned incl. null-cost variant)
- How to run:
  - `./mvnw -pl pos-inventory test` / `verify` and `./mvnw -pl pos-accounting test` (Java 25)
  - `./mvnw -pl pos-archunit -am -Dtest='com/positivity/archunit/*' -Dsurefire.failIfNoSpecifiedTests=false test` (full sweep, 20/20 green per story)

## Risk & Rollback
- Risk level: Medium — replenishment trigger/quantity math deliberately changes (forecast-aware; fixtures with no open supply/demand behave identically, proven); LOT-tracked SKUs now require lot numbers on all outbound flows (products default to NONE tracking, so nothing changes until catalog flags a SKU); everything else additive.
- Rollback plan: revert branch commits; migrations V19–V21 additive (nullable columns); the accounting seed additions are idempotent repeatable-migration rows.
- Known pre-existing failure (NOT introduced here, verified on the clean base): pos-accounting `ReportExportRenderingContractBehaviorIT.trialBalanceCsvMatchesJson` fails under full-suite H2 state pollution — identical on `ead7c7e45^..` base.

## Checklist
- [ ] Branch name matches `cap/` (session-designated branch)
- [x] PR title starts with `[CAP:]`
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (durion-side follow-up noted above)
- [ ] Required CI checks passing (verify on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145oPegbQy1DY4DXPmnj6x3

---
_Generated by [Claude Code](https://claude.ai/code/session_0145oPegbQy1DY4DXPmnj6x3)_