### PR TITLE
fix(pos-mcp-server): pass model to tool-calling chat options to fix HTTP 500

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
@@ -62,13 +62,16 @@ final class SpringAiPosAssistant implements PosAssistant {
             toolCallbacks.addAll(openApiToolProvider.resolveToolCallbacks(userMessage));
         }
 
+        DefaultToolCallingChatOptions.Builder optionsBuilder =
+                DefaultToolCallingChatOptions.builder().toolCallbacks(toolCallbacks);
+        // Only override the model when we resolved one; a null/blank override would clobber the
+        // chat model's configured default and fail with "model cannot be null or empty".
+        if (modelName != null && !modelName.isBlank()) {
+            optionsBuilder.model(modelName);
+        }
+
         String response = chatModel
-                .call(new Prompt(
-                        promptMessages,
-                        DefaultToolCallingChatOptions.builder()
-                                .toolCallbacks(toolCallbacks)
-                                .model(modelName)
-                                .build()))
+                .call(new Prompt(promptMessages, optionsBuilder.build()))
                 .getResult()
                 .getOutput()
                 .getText();

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
@@ -1,22 +1,23 @@
 package com.positivity.mcp.internal.orchestration;
 
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
-import java.util.function.Supplier;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.messages.Message;
-import org.springframework.ai.chat.messages.SystemMessage;
-import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.memory.ChatMemory;
-import org.springframework.ai.chat.model.ChatModel;
-import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
-import org.springframework.ai.tool.ToolCallback;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
 
 final class SpringAiPosAssistant implements PosAssistant {
 
@@ -25,6 +26,7 @@ final class SpringAiPosAssistant implements PosAssistant {
     private static final int MAX_CONTEXT_CHARS = 4_000;
 
     private final ChatModel chatModel;
+    private final @Nullable String modelName;
     private final Supplier<String> systemPromptSupplier;
     private final List<ToolCallback> staticToolCallbacks;
     private final QueryDocumentRetriever ragRetriever;
@@ -39,6 +41,7 @@ final class SpringAiPosAssistant implements PosAssistant {
             @NonNull Function<String, ChatMemory> chatMemoryProvider,
             @Nullable OpenApiToolProvider openApiToolProvider) {
         this.chatModel = chatModel;
+        this.modelName = resolveModelName(chatModel);
         this.systemPromptSupplier = systemPromptSupplier;
         this.staticToolCallbacks = SpringAiToolCallbackResolver.fromObjects(staticTools);
         this.ragRetriever = ragRetriever;
@@ -59,9 +62,13 @@ final class SpringAiPosAssistant implements PosAssistant {
             toolCallbacks.addAll(openApiToolProvider.resolveToolCallbacks(userMessage));
         }
 
-        String response = chatModel.call(new Prompt(
+        String response = chatModel
+                .call(new Prompt(
                         promptMessages,
-                        DefaultToolCallingChatOptions.builder().toolCallbacks(toolCallbacks).build()))
+                        DefaultToolCallingChatOptions.builder()
+                                .toolCallbacks(toolCallbacks)
+                                .model(modelName)
+                                .build()))
                 .getResult()
                 .getOutput()
                 .getText();
@@ -104,5 +111,16 @@ final class SpringAiPosAssistant implements PosAssistant {
             }
         }
         return builder.toString();
+    }
+
+    /**
+     * Resolves the model configured on the chat model's default options so that the per-request
+     * tool-calling options carry it explicitly. Ollama's option merge treats the runtime options'
+     * null {@code model} as an override and clobbers the configured default, which would fail with
+     * "model cannot be null or empty"; passing the model through avoids that.
+     */
+    private static @Nullable String resolveModelName(@NonNull ChatModel chatModel) {
+        ChatOptions defaultOptions = chatModel.getDefaultOptions();
+        return defaultOptions != null ? defaultOptions.getModel() : null;
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
@@ -67,12 +67,14 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
             toolCallbacks.addAll(openApiToolProvider.resolveToolCallbacks(userMessage));
         }
         AtomicReference<StringBuilder> responseText = new AtomicReference<>(new StringBuilder());
-        return streamingChatModel.stream(new Prompt(
-                        promptMessages,
-                        DefaultToolCallingChatOptions.builder()
-                                .toolCallbacks(toolCallbacks)
-                                .model(modelName)
-                                .build()))
+        DefaultToolCallingChatOptions.Builder optionsBuilder =
+                DefaultToolCallingChatOptions.builder().toolCallbacks(toolCallbacks);
+        // Only override the model when we resolved one; a null/blank override would clobber the
+        // chat model's configured default and fail with "model cannot be null or empty".
+        if (modelName != null && !modelName.isBlank()) {
+            optionsBuilder.model(modelName);
+        }
+        return streamingChatModel.stream(new Prompt(promptMessages, optionsBuilder.build()))
                 .map(response -> {
                     if (response.getResult() == null || response.getResult().getOutput() == null) {
                         return "";

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
@@ -1,23 +1,25 @@
 package com.positivity.mcp.internal.orchestration;
 
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
-import java.util.function.Supplier;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.messages.Message;
-import org.springframework.ai.chat.messages.SystemMessage;
-import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.memory.ChatMemory;
-import org.springframework.ai.chat.model.StreamingChatModel;
-import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
-import org.springframework.ai.tool.ToolCallback;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.StreamingChatModel;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
 import reactor.core.publisher.Flux;
 
 final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
@@ -27,6 +29,7 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
     private static final int MAX_CONTEXT_CHARS = 4_000;
 
     private final StreamingChatModel streamingChatModel;
+    private final @Nullable String modelName;
     private final Supplier<String> systemPromptSupplier;
     private final List<ToolCallback> staticToolCallbacks;
     private final QueryDocumentRetriever ragRetriever;
@@ -41,6 +44,7 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
             @NonNull Function<String, ChatMemory> chatMemoryProvider,
             @Nullable OpenApiToolProvider openApiToolProvider) {
         this.streamingChatModel = streamingChatModel;
+        this.modelName = resolveModelName(streamingChatModel);
         this.systemPromptSupplier = systemPromptSupplier;
         this.staticToolCallbacks = SpringAiToolCallbackResolver.fromObjects(staticTools);
         this.ragRetriever = ragRetriever;
@@ -49,7 +53,8 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
     }
 
     @Override
-    public @NonNull Flux<String> chat(@NonNull String memoryId, @NonNull String userMessage, @NonNull String userContext) {
+    public @NonNull Flux<String> chat(
+            @NonNull String memoryId, @NonNull String userMessage, @NonNull String userContext) {
         ChatMemory chatMemory = chatMemoryProvider.apply(memoryId);
         String systemPrompt = buildSystemPrompt(userMessage, userContext);
         List<Message> promptMessages = new ArrayList<>(chatMemory.get(memoryId));
@@ -62,10 +67,12 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
             toolCallbacks.addAll(openApiToolProvider.resolveToolCallbacks(userMessage));
         }
         AtomicReference<StringBuilder> responseText = new AtomicReference<>(new StringBuilder());
-        return streamingChatModel
-                .stream(new Prompt(
+        return streamingChatModel.stream(new Prompt(
                         promptMessages,
-                        DefaultToolCallingChatOptions.builder().toolCallbacks(toolCallbacks).build()))
+                        DefaultToolCallingChatOptions.builder()
+                                .toolCallbacks(toolCallbacks)
+                                .model(modelName)
+                                .build()))
                 .map(response -> {
                     if (response.getResult() == null || response.getResult().getOutput() == null) {
                         return "";
@@ -117,5 +124,20 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
             }
         }
         return builder.toString();
+    }
+
+    /**
+     * Resolves the model configured on the streaming chat model's default options so that the
+     * per-request tool-calling options carry it explicitly. Ollama's option merge treats the runtime
+     * options' null {@code model} as an override and clobbers the configured default, which would fail
+     * with "model cannot be null or empty"; passing the model through avoids that.
+     */
+    private static @Nullable String resolveModelName(@NonNull StreamingChatModel streamingChatModel) {
+        // Only ChatModel exposes getDefaultOptions(); the concrete Ollama bean implements both.
+        if (streamingChatModel instanceof ChatModel chatModel) {
+            ChatOptions defaultOptions = chatModel.getDefaultOptions();
+            return defaultOptions != null ? defaultOptions.getModel() : null;
+        }
+        return null;
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
@@ -12,15 +12,16 @@ import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.ollama.api.OllamaChatOptions;
 
 class SpringAiPosAssistantTest {
 
@@ -35,11 +36,12 @@ class SpringAiPosAssistantTest {
         QueryDocumentRetriever ragRetriever = mock(QueryDocumentRetriever.class);
         ChatMemory chatMemory = mock(ChatMemory.class);
         OpenApiToolProvider openApiToolProvider = mock(OpenApiToolProvider.class);
+        when(chatModel.getDefaultOptions())
+                .thenReturn(OllamaChatOptions.builder().model("qwen3.5:cloud").build());
         when(openApiToolProvider.resolveToolCallbacks(any())).thenReturn(List.of());
         when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse("resolved answer"));
         when(ragRetriever.retrieve("where is stock")).thenReturn(List.of(new Document("Inventory policy A")));
-        when(chatMemory.get("user-1::ROLE_TECH"))
-                .thenReturn(List.of(new AssistantMessage("previous assistant turn")));
+        when(chatMemory.get("user-1::ROLE_TECH")).thenReturn(List.of(new AssistantMessage("previous assistant turn")));
 
         SpringAiPosAssistant assistant = new SpringAiPosAssistant(
                 chatModel,
@@ -57,6 +59,8 @@ class SpringAiPosAssistantTest {
 
         ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
         verify(chatModel).call(promptCaptor.capture());
+        assertThat(promptCaptor.getValue().getOptions()).isNotNull();
+        assertThat(promptCaptor.getValue().getOptions().getModel()).isEqualTo("qwen3.5:cloud");
         List<Message> promptMessages = promptCaptor.getValue().getInstructions();
         assertThat(promptMessages).hasSize(3);
         assertThat(promptMessages.getFirst().getText()).isEqualTo("previous assistant turn");


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:<cap-id>` — N/A (bug fix, no capability change)
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
N/A — this change does not touch API/event contract behavior. No controllers, DTOs, `*Request`/`*Response`, events, `openapi.yaml`, or validation/error models were modified. Only the internal Spring AI `Prompt` option construction changed.

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A (no controller changed)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A

## Scope
- **What changed:** Set the model explicitly on the per-request tool-calling chat options in both `SpringAiPosAssistant` (blocking) and `SpringAiStreamingPosAssistant` (streaming). The model is resolved from the chat model's default options.
- **Why:** `MCP_CHAT_EXECUTE` returned HTTP 500 with `java.lang.IllegalArgumentException: model cannot be null or empty` (thrown from `OllamaChatModel.verifyPromptChatOptions`) whenever a chat request went through the tool-calling path (agent chat with selected tools).

### Root cause
The tool-calling path built the `Prompt` with `DefaultToolCallingChatOptions.builder().toolCallbacks(...).build()` — a per-request options object carrying a `null` model. Ollama's option merge treats that null model as an explicit override and clobbers the model configured on the `OllamaChatModel` default options (`qwen3.5:cloud`), leaving the request with no model.

The simple-chat path was unaffected because it sends a `Prompt` with **no** per-request options, so the configured default options (which include the model) are used as-is. This is why only tool-selected requests failed (e.g. the observed `ROLE_ADMIN` workorder query with tools=8).

### Fix
Resolve the model from the chat model's default options and set it explicitly on the per-request tool-calling options. `StreamingChatModel` does not expose `getDefaultOptions()`, so the streaming assistant reads it via the concrete bean's `ChatModel` interface (null-safe `instanceof` cast).

## Tests
- [x] Unit tests added/updated — `SpringAiPosAssistantTest` now stubs `getDefaultOptions()` and asserts the built `Prompt` carries the model (`qwen3.5:cloud`).
- [ ] Integration tests added/updated — N/A
- [ ] Provider behavioral contract tests added/updated — N/A
- **How to run:**
  ```bash
  ./mvnw -pl pos-mcp-server -am -Dtest=SpringAiPosAssistantTest,SpringAiStreamingPosAssistantTest,ModelFallbackConfigurationTest test
  ```

## Risk & Rollback
- Risk level: **Low** — narrowly scoped to how the per-request `Prompt` options are assembled; the model value is sourced from the already-configured chat model defaults.
- Rollback plan: revert this commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A (fix branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A
- [ ] Links to parent + child issues are present — N/A
- [ ] Contract guide updated (when contract semantics changed) — N/A (no contract change)
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy3STGHTHWc1vYfCf5MqPy)_