### PR TITLE
test(pos-inventory): cover batched costing method resolveAll precedence

### DIFF
--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CostingMethodResolverTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CostingMethodResolverTest.java
@@ -1,13 +1,22 @@
 package com.positivity.inventory.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.inventory.internal.entity.CostingMethodConfig;
 import com.positivity.inventory.internal.enums.CostingMethod;
 import com.positivity.inventory.internal.enums.CostingScopeType;
 import com.positivity.inventory.internal.repository.CostingMethodConfigRepository;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,68 +31,102 @@ class CostingMethodResolverTest {
     @Mock
     private CostingMethodConfigRepository configRepository;
 
-    private static final String SKU = "SKU-1";
+    @Mock
+    private SkuCategoryProvider skuCategoryProvider;
 
-    private CostingMethodResolver resolver(SkuCategoryProvider categoryProvider) {
-        return new CostingMethodResolver(configRepository, categoryProvider, CostingMethod.AVERAGE);
+    private static final String SKU_A = "SKU-A";
+    private static final String SKU_B = "SKU-B";
+    private static final String SKU_C = "SKU-C";
+    private static final String SKU_D = "SKU-D";
+
+    private CostingMethodResolver resolver(CostingMethod defaultMethod) {
+        return new CostingMethodResolver(configRepository, skuCategoryProvider, defaultMethod);
     }
 
-    private CostingMethodConfig config(CostingMethod method) {
-        return CostingMethodConfig.builder().method(method).build();
+    private CostingMethodConfig config(CostingScopeType scopeType, String scopeValue, CostingMethod method) {
+        return CostingMethodConfig.builder()
+                .scopeType(scopeType)
+                .scopeValue(scopeValue)
+                .method(method)
+                .active(true)
+                .build();
     }
 
     @Test
-    @DisplayName("no config anywhere: falls through to the deployment default")
-    void noConfig_returnsDeploymentDefault() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.empty());
+    @DisplayName("resolveAll applies SKU > category > DEFAULT precedence in one batched pass")
+    void resolveAll_appliesSkuCategoryDefaultPrecedence() {
+        CostingMethodResolver resolver = resolver(CostingMethod.AVERAGE);
+        Set<String> stockItems = Set.of(SKU_A, SKU_B, SKU_C, SKU_D);
+
+        when(configRepository.findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, stockItems))
+                .thenReturn(List.of(config(CostingScopeType.SKU, SKU_A, CostingMethod.STANDARD)));
+        when(skuCategoryProvider.categoryOfAll(Set.of(SKU_B, SKU_C, SKU_D)))
+                .thenReturn(Map.of(SKU_B, "CAT-1", SKU_C, "CAT-2"));
+        when(configRepository.findByScopeTypeAndScopeValueInAndActiveTrue(
+                        CostingScopeType.SKU_CATEGORY, Set.of("CAT-1", "CAT-2")))
+                .thenReturn(List.of(config(CostingScopeType.SKU_CATEGORY, "CAT-1", CostingMethod.AVERAGE)));
+        when(configRepository.findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT))
+                .thenReturn(Optional.of(config(CostingScopeType.DEFAULT, null, CostingMethod.STANDARD)));
+
+        Map<String, CostingMethod> resolved = resolver.resolveAll(stockItems);
+
+        assertThat(resolved).containsEntry(SKU_A, CostingMethod.STANDARD);
+        assertThat(resolved).containsEntry(SKU_B, CostingMethod.AVERAGE);
+        assertThat(resolved).containsEntry(SKU_C, CostingMethod.STANDARD);
+        assertThat(resolved).containsEntry(SKU_D, CostingMethod.STANDARD);
+        assertThat(resolved).hasSize(4);
+
+        verify(configRepository).findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, stockItems);
+        verify(skuCategoryProvider).categoryOfAll(Set.of(SKU_B, SKU_C, SKU_D));
+        verify(configRepository)
+                .findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU_CATEGORY, Set.of("CAT-1", "CAT-2"));
+        verify(configRepository).findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT);
+        verify(configRepository, never()).findByScopeTypeAndScopeValueAndActiveTrue(any(), anyString());
+        verify(skuCategoryProvider, never()).categoryOf(anyString());
+    }
+
+    @Test
+    @DisplayName("resolveAll falls back to deployment default when DEFAULT row is absent")
+    void resolveAll_noDefaultRow_usesDeploymentDefault() {
+        CostingMethodResolver resolver = resolver(CostingMethod.STANDARD);
+
+        when(configRepository.findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, Set.of(SKU_A)))
+                .thenReturn(List.of());
+        when(skuCategoryProvider.categoryOfAll(Set.of(SKU_A))).thenReturn(Map.of());
         when(configRepository.findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT))
                 .thenReturn(Optional.empty());
 
-        assertThat(resolver(new NoOpSkuCategoryProvider()).resolve(SKU)).isEqualTo(CostingMethod.AVERAGE);
+        Map<String, CostingMethod> resolved = resolver.resolveAll(Set.of(SKU_A));
+
+        assertThat(resolved).containsExactly(Map.entry(SKU_A, CostingMethod.STANDARD));
+        verify(configRepository, never())
+                .findByScopeTypeAndScopeValueInAndActiveTrue(eq(CostingScopeType.SKU_CATEGORY), anyCollection());
+        verify(configRepository, never()).findByScopeTypeAndScopeValueAndActiveTrue(any(), anyString());
     }
 
     @Test
-    @DisplayName("DEFAULT config row wins over the deployment default")
-    void defaultConfigRow_winsOverDeploymentDefault() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.empty());
-        when(configRepository.findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT))
-                .thenReturn(Optional.of(config(CostingMethod.STANDARD)));
+    @DisplayName("resolve delegates to resolveAll path so lookup stays batched")
+    void resolve_delegatesToResolveAllBatchedPath() {
+        CostingMethodResolver resolver = resolver(CostingMethod.AVERAGE);
 
-        assertThat(resolver(new NoOpSkuCategoryProvider()).resolve(SKU)).isEqualTo(CostingMethod.STANDARD);
+        when(configRepository.findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, Set.of(SKU_A)))
+                .thenReturn(List.of(config(CostingScopeType.SKU, SKU_A, CostingMethod.STANDARD)));
+
+        CostingMethod resolved = resolver.resolve(SKU_A);
+
+        assertThat(resolved).isEqualTo(CostingMethod.STANDARD);
+        verify(configRepository).findByScopeTypeAndScopeValueInAndActiveTrue(CostingScopeType.SKU, Set.of(SKU_A));
+        verify(configRepository, never()).findByScopeTypeAndScopeValueAndActiveTrue(any(), anyString());
     }
 
     @Test
-    @DisplayName("per-SKU config wins over everything")
-    void skuConfig_winsOverAll() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.of(config(CostingMethod.STANDARD)));
+    @DisplayName("resolveAll with empty input returns empty and hits no collaborators")
+    void resolveAll_emptyInput_returnsEmptyWithoutCalls() {
+        CostingMethodResolver resolver = resolver(CostingMethod.AVERAGE);
 
-        assertThat(resolver(new NoOpSkuCategoryProvider()).resolve(SKU)).isEqualTo(CostingMethod.STANDARD);
-    }
-
-    @Test
-    @DisplayName("category-scoped config is unresolvable with the NoOp provider: skips to DEFAULT")
-    void categoryUnresolvable_skipsToDefault() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.empty());
-        when(configRepository.findByScopeTypeAndScopeValueIsNullAndActiveTrue(CostingScopeType.DEFAULT))
-                .thenReturn(Optional.of(config(CostingMethod.AVERAGE)));
-
-        // NoOp provider returns no category, so SKU_CATEGORY rows are never consulted.
-        assertThat(resolver(new NoOpSkuCategoryProvider()).resolve(SKU)).isEqualTo(CostingMethod.AVERAGE);
-    }
-
-    @Test
-    @DisplayName("when a category IS resolvable, its config row is consulted between SKU and DEFAULT")
-    void categoryResolvable_categoryConfigConsulted() {
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU, SKU))
-                .thenReturn(Optional.empty());
-        when(configRepository.findByScopeTypeAndScopeValueAndActiveTrue(CostingScopeType.SKU_CATEGORY, "CAT-1"))
-                .thenReturn(Optional.of(config(CostingMethod.STANDARD)));
-
-        SkuCategoryProvider provider = stockItemId -> Optional.of("CAT-1");
-        assertThat(resolver(provider).resolve(SKU)).isEqualTo(CostingMethod.STANDARD);
+        assertThat(resolver.resolveAll(Set.of())).isEmpty();
+        verify(configRepository, never()).findByScopeTypeAndScopeValueInAndActiveTrue(any(), anyCollection());
+        verify(configRepository, never()).findByScopeTypeAndScopeValueIsNullAndActiveTrue(any());
+        verify(skuCategoryProvider, never()).categoryOfAll(anyCollection());
     }
 }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## Capability & Traceability
- Capability: `cap:<cap-id>`
- Parent STORY (durion): louisburroughs/durion#<parent-id>
- Child issue: louisburroughs/durion-positivity-backend#<child-id>
- Domain: `domain:<domain>`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
<!--
  The "Contract Sync Enforcement" check FAILS unless the text BACKEND_CONTRACT_GUIDE.md
  appears somewhere in this PR body whenever contract-relevant files change
  (controllers, DTOs, *Request/*Response, events, openapi.yaml, validation/error models).
  Keep the reference below and link it to the relevant domain anchor.
-->
- Contract guide entry (durion): `domains/<domain>/.business-rules/BACKEND_CONTRACT_GUIDE.md` → <link-to-anchor>
- Durion contract PR (if applicable): <link-to-durion-pr>

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope
- What changed:
- Why:

## Tests
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run:

## Risk & Rollback
- Risk level: Low / Medium / High
- Rollback plan:

## Checklist
- [ ] Branch name matches `cap/<cap-id>`
- [ ] PR title starts with `[CAP:<cap-id>]`
- [ ] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing
