### PR TITLE
[CAP:odoo-parity-inventory] Wave 7: cost revaluation workflow & putaway sublocation strategies

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-07-24T04:03:11.573928+00:00"
+generatedAt: "2026-07-24T11:52:55.059104+00:00"
 root: "."
 summary:
   manifestCount: 20
-  permissionCount: 386
-  uniquePermissionCount: 386
+  permissionCount: 387
+  uniquePermissionCount: 387
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -271,7 +271,7 @@ manifests:
     domain: "inventory"
     serviceName: "pos-inventory"
     version: "1.0"
-    permissionCount: 53
+    permissionCount: 54
     permissions:
       - name: "inventory:adjustment:approve"
         description: "Approve and post an adjustment to the ledger (creates ADJUSTMENT_IN/OUT events)"
@@ -377,6 +377,8 @@ manifests:
         description: "Short-close a dispatched transfer order with a loss/return disposition (parity-C3)"
       - name: "inventory:transfer:view"
         description: "View transfer orders, their lines, and lifecycle status"
+      - name: "inventory:valuation:adjust"
+        description: "Adjust valuation"
       - name: "inventory:valuation:view"
         description: "View valuation"
   - module: "pos-invoice"
@@ -1906,6 +1908,12 @@ permissions:
     source: "pos-inventory/src/main/resources/permissions.yaml"
   - name: "inventory:transfer:view"
     description: "View transfer orders, their lines, and lifecycle status"
+    domain: "inventory"
+    serviceName: "pos-inventory"
+    module: "pos-inventory"
+    source: "pos-inventory/src/main/resources/permissions.yaml"
+  - name: "inventory:valuation:adjust"
+    description: "Adjust valuation"
     domain: "inventory"
     serviceName: "pos-inventory"
     module: "pos-inventory"

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 36;
+    public static final int CATALOG_VERSION = 37;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -472,10 +472,13 @@ public final class GatewayPermissionCatalog {
         "PERM_order:return:view", // 414
 
         // ── New batch (bits 415–415) ──────────────────────────────────────────
-        "PERM_inventory:lot:manage",                         // 415
+        "PERM_inventory:lot:manage", // 415
 
         // ── New batch (bits 416–416) ──────────────────────────────────────────
-        "PERM_inventory:valuation:view"                     // 416
+        "PERM_inventory:valuation:view", // 416
+
+        // ── New batch (bits 417–417) ──────────────────────────────────────────
+        "PERM_inventory:valuation:adjust" // 417
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,9 +1142,9 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 36")
+    @DisplayName("CATALOG_VERSION is 37")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(36);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(37);
     }
 
     @Test
@@ -1247,8 +1247,9 @@ class SecurityGatewayConfigTest {
         assertThat(GatewayPermissionCatalog.authorityForBit(414)).isEqualTo("PERM_order:return:view");
         assertThat(GatewayPermissionCatalog.authorityForBit(415)).isEqualTo("PERM_inventory:lot:manage");
         assertThat(GatewayPermissionCatalog.authorityForBit(416)).isEqualTo("PERM_inventory:valuation:view");
+        assertThat(GatewayPermissionCatalog.authorityForBit(417)).isEqualTo("PERM_inventory:valuation:adjust");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(417)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(418)).isNull();
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ProductValueChangedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ProductValueChangedV1.java
@@ -1,0 +1,80 @@
+package com.positivity.domainevents.inventory;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: a SKU's inventory unit cost was manually revalued (odoo-parity J4, issue #1054; Odoo
+ * {@code product.value} / manual {@code stock.valuation.layer} analog).
+ *
+ * <p>Published by pos-inventory on {@code inventory.events.v1} with
+ * {@code eventType = "inventory.product_value.changed"} — one fact per applied revaluation (this is
+ * an occurrence, not a snapshot: it is never re-emitted). pos-accounting consumes it to post the
+ * revaluation journal entry for the value delta.
+ *
+ * <p>The revaluation corrects the SKU's configured standard price ({@code costingMethod = STANDARD})
+ * or its running weighted average ({@code costingMethod = AVERAGE}). {@code totalValueDelta} is the
+ * signed inventory value change — {@code (newUnitCost − previousUnitCost) × onHandQuantity} — at the
+ * on-hand quantity the costing engine had costed at the moment the revaluation was applied. A
+ * positive delta is a write-up, a negative delta a write-down. {@code previousUnitCost} is
+ * {@code null} when the SKU carried no prior cost of the resolved method (the baseline is treated as
+ * zero for the delta).
+ *
+ * @param revaluationId revaluation document identifier (aggregate id of the fact)
+ * @param sku stock-item identifier that was revalued (ledger stock-item string)
+ * @param costingMethod resolved costing method whose cost was corrected ({@code "STANDARD"} or
+ *     {@code "AVERAGE"})
+ * @param previousUnitCost unit cost before the revaluation, {@code null} when the SKU was uncosted
+ * @param newUnitCost corrected unit cost after the revaluation
+ * @param onHandQuantity on-hand quantity the engine had costed at revaluation time (delta basis)
+ * @param totalValueDelta signed inventory value change {@code (newUnitCost − previousUnitCost) ×
+ *     onHandQuantity}
+ * @param reason operator-supplied justification for the correction
+ * @param actor username of the actor whose approval applied the revaluation
+ * @param occurredAt when the revaluation was applied
+ */
+public record ProductValueChangedV1(
+        @NonNull UUID revaluationId,
+        @NonNull String sku,
+        @NonNull String costingMethod,
+        @Nullable BigDecimal previousUnitCost,
+        @NonNull BigDecimal newUnitCost,
+        long onHandQuantity,
+        @NonNull BigDecimal totalValueDelta,
+        @NonNull String reason,
+        @NonNull String actor,
+        @NonNull Instant occurredAt) {
+
+    public static final String EVENT_TYPE = "inventory.product_value.changed";
+    public static final int SCHEMA_VERSION = 1;
+
+    public ProductValueChangedV1 {
+        if (revaluationId == null) {
+            throw new IllegalArgumentException("revaluationId must not be null");
+        }
+        if (sku == null || sku.isBlank()) {
+            throw new IllegalArgumentException("sku must not be blank");
+        }
+        if (costingMethod == null || costingMethod.isBlank()) {
+            throw new IllegalArgumentException("costingMethod must not be blank");
+        }
+        if (newUnitCost == null) {
+            throw new IllegalArgumentException("newUnitCost must not be null");
+        }
+        if (totalValueDelta == null) {
+            throw new IllegalArgumentException("totalValueDelta must not be null");
+        }
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("reason must not be blank");
+        }
+        if (actor == null || actor.isBlank()) {
+            throw new IllegalArgumentException("actor must not be blank");
+        }
+        if (occurredAt == null) {
+            throw new IllegalArgumentException("occurredAt must not be null");
+        }
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ProductValueChangedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ProductValueChangedV1Test.java
@@ -1,0 +1,120 @@
+package com.positivity.domainevents.inventory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ProductValueChangedV1Test {
+
+    private static final UUID REVALUATION_ID = UUID.fromString("01980001-0000-7000-8000-000000000030");
+    private static final Instant OCCURRED_AT = Instant.parse("2026-07-24T12:00:00Z");
+
+    @Test
+    void carriesSchemaIdentity() {
+        assertThat(ProductValueChangedV1.EVENT_TYPE).isEqualTo("inventory.product_value.changed");
+        assertThat(ProductValueChangedV1.SCHEMA_VERSION).isEqualTo(1);
+    }
+
+    @Test
+    void carriesOldNewCostAndValueDelta() {
+        // AVERAGE write-up: 4.00 -> 5.00 over 10 on-hand => +10.00 delta.
+        ProductValueChangedV1 fact = new ProductValueChangedV1(
+                REVALUATION_ID,
+                "OIL-5W30-5QT",
+                "AVERAGE",
+                new BigDecimal("4.0000"),
+                new BigDecimal("5.0000"),
+                10L,
+                new BigDecimal("10.0000"),
+                "Q3 physical recount correction",
+                "cost-admin",
+                OCCURRED_AT);
+
+        assertThat(fact.previousUnitCost()).isEqualByComparingTo("4.00");
+        assertThat(fact.newUnitCost()).isEqualByComparingTo("5.00");
+        assertThat(fact.onHandQuantity()).isEqualTo(10L);
+        assertThat(fact.totalValueDelta()).isEqualByComparingTo("10.00");
+        assertThat(fact.costingMethod()).isEqualTo("AVERAGE");
+    }
+
+    @Test
+    void acceptsNullPreviousCostForUncostedSku() {
+        ProductValueChangedV1 fact = new ProductValueChangedV1(
+                REVALUATION_ID,
+                "SKU-NEW",
+                "STANDARD",
+                null,
+                new BigDecimal("6.0000"),
+                0L,
+                BigDecimal.ZERO,
+                "Initial standard price",
+                "cost-admin",
+                OCCURRED_AT);
+
+        assertThat(fact.previousUnitCost()).isNull();
+        assertThat(fact.costingMethod()).isEqualTo("STANDARD");
+    }
+
+    @Test
+    void rejectsBlankSkuMethodReasonActor() {
+        assertThatThrownBy(() -> new ProductValueChangedV1(
+                        REVALUATION_ID,
+                        " ",
+                        "AVERAGE",
+                        null,
+                        BigDecimal.ONE,
+                        0L,
+                        BigDecimal.ZERO,
+                        "r",
+                        "a",
+                        OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("sku");
+        assertThatThrownBy(() -> new ProductValueChangedV1(
+                        REVALUATION_ID, "SKU-1", " ", null, BigDecimal.ONE, 0L, BigDecimal.ZERO, "r", "a", OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("costingMethod");
+        assertThatThrownBy(() -> new ProductValueChangedV1(
+                        REVALUATION_ID,
+                        "SKU-1",
+                        "AVERAGE",
+                        null,
+                        BigDecimal.ONE,
+                        0L,
+                        BigDecimal.ZERO,
+                        " ",
+                        "a",
+                        OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("reason");
+        assertThatThrownBy(() -> new ProductValueChangedV1(
+                        REVALUATION_ID,
+                        "SKU-1",
+                        "AVERAGE",
+                        null,
+                        BigDecimal.ONE,
+                        0L,
+                        BigDecimal.ZERO,
+                        "r",
+                        " ",
+                        OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("actor");
+    }
+
+    @Test
+    void rejectsNullNewCostAndDelta() {
+        assertThatThrownBy(() -> new ProductValueChangedV1(
+                        REVALUATION_ID, "SKU-1", "AVERAGE", null, null, 0L, BigDecimal.ZERO, "r", "a", OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("newUnitCost");
+        assertThatThrownBy(() -> new ProductValueChangedV1(
+                        REVALUATION_ID, "SKU-1", "AVERAGE", null, BigDecimal.ONE, 0L, null, "r", "a", OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("totalValueDelta");
+    }
+}

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -40,6 +40,8 @@ tags:
   description: Inventory return-to-stock endpoints
 - name: Inventory Reference Data
   description: Inventory reference-data read endpoints
+- name: Inventory Revaluation
+  description: Approval-gated manual cost revaluation (odoo-parity J4)
 - name: Cycle Count Operations
   description: Cycle count submission and recount operations
 - name: Inventory Management
@@ -554,6 +556,173 @@ paths:
         - inventory:cycle_count:complete
       x-required-permissions:
       - inventory:cycle_count:complete
+  /v1/inventory/valuation/revaluations:
+    get:
+      tags:
+      - Inventory Revaluation
+      summary: List revaluations
+      description: Lists revaluation documents filtered by SKU and lifecycle status, newest first
+      operationId: listRevaluations
+      parameters:
+      - name: stockItemId
+        in: query
+        description: Filter by SKU / stock item identifier
+        required: false
+        schema:
+          type: string
+      - name: status
+        in: query
+        description: Filter by lifecycle status
+        required: false
+        schema:
+          type: string
+          enum:
+          - PENDING_APPROVAL
+          - AUTO_APPLIED
+          - APPLIED
+          - REJECTED
+      responses:
+        '200':
+          description: Revaluations retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RevaluationResponse'
+      security:
+      - bearerAuth:
+        - inventory:valuation:view
+        - inventory:valuation:adjust
+      x-required-permissions:
+      - inventory:valuation:view
+      - inventory:valuation:adjust
+    post:
+      tags:
+      - Inventory Revaluation
+      summary: Submit cost revaluation
+      description: Submits a manual cost revaluation for a SKU. Below the configured value-delta thresholds the revaluation is auto-applied (cost state restated and ProductValueChangedV1 emitted) in the same transaction; at or above them it enters PENDING_APPROVAL with no cost change.
+      operationId: createRevaluation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRevaluationRequest'
+        required: true
+      responses:
+        '201':
+          description: Revaluation created (AUTO_APPLIED or PENDING_APPROVAL)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevaluationResponse'
+        '400':
+          description: Invalid request (e.g. neither/both of newUnitCost and costDelta, or a negative result)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '403':
+          description: Missing inventory:valuation:adjust
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - inventory:valuation:adjust
+      x-required-permissions:
+      - inventory:valuation:adjust
+  /v1/inventory/valuation/revaluations/{revaluationId}/reject:
+    post:
+      tags:
+      - Inventory Revaluation
+      summary: Reject cost revaluation
+      description: Rejects a pending revaluation with a reason. The SKU cost state is untouched.
+      operationId: rejectRevaluation
+      parameters:
+      - name: revaluationId
+        in: path
+        description: Revaluation document ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RejectRevaluationRequest'
+        required: true
+      responses:
+        '200':
+          description: Revaluation rejected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevaluationResponse'
+        '404':
+          description: Revaluation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Revaluation is not in a rejectable state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - inventory:valuation:adjust
+      x-required-permissions:
+      - inventory:valuation:adjust
+  /v1/inventory/valuation/revaluations/{revaluationId}/approve:
+    post:
+      tags:
+      - Inventory Revaluation
+      summary: Approve cost revaluation
+      description: Approves a pending revaluation, restating the SKU cost state and emitting ProductValueChangedV1
+      operationId: approveRevaluation
+      parameters:
+      - name: revaluationId
+        in: path
+        description: Revaluation document ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Revaluation approved and applied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevaluationResponse'
+        '403':
+          description: Missing inventory:valuation:adjust
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '404':
+          description: Revaluation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Revaluation is not in an approvable state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - inventory:valuation:adjust
+      x-required-permissions:
+      - inventory:valuation:adjust
   /v1/inventory/transfer-orders:
     get:
       tags:
@@ -3505,6 +3674,41 @@ paths:
         - inventory:valuation:view
       x-required-permissions:
       - inventory:valuation:view
+  /v1/inventory/valuation/revaluations/{revaluationId}:
+    get:
+      tags:
+      - Inventory Revaluation
+      summary: Get revaluation details
+      description: Retrieves one revaluation document
+      operationId: getRevaluation
+      parameters:
+      - name: revaluationId
+        in: path
+        description: Revaluation document ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Revaluation found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevaluationResponse'
+        '404':
+          description: Revaluation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - inventory:valuation:view
+        - inventory:valuation:adjust
+      x-required-permissions:
+      - inventory:valuation:view
+      - inventory:valuation:adjust
   /v1/inventory/transfer-orders/{transferOrderId}:
     get:
       tags:
@@ -6269,6 +6473,119 @@ components:
       - scheduledDate
       - status
       - updatedAt
+    CreateRevaluationRequest:
+      type: object
+      description: Request to manually revalue a SKU's inventory unit cost
+      properties:
+        stockItemId:
+          type: string
+          description: SKU / stock item identifier to revalue
+          example: OIL-5W30-5QT
+          minLength: 1
+        newUnitCost:
+          type: number
+          description: Absolute corrected unit cost. Supply exactly one of newUnitCost or costDelta. Must be zero or positive
+          example: 5.5
+        costDelta:
+          type: number
+          description: Signed adjustment applied to the SKU's current cost (may be negative for a write-down). Supply exactly one of newUnitCost or costDelta
+          example: -0.75
+        reason:
+          type: string
+          description: Justification for the correction; recorded in the audit log
+          example: Q3 physical recount valuation correction
+          maxLength: 1000
+          minLength: 0
+      required:
+      - reason
+      - stockItemId
+    RevaluationResponse:
+      type: object
+      description: A manual cost-revaluation document with its approval/application state
+      properties:
+        revaluationId:
+          type: string
+          format: uuid
+          description: Revaluation document identifier
+        stockItemId:
+          type: string
+          description: SKU / stock item identifier that was revalued
+        costingMethod:
+          type: string
+          description: Resolved costing method whose cost was corrected
+          enum:
+          - STANDARD
+          - AVERAGE
+        previousUnitCost:
+          type: number
+          description: Unit cost before the revaluation; null when the SKU was uncosted
+        newUnitCost:
+          type: number
+          description: Corrected unit cost
+        onHandQuantity:
+          type: integer
+          format: int64
+          description: On-hand quantity the engine had costed at revaluation time (delta basis)
+        valueDelta:
+          type: number
+          description: 'Signed inventory value change: (newUnitCost - previousUnitCost) x onHandQuantity'
+        reason:
+          type: string
+          description: Justification for the correction
+        status:
+          type: string
+          description: Lifecycle status
+          enum:
+          - PENDING_APPROVAL
+          - AUTO_APPLIED
+          - APPLIED
+          - REJECTED
+        requiredApprovalTier:
+          type: string
+          description: Required approval tier; null when auto-applied
+          enum:
+          - TIER_1_MANAGER
+          - TIER_2_DIRECTOR
+        createdBy:
+          type: string
+          description: Actor who submitted the revaluation
+        approvedBy:
+          type: string
+          description: Actor who approved and applied the revaluation
+        rejectedBy:
+          type: string
+          description: Actor who rejected the revaluation
+        rejectionReason:
+          type: string
+          description: Reason the revaluation was rejected
+        createdAt:
+          type: string
+          format: date-time
+          description: When the document was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the document was last updated
+        appliedAt:
+          type: string
+          format: date-time
+          description: When the revaluation was applied to the cost state
+        rejectedAt:
+          type: string
+          format: date-time
+          description: When the revaluation was rejected
+    RejectRevaluationRequest:
+      type: object
+      description: Request to reject a pending revaluation; the SKU cost state is untouched
+      properties:
+        rejectionReason:
+          type: string
+          description: Reason explaining why the revaluation is being rejected
+          example: Recount disputed; leave standard price unchanged
+          maxLength: 1000
+          minLength: 0
+      required:
+      - rejectionReason
     CreateTransferOrderRequest:
       type: object
       description: Request to create a cross-site transfer order in DRAFT

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/EventTypes.java
@@ -83,6 +83,18 @@ public final class EventTypes {
                                 "Create or update the costing method for one scope")
                         .build(),
 
+                // RevaluationController - 3 events (odoo-parity J4, #1054)
+                EventTypeRegistration.write(
+                                "INVENTORY_REVALUATION_CREATE",
+                                "Submit a manual cost revaluation (auto-applies below threshold)")
+                        .build(),
+                EventTypeRegistration.approval(
+                                "INVENTORY_REVALUATION_APPROVE",
+                                "Approve a pending cost revaluation and restate the SKU cost state")
+                        .build(),
+                EventTypeRegistration.approval("INVENTORY_REVALUATION_REJECT", "Reject a pending cost revaluation")
+                        .build(),
+
                 // CycleCountController - 2 events
                 EventTypeRegistration.write("INVENTORY_CYCLE_COUNT_SUBMIT", "Submit a count for a cycle count task")
                         .build(),

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/RevaluationController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/RevaluationController.java
@@ -1,0 +1,233 @@
+package com.positivity.inventory.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.inventory.internal.dto.revaluation.CreateRevaluationRequest;
+import com.positivity.inventory.internal.dto.revaluation.RejectRevaluationRequest;
+import com.positivity.inventory.internal.dto.revaluation.RevaluationResponse;
+import com.positivity.inventory.internal.enums.RevaluationStatus;
+import com.positivity.inventory.service.RevaluationService;
+import com.positivity.shared.error.ApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for the manual cost-revaluation workflow (odoo-parity J4, issue #1054).
+ *
+ * <p>A revaluation corrects a SKU's standard price (STANDARD) or running average (AVERAGE). The
+ * inventory value delta gates the approval tier: below-threshold revaluations auto-apply (cost state
+ * restated, {@code ProductValueChangedV1} emitted) in the create transaction; above-threshold ones
+ * require a separate approval before applying. Mutations require {@code inventory:valuation:adjust};
+ * reads are visible to {@code inventory:valuation:view} or {@code inventory:valuation:adjust}.
+ */
+@RestController
+@RequestMapping("/v1/inventory/valuation/revaluations")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Inventory Revaluation", description = "Approval-gated manual cost revaluation (odoo-parity J4)")
+public class RevaluationController {
+
+    private final RevaluationService revaluationService;
+
+    /**
+     * Submits a revaluation; below-threshold revaluations auto-apply and restate the cost state.
+     *
+     * @param request the revaluation request
+     * @return the created revaluation with its resulting status
+     */
+    @PostMapping
+    @EmitEvent(id = "INVENTORY_REVALUATION_CREATE", apiVersion = "1")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:valuation:adjust"})
+    @PreAuthorize("hasAuthority('inventory:valuation:adjust')")
+    @Operation(
+            summary = "Submit cost revaluation",
+            description = "Submits a manual cost revaluation for a SKU. Below the configured value-delta thresholds"
+                    + " the revaluation is auto-applied (cost state restated and ProductValueChangedV1 emitted) in"
+                    + " the same transaction; at or above them it enters PENDING_APPROVAL with no cost change.",
+            tags = {"Inventory Revaluation"})
+    @ApiResponse(responseCode = "201", description = "Revaluation created (AUTO_APPLIED or PENDING_APPROVAL)")
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid request (e.g. neither/both of newUnitCost and costDelta, or a negative result)",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Missing inventory:valuation:adjust",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<RevaluationResponse> createRevaluation(@Valid @RequestBody CreateRevaluationRequest request) {
+        log.info("Received request to revalue {}", request.getStockItemId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(revaluationService.createRevaluation(request));
+    }
+
+    /**
+     * Approves a pending revaluation and applies it to the SKU cost state.
+     *
+     * @param revaluationId the revaluation document id
+     * @return the applied revaluation
+     */
+    @PostMapping("/{revaluationId}/approve")
+    @EmitEvent(id = "INVENTORY_REVALUATION_APPROVE", apiVersion = "1")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:valuation:adjust"})
+    @PreAuthorize("hasAuthority('inventory:valuation:adjust')")
+    @Operation(
+            summary = "Approve cost revaluation",
+            description = "Approves a pending revaluation, restating the SKU cost state and emitting"
+                    + " ProductValueChangedV1",
+            tags = {"Inventory Revaluation"})
+    @ApiResponse(responseCode = "200", description = "Revaluation approved and applied")
+    @ApiResponse(
+            responseCode = "403",
+            description = "Missing inventory:valuation:adjust",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Revaluation not found",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Revaluation is not in an approvable state",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<RevaluationResponse> approveRevaluation(
+            @Parameter(description = "Revaluation document ID", required = true) @PathVariable UUID revaluationId) {
+        log.info("Received request to approve revaluation {}", revaluationId);
+        return ResponseEntity.ok(revaluationService.approveRevaluation(revaluationId));
+    }
+
+    /**
+     * Rejects a pending revaluation; the SKU cost state is untouched.
+     *
+     * @param revaluationId the revaluation document id
+     * @param request the rejection request with reason
+     * @return the rejected revaluation
+     */
+    @PostMapping("/{revaluationId}/reject")
+    @EmitEvent(id = "INVENTORY_REVALUATION_REJECT", apiVersion = "1")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:valuation:adjust"})
+    @PreAuthorize("hasAuthority('inventory:valuation:adjust')")
+    @Operation(
+            summary = "Reject cost revaluation",
+            description = "Rejects a pending revaluation with a reason. The SKU cost state is untouched.",
+            tags = {"Inventory Revaluation"})
+    @ApiResponse(responseCode = "200", description = "Revaluation rejected")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Revaluation not found",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Revaluation is not in a rejectable state",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<RevaluationResponse> rejectRevaluation(
+            @Parameter(description = "Revaluation document ID", required = true) @PathVariable UUID revaluationId,
+            @Valid @RequestBody RejectRevaluationRequest request) {
+        log.info("Received request to reject revaluation {}", revaluationId);
+        return ResponseEntity.ok(revaluationService.rejectRevaluation(revaluationId, request));
+    }
+
+    /**
+     * Retrieves one revaluation document.
+     *
+     * @param revaluationId the revaluation document id
+     * @return the revaluation
+     */
+    @GetMapping("/{revaluationId}")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:valuation:view", "inventory:valuation:adjust"})
+    @PreAuthorize("hasAnyAuthority('inventory:valuation:view','inventory:valuation:adjust')")
+    @Operation(
+            summary = "Get revaluation details",
+            description = "Retrieves one revaluation document",
+            tags = {"Inventory Revaluation"})
+    @ApiResponse(responseCode = "200", description = "Revaluation found")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Revaluation not found",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<RevaluationResponse> getRevaluation(
+            @Parameter(description = "Revaluation document ID", required = true) @PathVariable UUID revaluationId) {
+        return ResponseEntity.ok(revaluationService.getRevaluation(revaluationId));
+    }
+
+    /**
+     * Lists revaluation documents matching the optional filters, newest first.
+     *
+     * @param stockItemId optional SKU filter
+     * @param status optional status filter
+     * @return matching revaluations
+     */
+    @GetMapping
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"inventory:valuation:view", "inventory:valuation:adjust"})
+    @PreAuthorize("hasAnyAuthority('inventory:valuation:view','inventory:valuation:adjust')")
+    @Operation(
+            summary = "List revaluations",
+            description = "Lists revaluation documents filtered by SKU and lifecycle status, newest first",
+            tags = {"Inventory Revaluation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Revaluations retrieved",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            array = @ArraySchema(schema = @Schema(implementation = RevaluationResponse.class))))
+    public ResponseEntity<List<RevaluationResponse>> listRevaluations(
+            @Parameter(description = "Filter by SKU / stock item identifier") @RequestParam(required = false)
+                    String stockItemId,
+            @Parameter(description = "Filter by lifecycle status") @RequestParam(required = false)
+                    RevaluationStatus status) {
+        return ResponseEntity.ok(revaluationService.listRevaluations(stockItemId, status));
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/revaluation/CreateRevaluationRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/revaluation/CreateRevaluationRequest.java
@@ -1,0 +1,55 @@
+package com.positivity.inventory.internal.dto.revaluation;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request DTO for submitting a manual cost revaluation (odoo-parity J4, issue #1054).
+ *
+ * <p>Supply exactly one of {@code newUnitCost} (the absolute corrected unit cost) or {@code costDelta}
+ * (a signed adjustment applied to the SKU's current cost). The revaluation targets whichever cost the
+ * SKU's resolved costing method uses — the standard price under STANDARD, the running average under
+ * AVERAGE.
+ */
+@Schema(description = "Request to manually revalue a SKU's inventory unit cost")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateRevaluationRequest {
+
+    @Schema(description = "SKU / stock item identifier to revalue", example = "OIL-5W30-5QT", requiredMode = REQUIRED)
+    @NotBlank(message = "Stock item ID is required")
+    private String stockItemId;
+
+    @Schema(
+            description = "Absolute corrected unit cost. Supply exactly one of newUnitCost or costDelta."
+                    + " Must be zero or positive",
+            example = "5.5000",
+            requiredMode = NOT_REQUIRED)
+    private BigDecimal newUnitCost;
+
+    @Schema(
+            description = "Signed adjustment applied to the SKU's current cost (may be negative for a write-down)."
+                    + " Supply exactly one of newUnitCost or costDelta",
+            example = "-0.7500",
+            requiredMode = NOT_REQUIRED)
+    private BigDecimal costDelta;
+
+    @Schema(
+            description = "Justification for the correction; recorded in the audit log",
+            example = "Q3 physical recount valuation correction",
+            requiredMode = REQUIRED)
+    @NotBlank(message = "Reason is required")
+    @Size(max = 1000, message = "Reason must not exceed 1000 characters")
+    private String reason;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/revaluation/RejectRevaluationRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/revaluation/RejectRevaluationRequest.java
@@ -1,0 +1,32 @@
+package com.positivity.inventory.internal.dto.revaluation;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request DTO for rejecting a pending revaluation (odoo-parity J4, issue #1054).
+ *
+ * <p>The rejecting actor is taken from the security context (ADR-0018), not from the body.
+ */
+@Schema(description = "Request to reject a pending revaluation; the SKU cost state is untouched")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RejectRevaluationRequest {
+
+    @Schema(
+            description = "Reason explaining why the revaluation is being rejected",
+            example = "Recount disputed; leave standard price unchanged",
+            requiredMode = REQUIRED)
+    @NotBlank(message = "Rejection reason is required")
+    @Size(max = 1000, message = "Rejection reason must not exceed 1000 characters")
+    private String rejectionReason;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/revaluation/RevaluationResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/revaluation/RevaluationResponse.java
@@ -1,0 +1,78 @@
+package com.positivity.inventory.internal.dto.revaluation;
+
+import com.positivity.inventory.internal.enums.ApprovalTier;
+import com.positivity.inventory.internal.enums.CostingMethod;
+import com.positivity.inventory.internal.enums.RevaluationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response DTO for a manual cost-revaluation document (odoo-parity J4, issue #1054).
+ */
+@Schema(description = "A manual cost-revaluation document with its approval/application state")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RevaluationResponse {
+
+    @Schema(description = "Revaluation document identifier")
+    private UUID revaluationId;
+
+    @Schema(description = "SKU / stock item identifier that was revalued")
+    private String stockItemId;
+
+    @Schema(description = "Resolved costing method whose cost was corrected")
+    private CostingMethod costingMethod;
+
+    @Schema(description = "Unit cost before the revaluation; null when the SKU was uncosted")
+    private BigDecimal previousUnitCost;
+
+    @Schema(description = "Corrected unit cost")
+    private BigDecimal newUnitCost;
+
+    @Schema(description = "On-hand quantity the engine had costed at revaluation time (delta basis)")
+    private long onHandQuantity;
+
+    @Schema(description = "Signed inventory value change: (newUnitCost - previousUnitCost) x onHandQuantity")
+    private BigDecimal valueDelta;
+
+    @Schema(description = "Justification for the correction")
+    private String reason;
+
+    @Schema(description = "Lifecycle status")
+    private RevaluationStatus status;
+
+    @Schema(description = "Required approval tier; null when auto-applied")
+    private ApprovalTier requiredApprovalTier;
+
+    @Schema(description = "Actor who submitted the revaluation")
+    private String createdBy;
+
+    @Schema(description = "Actor who approved and applied the revaluation")
+    private String approvedBy;
+
+    @Schema(description = "Actor who rejected the revaluation")
+    private String rejectedBy;
+
+    @Schema(description = "Reason the revaluation was rejected")
+    private String rejectionReason;
+
+    @Schema(description = "When the document was created")
+    private Instant createdAt;
+
+    @Schema(description = "When the document was last updated")
+    private Instant updatedAt;
+
+    @Schema(description = "When the revaluation was applied to the cost state")
+    private Instant appliedAt;
+
+    @Schema(description = "When the revaluation was rejected")
+    private Instant rejectedAt;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/PutawayRule.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/PutawayRule.java
@@ -1,9 +1,12 @@
 package com.positivity.inventory.internal.entity;
 
+import com.positivity.inventory.internal.enums.PutawayDestinationStrategy;
 import com.positivity.shared.id.UUIDv7Id;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -39,6 +42,16 @@ public class PutawayRule {
 
     @Column(nullable = false)
     private UUID destinationLocationId;
+
+    /**
+     * Destination-selection strategy (odoo-parity K2, issue #1055). Defaults to
+     * {@link PutawayDestinationStrategy#FIXED} so pre-K2 rules keep suggesting
+     * their configured {@code destinationLocationId} unchanged.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    @Builder.Default
+    private PutawayDestinationStrategy destinationStrategy = PutawayDestinationStrategy.FIXED;
 
     @Column(nullable = false)
     @Builder.Default

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/RevaluationRecord.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/RevaluationRecord.java
@@ -1,0 +1,125 @@
+package com.positivity.inventory.internal.entity;
+
+import com.positivity.inventory.internal.enums.ApprovalTier;
+import com.positivity.inventory.internal.enums.CostingMethod;
+import com.positivity.inventory.internal.enums.RevaluationStatus;
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Manual cost-revaluation document and audit log (odoo-parity J4, issue #1054; Odoo
+ * {@code product.value} analog). This single append-only row is both the approval-workflow document
+ * and the who/when/old/new audit record (ADR-0024) that governs a standard-price / AVCO correction —
+ * mirroring the costing-audit pattern of {@link CostMethodChangeLog} and the workflow lifecycle of
+ * {@link ScrapRecord}.
+ *
+ * <p>The revaluation targets the SKU's resolved {@link CostingMethod}: STANDARD restates
+ * {@code sku_cost_state.standard_cost}, AVERAGE restates {@code sku_cost_state.avg_cost}.
+ * {@code previousUnitCost} is the cost of that method before the change (null when the SKU was
+ * uncosted); {@code newUnitCost} the corrected value; {@code valueDelta} the signed inventory value
+ * change {@code (newUnitCost − previousUnitCost) × onHandQuantity}. The value delta gates the
+ * approval tier via the {@code REVALUATION} rows of {@code approval_threshold_config}.
+ */
+@Entity
+@Table(
+        name = "revaluation_record",
+        indexes = {
+            @Index(name = "idx_revaluation_record_status", columnList = "status"),
+            @Index(name = "idx_revaluation_record_stock_item", columnList = "stock_item_id")
+        })
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class RevaluationRecord {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "revaluation_id", updatable = false, nullable = false)
+    private UUID revaluationId;
+
+    /** SKU / stock-item identifier being revalued (ledger stock-item string). */
+    @Column(name = "stock_item_id", nullable = false, length = 255)
+    private String stockItemId;
+
+    /** Resolved costing method whose cost this revaluation corrects (STANDARD or AVERAGE). */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "costing_method", nullable = false, length = 32)
+    private CostingMethod costingMethod;
+
+    /** Unit cost before the revaluation; null when the SKU carried no prior cost of the method. */
+    @Column(name = "previous_unit_cost", precision = 19, scale = 6)
+    private BigDecimal previousUnitCost;
+
+    /** Corrected unit cost applied on approval. */
+    @Column(name = "new_unit_cost", nullable = false, precision = 19, scale = 6)
+    private BigDecimal newUnitCost;
+
+    /** On-hand quantity the engine had costed at revaluation time (delta basis). */
+    @Column(name = "on_hand_quantity", nullable = false)
+    private long onHandQuantity;
+
+    /** Signed inventory value change: (newUnitCost − previousUnitCost) × onHandQuantity. */
+    @Column(name = "value_delta", nullable = false, precision = 19, scale = 4)
+    private BigDecimal valueDelta;
+
+    /** Operator-supplied justification for the correction. */
+    @Column(nullable = false, length = 1000)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private RevaluationStatus status;
+
+    /** Required approval tier; null when auto-applied. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "required_approval_tier", length = 30)
+    private ApprovalTier requiredApprovalTier;
+
+    @Column(name = "created_by", nullable = false, length = 255)
+    private String createdBy;
+
+    @Column(name = "approved_by", length = 255)
+    private String approvedBy;
+
+    @Column(name = "rejected_by", length = 255)
+    private String rejectedBy;
+
+    @Column(name = "rejection_reason", length = 1000)
+    private String rejectionReason;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /** When the revaluation was applied to the cost state (auto or on approval). */
+    @Column(name = "applied_at")
+    private Instant appliedAt;
+
+    @Column(name = "rejected_at")
+    private Instant rejectedAt;
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/ApprovalFlowType.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/ApprovalFlowType.java
@@ -15,5 +15,11 @@ public enum ApprovalFlowType {
     CYCLE_COUNT,
 
     /** Scrap/write-off approvals (value-based thresholds via cost snapshot). */
-    SCRAP
+    SCRAP,
+
+    /**
+     * Manual cost-revaluation approvals (odoo-parity J4, issue #1054). Value-based thresholds via
+     * the absolute inventory value delta (|Δunit-cost| × on-hand).
+     */
+    REVALUATION
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/PutawayDestinationStrategy.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/PutawayDestinationStrategy.java
@@ -1,0 +1,32 @@
+package com.positivity.inventory.internal.enums;
+
+/**
+ * Destination-selection strategy for a {@code PutawayRule} (odoo-parity K2,
+ * issue #1055; Odoo's putaway rule {@code storage_category}/sublocation
+ * strategy analog).
+ *
+ * <p>The strategy decides which sublocation/bin a matched putaway rule
+ * suggests for a received line:
+ * <ul>
+ *   <li>{@link #FIXED} — the rule's configured {@code destinationLocationId},
+ *       unchanged pre-K2 behavior and the default.
+ *   <li>{@link #LAST_USED} — the sublocation most recently used for a
+ *       successful putaway of the same SKU, falling back to the rule's fixed
+ *       destination when the SKU has never been put away.
+ *   <li>{@link #CLOSEST_AVAILABLE} — the capacity-aware nearest bin, ranked by
+ *       odoo-parity H1 topology proximity to the rule's fixed destination and
+ *       skipping bins at or over capacity, falling back to the fixed
+ *       destination when no candidate has room.
+ * </ul>
+ */
+public enum PutawayDestinationStrategy {
+
+    /** The rule's configured fixed destination (default, pre-K2 behavior). */
+    FIXED,
+
+    /** Most recently used sublocation for the SKU, else the fixed destination. */
+    LAST_USED,
+
+    /** Capacity-aware nearest bin via H1 proximity, else the fixed destination. */
+    CLOSEST_AVAILABLE
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/RevaluationStatus.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/enums/RevaluationStatus.java
@@ -1,0 +1,28 @@
+package com.positivity.inventory.internal.enums;
+
+/**
+ * Status lifecycle for manual cost-revaluation documents (odoo-parity J4, issue #1054).
+ *
+ * <p>Mirrors the {@link ScrapStatus} lifecycle: a below-threshold revaluation auto-applies in the
+ * create transaction; an above-threshold one waits for approval before the cost state is restated.
+ *
+ * <ul>
+ * <li>PENDING_APPROVAL → APPLIED (on approval; cost state restated, fact emitted)</li>
+ * <li>PENDING_APPROVAL → REJECTED (state untouched)</li>
+ * <li>AUTO_APPLIED → (below-threshold; restated and fact emitted in the create transaction)</li>
+ * </ul>
+ */
+public enum RevaluationStatus {
+
+    /** Value delta exceeds a threshold; awaiting manual approval. No cost change yet. */
+    PENDING_APPROVAL,
+
+    /** Below all value thresholds; system-approved and applied in the create transaction. */
+    AUTO_APPLIED,
+
+    /** Manually approved and applied to the SKU cost state. Final successful state. */
+    APPLIED,
+
+    /** Rejected by an authorized user; cost state untouched. Final state. */
+    REJECTED
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/PutawayTaskRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/PutawayTaskRepository.java
@@ -25,4 +25,13 @@ public interface PutawayTaskRepository extends JpaRepository<PutawayTask, UUID> 
 
     boolean existsByProductIdAndSuggestedDestinationLocationIdAndStatusIn(
             UUID productId, UUID locationId, List<PutawayTaskStatus> statuses);
+
+    /**
+     * Most recently completed putaway task for a SKU that landed in a concrete
+     * destination bin (odoo-parity K2, issue #1055 — the LAST_USED strategy).
+     * Ordered by {@code updatedAt} descending so the freshest successful
+     * putaway wins; {@code actualDestinationLocationId} is guaranteed non-null.
+     */
+    Optional<PutawayTask> findFirstByProductIdAndStatusAndActualDestinationLocationIdIsNotNullOrderByUpdatedAtDesc(
+            UUID productId, PutawayTaskStatus status);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/RevaluationRecordRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/RevaluationRecordRepository.java
@@ -1,0 +1,10 @@
+package com.positivity.inventory.internal.repository;
+
+import com.positivity.inventory.internal.entity.RevaluationRecord;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+/** Repository for manual cost-revaluation documents (odoo-parity J4, issue #1054). */
+public interface RevaluationRecordRepository
+        extends JpaRepository<RevaluationRecord, UUID>, JpaSpecificationExecutor<RevaluationRecord> {}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/security/InventoryPermissionRegistry.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/security/InventoryPermissionRegistry.java
@@ -204,6 +204,14 @@ public class InventoryPermissionRegistry {
      */
     public static final String VALUATION_VIEW = "inventory:valuation:view";
 
+    /**
+     * Submit, approve, or reject a manual cost revaluation (standard-price / AVCO correction),
+     * odoo-parity J4 (issue #1054). Distinct from the read-only {@link #VALUATION_VIEW}: revaluation
+     * restates inventory value and posts a revaluation JE, so it gates all mutating revaluation
+     * actions.
+     */
+    public static final String VALUATION_ADJUST = "inventory:valuation:adjust";
+
     // ==================== PERMISSION REGISTRATION ====================
 
     /**
@@ -331,12 +339,17 @@ public class InventoryPermissionRegistry {
                 permission(INVENTORY_VIEW, "View on-hand inventory levels at locations", "LOW"),
                 permission(INVENTORY_SEARCH, "Search inventory across multiple locations", "LOW"),
 
-                // Valuation permissions (1)
+                // Valuation permissions (2)
                 permission(
                         VALUATION_VIEW,
                         "View inventory valuation (on-hand x current unit cost) at SKU level, including as-of",
                         "MEDIUM",
-                        "Issue #1052"));
+                        "Issue #1052"),
+                permission(
+                        VALUATION_ADJUST,
+                        "Submit, approve, or reject a manual cost revaluation (standard-price / AVCO correction)",
+                        "HIGH",
+                        "Issue #1054"));
     }
 
     /**
@@ -422,7 +435,7 @@ public class InventoryPermissionRegistry {
      * Valuation permissions
      */
     public static List<String> valuationPermissions() {
-        return Arrays.asList(VALUATION_VIEW);
+        return Arrays.asList(VALUATION_VIEW, VALUATION_ADJUST);
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ApprovalThresholdEvaluatorImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ApprovalThresholdEvaluatorImpl.java
@@ -103,6 +103,33 @@ public class ApprovalThresholdEvaluatorImpl implements ApprovalThresholdEvaluato
         return Optional.ofNullable(requiredTier);
     }
 
+    @Override
+    public Optional<ApprovalTier> evaluateRevaluationApprovalTier(@NonNull BigDecimal absValueDelta) {
+        List<ApprovalThresholdConfig> configs =
+                thresholdConfigRepository.findByFlowTypeAndActiveTrueOrderByApprovalTierAsc(
+                        ApprovalFlowType.REVALUATION);
+
+        if (configs.isEmpty()) {
+            log.warn(
+                    "No active REVALUATION approval threshold configurations found. Auto-approving revaluation delta {}",
+                    absValueDelta);
+            return Optional.empty();
+        }
+
+        // Revaluation thresholds are value-based only (odoo-parity J4): the highest tier whose value
+        // threshold is met wins; below all thresholds means auto-approval.
+        ApprovalTier requiredTier = null;
+        for (ApprovalThresholdConfig config : configs) {
+            if (absValueDelta.compareTo(config.getValueVarianceThreshold()) >= 0) {
+                requiredTier = config.getApprovalTier();
+            }
+        }
+        if (requiredTier != null) {
+            log.info("Revaluation value delta {} requires {} approval", absValueDelta, requiredTier);
+        }
+        return Optional.ofNullable(requiredTier);
+    }
+
     /**
      * Checks if variance exceeds ANY threshold in the configuration (OR logic).
      */

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
@@ -10,6 +10,7 @@ import com.positivity.domainevents.inventory.LeadTimeUpdatedV1;
 import com.positivity.domainevents.inventory.LotExpiryAlertV1;
 import com.positivity.domainevents.inventory.PickListUpdatedV1;
 import com.positivity.domainevents.inventory.PickTaskUpdatedV1;
+import com.positivity.domainevents.inventory.ProductValueChangedV1;
 import com.positivity.domainevents.inventory.ScrapPostedV1;
 import com.positivity.domainevents.inventory.StorageLocationOnHandUpdatedV1;
 import com.positivity.domainevents.inventory.TransferOrderUpdatedV1;
@@ -170,6 +171,19 @@ public class InventoryFactPublisher {
             return;
         }
         pending.scrapPosts.add(fact);
+    }
+
+    /**
+     * Record a product-value-changed occurrence fact (odoo-parity J4, issue #1054): a manual cost
+     * revaluation was applied to a SKU's cost state. Queued as-is — this is an occurrence, not a
+     * snapshot, and is never re-emitted. pos-accounting consumes it to post the revaluation JE.
+     */
+    public void recordProductValueChanged(@NonNull ProductValueChangedV1 fact) {
+        Pending pending = pending();
+        if (pending == null) {
+            return;
+        }
+        pending.productValueChanges.add(fact);
     }
 
     /**
@@ -377,6 +391,18 @@ public class InventoryFactPublisher {
                 log.warn("Skipping scrap-posted fact for {}: {}", scrapPost.scrapId(), e.getMessage());
             }
         }
+        for (ProductValueChangedV1 valueChange : pending.productValueChanges) {
+            try {
+                publish(
+                        writer,
+                        ProductValueChangedV1.EVENT_TYPE,
+                        ProductValueChangedV1.SCHEMA_VERSION,
+                        valueChange.revaluationId(),
+                        valueChange);
+            } catch (Exception e) {
+                log.warn("Skipping product-value-changed fact for {}: {}", valueChange.revaluationId(), e.getMessage());
+            }
+        }
         for (TransferOrderUpdatedV1 transferUpdate : pending.transferOrderUpdates) {
             try {
                 publish(
@@ -489,6 +515,7 @@ public class InventoryFactPublisher {
         private final List<ConsumptionRecordedV1> consumptions = new ArrayList<>();
         private final List<ExpectedSupplyDroppedV1> expectedSupplyDrops = new ArrayList<>();
         private final List<ScrapPostedV1> scrapPosts = new ArrayList<>();
+        private final List<ProductValueChangedV1> productValueChanges = new ArrayList<>();
         private final List<TransferOrderUpdatedV1> transferOrderUpdates = new ArrayList<>();
         private final List<BackorderCreatedV1> backorderCreations = new ArrayList<>();
         private final List<BackorderResolvedV1> backorderResolutions = new ArrayList<>();

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayDestinationResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayDestinationResolver.java
@@ -127,7 +127,10 @@ public class PutawayDestinationResolver {
     private boolean hasCapacity(UUID locationId, int quantity) {
         try {
             ValidationResult result = putawayValidationService.validateLocationCapacity(locationId, quantity);
-            return result == null || result.isValid();
+            // Fail closed: validateLocationCapacity is contractually non-null, so a null here means
+            // a broken contract (bad mock / future refactor) — treat the bin as unavailable rather
+            // than silently admitting a possibly over-capacity destination.
+            return result != null && result.isValid();
         } catch (LocationAtCapacityException e) {
             return false;
         } catch (IllegalArgumentException e) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayDestinationResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayDestinationResolver.java
@@ -1,0 +1,161 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.dto.ValidationResult;
+import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
+import com.positivity.inventory.internal.entity.PutawayRule;
+import com.positivity.inventory.internal.entity.PutawayTask;
+import com.positivity.inventory.internal.enums.PutawayDestinationStrategy;
+import com.positivity.inventory.internal.enums.PutawayFallbackReason;
+import com.positivity.inventory.internal.enums.PutawayTaskStatus;
+import com.positivity.inventory.internal.exception.LocationAtCapacityException;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
+import com.positivity.inventory.internal.repository.PutawayTaskRepository;
+import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingCandidate;
+import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingSelection;
+import com.positivity.inventory.service.PutawayValidationService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the suggested destination for a putaway line against a matched
+ * {@link PutawayRule}'s {@link PutawayDestinationStrategy} (odoo-parity K2,
+ * issue #1055).
+ *
+ * <p>The engine reuses the H1 proximity machinery — it never re-implements
+ * topology traversal. {@link PutawayDestinationStrategy#CLOSEST_AVAILABLE}
+ * ranks candidate bins with {@link ProximitySourcingStrategy} (BFS-hop over the
+ * replicated location tree) and gates each on the existing
+ * {@link PutawayValidationService#validateLocationCapacity capacity checks},
+ * skipping bins at or over capacity.
+ *
+ * <p>Fallback semantics (the K2 fallback chain): when a strategy's first choice
+ * cannot be honored the resolver returns the rule's fixed
+ * {@code destinationLocationId} (or the next-nearest bin, for
+ * {@code CLOSEST_AVAILABLE}) and records why via
+ * {@link ResolvedDestination#fallbackReason()}. {@link PutawayDestinationStrategy#FIXED}
+ * always returns the rule's destination with no fallback — byte-identical to
+ * pre-K2 behavior.
+ */
+@Component
+@RequiredArgsConstructor
+public class PutawayDestinationResolver {
+
+    private static final String STATUS_ACTIVE = "ACTIVE";
+
+    private final PutawayTaskRepository putawayTaskRepository;
+    private final ExtStorageLocationReplicaRepository extStorageLocationReplicaRepository;
+    private final ProximitySourcingStrategy proximitySourcingStrategy;
+    private final PutawayValidationService putawayValidationService;
+
+    /**
+     * Resolves the destination for a received line under the matched rule.
+     *
+     * @param rule the winning (highest-priority enabled) putaway rule
+     * @param productId the SKU being put away (LAST_USED / CLOSEST_AVAILABLE scope key)
+     * @param quantity the quantity being put away (capacity gating for CLOSEST_AVAILABLE)
+     */
+    public @NonNull ResolvedDestination resolve(@NonNull PutawayRule rule, @NonNull UUID productId, int quantity) {
+        PutawayDestinationStrategy strategy = rule.getDestinationStrategy() != null
+                ? rule.getDestinationStrategy()
+                : PutawayDestinationStrategy.FIXED;
+        return switch (strategy) {
+            case FIXED -> fixed(rule);
+            case LAST_USED -> resolveLastUsed(rule, productId);
+            case CLOSEST_AVAILABLE -> resolveClosestAvailable(rule, productId, quantity);
+        };
+    }
+
+    private ResolvedDestination fixed(PutawayRule rule) {
+        return new ResolvedDestination(rule.getDestinationLocationId(), null, null);
+    }
+
+    private ResolvedDestination resolveLastUsed(PutawayRule rule, UUID productId) {
+        return putawayTaskRepository
+                .findFirstByProductIdAndStatusAndActualDestinationLocationIdIsNotNullOrderByUpdatedAtDesc(
+                        productId, PutawayTaskStatus.COMPLETED)
+                .map(PutawayTask::getActualDestinationLocationId)
+                .map(lastUsed -> new ResolvedDestination(lastUsed, null, null))
+                // Never put away for this SKU yet: fall back to the rule's fixed destination.
+                .orElseGet(() -> new ResolvedDestination(
+                        rule.getDestinationLocationId(), null, PutawayFallbackReason.UNAVAILABLE));
+    }
+
+    private ResolvedDestination resolveClosestAvailable(PutawayRule rule, UUID productId, int quantity) {
+        UUID anchor = rule.getDestinationLocationId();
+
+        UUID siteId = extStorageLocationReplicaRepository
+                .findById(anchor)
+                .map(ExtStorageLocationReplica::getSiteId)
+                .orElse(null);
+        if (siteId == null) {
+            // Topology for the anchor is unknown; degrade to the fixed destination.
+            return fixed(rule);
+        }
+
+        List<SourcingCandidate> candidates = extStorageLocationReplicaRepository.findBySiteId(siteId).stream()
+                .filter(replica -> STATUS_ACTIVE.equalsIgnoreCase(replica.getStatus()))
+                .map(replica -> new SourcingCandidate(replica.getStorageLocationId(), null))
+                .toList();
+        if (candidates.isEmpty()) {
+            return fixed(rule);
+        }
+
+        List<SourcingCandidate> ordered = proximitySourcingStrategy.order(
+                new SourcingSelection(productId.toString(), siteId, anchor, candidates));
+        UUID nearest = ordered.get(0).locationId();
+
+        for (SourcingCandidate candidate : ordered) {
+            UUID candidateId = candidate.locationId();
+            if (hasCapacity(candidateId, quantity)) {
+                boolean fellBack = !candidateId.equals(nearest);
+                return new ResolvedDestination(
+                        candidateId,
+                        fellBack ? nearest : null,
+                        fellBack ? PutawayFallbackReason.DESTINATION_FULL : null);
+            }
+        }
+
+        // Every nearby bin is full: fall back to the rule's fixed destination.
+        return new ResolvedDestination(anchor, nearest, PutawayFallbackReason.DESTINATION_FULL);
+    }
+
+    private boolean hasCapacity(UUID locationId, int quantity) {
+        try {
+            ValidationResult result = putawayValidationService.validateLocationCapacity(locationId, quantity);
+            return result == null || result.isValid();
+        } catch (LocationAtCapacityException e) {
+            return false;
+        } catch (IllegalArgumentException e) {
+            // Inactive or unknown storage location — not a valid destination.
+            return false;
+        }
+    }
+
+    /**
+     * Resolved putaway destination.
+     *
+     * @param destinationLocationId the bin the task should suggest
+     * @param originalSuggestedLocationId the strategy's first choice when a
+     *     fallback occurred, else {@code null}
+     * @param fallbackReason why the first choice was not honored, else
+     *     {@code null} (no fallback)
+     */
+    public record ResolvedDestination(
+            @NonNull UUID destinationLocationId,
+            @Nullable UUID originalSuggestedLocationId,
+            @Nullable PutawayFallbackReason fallbackReason) {
+
+        public boolean isFallback() {
+            return fallbackReason != null;
+        }
+
+        public @NonNull Optional<UUID> originalSuggestedLocationIdOptional() {
+            return Optional.ofNullable(originalSuggestedLocationId);
+        }
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayGenerationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayGenerationServiceImpl.java
@@ -14,6 +14,7 @@ import com.positivity.inventory.internal.repository.PutawayRuleRepository;
 import com.positivity.inventory.internal.repository.PutawayTaskRepository;
 import com.positivity.inventory.service.PutawayGenerationService;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,7 @@ public class PutawayGenerationServiceImpl implements PutawayGenerationService {
     private final PutawayRuleRepository putawayRuleRepository;
     private final PutawayTaskRepository putawayTaskRepository;
     private final GoodsReceiptRepository goodsReceiptRepository;
+    private final PutawayDestinationResolver putawayDestinationResolver;
 
     @Override
     @Transactional
@@ -45,20 +47,13 @@ public class PutawayGenerationServiceImpl implements PutawayGenerationService {
                 .orElseThrow(() -> new ResourceNotFoundException("GoodsReceipt", sourceReceiptId.toString()));
 
         List<PutawayRule> enabledRules = putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc();
-        UUID suggestedDestination =
-                enabledRules.isEmpty() ? DEFAULT_LOCATION : enabledRules.get(0).getDestinationLocationId();
+        Optional<PutawayRule> winningRule =
+                enabledRules.isEmpty() ? Optional.empty() : Optional.of(enabledRules.get(0));
 
         List<ParsedPutawayLineItem> lineItems = resolveLineItems(request);
 
         List<PutawayTask> tasks = lineItems.stream()
-                .map(lineItem -> PutawayTask.builder()
-                        .sourceReceipt(sourceReceipt)
-                        .productId(lineItem.productId())
-                        .quantity(lineItem.quantity())
-                        .sourceLocationId(STAGING_LOCATION)
-                        .suggestedDestinationLocationId(suggestedDestination)
-                        .status(PutawayTaskStatus.UNASSIGNED)
-                        .build())
+                .map(lineItem -> toTask(sourceReceipt, lineItem, winningRule))
                 .toList();
 
         return putawayTaskRepository.saveAll(tasks).stream()
@@ -102,6 +97,32 @@ public class PutawayGenerationServiceImpl implements PutawayGenerationService {
 
         PutawayTask savedTask = putawayTaskRepository.save(task);
         return toResponse(savedTask);
+    }
+
+    /**
+     * Builds an unassigned putaway task for one received line, resolving the
+     * suggested destination via the winning rule's destination strategy
+     * (odoo-parity K2, issue #1055). With no matching rule the pre-K2 default
+     * location is used; a {@code FIXED} rule yields byte-identical pre-K2
+     * behavior (fixed destination, no fallback metadata).
+     */
+    private PutawayTask toTask(
+            GoodsReceiptEntity sourceReceipt, ParsedPutawayLineItem lineItem, Optional<PutawayRule> winningRule) {
+        PutawayDestinationResolver.ResolvedDestination destination = winningRule
+                .map(rule -> putawayDestinationResolver.resolve(rule, lineItem.productId(), lineItem.quantity()))
+                .orElseGet(() -> new PutawayDestinationResolver.ResolvedDestination(DEFAULT_LOCATION, null, null));
+
+        return PutawayTask.builder()
+                .sourceReceipt(sourceReceipt)
+                .productId(lineItem.productId())
+                .quantity(lineItem.quantity())
+                .sourceLocationId(STAGING_LOCATION)
+                .suggestedDestinationLocationId(destination.destinationLocationId())
+                .originalSuggestedLocationId(destination.originalSuggestedLocationId())
+                .finalSuggestedLocationId(destination.isFallback() ? destination.destinationLocationId() : null)
+                .fallbackReason(destination.fallbackReason())
+                .status(PutawayTaskStatus.UNASSIGNED)
+                .build();
     }
 
     private UUID parseRequiredUuid(String rawValue, String fieldName) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/RevaluationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/RevaluationServiceImpl.java
@@ -9,6 +9,7 @@ import com.positivity.inventory.internal.entity.SkuCostState;
 import com.positivity.inventory.internal.enums.ApprovalTier;
 import com.positivity.inventory.internal.enums.CostingMethod;
 import com.positivity.inventory.internal.enums.RevaluationStatus;
+import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.repository.RevaluationRecordRepository;
 import com.positivity.inventory.internal.repository.SkuCostStateRepository;
 import com.positivity.inventory.service.ApprovalThresholdEvaluator;
@@ -124,7 +125,7 @@ public class RevaluationServiceImpl implements RevaluationService {
         String actor = currentActor();
         RevaluationRecord record = revaluationRepository
                 .findById(revaluationId)
-                .orElseThrow(() -> new IllegalArgumentException("Revaluation not found: " + revaluationId));
+                .orElseThrow(() -> new ResourceNotFoundException("Revaluation", revaluationId.toString()));
 
         if (record.getStatus() != RevaluationStatus.PENDING_APPROVAL) {
             throw new IllegalStateException("Cannot approve revaluation in status: " + record.getStatus());
@@ -145,7 +146,7 @@ public class RevaluationServiceImpl implements RevaluationService {
         String actor = currentActor();
         RevaluationRecord record = revaluationRepository
                 .findById(revaluationId)
-                .orElseThrow(() -> new IllegalArgumentException("Revaluation not found: " + revaluationId));
+                .orElseThrow(() -> new ResourceNotFoundException("Revaluation", revaluationId.toString()));
 
         if (record.getStatus() != RevaluationStatus.PENDING_APPROVAL) {
             throw new IllegalStateException("Cannot reject revaluation in status: " + record.getStatus());
@@ -165,7 +166,7 @@ public class RevaluationServiceImpl implements RevaluationService {
     public @NonNull RevaluationResponse getRevaluation(@NonNull UUID revaluationId) {
         return toResponse(revaluationRepository
                 .findById(revaluationId)
-                .orElseThrow(() -> new IllegalArgumentException("Revaluation not found: " + revaluationId)));
+                .orElseThrow(() -> new ResourceNotFoundException("Revaluation", revaluationId.toString())));
     }
 
     @Override

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/RevaluationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/RevaluationServiceImpl.java
@@ -1,0 +1,282 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.domainevents.inventory.ProductValueChangedV1;
+import com.positivity.inventory.internal.dto.revaluation.CreateRevaluationRequest;
+import com.positivity.inventory.internal.dto.revaluation.RejectRevaluationRequest;
+import com.positivity.inventory.internal.dto.revaluation.RevaluationResponse;
+import com.positivity.inventory.internal.entity.RevaluationRecord;
+import com.positivity.inventory.internal.entity.SkuCostState;
+import com.positivity.inventory.internal.enums.ApprovalTier;
+import com.positivity.inventory.internal.enums.CostingMethod;
+import com.positivity.inventory.internal.enums.RevaluationStatus;
+import com.positivity.inventory.internal.repository.RevaluationRecordRepository;
+import com.positivity.inventory.internal.repository.SkuCostStateRepository;
+import com.positivity.inventory.service.ApprovalThresholdEvaluator;
+import com.positivity.inventory.service.RevaluationService;
+import com.positivity.security.common.SecurityContextHelper;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Manual cost-revaluation workflow (odoo-parity J4, issue #1054; Odoo {@code product.value} analog).
+ *
+ * <p>Approval model mirrors the D1 scrap workflow ({@link ScrapServiceImpl}): the absolute inventory
+ * value delta (|Δunit-cost| × on-hand) is evaluated against the {@code REVALUATION} rows of
+ * {@code approval_threshold_config}. Below all thresholds the revaluation auto-applies in the create
+ * transaction; at or above a threshold it enters {@code PENDING_APPROVAL} and no cost change happens
+ * until an approver acts. Following the D1 precedent, the approver need not differ from the submitter.
+ *
+ * <p>Applying a revaluation restates the SKU's running cost state — {@code standardCost} under
+ * STANDARD, {@code avgCost} under AVERAGE — and emits a {@code ProductValueChangedV1} fact carrying
+ * old/new unit cost, on-hand, and the signed value delta so accounting can post the revaluation JE.
+ * The {@link RevaluationRecord} row is the who/when/old/new audit log (ADR-0024).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RevaluationServiceImpl implements RevaluationService {
+
+    /** Money scale for the value delta. */
+    private static final int VALUE_SCALE = 4;
+
+    /** Cost scale for the SKU cost state columns. */
+    private static final int COST_SCALE = 6;
+
+    private final RevaluationRecordRepository revaluationRepository;
+    private final SkuCostStateRepository costStateRepository;
+    private final SkuCostStateInitializer costStateInitializer;
+    private final CostingMethodResolver methodResolver;
+    private final ApprovalThresholdEvaluator thresholdEvaluator;
+    private final InventoryFactPublisher inventoryFactPublisher;
+    private final Clock clock;
+
+    @Override
+    @Transactional
+    public @NonNull RevaluationResponse createRevaluation(@NonNull CreateRevaluationRequest request) {
+        String actor = currentActor();
+        String stockItemId = request.getStockItemId();
+
+        CostingMethod method = methodResolver.resolve(stockItemId);
+        SkuCostState state = loadOrSeedState(stockItemId);
+
+        BigDecimal previousUnitCost = currentCost(state, method);
+        BigDecimal newUnitCost = resolveNewUnitCost(request, previousUnitCost);
+        long onHand = state.getOnHandQty();
+
+        BigDecimal base = previousUnitCost != null ? previousUnitCost : BigDecimal.ZERO;
+        BigDecimal valueDelta = newUnitCost
+                .subtract(base)
+                .multiply(BigDecimal.valueOf(onHand))
+                .setScale(VALUE_SCALE, RoundingMode.HALF_UP);
+
+        RevaluationRecord record = RevaluationRecord.builder()
+                .stockItemId(stockItemId)
+                .costingMethod(method)
+                .previousUnitCost(previousUnitCost)
+                .newUnitCost(newUnitCost.setScale(COST_SCALE, RoundingMode.HALF_UP))
+                .onHandQuantity(onHand)
+                .valueDelta(valueDelta)
+                .reason(request.getReason())
+                .createdBy(actor)
+                .status(RevaluationStatus.PENDING_APPROVAL)
+                .build();
+
+        Optional<ApprovalTier> requiredTier = thresholdEvaluator.evaluateRevaluationApprovalTier(valueDelta.abs());
+        if (requiredTier.isPresent()) {
+            record.setRequiredApprovalTier(requiredTier.get());
+            record = revaluationRepository.save(record);
+            log.info(
+                    "Revaluation {} for {} created PENDING_APPROVAL (tier {}, value delta {})",
+                    record.getRevaluationId(),
+                    stockItemId,
+                    requiredTier.get(),
+                    valueDelta);
+            return toResponse(record);
+        }
+
+        record.setStatus(RevaluationStatus.AUTO_APPLIED);
+        record = revaluationRepository.save(record);
+        applyRevaluation(record, state, actor);
+        log.info(
+                "Revaluation {} for {} auto-applied (value delta {} below all thresholds)",
+                record.getRevaluationId(),
+                stockItemId,
+                valueDelta);
+        return toResponse(record);
+    }
+
+    @Override
+    @Transactional
+    public @NonNull RevaluationResponse approveRevaluation(@NonNull UUID revaluationId) {
+        String actor = currentActor();
+        RevaluationRecord record = revaluationRepository
+                .findById(revaluationId)
+                .orElseThrow(() -> new IllegalArgumentException("Revaluation not found: " + revaluationId));
+
+        if (record.getStatus() != RevaluationStatus.PENDING_APPROVAL) {
+            throw new IllegalStateException("Cannot approve revaluation in status: " + record.getStatus());
+        }
+
+        record.setApprovedBy(actor);
+        record.setStatus(RevaluationStatus.APPLIED);
+        SkuCostState state = loadOrSeedState(record.getStockItemId());
+        applyRevaluation(record, state, actor);
+        log.info("Revaluation {} approved and applied by {}", revaluationId, actor);
+        return toResponse(record);
+    }
+
+    @Override
+    @Transactional
+    public @NonNull RevaluationResponse rejectRevaluation(
+            @NonNull UUID revaluationId, @NonNull RejectRevaluationRequest request) {
+        String actor = currentActor();
+        RevaluationRecord record = revaluationRepository
+                .findById(revaluationId)
+                .orElseThrow(() -> new IllegalArgumentException("Revaluation not found: " + revaluationId));
+
+        if (record.getStatus() != RevaluationStatus.PENDING_APPROVAL) {
+            throw new IllegalStateException("Cannot reject revaluation in status: " + record.getStatus());
+        }
+
+        record.setStatus(RevaluationStatus.REJECTED);
+        record.setRejectedBy(actor);
+        record.setRejectionReason(request.getRejectionReason());
+        record.setRejectedAt(Instant.now(clock));
+        record = revaluationRepository.save(record);
+        log.info("Revaluation {} rejected by {}", revaluationId, actor);
+        return toResponse(record);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public @NonNull RevaluationResponse getRevaluation(@NonNull UUID revaluationId) {
+        return toResponse(revaluationRepository
+                .findById(revaluationId)
+                .orElseThrow(() -> new IllegalArgumentException("Revaluation not found: " + revaluationId)));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public @NonNull List<RevaluationResponse> listRevaluations(
+            @Nullable String stockItemId, @Nullable RevaluationStatus status) {
+        Specification<RevaluationRecord> spec = (root, query, cb) -> cb.conjunction();
+        if (stockItemId != null && !stockItemId.isBlank()) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("stockItemId"), stockItemId));
+        }
+        if (status != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), status));
+        }
+        return revaluationRepository.findAll(spec, Sort.by(Sort.Direction.DESC, "createdAt")).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /**
+     * Restates the SKU cost state to the record's new unit cost and emits the
+     * {@code ProductValueChangedV1} fact. Shared by the auto-apply and approve paths.
+     */
+    private void applyRevaluation(RevaluationRecord record, SkuCostState state, String applyingActor) {
+        BigDecimal newCost = record.getNewUnitCost();
+        if (record.getCostingMethod() == CostingMethod.STANDARD) {
+            state.setStandardCost(newCost);
+        } else {
+            state.setAvgCost(newCost);
+        }
+        costStateRepository.save(state);
+
+        Instant appliedAt = Instant.now(clock);
+        record.setAppliedAt(appliedAt);
+        revaluationRepository.save(record);
+
+        inventoryFactPublisher.recordProductValueChanged(new ProductValueChangedV1(
+                record.getRevaluationId(),
+                record.getStockItemId(),
+                record.getCostingMethod().name(),
+                record.getPreviousUnitCost(),
+                newCost,
+                record.getOnHandQuantity(),
+                record.getValueDelta(),
+                record.getReason(),
+                applyingActor,
+                appliedAt));
+    }
+
+    /** Current cost of the resolved method: standard price under STANDARD, running average under AVERAGE. */
+    private @Nullable BigDecimal currentCost(SkuCostState state, CostingMethod method) {
+        return method == CostingMethod.STANDARD ? state.getStandardCost() : state.getAvgCost();
+    }
+
+    /**
+     * Resolves the corrected unit cost from the request. Exactly one of {@code newUnitCost} or
+     * {@code costDelta} must be supplied; the result must be zero or positive.
+     */
+    private BigDecimal resolveNewUnitCost(CreateRevaluationRequest request, @Nullable BigDecimal previousUnitCost) {
+        BigDecimal absolute = request.getNewUnitCost();
+        BigDecimal delta = request.getCostDelta();
+        if ((absolute == null) == (delta == null)) {
+            throw new IllegalArgumentException("Supply exactly one of newUnitCost or costDelta");
+        }
+        BigDecimal result;
+        if (absolute != null) {
+            result = absolute;
+        } else {
+            BigDecimal base = previousUnitCost != null ? previousUnitCost : BigDecimal.ZERO;
+            result = base.add(delta);
+        }
+        if (result.signum() < 0) {
+            throw new IllegalArgumentException("Resulting unit cost must not be negative: " + result);
+        }
+        return result;
+    }
+
+    private SkuCostState loadOrSeedState(String stockItemId) {
+        return costStateRepository.findByStockItemId(stockItemId).orElseGet(() -> {
+            costStateInitializer.createRowIfAbsent(stockItemId);
+            return costStateRepository
+                    .findByStockItemId(stockItemId)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "sku_cost_state row missing after initialization for " + stockItemId));
+        });
+    }
+
+    private String currentActor() {
+        return SecurityContextHelper.getCurrentUsername()
+                .orElseThrow(() -> new IllegalStateException("No current user"));
+    }
+
+    private RevaluationResponse toResponse(RevaluationRecord record) {
+        return RevaluationResponse.builder()
+                .revaluationId(record.getRevaluationId())
+                .stockItemId(record.getStockItemId())
+                .costingMethod(record.getCostingMethod())
+                .previousUnitCost(record.getPreviousUnitCost())
+                .newUnitCost(record.getNewUnitCost())
+                .onHandQuantity(record.getOnHandQuantity())
+                .valueDelta(record.getValueDelta())
+                .reason(record.getReason())
+                .status(record.getStatus())
+                .requiredApprovalTier(record.getRequiredApprovalTier())
+                .createdBy(record.getCreatedBy())
+                .approvedBy(record.getApprovedBy())
+                .rejectedBy(record.getRejectedBy())
+                .rejectionReason(record.getRejectionReason())
+                .createdAt(record.getCreatedAt())
+                .updatedAt(record.getUpdatedAt())
+                .appliedAt(record.getAppliedAt())
+                .rejectedAt(record.getRejectedAt())
+                .build();
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ApprovalThresholdEvaluator.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ApprovalThresholdEvaluator.java
@@ -29,4 +29,15 @@ public interface ApprovalThresholdEvaluator {
      * @return optional approval tier, empty if auto-approval is allowed
      */
     Optional<ApprovalTier> evaluateScrapApprovalTier(@NonNull BigDecimal scrapValue);
+
+    /**
+     * Evaluates a manual cost-revaluation's absolute inventory value delta
+     * (|Δunit-cost| × on-hand) against the revaluation flow's value-based
+     * thresholds (odoo-parity J4, issue #1054). Unit and percentage thresholds
+     * do not apply to revaluations.
+     *
+     * @param absValueDelta absolute inventory value change the revaluation causes
+     * @return optional approval tier, empty if auto-approval is allowed
+     */
+    Optional<ApprovalTier> evaluateRevaluationApprovalTier(@NonNull BigDecimal absValueDelta);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/RevaluationService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/RevaluationService.java
@@ -1,0 +1,70 @@
+package com.positivity.inventory.service;
+
+import com.positivity.inventory.internal.dto.revaluation.CreateRevaluationRequest;
+import com.positivity.inventory.internal.dto.revaluation.RejectRevaluationRequest;
+import com.positivity.inventory.internal.dto.revaluation.RevaluationResponse;
+import com.positivity.inventory.internal.enums.RevaluationStatus;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Manual cost-revaluation workflow (odoo-parity J4, issue #1054).
+ *
+ * <p>An operator corrects a SKU's standard price (STANDARD method) or running average (AVERAGE) via
+ * an approval-gated document. The value delta (|Δunit-cost| × on-hand) gates the approval tier: a
+ * below-threshold revaluation applies immediately, an above-threshold one waits for approval. On
+ * application the SKU cost state is restated and a {@code ProductValueChangedV1} fact is emitted.
+ */
+public interface RevaluationService {
+
+    /**
+     * Submits a revaluation. Below the value threshold it is auto-applied (cost state restated and
+     * the fact emitted) in the same transaction; above it (or an unknown value) it enters
+     * {@code PENDING_APPROVAL} with no cost change.
+     *
+     * @param request the revaluation request
+     * @return the created revaluation with its resulting status
+     */
+    @NonNull
+    RevaluationResponse createRevaluation(@NonNull CreateRevaluationRequest request);
+
+    /**
+     * Approves a pending revaluation, restating the SKU cost state and emitting the fact.
+     *
+     * @param revaluationId the revaluation document id
+     * @return the applied revaluation
+     */
+    @NonNull
+    RevaluationResponse approveRevaluation(@NonNull UUID revaluationId);
+
+    /**
+     * Rejects a pending revaluation; the SKU cost state is untouched.
+     *
+     * @param revaluationId the revaluation document id
+     * @param request the rejection request with reason
+     * @return the rejected revaluation
+     */
+    @NonNull
+    RevaluationResponse rejectRevaluation(@NonNull UUID revaluationId, @NonNull RejectRevaluationRequest request);
+
+    /**
+     * Retrieves one revaluation document.
+     *
+     * @param revaluationId the revaluation document id
+     * @return the revaluation
+     */
+    @NonNull
+    RevaluationResponse getRevaluation(@NonNull UUID revaluationId);
+
+    /**
+     * Lists revaluation documents matching the optional filters, newest first.
+     *
+     * @param stockItemId optional SKU filter
+     * @param status optional status filter
+     * @return matching revaluations
+     */
+    @NonNull
+    List<RevaluationResponse> listRevaluations(@Nullable String stockItemId, @Nullable RevaluationStatus status);
+}

--- a/pos-inventory/src/main/resources/db/migration/V29__create_revaluation_record.sql
+++ b/pos-inventory/src/main/resources/db/migration/V29__create_revaluation_record.sql
@@ -1,0 +1,73 @@
+-- odoo-parity J4 (#1054, spec §10 WS-J; ADR-0024/ADR-0048): manual cost-revaluation workflow.
+-- An operator corrects a SKU's standard price (STANDARD) or running average (AVERAGE); the
+-- inventory value delta gates an approval tier reusing the D1 approval_threshold_config machinery
+-- with a new REVALUATION flow. On application the sku_cost_state cost is restated and a
+-- ProductValueChangedV1 fact is emitted (accounting posts the revaluation JE).
+
+-- 1. Widen the shared approval-flow discriminator to admit the REVALUATION flow (value-based
+--    thresholds, like SCRAP). Existing CYCLE_COUNT/SCRAP rows are unaffected.
+ALTER TABLE approval_threshold_config DROP CONSTRAINT approval_threshold_config_flow_type_check;
+
+ALTER TABLE approval_threshold_config ADD CONSTRAINT approval_threshold_config_flow_type_check
+    CHECK (((flow_type)::text = ANY ((ARRAY[
+        'CYCLE_COUNT'::character varying,
+        'SCRAP'::character varying,
+        'REVALUATION'::character varying])::text[])));
+
+-- Revaluation flow thresholds (value-based via |Δunit-cost| × on-hand; unit/percentage columns
+-- are NOT NULL for the shared table but unused by revaluation evaluation — zeroes). A delta at or
+-- above $100 needs manager approval, $1000 needs director approval; below $100 auto-applies.
+INSERT INTO approval_threshold_config (
+    config_id,
+    flow_type,
+    approval_tier,
+    unit_variance_threshold,
+    value_variance_threshold,
+    percentage_variance_threshold,
+    active,
+    created_at,
+    updated_at
+)
+VALUES
+    ('01980001-0000-7000-8000-000000000031'::uuid, 'REVALUATION', 'TIER_1_MANAGER', 0, 100, 0, TRUE, NOW(), NOW()),
+    ('01980001-0000-7000-8000-000000000032'::uuid, 'REVALUATION', 'TIER_2_DIRECTOR', 0, 1000, 0, TRUE, NOW(), NOW());
+
+-- 2. Revaluation document + who/when/old/new audit log (ADR-0024). One append-only row per
+--    revaluation: workflow status plus the immutable old/new cost, on-hand basis, value delta,
+--    reason, and actor. previous_unit_cost is NULL when the SKU carried no prior cost of the
+--    resolved method. costing_method and cost columns share sku_cost_state scales (6 for cost,
+--    4 for the money delta).
+CREATE TABLE revaluation_record (
+    revaluation_id uuid NOT NULL,
+    stock_item_id character varying(255) NOT NULL,
+    costing_method character varying(32) NOT NULL,
+    previous_unit_cost numeric(19,6),
+    new_unit_cost numeric(19,6) NOT NULL,
+    on_hand_quantity bigint NOT NULL,
+    value_delta numeric(19,4) NOT NULL,
+    reason character varying(1000) NOT NULL,
+    status character varying(30) NOT NULL,
+    required_approval_tier character varying(30),
+    created_by character varying(255) NOT NULL,
+    approved_by character varying(255),
+    rejected_by character varying(255),
+    rejection_reason character varying(1000),
+    created_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    applied_at timestamp(6) with time zone,
+    rejected_at timestamp(6) with time zone,
+    CONSTRAINT revaluation_record_pkey PRIMARY KEY (revaluation_id),
+    CONSTRAINT revaluation_record_costing_method_check
+        CHECK (((costing_method)::text = ANY ((ARRAY['STANDARD'::character varying, 'AVERAGE'::character varying])::text[]))),
+    CONSTRAINT revaluation_record_status_check
+        CHECK (((status)::text = ANY ((ARRAY[
+            'PENDING_APPROVAL'::character varying,
+            'AUTO_APPLIED'::character varying,
+            'APPLIED'::character varying,
+            'REJECTED'::character varying])::text[]))),
+    CONSTRAINT revaluation_record_required_approval_tier_check
+        CHECK ((required_approval_tier IS NULL OR (required_approval_tier)::text = ANY ((ARRAY['TIER_1_MANAGER'::character varying, 'TIER_2_DIRECTOR'::character varying])::text[])))
+);
+
+CREATE INDEX idx_revaluation_record_status ON revaluation_record (status);
+CREATE INDEX idx_revaluation_record_stock_item ON revaluation_record (stock_item_id);

--- a/pos-inventory/src/main/resources/db/migration/V30__add_putaway_rule_destination_strategy.sql
+++ b/pos-inventory/src/main/resources/db/migration/V30__add_putaway_rule_destination_strategy.sql
@@ -1,0 +1,5 @@
+-- odoo-parity K2 (issue #1055): destination-selection strategy on putaway rules.
+-- Additive, non-null with a FIXED default so every existing rule keeps its
+-- pre-K2 fixed-destination behavior.
+ALTER TABLE putaway_rule
+    ADD COLUMN destination_strategy varchar(32) NOT NULL DEFAULT 'FIXED';

--- a/pos-inventory/src/main/resources/permissions.yaml
+++ b/pos-inventory/src/main/resources/permissions.yaml
@@ -106,5 +106,7 @@ permissions:
     description: "Short-close a dispatched transfer order with a loss/return disposition (parity-C3)"
   - name: "inventory:transfer:view"
     description: "View transfer orders, their lines, and lifecycle status"
+  - name: "inventory:valuation:adjust"
+    description: "Adjust valuation"
   - name: "inventory:valuation:view"
     description: "View valuation"

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayDestinationResolverTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayDestinationResolverTest.java
@@ -1,0 +1,243 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.dto.ValidationResult;
+import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
+import com.positivity.inventory.internal.entity.PutawayRule;
+import com.positivity.inventory.internal.entity.PutawayTask;
+import com.positivity.inventory.internal.enums.PutawayDestinationStrategy;
+import com.positivity.inventory.internal.enums.PutawayFallbackReason;
+import com.positivity.inventory.internal.enums.PutawayTaskStatus;
+import com.positivity.inventory.internal.exception.LocationAtCapacityException;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
+import com.positivity.inventory.internal.repository.PutawayTaskRepository;
+import com.positivity.inventory.internal.service.PutawayDestinationResolver.ResolvedDestination;
+import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingCandidate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PutawayDestinationResolverTest {
+
+    private static final UUID ANCHOR = UUID.fromString("00000000-0000-0000-0000-0000000000a0");
+    private static final UUID NEAR = UUID.fromString("00000000-0000-0000-0000-0000000000b0");
+    private static final UUID FAR = UUID.fromString("00000000-0000-0000-0000-0000000000c0");
+    private static final UUID SITE = UUID.fromString("00000000-0000-0000-0000-0000000000f0");
+    private static final UUID PRODUCT = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID LAST_USED_BIN = UUID.fromString("00000000-0000-0000-0000-0000000000d0");
+    private static final int QTY = 5;
+
+    @Mock
+    private PutawayTaskRepository putawayTaskRepository;
+
+    @Mock
+    private ExtStorageLocationReplicaRepository extStorageLocationReplicaRepository;
+
+    @Mock
+    private ProximitySourcingStrategy proximitySourcingStrategy;
+
+    @Mock
+    private com.positivity.inventory.service.PutawayValidationService putawayValidationService;
+
+    private PutawayDestinationResolver resolver() {
+        return new PutawayDestinationResolver(
+                putawayTaskRepository,
+                extStorageLocationReplicaRepository,
+                proximitySourcingStrategy,
+                putawayValidationService);
+    }
+
+    private PutawayRule rule(PutawayDestinationStrategy strategy) {
+        return PutawayRule.builder()
+                .priority(1)
+                .destinationLocationId(ANCHOR)
+                .destinationStrategy(strategy)
+                .build();
+    }
+
+    // ─── FIXED ──────────────────────────────────────────────────────────────
+
+    @Test
+    void fixed_returnsRuleDestination_withNoFallback_andNoLookups() {
+        ResolvedDestination result = resolver().resolve(rule(PutawayDestinationStrategy.FIXED), PRODUCT, QTY);
+
+        assertThat(result.destinationLocationId()).isEqualTo(ANCHOR);
+        assertThat(result.isFallback()).isFalse();
+        assertThat(result.fallbackReason()).isNull();
+        assertThat(result.originalSuggestedLocationId()).isNull();
+        verifyNoInteractions(
+                putawayTaskRepository,
+                extStorageLocationReplicaRepository,
+                proximitySourcingStrategy,
+                putawayValidationService);
+    }
+
+    @Test
+    void nullStrategy_defaultsToFixed() {
+        PutawayRule rule =
+                PutawayRule.builder().priority(1).destinationLocationId(ANCHOR).build();
+        rule.setDestinationStrategy(null);
+
+        ResolvedDestination result = resolver().resolve(rule, PRODUCT, QTY);
+
+        assertThat(result.destinationLocationId()).isEqualTo(ANCHOR);
+        assertThat(result.isFallback()).isFalse();
+    }
+
+    // ─── LAST_USED ──────────────────────────────────────────────────────────
+
+    @Test
+    void lastUsed_picksMostRecentlyUsedBinForSku() {
+        PutawayTask completed = PutawayTask.builder()
+                .actualDestinationLocationId(LAST_USED_BIN)
+                .status(PutawayTaskStatus.COMPLETED)
+                .build();
+        when(putawayTaskRepository
+                        .findFirstByProductIdAndStatusAndActualDestinationLocationIdIsNotNullOrderByUpdatedAtDesc(
+                                PRODUCT, PutawayTaskStatus.COMPLETED))
+                .thenReturn(Optional.of(completed));
+
+        ResolvedDestination result = resolver().resolve(rule(PutawayDestinationStrategy.LAST_USED), PRODUCT, QTY);
+
+        assertThat(result.destinationLocationId()).isEqualTo(LAST_USED_BIN);
+        assertThat(result.isFallback()).isFalse();
+        assertThat(result.fallbackReason()).isNull();
+    }
+
+    @Test
+    void lastUsed_neverUsed_fallsBackToFixedDestination_withUnavailableReason() {
+        when(putawayTaskRepository
+                        .findFirstByProductIdAndStatusAndActualDestinationLocationIdIsNotNullOrderByUpdatedAtDesc(
+                                PRODUCT, PutawayTaskStatus.COMPLETED))
+                .thenReturn(Optional.empty());
+
+        ResolvedDestination result = resolver().resolve(rule(PutawayDestinationStrategy.LAST_USED), PRODUCT, QTY);
+
+        assertThat(result.destinationLocationId()).isEqualTo(ANCHOR);
+        assertThat(result.isFallback()).isTrue();
+        assertThat(result.fallbackReason()).isEqualTo(PutawayFallbackReason.UNAVAILABLE);
+    }
+
+    // ─── CLOSEST_AVAILABLE ──────────────────────────────────────────────────
+
+    private void stubSiteWithBins() {
+        when(extStorageLocationReplicaRepository.findById(ANCHOR)).thenReturn(Optional.of(bin(ANCHOR)));
+        when(extStorageLocationReplicaRepository.findBySiteId(SITE))
+                .thenReturn(List.of(bin(ANCHOR), bin(NEAR), bin(FAR)));
+    }
+
+    @Test
+    void closestAvailable_picksNearestBinWithRoom() {
+        stubSiteWithBins();
+        when(proximitySourcingStrategy.order(any()))
+                .thenReturn(List.of(candidate(NEAR), candidate(FAR), candidate(ANCHOR)));
+        // NEAR has room.
+        when(putawayValidationService.validateLocationCapacity(NEAR, QTY)).thenReturn(ValidationResult.success());
+
+        ResolvedDestination result =
+                resolver().resolve(rule(PutawayDestinationStrategy.CLOSEST_AVAILABLE), PRODUCT, QTY);
+
+        assertThat(result.destinationLocationId()).isEqualTo(NEAR);
+        assertThat(result.isFallback()).isFalse();
+        assertThat(result.fallbackReason()).isNull();
+        assertThat(result.originalSuggestedLocationId()).isNull();
+        // Nearest had room — no need to evaluate farther bins.
+        Mockito.verify(putawayValidationService, never()).validateLocationCapacity(eq(FAR), any(int.class));
+    }
+
+    @Test
+    void closestAvailable_skipsFullNearestBin_fallsThroughToNextNearest() {
+        stubSiteWithBins();
+        when(proximitySourcingStrategy.order(any()))
+                .thenReturn(List.of(candidate(NEAR), candidate(FAR), candidate(ANCHOR)));
+        when(putawayValidationService.validateLocationCapacity(NEAR, QTY))
+                .thenThrow(new LocationAtCapacityException(NEAR, 10, 10));
+        when(putawayValidationService.validateLocationCapacity(FAR, QTY)).thenReturn(ValidationResult.success());
+
+        ResolvedDestination result =
+                resolver().resolve(rule(PutawayDestinationStrategy.CLOSEST_AVAILABLE), PRODUCT, QTY);
+
+        assertThat(result.destinationLocationId()).isEqualTo(FAR);
+        assertThat(result.isFallback()).isTrue();
+        assertThat(result.fallbackReason()).isEqualTo(PutawayFallbackReason.DESTINATION_FULL);
+        assertThat(result.originalSuggestedLocationId()).isEqualTo(NEAR);
+    }
+
+    @Test
+    void closestAvailable_allBinsFull_fallsBackToFixedDestination() {
+        stubSiteWithBins();
+        when(proximitySourcingStrategy.order(any()))
+                .thenReturn(List.of(candidate(NEAR), candidate(FAR), candidate(ANCHOR)));
+        when(putawayValidationService.validateLocationCapacity(any(UUID.class), eq(QTY)))
+                .thenThrow(new LocationAtCapacityException(NEAR, 10, 10));
+
+        ResolvedDestination result =
+                resolver().resolve(rule(PutawayDestinationStrategy.CLOSEST_AVAILABLE), PRODUCT, QTY);
+
+        assertThat(result.destinationLocationId()).isEqualTo(ANCHOR);
+        assertThat(result.isFallback()).isTrue();
+        assertThat(result.fallbackReason()).isEqualTo(PutawayFallbackReason.DESTINATION_FULL);
+        assertThat(result.originalSuggestedLocationId()).isEqualTo(NEAR);
+    }
+
+    @Test
+    void closestAvailable_unknownAnchorSite_degradesToFixed() {
+        when(extStorageLocationReplicaRepository.findById(ANCHOR)).thenReturn(Optional.empty());
+
+        ResolvedDestination result =
+                resolver().resolve(rule(PutawayDestinationStrategy.CLOSEST_AVAILABLE), PRODUCT, QTY);
+
+        assertThat(result.destinationLocationId()).isEqualTo(ANCHOR);
+        assertThat(result.isFallback()).isFalse();
+        verifyNoInteractions(proximitySourcingStrategy, putawayValidationService);
+    }
+
+    @Test
+    void closestAvailable_noActiveCandidateBins_degradesToFixed() {
+        when(extStorageLocationReplicaRepository.findById(ANCHOR)).thenReturn(Optional.of(bin(ANCHOR)));
+        when(extStorageLocationReplicaRepository.findBySiteId(SITE)).thenReturn(List.of(inactiveBin(NEAR)));
+
+        ResolvedDestination result =
+                resolver().resolve(rule(PutawayDestinationStrategy.CLOSEST_AVAILABLE), PRODUCT, QTY);
+
+        assertThat(result.destinationLocationId()).isEqualTo(ANCHOR);
+        assertThat(result.isFallback()).isFalse();
+        verifyNoInteractions(proximitySourcingStrategy, putawayValidationService);
+    }
+
+    private ExtStorageLocationReplica bin(UUID id) {
+        return ExtStorageLocationReplica.builder()
+                .storageLocationId(id)
+                .siteId(SITE)
+                .status("ACTIVE")
+                .maxUnitCapacity(100)
+                .aggregateVersion(1L)
+                .build();
+    }
+
+    private ExtStorageLocationReplica inactiveBin(UUID id) {
+        return ExtStorageLocationReplica.builder()
+                .storageLocationId(id)
+                .siteId(SITE)
+                .status("INACTIVE")
+                .maxUnitCapacity(100)
+                .aggregateVersion(1L)
+                .build();
+    }
+
+    private SourcingCandidate candidate(UUID id) {
+        return new SourcingCandidate(id, null);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/RevaluationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/RevaluationServiceImplTest.java
@@ -1,0 +1,300 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.inventory.ProductValueChangedV1;
+import com.positivity.inventory.internal.dto.revaluation.CreateRevaluationRequest;
+import com.positivity.inventory.internal.dto.revaluation.RejectRevaluationRequest;
+import com.positivity.inventory.internal.dto.revaluation.RevaluationResponse;
+import com.positivity.inventory.internal.entity.RevaluationRecord;
+import com.positivity.inventory.internal.entity.SkuCostState;
+import com.positivity.inventory.internal.enums.ApprovalTier;
+import com.positivity.inventory.internal.enums.CostingMethod;
+import com.positivity.inventory.internal.enums.RevaluationStatus;
+import com.positivity.inventory.internal.repository.RevaluationRecordRepository;
+import com.positivity.inventory.internal.repository.SkuCostStateRepository;
+import com.positivity.inventory.service.ApprovalThresholdEvaluator;
+import com.positivity.security.common.GatewaySecurityConstants;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Unit tests for {@link RevaluationServiceImpl} (odoo-parity J4, issue #1054): value-delta approval
+ * gating, STANDARD vs AVERAGE cost restatement, delta = Δcost × on-hand, and fact emission.
+ */
+@ExtendWith(MockitoExtension.class)
+class RevaluationServiceImplTest {
+
+    private static final String ACTOR = "cost-admin";
+    private static final String SKU = "OIL-5W30-5QT";
+
+    @Mock
+    private RevaluationRecordRepository revaluationRepository;
+
+    @Mock
+    private SkuCostStateRepository costStateRepository;
+
+    @Mock
+    private SkuCostStateInitializer costStateInitializer;
+
+    @Mock
+    private CostingMethodResolver methodResolver;
+
+    @Mock
+    private ApprovalThresholdEvaluator thresholdEvaluator;
+
+    @Mock
+    private InventoryFactPublisher inventoryFactPublisher;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-07-24T00:00:00Z"), ZoneOffset.UTC);
+
+    private RevaluationServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RevaluationServiceImpl(
+                revaluationRepository,
+                costStateRepository,
+                costStateInitializer,
+                methodResolver,
+                thresholdEvaluator,
+                inventoryFactPublisher,
+                fixedClock);
+        setUpAuthenticatedActor();
+        // Mirror the DB @GeneratedValue: assign a UUIDv7 surrogate id on first save if absent.
+        lenient().when(revaluationRepository.save(any(RevaluationRecord.class))).thenAnswer(inv -> {
+            RevaluationRecord saved = inv.getArgument(0);
+            if (saved.getRevaluationId() == null) {
+                saved.setRevaluationId(UUID.randomUUID());
+            }
+            return saved;
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void autoAppliesBelowThresholdRestatesAverageAndEmitsFactWithCorrectDelta() {
+        SkuCostState state = state(new BigDecimal("4.000000"), null, 10L);
+        when(methodResolver.resolve(SKU)).thenReturn(CostingMethod.AVERAGE);
+        when(costStateRepository.findByStockItemId(SKU)).thenReturn(Optional.of(state));
+        // delta = (5.00 - 4.00) * 10 = 10.00, below all thresholds -> auto-apply
+        when(thresholdEvaluator.evaluateRevaluationApprovalTier(any())).thenReturn(Optional.empty());
+
+        RevaluationResponse response = service.createRevaluation(request(new BigDecimal("5.0000"), null));
+
+        assertThat(response.getStatus()).isEqualTo(RevaluationStatus.AUTO_APPLIED);
+        assertThat(response.getValueDelta()).isEqualByComparingTo("10.00");
+        assertThat(response.getCostingMethod()).isEqualTo(CostingMethod.AVERAGE);
+
+        // AVERAGE restates avgCost (not standardCost)
+        assertThat(state.getAvgCost()).isEqualByComparingTo("5.00");
+        assertThat(state.getStandardCost()).isNull();
+        verify(costStateRepository).save(state);
+
+        // value delta passed to the evaluator == Δcost × on-hand
+        ArgumentCaptor<BigDecimal> deltaCaptor = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(thresholdEvaluator).evaluateRevaluationApprovalTier(deltaCaptor.capture());
+        assertThat(deltaCaptor.getValue()).isEqualByComparingTo("10.00");
+
+        // fact carries old/new cost + delta
+        ArgumentCaptor<ProductValueChangedV1> factCaptor = ArgumentCaptor.forClass(ProductValueChangedV1.class);
+        verify(inventoryFactPublisher).recordProductValueChanged(factCaptor.capture());
+        ProductValueChangedV1 fact = factCaptor.getValue();
+        assertThat(fact.sku()).isEqualTo(SKU);
+        assertThat(fact.costingMethod()).isEqualTo("AVERAGE");
+        assertThat(fact.previousUnitCost()).isEqualByComparingTo("4.00");
+        assertThat(fact.newUnitCost()).isEqualByComparingTo("5.00");
+        assertThat(fact.onHandQuantity()).isEqualTo(10L);
+        assertThat(fact.totalValueDelta()).isEqualByComparingTo("10.00");
+        assertThat(fact.actor()).isEqualTo(ACTOR);
+    }
+
+    @Test
+    void aboveThresholdStaysPendingWithNoCostChangeOrFact() {
+        SkuCostState state = state(new BigDecimal("4.000000"), null, 200L);
+        when(methodResolver.resolve(SKU)).thenReturn(CostingMethod.AVERAGE);
+        when(costStateRepository.findByStockItemId(SKU)).thenReturn(Optional.of(state));
+        // delta = (9.00 - 4.00) * 200 = 1000.00 -> director tier required
+        when(thresholdEvaluator.evaluateRevaluationApprovalTier(any()))
+                .thenReturn(Optional.of(ApprovalTier.TIER_2_DIRECTOR));
+
+        RevaluationResponse response = service.createRevaluation(request(new BigDecimal("9.0000"), null));
+
+        assertThat(response.getStatus()).isEqualTo(RevaluationStatus.PENDING_APPROVAL);
+        assertThat(response.getRequiredApprovalTier()).isEqualTo(ApprovalTier.TIER_2_DIRECTOR);
+        assertThat(response.getValueDelta()).isEqualByComparingTo("1000.00");
+        // no cost change, no fact until approved
+        assertThat(state.getAvgCost()).isEqualByComparingTo("4.00");
+        verify(costStateRepository, never()).save(any());
+        verifyNoInteractions(inventoryFactPublisher);
+    }
+
+    @Test
+    void approveAppliesStandardCostAndEmitsFact() {
+        RevaluationRecord pending = RevaluationRecord.builder()
+                .revaluationId(UUID.randomUUID())
+                .stockItemId(SKU)
+                .costingMethod(CostingMethod.STANDARD)
+                .previousUnitCost(new BigDecimal("6.000000"))
+                .newUnitCost(new BigDecimal("8.000000"))
+                .onHandQuantity(150L)
+                .valueDelta(new BigDecimal("300.0000"))
+                .reason("Standard price correction")
+                .status(RevaluationStatus.PENDING_APPROVAL)
+                .requiredApprovalTier(ApprovalTier.TIER_1_MANAGER)
+                .createdBy("submitter")
+                .build();
+        SkuCostState state = state(new BigDecimal("2.000000"), new BigDecimal("6.000000"), 150L);
+        when(revaluationRepository.findById(pending.getRevaluationId())).thenReturn(Optional.of(pending));
+        when(costStateRepository.findByStockItemId(SKU)).thenReturn(Optional.of(state));
+
+        RevaluationResponse response = service.approveRevaluation(pending.getRevaluationId());
+
+        assertThat(response.getStatus()).isEqualTo(RevaluationStatus.APPLIED);
+        assertThat(response.getApprovedBy()).isEqualTo(ACTOR);
+        // STANDARD restates standardCost (not avgCost)
+        assertThat(state.getStandardCost()).isEqualByComparingTo("8.00");
+        assertThat(state.getAvgCost()).isEqualByComparingTo("2.00");
+        verify(costStateRepository).save(state);
+
+        ArgumentCaptor<ProductValueChangedV1> factCaptor = ArgumentCaptor.forClass(ProductValueChangedV1.class);
+        verify(inventoryFactPublisher).recordProductValueChanged(factCaptor.capture());
+        ProductValueChangedV1 fact = factCaptor.getValue();
+        assertThat(fact.costingMethod()).isEqualTo("STANDARD");
+        assertThat(fact.newUnitCost()).isEqualByComparingTo("8.00");
+        assertThat(fact.totalValueDelta()).isEqualByComparingTo("300.00");
+        assertThat(fact.actor()).isEqualTo(ACTOR);
+    }
+
+    @Test
+    void rejectLeavesCostStateUntouched() {
+        RevaluationRecord pending = RevaluationRecord.builder()
+                .revaluationId(UUID.randomUUID())
+                .stockItemId(SKU)
+                .costingMethod(CostingMethod.AVERAGE)
+                .newUnitCost(new BigDecimal("9.000000"))
+                .onHandQuantity(200L)
+                .valueDelta(new BigDecimal("1000.0000"))
+                .reason("r")
+                .status(RevaluationStatus.PENDING_APPROVAL)
+                .createdBy("submitter")
+                .build();
+        when(revaluationRepository.findById(pending.getRevaluationId())).thenReturn(Optional.of(pending));
+
+        RevaluationResponse response =
+                service.rejectRevaluation(pending.getRevaluationId(), reject("Disputed recount"));
+
+        assertThat(response.getStatus()).isEqualTo(RevaluationStatus.REJECTED);
+        assertThat(response.getRejectedBy()).isEqualTo(ACTOR);
+        assertThat(response.getRejectionReason()).isEqualTo("Disputed recount");
+        verify(costStateRepository, never()).save(any());
+        verifyNoInteractions(inventoryFactPublisher);
+    }
+
+    @Test
+    void costDeltaResolvesNewCostFromCurrent() {
+        SkuCostState state = state(new BigDecimal("4.000000"), null, 10L);
+        when(methodResolver.resolve(SKU)).thenReturn(CostingMethod.AVERAGE);
+        when(costStateRepository.findByStockItemId(SKU)).thenReturn(Optional.of(state));
+        when(thresholdEvaluator.evaluateRevaluationApprovalTier(any())).thenReturn(Optional.empty());
+
+        // costDelta -0.50 on current 4.00 => new 3.50, delta = -0.50 * 10 = -5.00
+        RevaluationResponse response = service.createRevaluation(request(null, new BigDecimal("-0.5000")));
+
+        assertThat(response.getNewUnitCost()).isEqualByComparingTo("3.50");
+        assertThat(response.getValueDelta()).isEqualByComparingTo("-5.00");
+        assertThat(state.getAvgCost()).isEqualByComparingTo("3.50");
+    }
+
+    @Test
+    void rejectsWhenNeitherOrBothCostFieldsSupplied() {
+        when(methodResolver.resolve(SKU)).thenReturn(CostingMethod.AVERAGE);
+        when(costStateRepository.findByStockItemId(SKU))
+                .thenReturn(Optional.of(state(new BigDecimal("4.000000"), null, 10L)));
+
+        assertThatThrownBy(() -> service.createRevaluation(request(null, null)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+        assertThatThrownBy(() -> service.createRevaluation(request(new BigDecimal("5.0000"), new BigDecimal("1.0000"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void seedsCostStateForUnseenSku() {
+        SkuCostState seeded = state(null, null, 0L);
+        when(methodResolver.resolve(SKU)).thenReturn(CostingMethod.STANDARD);
+        when(costStateRepository.findByStockItemId(SKU))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(seeded));
+        when(thresholdEvaluator.evaluateRevaluationApprovalTier(any())).thenReturn(Optional.empty());
+
+        RevaluationResponse response = service.createRevaluation(request(new BigDecimal("6.0000"), null));
+
+        verify(costStateInitializer).createRowIfAbsent(SKU);
+        assertThat(response.getStatus()).isEqualTo(RevaluationStatus.AUTO_APPLIED);
+        assertThat(response.getPreviousUnitCost()).isNull();
+        // onHand 0 => value delta 0
+        assertThat(response.getValueDelta()).isEqualByComparingTo("0.00");
+        assertThat(seeded.getStandardCost()).isEqualByComparingTo("6.00");
+    }
+
+    private SkuCostState state(BigDecimal avgCost, BigDecimal standardCost, long onHand) {
+        return SkuCostState.builder()
+                .costStateId(UUID.randomUUID())
+                .stockItemId(SKU)
+                .avgCost(avgCost)
+                .standardCost(standardCost)
+                .onHandQty(onHand)
+                .build();
+    }
+
+    private CreateRevaluationRequest request(BigDecimal newUnitCost, BigDecimal costDelta) {
+        return CreateRevaluationRequest.builder()
+                .stockItemId(SKU)
+                .newUnitCost(newUnitCost)
+                .costDelta(costDelta)
+                .reason("Q3 recount correction")
+                .build();
+    }
+
+    private RejectRevaluationRequest reject(String reason) {
+        return RejectRevaluationRequest.builder().rejectionReason(reason).build();
+    }
+
+    private void setUpAuthenticatedActor() {
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(ACTOR, "password");
+        authentication.setDetails(Map.of(
+                GatewaySecurityConstants.DETAIL_USER_ID,
+                "actor-person-id-001",
+                GatewaySecurityConstants.DETAIL_USERNAME,
+                ACTOR));
+        authentication.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/RevaluationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/RevaluationServiceImplTest.java
@@ -18,6 +18,7 @@ import com.positivity.inventory.internal.entity.SkuCostState;
 import com.positivity.inventory.internal.enums.ApprovalTier;
 import com.positivity.inventory.internal.enums.CostingMethod;
 import com.positivity.inventory.internal.enums.RevaluationStatus;
+import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.repository.RevaluationRecordRepository;
 import com.positivity.inventory.internal.repository.SkuCostStateRepository;
 import com.positivity.inventory.service.ApprovalThresholdEvaluator;
@@ -243,6 +244,17 @@ class RevaluationServiceImplTest {
         assertThatThrownBy(() -> service.createRevaluation(request(new BigDecimal("5.0000"), new BigDecimal("1.0000"))))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void missingRevaluationThrowsNotFound() {
+        UUID unknown = UUID.fromString("00000000-0000-0000-0000-0000000000ff");
+        when(revaluationRepository.findById(unknown)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.approveRevaluation(unknown)).isInstanceOf(ResourceNotFoundException.class);
+        assertThatThrownBy(() -> service.rejectRevaluation(unknown, new RejectRevaluationRequest("no")))
+                .isInstanceOf(ResourceNotFoundException.class);
+        assertThatThrownBy(() -> service.getRevaluation(unknown)).isInstanceOf(ResourceNotFoundException.class);
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayGenerationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayGenerationServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -15,9 +16,12 @@ import com.positivity.inventory.internal.entity.PutawayRule;
 import com.positivity.inventory.internal.entity.PutawayTask;
 import com.positivity.inventory.internal.enums.PutawayTaskStatus;
 import com.positivity.inventory.internal.exception.TaskNotFoundException;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
 import com.positivity.inventory.internal.repository.GoodsReceiptRepository;
 import com.positivity.inventory.internal.repository.PutawayRuleRepository;
 import com.positivity.inventory.internal.repository.PutawayTaskRepository;
+import com.positivity.inventory.internal.service.ProximitySourcingStrategy;
+import com.positivity.inventory.internal.service.PutawayDestinationResolver;
 import com.positivity.inventory.internal.service.PutawayGenerationServiceImpl;
 import java.util.Collections;
 import java.util.List;
@@ -43,12 +47,26 @@ class PutawayGenerationServiceImplTest {
     @Mock
     private GoodsReceiptRepository goodsReceiptRepository;
 
+    @Mock
+    private ExtStorageLocationReplicaRepository extStorageLocationReplicaRepository;
+
+    @Mock
+    private ProximitySourcingStrategy proximitySourcingStrategy;
+
+    @Mock
+    private PutawayValidationService putawayValidationService;
+
     private PutawayGenerationServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        service =
-                new PutawayGenerationServiceImpl(putawayRuleRepository, putawayTaskRepository, goodsReceiptRepository);
+        PutawayDestinationResolver destinationResolver = new PutawayDestinationResolver(
+                putawayTaskRepository,
+                extStorageLocationReplicaRepository,
+                proximitySourcingStrategy,
+                putawayValidationService);
+        service = new PutawayGenerationServiceImpl(
+                putawayRuleRepository, putawayTaskRepository, goodsReceiptRepository, destinationResolver);
         lenient()
                 .when(goodsReceiptRepository.findById(any(UUID.class)))
                 .thenAnswer(inv -> Optional.of(receipt(inv.getArgument(0))));
@@ -74,6 +92,67 @@ class PutawayGenerationServiceImplTest {
         PutawayTaskResponse response = responses.get(0);
         assertThat(response.getStatus()).isEqualTo(PutawayTaskStatus.UNASSIGNED.toString());
         assertThat(response.getSuggestedDestinationLocationId()).isEqualTo(DEST_A);
+    }
+
+    @Test
+    void generateTasksForReceipt_lastUsedRule_suggestsMostRecentlyUsedBin() {
+        UUID lastUsedBin = UUID.fromString("00000000-0000-0000-0000-0000000000d0");
+        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                .sourceReceiptId(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                .productId(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                .quantity(5)
+                .build();
+        PutawayRule rule = PutawayRule.builder()
+                .priority(1)
+                .destinationLocationId(DEST_A)
+                .destinationStrategy(com.positivity.inventory.internal.enums.PutawayDestinationStrategy.LAST_USED)
+                .build();
+        when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc()).thenReturn(List.of(rule));
+        when(putawayTaskRepository
+                        .findFirstByProductIdAndStatusAndActualDestinationLocationIdIsNotNullOrderByUpdatedAtDesc(
+                                any(UUID.class), eq(PutawayTaskStatus.COMPLETED)))
+                .thenReturn(Optional.of(PutawayTask.builder()
+                        .actualDestinationLocationId(lastUsedBin)
+                        .status(PutawayTaskStatus.COMPLETED)
+                        .build()));
+        when(putawayTaskRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<PutawayTaskResponse> responses = service.generateTasksForReceipt(request);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getSuggestedDestinationLocationId()).isEqualTo(lastUsedBin);
+        assertThat(responses.get(0).getFallbackReason()).isNull();
+    }
+
+    @Test
+    void generateTasksForReceipt_lastUsedRuleNeverUsed_fallsBackToFixedWithReason() {
+        GeneratePutawayTasksRequest request = GeneratePutawayTasksRequest.builder()
+                .sourceReceiptId(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                .productId(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001").toString())
+                .quantity(5)
+                .build();
+        PutawayRule rule = PutawayRule.builder()
+                .priority(1)
+                .destinationLocationId(DEST_A)
+                .destinationStrategy(com.positivity.inventory.internal.enums.PutawayDestinationStrategy.LAST_USED)
+                .build();
+        when(putawayRuleRepository.findAllByIsEnabledTrueOrderByPriorityAsc()).thenReturn(List.of(rule));
+        when(putawayTaskRepository
+                        .findFirstByProductIdAndStatusAndActualDestinationLocationIdIsNotNullOrderByUpdatedAtDesc(
+                                any(UUID.class), eq(PutawayTaskStatus.COMPLETED)))
+                .thenReturn(Optional.empty());
+        when(putawayTaskRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<PutawayTaskResponse> responses = service.generateTasksForReceipt(request);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getSuggestedDestinationLocationId()).isEqualTo(DEST_A);
+        assertThat(responses.get(0).getFallbackReason())
+                .isEqualTo(com.positivity.inventory.internal.enums.PutawayFallbackReason.UNAVAILABLE.name());
     }
 
     @Test

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 36;
+    public static final int CATALOG_VERSION = 37;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -501,7 +501,10 @@ public final class DownstreamPermissionCatalog {
         "PERM_inventory:lot:manage",                         // 415
 
         // ── New batch (bits 416–416) ──────────────────────────────────────────
-        "PERM_inventory:valuation:view"                     // 416
+        "PERM_inventory:valuation:view",                     // 416
+
+        // ── New batch (bits 417–417) ──────────────────────────────────────────
+        "PERM_inventory:valuation:adjust"                   // 417
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -541,13 +541,15 @@ public enum PermissionCode {
     // ── Inventory (new) ────────────────────────────────────────────────────────
     INVENTORY__LOT__MANAGE(415, "inventory:lot:manage"),
     // ── Inventory (new) ────────────────────────────────────────────────────────
-    INVENTORY__VALUATION__VIEW(416, "inventory:valuation:view");
+    INVENTORY__VALUATION__VIEW(416, "inventory:valuation:view"),
+    // ── Inventory (new) ────────────────────────────────────────────────────────
+    INVENTORY__VALUATION__ADJUST(417, "inventory:valuation:adjust");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 36;
+    public static final int CATALOG_VERSION = 37;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 417;
-    private static final int EXPECTED_CATALOG_VERSION = 36;
+    private static final int EXPECTED_PERMISSION_COUNT = 418;
+    private static final int EXPECTED_CATALOG_VERSION = 37;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — EXPECTED_PERMISSION_COUNT entries


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-inventory`
- Parent STORY (durion): the odoo-parity inventory plan `domains/inventory/plan-odoo-parity-pos-inventory.md` (Wave 7)
- Child issues: louisburroughs/durion-positivity-backend#1054, #1055 (#1056 J5 is **gated** — not in this PR)
- Domain: `domain:inventory`

## Contract References
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` — revaluation + `ProductValueChangedV1` fact surface
- Governing ADR: durion ADR-0048 (inventory-owned valuation with configurable costing method), ACCEPTED — J4 builds on it

## Contract Chain (Controller added — J4 RevaluationController)
- [x] OpenAPI annotations on the new revaluation endpoints
- [x] `pos-inventory/openapi.yaml` regenerated
- [ ] Angular SDK regeneration rides the next SDK refresh (batched across the odoo-parity waves)

## Scope
The final buildable wave of the odoo-parity inventory build.

- **J4 (#1054)** — approval-gated cost revaluation. `POST /v1/inventory/valuation/revaluations` (+ approve/reject/read) corrects a SKU's standard price (STANDARD) or running average (AVCO); impact (Δcost × on-hand) drives an approval tier reusing the D1 `ApprovalThresholdConfig` machinery (new `ApprovalFlowType.REVALUATION`, seeded $100 manager / $1000 director; auto-approve below threshold). On apply: `SkuCostState` updated atomically, `RevaluationRecord` audit written (V29), and a new **`ProductValueChangedV1`** fact emitted via the outbox (Odoo `product.value` analog: old/new cost, on-hand, signed value delta, reason, actor) for a future accounting revaluation-JE consumer. **New permission `inventory:valuation:adjust` → bit 417, CATALOG_VERSION 37, count 418.**
- **K2 (#1055)** — putaway sublocation strategies on `PutawayRule` (`FIXED` default / `LAST_USED` / `CLOSEST_AVAILABLE`; V30 additive column). `LAST_USED` targets the SKU's most-recent completed putaway destination (fixed fallback when never used); `CLOSEST_AVAILABLE` ranks site bins by reusing H1's `ProximitySourcingStrategy` (no topology re-implementation), gated on capacity — skips full bins, falls through nearest→next→fixed. FIXED and the no-rule path are byte-identical to pre-K2. No new permission.

**J5 (#1056, landed costs) is deliberately NOT in this PR** — it remains gated on confirmed accounting-side demand per the plan; the issue stays open as a gate marker.

Why: parity with Odoo's manual inventory revaluation (`stock.valuation.layer` manual adjustment) and putaway destination strategies.

## Tests
- [x] Unit tests added/updated (revaluation approval tiers + fact emission; putaway strategy resolution incl. capacity fallthrough)
- [x] Integration/behavioral coverage (revaluation service IT; putaway generation wiring; existing FIXED contract IT still guards the end-to-end path)
- [x] Provider fact test (`ProductValueChangedV1`)
- How to run: `./mvnw -pl pos-inventory -am test`; catalog pins `./mvnw -pl pos-api-gateway,pos-security-service -Dtest=PermissionCodeTest,SecurityGatewayConfigTest test`; full ArchUnit sweep `./mvnw -pl pos-archunit -am -Dtest='com/positivity/archunit/*' -Dsurefire.failIfNoSpecifiedTests=false test`

## Risk & Rollback
- Risk level: Low–Medium — J4 mutates `SkuCostState` only through an approval-gated flow; K2 changes putaway destination selection behind a per-rule strategy (default FIXED = unchanged).
- Rollback plan: revert the Wave-7 merge commit; Flyway V29–V30 are additive (new table + defaulted column); the new fact has no consumer yet so no downstream break.

## Checklist
- [x] Branch is the shared odoo-parity execution branch `claude/odoo-pos-inventory-comparison-ywp0ev`
- [x] PR title starts with `[CAP:odoo-parity-inventory]`
- [x] Links to child issues present
- [x] Contract guide referenced (BACKEND_CONTRACT_GUIDE.md)
- [x] Required CI checks passing (local: pos-inventory suites, both catalog pinned tests, full pos-archunit sweep green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0145oPegbQy1DY4DXPmnj6x3)_