### PR TITLE
pos-mcp-server: thread persisted session workflow state into tool selection (#778)

### DIFF
--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -90,9 +90,11 @@ sentinel marks operations available to any authenticated caller.
 **Permission-code extraction:** `CurrentUserContextResolver` derives bare `domain:resource:action` codes from the
 `Authentication` authorities (mixed `ROLE_*`, `PERM_*`, and bare forms) and always includes `AUTHENTICATED`.
 
-> **Known limitation — workflow state:** managers currently always evaluate with `WORKFLOW_IDLE`. Deriving workflow
-> state from session context to activate non-IDLE tool sets (`CREATING_PO`, `PROCESSING_RETURN`, …) is not yet
-> implemented — tracked as a backlog item.
+> **Workflow state (#778):** both session managers resolve the caller's persisted `NltiSession.workflowState`
+> (their most-recently-updated session) and thread it into tool selection, so non-IDLE tool sets (`CREATING_PO`,
+> `RECEIVING_ASN`, `INVENTORY_RECON`, `PROCESSING_RETURN`) activate when a session is in that state. Callers with no
+> session fall back to message-heuristic derivation. Advance a session's state explicitly via
+> `POST /v1/nlt/sessions/{sessionId}/workflow-state` (ownership-checked; guarded by `nlti:request:submit`).
 
 ### Facade tools
 
@@ -221,8 +223,6 @@ docker compose up
 
 Tracked separately as GitHub issues. Open items not yet implemented in code:
 
-- **Workflow-state derivation beyond `IDLE`** — persist workflow state on `NltiSession` and thread it through both
-  session managers so non-IDLE tool sets activate.
 - **Legacy role-gating cleanup** — drop `mcp_role` / `mcp_tool_role`, `ToolRegistryRoleMapper`, and the role-gated
   repository queries now superseded by permission gating.
 - **`AUTHENTICATED` sentinel everywhere** — promote `requiredPermissionsOperationCustomizer` to `pos-security-common`

--- a/pos-mcp-server/openapi.yaml
+++ b/pos-mcp-server/openapi.yaml
@@ -321,6 +321,38 @@ paths:
         - mcp:system_prompt:create
       x-required-permissions:
       - mcp:system_prompt:create
+  /v1/nlt/sessions/{sessionId}/workflow-state:
+    post:
+      tags:
+      - NLTI
+      summary: Set the session workflow state
+      description: Advances the operational workflow state of the caller's NLTI session so subsequent chat turns receive the workflow-gated tool set.
+      operationId: setWorkflowState
+      parameters:
+      - name: sessionId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkflowStateUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowStateResponse'
+      security:
+      - bearerAuth:
+        - nlti:request:submit
+      x-required-permissions:
+      - nlti:request:submit
   /v1/nlt/requests:
     post:
       tags:
@@ -422,8 +454,11 @@ paths:
             text/event-stream:
               schema:
                 type: array
+                additionalProperties: {}
+                contains: {}
                 items:
                   $ref: '#/components/schemas/ServerSentEventString'
+                unevaluatedItems: {}
       security:
       - bearerAuth:
         - mcp:chat:stream
@@ -527,10 +562,12 @@ paths:
         required: false
         schema:
           type: array
+          contains: {}
           default:
           - timestamp,ASC
           items:
             type: string
+          unevaluatedItems: {}
       responses:
         '200':
           description: OK
@@ -733,6 +770,41 @@ components:
           description: Granted permission codes (a caller holding any one may select the tool)
           items:
             type: string
+    WorkflowStateUpdateRequest:
+      type: object
+      description: Requested workflow state for the session
+      properties:
+        workflowState:
+          type: string
+          description: The operational workflow state to set on the session
+          enum:
+          - IDLE
+          - CREATING_PO
+          - RECEIVING_ASN
+          - INVENTORY_RECON
+          - PROCESSING_RETURN
+      required:
+      - workflowState
+    WorkflowStateResponse:
+      type: object
+      description: The session's workflow state after the update
+      properties:
+        sessionId:
+          type: string
+          format: uuid
+          description: Session identifier
+        workflowState:
+          type: string
+          description: Current workflow state
+          enum:
+          - IDLE
+          - CREATING_PO
+          - RECEIVING_ASN
+          - INVENTORY_RECON
+          - PROCESSING_RETURN
+      required:
+      - sessionId
+      - workflowState
     NltiRequestDTO:
       type: object
       description: Natural-language task interpretation request submitted by a client

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/EventTypes.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/EventTypes.java
@@ -34,6 +34,9 @@ public final class EventTypes {
                         .build(),
                 EventTypeRegistration.write("NLTI_REQUEST_SUBMIT", "Submit a NLTI natural language request")
                         .build(),
+                EventTypeRegistration.write(
+                                "NLTI_SESSION_WORKFLOW_STATE_SET", "Advance the workflow state of a NLTI session")
+                        .build(),
                 EventTypeRegistration.fastRead("NLTI_AUDIT_QUERY", "Query the NLTI audit event ledger")
                         .build(),
                 EventTypeRegistration.approval(

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/NltiController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/NltiController.java
@@ -1,18 +1,24 @@
 package com.positivity.mcp.internal.controller;
 
 import com.positivity.events.EmitEvent;
+import com.positivity.mcp.internal.domain.WorkflowState;
 import com.positivity.mcp.internal.dto.NltiRequestDTO;
 import com.positivity.mcp.internal.dto.NltiResponseV1;
 import com.positivity.mcp.internal.security.McpPermissions;
+import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.service.NltiRequestService;
+import com.positivity.security.common.SecurityContextHelper;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -28,9 +34,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class NltiController {
 
     private final NltiRequestService nltiRequestService;
+    private final NltiWorkflowStateService workflowStateService;
 
-    NltiController(@NonNull NltiRequestService nltiRequestService) {
+    NltiController(
+            @NonNull NltiRequestService nltiRequestService, @NonNull NltiWorkflowStateService workflowStateService) {
         this.nltiRequestService = nltiRequestService;
+        this.workflowStateService = workflowStateService;
     }
 
     @PostMapping("/requests")
@@ -54,4 +63,41 @@ public class NltiController {
                         response.correlationId().toString())
                 .body(response);
     }
+
+    /**
+     * #778: explicit write path that advances a session's operational {@link WorkflowState} as a
+     * workflow progresses (e.g. entering a purchase-order flow), so subsequent chat turns on that
+     * session receive the workflow-gated tool set. Ownership-checked: the caller may only advance
+     * their own session.
+     */
+    @PostMapping("/sessions/{sessionId}/workflow-state")
+    @EmitEvent(id = "NLTI_SESSION_WORKFLOW_STATE_SET", apiVersion = "1")
+    @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_REQUEST_SUBMIT + "')")
+    @Operation(
+            summary = "Set the session workflow state",
+            description =
+                    "Advances the operational workflow state of the caller's NLTI session so subsequent chat turns receive the workflow-gated tool set.")
+    ResponseEntity<WorkflowStateResponse> setWorkflowState(
+            @PathVariable @NonNull UUID sessionId, @Valid @RequestBody @NonNull WorkflowStateUpdateRequest request) {
+        String subjectId = SecurityContextHelper.getCurrentUsernameOrDefault("system");
+        WorkflowState updatedState = workflowStateService.advance(sessionId, subjectId, request.workflowState());
+        return ResponseEntity.ok(new WorkflowStateResponse(sessionId, updatedState));
+    }
+
+    @Schema(name = "WorkflowStateUpdateRequest", description = "Requested workflow state for the session")
+    public record WorkflowStateUpdateRequest(
+            @Schema(
+                    description = "The operational workflow state to set on the session",
+                    requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotNull
+            @NonNull
+            WorkflowState workflowState) {}
+
+    @Schema(name = "WorkflowStateResponse", description = "The session's workflow state after the update")
+    public record WorkflowStateResponse(
+            @Schema(description = "Session identifier", requiredMode = Schema.RequiredMode.REQUIRED) @NonNull
+            UUID sessionId,
+
+            @Schema(description = "Current workflow state", requiredMode = Schema.RequiredMode.REQUIRED) @NonNull
+            WorkflowState workflowState) {}
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/NltiController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/NltiController.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -79,7 +80,12 @@ public class NltiController {
                     "Advances the operational workflow state of the caller's NLTI session so subsequent chat turns receive the workflow-gated tool set.")
     ResponseEntity<WorkflowStateResponse> setWorkflowState(
             @PathVariable @NonNull UUID sessionId, @Valid @RequestBody @NonNull WorkflowStateUpdateRequest request) {
-        String subjectId = SecurityContextHelper.getCurrentUsernameOrDefault("system");
+        // Fail fast on a missing authenticated principal rather than defaulting to a sentinel subject:
+        // subjectId is the ownership key for this session-mutating call, so an unresolved username must
+        // never silently pass through (or mis-attribute the ownership check).
+        String subjectId = SecurityContextHelper.getCurrentUsername()
+                .orElseThrow(() -> new AuthenticationCredentialsNotFoundException(
+                        "No authenticated username available for workflow-state update"));
         WorkflowState updatedState = workflowStateService.advance(sessionId, subjectId, request.workflowState());
         return ResponseEntity.ok(new WorkflowStateResponse(sessionId, updatedState));
     }
@@ -90,7 +96,6 @@ public class NltiController {
                     description = "The operational workflow state to set on the session",
                     requiredMode = Schema.RequiredMode.REQUIRED)
             @NotNull
-            @NonNull
             WorkflowState workflowState) {}
 
     @Schema(name = "WorkflowStateResponse", description = "The session's workflow state after the update")

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -4,12 +4,14 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.positivity.mcp.internal.classification.SimpleChatRuleCatalog;
 import com.positivity.mcp.internal.client.RoleDefaultPermissionsClient;
+import com.positivity.mcp.internal.domain.WorkflowState;
 import com.positivity.mcp.internal.exception.RateLimitExceededException;
 import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.positivity.mcp.internal.orchestration.memory.SemanticChatMemoryStore;
 import com.positivity.mcp.internal.orchestration.memory.SessionSummary;
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
+import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import com.positivity.mcp.internal.service.PermissionCodes;
 import com.positivity.mcp.internal.service.RequestScopedUserContext;
@@ -27,6 +29,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -83,6 +86,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
     private final @Nullable OpenApiToolProvider openApiToolProvider;
     private final @Nullable RequestScopedUserContext requestScopedUserContext;
     private final @Nullable RoleDefaultPermissionsClient roleDefaultPermissionsClient;
+    private final NltiWorkflowStateService workflowStateService;
     private final Clock clock;
 
     private final int memoryMaxMessages;
@@ -104,6 +108,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             @Nullable OpenApiToolProvider openApiToolProvider,
             @Nullable RequestScopedUserContext requestScopedUserContext,
             @Nullable RoleDefaultPermissionsClient roleDefaultPermissionsClient,
+            @NonNull NltiWorkflowStateService workflowStateService,
             @NonNull Clock clock,
             @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
             @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
@@ -124,6 +129,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         this.openApiToolProvider = openApiToolProvider;
         this.requestScopedUserContext = requestScopedUserContext;
         this.roleDefaultPermissionsClient = roleDefaultPermissionsClient;
+        this.workflowStateService = workflowStateService;
         this.clock = clock;
         this.memoryMaxMessages = memoryMaxMessages;
         this.rateLimitPerSession = rateLimitPerSession;
@@ -184,8 +190,14 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                 return simpleChat(currentUserContext, message, startMs);
             }
 
-            ToolSelectionEngine.ToolSelectionResult selection =
-                    toolSelectionEngine.selectRoleTools(role, currentUserContext.permissionCodes(), message);
+            // #778: gate tool selection by the subject's persisted session workflow state when they
+            // have one; otherwise fall back to message-heuristic derivation (session-less callers).
+            Optional<WorkflowState> persistedState = workflowStateService.resolveActiveState(username);
+            ToolSelectionEngine.ToolSelectionResult selection = persistedState
+                    .map(state -> toolSelectionEngine.selectRoleTools(
+                            role, currentUserContext.permissionCodes(), message, state))
+                    .orElseGet(() ->
+                            toolSelectionEngine.selectRoleTools(role, currentUserContext.permissionCodes(), message));
             List<Object> selectedTools =
                     sharedOrchestrationSupport.mergeTools(selection.roleTools(), selection.fallbackTools());
             String cacheKey = sharedOrchestrationSupport.toolCacheKey(selectedTools);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -4,10 +4,12 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.positivity.mcp.internal.classification.SimpleChatRuleCatalog;
 import com.positivity.mcp.internal.client.RoleDefaultPermissionsClient;
+import com.positivity.mcp.internal.domain.WorkflowState;
 import com.positivity.mcp.internal.exception.RateLimitExceededException;
 import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
+import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import com.positivity.mcp.internal.service.PermissionCodes;
 import com.positivity.mcp.internal.service.RequestScopedUserContext;
@@ -24,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -81,6 +84,8 @@ public class StreamingSessionAgentManager
     @Nullable
     private final RoleDefaultPermissionsClient roleDefaultPermissionsClient;
 
+    private final NltiWorkflowStateService workflowStateService;
+
     private final Clock clock;
 
     private final int memoryMaxMessages;
@@ -98,6 +103,7 @@ public class StreamingSessionAgentManager
             @Nullable OpenApiToolProvider openApiToolProvider,
             @Nullable RequestScopedUserContext requestScopedUserContext,
             @Nullable RoleDefaultPermissionsClient roleDefaultPermissionsClient,
+            @NonNull NltiWorkflowStateService workflowStateService,
             @NonNull Clock clock,
             @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
             @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
@@ -114,6 +120,7 @@ public class StreamingSessionAgentManager
         this.openApiToolProvider = openApiToolProvider;
         this.requestScopedUserContext = requestScopedUserContext;
         this.roleDefaultPermissionsClient = roleDefaultPermissionsClient;
+        this.workflowStateService = workflowStateService;
         this.clock = clock;
         this.memoryMaxMessages = memoryMaxMessages;
         this.rateLimitPerSession = rateLimitPerSession;
@@ -155,8 +162,14 @@ public class StreamingSessionAgentManager
                 tokenCount(message),
                 messagePreview);
 
-        ToolSelectionEngine.ToolSelectionResult selection =
-                toolSelectionEngine.selectRoleTools(role, currentUserContext.permissionCodes(), message);
+        // #778: gate tool selection by the subject's persisted session workflow state when they have
+        // one; otherwise fall back to message-heuristic derivation (session-less callers).
+        Optional<WorkflowState> persistedState = workflowStateService.resolveActiveState(username);
+        ToolSelectionEngine.ToolSelectionResult selection = persistedState
+                .map(state ->
+                        toolSelectionEngine.selectRoleTools(role, currentUserContext.permissionCodes(), message, state))
+                .orElseGet(
+                        () -> toolSelectionEngine.selectRoleTools(role, currentUserContext.permissionCodes(), message));
         List<Object> allTools = sharedOrchestrationSupport.mergeTools(selection.roleTools(), selection.fallbackTools());
         String cacheKey = sharedOrchestrationSupport.toolCacheKey(allTools);
         LOGGER.debug(

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/NltiSessionRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/NltiSessionRepository.java
@@ -8,4 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface NltiSessionRepository extends JpaRepository<NltiSession, UUID> {
 
     Optional<NltiSession> findByIdAndSubjectId(UUID id, String subjectId);
+
+    /**
+     * The subject's most-recently-updated session — treated as their active session when the
+     * session-less chat path resolves the persisted workflow state (#778).
+     */
+    Optional<NltiSession> findFirstBySubjectIdOrderByUpdatedAtDesc(String subjectId);
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/NltiWorkflowStateService.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/NltiWorkflowStateService.java
@@ -1,0 +1,67 @@
+package com.positivity.mcp.internal.service;
+
+import com.positivity.mcp.internal.domain.WorkflowState;
+import com.positivity.mcp.internal.entity.NltiSession;
+import com.positivity.mcp.internal.exception.SessionOwnershipViolationException;
+import com.positivity.mcp.internal.repository.NltiSessionRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Reads and advances the session-owned {@link WorkflowState} on {@link NltiSession} (#778).
+ *
+ * <p>The session-less chat path uses {@link #resolveActiveState(String)} to gate tool selection by
+ * the subject's persisted workflow state (falling back to message heuristics when the subject has no
+ * session). {@link #advance(UUID, String, WorkflowState)} is the explicit write path that moves a
+ * session to a non-IDLE state as a workflow progresses; it is ownership-checked so a subject can only
+ * mutate their own session.
+ */
+@Service
+public class NltiWorkflowStateService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NltiWorkflowStateService.class);
+
+    private final NltiSessionRepository sessionRepository;
+
+    public NltiWorkflowStateService(@NonNull NltiSessionRepository sessionRepository) {
+        this.sessionRepository = sessionRepository;
+    }
+
+    /**
+     * The subject's active (most-recently-updated) session workflow state, or empty when the subject
+     * has no session. An empty result tells the caller to fall back to message-heuristic derivation.
+     */
+    @Transactional(readOnly = true)
+    public @NonNull Optional<WorkflowState> resolveActiveState(@NonNull String subjectId) {
+        return sessionRepository
+                .findFirstBySubjectIdOrderByUpdatedAtDesc(subjectId)
+                .map(NltiSession::getWorkflowState);
+    }
+
+    /**
+     * Advances the given session (which must belong to {@code subjectId}) to {@code newState} and
+     * returns the persisted state. Returns the {@link WorkflowState} (not the entity) so callers such
+     * as controllers never depend on the persistence layer.
+     *
+     * @throws SessionOwnershipViolationException when the session does not exist or is not owned by
+     *     the subject — matching {@code NltiRequestServiceImpl}'s ownership posture.
+     */
+    @Transactional
+    public @NonNull WorkflowState advance(
+            @NonNull UUID sessionId, @NonNull String subjectId, @NonNull WorkflowState newState) {
+        NltiSession session = sessionRepository
+                .findByIdAndSubjectId(sessionId, subjectId)
+                .orElseThrow(() -> new SessionOwnershipViolationException(
+                        "Session is not owned by the authenticated subject or does not exist: " + sessionId));
+        WorkflowState previous = session.getWorkflowState();
+        session.setWorkflowState(newState);
+        NltiSession saved = sessionRepository.save(session);
+        LOGGER.info("NLTI session {} workflow state advanced {} -> {}", sessionId, previous, newState);
+        return saved.getWorkflowState();
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/NltiControllerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/NltiControllerTest.java
@@ -200,10 +200,12 @@ class NltiControllerTest {
     // ─── #778: workflow-state write endpoint ──────────────────────────────────
 
     @Test
-    @WithMockUser(authorities = "nlti:request:submit")
+    @WithGatewayUser(username = "alice", authorities = "nlti:request:submit")
     @DisplayName("POST /v1/nlt/sessions/{id}/workflow-state returns 200 with the updated state")
     void setWorkflowState_returns200WithUpdatedState() throws Exception {
-        when(workflowStateService.advance(eq(SESSION_ID), any(), eq(WorkflowState.CREATING_PO)))
+        // A gateway-style principal (username in the details map) so the controller resolves the
+        // subject the same way session creation does — the ownership key must match.
+        when(workflowStateService.advance(eq(SESSION_ID), eq("alice"), eq(WorkflowState.CREATING_PO)))
                 .thenReturn(WorkflowState.CREATING_PO);
 
         mockMvc.perform(post("/v1/nlt/sessions/" + SESSION_ID + "/workflow-state")
@@ -235,6 +237,37 @@ class NltiControllerTest {
      *
      * Issue: NLTI-001
      */
+    /**
+     * A gateway-style authenticated principal: puts the username in the authentication details map
+     * (as {@code GatewayAuthoritiesFilter} does in production) so {@code SecurityContextHelper
+     * .getCurrentUsername()} resolves it. Uses the {@code @WithSecurityContext} listener mechanism
+     * (like {@code @WithMockUser}) so method security and the details lookup both see the same context.
+     */
+    @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+    @org.springframework.security.test.context.support.WithSecurityContext(factory = GatewayUserFactory.class)
+    @interface WithGatewayUser {
+        String username();
+
+        String[] authorities() default {};
+    }
+
+    static class GatewayUserFactory
+            implements org.springframework.security.test.context.support.WithSecurityContextFactory<WithGatewayUser> {
+        @Override
+        public org.springframework.security.core.context.SecurityContext createSecurityContext(WithGatewayUser user) {
+            var authorities = java.util.Arrays.stream(user.authorities())
+                    .map(org.springframework.security.core.authority.SimpleGrantedAuthority::new)
+                    .toList();
+            var token = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                    user.username(), "n/a", authorities);
+            token.setDetails(java.util.Map.of(
+                    com.positivity.security.common.GatewaySecurityConstants.DETAIL_USERNAME, user.username()));
+            var context = org.springframework.security.core.context.SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(token);
+            return context;
+        }
+    }
+
     @TestConfiguration
     @EnableMethodSecurity(prePostEnabled = true)
     static class SliceTestConfig {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/NltiControllerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/NltiControllerTest.java
@@ -1,14 +1,17 @@
 package com.positivity.mcp.internal.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.positivity.mcp.internal.domain.WorkflowState;
 import com.positivity.mcp.internal.dto.NltiRequestDTO;
 import com.positivity.mcp.internal.dto.NltiResponseV1;
+import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.service.NltiRequestService;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -64,6 +67,9 @@ class NltiControllerTest {
 
     @MockitoBean
     private NltiRequestService nltiRequestService;
+
+    @MockitoBean
+    private NltiWorkflowStateService workflowStateService;
 
     // ─── AC-1: POST with valid prompt → 202 with required envelope fields ─────
 
@@ -189,6 +195,32 @@ class NltiControllerTest {
                 .andExpect(jsonPath("$.status").value(401))
                 .andExpect(jsonPath("$.correlationId").isNotEmpty())
                 .andExpect(jsonPath("$.timestamp").isNotEmpty());
+    }
+
+    // ─── #778: workflow-state write endpoint ──────────────────────────────────
+
+    @Test
+    @WithMockUser(authorities = "nlti:request:submit")
+    @DisplayName("POST /v1/nlt/sessions/{id}/workflow-state returns 200 with the updated state")
+    void setWorkflowState_returns200WithUpdatedState() throws Exception {
+        when(workflowStateService.advance(eq(SESSION_ID), any(), eq(WorkflowState.CREATING_PO)))
+                .thenReturn(WorkflowState.CREATING_PO);
+
+        mockMvc.perform(post("/v1/nlt/sessions/" + SESSION_ID + "/workflow-state")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"workflowState\":\"CREATING_PO\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessionId").value(SESSION_ID.toString()))
+                .andExpect(jsonPath("$.workflowState").value("CREATING_PO"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/nlt/sessions/{id}/workflow-state without auth returns 401")
+    void setWorkflowState_withoutAuth_returns401() throws Exception {
+        mockMvc.perform(post("/v1/nlt/sessions/" + SESSION_ID + "/workflow-state")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"workflowState\":\"CREATING_PO\"}"))
+                .andExpect(status().isUnauthorized());
     }
 
     // ─── Test slice configuration ─────────────────────────────────────────────

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/NltiExceptionHandlerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/NltiExceptionHandlerTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.positivity.mcp.internal.dto.NltiRequestDTO;
 import com.positivity.mcp.internal.exception.RateLimitExceededException;
 import com.positivity.mcp.internal.exception.SessionOwnershipViolationException;
+import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.service.NltiRequestService;
 import jakarta.validation.ConstraintViolationException;
 import java.util.Set;
@@ -58,6 +59,9 @@ class NltiExceptionHandlerTest {
 
     @MockitoBean
     private NltiRequestService nltiRequestService;
+
+    @MockitoBean
+    private NltiWorkflowStateService workflowStateService;
 
     private String validRequestBody() throws Exception {
         return objectMapper.writeValueAsString(new NltiRequestDTO("test prompt for handler", null, null));

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -20,12 +20,14 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.positivity.mcp.internal.classification.SimpleChatRuleDefaults;
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.domain.ToolSelectionContext;
+import com.positivity.mcp.internal.domain.WorkflowState;
 import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
 import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
 import com.positivity.mcp.internal.orchestration.tools.InventoryFacadeTool;
 import com.positivity.mcp.internal.orchestration.tools.OrderFacadeTool;
+import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.internal.service.ToolRegistryService;
 import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry;
 import com.positivity.mcp.internal.telemetry.NltiTelemetryEmitter;
@@ -36,6 +38,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -111,6 +114,9 @@ class SessionAgentManagerTest {
     @Mock
     private NltiTelemetryEmitter telemetryEmitter;
 
+    @Mock
+    private NltiWorkflowStateService workflowStateService;
+
     // Real instance required: Mockito subclasses cause @Tool duplicate registration
     // in the assistant runtime
     private ExaWebSearchTool exaWebSearchTool;
@@ -134,6 +140,8 @@ class SessionAgentManagerTest {
         lenient()
                 .when(toolSelectionEngine.selectRoleTools(anyString(), anySet(), anyString()))
                 .thenReturn(new ToolSelectionEngine.ToolSelectionResult(List.of(), List.of()));
+        // #778: default to session-less so existing tests exercise the message-heuristic path.
+        lenient().when(workflowStateService.resolveActiveState(anyString())).thenReturn(Optional.empty());
         lenient().when(rolePromptResolver.resolvePrompt(anyString())).thenReturn("Default role prompt");
         lenient()
                 .when(rolePromptResolver.assemble(anyString(), anyString()))
@@ -180,6 +188,7 @@ class SessionAgentManagerTest {
                 null,
                 null,
                 null, // roleDefaultPermissionsClient
+                workflowStateService,
                 FIXED_CLOCK,
                 30,
                 500,
@@ -343,6 +352,28 @@ class SessionAgentManagerTest {
     }
 
     @Test
+    @DisplayName("chat threads the persisted non-IDLE session workflow state into tool selection (#778)")
+    void chat_usesPersistedWorkflowState_whenSessionPresent() {
+        String message = "create a purchase order for vendor acme";
+        when(workflowStateService.resolveActiveState("user-1")).thenReturn(Optional.of(WorkflowState.CREATING_PO));
+        when(toolSelectionEngine.selectRoleTools(anyString(), anySet(), anyString(), any(WorkflowState.class)))
+                .thenReturn(
+                        new ToolSelectionEngine.ToolSelectionResult(List.of(), List.of(), WorkflowState.CREATING_PO));
+        when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse("ok"));
+
+        manager.chat(userContext("user-1", USER_ID, "ROLE_ADMIN"), message);
+
+        // The persisted session state (not a message heuristic) gates selection.
+        verify(toolSelectionEngine)
+                .selectRoleTools(
+                        eq("ROLE_ADMIN"),
+                        eq(Set.of("AUTHENTICATED", "mcp:chat:execute")),
+                        eq(message),
+                        eq(WorkflowState.CREATING_PO));
+        verify(toolSelectionEngine, never()).selectRoleTools(anyString(), anySet(), anyString());
+    }
+
+    @Test
     @DisplayName("getOrCreateAgent rebuilds agent after cache TTL expiry")
     void getOrCreateAgent_rebuildsAgentAfterCacheTtlExpiry() {
         SessionAgentManager expiringManager = new SessionAgentManager(
@@ -361,6 +392,7 @@ class SessionAgentManagerTest {
                 null,
                 null,
                 null, // roleDefaultPermissionsClient
+                workflowStateService,
                 FIXED_CLOCK,
                 0,
                 500,
@@ -401,6 +433,7 @@ class SessionAgentManagerTest {
                 null,
                 null,
                 null, // roleDefaultPermissionsClient
+                workflowStateService,
                 FIXED_CLOCK,
                 30,
                 500,

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -27,6 +27,7 @@ import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFacto
 import com.positivity.mcp.internal.orchestration.tools.ExaWebSearchTool;
 import com.positivity.mcp.internal.orchestration.tools.InventoryFacadeTool;
 import com.positivity.mcp.internal.orchestration.tools.OrderFacadeTool;
+import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import com.positivity.mcp.internal.service.RequestScopedUserContext;
 import com.positivity.mcp.internal.service.ToolRegistryService;
@@ -40,6 +41,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -111,6 +113,9 @@ class StreamingSessionAgentManagerTest {
     @Mock
     private NltiTelemetryEmitter telemetryEmitter;
 
+    @Mock
+    private NltiWorkflowStateService workflowStateService;
+
     // Real instance required to prevent @Tool duplicate registration
     private ExaWebSearchTool exaWebSearchTool;
     private InventoryFacadeTool inventoryFacadeTool;
@@ -130,6 +135,8 @@ class StreamingSessionAgentManagerTest {
         // bleed
         when(toolRegistry.resolveDomainTools(any())).thenAnswer(inv -> new ArrayList<>());
         when(toolRegistry.preloadableRoleIdentifiers()).thenReturn(Set.of("ROLE_CASHIER", "ROLE_MANAGER"));
+        // #778: default to session-less so existing tests exercise the message-heuristic path.
+        lenient().when(workflowStateService.resolveActiveState(any())).thenReturn(Optional.empty());
         lenient().when(rolePromptResolver.resolvePrompt(any())).thenReturn("Default role prompt");
         lenient()
                 .when(rolePromptResolver.assemble(any(), any()))
@@ -173,6 +180,7 @@ class StreamingSessionAgentManagerTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                workflowStateService,
                 FIXED_CLOCK,
                 30,
                 500,
@@ -346,6 +354,7 @@ class StreamingSessionAgentManagerTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                workflowStateService,
                 FIXED_CLOCK,
                 30,
                 500,
@@ -410,6 +419,7 @@ class StreamingSessionAgentManagerTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                workflowStateService,
                 FIXED_CLOCK,
                 0,
                 500,
@@ -444,6 +454,7 @@ class StreamingSessionAgentManagerTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                workflowStateService,
                 FIXED_CLOCK,
                 30,
                 500,
@@ -505,6 +516,7 @@ class StreamingSessionAgentManagerTest {
                 openApiToolProvider,
                 requestContext,
                 null, // roleDefaultPermissionsClient
+                workflowStateService,
                 FIXED_CLOCK,
                 30,
                 500,

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/NltiWorkflowStateServiceTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/NltiWorkflowStateServiceTest.java
@@ -1,0 +1,83 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.domain.WorkflowState;
+import com.positivity.mcp.internal.entity.NltiSession;
+import com.positivity.mcp.internal.exception.SessionOwnershipViolationException;
+import com.positivity.mcp.internal.repository.NltiSessionRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NltiWorkflowStateServiceTest {
+
+    private static final String SUBJECT = "alice";
+    private static final UUID SESSION_ID = UUID.fromString("00000000-0000-7000-8000-000000000901");
+
+    @Mock
+    private NltiSessionRepository sessionRepository;
+
+    @InjectMocks
+    private NltiWorkflowStateService service;
+
+    @Test
+    @DisplayName("resolveActiveState returns the subject's most-recent session state")
+    void resolveActiveState_returnsMostRecentState() {
+        NltiSession session = new NltiSession();
+        session.setId(SESSION_ID);
+        session.setSubjectId(SUBJECT);
+        session.setWorkflowState(WorkflowState.CREATING_PO);
+        when(sessionRepository.findFirstBySubjectIdOrderByUpdatedAtDesc(SUBJECT))
+                .thenReturn(Optional.of(session));
+
+        assertThat(service.resolveActiveState(SUBJECT)).contains(WorkflowState.CREATING_PO);
+    }
+
+    @Test
+    @DisplayName("resolveActiveState is empty when the subject has no session (heuristic fallback)")
+    void resolveActiveState_emptyWhenNoSession() {
+        when(sessionRepository.findFirstBySubjectIdOrderByUpdatedAtDesc(SUBJECT))
+                .thenReturn(Optional.empty());
+
+        assertThat(service.resolveActiveState(SUBJECT)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("advance sets and saves the new state on an owned session")
+    void advance_setsAndSavesState_whenOwned() {
+        NltiSession session = new NltiSession();
+        session.setId(SESSION_ID);
+        session.setSubjectId(SUBJECT);
+        session.setWorkflowState(WorkflowState.IDLE);
+        when(sessionRepository.findByIdAndSubjectId(SESSION_ID, SUBJECT)).thenReturn(Optional.of(session));
+        when(sessionRepository.save(any(NltiSession.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        WorkflowState result = service.advance(SESSION_ID, SUBJECT, WorkflowState.RECEIVING_ASN);
+
+        assertThat(result).isEqualTo(WorkflowState.RECEIVING_ASN);
+        assertThat(session.getWorkflowState()).isEqualTo(WorkflowState.RECEIVING_ASN);
+        verify(sessionRepository).save(session);
+    }
+
+    @Test
+    @DisplayName("advance rejects a session not owned by the subject (fail-closed)")
+    void advance_throwsWhenNotOwned() {
+        when(sessionRepository.findByIdAndSubjectId(SESSION_ID, SUBJECT)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.advance(SESSION_ID, SUBJECT, WorkflowState.CREATING_PO))
+                .isInstanceOf(SessionOwnershipViolationException.class);
+        verify(sessionRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Backend issue: #778 (derive workflow state beyond IDLE for tool gating)
- Domain: `domain:nlti`

## Contract References
This adds one internal `pos-mcp-server` endpoint (`POST /v1/nlt/sessions/{sessionId}/workflow-state`) and regenerates the module `openapi.yaml`. No shared/domain contract semantics change, so `BACKEND_CONTRACT_GUIDE.md` is unaffected and no durion contract PR is required. The endpoint is an internal NLTI session-management call, not a public gateway/frontend API.

## Contract Chain (Controller changed — `NltiController`)
- [x] OpenAPI annotations added on the new controller method (`@Operation`, `@Schema`)
- [x] `openapi.yaml` regenerated (`pos-mcp-server`, via the `openapi` profile — booted the app on H2)
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — **deferred** follow-up; no frontend consumer yet (same posture as #782). The new endpoint is internal session management.

## Scope
**What changed:** the session managers gate tool selection by the caller's **persisted** `NltiSession.workflowState` instead of always evaluating `IDLE`, and a small explicit write path advances that state as a workflow progresses. Design approach chosen: read-only threading + explicit write API (no change to the public `/v1/mcp/chat` contract).

| Area | Change |
|---|---|
| `NltiWorkflowStateService` (new) | `resolveActiveState(subjectId)` → the subject's most-recently-updated session state (empty when none); `advance(sessionId, subjectId, state)` → ownership-checked write path returning the `WorkflowState` (not the entity, so controllers stay off the persistence layer) |
| `SessionAgentManager` / `StreamingSessionAgentManager` | resolve the active state and pass it into the workflow-state-aware `selectRoleTools` overload; callers with **no** session fall back to the existing message-heuristic derivation |
| `NltiController` | `POST /v1/nlt/sessions/{sessionId}/workflow-state` advances the caller's own session (guarded by `nlti:request:submit`, `@EmitEvent NLTI_SESSION_WORKFLOW_STATE_SET`) |
| `EventTypes` | registers `NLTI_SESSION_WORKFLOW_STATE_SET` (write preset) |
| `NltiSessionRepository` | `findFirstBySubjectIdOrderByUpdatedAtDesc` |
| README | workflow-state note updated; completed backlog item removed |

**Already shipped in #1102:** AC3 (loader preloads the union of tool sets across non-IDLE workflow states) — `MasterAgentRegistryLoader`.

**Why:** `NltiSession.workflowState` was persisted but never read for tool selection (managers always evaluated `IDLE`) and never advanced, so non-IDLE tool sets (`CREATING_PO`, `RECEIVING_ASN`, `INVENTORY_RECON`, `PROCESSING_RETURN`) could never activate.

## Tests
- [x] Unit tests — `NltiWorkflowStateServiceTest` (resolve most-recent / empty; advance sets+saves; advance fail-closed on foreign session)
- [x] Component tests — `SessionAgentManagerTest` asserts a persisted non-IDLE session threads that state into gated selection (AC4); `NltiControllerTest` slice covers the new endpoint (200 + 401)
- [x] Both manager tests updated for the new constructor dependency
- **How to run:** `./mvnw -pl pos-mcp-server -am test`. Verified offline under JDK 25: affected suites + module ArchUnit = 47 green; the `openapi` profile boots the full context with the new beans.

## Risk & Rollback
- **Risk level:** Low–Medium — behavior change is confined to `pos-mcp-server` tool selection. Session-less callers are unaffected (heuristic fallback preserved). The write endpoint is ownership-checked and additive.
- **Rollback:** revert the branch. No schema migration; `NltiSession.workflow_state` already exists.

## Out of scope (tracked on the issue)
- Automatic state advancement from tool-execution side-effects (this PR provides the explicit write path; a self-driving trigger was the alternative approach not chosen).
- Angular SDK regen for the new internal endpoint.

## Checklist
- [ ] Branch name matches `cap/` — n/a (designated branch; single issue, no capability id)
- [x] Links to issue present (#778)
- [x] Contract guide referenced (n/a — no contract-semantic change; `BACKEND_CONTRACT_GUIDE.md` unaffected)
- [ ] Required CI checks passing (pending CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoVuahmdLWUxubXLnGDFik

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoVuahmdLWUxubXLnGDFik)_