### PR TITLE
ci: skip pos-archunit tests in nightly full-coverage Sonar job (#909)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,8 +642,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        # This `verify` on the -am reactor takes the domain modules through package, where
+        # spring-boot:repackage swaps their jars for fat jars whose classes hide under
+        # BOOT-INF/classes. pos-archunit's cross-module rules (and ClasspathVisibilityGuardTest)
+        # would then see nothing and fail (#909), exactly as in the integration-tests job. Skip
+        # pos-archunit's tests here (-Darchunit.skipTests=true): it has no production code so it
+        # adds no coverage, and its rules are enforced at the `test` phase in the per-module
+        # unit/integration jobs.
         run: |
-          ./mvnw -pl ${{ env.COVERAGE_AGGREGATE_MODULE }} -am -DskipITs verify -T 1C -B \
+          ./mvnw -pl ${{ env.COVERAGE_AGGREGATE_MODULE }} -am -DskipITs -Darchunit.skipTests=true verify -T 1C -B \
             org.sonarsource.scanner.maven:sonar-maven-plugin:${{ env.SONAR_MAVEN_PLUGIN_VERSION }}:sonar \
             -Dsonar.projectKey=louisburroughs_durion-positivity-backend \
             -Dsonar.organization=louisburroughs \

--- a/pos-archunit/pom.xml
+++ b/pos-archunit/pom.xml
@@ -12,7 +12,20 @@
     <description>Architecture testing aggregator for all POS domain modules using ArchUnit</description>
     <packaging>jar</packaging>
 
-
+    <properties>
+        <!--
+            Module-scoped switch to skip this module's ArchUnit tests without disabling tests
+            reactor-wide. The cross-module rules (and ClasspathVisibilityGuardTest) only work when
+            sibling modules resolve to target/classes; a full-reactor `verify` first repackages the
+            domain modules into Spring Boot fat jars (classes under BOOT-INF/classes) where ArchUnit
+            cannot see them, so the guard fails vacuous-pass detection (#909). The nightly
+            "Full Coverage SonarCloud Analysis" job runs exactly such a `-pl pos-coverage-aggregate
+            -am verify`, so it sets -Darchunit.skipTests=true. pos-archunit has no production code,
+            so skipping its tests there costs no coverage; the rules stay enforced in the per-module
+            unit/integration jobs, which run pos-archunit at the `test` phase.
+        -->
+        <archunit.skipTests>false</archunit.skipTests>
+    </properties>
 
     <dependencies>
         <!-- ArchUnit for architecture testing -->
@@ -182,6 +195,13 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${archunit.skipTests}</skipTests>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The nightly "Full Coverage SonarCloud Analysis" job runs
`./mvnw -pl pos-coverage-aggregate -am -DskipITs verify`. Because
pos-coverage-aggregate depends on pos-archunit, `-am` pulls pos-archunit
into the reactor, and `verify` first takes the domain modules through
`package`, where spring-boot:repackage swaps their jars for fat jars.
pos-archunit's cross-module ArchUnit rules then resolve siblings to those
fat jars, whose application classes live under BOOT-INF/classes where the
ArchUnit importer cannot see them. ClasspathVisibilityGuardTest detects the
resulting vacuous state and fails the build (#909) — exactly the failure the
unit- and integration-test jobs already avoid by stopping pos-archunit at the
`test` phase.

Skip pos-archunit's tests in that job via a new module-scoped
`archunit.skipTests` property (default false), set to true only in the
nightly command. pos-archunit has no production code, so skipping its tests
there costs no coverage, and the architecture rules remain enforced at the
`test` phase in the per-module unit/integration jobs that run on every
push and PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UhbE39wUP3X7JNNJxN5K1G