### PR TITLE
perf(inventory): batch-load cost state in valuation read model

### DIFF
--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -51,6 +51,7 @@ import com.positivity.inventory.internal.exception.TransferLocationNotEligibleEx
 import com.positivity.inventory.internal.exception.TransferOrderNotFoundException;
 import com.positivity.inventory.internal.exception.TransferQuantityExceededException;
 import com.positivity.inventory.internal.exception.UomConversionUndefinedException;
+import com.positivity.inventory.internal.exception.ValuationAsOfSkuCapExceededException;
 import com.positivity.inventory.internal.exception.WorkorderClosedException;
 import com.positivity.inventory.internal.exception.WorkorderConsumptionException;
 import com.positivity.shared.error.ApiError;
@@ -192,6 +193,11 @@ public class InventoryGlobalExceptionHandler {
     public ResponseEntity<ApiError> handleAsOfInFuture(AsOfInFutureException ex) {
         // odoo-parity A3 (#1029): deterministic 422 for future-dated point-in-time queries.
         return build(HttpStatus.valueOf(422), "AS_OF_IN_FUTURE", ex.getMessage());
+    }
+
+    @ExceptionHandler(ValuationAsOfSkuCapExceededException.class)
+    public ResponseEntity<ApiError> handleValuationAsOfSkuCapExceeded(ValuationAsOfSkuCapExceededException ex) {
+        return build(HttpStatus.valueOf(422), ValuationAsOfSkuCapExceededException.ERROR_CODE, ex.getMessage());
     }
 
     @ExceptionHandler(SnoozeUntilNotInFutureException.class)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ValuationController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ValuationController.java
@@ -56,8 +56,9 @@ public class ValuationController {
                     + " sourced from each SKU's running cost state per its resolved costing method (AVERAGE or"
                     + " STANDARD); uncosted SKUs report a null unit cost and zero value. With 'asOf', the"
                     + " valuation is reconstructed from the ledger as of that instant (on-hand and unit cost both"
-                    + " replayed); as-of requests additionally require 'inventory:ledger:view' and reject future"
-                    + " instants with 422.",
+                    + " replayed); as-of requests additionally require 'inventory:ledger:view', reject future"
+                    + " instants with 422, and may reject uncapped full-catalog requests with 422 when the"
+                    + " SKU fan-out exceeds the configured safety cap.",
             tags = {"Inventory Valuation"})
     @ApiResponse(
             responseCode = "200",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/ValuationAsOfSkuCapExceededException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/ValuationAsOfSkuCapExceededException.java
@@ -1,0 +1,13 @@
+package com.positivity.inventory.internal.exception;
+
+/**
+ * Raised when a full-catalog as-of valuation would process too many SKUs for one request.
+ */
+public class ValuationAsOfSkuCapExceededException extends RuntimeException {
+    public static final String ERROR_CODE = "VALUATION_AS_OF_SKU_CAP_EXCEEDED";
+
+    public ValuationAsOfSkuCapExceededException(int skuCount, int cap) {
+        super("as-of valuation rejected: " + skuCount + " SKUs exceed cap " + cap
+                + "; refine with sku/location filters or use smaller windows");
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CostingMethodConfigRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/CostingMethodConfigRepository.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.internal.repository;
 
 import com.positivity.inventory.internal.entity.CostingMethodConfig;
 import com.positivity.inventory.internal.enums.CostingScopeType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -16,6 +17,9 @@ public interface CostingMethodConfigRepository extends JpaRepository<CostingMeth
 
     Optional<CostingMethodConfig> findByScopeTypeAndScopeValueAndActiveTrue(
             CostingScopeType scopeType, String scopeValue);
+
+    List<CostingMethodConfig> findByScopeTypeAndScopeValueInAndActiveTrue(
+            CostingScopeType scopeType, Collection<String> scopeValues);
 
     Optional<CostingMethodConfig> findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType scopeType);
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
@@ -266,6 +266,16 @@ public interface InventoryLedgerEntryRepository
                     String stockItemId, Collection<InventoryLedgerEventType> eventTypes, java.time.Instant asOf);
 
     /**
+     * Ordered on-hand-affecting entry stream for multiple SKUs up to an instant (timestamp
+     * inclusive), grouped by stock item id and ordered deterministically within each SKU.
+     */
+    List<InventoryLedgerEntry>
+            findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                    Collection<String> stockItemIds,
+                    Collection<InventoryLedgerEventType> eventTypes,
+                    java.time.Instant asOf);
+
+    /**
      * Sum of {@code changeInQuantity} for one event type attributed to a source
      * transaction (allocation ledger events carry the allocation id as
      * {@code sourceTransactionId}). Used to derive how much of an allocation

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/SkuCostStateRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/SkuCostStateRepository.java
@@ -1,6 +1,8 @@
 package com.positivity.inventory.internal.repository;
 
 import com.positivity.inventory.internal.entity.SkuCostState;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +11,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SkuCostStateRepository extends JpaRepository<SkuCostState, UUID> {
 
     Optional<SkuCostState> findByStockItemId(String stockItemId);
+
+    List<SkuCostState> findByStockItemIdIn(Collection<String> stockItemIds);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CostingMethodResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CostingMethodResolver.java
@@ -86,12 +86,15 @@ public class CostingMethodResolver {
             }
         }
 
-        CostingMethod fallback = configRepository
-                .findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT)
-                .map(CostingMethodConfig::getMethod)
-                .orElse(defaultMethod);
-
-        stockItemIds.forEach(skuId -> resolved.putIfAbsent(skuId, fallback));
+        Set<String> stillUnresolved = new HashSet<>(stockItemIds);
+        stillUnresolved.removeAll(resolved.keySet());
+        if (!stillUnresolved.isEmpty()) {
+            CostingMethod fallback = configRepository
+                    .findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT)
+                    .map(CostingMethodConfig::getMethod)
+                    .orElse(defaultMethod);
+            stillUnresolved.forEach(skuId -> resolved.putIfAbsent(skuId, fallback));
+        }
         return Map.copyOf(resolved);
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CostingMethodResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CostingMethodResolver.java
@@ -4,7 +4,10 @@ import com.positivity.inventory.internal.entity.CostingMethodConfig;
 import com.positivity.inventory.internal.enums.CostingMethod;
 import com.positivity.inventory.internal.enums.CostingScopeType;
 import com.positivity.inventory.internal.repository.CostingMethodConfigRepository;
-import java.util.Optional;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -48,25 +51,47 @@ public class CostingMethodResolver {
 
     /** Resolves the effective costing method for one SKU. */
     public @NonNull CostingMethod resolve(@NonNull String stockItemId) {
-        Optional<CostingMethod> bySku = configRepository
-                .findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, stockItemId)
-                .map(CostingMethodConfig::getMethod);
-        if (bySku.isPresent()) {
-            return bySku.get();
+        return resolveAll(Set.of(stockItemId)).get(stockItemId);
+    }
+
+    /** Resolves the effective costing method for many SKUs in one repository round-trip per scope. */
+    public @NonNull Map<String, CostingMethod> resolveAll(@NonNull Set<String> stockItemIds) {
+        if (stockItemIds.isEmpty()) {
+            return Map.of();
         }
 
-        Optional<CostingMethod> byCategory = skuCategoryProvider
-                .categoryOf(stockItemId)
-                .flatMap(category -> configRepository.findByScopeTypeAndScopeValueAndActiveTrue(
-                        CostingScopeType.SKU_CATEGORY, category))
-                .map(CostingMethodConfig::getMethod);
-        if (byCategory.isPresent()) {
-            return byCategory.get();
+        Map<String, CostingMethod> resolved = new HashMap<>(stockItemIds.size());
+
+        configRepository
+                .findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, stockItemIds)
+                .forEach(config -> resolved.put(config.getScopeValue(), config.getMethod()));
+
+        Set<String> unresolved = new HashSet<>(stockItemIds);
+        unresolved.removeAll(resolved.keySet());
+
+        if (!unresolved.isEmpty()) {
+            Map<String, String> categoryBySku = skuCategoryProvider.categoryOfAll(unresolved);
+            if (!categoryBySku.isEmpty()) {
+                Set<String> categories = new HashSet<>(categoryBySku.values());
+                Map<String, CostingMethod> categoryMethods = new HashMap<>(categories.size());
+                configRepository
+                        .findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU_CATEGORY, categories)
+                        .forEach(config -> categoryMethods.put(config.getScopeValue(), config.getMethod()));
+                categoryBySku.forEach((skuId, category) -> {
+                    CostingMethod method = categoryMethods.get(category);
+                    if (method != null) {
+                        resolved.putIfAbsent(skuId, method);
+                    }
+                });
+            }
         }
 
-        return configRepository
+        CostingMethod fallback = configRepository
                 .findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT)
                 .map(CostingMethodConfig::getMethod)
                 .orElse(defaultMethod);
