### PR TITLE
fix(pos-inventory): rename purchase_suggestion.item_sku to itemsku to fix startup schema validation

### DIFF
--- a/pos-inventory/src/main/resources/db/migration/V31__rename_purchase_suggestion_item_sku.sql
+++ b/pos-inventory/src/main/resources/db/migration/V31__rename_purchase_suggestion_item_sku.sql
@@ -1,0 +1,17 @@
+-- Fix pos-inventory startup schema validation failure (missing column [itemsku] in
+-- table [purchase_suggestion]).
+--
+-- The PurchaseSuggestion entity's `itemSKU` field carries no explicit @Column mapping, so
+-- Hibernate's CamelCaseToUnderscoresNamingStrategy resolves it. That strategy only inserts an
+-- underscore before an uppercase letter that is followed by a lowercase one, so the trailing
+-- all-caps acronym in `itemSKU` is NOT split: the field maps to column `itemsku`, exactly as
+-- the sibling replenishment_policy.itemsku / replenishment_task.itemsku columns (also mapped
+-- from an `itemSKU` field) were created in the V1 baseline.
+--
+-- V22 created this column as `item_sku` (with an underscore), which does not match the mapped
+-- name, so schema validation aborts startup. Rename it to `itemsku` to align with the entity
+-- and the mirrored replenishment tables. Postgres rewrites the dependent
+-- idx_purchase_suggestion_sku_location_status index to follow the rename, so no index rebuild
+-- is needed.
+ALTER TABLE purchase_suggestion
+    RENAME COLUMN item_sku TO itemsku;


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — startup defect fix (no capability change)
- Domain: `domain:inventory`

## Contract References
- n/a — this PR touches only a Flyway migration. No controllers, DTOs, `*Request`/`*Response`, events, `openapi.yaml`, or validation/error models change, so there is no API/event contract impact.

## Contract Chain (when a Controller changed)
- n/a — no controller changed.

## Scope
- **What changed:** Added `V31__rename_purchase_suggestion_item_sku.sql`, which renames column `purchase_suggestion.item_sku` → `purchase_suggestion.itemsku`.
- **Why:** `pos-inventory` failed startup with a Hibernate schema validation error:
  `Schema validation: missing column [itemsku] in table [purchase_suggestion]`.

  The `PurchaseSuggestion.itemSKU` entity field carries no explicit `@Column` mapping, so Hibernate's `CamelCaseToUnderscoresNamingStrategy` derives the column name. That strategy inserts an underscore only before an uppercase letter that is *followed by a lowercase one*, so the trailing all-caps acronym in `itemSKU` is **not** split — the field maps to column `itemsku`. This matches the sibling `replenishment_policy.itemsku` / `replenishment_task.itemsku` columns (also mapped from an `itemSKU` field) created in the V1 baseline.

  `V22__create_purchase_suggestion.sql` created the column as `item_sku` (with an underscore), which does not match the mapped name, so validation aborted context initialization. V31 renames it to align with the entity and the mirrored replenishment tables. Postgres rewrites the dependent `idx_purchase_suggestion_sku_location_status` index to follow the rename, so no index rebuild is required. Repositories use derived queries (`findByItemSKU...`) that resolve through the entity property, so no query/native-SQL changes are needed.

  V31 is a new migration rather than an edit to the already-applied V22, keeping migration history immutable and fixing environments that already ran V22.

## Tests
- [ ] Unit tests added/updated — n/a (schema-only fix; existing tests exercise the entity mapping)
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a
- **How to run:** `./mvnw -pl pos-inventory -am test`; the fix is validated by `pos-inventory` starting cleanly against Postgres (schema validation passes).

## Risk & Rollback
- Risk level: **Low** — single-column rename on a table introduced in V22 (not yet released to prod); index and constraints are preserved by the rename.
- Rollback plan: revert this commit and apply a compensating migration renaming `itemsku` back to `item_sku` (the pre-V31 state), or restore from backup. No data transformation is involved.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, automated fix branch
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability
- [ ] Links to parent + child issues are present — n/a
- [ ] Contract guide updated (when contract semantics changed) — n/a, no contract change
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgawXMpg242EZp9cNNwxrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgawXMpg242EZp9cNNwxrR)_