### PR TITLE
cap/1097 Sonar security and reliability remediation pass

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/AccountingPeriodController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/AccountingPeriodController.java
@@ -40,237 +40,154 @@ import org.springframework.web.bind.annotation.RestController;
  * org-level hard-lock date (Story B2, issue #944).
  *
  * @see <a href=
- *      "domains/accounting/plan-odoo-parity-pos-accounting.md">Odoo Parity Plan -
+ *      "domains/accounting/plan-odoo-parity-pos-accounting.md">Odoo Parity Plan
+ *      -
  *      Stories B1/B2</a>
  */
 @RestController
 @RequestMapping("/v1/accounting/periods")
-@Tag(
-        name = "Accounting Periods",
-        description = "Accounting period lifecycle: list periods, close a period, reopen a closed period,"
+@Tag(name = "Accounting Periods", description = "Accounting period lifecycle: list periods, close a period, reopen a closed period,"
                 + " and manage the org-level hard-lock date.")
 @RequiredArgsConstructor
 @Validated
 public class AccountingPeriodController {
 
-    private static final Logger log = LoggerFactory.getLogger(AccountingPeriodController.class);
+        private static final Logger log = LoggerFactory.getLogger(AccountingPeriodController.class);
 
-    private final AccountingPeriodService accountingPeriodService;
-    private final AccountingConfigurationService accountingConfigurationService;
+        private final AccountingPeriodService accountingPeriodService;
+        private final AccountingConfigurationService accountingConfigurationService;
 
-    @GetMapping
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:period:view"})
-    @PreAuthorize("hasAuthority('accounting:period:view')")
-    @EmitEvent(id = "ACCOUNTING_PERIOD_LIST", apiVersion = "1")
-    @Operation(
-            summary = "List accounting periods",
-            operationId = "listAccountingPeriods",
-            description = "Lists all known accounting periods, most recent first (descending period code)."
-                    + " Use this tool to review period statuses before closing or reopening a period."
-                    + " Periods are auto-provisioned on first posting, so months never posted into may be absent;"
-                    + " an absent month counts as OPEN for posting purposes."
-                    + " No preconditions and no side effects; nothing is created by this call.",
-            tags = {"Accounting Periods"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Accounting periods listed, most recent first",
-            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AccountingPeriodResponse.class))))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:period:view permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<List<AccountingPeriodResponse>> listAccountingPeriods() {
-        log.info("List accounting periods");
-        List<AccountingPeriodResponse> response = accountingPeriodService.listPeriods();
-        return ResponseEntity.ok(response);
-    }
+        @GetMapping
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:view" })
+        @PreAuthorize("hasAuthority('accounting:period:view')")
+        @EmitEvent(id = "ACCOUNTING_PERIOD_LIST", apiVersion = "1")
+        @Operation(summary = "List accounting periods", operationId = "listAccountingPeriods", description = "Lists all known accounting periods, most recent first (descending period code)."
+                        + " Use this tool to review period statuses before closing or reopening a period."
+                        + " Periods are auto-provisioned on first posting, so months never posted into may be absent;"
+                        + " an absent month counts as OPEN for posting purposes."
+                        + " No preconditions and no side effects; nothing is created by this call.", tags = {
+                                        "Accounting Periods" })
+        @ApiResponse(responseCode = "200", description = "Accounting periods listed, most recent first", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AccountingPeriodResponse.class))))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<List<AccountingPeriodResponse>> listAccountingPeriods() {
+                log.info("List accounting periods");
+                List<AccountingPeriodResponse> response = accountingPeriodService.listPeriods();
+                return ResponseEntity.ok(response);
+        }
 
-    @PostMapping("/{periodCode}/close")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:period:close"})
-    @PreAuthorize("hasAuthority('accounting:period:close')")
-    @EmitEvent(id = "ACCOUNTING_PERIOD_CLOSE", apiVersion = "1")
-    @Operation(
-            summary = "Close an accounting period",
-            operationId = "closeAccountingPeriod",
-            description = "Closes an OPEN accounting period (OPEN → CLOSED), recording its lifecycle status as"
-                    + " CLOSED. Use this tool during month-end close after all journal entries for the month"
-                    + " are posted; use reopenAccountingPeriod to reverse the transition."
-                    + " Note: journal-entry posting paths do not yet reject postings dated into a CLOSED period;"
-                    + " that enforcement (error code PERIOD_CLOSED) arrives with the period-enforcement story"
-                    + " (parity-B2)."
-                    + " Preconditions: the period must not already be CLOSED, and no DRAFT journal entries may"
-                    + " be dated inside the period. A valid YYYY-MM period with no row whose month has already"
-                    + " started is auto-provisioned and then closed."
-                    + " The close is audit-logged with the acting user and emits ACCOUNTING_PERIOD_CLOSE."
-                    + " Returns 409 PERIOD_ALREADY_CLOSED if the period is already closed, and 422"
-                    + " PERIOD_HAS_DRAFT_ENTRIES listing the blocking draft journal entry IDs in fieldErrors —"
-                    + " post or delete those entries before retrying.",
-            tags = {"Accounting Periods"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Period closed; the updated period is returned",
-            content = @Content(schema = @Schema(implementation = AccountingPeriodResponse.class)))
-    @ApiResponse(
-            responseCode = "400",
-            description = "periodCode is not a valid YYYY-MM period code",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:period:close permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Period not found and its month has not started (PERIOD_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "409",
-            description = "Period is already closed (PERIOD_ALREADY_CLOSED)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "422",
-            description = "DRAFT journal entries are dated inside the period (PERIOD_HAS_DRAFT_ENTRIES);"
-                    + " fieldErrors lists the blocking draftJournalEntryIds",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<AccountingPeriodResponse> closeAccountingPeriod(
-            @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06")
-                    @PathVariable
-                    String periodCode) {
-        log.info("Close accounting period {}", periodCode);
-        AccountingPeriodResponse response = accountingPeriodService.closePeriod(periodCode);
-        return ResponseEntity.ok(response);
-    }
+        @PostMapping("/{periodCode}/close")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:close" })
+        @PreAuthorize("hasAuthority('accounting:period:close')")
+        @EmitEvent(id = "ACCOUNTING_PERIOD_CLOSE", apiVersion = "1")
+        @Operation(summary = "Close an accounting period", operationId = "closeAccountingPeriod", description = "Closes an OPEN accounting period (OPEN → CLOSED), recording its lifecycle status as"
+                        + " CLOSED. Use this tool during month-end close after all journal entries for the month"
+                        + " are posted; use reopenAccountingPeriod to reverse the transition."
+                        + " Note: journal-entry posting paths do not yet reject postings dated into a CLOSED period;"
+                        + " that enforcement (error code PERIOD_CLOSED) arrives with the period-enforcement story"
+                        + " (parity-B2)."
+                        + " Preconditions: the period must not already be CLOSED, and no DRAFT journal entries may"
+                        + " be dated inside the period. A valid YYYY-MM period with no row whose month has already"
+                        + " started is auto-provisioned and then closed."
+                        + " The close is audit-logged with the acting user and emits ACCOUNTING_PERIOD_CLOSE."
+                        + " Returns 409 PERIOD_ALREADY_CLOSED if the period is already closed, and 422"
+                        + " PERIOD_HAS_DRAFT_ENTRIES listing the blocking draft journal entry IDs in fieldErrors —"
+                        + " post or delete those entries before retrying.", tags = { "Accounting Periods" })
+        @ApiResponse(responseCode = "200", description = "Period closed; the updated period is returned", content = @Content(schema = @Schema(implementation = AccountingPeriodResponse.class)))
+        @ApiResponse(responseCode = "400", description = "periodCode is not a valid YYYY-MM period code", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:close permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Period not found and its month has not started (PERIOD_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "409", description = "Period is already closed (PERIOD_ALREADY_CLOSED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "422", description = "DRAFT journal entries are dated inside the period (PERIOD_HAS_DRAFT_ENTRIES);"
+                        + " fieldErrors lists the blocking draftJournalEntryIds", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<AccountingPeriodResponse> closeAccountingPeriod(
+                        @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06") @PathVariable String periodCode) {
+                log.info("Close accounting period {}", sanitizeForLog(periodCode));
+                AccountingPeriodResponse response = accountingPeriodService.closePeriod(periodCode);
+                return ResponseEntity.ok(response);
+        }
 
-    @PostMapping("/{periodCode}/reopen")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:period:reopen"})
-    @PreAuthorize("hasAuthority('accounting:period:reopen')")
-    @EmitEvent(id = "ACCOUNTING_PERIOD_REOPEN", apiVersion = "1")
-    @Operation(
-            summary = "Reopen a closed accounting period",
-            operationId = "reopenAccountingPeriod",
-            description = "Reopens a CLOSED accounting period (CLOSED → OPEN), resetting its lifecycle status"
-                    + " to OPEN."
-                    + " Use this tool only when late adjustments must be posted into an already-closed month;"
-                    + " use closeAccountingPeriod to close it again afterwards."
-                    + " Preconditions: a period row must exist for the code and be CLOSED."
-                    + " Required input: a non-blank justification (max 500 characters) which is recorded on the"
-                    + " period and in the audit trail with the acting user."
-                    + " Emits ACCOUNTING_PERIOD_REOPEN. Returns 409 PERIOD_ALREADY_OPEN if the period is not"
-                    + " closed, and 400 if the justification is missing or blank.",
-            tags = {"Accounting Periods"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Period reopened; the updated period is returned",
-            content = @Content(schema = @Schema(implementation = AccountingPeriodResponse.class)))
-    @ApiResponse(
-            responseCode = "400",
-            description = "periodCode is not a valid YYYY-MM period code, or justification is missing or blank",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:period:reopen permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "No period row exists for the code (PERIOD_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "409",
-            description = "Period is already open (PERIOD_ALREADY_OPEN)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<AccountingPeriodResponse> reopenAccountingPeriod(
-            @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06")
-                    @PathVariable
-                    String periodCode,
-            @Valid @RequestBody AccountingPeriodReopenRequest request) {
-        log.info("Reopen accounting period {}", periodCode);
-        AccountingPeriodResponse response =
-                accountingPeriodService.reopenPeriod(periodCode, request.getJustification());
-        return ResponseEntity.ok(response);
-    }
+        @PostMapping("/{periodCode}/reopen")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:reopen" })
+        @PreAuthorize("hasAuthority('accounting:period:reopen')")
+        @EmitEvent(id = "ACCOUNTING_PERIOD_REOPEN", apiVersion = "1")
+        @Operation(summary = "Reopen a closed accounting period", operationId = "reopenAccountingPeriod", description = "Reopens a CLOSED accounting period (CLOSED → OPEN), resetting its lifecycle status"
+                        + " to OPEN."
+                        + " Use this tool only when late adjustments must be posted into an already-closed month;"
+                        + " use closeAccountingPeriod to close it again afterwards."
+                        + " Preconditions: a period row must exist for the code and be CLOSED."
+                        + " Required input: a non-blank justification (max 500 characters) which is recorded on the"
+                        + " period and in the audit trail with the acting user."
+                        + " Emits ACCOUNTING_PERIOD_REOPEN. Returns 409 PERIOD_ALREADY_OPEN if the period is not"
+                        + " closed, and 400 if the justification is missing or blank.", tags = { "Accounting Periods" })
+        @ApiResponse(responseCode = "200", description = "Period reopened; the updated period is returned", content = @Content(schema = @Schema(implementation = AccountingPeriodResponse.class)))
+        @ApiResponse(responseCode = "400", description = "periodCode is not a valid YYYY-MM period code, or justification is missing or blank", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:reopen permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "No period row exists for the code (PERIOD_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "409", description = "Period is already open (PERIOD_ALREADY_OPEN)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<AccountingPeriodResponse> reopenAccountingPeriod(
+                        @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06") @PathVariable String periodCode,
+                        @Valid @RequestBody AccountingPeriodReopenRequest request) {
+                log.info("Reopen accounting period {}", sanitizeForLog(periodCode));
+                AccountingPeriodResponse response = accountingPeriodService.reopenPeriod(periodCode,
+                                request.getJustification());
+                return ResponseEntity.ok(response);
+        }
 
-    @GetMapping("/hard-lock")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:period:view"})
-    @PreAuthorize("hasAuthority('accounting:period:view')")
-    @EmitEvent(id = "ACCOUNTING_PERIOD_HARD_LOCK_VIEW", apiVersion = "1")
-    @Operation(
-            summary = "Get the accounting hard-lock date",
-            operationId = "getAccountingHardLockDate",
-            description = "Returns the org-level hard-lock date: journal entries dated strictly before this"
-                    + " date are permanently rejected (422 PERIOD_HARD_LOCKED) with no override path — unlike"
-                    + " a CLOSED period, which accounting:period:override plus a justification can bypass."
-                    + " Use this tool to check the current lock boundary before posting backdated entries or"
-                    + " before moving the lock with setAccountingHardLockDate."
-                    + " Returns hardLockDate: null when no hard lock has been configured yet."
-                    + " No preconditions and no side effects.",
-            tags = {"Accounting Periods"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Current hard-lock date returned; hardLockDate is null when no hard lock is set",
-            content = @Content(schema = @Schema(implementation = HardLockDateResponse.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:period:view permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<HardLockDateResponse> getHardLockDate() {
-        log.debug("Get accounting hard-lock date");
-        LocalDate hardLockDate =
-                accountingConfigurationService.getHardLockDate().orElse(null);
-        return ResponseEntity.ok(new HardLockDateResponse(hardLockDate));
-    }
+        @GetMapping("/hard-lock")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:view" })
+        @PreAuthorize("hasAuthority('accounting:period:view')")
+        @EmitEvent(id = "ACCOUNTING_PERIOD_HARD_LOCK_VIEW", apiVersion = "1")
+        @Operation(summary = "Get the accounting hard-lock date", operationId = "getAccountingHardLockDate", description = "Returns the org-level hard-lock date: journal entries dated strictly before this"
+                        + " date are permanently rejected (422 PERIOD_HARD_LOCKED) with no override path — unlike"
+                        + " a CLOSED period, which accounting:period:override plus a justification can bypass."
+                        + " Use this tool to check the current lock boundary before posting backdated entries or"
+                        + " before moving the lock with setAccountingHardLockDate."
+                        + " Returns hardLockDate: null when no hard lock has been configured yet."
+                        + " No preconditions and no side effects.", tags = { "Accounting Periods" })
+        @ApiResponse(responseCode = "200", description = "Current hard-lock date returned; hardLockDate is null when no hard lock is set", content = @Content(schema = @Schema(implementation = HardLockDateResponse.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<HardLockDateResponse> getHardLockDate() {
+                log.debug("Get accounting hard-lock date");
+                LocalDate hardLockDate = accountingConfigurationService.getHardLockDate().orElse(null);
+                return ResponseEntity.ok(new HardLockDateResponse(hardLockDate));
+        }
 
-    @PutMapping("/hard-lock")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:period:hard_lock"})
-    @PreAuthorize("hasAuthority('accounting:period:hard_lock')")
-    @EmitEvent(id = "ACCOUNTING_PERIOD_HARD_LOCK_SET", apiVersion = "1")
-    @Operation(
-            summary = "Set the accounting hard-lock date",
-            operationId = "setAccountingHardLockDate",
-            description = "Sets the org-level hard-lock date: from then on, journal entries dated strictly"
-                    + " before this date are permanently rejected (422 PERIOD_HARD_LOCKED) with NO override"
-                    + " path — not even accounting:period:override can bypass it (that permission only covers"
-                    + " CLOSED periods, error PERIOD_CLOSED)."
-                    + " Use this tool after statutory filings or audits to make history immutable; use"
-                    + " closeAccountingPeriod for the reversible month-end close instead."
-                    + " The date is monotonic-forward-only: it must be on or after the currently stored"
-                    + " hard-lock date, and moving it backward is rejected with 422 HARD_LOCK_DATE_REGRESSION"
-                    + " — effectively irreversible, so set it deliberately."
-                    + " Required inputs: hardLockDate (ISO date) and a non-blank justification (max 500"
-                    + " characters), recorded in the audit trail with the acting user."
-                    + " Emits ACCOUNTING_PERIOD_HARD_LOCK_SET and returns the stored hard-lock date."
-                    + " Returns 400 if the date is missing or the justification is missing or blank.",
-            tags = {"Accounting Periods"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Hard-lock date updated; the stored value is returned",
-            content = @Content(schema = @Schema(implementation = HardLockDateResponse.class)))
-    @ApiResponse(
-            responseCode = "400",
-            description = "hardLockDate is missing, or justification is missing, blank, or over 500 characters"
-                    + " (ARGUMENT_NOT_VALID)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:period:hard_lock permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "422",
-            description = "Requested date is before the currently stored hard-lock date"
-                    + " (HARD_LOCK_DATE_REGRESSION) — the hard lock only moves forward",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<HardLockDateResponse> setHardLockDate(@Valid @RequestBody HardLockDateUpdateRequest request) {
-        log.info("Set accounting hard-lock date to {}", request.getHardLockDate());
-        LocalDate stored =
-                accountingConfigurationService.setHardLockDate(request.getHardLockDate(), request.getJustification());
-        return ResponseEntity.ok(new HardLockDateResponse(stored));
-    }
+        @PutMapping("/hard-lock")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:hard_lock" })
+        @PreAuthorize("hasAuthority('accounting:period:hard_lock')")
+        @EmitEvent(id = "ACCOUNTING_PERIOD_HARD_LOCK_SET", apiVersion = "1")
+        @Operation(summary = "Set the accounting hard-lock date", operationId = "setAccountingHardLockDate", description = "Sets the org-level hard-lock date: from then on, journal entries dated strictly"
+                        + " before this date are permanently rejected (422 PERIOD_HARD_LOCKED) with NO override"
+                        + " path — not even accounting:period:override can bypass it (that permission only covers"
+                        + " CLOSED periods, error PERIOD_CLOSED)."
+                        + " Use this tool after statutory filings or audits to make history immutable; use"
+                        + " closeAccountingPeriod for the reversible month-end close instead."
+                        + " The date is monotonic-forward-only: it must be on or after the currently stored"
+                        + " hard-lock date, and moving it backward is rejected with 422 HARD_LOCK_DATE_REGRESSION"
+                        + " — effectively irreversible, so set it deliberately."
+                        + " Required inputs: hardLockDate (ISO date) and a non-blank justification (max 500"
+                        + " characters), recorded in the audit trail with the acting user."
+                        + " Emits ACCOUNTING_PERIOD_HARD_LOCK_SET and returns the stored hard-lock date."
+                        + " Returns 400 if the date is missing or the justification is missing or blank.", tags = {
+                                        "Accounting Periods" })
+        @ApiResponse(responseCode = "200", description = "Hard-lock date updated; the stored value is returned", content = @Content(schema = @Schema(implementation = HardLockDateResponse.class)))
+        @ApiResponse(responseCode = "400", description = "hardLockDate is missing, or justification is missing, blank, or over 500 characters"
+                        + " (ARGUMENT_NOT_VALID)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:hard_lock permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "422", description = "Requested date is before the currently stored hard-lock date"
+                        + " (HARD_LOCK_DATE_REGRESSION) — the hard lock only moves forward", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<HardLockDateResponse> setHardLockDate(
+                        @Valid @RequestBody HardLockDateUpdateRequest request) {
+                log.info("Set accounting hard-lock date to {}", sanitizeForLog(request.getHardLockDate()));
+                LocalDate stored = accountingConfigurationService.setHardLockDate(request.getHardLockDate(),
+                                request.getJustification());
+                return ResponseEntity.ok(new HardLockDateResponse(stored));
+        }
+
+        private static String sanitizeForLog(Object value) {
+                if (value == null) {
+                        return "null";
+                }
+                return value.toString().replace('\n', '_').replace('\r', '_');
+        }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/AccountingPeriodController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/AccountingPeriodController.java
@@ -20,6 +20,8 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -100,8 +102,10 @@ public class AccountingPeriodController {
         @ApiResponse(responseCode = "422", description = "DRAFT journal entries are dated inside the period (PERIOD_HAS_DRAFT_ENTRIES);"
                         + " fieldErrors lists the blocking draftJournalEntryIds", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<AccountingPeriodResponse> closeAccountingPeriod(
-                        @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06") @PathVariable String periodCode) {
-                log.info("Close accounting period {}", sanitizeForLog(periodCode));
+                        @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06") @PathVariable @NonNull String periodCode) {
+                if (log.isInfoEnabled()) {
+                        log.info("Close accounting period {}", sanitizeForLog(periodCode));
+                }
                 AccountingPeriodResponse response = accountingPeriodService.closePeriod(periodCode);
                 return ResponseEntity.ok(response);
         }
@@ -125,9 +129,11 @@ public class AccountingPeriodController {
         @ApiResponse(responseCode = "404", description = "No period row exists for the code (PERIOD_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "409", description = "Period is already open (PERIOD_ALREADY_OPEN)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<AccountingPeriodResponse> reopenAccountingPeriod(
-                        @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06") @PathVariable String periodCode,
-                        @Valid @RequestBody AccountingPeriodReopenRequest request) {
-                log.info("Reopen accounting period {}", sanitizeForLog(periodCode));
+                        @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06") @PathVariable @NonNull String periodCode,
+                        @Valid @RequestBody @NonNull AccountingPeriodReopenRequest request) {
+                if (log.isInfoEnabled()) {
+                        log.info("Reopen accounting period {}", sanitizeForLog(periodCode));
+                }
                 AccountingPeriodResponse response = accountingPeriodService.reopenPeriod(periodCode,
                                 request.getJustification());
                 return ResponseEntity.ok(response);
@@ -177,14 +183,16 @@ public class AccountingPeriodController {
         @ApiResponse(responseCode = "422", description = "Requested date is before the currently stored hard-lock date"
                         + " (HARD_LOCK_DATE_REGRESSION) — the hard lock only moves forward", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<HardLockDateResponse> setHardLockDate(
-                        @Valid @RequestBody HardLockDateUpdateRequest request) {
-                log.info("Set accounting hard-lock date to {}", sanitizeForLog(request.getHardLockDate()));
+                        @Valid @RequestBody @NonNull HardLockDateUpdateRequest request) {
+                if (log.isInfoEnabled()) {
+                        log.info("Set accounting hard-lock date to {}", sanitizeForLog(request.getHardLockDate()));
+                }
                 LocalDate stored = accountingConfigurationService.setHardLockDate(request.getHardLockDate(),
                                 request.getJustification());
                 return ResponseEntity.ok(new HardLockDateResponse(stored));
         }
 
-        private static String sanitizeForLog(Object value) {
+        private static String sanitizeForLog(@Nullable Object value) {
                 if (value == null) {
                         return "null";
                 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/BankReconciliationController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/BankReconciliationController.java
@@ -27,6 +27,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
@@ -84,8 +86,10 @@ public class BankReconciliationController {
         @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "422", description = "GL account is not reconcilable (ACCOUNT_NOT_RECONCILABLE)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<BankReconciliationResponse> importReconciliation(
-                        @Valid @RequestBody BankReconciliationImportRequest request) {
-                log.info("Import bank reconciliation for account {}", sanitizeForLog(request.getGlAccountId()));
+                        @Valid @RequestBody @NonNull BankReconciliationImportRequest request) {
+                if (log.isInfoEnabled()) {
+                        log.info("Import bank reconciliation for account {}", sanitizeForLog(request.getGlAccountId()));
+                }
                 return ResponseEntity.ok(bankReconciliationService.importStatement(request));
         }
 
@@ -155,9 +159,11 @@ public class BankReconciliationController {
                         + " (RECONCILIATION_LINE_INELIGIBLE)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "422", description = "Matched sets do not net to equal amounts (MATCH_AMOUNT_MISMATCH)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<BankReconciliationResponse> matchReconciliation(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId,
-                        @Valid @RequestBody ReconciliationMatchRequest request) {
-                log.info("Match lines in reconciliation {}", sanitizeForLog(reconciliationId));
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId,
+                        @Valid @RequestBody @NonNull ReconciliationMatchRequest request) {
+                if (log.isInfoEnabled()) {
+                        log.info("Match lines in reconciliation {}", sanitizeForLog(reconciliationId));
+                }
                 return ResponseEntity.ok(bankReconciliationService.match(reconciliationId, request));
         }
 
@@ -175,9 +181,11 @@ public class BankReconciliationController {
         @ApiResponse(responseCode = "404", description = "Reconciliation or match group not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<BankReconciliationResponse> unmatchReconciliation(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId,
-                        @Valid @RequestBody ReconciliationUnmatchRequest request) {
-                log.info("Unmatch in reconciliation {}", sanitizeForLog(reconciliationId));
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId,
+                        @Valid @RequestBody @NonNull ReconciliationUnmatchRequest request) {
+                if (log.isInfoEnabled()) {
+                        log.info("Unmatch in reconciliation {}", sanitizeForLog(reconciliationId));
+                }
                 return ResponseEntity.ok(bankReconciliationService.unmatch(reconciliationId, request));
         }
 
@@ -200,12 +208,14 @@ public class BankReconciliationController {
                         + " or the amount sign is not permitted for the type — BANK_FEE/NSF_FEE must be negative,"
                         + " INTEREST_EARNED must be positive (RECONCILIATION_ADJUSTMENT_SIGN_INVALID)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<BankReconciliationResponse> addReconciliationAdjustment(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId,
-                        @Valid @RequestBody ReconciliationAdjustmentRequest request) {
-                log.info(
-                                "Record {} adjustment on reconciliation {}",
-                                sanitizeForLog(request.getType()),
-                                sanitizeForLog(reconciliationId));
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId,
+                        @Valid @RequestBody @NonNull ReconciliationAdjustmentRequest request) {
+                if (log.isInfoEnabled()) {
+                        log.info(
+                                        "Record {} adjustment on reconciliation {}",
+                                        sanitizeForLog(request.getType()),
+                                        sanitizeForLog(reconciliationId));
+                }
                 return ResponseEntity.ok(bankReconciliationService.addAdjustment(reconciliationId, request));
         }
 
@@ -226,12 +236,14 @@ public class BankReconciliationController {
         @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         @ApiResponse(responseCode = "422", description = "Reconciliation does not balance (RECONCILIATION_NOT_BALANCED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<BankReconciliationResponse> finalizeReconciliation(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
-                log.info("Finalize reconciliation {}", sanitizeForLog(reconciliationId));
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId) {
+                if (log.isInfoEnabled()) {
+                        log.info("Finalize reconciliation {}", sanitizeForLog(reconciliationId));
+                }
                 return ResponseEntity.ok(bankReconciliationService.finalizeReconciliation(reconciliationId));
         }
 
-        private static String sanitizeForLog(Object value) {
+        private static String sanitizeForLog(@Nullable Object value) {
                 if (value == null) {
                         return "null";
                 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/BankReconciliationController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/BankReconciliationController.java
@@ -44,390 +44,227 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * REST controller for the manual CSV bank reconciliation workflow (Story F2, issue
- * #965, decisions D-5/D-6): import a bank statement CSV for a reconcilable GL cash
+ * REST controller for the manual CSV bank reconciliation workflow (Story F2,
+ * issue
+ * #965, decisions D-5/D-6): import a bank statement CSV for a reconcilable GL
+ * cash
  * account, match statement lines to posted GL journal-entry lines, record
- * adjustments (which post real balanced journal entries through the accounting-period
+ * adjustments (which post real balanced journal entries through the
+ * accounting-period
  * gate), and finalize only when the statement and GL ending balances agree.
  *
- * <p>Reads require {@code accounting:reconciliation:view}; mutations require
+ * <p>
+ * Reads require {@code accounting:reconciliation:view}; mutations require
  * {@code accounting:reconciliation:adjust}.
  */
 @RestController
 @RequestMapping("/v1/accounting/reconciliations")
-@Tag(
-        name = "Bank Reconciliation",
-        description = "Manual CSV bank reconciliation: import a statement, match lines to posted GL entries,"
+@Tag(name = "Bank Reconciliation", description = "Manual CSV bank reconciliation: import a statement, match lines to posted GL entries,"
                 + " record adjustments, and finalize when balanced.")
 @RequiredArgsConstructor
 @Validated
 public class BankReconciliationController {
 
-    private static final Logger log = LoggerFactory.getLogger(BankReconciliationController.class);
+        private static final Logger log = LoggerFactory.getLogger(BankReconciliationController.class);
 
-    private final BankReconciliationService bankReconciliationService;
+        private final BankReconciliationService bankReconciliationService;
 
-    @PostMapping("/import")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:adjust"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_IMPORT", apiVersion = "1")
-    @Operation(
-            summary = "Import a bank statement CSV and start a reconciliation",
-            operationId = "importReconciliation",
-            description = "Parses a bank statement CSV (columns: date, description, amount [signed], reference) for a"
-                    + " reconcilable GL cash account and creates an IN_PROGRESS reconciliation with its imported"
-                    + " statement lines (UNMATCHED). The GL ending balance is snapshotted from posted journal-entry"
-                    + " lines on the account as-of the statement date. Returns 422 ACCOUNT_NOT_RECONCILABLE if the"
-                    + " account's reconcilable flag (story H1) is false, and 400 if the CSV is malformed.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Reconciliation created",
-            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-    @ApiResponse(
-            responseCode = "400",
-            description = "Request body invalid or CSV malformed (ARGUMENT_NOT_VALID / VALIDATION_ERROR)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:adjust permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "422",
-            description = "GL account is not reconcilable (ACCOUNT_NOT_RECONCILABLE)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<BankReconciliationResponse> importReconciliation(
-            @Valid @RequestBody BankReconciliationImportRequest request) {
-        log.info("Import bank reconciliation for account {}", request.getGlAccountId());
-        return ResponseEntity.ok(bankReconciliationService.importStatement(request));
-    }
+        @PostMapping("/import")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_IMPORT", apiVersion = "1")
+        @Operation(summary = "Import a bank statement CSV and start a reconciliation", operationId = "importReconciliation", description = "Parses a bank statement CSV (columns: date, description, amount [signed], reference) for a"
+                        + " reconcilable GL cash account and creates an IN_PROGRESS reconciliation with its imported"
+                        + " statement lines (UNMATCHED). The GL ending balance is snapshotted from posted journal-entry"
+                        + " lines on the account as-of the statement date. Returns 422 ACCOUNT_NOT_RECONCILABLE if the"
+                        + " account's reconcilable flag (story H1) is false, and 400 if the CSV is malformed.", tags = {
+                                        "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Reconciliation created", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+        @ApiResponse(responseCode = "400", description = "Request body invalid or CSV malformed (ARGUMENT_NOT_VALID / VALIDATION_ERROR)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "422", description = "GL account is not reconcilable (ACCOUNT_NOT_RECONCILABLE)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<BankReconciliationResponse> importReconciliation(
+                        @Valid @RequestBody BankReconciliationImportRequest request) {
+                log.info("Import bank reconciliation for account {}", sanitizeForLog(request.getGlAccountId()));
+                return ResponseEntity.ok(bankReconciliationService.importStatement(request));
+        }
 
-    @GetMapping("/adjustment-types")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:view"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_ADJUSTMENT_TYPES_LIST", apiVersion = "1")
-    @Operation(
-            summary = "List reconciliation adjustment types",
-            operationId = "listReconciliationAdjustmentTypes",
-            description = "Returns the supported reconciliation adjustment types (decision D-6) so the frontend never"
-                    + " hardcodes the enum. No preconditions and no side effects.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Adjustment types listed",
-            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AdjustmentTypeResponse.class))))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:view permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<List<AdjustmentTypeResponse>> listAdjustmentTypes() {
-        List<AdjustmentTypeResponse> types = Arrays.stream(BankAdjustmentType.values())
-                .map(AdjustmentTypeResponse::from)
-                .toList();
-        return ResponseEntity.ok(types);
-    }
+        @GetMapping("/adjustment-types")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_ADJUSTMENT_TYPES_LIST", apiVersion = "1")
+        @Operation(summary = "List reconciliation adjustment types", operationId = "listReconciliationAdjustmentTypes", description = "Returns the supported reconciliation adjustment types (decision D-6) so the frontend never"
+                        + " hardcodes the enum. No preconditions and no side effects.", tags = {
+                                        "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Adjustment types listed", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AdjustmentTypeResponse.class))))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<List<AdjustmentTypeResponse>> listAdjustmentTypes() {
+                List<AdjustmentTypeResponse> types = Arrays.stream(BankAdjustmentType.values())
+                                .map(AdjustmentTypeResponse::from)
+                                .toList();
+                return ResponseEntity.ok(types);
+        }
 
-    @GetMapping
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:view"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_LIST", apiVersion = "1")
-    @Operation(
-            summary = "List reconciliations",
-            operationId = "listReconciliations",
-            description = "Lists reconciliations, optionally filtered by glAccountId and/or status, most recent first."
-                    + " Paginated. No side effects.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Reconciliations listed",
-            content = @Content(schema = @Schema(implementation = BankReconciliationListResponse.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:view permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<BankReconciliationListResponse> listReconciliations(
-            @Parameter(description = "Filter by reconciled GL account id") @RequestParam(required = false)
-                    UUID glAccountId,
-            @Parameter(description = "Filter by reconciliation status") @RequestParam(required = false)
-                    ReconciliationStatus status,
-            @Parameter(description = "Zero-based page index", example = "0") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "Page size", example = "20") @RequestParam(defaultValue = "20") int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return ResponseEntity.ok(bankReconciliationService.list(glAccountId, status, pageable));
-    }
+        @GetMapping
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_LIST", apiVersion = "1")
+        @Operation(summary = "List reconciliations", operationId = "listReconciliations", description = "Lists reconciliations, optionally filtered by glAccountId and/or status, most recent first."
+                        + " Paginated. No side effects.", tags = { "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Reconciliations listed", content = @Content(schema = @Schema(implementation = BankReconciliationListResponse.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<BankReconciliationListResponse> listReconciliations(
+                        @Parameter(description = "Filter by reconciled GL account id") @RequestParam(required = false) UUID glAccountId,
+                        @Parameter(description = "Filter by reconciliation status") @RequestParam(required = false) ReconciliationStatus status,
+                        @Parameter(description = "Zero-based page index", example = "0") @RequestParam(defaultValue = "0") int page,
+                        @Parameter(description = "Page size", example = "20") @RequestParam(defaultValue = "20") int size) {
+                Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+                return ResponseEntity.ok(bankReconciliationService.list(glAccountId, status, pageable));
+        }
 
-    @GetMapping("/{reconciliationId}")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:view"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_GET", apiVersion = "1")
-    @Operation(
-            summary = "Get a reconciliation",
-            operationId = "getReconciliation",
-            description = "Returns one reconciliation with its imported statement lines and adjustments. Returns 404"
-                    + " RECONCILIATION_NOT_FOUND if the id is unknown.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Reconciliation found",
-            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:view permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<BankReconciliationResponse> getReconciliation(
-            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
-        return ResponseEntity.ok(bankReconciliationService.get(reconciliationId));
-    }
+        @GetMapping("/{reconciliationId}")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_GET", apiVersion = "1")
+        @Operation(summary = "Get a reconciliation", operationId = "getReconciliation", description = "Returns one reconciliation with its imported statement lines and adjustments. Returns 404"
+                        + " RECONCILIATION_NOT_FOUND if the id is unknown.", tags = { "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Reconciliation found", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<BankReconciliationResponse> getReconciliation(
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
+                return ResponseEntity.ok(bankReconciliationService.get(reconciliationId));
+        }
 
-    @PostMapping("/{reconciliationId}/match")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:adjust"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_MATCH", apiVersion = "1")
-    @Operation(
-            summary = "Match statement lines to GL lines",
-            operationId = "matchReconciliation",
-            description = "Matches a set of statement lines to a set of posted GL journal-entry lines on the reconciled"
-                    + " account (1-to-1 or N-to-1). The two sets must net to equal signed amounts within ±0.01."
-                    + " Marks the statement lines MATCHED and records the linkage. Returns 404"
-                    + " RECONCILIATION_NOT_FOUND if the reconciliation or a line is missing, 409"
-                    + " RECONCILIATION_ALREADY_FINALIZED if the reconciliation is finalized, and 422"
-                    + " MATCH_AMOUNT_MISMATCH if the sets do not net.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Lines matched",
-            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-    @ApiResponse(
-            responseCode = "400",
-            description = "Request body invalid (ARGUMENT_NOT_VALID / VALIDATION_ERROR)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:adjust permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Reconciliation or a referenced line not found (RECONCILIATION_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "409",
-            description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED), or a statement/GL"
-                    + " line is ineligible — not UNMATCHED, not POSTED, or already reconciled"
-                    + " (RECONCILIATION_LINE_INELIGIBLE)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "422",
-            description = "Matched sets do not net to equal amounts (MATCH_AMOUNT_MISMATCH)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<BankReconciliationResponse> matchReconciliation(
-            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId,
-            @Valid @RequestBody ReconciliationMatchRequest request) {
-        log.info("Match lines in reconciliation {}", reconciliationId);
-        return ResponseEntity.ok(bankReconciliationService.match(reconciliationId, request));
-    }
+        @PostMapping("/{reconciliationId}/match")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_MATCH", apiVersion = "1")
+        @Operation(summary = "Match statement lines to GL lines", operationId = "matchReconciliation", description = "Matches a set of statement lines to a set of posted GL journal-entry lines on the reconciled"
+                        + " account (1-to-1 or N-to-1). The two sets must net to equal signed amounts within ±0.01."
+                        + " Marks the statement lines MATCHED and records the linkage. Returns 404"
+                        + " RECONCILIATION_NOT_FOUND if the reconciliation or a line is missing, 409"
+                        + " RECONCILIATION_ALREADY_FINALIZED if the reconciliation is finalized, and 422"
+                        + " MATCH_AMOUNT_MISMATCH if the sets do not net.", tags = { "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Lines matched", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+        @ApiResponse(responseCode = "400", description = "Request body invalid (ARGUMENT_NOT_VALID / VALIDATION_ERROR)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Reconciliation or a referenced line not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED), or a statement/GL"
+                        + " line is ineligible — not UNMATCHED, not POSTED, or already reconciled"
+                        + " (RECONCILIATION_LINE_INELIGIBLE)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "422", description = "Matched sets do not net to equal amounts (MATCH_AMOUNT_MISMATCH)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<BankReconciliationResponse> matchReconciliation(
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId,
+                        @Valid @RequestBody ReconciliationMatchRequest request) {
+                log.info("Match lines in reconciliation {}", sanitizeForLog(reconciliationId));
+                return ResponseEntity.ok(bankReconciliationService.match(reconciliationId, request));
+        }
 
-    @PostMapping("/{reconciliationId}/unmatch")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:adjust"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_UNMATCH", apiVersion = "1")
-    @Operation(
-            summary = "Reverse a match",
-            operationId = "unmatchReconciliation",
-            description = "Reverses a match by matchId or by statement line ids, returning the affected statement lines"
-                    + " to UNMATCHED and releasing the linked GL lines. Returns 404 RECONCILIATION_NOT_FOUND if the"
-                    + " reconciliation or match group is missing, and 409 RECONCILIATION_ALREADY_FINALIZED if the"
-                    + " reconciliation is finalized.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Match reversed",
-            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-    @ApiResponse(
-            responseCode = "400",
-            description = "Neither matchId nor statementLineIds resolved to a single match group (VALIDATION_ERROR)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:adjust permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Reconciliation or match group not found (RECONCILIATION_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "409",
-            description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<BankReconciliationResponse> unmatchReconciliation(
-            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId,
-            @Valid @RequestBody ReconciliationUnmatchRequest request) {
-        log.info("Unmatch in reconciliation {}", reconciliationId);
-        return ResponseEntity.ok(bankReconciliationService.unmatch(reconciliationId, request));
-    }
+        @PostMapping("/{reconciliationId}/unmatch")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_UNMATCH", apiVersion = "1")
+        @Operation(summary = "Reverse a match", operationId = "unmatchReconciliation", description = "Reverses a match by matchId or by statement line ids, returning the affected statement lines"
+                        + " to UNMATCHED and releasing the linked GL lines. Returns 404 RECONCILIATION_NOT_FOUND if the"
+                        + " reconciliation or match group is missing, and 409 RECONCILIATION_ALREADY_FINALIZED if the"
+                        + " reconciliation is finalized.", tags = { "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Match reversed", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+        @ApiResponse(responseCode = "400", description = "Neither matchId nor statementLineIds resolved to a single match group (VALIDATION_ERROR)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Reconciliation or match group not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<BankReconciliationResponse> unmatchReconciliation(
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId,
+                        @Valid @RequestBody ReconciliationUnmatchRequest request) {
+                log.info("Unmatch in reconciliation {}", sanitizeForLog(reconciliationId));
+                return ResponseEntity.ok(bankReconciliationService.unmatch(reconciliationId, request));
+        }
 
-    @PostMapping("/{reconciliationId}/adjustments")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:adjust"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_ADJUSTMENT", apiVersion = "1")
-    @Operation(
-            summary = "Record a reconciliation adjustment",
-            operationId = "addReconciliationAdjustment",
-            description = "Records a signed adjustment and posts a real balanced journal entry (Dr/Cr the reconciled"
-                    + " cash account against the type's mapped counter account) through the accounting-period gate."
-                    + " Returns 404 RECONCILIATION_NOT_FOUND if the reconciliation is missing, 409"
-                    + " RECONCILIATION_ALREADY_FINALIZED if it is finalized, and 422 PERIOD_CLOSED / PERIOD_HARD_LOCKED"
-                    + " if the adjustment JE is dated into a locked accounting period.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Adjustment recorded and JE posted",
-            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-    @ApiResponse(
-            responseCode = "400",
-            description = "Request body invalid or amount is zero (ARGUMENT_NOT_VALID / VALIDATION_ERROR)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:adjust permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "409",
-            description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "422",
-            description =
-                    "Adjustment JE dated into a CLOSED or hard-locked period (PERIOD_CLOSED / PERIOD_HARD_LOCKED),"
-                            + " or the amount sign is not permitted for the type — BANK_FEE/NSF_FEE must be negative,"
-                            + " INTEREST_EARNED must be positive (RECONCILIATION_ADJUSTMENT_SIGN_INVALID)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<BankReconciliationResponse> addReconciliationAdjustment(
-            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId,
-            @Valid @RequestBody ReconciliationAdjustmentRequest request) {
-        log.info("Record {} adjustment on reconciliation {}", request.getType(), reconciliationId);
-        return ResponseEntity.ok(bankReconciliationService.addAdjustment(reconciliationId, request));
-    }
+        @PostMapping("/{reconciliationId}/adjustments")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_ADJUSTMENT", apiVersion = "1")
+        @Operation(summary = "Record a reconciliation adjustment", operationId = "addReconciliationAdjustment", description = "Records a signed adjustment and posts a real balanced journal entry (Dr/Cr the reconciled"
+                        + " cash account against the type's mapped counter account) through the accounting-period gate."
+                        + " Returns 404 RECONCILIATION_NOT_FOUND if the reconciliation is missing, 409"
+                        + " RECONCILIATION_ALREADY_FINALIZED if it is finalized, and 422 PERIOD_CLOSED / PERIOD_HARD_LOCKED"
+                        + " if the adjustment JE is dated into a locked accounting period.", tags = {
+                                        "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Adjustment recorded and JE posted", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+        @ApiResponse(responseCode = "400", description = "Request body invalid or amount is zero (ARGUMENT_NOT_VALID / VALIDATION_ERROR)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "422", description = "Adjustment JE dated into a CLOSED or hard-locked period (PERIOD_CLOSED / PERIOD_HARD_LOCKED),"
+                        + " or the amount sign is not permitted for the type — BANK_FEE/NSF_FEE must be negative,"
+                        + " INTEREST_EARNED must be positive (RECONCILIATION_ADJUSTMENT_SIGN_INVALID)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<BankReconciliationResponse> addReconciliationAdjustment(
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId,
+                        @Valid @RequestBody ReconciliationAdjustmentRequest request) {
+                log.info(
+                                "Record {} adjustment on reconciliation {}",
+                                sanitizeForLog(request.getType()),
+                                sanitizeForLog(reconciliationId));
+                return ResponseEntity.ok(bankReconciliationService.addAdjustment(reconciliationId, request));
+        }
 
-    @PostMapping("/{reconciliationId}/finalize")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:adjust"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_FINALIZE", apiVersion = "1")
-    @Operation(
-            summary = "Finalize a reconciliation",
-            operationId = "finalizeReconciliation",
-            description = "Finalizes a reconciliation (IN_PROGRESS to FINALIZED) only when it balances: the statement"
-                    + " ending balance must equal the GL ending balance plus the sum of adjustments, within ±0.01"
-                    + " (matched GL lines are already reflected in the GL ending balance). Returns 404"
-                    + " RECONCILIATION_NOT_FOUND if missing, 409"
-                    + " RECONCILIATION_ALREADY_FINALIZED if already finalized, and 422 RECONCILIATION_NOT_BALANCED"
-                    + " (with the outstanding difference) if it does not balance.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Reconciliation finalized",
-            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:adjust permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "409",
-            description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "422",
-            description = "Reconciliation does not balance (RECONCILIATION_NOT_BALANCED)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<BankReconciliationResponse> finalizeReconciliation(
-            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
-        log.info("Finalize reconciliation {}", reconciliationId);
-        return ResponseEntity.ok(bankReconciliationService.finalizeReconciliation(reconciliationId));
-    }
+        @PostMapping("/{reconciliationId}/finalize")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_FINALIZE", apiVersion = "1")
+        @Operation(summary = "Finalize a reconciliation", operationId = "finalizeReconciliation", description = "Finalizes a reconciliation (IN_PROGRESS to FINALIZED) only when it balances: the statement"
+                        + " ending balance must equal the GL ending balance plus the sum of adjustments, within ±0.01"
+                        + " (matched GL lines are already reflected in the GL ending balance). Returns 404"
+                        + " RECONCILIATION_NOT_FOUND if missing, 409"
+                        + " RECONCILIATION_ALREADY_FINALIZED if already finalized, and 422 RECONCILIATION_NOT_BALANCED"
+                        + " (with the outstanding difference) if it does not balance.", tags = {
+                                        "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Reconciliation finalized", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "422", description = "Reconciliation does not balance (RECONCILIATION_NOT_BALANCED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<BankReconciliationResponse> finalizeReconciliation(
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
+                log.info("Finalize reconciliation {}", sanitizeForLog(reconciliationId));
+                return ResponseEntity.ok(bankReconciliationService.finalizeReconciliation(reconciliationId));
+        }
 
-    @GetMapping("/{reconciliationId}/report")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:view"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_REPORT", apiVersion = "1")
-    @Operation(
-            summary = "Reconciliation report",
-            operationId = "getReconciliationReport",
-            description = "Returns the reconciliation report: opening (GL) and closing (statement) balances, matched"
-                    + " vs outstanding lines, adjustments, and the outstanding difference. Returns 404"
-                    + " RECONCILIATION_NOT_FOUND if the id is unknown.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Report generated",
-            content = @Content(schema = @Schema(implementation = ReconciliationReportResponse.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:view permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<ReconciliationReportResponse> getReconciliationReport(
-            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
-        return ResponseEntity.ok(bankReconciliationService.report(reconciliationId));
-    }
+        private static String sanitizeForLog(Object value) {
+                if (value == null) {
+                        return "null";
+                }
+                return value.toString().replace('\n', '_').replace('\r', '_');
+        }
 
-    @GetMapping("/{reconciliationId}/audit")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:view"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_AUDIT", apiVersion = "1")
-    @Operation(
-            summary = "Reconciliation audit trail",
-            operationId = "getReconciliationAudit",
-            description = "Returns the audit trail of a reconciliation's actions (import, matches, adjustments,"
-                    + " finalize), ordered by time. Returns 404 RECONCILIATION_NOT_FOUND if the id is unknown.",
-            tags = {"Bank Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Audit trail generated",
-            content = @Content(schema = @Schema(implementation = ReconciliationAuditResponse.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:view permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<ReconciliationAuditResponse> getReconciliationAudit(
-            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
-        return ResponseEntity.ok(bankReconciliationService.audit(reconciliationId));
-    }
+        @GetMapping("/{reconciliationId}/report")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_REPORT", apiVersion = "1")
+        @Operation(summary = "Reconciliation report", operationId = "getReconciliationReport", description = "Returns the reconciliation report: opening (GL) and closing (statement) balances, matched"
+                        + " vs outstanding lines, adjustments, and the outstanding difference. Returns 404"
+                        + " RECONCILIATION_NOT_FOUND if the id is unknown.", tags = { "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Report generated", content = @Content(schema = @Schema(implementation = ReconciliationReportResponse.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<ReconciliationReportResponse> getReconciliationReport(
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
+                return ResponseEntity.ok(bankReconciliationService.report(reconciliationId));
+        }
+
+        @GetMapping("/{reconciliationId}/audit")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_AUDIT", apiVersion = "1")
+        @Operation(summary = "Reconciliation audit trail", operationId = "getReconciliationAudit", description = "Returns the audit trail of a reconciliation's actions (import, matches, adjustments,"
+                        + " finalize), ordered by time. Returns 404 RECONCILIATION_NOT_FOUND if the id is unknown.", tags = {
+                                        "Bank Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Audit trail generated", content = @Content(schema = @Schema(implementation = ReconciliationAuditResponse.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<ReconciliationAuditResponse> getReconciliationAudit(
+                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
+                return ResponseEntity.ok(bankReconciliationService.audit(reconciliationId));
+        }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/SettlementReconciliationController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/SettlementReconciliationController.java
@@ -40,176 +40,124 @@ import org.springframework.web.bind.annotation.RestController;
  * write-off (reversible JE below the configured threshold).
  *
  * @see <a href=
- *      "domains/accounting/plan-odoo-parity-pos-accounting.md">Odoo Parity Plan -
+ *      "domains/accounting/plan-odoo-parity-pos-accounting.md">Odoo Parity Plan
+ *      -
  *      Story F1c</a>
  */
 @RestController
 @RequestMapping("/v1/accounting/settlements")
-@Tag(
-        name = "Settlement Reconciliation",
-        description = "Processor settlement reconciliation review: list settlement lines, manually match an"
+@Tag(name = "Settlement Reconciliation", description = "Processor settlement reconciliation review: list settlement lines, manually match an"
                 + " unmatched line to a receivable payment, and write off small unmatched lines.")
 @RequiredArgsConstructor
 @Validated
 public class SettlementReconciliationController {
 
-    private static final Logger log = LoggerFactory.getLogger(SettlementReconciliationController.class);
+        private static final Logger log = LoggerFactory.getLogger(SettlementReconciliationController.class);
 
-    private final SettlementReconciliationService settlementReconciliationService;
+        private final SettlementReconciliationService settlementReconciliationService;
 
-    @GetMapping("/{settlementId}/lines")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:view"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-    @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINES_LIST", apiVersion = "1")
-    @Operation(
-            summary = "List settlement lines",
-            operationId = "listSettlementLines",
-            description = "Lists the lines of one processor settlement (payout), optionally filtered to only the"
-                    + " UNMATCHED lines awaiting review. Use this tool to triage a settlement before manually"
-                    + " matching or writing off its unmatched lines. Matched lines are already posted; unmatched"
-                    + " lines park their gross in the settlement suspense account until resolved (decision D-13)."
-                    + " No preconditions and no side effects; an unknown settlementId returns an empty list.",
-            tags = {"Settlement Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Settlement lines listed",
-            content = @Content(array = @ArraySchema(schema = @Schema(implementation = SettlementLineResponse.class))))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:view permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<List<SettlementLineResponse>> listSettlementLines(
-            @Parameter(
-                            description = "Provider settlement (payout) id",
-                            required = true,
-                            example = "stl_1Mx3k2eZvKYlo2C0")
-                    @PathVariable
-                    String settlementId,
-            @Parameter(description = "When true, return only UNMATCHED lines", example = "true")
-                    @RequestParam(name = "unmatchedOnly", defaultValue = "false")
-                    boolean unmatchedOnly) {
-        log.info("List settlement lines for {} (unmatchedOnly={})", settlementId, unmatchedOnly);
-        List<SettlementLineResponse> response =
-                settlementReconciliationService.listLines(settlementId, unmatchedOnly).stream()
-                        .map(SettlementLineResponse::from)
-                        .toList();
-        return ResponseEntity.ok(response);
-    }
+        @GetMapping("/{settlementId}/lines")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+        @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINES_LIST", apiVersion = "1")
+        @Operation(summary = "List settlement lines", operationId = "listSettlementLines", description = "Lists the lines of one processor settlement (payout), optionally filtered to only the"
+                        + " UNMATCHED lines awaiting review. Use this tool to triage a settlement before manually"
+                        + " matching or writing off its unmatched lines. Matched lines are already posted; unmatched"
+                        + " lines park their gross in the settlement suspense account until resolved (decision D-13)."
+                        + " No preconditions and no side effects; an unknown settlementId returns an empty list.", tags = {
+                                        "Settlement Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Settlement lines listed", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SettlementLineResponse.class))))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<List<SettlementLineResponse>> listSettlementLines(
+                        @Parameter(description = "Provider settlement (payout) id", required = true, example = "stl_1Mx3k2eZvKYlo2C0") @PathVariable String settlementId,
+                        @Parameter(description = "When true, return only UNMATCHED lines", example = "true") @RequestParam(name = "unmatchedOnly", defaultValue = "false") boolean unmatchedOnly) {
+                log.info(
+                                "List settlement lines for {} (unmatchedOnly={})",
+                                sanitizeForLog(settlementId),
+                                sanitizeForLog(unmatchedOnly));
+                List<SettlementLineResponse> response = settlementReconciliationService
+                                .listLines(settlementId, unmatchedOnly).stream()
+                                .map(SettlementLineResponse::from)
+                                .toList();
+                return ResponseEntity.ok(response);
+        }
 
-    @PostMapping("/lines/{lineId}/match")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:adjust"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-    @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINE_MATCH", apiVersion = "1")
-    @Operation(
-            summary = "Manually match a settlement line",
-            operationId = "matchSettlementLine",
-            description = "Manually matches an UNMATCHED settlement line to an AR receivable payment, posting a"
-                    + " reclass entry (Dr Settlement Suspense / Cr Undeposited Funds) that clears the line's gross"
-                    + " out of suspense. Use this tool when the automatic gross match could not identify the"
-                    + " payment. AP (vendor) matching is not supported in v1."
-                    + " Preconditions: the line must exist and be UNMATCHED, its parent settlement must already"
-                    + " be POSTED, and the receivable payment must exist. Returns 404 if the line or payment is"
-                    + " not found (SETTLEMENT_LINE_NOT_FOUND / RECEIVABLE_PAYMENT_NOT_FOUND), 409 if the line is"
-                    + " no longer UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED) or the settlement has not yet posted"
-                    + " (SETTLEMENT_NOT_POSTED), and 422 if the reclass entry is dated into a locked accounting"
-                    + " period (PERIOD_CLOSED / PERIOD_HARD_LOCKED). Emits ACCOUNTING_SETTLEMENT_LINE_MATCH.",
-            tags = {"Settlement Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Line matched; the updated line is returned",
-            content = @Content(schema = @Schema(implementation = SettlementLineResponse.class)))
-    @ApiResponse(
-            responseCode = "400",
-            description = "receivablePaymentId is missing (ARGUMENT_NOT_VALID)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:adjust permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Settlement line or receivable payment not found"
-                    + " (SETTLEMENT_LINE_NOT_FOUND / RECEIVABLE_PAYMENT_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "409",
-            description = "Settlement line is not UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED), or the settlement"
-                    + " has not yet posted (SETTLEMENT_NOT_POSTED)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "422",
-            description = "Reclass entry is dated into a CLOSED or hard-locked accounting period"
-                    + " (PERIOD_CLOSED / PERIOD_HARD_LOCKED)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<SettlementLineResponse> matchSettlementLine(
-            @Parameter(description = "Settlement line id", required = true) @PathVariable UUID lineId,
-            @Valid @RequestBody SettlementManualMatchRequest request) {
-        log.info("Manual match settlement line {} to receivable payment {}", lineId, request.getReceivablePaymentId());
-        SettlementLineResponse response = SettlementLineResponse.from(
-                settlementReconciliationService.manualMatchToReceivable(lineId, request.getReceivablePaymentId()));
-        return ResponseEntity.ok(response);
-    }
+        @PostMapping("/lines/{lineId}/match")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+        @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINE_MATCH", apiVersion = "1")
+        @Operation(summary = "Manually match a settlement line", operationId = "matchSettlementLine", description = "Manually matches an UNMATCHED settlement line to an AR receivable payment, posting a"
+                        + " reclass entry (Dr Settlement Suspense / Cr Undeposited Funds) that clears the line's gross"
+                        + " out of suspense. Use this tool when the automatic gross match could not identify the"
+                        + " payment. AP (vendor) matching is not supported in v1."
+                        + " Preconditions: the line must exist and be UNMATCHED, its parent settlement must already"
+                        + " be POSTED, and the receivable payment must exist. Returns 404 if the line or payment is"
+                        + " not found (SETTLEMENT_LINE_NOT_FOUND / RECEIVABLE_PAYMENT_NOT_FOUND), 409 if the line is"
+                        + " no longer UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED) or the settlement has not yet posted"
+                        + " (SETTLEMENT_NOT_POSTED), and 422 if the reclass entry is dated into a locked accounting"
+                        + " period (PERIOD_CLOSED / PERIOD_HARD_LOCKED). Emits ACCOUNTING_SETTLEMENT_LINE_MATCH.", tags = {
+                                        "Settlement Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Line matched; the updated line is returned", content = @Content(schema = @Schema(implementation = SettlementLineResponse.class)))
+        @ApiResponse(responseCode = "400", description = "receivablePaymentId is missing (ARGUMENT_NOT_VALID)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Settlement line or receivable payment not found"
+                        + " (SETTLEMENT_LINE_NOT_FOUND / RECEIVABLE_PAYMENT_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "409", description = "Settlement line is not UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED), or the settlement"
+                        + " has not yet posted (SETTLEMENT_NOT_POSTED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "422", description = "Reclass entry is dated into a CLOSED or hard-locked accounting period"
+                        + " (PERIOD_CLOSED / PERIOD_HARD_LOCKED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<SettlementLineResponse> matchSettlementLine(
+                        @Parameter(description = "Settlement line id", required = true) @PathVariable UUID lineId,
+                        @Valid @RequestBody SettlementManualMatchRequest request) {
+                log.info(
+                                "Manual match settlement line {} to receivable payment {}",
+                                sanitizeForLog(lineId),
+                                sanitizeForLog(request.getReceivablePaymentId()));
+                SettlementLineResponse response = SettlementLineResponse.from(
+                                settlementReconciliationService.manualMatchToReceivable(lineId,
+                                                request.getReceivablePaymentId()));
+                return ResponseEntity.ok(response);
+        }
 
-    @PostMapping("/lines/{lineId}/write-off")
-    @SecurityRequirement(
-            name = "bearerAuth",
-            scopes = {"accounting:reconciliation:adjust"})
-    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-    @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINE_WRITE_OFF", apiVersion = "1")
-    @Operation(
-            summary = "Write off a small unmatched settlement line",
-            operationId = "writeOffSettlementLine",
-            description = "Writes off an UNMATCHED settlement line whose gross is at or below the configured"
-                    + " reconciliation write-off threshold (default $25.00, decision D-14), posting a reversible"
-                    + " adjustment entry (Dr Settlement Suspense / Cr Settlement Adjustment) — never a silent"
-                    + " status flip. Use this tool only for genuinely unidentifiable small residuals; above the"
-                    + " threshold there is no self-service write-off — manually match or escalate."
-                    + " Preconditions: the line must exist and be UNMATCHED, its gross must not exceed the"
-                    + " threshold (compared on absolute value), and a non-blank reason (max 500 chars) is required"
-                    + " and audited. Respects accounting period locks (Story B2). Emits"
-                    + " ACCOUNTING_SETTLEMENT_LINE_WRITE_OFF. Returns 422 when the absolute gross exceeds the"
-                    + " threshold (WRITE_OFF_THRESHOLD_EXCEEDED) or the adjustment entry is dated into a locked"
-                    + " accounting period (PERIOD_CLOSED / PERIOD_HARD_LOCKED), and 409 when the line is no longer"
-                    + " UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED) or the settlement has not yet posted"
-                    + " (SETTLEMENT_NOT_POSTED).",
-            tags = {"Settlement Reconciliation"})
-    @ApiResponse(
-            responseCode = "200",
-            description = "Line written off; the updated line is returned",
-            content = @Content(schema = @Schema(implementation = SettlementLineResponse.class)))
-    @ApiResponse(
-            responseCode = "400",
-            description = "reason is missing, blank, or over 500 characters (ARGUMENT_NOT_VALID)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "403",
-            description = "Caller lacks the accounting:reconciliation:adjust permission",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "404",
-            description = "Settlement line not found (SETTLEMENT_LINE_NOT_FOUND)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "409",
-            description = "Settlement line is not UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED), or the settlement"
-                    + " has not yet posted (SETTLEMENT_NOT_POSTED)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    @ApiResponse(
-            responseCode = "422",
-            description = "Line absolute gross exceeds the write-off threshold (WRITE_OFF_THRESHOLD_EXCEEDED);"
-                    + " manual match or escalate — or the adjustment entry is dated into a CLOSED or hard-locked"
-                    + " accounting period (PERIOD_CLOSED / PERIOD_HARD_LOCKED)",
-            content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<SettlementLineResponse> writeOffSettlementLine(
-            @Parameter(description = "Settlement line id", required = true) @PathVariable UUID lineId,
-            @Valid @RequestBody SettlementWriteOffRequest request) {
-        log.info("Write off settlement line {}", lineId);
-        SettlementLineResponse response =
-                SettlementLineResponse.from(settlementReconciliationService.writeOffLine(lineId, request.getReason()));
-        return ResponseEntity.ok(response);
-    }
+        @PostMapping("/lines/{lineId}/write-off")
+        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
+        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+        @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINE_WRITE_OFF", apiVersion = "1")
+        @Operation(summary = "Write off a small unmatched settlement line", operationId = "writeOffSettlementLine", description = "Writes off an UNMATCHED settlement line whose gross is at or below the configured"
+                        + " reconciliation write-off threshold (default $25.00, decision D-14), posting a reversible"
+                        + " adjustment entry (Dr Settlement Suspense / Cr Settlement Adjustment) — never a silent"
+                        + " status flip. Use this tool only for genuinely unidentifiable small residuals; above the"
+                        + " threshold there is no self-service write-off — manually match or escalate."
+                        + " Preconditions: the line must exist and be UNMATCHED, its gross must not exceed the"
+                        + " threshold (compared on absolute value), and a non-blank reason (max 500 chars) is required"
+                        + " and audited. Respects accounting period locks (Story B2). Emits"
+                        + " ACCOUNTING_SETTLEMENT_LINE_WRITE_OFF. Returns 422 when the absolute gross exceeds the"
+                        + " threshold (WRITE_OFF_THRESHOLD_EXCEEDED) or the adjustment entry is dated into a locked"
+                        + " accounting period (PERIOD_CLOSED / PERIOD_HARD_LOCKED), and 409 when the line is no longer"
+                        + " UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED) or the settlement has not yet posted"
+                        + " (SETTLEMENT_NOT_POSTED).", tags = { "Settlement Reconciliation" })
+        @ApiResponse(responseCode = "200", description = "Line written off; the updated line is returned", content = @Content(schema = @Schema(implementation = SettlementLineResponse.class)))
+        @ApiResponse(responseCode = "400", description = "reason is missing, blank, or over 500 characters (ARGUMENT_NOT_VALID)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "404", description = "Settlement line not found (SETTLEMENT_LINE_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "409", description = "Settlement line is not UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED), or the settlement"
+                        + " has not yet posted (SETTLEMENT_NOT_POSTED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        @ApiResponse(responseCode = "422", description = "Line absolute gross exceeds the write-off threshold (WRITE_OFF_THRESHOLD_EXCEEDED);"
+                        + " manual match or escalate — or the adjustment entry is dated into a CLOSED or hard-locked"
+                        + " accounting period (PERIOD_CLOSED / PERIOD_HARD_LOCKED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
+        public ResponseEntity<SettlementLineResponse> writeOffSettlementLine(
+                        @Parameter(description = "Settlement line id", required = true) @PathVariable UUID lineId,
+                        @Valid @RequestBody SettlementWriteOffRequest request) {
+                log.info("Write off settlement line {}", sanitizeForLog(lineId));
+                SettlementLineResponse response = SettlementLineResponse
+                                .from(settlementReconciliationService.writeOffLine(lineId, request.getReason()));
+                return ResponseEntity.ok(response);
+        }
+
+        private static String sanitizeForLog(Object value) {
+                if (value == null) {
+                        return "null";
+                }
+                return value.toString().replace('\n', '_').replace('\r', '_');
+        }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/SettlementReconciliationController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/SettlementReconciliationController.java
@@ -18,6 +18,8 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -69,12 +71,14 @@ public class SettlementReconciliationController {
         @ApiResponse(responseCode = "200", description = "Settlement lines listed", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SettlementLineResponse.class))))
         @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<List<SettlementLineResponse>> listSettlementLines(
-                        @Parameter(description = "Provider settlement (payout) id", required = true, example = "stl_1Mx3k2eZvKYlo2C0") @PathVariable String settlementId,
+                        @Parameter(description = "Provider settlement (payout) id", required = true, example = "stl_1Mx3k2eZvKYlo2C0") @PathVariable @NonNull String settlementId,
                         @Parameter(description = "When true, return only UNMATCHED lines", example = "true") @RequestParam(name = "unmatchedOnly", defaultValue = "false") boolean unmatchedOnly) {
-                log.info(
-                                "List settlement lines for {} (unmatchedOnly={})",
-                                sanitizeForLog(settlementId),
-                                sanitizeForLog(unmatchedOnly));
+                if (log.isInfoEnabled()) {
+                        log.info(
+                                        "List settlement lines for {} (unmatchedOnly={})",
+                                        sanitizeForLog(settlementId),
+                                        sanitizeForLog(unmatchedOnly));
+                }
                 List<SettlementLineResponse> response = settlementReconciliationService
                                 .listLines(settlementId, unmatchedOnly).stream()
                                 .map(SettlementLineResponse::from)
@@ -107,12 +111,14 @@ public class SettlementReconciliationController {
         @ApiResponse(responseCode = "422", description = "Reclass entry is dated into a CLOSED or hard-locked accounting period"
                         + " (PERIOD_CLOSED / PERIOD_HARD_LOCKED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<SettlementLineResponse> matchSettlementLine(
-                        @Parameter(description = "Settlement line id", required = true) @PathVariable UUID lineId,
-                        @Valid @RequestBody SettlementManualMatchRequest request) {
-                log.info(
-                                "Manual match settlement line {} to receivable payment {}",
-                                sanitizeForLog(lineId),
-                                sanitizeForLog(request.getReceivablePaymentId()));
+                        @Parameter(description = "Settlement line id", required = true) @PathVariable @NonNull UUID lineId,
+                        @Valid @RequestBody @NonNull SettlementManualMatchRequest request) {
+                if (log.isInfoEnabled()) {
+                        log.info(
+                                        "Manual match settlement line {} to receivable payment {}",
+                                        sanitizeForLog(lineId),
+                                        sanitizeForLog(request.getReceivablePaymentId()));
+                }
                 SettlementLineResponse response = SettlementLineResponse.from(
                                 settlementReconciliationService.manualMatchToReceivable(lineId,
                                                 request.getReceivablePaymentId()));
@@ -146,15 +152,17 @@ public class SettlementReconciliationController {
                         + " manual match or escalate — or the adjustment entry is dated into a CLOSED or hard-locked"
                         + " accounting period (PERIOD_CLOSED / PERIOD_HARD_LOCKED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
         public ResponseEntity<SettlementLineResponse> writeOffSettlementLine(
-                        @Parameter(description = "Settlement line id", required = true) @PathVariable UUID lineId,
-                        @Valid @RequestBody SettlementWriteOffRequest request) {
-                log.info("Write off settlement line {}", sanitizeForLog(lineId));
+                        @Parameter(description = "Settlement line id", required = true) @PathVariable @NonNull UUID lineId,
+                        @Valid @RequestBody @NonNull SettlementWriteOffRequest request) {
+                if (log.isInfoEnabled()) {
+                        log.info("Write off settlement line {}", sanitizeForLog(lineId));
+                }
                 SettlementLineResponse response = SettlementLineResponse
                                 .from(settlementReconciliationService.writeOffLine(lineId, request.getReason()));
                 return ResponseEntity.ok(response);
         }
 
-        private static String sanitizeForLog(Object value) {
+        private static String sanitizeForLog(@Nullable Object value) {
                 if (value == null) {
                         return "null";
                 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportArtifact.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportArtifact.java
@@ -1,15 +1,50 @@
 package com.positivity.accounting.internal.dto;
 
+import java.util.Arrays;
 import org.jspecify.annotations.NonNull;
 
 /**
  * Rendered export artifact held for download (issue #999).
  *
  * @param content     rendered bytes (CSV text or PDF binary)
- * @param contentType MIME type of the artifact ({@code text/csv} or {@code application/pdf})
+ * @param contentType MIME type of the artifact ({@code text/csv} or
+ *                    {@code application/pdf})
  * @param filename    suggested download filename including extension
  */
 public record ReportExportArtifact(
-        byte @NonNull [] content,
-        @NonNull String contentType,
-        @NonNull String filename) {}
+                byte @NonNull [] content,
+                @NonNull String contentType,
+                @NonNull String filename) {
+
+        @Override
+        public boolean equals(Object obj) {
+                if (this == obj) {
+                        return true;
+                }
+                if (!(obj instanceof ReportExportArtifact(byte[] otherContent, String otherContentType, String otherFilename))) {
+                        return false;
+                }
+                return Arrays.equals(content, otherContent)
+                                && contentType.equals(otherContentType)
+                                && filename.equals(otherFilename);
+        }
+
+        @Override
+        public int hashCode() {
+                int result = Arrays.hashCode(content);
+                result = 31 * result + contentType.hashCode();
+                result = 31 * result + filename.hashCode();
+                return result;
+        }
+
+        @Override
+        public String toString() {
+                return "ReportExportArtifact[content="
+                                + Arrays.toString(content)
+                                + ", contentType="
+                                + contentType
+                                + ", filename="
+                                + filename
+                                + "]";
+        }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/TaxLiabilitySnapshotRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/TaxLiabilitySnapshotRepository.java
@@ -6,14 +6,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 /**
- * Repository for frozen Sales-Tax Liability snapshots (issue #998). Snapshots are insert-only
- * except for the {@code ACTIVE -> SUPERSEDED} lifecycle transition; there are no delete or content
+ * Repository for frozen Sales-Tax Liability snapshots (issue #998). Snapshots
+ * are insert-only
+ * except for the {@code ACTIVE -> SUPERSEDED} lifecycle transition; there are
+ * no delete or content
  * update paths.
  */
-@Repository
 public interface TaxLiabilitySnapshotRepository extends JpaRepository<TaxLiabilitySnapshot, UUID> {
 
     Optional<TaxLiabilitySnapshot> findByPeriodIdAndStatus(UUID periodId, TaxLiabilitySnapshotStatus status);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
@@ -104,8 +104,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
      * for the Aged Payables report: everything except settled ({@code PAID}),
      * voided ({@code VOIDED}), and rejected ({@code REJECTED}) bills.
      */
-    private static final Set<VendorBillStatus> OPEN_PAYABLE_STATUSES =
-            Set.of(VendorBillStatus.PENDING_RECEIPT_MATCH, VendorBillStatus.MATCH_EXCEPTION, VendorBillStatus.APPROVED);
+    private static final Set<VendorBillStatus> OPEN_PAYABLE_STATUSES = Set.of(VendorBillStatus.PENDING_RECEIPT_MATCH,
+            VendorBillStatus.MATCH_EXCEPTION, VendorBillStatus.APPROVED);
 
     /**
      * Chart-of-accounts code of the single Sales-Tax Payable account (D-4: one GL
@@ -171,8 +171,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
 
         // Load all income statement mappings (ordered by display order)
-        List<StatementLineMapping> mappings =
-                statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
+        List<StatementLineMapping> mappings = statementLineMappingRepository
+                .findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
                         StatementType.INCOME_STATEMENT);
 
         if (mappings.isEmpty()) {
@@ -252,8 +252,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         LocalDateTime asOfDateTime = asOfDate.atTime(LocalTime.MAX);
 
         // Load all balance sheet mappings (ordered by display order)
-        List<StatementLineMapping> mappings =
-                statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
+        List<StatementLineMapping> mappings = statementLineMappingRepository
+                .findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
                         StatementType.BALANCE_SHEET);
 
         if (mappings.isEmpty()) {
@@ -310,8 +310,7 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
         // Validate balance sheet equation: Assets = Liabilities + Equity (within
         // tolerance)
-        BigDecimal difference =
-                totalAssets.subtract(totalLiabilities.add(totalEquity)).abs();
+        BigDecimal difference = totalAssets.subtract(totalLiabilities.add(totalEquity)).abs();
         boolean balanced = difference.compareTo(BALANCE_TOLERANCE) <= 0;
 
         if (!balanced) {
@@ -350,8 +349,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         // Per-account aggregation happens in the database (grouped JPQL over
         // POSTED lines, ordered by account code) — the line set is never
         // materialized in memory.
-        List<TrialBalanceAccountTotal> accountTotals =
-                journalEntryRepository.sumPostedDebitsCreditsByAccountAsOf(asOfDateTime);
+        List<TrialBalanceAccountTotal> accountTotals = journalEntryRepository
+                .sumPostedDebitsCreditsByAccountAsOf(asOfDateTime);
 
         List<TrialBalanceRow> rows = accountTotals.stream()
                 .map(total -> TrialBalanceRow.builder()
@@ -364,10 +363,10 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                         .build())
                 .toList();
 
-        BigDecimal totalDebit =
-                rows.stream().map(TrialBalanceRow::getTotalDebit).reduce(BigDecimal.ZERO, BigDecimal::add);
-        BigDecimal totalCredit =
-                rows.stream().map(TrialBalanceRow::getTotalCredit).reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalDebit = rows.stream().map(TrialBalanceRow::getTotalDebit).reduce(BigDecimal.ZERO,
+                BigDecimal::add);
+        BigDecimal totalCredit = rows.stream().map(TrialBalanceRow::getTotalCredit).reduce(BigDecimal.ZERO,
+                BigDecimal::add);
 
         // Computed, never assumed: an unbalanced ledger (A1 constraint
         // violation) must surface operationally as balanced = false.
@@ -415,13 +414,13 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
      * chronological cut. A clean ledger yields an empty footnote.
      */
     private List<EntryNumberGapCheck> checkEntryNumberGaps(LocalDate asOf) {
-        String asOfScopeBoundary =
-                String.format("%s%04d%02d", ENTRY_NUMBER_SCOPE_PREFIX, asOf.getYear(), asOf.getMonthValue());
+        String asOfScopeBoundary = String.format("%s%04d%02d", ENTRY_NUMBER_SCOPE_PREFIX, asOf.getYear(),
+                asOf.getMonthValue());
 
         return accountingSequenceRepository.findAllByOrderByScopeKeyAsc().stream()
                 .map(AccountingSequence::getScopeKey)
-                .filter(scopeKey ->
-                        scopeKey.startsWith(ENTRY_NUMBER_SCOPE_PREFIX) && scopeKey.compareTo(asOfScopeBoundary) <= 0)
+                .filter(scopeKey -> scopeKey.startsWith(ENTRY_NUMBER_SCOPE_PREFIX)
+                        && scopeKey.compareTo(asOfScopeBoundary) <= 0)
                 .map(scopeKey -> EntryNumberGapCheck.builder()
                         .scopeKey(scopeKey)
                         .missingNumbers(accountingSequenceRepository.findMissingEntryNumbers(scopeKey))
@@ -497,8 +496,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
 
         // Find all posted journal entries affecting this account
-        List<JournalEntry> entries =
-                journalEntryRepository.findPostedEntriesForAccount(glAccountId, startDateTime, endDateTime);
+        List<JournalEntry> entries = journalEntryRepository.findPostedEntriesForAccount(glAccountId, startDateTime,
+                endDateTime);
 
         // Extract journal lines for this account
         return entries.stream()
@@ -539,8 +538,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         if (accountId != null) {
             UUID glAccountId = parseAccountId(accountId);
             log.info("Generating general ledger for account {} for period {} to {}", glAccountId, startDate, endDate);
-            List<JournalEntry> entries =
-                    journalEntryRepository.findPostedEntriesForAccount(glAccountId, startDateTime, endDateTime);
+            List<JournalEntry> entries = journalEntryRepository.findPostedEntriesForAccount(glAccountId, startDateTime,
+                    endDateTime);
             collectAccountLines(entries, glAccountId, linesByAccount);
         } else {
             log.info("Generating general ledger for all accounts for period {} to {}", startDate, endDate);
@@ -605,12 +604,18 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
         log.info("Generating aged receivables as of {}", asOfDate);
 
-        // As-of semantics (finding 10): items whose aging date is after asOfDate are excluded
-        // (daysPastDue < 0), and buckets are keyed on asOfDate. KNOWN LIMITATION: the open balance is
-        // the invoice's CURRENT balance (InvoiceBalanceCalculator derives it from all payment
-        // applications/reversals/credit-memos to date), not a balance reconstructed as-of asOfDate, so
-        // a back-dated asOfDate reflects today's balances against historical aging dates. A true
-        // historical-balance reconstruction is deferred (needs point-in-time application replay).
+        // As-of semantics (finding 10): items whose aging date is after asOfDate are
+        // excluded
+        // (daysPastDue < 0), and buckets are keyed on asOfDate. KNOWN LIMITATION: the
+        // open balance is
+        // the invoice's CURRENT balance (InvoiceBalanceCalculator derives it from all
+        // payment
+        // applications/reversals/credit-memos to date), not a balance reconstructed
+        // as-of asOfDate, so
+        // a back-dated asOfDate reflects today's balances against historical aging
+        // dates. A true
+        // historical-balance reconstruction is deferred (needs point-in-time
+        // application replay).
         // AR-eligible invoices; open balance is derived from accounting-owned
         // facts (payment applications, reversals, credit memos) via the shared
         // InvoiceBalanceCalculator — never fetched from another service.
@@ -675,13 +680,17 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
         log.info("Generating aged payables as of {}", asOfDate);
 
-        // As-of semantics (finding 10): items whose aging date is after asOfDate are excluded
-        // (daysPastDue < 0), and buckets are keyed on asOfDate. KNOWN LIMITATION: the open balance is
-        // the bill's CURRENT balance (total minus all allocations to date), not a balance reconstructed
+        // As-of semantics (finding 10): items whose aging date is after asOfDate are
+        // excluded
+        // (daysPastDue < 0), and buckets are keyed on asOfDate. KNOWN LIMITATION: the
+        // open balance is
+        // the bill's CURRENT balance (total minus all allocations to date), not a
+        // balance reconstructed
         // as-of asOfDate. A true historical-balance reconstruction is deferred.
         List<VendorBill> bills = vendorBillRepository.findByStatusIn(OPEN_PAYABLE_STATUSES);
 
-        // Batch every bill's allocated total in one query to avoid a per-bill N+1 (finding 9).
+        // Batch every bill's allocated total in one query to avoid a per-bill N+1
+        // (finding 9).
         List<UUID> billIds = bills.stream().map(VendorBill::getVendorBillId).toList();
         Map<UUID, BigDecimal> allocatedByBill = billIds.isEmpty()
                 ? Map.of()
@@ -702,8 +711,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
             if (daysPastDue < 0) {
                 continue; // future-dated as of asOfDate — not yet an outstanding item (finding 10)
             }
-            VendorAging aging =
-                    byVendor.computeIfAbsent(bill.getVendorId(), key -> new VendorAging(bill.getVendorName()));
+            VendorAging aging = byVendor.computeIfAbsent(bill.getVendorId(),
+                    key -> new VendorAging(bill.getVendorName()));
             aging.buckets.add(daysPastDue, openBalance);
         }
 
@@ -721,7 +730,7 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                             .build();
                 })
                 .sorted(Comparator.comparing(
-                                AgedPayablesRow::getVendorName, Comparator.nullsLast(Comparator.naturalOrder()))
+                        AgedPayablesRow::getVendorName, Comparator.nullsLast(Comparator.naturalOrder()))
                         .thenComparing(AgedPayablesRow::getVendorId))
                 .toList();
 
@@ -762,12 +771,12 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
         Map<JurisdictionKey, JurisdictionAccumulator> byJurisdiction = new HashMap<>();
 
-        // --- Invoice side (accrual): tax bucketed by the invoice's finalization period ---
+        // --- Invoice side (accrual): tax bucketed by the invoice's finalization period
+        // ---
         List<ExtInvoice> invoices = extInvoiceRepository.findByFinalizedAtBetween(startInstant, endInstant);
-        List<UUID> invoiceIds =
-                invoices.stream().map(ExtInvoice::getInvoiceId).distinct().toList();
-        List<ExtInvoiceTax> invoiceTaxRows =
-                invoiceIds.isEmpty() ? List.of() : extInvoiceTaxRepository.findByInvoiceIdIn(invoiceIds);
+        List<UUID> invoiceIds = invoices.stream().map(ExtInvoice::getInvoiceId).distinct().toList();
+        List<ExtInvoiceTax> invoiceTaxRows = invoiceIds.isEmpty() ? List.of()
+                : extInvoiceTaxRepository.findByInvoiceIdIn(invoiceIds);
 
         for (ExtInvoiceTax row : invoiceTaxRows) {
             JurisdictionAccumulator acc = accumulatorFor(byJurisdiction, row);
@@ -785,7 +794,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
         // --- Credit side (accrual): reversals bucketed by the credit's POSTING period,
         // whatever status the credit now carries (issue #997 — a later APPLIED/VOIDED
-        // transition does not remove the Dr 2200 entry, so dropping it here would show up
+        // transition does not remove the Dr 2200 entry, so dropping it here would show
+        // up
         // as GL drift). Attribution comes from the credit's own frozen per-jurisdiction
         // breakdown (issue #996), falling back to the pro-rata allocator for credits
         // issued before that breakdown existed. ---
@@ -797,15 +807,14 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                     .map(CreditMemo::getOriginalInvoiceId)
                     .distinct()
                     .toList();
-            Map<UUID, List<ExtInvoiceTax>> taxByOriginalInvoice =
-                    extInvoiceTaxRepository.findByInvoiceIdIn(originalInvoiceIds).stream()
-                            .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
+            Map<UUID, List<ExtInvoiceTax>> taxByOriginalInvoice = extInvoiceTaxRepository
+                    .findByInvoiceIdIn(originalInvoiceIds).stream()
+                    .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
 
-            List<UUID> creditMemoIds =
-                    credits.stream().map(CreditMemo::getCreditMemoId).toList();
-            Map<UUID, List<CreditMemoTax>> attributionByCredit =
-                    creditMemoTaxRepository.findByCreditMemoIdIn(creditMemoIds).stream()
-                            .collect(Collectors.groupingBy(CreditMemoTax::getCreditMemoId));
+            List<UUID> creditMemoIds = credits.stream().map(CreditMemo::getCreditMemoId).toList();
+            Map<UUID, List<CreditMemoTax>> attributionByCredit = creditMemoTaxRepository
+                    .findByCreditMemoIdIn(creditMemoIds).stream()
+                    .collect(Collectors.groupingBy(CreditMemoTax::getCreditMemoId));
 
             for (CreditMemo credit : credits) {
                 unattributedCredits = unattributedCredits.add(netCreditAcrossJurisdictions(
@@ -813,10 +822,14 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
             }
         }
 
-        // --- Void side (issue #997 symmetry): a void posts a reversing Cr 2200 entry in the
-        // period it happens, so the report restores the reversed tax per jurisdiction in that
-        // same period (negative creditsNetted). The memo's original posting-period contribution
-        // above is untouched — no retroactive restatement; a memo posted and voided in the same
+        // --- Void side (issue #997 symmetry): a void posts a reversing Cr 2200 entry
+        // in the
+        // period it happens, so the report restores the reversed tax per jurisdiction
+        // in that
+        // same period (negative creditsNetted). The memo's original posting-period
+        // contribution
+        // above is untouched — no retroactive restatement; a memo posted and voided in
+        // the same
         // period contributes net zero. ---
         List<CreditMemo> voids = creditMemoRepository.findByStatusAndVoidedTimestampBetween(
                 CreditMemoStatus.VOIDED, startInstant, endInstant);
@@ -825,16 +838,15 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                     .map(CreditMemo::getOriginalInvoiceId)
                     .distinct()
                     .toList();
-            Map<UUID, List<ExtInvoiceTax>> taxByVoidInvoice =
-                    extInvoiceTaxRepository.findByInvoiceIdIn(voidInvoiceIds).stream()
-                            .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
-            Map<UUID, List<CreditMemoTax>> attributionByVoid =
-                    creditMemoTaxRepository
-                            .findByCreditMemoIdIn(voids.stream()
-                                    .map(CreditMemo::getCreditMemoId)
-                                    .toList())
-                            .stream()
-                            .collect(Collectors.groupingBy(CreditMemoTax::getCreditMemoId));
+            Map<UUID, List<ExtInvoiceTax>> taxByVoidInvoice = extInvoiceTaxRepository.findByInvoiceIdIn(voidInvoiceIds)
+                    .stream()
+                    .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
+            Map<UUID, List<CreditMemoTax>> attributionByVoid = creditMemoTaxRepository
+                    .findByCreditMemoIdIn(voids.stream()
+                            .map(CreditMemo::getCreditMemoId)
+                            .toList())
+                    .stream()
+                    .collect(Collectors.groupingBy(CreditMemoTax::getCreditMemoId));
 
             for (CreditMemo voided : voids) {
                 unattributedCredits = unattributedCredits.subtract(netCreditAcrossJurisdictions(
@@ -854,8 +866,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         BigDecimal totalCreditsNetted = sum(rows, TaxLiabilityRow::getCreditsNetted);
         BigDecimal totalNetTax = sum(rows, TaxLiabilityRow::getNetTax);
 
-        TaxLiabilityReconciliation reconciliation =
-                reconcileAgainstTaxPayable(totalNetTax, unattributedCredits, startDateTime, endDateTime);
+        TaxLiabilityReconciliation reconciliation = reconcileAgainstTaxPayable(totalNetTax, unattributedCredits,
+                startDateTime, endDateTime);
 
         log.info(
                 "Sales-tax liability generated for {}..{}: jurisdictions={}, gross={}, credits={}, netTax={}, glDrift={}",
@@ -882,27 +894,39 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
     }
 
     /**
-     * Net one credit memo's {@code taxAmountReversed} into the per-jurisdiction accumulators.
+     * Net one credit memo's {@code taxAmountReversed} into the per-jurisdiction
+     * accumulators.
      *
-     * <p>Attribution source, in order of preference:
+     * <p>
+     * Attribution source, in order of preference:
      *
      * <ol>
-     *   <li><b>The credit's own frozen breakdown</b> ({@code credit_memo_tax}, issue #996) —
-     *       written at credit-memo creation and summing exactly to the scalar. This is the
-     *       actual jurisdictional tax reversed, not an estimate of it.</li>
-     *   <li><b>Pro-rata fallback</b> ({@link TaxCreditAllocator}) for credits issued before
-     *       that table existed: allocate the scalar across the original invoice's
-     *       per-jurisdiction collected tax.</li>
+     * <li><b>The credit's own frozen breakdown</b> ({@code credit_memo_tax}, issue
+     * #996) —
+     * written at credit-memo creation and summing exactly to the scalar. This is
+     * the
+     * actual jurisdictional tax reversed, not an estimate of it.</li>
+     * <li><b>Pro-rata fallback</b> ({@link TaxCreditAllocator}) for credits issued
+     * before
+     * that table existed: allocate the scalar across the original invoice's
+     * per-jurisdiction collected tax.</li>
      * </ol>
      *
-     * @param restore when true (issue #997 void symmetry) every attributed amount is applied with
-     *                the opposite sign — the void-period restoration of a previously netted
-     *                reversal — using the identical attribution source, so restore amounts mirror
+     * @param restore when true (issue #997 void symmetry) every attributed amount
+     *                is applied with
+     *                the opposite sign — the void-period restoration of a
+     *                previously netted
+     *                reversal — using the identical attribution source, so restore
+     *                amounts mirror
      *                the netted ones jurisdiction-for-jurisdiction
-     * @return the portion of this credit's reversed tax that could <em>not</em> be attributed
-     *         to any jurisdiction (zero in the normal case). Surfacing it in the reconciliation
-     *         block explains the resulting GL drift instead of leaving it phantom. Callers on the
-     *         restore path subtract this value so an unattributed void cancels its unattributed
+     * @return the portion of this credit's reversed tax that could <em>not</em> be
+     *         attributed
+     *         to any jurisdiction (zero in the normal case). Surfacing it in the
+     *         reconciliation
+     *         block explains the resulting GL drift instead of leaving it phantom.
+     *         Callers on the
+     *         restore path subtract this value so an unattributed void cancels its
+     *         unattributed
      *         posting symmetrically.
      */
     private BigDecimal netCreditAcrossJurisdictions(
@@ -930,26 +954,35 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
             return BigDecimal.ZERO;
         }
 
-        // (2) Fallback for pre-#996 credits: pro-rata across the original invoice's collected tax.
+        // (2) Fallback for pre-#996 credits: pro-rata across the original invoice's
+        // collected tax.
         List<ExtInvoiceTax> originalRows = taxByOriginalInvoice.getOrDefault(credit.getOriginalInvoiceId(), List.of());
 
-        // Weights are the original invoice's per-jurisdiction collected tax. Ensure every
+        // Weights are the original invoice's per-jurisdiction collected tax. Ensure
+        // every
         // jurisdiction the credit touches has a row so its type/code is recoverable.
-        // Build the weights first and only materialize accumulator rows once the allocation has
-        // actually produced a share. Creating them up front left all-zero phantom jurisdiction rows
-        // in the report whenever attribution turned out to be impossible (a fully-exempt original
-        // invoice, say) — jurisdictions the period never collected or credited a cent in.
+        // Build the weights first and only materialize accumulator rows once the
+        // allocation has
+        // actually produced a share. Creating them up front left all-zero phantom
+        // jurisdiction rows
+        // in the report whenever attribution turned out to be impossible (a
+        // fully-exempt original
+        // invoice, say) — jurisdictions the period never collected or credited a cent
+        // in.
         Map<JurisdictionKey, BigDecimal> weights = new LinkedHashMap<>();
         for (ExtInvoiceTax row : originalRows) {
             weights.merge(keyFor(row), nullSafe(row.getTaxAmount()), BigDecimal::add);
         }
 
-        Map<JurisdictionKey, BigDecimal> allocated =
-                weights.isEmpty() ? Map.of() : TaxCreditAllocator.allocate(reversed, weights);
+        Map<JurisdictionKey, BigDecimal> allocated = weights.isEmpty() ? Map.of()
+                : TaxCreditAllocator.allocate(reversed, weights);
         if (allocated.isEmpty()) {
-            // Either the original invoice has no replicated tax rows at all, or every row carries
-            // zero tax_amount (e.g. a fully-exempt invoice). Netting against a jurisdiction that
-            // collected no tax would hide the mismatch, so the reversal stays unattributed — and
+            // Either the original invoice has no replicated tax rows at all, or every row
+            // carries
+            // zero tax_amount (e.g. a fully-exempt invoice). Netting against a jurisdiction
+            // that
+            // collected no tax would hide the mismatch, so the reversal stays unattributed
+            // — and
             // is reported as such, which is what makes the resulting drift explainable.
             log.warn(
                     "Credit memo {} reverses tax {} but carries no frozen jurisdiction breakdown and its original "
@@ -967,15 +1000,22 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
     }
 
     /**
-     * Reconcile the report's total net tax against the Sales-Tax Payable (2200) account's
+     * Reconcile the report's total net tax against the Sales-Tax Payable (2200)
+     * account's
      * credit-normal period activity. {@code sumPostedBalanceForAccount} returns
-     * {@code Σdebit - Σcredit}; the credit-normal (liability) net owed is its negation.
-     * Invoice finalization posts {@code Cr 2200}, credit memos post {@code Dr 2200}, so on
-     * a clean ledger the 2200 net activity equals the report net tax and drift is zero.
+     * {@code Σdebit - Σcredit}; the credit-normal (liability) net owed is its
+     * negation.
+     * Invoice finalization posts {@code Cr 2200}, credit memos post
+     * {@code Dr 2200}, so on
+     * a clean ledger the 2200 net activity equals the report net tax and drift is
+     * zero.
      *
-     * <p>{@code unattributedCredits} is the reversed tax that could not be tied to any
-     * jurisdiction (issue #996). It is excluded from the jurisdiction rows by design, so it
-     * necessarily inflates the drift by its own value — reporting it makes that component of
+     * <p>
+     * {@code unattributedCredits} is the reversed tax that could not be tied to any
+     * jurisdiction (issue #996). It is excluded from the jurisdiction rows by
+     * design, so it
+     * necessarily inflates the drift by its own value — reporting it makes that
+     * component of
      * the drift explainable rather than phantom.
      */
     private TaxLiabilityReconciliation reconcileAgainstTaxPayable(
@@ -987,16 +1027,21 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         BigDecimal glNetActivity = glAccountRepository
                 .findByAccountCode(SALES_TAX_PAYABLE_ACCOUNT_CODE)
                 .map(account -> nullSafe(journalEntryRepository.sumPostedBalanceForAccount(
-                                account.getGlAccountId(), startDateTime, endDateTime))
+                        account.getGlAccountId(), startDateTime, endDateTime))
                         .negate())
                 .orElse(BigDecimal.ZERO);
 
         BigDecimal drift = reportNetTax.subtract(glNetActivity);
-        // Unattributed credits are excluded from the jurisdiction rows by construction, so they
-        // inflate reportNetTax by exactly their own value while the GL still carries the matching
-        // Dr 2200. That component of the drift is therefore fully explained. `reconciled` flags
-        // the *unexplained* remainder, so a ledger whose only discrepancy is a credit we could not
-        // attribute still reads reconciled (issue #996 AC-3) — the amount stays visible in
+        // Unattributed credits are excluded from the jurisdiction rows by construction,
+        // so they
+        // inflate reportNetTax by exactly their own value while the GL still carries
+        // the matching
+        // Dr 2200. That component of the drift is therefore fully explained.
+        // `reconciled` flags
+        // the *unexplained* remainder, so a ledger whose only discrepancy is a credit
+        // we could not
+        // attribute still reads reconciled (issue #996 AC-3) — the amount stays visible
+        // in
         // `unattributedCredits` rather than being silently folded away.
         BigDecimal unexplainedDrift = drift.subtract(unattributedCredits);
         boolean reconciled = unexplainedDrift.abs().compareTo(RECON_TOLERANCE) <= 0;
@@ -1025,7 +1070,10 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         return rows.stream().map(extractor).reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
-    /** Mutable per-jurisdiction accumulator, materialized into a {@link TaxLiabilityRow}. */
+    /**
+     * Mutable per-jurisdiction accumulator, materialized into a
+     * {@link TaxLiabilityRow}.
+     */
     private static final class JurisdictionAccumulator {
         private BigDecimal taxableBase = BigDecimal.ZERO;
         private BigDecimal exemptBase = BigDecimal.ZERO;
@@ -1090,13 +1138,13 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
     private GeneralLedgerAccountSection buildAccountSection(
             UUID glAccountId, @Nullable GLAccount account, List<JournalEntryLine> lines, LocalDateTime startDateTime) {
 
-        BigDecimal openingBalance =
-                nullSafe(journalEntryRepository.sumPostedBalanceForAccountBefore(glAccountId, startDateTime));
+        BigDecimal openingBalance = nullSafe(
+                journalEntryRepository.sumPostedBalanceForAccountBefore(glAccountId, startDateTime));
 
         // Chronological order: transaction date, then entry number, with stable
         // tie-breakers so equal-keyed lines are deterministic.
         lines.sort(Comparator.comparing(
-                        (JournalEntryLine line) -> line.getJournalEntry().getTransactionDate())
+                (JournalEntryLine line) -> line.getJournalEntry().getTransactionDate())
                 .thenComparing(
                         line -> line.getJournalEntry().getEntryNumber(),
                         Comparator.nullsLast(Comparator.naturalOrder()))
@@ -1128,10 +1176,10 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                     .build());
         }
 
-        String accountNumber =
-                account != null ? account.getAccountCode() : firstNonNull(lines, JournalEntryLine::getAccountCode);
-        String accountName =
-                account != null ? account.getAccountName() : firstNonNull(lines, JournalEntryLine::getAccountName);
+        String accountNumber = account != null ? account.getAccountCode()
+                : firstNonNull(lines, JournalEntryLine::getAccountCode);
+        String accountName = account != null ? account.getAccountName()
+                : firstNonNull(lines, JournalEntryLine::getAccountName);
 
         return GeneralLedgerAccountSection.builder()
                 .accountId(glAccountId.toString())
@@ -1217,7 +1265,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
      * Item-level aging accumulator: each item's full open balance lands in exactly
      * one bucket keyed on whole days past due ({@code asOfDate - agingDate}).
      * Boundaries: {@code 0 <= d <= 30} current, {@code 31..60}, {@code 61..90},
-     * {@code d >= 91} 90+. Callers exclude future-dated items ({@code d < 0}) before
+     * {@code d >= 91} 90+. Callers exclude future-dated items ({@code d < 0})
+     * before
      * adding, so {@code current} holds only items already dated on/before asOfDate
      * (finding 10).
      */

--- a/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
@@ -19,21 +19,32 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * ADR-0044 domain-wall check: {@code internal.client} (and client-config) sources must not target
- * other <em>domain</em> modules — synchronous REST is allowed only toward the utility whitelist.
+ * ADR-0044 domain-wall check: {@code internal.client} (and client-config)
+ * sources must not target
+ * other <em>domain</em> modules — synchronous REST is allowed only toward the
+ * utility whitelist.
  *
- * <p>Detection is source-based (RestClient base URLs, {@code *.service-id} / {@code *.base-url}
- * config keys, {@code lb://} URIs) because the targets live in string literals and {@code @Value}
+ * <p>
+ * Detection is source-based (RestClient base URLs, {@code *.service-id} /
+ * {@code *.base-url}
+ * config keys, {@code lb://} URIs) because the targets live in string literals
+ * and {@code @Value}
  * defaults rather than in the type graph.
  *
- * <p><strong>Build-failing since Phase 5.6 (#902):</strong> the ADR-0044 migration is complete
- * and any new synchronous domain→domain client fails the build. The utility whitelist below is
- * the single source of truth; changing it — or adding a scoped per-module exception — requires
+ * <p>
+ * <strong>Build-failing since Phase 5.6 (#902):</strong> the ADR-0044 migration
+ * is complete
+ * and any new synchronous domain→domain client fails the build. The utility
+ * whitelist below is
+ * the single source of truth; changing it — or adding a scoped per-module
+ * exception — requires
  * amending ADR-0044.
  */
 class DomainWallsTest {
 
-    /** ADR-0044 §1 utility modules (plus this repo's module-name aliases for them). */
+    /**
+     * ADR-0044 §1 utility modules (plus this repo's module-name aliases for them).
+     */
     private static final Set<String> UTILITY_MODULES = Set.of(
             "pos-api-gateway",
             "pos-security-service",
@@ -49,36 +60,55 @@ class DomainWallsTest {
             "pos-document-helper");
 
     /**
-     * Scoped per-consumer exceptions to ADR-0044 R1: origin module → the exact set of domain
-     * modules its {@code internal.client} sources may target synchronously. NOT a widening of the
-     * utility whitelist — every entry requires an ADR-0044 amendment, and any other module (or any
+     * Scoped per-consumer exceptions to ADR-0044 R1: origin module → the exact set
+     * of domain
+     * modules its {@code internal.client} sources may target synchronously. NOT a
+     * widening of the
+     * utility whitelist — every entry requires an ADR-0044 amendment, and any other
+     * module (or any
      * other target) still fails.
      *
-     * <p>pos-warranty: warranty v2 (#924) migrated its candidate-line/eligibility/vehicle-snapshot
-     * reads to event-fed {@code ext_*} replicas (ext_vehicle, ext_workorder, ext_invoice,
-     * ext_catalog) and pos-customer's dead client was deleted. The sole remaining synchronous target
-     * is pos-invoice: settlement adjustment/refund writes plus their reconciliation reads stay
-     * synchronous permanently per the <b>ADR-0044 amendment 2026-07-22</b> ("Pos-warranty settlement
-     * remains synchronous against pos-invoice") — a money-moving counter-flow that must fail loudly
-     * in the request path, with reconciliation reading authoritative post-write state. Widening any
+     * <p>
+     * pos-warranty: warranty v2 (#924) migrated its
+     * candidate-line/eligibility/vehicle-snapshot
+     * reads to event-fed {@code ext_*} replicas (ext_vehicle, ext_workorder,
+     * ext_invoice,
+     * ext_catalog) and pos-customer's dead client was deleted. The sole remaining
+     * synchronous target
+     * is pos-invoice: settlement adjustment/refund writes plus their reconciliation
+     * reads stay
+     * synchronous permanently per the <b>ADR-0044 amendment 2026-07-22</b>
+     * ("Pos-warranty settlement
+     * remains synchronous against pos-invoice") — a money-moving counter-flow that
+     * must fail loudly
+     * in the request path, with reconciliation reading authoritative post-write
+     * state. Widening any
      * edge requires a further ADR-0044 amendment.
      *
-     * <p>pos-order: the counter-sale checkout handshake (order parity stories C1–C3, #1071/#1072)
-     * creates the fronting invoice at checkout and reverses settled payments in the cancellation
-     * saga — the same money-moving counter-flow class, permitted per the <b>ADR-0044 amendment
-     * 2026-07-23</b> ("Pos-order checkout/cancellation is synchronous against pos-invoice").
+     * <p>
+     * pos-order: the counter-sale checkout handshake (order parity stories C1–C3,
+     * #1071/#1072)
+     * creates the fronting invoice at checkout and reverses settled payments in the
+     * cancellation
+     * saga — the same money-moving counter-flow class, permitted per the
+     * <b>ADR-0044 amendment
+     * 2026-07-23</b> ("Pos-order checkout/cancellation is synchronous against
+     * pos-invoice").
      * Settlement signals stay asynchronous on {@code payment.events.v1}.
      */
     private static final Map<String, Set<String>> SCOPED_MODULE_EXCEPTIONS = Map.of(
             "pos-warranty", Set.of("pos-invoice"),
             "pos-order", Set.of("pos-invoice"));
 
-    /** Startup-infra classes exempt per ADR-0044 R2 (registration calls, best-effort at boot). */
-    private static final Pattern EXEMPT_FILES =
-            Pattern.compile(".*(EventTypeInitializer|PermissionRegistration|PermissionInitializer|PermissionRegistry"
+    /**
+     * Startup-infra classes exempt per ADR-0044 R2 (registration calls, best-effort
+     * at boot).
+     */
+    private static final Pattern EXEMPT_FILES = Pattern
+            .compile(".*(EventTypeInitializer|PermissionRegistration|PermissionInitializer|PermissionRegistry"
                     + "|TemplateInitializer|PermissionVersionStartupCheck)\\.java$");
 
-    private static final Pattern POS_SERVICE_TOKEN = Pattern.compile("\"[^\"]*?(pos-[a-z][a-z0-9-]*+)[^\"]*?\"");
+    private static final Pattern POS_SERVICE_TOKEN = Pattern.compile("pos-[a-z][a-z0-9-]*");
     private static final Pattern SERVICE_ID_DEFAULT = Pattern.compile("\\$\\{[a-z0-9.-]*service-id:([a-z][a-z0-9-]*)}");
     private static final Pattern LOAD_BALANCED_URI = Pattern.compile("lb://([A-Za-z0-9-]+)");
 
@@ -126,7 +156,10 @@ class DomainWallsTest {
                 violations.isEmpty(), "ADR-0044: internal.client sources may only target utility modules\n" + report);
     }
 
-    /** internal/client sources plus internal/config client wiring (base URLs often live there). */
+    /**
+     * internal/client sources plus internal/config client wiring (base URLs often
+     * live there).
+     */
     private static List<Path> clientSources(Path module) throws IOException {
         Path srcRoot = module.resolve("src/main/java");
         if (!Files.isDirectory(srcRoot)) {
@@ -147,7 +180,10 @@ class DomainWallsTest {
         return sources;
     }
 
-    /** Extract pos-* service references from code lines (comments stripped to reduce noise). */
+    /**
+     * Extract pos-* service references from code lines (comments stripped to reduce
+     * noise).
+     */
     private static Set<String> referencedServices(Path source) throws IOException {
         Set<String> targets = new LinkedHashSet<>();
         for (String line : Files.readAllLines(source)) {
@@ -157,7 +193,7 @@ class DomainWallsTest {
             }
             Matcher pos = POS_SERVICE_TOKEN.matcher(code);
             while (pos.find()) {
-                targets.add(pos.group(1));
+                targets.add(pos.group());
             }
             Matcher serviceId = SERVICE_ID_DEFAULT.matcher(code);
             while (serviceId.find()) {

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/TusUploadServiceImpl.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/service/TusUploadServiceImpl.java
@@ -88,7 +88,7 @@ public class TusUploadServiceImpl implements TusUploadService {
     }
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = IOException.class)
     public long appendChunk(@NonNull UUID uploadId, long expectedOffset, @NonNull InputStream data, long chunkLength)
             throws IOException {
         TusUpload upload = findOrThrow(uploadId);

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ProductUomRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ProductUomRepository.java
@@ -5,9 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface ProductUomRepository extends JpaRepository<ProductUomEntity, UUID> {
 
     List<ProductUomEntity> findByProductIdOrderByUomCodeAsc(UUID productId);

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SubstitutionGroupMemberRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SubstitutionGroupMemberRepository.java
@@ -5,9 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface SubstitutionGroupMemberRepository extends JpaRepository<SubstitutionGroupMemberEntity, UUID> {
 
     Optional<SubstitutionGroupMemberEntity> findByProductId(UUID productId);

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SubstitutionGroupRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SubstitutionGroupRepository.java
@@ -3,7 +3,6 @@ package com.positivity.catalog.internal.repository;
 import com.positivity.catalog.internal.entity.SubstitutionGroupEntity;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
-public interface SubstitutionGroupRepository extends JpaRepository<SubstitutionGroupEntity, UUID> {}
+public interface SubstitutionGroupRepository extends JpaRepository<SubstitutionGroupEntity, UUID> {
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/DomainEventEnvelope.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/DomainEventEnvelope.java
@@ -4,31 +4,45 @@ import com.positivity.shared.id.UUIDv7Generator;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
-import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Standard envelope for all cross-module domain and command events (ADR-0044 §3).
+ * Standard envelope for all cross-module domain and command events (ADR-0044
+ * §3).
  *
- * <p>Every message on a {@code {domain}.events.v1} or {@code {domain}.commands.v1} topic is one
- * serialized envelope. The payload type is a versioned DTO from this library so producers and
- * consumers compile against the same contract; payload changes within a schema version must be
+ * <p>
+ * Every message on a {@code {domain}.events.v1} or {@code {domain}.commands.v1}
+ * topic is one
+ * serialized envelope. The payload type is a versioned DTO from this library so
+ * producers and
+ * consumers compile against the same contract; payload changes within a schema
+ * version must be
  * additive-only.
  *
- * <p>The {@code actor} field is audit metadata only. Consumers must never use it to derive or
- * bypass permission checks (ADR-0044 §5); user permissions are enforced at the synchronous edge
+ * <p>
+ * The {@code actor} field is audit metadata only. Consumers must never use it
+ * to derive or
+ * bypass permission checks (ADR-0044 §5); user permissions are enforced at the
+ * synchronous edge
  * where the initiating request entered the system.
  *
- * @param eventId          unique UUIDv7 id of this event (idempotency key for consumers)
- * @param eventType        dotted lowercase type, e.g. {@code customer.party.updated}
- * @param schemaVersion    payload schema version (>= 1); breaking changes require a new topic
- * @param aggregateId      id of the owning aggregate; also used as the Kafka record key
- * @param aggregateVersion monotonic per-aggregate sequence for gap and staleness detection
+ * @param eventId          unique UUIDv7 id of this event (idempotency key for
+ *                         consumers)
+ * @param eventType        dotted lowercase type, e.g.
+ *                         {@code customer.party.updated}
+ * @param schemaVersion    payload schema version (>= 1); breaking changes
+ *                         require a new topic
+ * @param aggregateId      id of the owning aggregate; also used as the Kafka
+ *                         record key
+ * @param aggregateVersion monotonic per-aggregate sequence for gap and
+ *                         staleness detection
  * @param occurredAtUtc    when the state change was committed by the owner
  * @param sourceService    producing service name, e.g. {@code pos-customer}
- * @param correlationId    correlation id propagated from the initiating request, if available
- * @param actor            initiating user id or service name — audit only, never authorization
+ * @param correlationId    correlation id propagated from the initiating
+ *                         request, if available
+ * @param actor            initiating user id or service name — audit only,
+ *                         never authorization
  * @param payload          versioned payload DTO
  * @param <T>              payload contract type
  */
@@ -44,9 +58,6 @@ public record DomainEventEnvelope<T>(
         @Nullable String actor,
         @NonNull T payload) {
 
-    private static final Pattern EVENT_TYPE_PATTERN = Pattern.compile("[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)+");
-    private static final Pattern SOURCE_SERVICE_PATTERN = Pattern.compile("pos-[a-z][a-z0-9-]*");
-
     public DomainEventEnvelope {
         requireNonNull(eventId, "eventId");
         requireNonNull(eventType, "eventType");
@@ -54,7 +65,7 @@ public record DomainEventEnvelope<T>(
         requireNonNull(occurredAtUtc, "occurredAtUtc");
         requireNonNull(sourceService, "sourceService");
         requireNonNull(payload, "payload");
-        if (!EVENT_TYPE_PATTERN.matcher(eventType).matches()) {
+        if (!isValidEventType(eventType)) {
             throw new IllegalArgumentException(
                     "eventType must be dotted lowercase (e.g. customer.party.updated) but was: " + eventType);
         }
@@ -64,14 +75,57 @@ public record DomainEventEnvelope<T>(
         if (aggregateVersion < 0) {
             throw new IllegalArgumentException("aggregateVersion must be >= 0 but was: " + aggregateVersion);
         }
-        if (!SOURCE_SERVICE_PATTERN.matcher(sourceService).matches()) {
+        if (!isValidServiceName(sourceService)) {
             throw new IllegalArgumentException("sourceService must be a pos-* service name but was: " + sourceService);
         }
     }
 
+    private static boolean isValidEventType(@Nullable String eventType) {
+        if (eventType == null || eventType.isBlank()) {
+            return false;
+        }
+        String[] segments = eventType.split("\\.");
+        if (segments.length < 2) {
+            return false;
+        }
+        for (String segment : segments) {
+            if (!isLowercaseToken(segment)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isValidServiceName(@Nullable String sourceService) {
+        if (sourceService == null || !sourceService.startsWith("pos-")) {
+            return false;
+        }
+        return isLowercaseToken(sourceService.substring(4));
+    }
+
+    private static boolean isLowercaseToken(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        char first = value.charAt(0);
+        if (!Character.isLowerCase(first)) {
+            return false;
+        }
+        for (int i = 1; i < value.length(); i++) {
+            char current = value.charAt(i);
+            boolean isAlphaNum = (current >= 'a' && current <= 'z') || (current >= '0' && current <= '9');
+            if (!(isAlphaNum || current == '-')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
-     * Create an envelope with a freshly generated UUIDv7 {@code eventId} and the current time from
-     * the given clock. Producers should use their injected {@link Clock} so tests stay
+     * Create an envelope with a freshly generated UUIDv7 {@code eventId} and the
+     * current time from
+     * the given clock. Producers should use their injected {@link Clock} so tests
+     * stay
      * deterministic.
      */
     public static <T> @NonNull DomainEventEnvelope<T> of(
@@ -97,7 +151,10 @@ public record DomainEventEnvelope<T>(
                 payload);
     }
 
-    /** The Kafka record key: aggregateId, so per-aggregate ordering is preserved (ADR-0044 §3). */
+    /**
+     * The Kafka record key: aggregateId, so per-aggregate ordering is preserved
+     * (ADR-0044 §3).
+     */
     public @NonNull String recordKey() {
         return aggregateId.toString();
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AllocationConsistencyVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AllocationConsistencyVerifier.java
@@ -18,40 +18,70 @@ import org.springframework.transaction.annotation.Transactional;
  * DECISION-INVENTORY-005, applied by a human. Mirrors
  * {@link StockSummaryDriftVerifier}.
  *
- * <p><b>Invariant A — per allocation.</b> Allocation ledger events carry the
+ * <p>
+ * <b>Invariant A — per allocation.</b> Allocation ledger events carry the
  * allocation id as {@code sourceTransactionId} ({@code ReservationServiceImpl.
- * writeAllocationLedgerEntry}, {@code ConsumptionServiceImpl.closeAllocations});
+ * writeAllocationLedgerEntry},
+ * {@code ConsumptionServiceImpl.closeAllocations});
  * both {@code ALLOCATION_CREATED} and {@code ALLOCATION_RELEASED} are recorded
  * with positive {@code changeInQuantity}, so per-allocation outstanding is
  * {@code Σcreated − Σreleased}. Expected footprint, derived from the writers:
  *
  * <table border="1">
- *   <caption>Expected ledger footprint per allocation state</caption>
- *   <tr><th>allocationState / locationId / status</th><th>created</th><th>released</th><th>outstanding</th></tr>
- *   <tr><td>SOFT (any status) or locationId null</td><td>0</td><td>0</td><td>0 — only a located HARD
- *       promotion writes ALLOCATION_CREATED, and cancel/consume release only located HARD rows</td></tr>
- *   <tr><td>HARD, located, ALLOCATED or PICKED</td><td>allocatedQuantity (written exactly once at
- *       promote)</td><td>[0, created)</td><td>(0, allocatedQuantity] — partial consumption may release
- *       part while the row stays ALLOCATED; full release always flips the status to RELEASED</td></tr>
- *   <tr><td>HARD, located, RELEASED</td><td>allocatedQuantity</td><td>== created</td><td>0 —
- *       cancel releases the un-consumed remainder, consumption releases the rest</td></tr>
- *   <tr><td>orphan ledger key (no matching allocation row, or null key)</td>
- *       <td colspan="3">created must equal released; a non-zero outstanding is unaccounted stock</td></tr>
+ * <caption>Expected ledger footprint per allocation state</caption>
+ * <tr>
+ * <th>allocationState / locationId / status</th>
+ * <th>created</th>
+ * <th>released</th>
+ * <th>outstanding</th>
+ * </tr>
+ * <tr>
+ * <td>SOFT (any status) or locationId null</td>
+ * <td>0</td>
+ * <td>0</td>
+ * <td>0 — only a located HARD
+ * promotion writes ALLOCATION_CREATED, and cancel/consume release only located
+ * HARD rows</td>
+ * </tr>
+ * <tr>
+ * <td>HARD, located, ALLOCATED or PICKED</td>
+ * <td>allocatedQuantity (written exactly once at
+ * promote)</td>
+ * <td>[0, created)</td>
+ * <td>(0, allocatedQuantity] — partial consumption may release
+ * part while the row stays ALLOCATED; full release always flips the status to
+ * RELEASED</td>
+ * </tr>
+ * <tr>
+ * <td>HARD, located, RELEASED</td>
+ * <td>allocatedQuantity</td>
+ * <td>== created</td>
+ * <td>0 —
+ * cancel releases the un-consumed remainder, consumption releases the rest</td>
+ * </tr>
+ * <tr>
+ * <td>orphan ledger key (no matching allocation row, or null key)</td>
+ * <td colspan="3">created must equal released; a non-zero outstanding is
+ * unaccounted stock</td>
+ * </tr>
  * </table>
  *
- * <p>Note the spec's shorthand "outstanding ∈ {0, allocatedQuantity}" is
+ * <p>
+ * Note the spec's shorthand "outstanding ∈ {0, allocatedQuantity}" is
  * refined here: partial consumption (CAP-218 #662) legitimately leaves
  * outstanding strictly between 0 and allocatedQuantity while the allocation
  * is still open, so the verifier checks the per-state table above instead of
  * the two-point set.
  *
- * <p><b>Invariant B — per location.</b> The stock summary {@code allocated}
+ * <p>
+ * <b>Invariant B — per location.</b> The stock summary {@code allocated}
  * column (maintained by {@code LedgerPostingServiceImpl}) must equal ledger
  * outstanding allocations ({@code Σ ALLOCATION_CREATED − Σ
  * ALLOCATION_RELEASED}) per location — the set-based twin of
  * {@code InventoryLedgerEntryRepository#calculateOutstandingAllocationsByLocation}.
  *
- * <p>Both diffs run entirely in SQL and return only violating keys
+ * <p>
+ * Both diffs run entirely in SQL and return only violating keys
  * ({@link AllocationRepository#findConsistencyViolations},
  * {@link InventoryStockSummaryRepository#findAllocatedDriftByLocation}), so
  * the job holds no table-sized state in application memory. Findings are
@@ -62,7 +92,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class AllocationConsistencyVerifier {
 
-    /** Cap on per-key WARN lines per pass; the total always lands in the summary ERROR + counter. */
+    /**
+     * Cap on per-key WARN lines per pass; the total always lands in the summary
+     * ERROR + counter.
+     */
     private static final int MAX_DETAILED_VIOLATION_LOGS = 50;
 
     private final AllocationRepository allocationRepository;
@@ -78,9 +111,8 @@ public class AllocationConsistencyVerifier {
         this.violationCounter = meterRegistry.counter("inventory.allocation.consistency.violations.total");
     }
 
-    @Scheduled(
-            fixedDelayString = "${pos.inventory.allocation-verify.interval-ms:3600000}",
-            initialDelayString = "${pos.inventory.allocation-verify.initial-delay-ms:600000}")
+    @Scheduled(fixedDelayString = "${pos.inventory.allocation-verify.interval-ms:3600000}", initialDelayString = "${pos.inventory.allocation-verify.initial-delay-ms:600000}")
+    @Transactional(readOnly = true)
     public void verifyScheduled() {
         try {
             verify();
@@ -90,16 +122,17 @@ public class AllocationConsistencyVerifier {
         }
     }
 
-    /** Runs one full sweep and returns the number of violations (both invariants). */
-    @Transactional(readOnly = true)
+    /**
+     * Runs one full sweep and returns the number of violations (both invariants).
+     */
     public int verify() {
         String created = InventoryLedgerEventType.ALLOCATION_CREATED.name();
         String released = InventoryLedgerEventType.ALLOCATION_RELEASED.name();
 
-        List<AllocationRepository.AllocationConsistencyRow> perAllocation =
-                allocationRepository.findConsistencyViolations(created, released);
-        List<InventoryStockSummaryRepository.AllocatedDriftRow> perLocation =
-                summaryRepository.findAllocatedDriftByLocation(created, released);
+        List<AllocationRepository.AllocationConsistencyRow> perAllocation = allocationRepository
+                .findConsistencyViolations(created, released);
+        List<InventoryStockSummaryRepository.AllocatedDriftRow> perLocation = summaryRepository
+                .findAllocatedDriftByLocation(created, released);
 
         int logged = 0;
         for (AllocationRepository.AllocationConsistencyRow row : perAllocation) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SerialUnitOnHandVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SerialUnitOnHandVerifier.java
@@ -12,14 +12,20 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Scheduled report-only reconciliation of serial-derived on-hand against the ledger read model
+ * Scheduled report-only reconciliation of serial-derived on-hand against the
+ * ledger read model
  * (odoo-parity E4, issue #1050; spec §6 E4 verifier) — the serial analogue of
- * {@link StockSummaryDriftVerifier}. For every (stockItemId, locationId) with serial units, it
- * compares the count of {@code IN_STOCK} units to the lot-agnostic {@code inventory_stock_summary}
+ * {@link StockSummaryDriftVerifier}. For every (stockItemId, locationId) with
+ * serial units, it
+ * compares the count of {@code IN_STOCK} units to the lot-agnostic
+ * {@code inventory_stock_summary}
  * on-hand and logs/counts any mismatch. NEVER mutates either table.
  *
- * <p>A SERIAL-tracked SKU maintains the serial=quantity invariant on every posting, so a drift
- * here means a serial row was tampered with or a posting bypassed the funnel — an alerting signal,
+ * <p>
+ * A SERIAL-tracked SKU maintains the serial=quantity invariant on every
+ * posting, so a drift
+ * here means a serial row was tampered with or a posting bypassed the funnel —
+ * an alerting signal,
  * not an auto-repair trigger.
  */
 @Component
@@ -39,9 +45,8 @@ public class SerialUnitOnHandVerifier {
         this.driftCounter = meterRegistry.counter("inventory.serial_unit.drift.total");
     }
 
-    @Scheduled(
-            fixedDelayString = "${pos.inventory.serial-unit.verify-interval-ms:3600000}",
-            initialDelayString = "${pos.inventory.serial-unit.verify-initial-delay-ms:600000}")
+    @Scheduled(fixedDelayString = "${pos.inventory.serial-unit.verify-interval-ms:3600000}", initialDelayString = "${pos.inventory.serial-unit.verify-initial-delay-ms:600000}")
+    @Transactional(readOnly = true)
     public void verifyScheduled() {
         try {
             verify();
@@ -51,20 +56,24 @@ public class SerialUnitOnHandVerifier {
         }
     }
 
-    /** Cap on per-key WARN lines per pass; the total always lands in the summary ERROR + counter. */
+    /**
+     * Cap on per-key WARN lines per pass; the total always lands in the summary
+     * ERROR + counter.
+     */
     private static final int MAX_DETAILED_DRIFT_LOGS = 50;
 
     /**
-     * Runs one full comparison pass and returns the number of drifted (stockItemId, locationId)
-     * keys: keys where the count of {@code IN_STOCK} serial units disagrees with the lot-agnostic
+     * Runs one full comparison pass and returns the number of drifted (stockItemId,
+     * locationId)
+     * keys: keys where the count of {@code IN_STOCK} serial units disagrees with
+     * the lot-agnostic
      * summary on-hand.
      *
      * @return number of drifted keys
      */
-    @Transactional(readOnly = true)
     public int verify() {
-        List<InventorySerialUnitRepository.SerialOnHandRow> rows =
-                serialRepository.serialOnHandByStockItemAndLocation(InventorySerialStatus.IN_STOCK);
+        List<InventorySerialUnitRepository.SerialOnHandRow> rows = serialRepository
+                .serialOnHandByStockItemAndLocation(InventorySerialStatus.IN_STOCK);
 
         int driftedKeys = 0;
         for (InventorySerialUnitRepository.SerialOnHandRow row : rows) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryDriftVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryDriftVerifier.java
@@ -29,9 +29,8 @@ public class StockSummaryDriftVerifier {
         this.driftCounter = meterRegistry.counter("inventory.stock_summary.drift.total");
     }
 
-    @Scheduled(
-            fixedDelayString = "${pos.inventory.stock-summary.verify-interval-ms:3600000}",
-            initialDelayString = "${pos.inventory.stock-summary.verify-initial-delay-ms:600000}")
+    @Scheduled(fixedDelayString = "${pos.inventory.stock-summary.verify-interval-ms:3600000}", initialDelayString = "${pos.inventory.stock-summary.verify-initial-delay-ms:600000}")
+    @Transactional(readOnly = true)
     public void verifyScheduled() {
         try {
             verify();
@@ -41,24 +40,26 @@ public class StockSummaryDriftVerifier {
         }
     }
 
-    /** Cap on per-key WARN lines per pass; the total always lands in the summary ERROR + counter. */
+    /**
+     * Cap on per-key WARN lines per pass; the total always lands in the summary
+     * ERROR + counter.
+     */
     private static final int MAX_DETAILED_DRIFT_LOGS = 50;
 
     /**
      * Runs one full comparison pass and returns the number of drifted keys.
      *
-     * <p>The diff is computed set-based in the database
+     * <p>
+     * The diff is computed set-based in the database
      * ({@link InventoryStockSummaryRepository#findDriftRows}) and returns only
      * mismatching keys, so this job holds no table-sized state in application
      * memory regardless of catalog × location cardinality.
      */
-    @Transactional(readOnly = true)
     public int verify() {
         List<String> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes().stream()
                 .map(Enum::name)
                 .toList();
-        List<String> summaryTypes =
-                StockSummaryEventSets.SUMMARY_TYPES.stream().map(Enum::name).toList();
+        List<String> summaryTypes = StockSummaryEventSets.SUMMARY_TYPES.stream().map(Enum::name).toList();
 
         List<InventoryStockSummaryRepository.DriftRow> drifted = summaryRepository.findDriftRows(
                 onHandTypes,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolver.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolver.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -23,9 +24,11 @@ import org.springframework.ai.tool.metadata.ToolMetadata;
 final class SpringAiToolCallbackResolver {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
+    };
 
-    private SpringAiToolCallbackResolver() {}
+    private SpringAiToolCallbackResolver() {
+    }
 
     static @NonNull List<ToolCallback> fromObjects(@NonNull List<Object> toolObjects) {
         List<ToolCallback> callbacks = new ArrayList<>();
@@ -65,7 +68,7 @@ final class SpringAiToolCallbackResolver {
             this.toolDefinition = DefaultToolDefinition.builder()
                     .name(method.getName())
                     .description(description)
-                .inputSchema(buildInputSchema(parameterBindings, method.getName()))
+                    .inputSchema(buildInputSchema(parameterBindings, method.getName()))
                     .build();
         }
 
@@ -99,13 +102,13 @@ final class SpringAiToolCallbackResolver {
             Object[] resolved = new Object[parameters.length];
             for (ParameterBinding binding : bindings) {
                 Object rawValue = firstPresent(arguments, binding.candidateNames());
-                resolved[binding.index()] =
-                        rawValue == null ? null : OBJECT_MAPPER.convertValue(rawValue, binding.parameterType());
+                resolved[binding.index()] = rawValue == null ? null
+                        : OBJECT_MAPPER.convertValue(rawValue, binding.parameterType());
             }
             return resolved;
         }
 
-        private static @NonNull Object firstPresent(
+        private static @Nullable Object firstPresent(
                 @NonNull Map<String, Object> arguments, @NonNull List<String> candidateNames) {
             for (String candidateName : candidateNames) {
                 if (arguments.containsKey(candidateName)) {

--- a/pos-security-common/src/test/java/com/positivity/security/common/GatewayAuthoritiesFilterTest.java
+++ b/pos-security-common/src/test/java/com/positivity/security/common/GatewayAuthoritiesFilterTest.java
@@ -16,175 +16,187 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 class GatewayAuthoritiesFilterTest {
 
-    private final GatewayAuthoritiesFilter filter = new GatewayAuthoritiesFilter();
+        private final GatewayAuthoritiesFilter filter = new GatewayAuthoritiesFilter();
 
-    @AfterEach
-    void clearSecurityContext() {
-        SecurityContextHolder.clearContext();
-    }
+        @AfterEach
+        void clearSecurityContext() {
+                SecurityContextHolder.clearContext();
+        }
 
-    @Test
-    @DisplayName("gateway PERM authorities also grant plain permission strings for downstream @PreAuthorize checks")
-    void permPrefixedAuthorityAlsoAddsPlainPermissionAuthority() throws ServletException, IOException {
-        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/v1/mcp/chat");
-        request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
-        request.addHeader(GatewaySecurityConstants.HEADER_AUTHORITIES, "ROLE_USER,PERM_mcp:chat:execute");
+        private static String currentCatalogVersionHeaderValue() {
+                try {
+                        return String.valueOf(
+                                        DownstreamPermissionCatalog.class.getField("CATALOG_VERSION").getInt(null));
+                } catch (ReflectiveOperationException exception) {
+                        throw new AssertionError("Unable to read catalog version", exception);
+                }
+        }
 
-        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+        @Test
+        @DisplayName("gateway PERM authorities also grant plain permission strings for downstream @PreAuthorize checks")
+        void permPrefixedAuthorityAlsoAddsPlainPermissionAuthority() throws ServletException, IOException {
+                MockHttpServletRequest request = new MockHttpServletRequest("POST", "/v1/mcp/chat");
+                request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
+                request.addHeader(GatewaySecurityConstants.HEADER_AUTHORITIES, "ROLE_USER,PERM_mcp:chat:execute");
 
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
-        assertThat(SecurityContextHolder.getContext().getAuthentication().getName())
-                .isEqualTo("alice");
+                filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
 
-        Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
-                .map(grantedAuthority -> grantedAuthority.getAuthority())
-                .collect(Collectors.toSet());
+                assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+                assertThat(SecurityContextHolder.getContext().getAuthentication().getName())
+                                .isEqualTo("alice");
 
-        assertThat(authorities)
-                .contains("ROLE_USER")
-                .contains("PERM_mcp:chat:execute")
-                .contains("mcp:chat:execute");
-    }
+                Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities()
+                                .stream()
+                                .map(grantedAuthority -> grantedAuthority.getAuthority())
+                                .collect(Collectors.toSet());
 
-    @Test
-    @DisplayName("gateway X-Roles header is merged into downstream granted authorities")
-    void rolesHeaderAddsRoleAuthorities() throws ServletException, IOException {
-        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/v1/mcp/chat");
-        request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
-        request.addHeader(GatewaySecurityConstants.HEADER_AUTHORITIES, "PERM_mcp:chat:execute");
-        request.addHeader(GatewaySecurityConstants.HEADER_ROLES, "ROLE_ADMIN");
+                assertThat(authorities)
+                                .contains("ROLE_USER")
+                                .contains("PERM_mcp:chat:execute")
+                                .contains("mcp:chat:execute");
+        }
 
-        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+        @Test
+        @DisplayName("gateway X-Roles header is merged into downstream granted authorities")
+        void rolesHeaderAddsRoleAuthorities() throws ServletException, IOException {
+                MockHttpServletRequest request = new MockHttpServletRequest("POST", "/v1/mcp/chat");
+                request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
+                request.addHeader(GatewaySecurityConstants.HEADER_AUTHORITIES, "PERM_mcp:chat:execute");
+                request.addHeader(GatewaySecurityConstants.HEADER_ROLES, "ROLE_ADMIN");
 
-        Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
-                .map(grantedAuthority -> grantedAuthority.getAuthority())
-                .collect(Collectors.toSet());
+                filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
 
-        assertThat(authorities)
-                .contains("ROLE_ADMIN")
-                .contains("PERM_mcp:chat:execute")
-                .contains("mcp:chat:execute");
-    }
+                Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities()
+                                .stream()
+                                .map(grantedAuthority -> grantedAuthority.getAuthority())
+                                .collect(Collectors.toSet());
 
-    @Test
-    @DisplayName("X-Perm-Bits is decoded to PERM_ and plain authorities when version matches")
-    void permBitsHeader_decodesAndExpands() throws ServletException, IOException {
-        java.util.BitSet bits = new java.util.BitSet();
-        bits.set(27); // PERM_crm:party:view
-        bits.set(28); // PERM_crm:party:search
-        String encoded = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bits.toByteArray());
+                assertThat(authorities)
+                                .contains("ROLE_ADMIN")
+                                .contains("PERM_mcp:chat:execute")
+                                .contains("mcp:chat:execute");
+        }
 
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
-        request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
-        request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, encoded);
-        request.addHeader(
-                GatewaySecurityConstants.HEADER_PERM_VER, String.valueOf(DownstreamPermissionCatalog.CATALOG_VERSION));
+        @Test
+        @DisplayName("X-Perm-Bits is decoded to PERM_ and plain authorities when version matches")
+        void permBitsHeader_decodesAndExpands() throws ServletException, IOException {
+                java.util.BitSet bits = new java.util.BitSet();
+                bits.set(27); // PERM_crm:party:view
+                bits.set(28); // PERM_crm:party:search
+                String encoded = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bits.toByteArray());
 
-        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
+                request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
+                request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, encoded);
+                request.addHeader(GatewaySecurityConstants.HEADER_PERM_VER, currentCatalogVersionHeaderValue());
 
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
-        Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
-                .map(org.springframework.security.core.GrantedAuthority::getAuthority)
-                .collect(Collectors.toSet());
+                filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
 
-        assertThat(authorities)
-                .contains("PERM_crm:party:view")
-                .contains("crm:party:view")
-                .contains("PERM_crm:party:search")
-                .contains("crm:party:search");
-    }
+                assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+                Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities()
+                                .stream()
+                                .map(grantedAuthority -> grantedAuthority.getAuthority())
+                                .collect(Collectors.toSet());
 
-    @Test
-    @DisplayName("X-Perm-Bits merges X-Roles into the authority set")
-    void permBitsAndRolesHeader_bothGranted() throws ServletException, IOException {
-        java.util.BitSet bits = new java.util.BitSet();
-        bits.set(27); // PERM_crm:party:view
-        String encoded = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bits.toByteArray());
+                assertThat(authorities)
+                                .contains("PERM_crm:party:view")
+                                .contains("crm:party:view")
+                                .contains("PERM_crm:party:search")
+                                .contains("crm:party:search");
+        }
 
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
-        request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
-        request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, encoded);
-        request.addHeader(
-                GatewaySecurityConstants.HEADER_PERM_VER, String.valueOf(DownstreamPermissionCatalog.CATALOG_VERSION));
-        request.addHeader(GatewaySecurityConstants.HEADER_ROLES, "ROLE_ADMIN");
+        @Test
+        @DisplayName("X-Perm-Bits merges X-Roles into the authority set")
+        void permBitsAndRolesHeader_bothGranted() throws ServletException, IOException {
+                java.util.BitSet bits = new java.util.BitSet();
+                bits.set(27); // PERM_crm:party:view
+                String encoded = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bits.toByteArray());
 
-        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
+                request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
+                request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, encoded);
+                request.addHeader(GatewaySecurityConstants.HEADER_PERM_VER, currentCatalogVersionHeaderValue());
+                request.addHeader(GatewaySecurityConstants.HEADER_ROLES, "ROLE_ADMIN");
 
-        Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
-                .map(org.springframework.security.core.GrantedAuthority::getAuthority)
-                .collect(Collectors.toSet());
+                filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
 
-        assertThat(authorities)
-                .contains("PERM_crm:party:view")
-                .contains("crm:party:view")
-                .contains("ROLE_ADMIN");
-    }
+                Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities()
+                                .stream()
+                                .map(grantedAuthority -> grantedAuthority.getAuthority())
+                                .collect(Collectors.toSet());
 
-    @Test
-    @DisplayName("X-Authorities CSV still works when X-Perm-Bits is absent (legacy fallback)")
-    void legacyXAuthoritiesCsv_worksWhenPermBitsAbsent() throws ServletException, IOException {
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
-        request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
-        request.addHeader(GatewaySecurityConstants.HEADER_AUTHORITIES, "PERM_crm:party:view,PERM_crm:party:search");
+                assertThat(authorities)
+                                .contains("PERM_crm:party:view")
+                                .contains("crm:party:view")
+                                .contains("ROLE_ADMIN");
+        }
 
-        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+        @Test
+        @DisplayName("X-Authorities CSV still works when X-Perm-Bits is absent (legacy fallback)")
+        void legacyXAuthoritiesCsv_worksWhenPermBitsAbsent() throws ServletException, IOException {
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
+                request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
+                request.addHeader(GatewaySecurityConstants.HEADER_AUTHORITIES,
+                                "PERM_crm:party:view,PERM_crm:party:search");
 
-        Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
-                .map(org.springframework.security.core.GrantedAuthority::getAuthority)
-                .collect(Collectors.toSet());
+                filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
 
-        assertThat(authorities)
-                .contains("PERM_crm:party:view")
-                .contains("crm:party:view")
-                .contains("PERM_crm:party:search")
-                .contains("crm:party:search");
-    }
+                Set<String> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities()
+                                .stream()
+                                .map(grantedAuthority -> grantedAuthority.getAuthority())
+                                .collect(Collectors.toSet());
 
-    @Test
-    @DisplayName("X-Perm-Bits with wrong catalog version clears the security context (fail closed)")
-    void permBitsWithWrongVersion_clearsAuth() throws ServletException, IOException {
-        java.util.BitSet bits = new java.util.BitSet();
-        bits.set(27);
-        String encoded = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bits.toByteArray());
+                assertThat(authorities)
+                                .contains("PERM_crm:party:view")
+                                .contains("crm:party:view")
+                                .contains("PERM_crm:party:search")
+                                .contains("crm:party:search");
+        }
 
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
-        request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
-        request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, encoded);
-        request.addHeader(GatewaySecurityConstants.HEADER_PERM_VER, "999");
+        @Test
+        @DisplayName("X-Perm-Bits with wrong catalog version clears the security context (fail closed)")
+        void permBitsWithWrongVersion_clearsAuth() throws ServletException, IOException {
+                java.util.BitSet bits = new java.util.BitSet();
+                bits.set(27);
+                String encoded = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bits.toByteArray());
 
-        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
+                request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
+                request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, encoded);
+                request.addHeader(GatewaySecurityConstants.HEADER_PERM_VER, "999");
 
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-    }
+                filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
 
-    @Test
-    @DisplayName("X-Perm-Bits with malformed Base64 clears the security context (fail closed)")
-    void permBitsWithInvalidBase64_clearsAuth() throws ServletException, IOException {
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
-        request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
-        request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, "!!!not-valid-base64!!!");
-        request.addHeader(
-                GatewaySecurityConstants.HEADER_PERM_VER, String.valueOf(DownstreamPermissionCatalog.CATALOG_VERSION));
+                assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
 
-        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+        @Test
+        @DisplayName("X-Perm-Bits with malformed Base64 clears the security context (fail closed)")
+        void permBitsWithInvalidBase64_clearsAuth() throws ServletException, IOException {
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
+                request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
+                request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, "!!!not-valid-base64!!!");
+                request.addHeader(GatewaySecurityConstants.HEADER_PERM_VER, currentCatalogVersionHeaderValue());
 
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-    }
+                filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
 
-    @Test
-    @DisplayName("X-Perm-Bits with missing X-Perm-Ver header clears the security context (fail closed)")
-    void permBitsWithMissingVersion_clearsAuth() throws ServletException, IOException {
-        java.util.BitSet bits = new java.util.BitSet();
-        bits.set(27);
-        String encoded = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bits.toByteArray());
+                assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
 
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
-        request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
-        request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, encoded);
-        // No X-Perm-Ver header added
+        @Test
+        @DisplayName("X-Perm-Bits with missing X-Perm-Ver header clears the security context (fail closed)")
+        void permBitsWithMissingVersion_clearsAuth() throws ServletException, IOException {
+                java.util.BitSet bits = new java.util.BitSet();
+                bits.set(27);
+                String encoded = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bits.toByteArray());
 
-        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/customers");
+                request.addHeader(GatewaySecurityConstants.HEADER_USER, "alice");
+                request.addHeader(GatewaySecurityConstants.HEADER_PERM_BITS, encoded);
+                // No X-Perm-Ver header added
 
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-    }
+                filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+                assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaCommandListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaCommandListener.java
@@ -28,11 +28,15 @@ import tools.jackson.databind.ObjectMapper;
  * Current supported command types:
  * <ul>
  * <li>{@code ASSIGNMENT_UPDATED}</li>
- * <li>{@code workorder.outbox.replay-requested} — consumer-initiated drift repair (ADR-0044 §4):
- * re-queues published outbox events created at or after {@code payload.since} for
+ * <li>{@code workorder.outbox.replay-requested} — consumer-initiated drift
+ * repair (ADR-0044 §4):
+ * re-queues published outbox events created at or after {@code payload.since}
+ * for
  * re-publication; consumers dedupe by eventId so replay is idempotent.</li>
- * <li>{@code workorder.invoice.regenerate-requested} — async invoice regeneration (ADR-0044 R4,
- * #842): generates the invoice draft for {@code payload.workorderId}; idempotent per workorder,
+ * <li>{@code workorder.invoice.regenerate-requested} — async invoice
+ * regeneration (ADR-0044 R4,
+ * #842): generates the invoice draft for {@code payload.workorderId};
+ * idempotent per workorder,
  * and the result flows back to callers via {@code invoice.events.v1}.</li>
  * </ul>
  * </p>
@@ -45,16 +49,28 @@ public class KafkaCommandListener {
 
     private static final String PAYLOAD = "payload";
     private static final String COMMAND_ASSIGNMENT_UPDATED = "ASSIGNMENT_UPDATED";
-    /** Canonical dotted name normalized to command-type form: WORKORDER_OUTBOX_REPLAY_REQUESTED. */
+    /**
+     * Canonical dotted name normalized to command-type form:
+     * WORKORDER_OUTBOX_REPLAY_REQUESTED.
+     */
     private static final String COMMAND_OUTBOX_REPLAY_REQUESTED = "WORKORDER_OUTBOX_REPLAY_REQUESTED";
 
-    /** Canonical dotted name normalized: workorder.invoice.regenerate-requested (#842). */
+    /**
+     * Canonical dotted name normalized: workorder.invoice.regenerate-requested
+     * (#842).
+     */
     private static final String COMMAND_INVOICE_REGENERATE_REQUESTED = "WORKORDER_INVOICE_REGENERATE_REQUESTED";
 
-    /** Covers the sub-millisecond skew between outbox createdAt and the eventId timestamp. */
+    /**
+     * Covers the sub-millisecond skew between outbox createdAt and the eventId
+     * timestamp.
+     */
     private static final Duration REPLAY_WINDOW_SLACK = Duration.ofSeconds(1);
 
-    /** Replay commands older than this are rejected (PR #849 review — bound repair cost). */
+    /**
+     * Replay commands older than this are rejected (PR #849 review — bound repair
+     * cost).
+     */
     @Value("${workorder.outbox.replay.max-lookback:P30D}")
     private Duration replayMaxLookback;
 
@@ -64,9 +80,7 @@ public class KafkaCommandListener {
     private final OutboxReplayService outboxReplayService;
     private final WorkorderInvoiceService workorderInvoiceService;
 
-    @KafkaListener(
-            topics = "${workorder.kafka.commands-topic:workorder.commands.v1}",
-            groupId = "${workorder.kafka.consumer-group:workorder-commands}")
+    @KafkaListener(topics = "${workorder.kafka.commands-topic:workorder.commands.v1}", groupId = "${workorder.kafka.consumer-group:workorder-commands}")
     public void onCommand(@NonNull String message) {
         try {
             JsonNode root = objectMapper.readTree(message);
@@ -99,8 +113,9 @@ public class KafkaCommandListener {
                 return;
             }
 
-            JsonNode payloadNode =
-                    hasCommandType && root.has(PAYLOAD) && !root.get(PAYLOAD).isNull() ? root.get(PAYLOAD) : root;
+            JsonNode payloadNode = hasCommandType && root.has(PAYLOAD) && !root.get(PAYLOAD).isNull()
+                    ? root.get(PAYLOAD)
+                    : root;
 
             AssignmentUpdatedEvent event = objectMapper.treeToValue(payloadNode, AssignmentUpdatedEvent.class);
             if (event.getWorkorderId() == null || event.getPayload() == null) {
@@ -124,8 +139,7 @@ public class KafkaCommandListener {
 
     private void handleInvoiceRegenerateRequested(@NonNull JsonNode root) {
         JsonNode payloadNode = root.get(PAYLOAD);
-        String rawWorkorderId =
-                payloadNode == null ? null : payloadNode.path("workorderId").stringValue(null);
+        String rawWorkorderId = payloadNode == null ? null : payloadNode.path("workorderId").stringValue(null);
         UUID workorderId;
         try {
             workorderId = UUID.fromString(rawWorkorderId);
@@ -133,10 +147,12 @@ public class KafkaCommandListener {
             log.warn("Ignoring invoice regeneration command with missing/malformed workorderId: {}", root);
             return;
         }
-        String idempotencyKey = payloadNode.path("idempotencyKey").stringValue(null);
+        String idempotencyKey = payloadNode == null ? null : payloadNode.path("idempotencyKey").stringValue(null);
         try {
-            // Idempotent per workorder: generateInvoice returns the existing invoice on replay,
-            // so command redelivery is harmless. Business failures (workorder missing or not
+            // Idempotent per workorder: generateInvoice returns the existing invoice on
+            // replay,
+            // so command redelivery is harmless. Business failures (workorder missing or
+            // not
             // COMPLETED) are permanent — log and drop rather than poison the partition.
             var response = workorderInvoiceService.generateInvoice(workorderId, idempotencyKey);
             log.info(
@@ -158,7 +174,8 @@ public class KafkaCommandListener {
         }
         Instant lookbackLimit = Instant.now(clock).minus(replayMaxLookback);
         if (since.isBefore(lookbackLimit)) {
-            // PR #849 review: a malformed or ancient `since` must not trigger a huge re-emit.
+            // PR #849 review: a malformed or ancient `since` must not trigger a huge
+            // re-emit.
             log.warn(
                     "Ignoring outbox replay command: since={} exceeds max lookback {} (limit {})",
                     since,


### PR DESCRIPTION
## Summary
This PR delivers the issue-1097 Sonar remediation pass across accounting, inventory, workorder, bulk-loader, domain-events, mcp-server, and supporting tests.

## What changed
- Fixed reliability findings around transaction boundaries and checked-exception rollback behavior.
- Hardened log handling in accounting controllers with sanitized logging and nullability-safe signatures.
- Improved null-safety handling in targeted flows (including workorder command listener and Spring AI callback resolution).
- Reworked domain-events validation logic to avoid problematic regex behavior.
- Updated byte-array DTO equality/hashCode behavior for correctness.
- Refined test and archunit patterns and repository query paths touched by Sonar findings.
- Stabilized GatewayAuthoritiesFilterTest to avoid stale inlined permission-catalog version assumptions.

## Validation
- Local compile passed for pos-accounting and dependencies.
- Local targeted tests passed for GatewayAuthoritiesFilterTest.
- Broader local test slice passed for pos-accounting with upstream dependencies.
- CI rerun on latest head is in progress:
  https://github.com/louisburroughs/durion-positivity-backend/actions/runs/30105254304

## Notes
- Prior failed run on older SHA (823e109b5) showed CI dependency-resolution failures in matrix jobs.
- Latest run is on current head (f5fbe0384).