+
+        stockItemIds.forEach(skuId -> resolved.putIfAbsent(skuId, fallback));
+        return Map.copyOf(resolved);
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SkuCategoryProvider.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SkuCategoryProvider.java
@@ -1,5 +1,8 @@
 package com.positivity.inventory.internal.service;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.jspecify.annotations.NonNull;
 
@@ -18,4 +21,16 @@ public interface SkuCategoryProvider {
     /** The SKU's category, or empty when no category source exists. */
     @NonNull
     Optional<String> categoryOf(@NonNull String stockItemId);
+
+    /** Batch variant for callers that need categories for many SKUs. */
+    default @NonNull Map<String, String> categoryOfAll(@NonNull Collection<String> stockItemIds) {
+        if (stockItemIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, String> categories = new HashMap<>();
+        for (String stockItemId : stockItemIds) {
+            categoryOf(stockItemId).ifPresent(category -> categories.put(stockItemId, category));
+        }
+        return Map.copyOf(categories);
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ValuationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ValuationServiceImpl.java
@@ -109,7 +109,7 @@ public class ValuationServiceImpl implements ValuationService {
 
         Set<InventoryLedgerEventType> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes();
         List<SkuQty> onHands = asOfOnHands(locationId, sku, onHandTypes, asOf);
-        if ((sku == null || sku.isBlank()) && onHands.size() > asOfSkuCap) {
+        if (locationId == null && (sku == null || sku.isBlank()) && onHands.size() > asOfSkuCap) {
             throw new ValuationAsOfSkuCapExceededException(onHands.size(), asOfSkuCap);
         }
         Set<String> stockItemIds = stockItemIds(onHands);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ValuationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ValuationServiceImpl.java
@@ -109,9 +109,7 @@ public class ValuationServiceImpl implements ValuationService {
 
         Set<InventoryLedgerEventType> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes();
         List<SkuQty> onHands = asOfOnHands(locationId, sku, onHandTypes, asOf);
-        if (locationId == null && (sku == null || sku.isBlank()) && onHands.size() > asOfSkuCap) {
-            throw new ValuationAsOfSkuCapExceededException(onHands.size(), asOfSkuCap);
-        }
+        enforceFullCatalogAsOfCap(locationId, sku, onHands.size());
         Set<String> stockItemIds = stockItemIds(onHands);
         Map<String, CostingMethod> methods = methodResolver.resolveAll(stockItemIds);
         Map<String, SkuCostState> costStates = findCostStatesByStockItemId(stockItemIds);
@@ -207,6 +205,16 @@ public class ValuationServiceImpl implements ValuationService {
             stockItemIds.add(onHand.stockItemId());
         }
         return stockItemIds;
+    }
+
+    private void enforceFullCatalogAsOfCap(@Nullable UUID locationId, @Nullable String sku, int skuCount) {
+        if (isFullCatalogAsOf(locationId, sku) && skuCount > asOfSkuCap) {
+            throw new ValuationAsOfSkuCapExceededException(skuCount, asOfSkuCap);
+        }
+    }
+
+    private static boolean isFullCatalogAsOf(@Nullable UUID locationId, @Nullable String sku) {
+        return locationId == null && (sku == null || sku.isBlank());
     }
 
     private Map<String, SkuCostState> findCostStatesByStockItemId(Set<String> stockItemIds) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ValuationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ValuationServiceImpl.java
@@ -6,6 +6,7 @@ import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.entity.SkuCostState;
 import com.positivity.inventory.internal.enums.CostingMethod;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.exception.ValuationAsOfSkuCapExceededException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.SkuCostStateRepository;
@@ -15,12 +16,15 @@ import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +60,7 @@ public class ValuationServiceImpl implements ValuationService {
     private final SkuCostStateRepository costStateRepository;
     private final CostingMethodResolver methodResolver;
     private final AsOfQueryGuard asOfQueryGuard;
+    private final int asOfSkuCap;
     private final Map<CostingMethod, CostingStrategy> strategies;
 
     public ValuationServiceImpl(
@@ -64,12 +69,14 @@ public class ValuationServiceImpl implements ValuationService {
             SkuCostStateRepository costStateRepository,
             CostingMethodResolver methodResolver,
             AsOfQueryGuard asOfQueryGuard,
-            List<CostingStrategy> costingStrategies) {
+            List<CostingStrategy> costingStrategies,
+            @Value("${pos.inventory.valuation.as-of-sku-cap:1000}") int asOfSkuCap) {
         this.stockSummaryRepository = stockSummaryRepository;
         this.ledgerRepository = ledgerRepository;
         this.costStateRepository = costStateRepository;
         this.methodResolver = methodResolver;
         this.asOfQueryGuard = asOfQueryGuard;
+        this.asOfSkuCap = asOfSkuCap;
         this.strategies = new EnumMap<>(CostingMethod.class);
         for (CostingStrategy strategy : costingStrategies) {
             this.strategies.put(strategy.method(), strategy);
@@ -81,10 +88,13 @@ public class ValuationServiceImpl implements ValuationService {
     @NonNull
     public ValuationReportResponse getValuation(@Nullable UUID locationId, @Nullable String sku) {
         List<SkuQty> onHands = currentOnHands(locationId, sku);
+        Set<String> stockItemIds = stockItemIds(onHands);
+        Map<String, CostingMethod> methods = methodResolver.resolveAll(stockItemIds);
+        Map<String, SkuCostState> costStates = findCostStatesByStockItemId(stockItemIds);
         List<ValuationRow> rows = new ArrayList<>(onHands.size());
         for (SkuQty item : onHands) {
-            CostingMethod method = methodResolver.resolve(item.stockItemId());
-            BigDecimal unitCost = currentUnitCost(item.stockItemId(), method);
+            CostingMethod method = methods.get(item.stockItemId());
+            BigDecimal unitCost = currentUnitCost(costStates.get(item.stockItemId()), method);
             rows.add(buildRow(item.stockItemId(), item.onHand(), method, unitCost));
         }
         return report(locationId, null, rows);
@@ -99,10 +109,22 @@ public class ValuationServiceImpl implements ValuationService {
 
         Set<InventoryLedgerEventType> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes();
         List<SkuQty> onHands = asOfOnHands(locationId, sku, onHandTypes, asOf);
+        if ((sku == null || sku.isBlank()) && onHands.size() > asOfSkuCap) {
+            throw new ValuationAsOfSkuCapExceededException(onHands.size(), asOfSkuCap);
+        }
+        Set<String> stockItemIds = stockItemIds(onHands);
+        Map<String, CostingMethod> methods = methodResolver.resolveAll(stockItemIds);
+        Map<String, SkuCostState> costStates = findCostStatesByStockItemId(stockItemIds);
+        Map<String, List<InventoryLedgerEntry>> entriesBySku =
+                asOfEntriesByStockItemId(stockItemIds, onHandTypes, asOf);
         List<ValuationRow> rows = new ArrayList<>(onHands.size());
         for (SkuQty item : onHands) {
-            CostingMethod method = methodResolver.resolve(item.stockItemId());
-            BigDecimal unitCost = unitCostAsOf(item.stockItemId(), method, onHandTypes, asOf);
+            CostingMethod method = methods.get(item.stockItemId());
+            BigDecimal standardCost = costStates.containsKey(item.stockItemId())
+                    ? costStates.get(item.stockItemId()).getStandardCost()
+                    : null;
+            BigDecimal unitCost = unitCostAsOf(
+                    item.stockItemId(), method, standardCost, entriesBySku.getOrDefault(item.stockItemId(), List.of()));
             rows.add(buildRow(item.stockItemId(), item.onHand(), method, unitCost));
         }
         return report(locationId, asOf, rows);
@@ -159,8 +181,7 @@ public class ValuationServiceImpl implements ValuationService {
 
     // ─── Unit cost derivation ────────────────────────────────────────────────
 
-    private @Nullable BigDecimal currentUnitCost(String sku, CostingMethod method) {
-        SkuCostState state = costStateRepository.findByStockItemId(sku).orElse(null);
+    private @Nullable BigDecimal currentUnitCost(@Nullable SkuCostState state, CostingMethod method) {
         if (state == null) {
             return null;
         }
@@ -168,25 +189,51 @@ public class ValuationServiceImpl implements ValuationService {
     }
 
     private @Nullable BigDecimal unitCostAsOf(
-            String sku, CostingMethod method, Set<InventoryLedgerEventType> onHandTypes, Instant asOf) {
+            String sku, CostingMethod method, @Nullable BigDecimal standardCost, List<InventoryLedgerEntry> entries) {
         CostingStrategy strategy = strategy(method);
-        // The standard price is not carried on the ledger; seed it from the current cost state.
-        BigDecimal standardCost = costStateRepository
-                .findByStockItemId(sku)
-                .map(SkuCostState::getStandardCost)
-                .orElse(null);
-
         CostingStrategy.CostState state = new CostingStrategy.CostState(null, 0L, standardCost);
-        for (InventoryLedgerEntry entry :
-                ledgerRepository
-                        .findByStockItemIdAndEventTypeInAndTimestampLessThanEqualOrderByTimestampAscLedgerEntryIdAsc(
-                                sku, onHandTypes, asOf)) {
+        for (InventoryLedgerEntry entry : entries) {
             int change = entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
             CostingStrategy.CostingInput input =
                     new CostingStrategy.CostingInput(sku, entry.getEventType(), change, entry.getUnitCost(), state);
             state = strategy.cost(input).state();
         }
         return deriveUnitCost(state.avgCost(), state.standardCost(), method);
+    }
+
+    private static Set<String> stockItemIds(List<SkuQty> onHands) {
+        Set<String> stockItemIds = new HashSet<>(onHands.size());
+        for (SkuQty onHand : onHands) {
+            stockItemIds.add(onHand.stockItemId());
+        }
+        return stockItemIds;
+    }
+
+    private Map<String, SkuCostState> findCostStatesByStockItemId(Set<String> stockItemIds) {
+        if (stockItemIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, SkuCostState> costStates = new HashMap<>(stockItemIds.size());
+        for (SkuCostState state : costStateRepository.findByStockItemIdIn(stockItemIds)) {
+            costStates.put(state.getStockItemId(), state);
+        }
+        return Map.copyOf(costStates);
+    }
+
+    private Map<String, List<InventoryLedgerEntry>> asOfEntriesByStockItemId(
+            Set<String> stockItemIds, Set<InventoryLedgerEventType> onHandTypes, Instant asOf) {
+        if (stockItemIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, List<InventoryLedgerEntry>> entriesBySku = new HashMap<>(stockItemIds.size());
+        for (InventoryLedgerEntry entry : ledgerRepository
+                .findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                        stockItemIds, onHandTypes, asOf)) {
+            entriesBySku
+                    .computeIfAbsent(entry.getStockItemId(), ignored -> new ArrayList<>())
+                    .add(entry);
+        }
+        return Map.copyOf(entriesBySku);
     }
 
     /**

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CostingMethodResolverTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CostingMethodResolverTest.java
@@ -1,13 +1,22 @@
 package com.positivity.inventory.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.inventory.internal.entity.CostingMethodConfig;
 import com.positivity.inventory.internal.enums.CostingMethod;
 import com.positivity.inventory.internal.enums.CostingScopeType;
 import com.positivity.inventory.internal.repository.CostingMethodConfigRepository;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,68 +31,102 @@ class CostingMethodResolverTest {
     @Mock
     private CostingMethodConfigRepository configRepository;
 
-    private static final String SKU = "SKU-1";
+    @Mock
+    private SkuCategoryProvider skuCategoryProvider;
 
-    private CostingMethodResolver resolver(SkuCategoryProvider categoryProvider) {
-        return new CostingMethodResolver(configRepository, categoryProvider, CostingMethod.AVERAGE);
+    private static final String SKU_A = "SKU-A";
+    private static final String SKU_B = "SKU-B";
+    private static final String SKU_C = "SKU-C";
+    private static final String SKU_D = "SKU-D";
+
+    private CostingMethodResolver resolver(CostingMethod defaultMethod) {
+        return new CostingMethodResolver(configRepository, skuCategoryProvider, defaultMethod);
     }
 
-    private CostingMethodConfig config(CostingMethod method) {
-        return CostingMethodConfig.builder().method(method).build();
+    private CostingMethodConfig config(CostingScopeType scopeType, String scopeValue, CostingMethod method) {
+        return CostingMethodConfig.builder()
+                .scopeType(scopeType)
+                .scopeValue(scopeValue)
+                .method(method)
+                .active(true)
+                .build();
     }
 
     @Test
-    @DisplayName("no config anywhere: falls through to the deployment default")
-    void noConfig_returnsDeploymentDefault() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.empty());
+    @DisplayName("resolveAll applies SKU > category > DEFAULT precedence in one batched pass")
+    void resolveAll_appliesSkuCategoryDefaultPrecedence() {
+        CostingMethodResolver resolver = resolver(CostingMethod.AVERAGE);
+        Set<String> stockItems = Set.of(SKU_A, SKU_B, SKU_C, SKU_D);
+
+        when(configRepository.findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, stockItems))
+                .thenReturn(List.of(config(CostingScopeType.SKU, SKU_A, CostingMethod.STANDARD)));
+        when(skuCategoryProvider.categoryOfAll(Set.of(SKU_B, SKU_C, SKU_D)))
+                .thenReturn(Map.of(SKU_B, "CAT-1", SKU_C, "CAT-2"));
+        when(configRepository.findByScopeTypeAndScopeValueInAndActiveTrue(
+                        CostingScopeType.SKU_CATEGORY, Set.of("CAT-1", "CAT-2")))
+                .thenReturn(List.of(config(CostingScopeType.SKU_CATEGORY, "CAT-1", CostingMethod.AVERAGE)));
+        when(configRepository.findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT))
+                .thenReturn(Optional.of(config(CostingScopeType.DEFAULT, null, CostingMethod.STANDARD)));
+
+        Map<String, CostingMethod> resolved = resolver.resolveAll(stockItems);
+
+        assertThat(resolved).containsEntry(SKU_A, CostingMethod.STANDARD);
+        assertThat(resolved).containsEntry(SKU_B, CostingMethod.AVERAGE);
+        assertThat(resolved).containsEntry(SKU_C, CostingMethod.STANDARD);
+        assertThat(resolved).containsEntry(SKU_D, CostingMethod.STANDARD);
+        assertThat(resolved).hasSize(4);
+
+        verify(configRepository).findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, stockItems);
+        verify(skuCategoryProvider).categoryOfAll(Set.of(SKU_B, SKU_C, SKU_D));
+        verify(configRepository)
+                .findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU_CATEGORY, Set.of("CAT-1", "CAT-2"));
+        verify(configRepository).findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT);
+        verify(configRepository, never()).findByScopeTypeAndScopeValueAndActiveTrue(any(), anyString());
+        verify(skuCategoryProvider, never()).categoryOf(anyString());
+    }
+
+    @Test
+    @DisplayName("resolveAll falls back to deployment default when DEFAULT row is absent")
+    void resolveAll_noDefaultRow_usesDeploymentDefault() {
+        CostingMethodResolver resolver = resolver(CostingMethod.STANDARD);
+
+        when(configRepository.findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, Set.of(SKU_A)))
+                .thenReturn(List.of());
+        when(skuCategoryProvider.categoryOfAll(Set.of(SKU_A))).thenReturn(Map.of());
         when(configRepository.findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT))
                 .thenReturn(Optional.empty());
 
-        assertThat(resolver(new NoOpSkuCategoryProvider()).resolve(SKU)).isEqualTo(CostingMethod.AVERAGE);
+        Map<String, CostingMethod> resolved = resolver.resolveAll(Set.of(SKU_A));
+
+        assertThat(resolved).containsExactly(Map.entry(SKU_A, CostingMethod.STANDARD));
+        verify(configRepository, never())
+                .findByScopeTypeAndScopeValueInAndActiveTrue(eq(CostingScopeType.SKU_CATEGORY), anyCollection());
+        verify(configRepository, never()).findByScopeTypeAndScopeValueAndActiveTrue(any(), anyString());
     }
 
     @Test
-    @DisplayName("DEFAULT config row wins over the deployment default")
-    void defaultConfigRow_winsOverDeploymentDefault() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.empty());
-        when(configRepository.findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT))
-                .thenReturn(Optional.of(config(CostingMethod.STANDARD)));
+    @DisplayName("resolve delegates to resolveAll path so lookup stays batched")
+    void resolve_delegatesToResolveAllBatchedPath() {
+        CostingMethodResolver resolver = resolver(CostingMethod.AVERAGE);
 
-        assertThat(resolver(new NoOpSkuCategoryProvider()).resolve(SKU)).isEqualTo(CostingMethod.STANDARD);
+        when(configRepository.findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, Set.of(SKU_A)))
+                .thenReturn(List.of(config(CostingScopeType.SKU, SKU_A, CostingMethod.STANDARD)));
+
+        CostingMethod resolved = resolver.resolve(SKU_A);
+
+        assertThat(resolved).isEqualTo(CostingMethod.STANDARD);
+        verify(configRepository).findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, Set.of(SKU_A));
+        verify(configRepository, never()).findByScopeTypeAndScopeValueAndActiveTrue(any(), anyString());
     }
 
     @Test
-    @DisplayName("per-SKU config wins over everything")
-    void skuConfig_winsOverAll() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.of(config(CostingMethod.STANDARD)));
+    @DisplayName("resolveAll with empty input returns empty and hits no collaborators")
+    void resolveAll_emptyInput_returnsEmptyWithoutCalls() {
+        CostingMethodResolver resolver = resolver(CostingMethod.AVERAGE);
 
-        assertThat(resolver(new NoOpSkuCategoryProvider()).resolve(SKU)).isEqualTo(CostingMethod.STANDARD);
-    }
-
-    @Test
-    @DisplayName("category-scoped config is unresolvable with the NoOp provider: skips to DEFAULT")
-    void categoryUnresolvable_skipsToDefault() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.empty());
-        when(configRepository.findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT))
-                .thenReturn(Optional.of(config(CostingMethod.AVERAGE)));
-
-        // NoOp provider returns no category, so SKU_CATEGORY rows are never consulted.
-        assertThat(resolver(new NoOpSkuCategoryProvider()).resolve(SKU)).isEqualTo(CostingMethod.AVERAGE);
-    }
-
-    @Test
-    @DisplayName("when a category IS resolvable, its config row is consulted between SKU and DEFAULT")
-    void categoryResolvable_categoryConfigConsulted() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.empty());
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU_CATEGORY, "CAT-1"))
-                .thenReturn(Optional.of(config(CostingMethod.STANDARD)));
-
-        SkuCategoryProvider provider = stockItemId -> Optional.of("CAT-1");
-        assertThat(resolver(provider).resolve(SKU)).isEqualTo(CostingMethod.STANDARD);
+        assertThat(resolver.resolveAll(Set.of())).isEmpty();
+        verify(configRepository, never()).findByScopeTypeAndScopeValueInAndActiveTrue(any(), anyCollection());
+        verify(configRepository, never()).findByScopeTypeAndScopeValueIsNullAndActiveTrue(any());
+        verify(skuCategoryProvider, never()).categoryOfAll(anyCollection());
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ValuationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ValuationServiceImplTest.java
@@ -371,6 +371,30 @@ class ValuationServiceImplTest {
     }
 
     @Test
+    void asOfValuation_multipleSkus_usesBulkReplayQueryOnce() {
+        when(ledgerRepository.sumOnHandBySkuAsOf(any(), eq(AS_OF)))
+                .thenReturn(List.of(ledgerSkuOnHand(SKU_A, 2L), ledgerSkuOnHand(SKU_B, 3L)));
+        when(methodResolver.resolveAll(anySet()))
+                .thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE, SKU_B, CostingMethod.AVERAGE));
+        when(costStateRepository.findByStockItemIdIn(anyCollection())).thenReturn(List.of());
+        when(ledgerRepository
+                        .findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                                anyCollection(), any(), eq(AS_OF)))
+                .thenReturn(List.of(
+                        entry(SKU_A, InventoryLedgerEventType.GOODS_RECEIPT, 2, new BigDecimal("5.0000")),
+                        entry(SKU_B, InventoryLedgerEventType.GOODS_RECEIPT, 3, new BigDecimal("7.0000"))));
+
+        ValuationReportResponse report = service.getValuationAsOf(null, null, AS_OF);
+
+        assertThat(report.getTotalOnHandValue()).isEqualByComparingTo("31.0000");
+        verify(methodResolver, times(1)).resolveAll(anySet());
+        verify(costStateRepository, times(1)).findByStockItemIdIn(anyCollection());
+        verify(ledgerRepository, times(1))
+                .findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                        anyCollection(), any(), eq(AS_OF));
+    }
+
+    @Test
     void asOfValuation_fullCatalog_exceedingCap_throws422DomainException() {
         ValuationServiceImpl smallCapService = new ValuationServiceImpl(
                 stockSummaryRepository,
@@ -386,5 +410,33 @@ class ValuationServiceImplTest {
         assertThatThrownBy(() -> smallCapService.getValuationAsOf(null, null, AS_OF))
                 .isInstanceOf(com.positivity.inventory.internal.exception.ValuationAsOfSkuCapExceededException.class)
                 .hasMessageContaining("exceed cap");
+    }
+
+    @Test
+    void asOfValuation_locationScoped_exceedingCap_doesNotThrow() {
+        ValuationServiceImpl smallCapService = new ValuationServiceImpl(
+                stockSummaryRepository,
+                ledgerRepository,
+                costStateRepository,
+                methodResolver,
+                asOfQueryGuard,
+                List.of(new AverageCostingStrategy(), new StandardCostingStrategy()),
+                1);
+        when(ledgerRepository.findPositiveOnHandByLocationAsOf(eq(LOC_1), any(), eq(AS_OF)))
+                .thenReturn(List.of(ledgerSkuOnHand(SKU_A, 1L), ledgerSkuOnHand(SKU_B, 1L)));
+        when(methodResolver.resolveAll(anySet()))
+                .thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE, SKU_B, CostingMethod.AVERAGE));
+        when(costStateRepository.findByStockItemIdIn(anyCollection())).thenReturn(List.of());
+        when(ledgerRepository
+                        .findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                                anyCollection(), any(), eq(AS_OF)))
+                .thenReturn(List.of(
+                        entry(SKU_A, InventoryLedgerEventType.GOODS_RECEIPT, 1, new BigDecimal("2.0000")),
+                        entry(SKU_B, InventoryLedgerEventType.GOODS_RECEIPT, 1, new BigDecimal("3.0000"))));
+
+        ValuationReportResponse report = smallCapService.getValuationAsOf(LOC_1, null, AS_OF);
+
+        assertThat(report.getRows()).hasSize(2);
+        assertThat(report.getTotalOnHandValue()).isEqualByComparingTo("5.0000");
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ValuationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ValuationServiceImplTest.java
@@ -1,9 +1,14 @@
 package com.positivity.inventory.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.inventory.internal.dto.valuation.ValuationReportResponse;
@@ -19,6 +24,7 @@ import com.positivity.inventory.internal.repository.SkuCostStateRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,7 +72,15 @@ class ValuationServiceImplTest {
                 costStateRepository,
                 methodResolver,
                 asOfQueryGuard,
-                List.of(new AverageCostingStrategy(), new StandardCostingStrategy()));
+                List.of(new AverageCostingStrategy(), new StandardCostingStrategy()),
+                1000);
+        lenient().when(methodResolver.resolveAll(anySet())).thenReturn(Map.of());
+        lenient().when(costStateRepository.findByStockItemIdIn(anyCollection())).thenReturn(List.of());
+        lenient()
+                .when(ledgerRepository
+                        .findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                                anyCollection(), any(), any()))
+                .thenReturn(List.of());
     }
 
     private static SkuCostState costState(String sku, BigDecimal avg, BigDecimal std, long qty) {
@@ -106,8 +120,10 @@ class ValuationServiceImplTest {
         };
     }
 
-    private static InventoryLedgerEntry entry(InventoryLedgerEventType type, int change, BigDecimal unitCost) {
+    private static InventoryLedgerEntry entry(
+            String sku, InventoryLedgerEventType type, int change, BigDecimal unitCost) {
         return InventoryLedgerEntry.builder()
+                .stockItemId(sku)
                 .eventType(type)
                 .changeInQuantity(change)
                 .unitCost(unitCost)
@@ -119,9 +135,9 @@ class ValuationServiceImplTest {
     @Test
     void currentValuation_average_valueIsOnHandTimesAvgCost() {
         when(stockSummaryRepository.sumOnHandBySku()).thenReturn(List.of(skuOnHand(SKU_A, 20L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.AVERAGE);
-        when(costStateRepository.findByStockItemId(SKU_A))
-                .thenReturn(Optional.of(costState(SKU_A, new BigDecimal("6.000000"), null, 20L)));
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE));
+        when(costStateRepository.findByStockItemIdIn(anyCollection()))
+                .thenReturn(List.of(costState(SKU_A, new BigDecimal("6.000000"), null, 20L)));
 
         ValuationReportResponse report = service.getValuation(null, null);
 
@@ -142,9 +158,9 @@ class ValuationServiceImplTest {
     @Test
     void currentValuation_standard_usesStandardPrice() {
         when(stockSummaryRepository.sumOnHandBySku()).thenReturn(List.of(skuOnHand(SKU_A, 10L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.STANDARD);
-        when(costStateRepository.findByStockItemId(SKU_A))
-                .thenReturn(Optional.of(costState(SKU_A, new BigDecimal("6.500000"), new BigDecimal("8.000000"), 10L)));
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.STANDARD));
+        when(costStateRepository.findByStockItemIdIn(anyCollection()))
+                .thenReturn(List.of(costState(SKU_A, new BigDecimal("6.500000"), new BigDecimal("8.000000"), 10L)));
 
         ValuationReportResponse report = service.getValuation(null, null);
 
@@ -156,9 +172,9 @@ class ValuationServiceImplTest {
     @Test
     void currentValuation_standard_fallsBackToLatestReceiptMemoWhenNoStandardPrice() {
         when(stockSummaryRepository.sumOnHandBySku()).thenReturn(List.of(skuOnHand(SKU_A, 10L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.STANDARD);
-        when(costStateRepository.findByStockItemId(SKU_A))
-                .thenReturn(Optional.of(costState(SKU_A, new BigDecimal("6.500000"), null, 10L)));
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.STANDARD));
+        when(costStateRepository.findByStockItemIdIn(anyCollection()))
+                .thenReturn(List.of(costState(SKU_A, new BigDecimal("6.500000"), null, 10L)));
 
         ValuationReportResponse report = service.getValuation(null, null);
 
@@ -172,8 +188,8 @@ class ValuationServiceImplTest {
     @Test
     void currentValuation_uncostedSku_surfacesZeroNotCrash() {
         when(stockSummaryRepository.sumOnHandBySku()).thenReturn(List.of(skuOnHand(SKU_A, 5L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.AVERAGE);
-        when(costStateRepository.findByStockItemId(SKU_A)).thenReturn(Optional.empty());
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE));
+        when(costStateRepository.findByStockItemIdIn(anyCollection())).thenReturn(List.of());
 
         ValuationReportResponse report = service.getValuation(null, null);
 
@@ -187,8 +203,9 @@ class ValuationServiceImplTest {
     @Test
     void currentValuation_standardWithNullAvgAndNullStandard_isUncosted() {
         when(stockSummaryRepository.sumOnHandBySku()).thenReturn(List.of(skuOnHand(SKU_A, 5L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.STANDARD);
-        when(costStateRepository.findByStockItemId(SKU_A)).thenReturn(Optional.of(costState(SKU_A, null, null, 5L)));
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.STANDARD));
+        when(costStateRepository.findByStockItemIdIn(anyCollection()))
+                .thenReturn(List.of(costState(SKU_A, null, null, 5L)));
 
         ValuationReportResponse report = service.getValuation(null, null);
 
@@ -202,12 +219,12 @@ class ValuationServiceImplTest {
     void currentValuation_siteFiltered_aggregatesOnlyThatSite() {
         when(stockSummaryRepository.sumOnHandBySkuAtLocation(LOC_1))
                 .thenReturn(List.of(skuOnHand(SKU_A, 7L), skuOnHand(SKU_B, 3L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.AVERAGE);
-        when(methodResolver.resolve(SKU_B)).thenReturn(CostingMethod.AVERAGE);
-        when(costStateRepository.findByStockItemId(SKU_A))
-                .thenReturn(Optional.of(costState(SKU_A, new BigDecimal("2.000000"), null, 7L)));
-        when(costStateRepository.findByStockItemId(SKU_B))
-                .thenReturn(Optional.of(costState(SKU_B, new BigDecimal("10.000000"), null, 3L)));
+        when(methodResolver.resolveAll(anySet()))
+                .thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE, SKU_B, CostingMethod.AVERAGE));
+        when(costStateRepository.findByStockItemIdIn(anyCollection()))
+                .thenReturn(List.of(
+                        costState(SKU_A, new BigDecimal("2.000000"), null, 7L),
+                        costState(SKU_B, new BigDecimal("10.000000"), null, 3L)));
 
         ValuationReportResponse report = service.getValuation(LOC_1, null);
 
@@ -226,9 +243,9 @@ class ValuationServiceImplTest {
                 .build();
         when(stockSummaryRepository.findByStockItemIdAndLocationId(SKU_A, LOC_1))
                 .thenReturn(Optional.of(row));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.AVERAGE);
-        when(costStateRepository.findByStockItemId(SKU_A))
-                .thenReturn(Optional.of(costState(SKU_A, new BigDecimal("5.000000"), null, 4L)));
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE));
+        when(costStateRepository.findByStockItemIdIn(anyCollection()))
+                .thenReturn(List.of(costState(SKU_A, new BigDecimal("5.000000"), null, 4L)));
 
         ValuationReportResponse report = service.getValuation(LOC_1, SKU_A);
 
@@ -253,14 +270,14 @@ class ValuationServiceImplTest {
     void asOfValuation_average_reconstructsRunningCostByReplay() {
         // Receipt 10 @ 5, then receipt 10 @ 7 → running average 6; on-hand 20.
         when(ledgerRepository.sumOnHandBySkuAsOf(any(), eq(AS_OF))).thenReturn(List.of(ledgerSkuOnHand(SKU_A, 20L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.AVERAGE);
-        lenient().when(costStateRepository.findByStockItemId(SKU_A)).thenReturn(Optional.empty());
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE));
+        when(costStateRepository.findByStockItemIdIn(anyCollection())).thenReturn(List.of());
         when(ledgerRepository
-                        .findByStockItemIdAndEventTypeInAndTimestampLessThanEqualOrderByTimestampAscLedgerEntryIdAsc(
-                                eq(SKU_A), any(), eq(AS_OF)))
+                        .findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                                anyCollection(), any(), eq(AS_OF)))
                 .thenReturn(List.of(
-                        entry(InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("5.0000")),
-                        entry(InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("7.0000"))));
+                        entry(SKU_A, InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("5.0000")),
+                        entry(SKU_A, InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("7.0000"))));
 
         ValuationReportResponse report = service.getValuationAsOf(null, null, AS_OF);
 
@@ -274,15 +291,15 @@ class ValuationServiceImplTest {
     void asOfValuation_average_afterSubsequentIssue_keepsRunningAverage() {
         // Receipt 10 @ 5, receipt 10 @ 7 (avg 6), then issue 5 → on-hand 15, avg stays 6.
         when(ledgerRepository.sumOnHandBySkuAsOf(any(), eq(AS_OF))).thenReturn(List.of(ledgerSkuOnHand(SKU_A, 15L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.AVERAGE);
-        lenient().when(costStateRepository.findByStockItemId(SKU_A)).thenReturn(Optional.empty());
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE));
+        when(costStateRepository.findByStockItemIdIn(anyCollection())).thenReturn(List.of());
         when(ledgerRepository
-                        .findByStockItemIdAndEventTypeInAndTimestampLessThanEqualOrderByTimestampAscLedgerEntryIdAsc(
-                                eq(SKU_A), any(), eq(AS_OF)))
+                        .findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                                anyCollection(), any(), eq(AS_OF)))
                 .thenReturn(List.of(
-                        entry(InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("5.0000")),
-                        entry(InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("7.0000")),
-                        entry(InventoryLedgerEventType.GOODS_ISSUE, -5, new BigDecimal("6.0000"))));
+                        entry(SKU_A, InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("5.0000")),
+                        entry(SKU_A, InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("7.0000")),
+                        entry(SKU_A, InventoryLedgerEventType.GOODS_ISSUE, -5, new BigDecimal("6.0000"))));
 
         ValuationReportResponse report = service.getValuationAsOf(null, null, AS_OF);
 
@@ -295,13 +312,14 @@ class ValuationServiceImplTest {
     @Test
     void asOfValuation_standard_seedsStandardPriceFromCurrentState() {
         when(ledgerRepository.sumOnHandBySkuAsOf(any(), eq(AS_OF))).thenReturn(List.of(ledgerSkuOnHand(SKU_A, 10L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.STANDARD);
-        when(costStateRepository.findByStockItemId(SKU_A))
-                .thenReturn(Optional.of(costState(SKU_A, new BigDecimal("5.000000"), new BigDecimal("9.000000"), 10L)));
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.STANDARD));
+        when(costStateRepository.findByStockItemIdIn(anyCollection()))
+                .thenReturn(List.of(costState(SKU_A, new BigDecimal("5.000000"), new BigDecimal("9.000000"), 10L)));
         when(ledgerRepository
-                        .findByStockItemIdAndEventTypeInAndTimestampLessThanEqualOrderByTimestampAscLedgerEntryIdAsc(
-                                eq(SKU_A), any(), eq(AS_OF)))
-                .thenReturn(List.of(entry(InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("5.0000"))));
+                        .findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                                anyCollection(), any(), eq(AS_OF)))
+                .thenReturn(
+                        List.of(entry(SKU_A, InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("5.0000"))));
 
         ValuationReportResponse report = service.getValuationAsOf(null, null, AS_OF);
 
@@ -323,16 +341,50 @@ class ValuationServiceImplTest {
     void asOfValuation_siteFiltered_usesPositiveOnHandByLocation() {
         when(ledgerRepository.findPositiveOnHandByLocationAsOf(eq(LOC_2), any(), eq(AS_OF)))
                 .thenReturn(List.of(ledgerSkuOnHand(SKU_A, 8L)));
-        when(methodResolver.resolve(SKU_A)).thenReturn(CostingMethod.AVERAGE);
-        lenient().when(costStateRepository.findByStockItemId(SKU_A)).thenReturn(Optional.empty());
+        when(methodResolver.resolveAll(anySet())).thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE));
+        when(costStateRepository.findByStockItemIdIn(anyCollection())).thenReturn(List.of());
         when(ledgerRepository
-                        .findByStockItemIdAndEventTypeInAndTimestampLessThanEqualOrderByTimestampAscLedgerEntryIdAsc(
-                                eq(SKU_A), any(), eq(AS_OF)))
-                .thenReturn(List.of(entry(InventoryLedgerEventType.GOODS_RECEIPT, 8, new BigDecimal("4.0000"))));
+                        .findByStockItemIdInAndEventTypeInAndTimestampLessThanEqualOrderByStockItemIdAscTimestampAscLedgerEntryIdAsc(
+                                anyCollection(), any(), eq(AS_OF)))
+                .thenReturn(List.of(entry(SKU_A, InventoryLedgerEventType.GOODS_RECEIPT, 8, new BigDecimal("4.0000"))));
 
         ValuationReportResponse report = service.getValuationAsOf(LOC_2, null, AS_OF);
 
         assertThat(report.getLocationId()).isEqualTo(LOC_2);
         assertThat(report.getRows().get(0).getOnHandValue()).isEqualByComparingTo("32.0000");
+    }
+
+    @Test
+    void currentValuation_multipleSkus_usesBulkRepositoryCalls() {
+        when(stockSummaryRepository.sumOnHandBySku()).thenReturn(List.of(skuOnHand(SKU_A, 2L), skuOnHand(SKU_B, 3L)));
+        when(methodResolver.resolveAll(anySet()))
+                .thenReturn(Map.of(SKU_A, CostingMethod.AVERAGE, SKU_B, CostingMethod.STANDARD));
+        when(costStateRepository.findByStockItemIdIn(anyCollection()))
+                .thenReturn(List.of(
+                        costState(SKU_A, new BigDecimal("2.000000"), null, 2L),
+                        costState(SKU_B, new BigDecimal("3.000000"), new BigDecimal("4.000000"), 3L)));
+
+        service.getValuation(null, null);
+
+        verify(methodResolver, times(1)).resolveAll(anySet());
+        verify(costStateRepository, times(1)).findByStockItemIdIn(anyCollection());
+    }
+
+    @Test
+    void asOfValuation_fullCatalog_exceedingCap_throws422DomainException() {
+        ValuationServiceImpl smallCapService = new ValuationServiceImpl(
+                stockSummaryRepository,
+                ledgerRepository,
+                costStateRepository,
+                methodResolver,
+                asOfQueryGuard,
+                List.of(new AverageCostingStrategy(), new StandardCostingStrategy()),
+                1);
+        when(ledgerRepository.sumOnHandBySkuAsOf(any(), eq(AS_OF)))
+                .thenReturn(List.of(ledgerSkuOnHand(SKU_A, 1L), ledgerSkuOnHand(SKU_B, 1L)));
+
+        assertThatThrownBy(() -> smallCapService.getValuationAsOf(null, null, AS_OF))
+                .isInstanceOf(com.positivity.inventory.internal.exception.ValuationAsOfSkuCapExceededException.class)
+                .hasMessageContaining("exceed cap");
     }
 }


### PR DESCRIPTION
## Summary
- remove N+1 in current valuation by batch-resolving costing methods and loading sku_cost_state in bulk
- remove per-SKU as-of replay queries by loading ordered ledger entries for all requested SKUs in one query and replaying per-SKU in memory
- add as-of full-catalog SKU safety cap with deterministic 422 response and update valuation endpoint docs/tests

## Contract Sync
- Canonical guide reference: BACKEND_CONTRACT_GUIDE.md
- Contract semantics: no payload shape changes; valuation behavior and error handling preserved except explicit 422 guard for over-cap full-catalog as-of requests

## Testing
- ./mvnw -pl pos-inventory -am -Dtest=ValuationServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test

Closes #1097