### PR TITLE
fix(pos-mcp-server): fix MCP chat HTTP 500 (tool-calling options) and RAG vector-store schema mismatch

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
@@ -17,6 +17,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 
 final class SpringAiPosAssistant implements PosAssistant {
@@ -26,7 +27,6 @@ final class SpringAiPosAssistant implements PosAssistant {
     private static final int MAX_CONTEXT_CHARS = 4_000;
 
     private final ChatModel chatModel;
-    private final @Nullable String modelName;
     private final Supplier<String> systemPromptSupplier;
     private final List<ToolCallback> staticToolCallbacks;
     private final QueryDocumentRetriever ragRetriever;
@@ -41,7 +41,6 @@ final class SpringAiPosAssistant implements PosAssistant {
             @NonNull Function<String, ChatMemory> chatMemoryProvider,
             @Nullable OpenApiToolProvider openApiToolProvider) {
         this.chatModel = chatModel;
-        this.modelName = resolveModelName(chatModel);
         this.systemPromptSupplier = systemPromptSupplier;
         this.staticToolCallbacks = SpringAiToolCallbackResolver.fromObjects(staticTools);
         this.ragRetriever = ragRetriever;
@@ -62,16 +61,8 @@ final class SpringAiPosAssistant implements PosAssistant {
             toolCallbacks.addAll(openApiToolProvider.resolveToolCallbacks(userMessage));
         }
 
-        DefaultToolCallingChatOptions.Builder optionsBuilder =
-                DefaultToolCallingChatOptions.builder().toolCallbacks(toolCallbacks);
-        // Only override the model when we resolved one; a null/blank override would clobber the
-        // chat model's configured default and fail with "model cannot be null or empty".
-        if (modelName != null && !modelName.isBlank()) {
-            optionsBuilder.model(modelName);
-        }
-
         String response = chatModel
-                .call(new Prompt(promptMessages, optionsBuilder.build()))
+                .call(new Prompt(promptMessages, toolCallingOptions(chatModel.getDefaultOptions(), toolCallbacks)))
                 .getResult()
                 .getOutput()
                 .getText();
@@ -117,13 +108,27 @@ final class SpringAiPosAssistant implements PosAssistant {
     }
 
     /**
-     * Resolves the model configured on the chat model's default options so that the per-request
-     * tool-calling options carry it explicitly. Ollama's option merge treats the runtime options'
-     * null {@code model} as an override and clobbers the configured default, which would fail with
-     * "model cannot be null or empty"; passing the model through avoids that.
+     * Builds the per-request tool-calling options by copying the chat model's configured default
+     * options and attaching the resolved tool callbacks.
+     *
+     * <p>The copy must retain the provider-specific options type: {@code OllamaChatModel} casts the
+     * prompt's runtime options directly to {@code OllamaChatOptions}, so a generic
+     * {@link DefaultToolCallingChatOptions} would fail with {@code ClassCastException}. Copying the
+     * default options via {@code mutate()} also preserves the configured model, avoiding the
+     * "model cannot be null or empty" failure that a fresh options object (with a null model) would
+     * trigger through Ollama's option merge.
      */
-    private static @Nullable String resolveModelName(@NonNull ChatModel chatModel) {
-        ChatOptions defaultOptions = chatModel.getDefaultOptions();
-        return defaultOptions != null ? defaultOptions.getModel() : null;
+    static @NonNull ChatOptions toolCallingOptions(
+            @Nullable ChatOptions defaultOptions, @NonNull List<ToolCallback> toolCallbacks) {
+        if (defaultOptions instanceof ToolCallingChatOptions toolCallingDefaults) {
+            return toolCallingDefaults.mutate().toolCallbacks(toolCallbacks).build();
+        }
+        DefaultToolCallingChatOptions.Builder builder =
+                DefaultToolCallingChatOptions.builder().toolCallbacks(toolCallbacks);
+        String model = defaultOptions != null ? defaultOptions.getModel() : null;
+        if (model != null && !model.isBlank()) {
+            builder.model(model);
+        }
+        return builder.build();
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
@@ -18,7 +18,6 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.StreamingChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 import reactor.core.publisher.Flux;
 
@@ -29,7 +28,6 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
     private static final int MAX_CONTEXT_CHARS = 4_000;
 
     private final StreamingChatModel streamingChatModel;
-    private final @Nullable String modelName;
     private final Supplier<String> systemPromptSupplier;
     private final List<ToolCallback> staticToolCallbacks;
     private final QueryDocumentRetriever ragRetriever;
@@ -44,7 +42,6 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
             @NonNull Function<String, ChatMemory> chatMemoryProvider,
             @Nullable OpenApiToolProvider openApiToolProvider) {
         this.streamingChatModel = streamingChatModel;
-        this.modelName = resolveModelName(streamingChatModel);
         this.systemPromptSupplier = systemPromptSupplier;
         this.staticToolCallbacks = SpringAiToolCallbackResolver.fromObjects(staticTools);
         this.ragRetriever = ragRetriever;
@@ -67,14 +64,8 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
             toolCallbacks.addAll(openApiToolProvider.resolveToolCallbacks(userMessage));
         }
         AtomicReference<StringBuilder> responseText = new AtomicReference<>(new StringBuilder());
-        DefaultToolCallingChatOptions.Builder optionsBuilder =
-                DefaultToolCallingChatOptions.builder().toolCallbacks(toolCallbacks);
-        // Only override the model when we resolved one; a null/blank override would clobber the
-        // chat model's configured default and fail with "model cannot be null or empty".
-        if (modelName != null && !modelName.isBlank()) {
-            optionsBuilder.model(modelName);
-        }
-        return streamingChatModel.stream(new Prompt(promptMessages, optionsBuilder.build()))
+        return streamingChatModel.stream(new Prompt(
+                        promptMessages, SpringAiPosAssistant.toolCallingOptions(defaultOptions(), toolCallbacks)))
                 .map(response -> {
                     if (response.getResult() == null || response.getResult().getOutput() == null) {
                         return "";
@@ -129,17 +120,11 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
     }
 
     /**
-     * Resolves the model configured on the streaming chat model's default options so that the
-     * per-request tool-calling options carry it explicitly. Ollama's option merge treats the runtime
-     * options' null {@code model} as an override and clobbers the configured default, which would fail
-     * with "model cannot be null or empty"; passing the model through avoids that.
+     * Returns the streaming chat model's configured default options, used as the base for the
+     * per-request tool-calling options. Only {@link ChatModel} exposes {@code getDefaultOptions()};
+     * the concrete Ollama bean implements both {@link StreamingChatModel} and {@link ChatModel}.
      */
-    private static @Nullable String resolveModelName(@NonNull StreamingChatModel streamingChatModel) {
-        // Only ChatModel exposes getDefaultOptions(); the concrete Ollama bean implements both.
-        if (streamingChatModel instanceof ChatModel chatModel) {
-            ChatOptions defaultOptions = chatModel.getDefaultOptions();
-            return defaultOptions != null ? defaultOptions.getModel() : null;
-        }
-        return null;
+    private @Nullable ChatOptions defaultOptions() {
+        return streamingChatModel instanceof ChatModel chatModel ? chatModel.getDefaultOptions() : null;
     }
 }

--- a/pos-mcp-server/src/main/resources/db/migration/V24__align_pgvector_document_columns.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V24__align_pgvector_document_columns.sql
@@ -1,0 +1,10 @@
+-- Align mcp_document_embedding with Spring AI PgVectorStore's fixed schema.
+-- PgVectorStore hardcodes the column names id / content / metadata / embedding
+-- (see PgVectorStore.DocumentRowMapper and its CREATE TABLE / INSERT templates),
+-- but V2 created the table with embedding_id / text. That mismatch made
+-- similaritySearch fail with "The column name id was not found in this ResultSet"
+-- (RAG silently degraded to empty context via ResilientContentRetriever) and would
+-- likewise have broken PgVectorStore.add() inserts. Rename the two columns to match;
+-- metadata (jsonb) and embedding (vector) already carry the expected names.
+ALTER TABLE mcp_document_embedding RENAME COLUMN embedding_id TO id;
+ALTER TABLE mcp_document_embedding RENAME COLUMN text TO content;

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
@@ -59,8 +59,13 @@ class SpringAiPosAssistantTest {
 
         ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
         verify(chatModel).call(promptCaptor.capture());
-        assertThat(promptCaptor.getValue().getOptions()).isNotNull();
+        // Runtime options must be the provider-specific OllamaChatOptions: OllamaChatModel casts the
+        // prompt options directly to OllamaChatOptions, so a generic DefaultToolCallingChatOptions
+        // would throw ClassCastException at request time.
+        assertThat(promptCaptor.getValue().getOptions()).isInstanceOf(OllamaChatOptions.class);
         assertThat(promptCaptor.getValue().getOptions().getModel()).isEqualTo("qwen3.5:cloud");
+        assertThat(((OllamaChatOptions) promptCaptor.getValue().getOptions()).getToolCallbacks())
+                .hasSize(1);
         List<Message> promptMessages = promptCaptor.getValue().getInstructions();
         assertThat(promptMessages).hasSize(3);
         assertThat(promptMessages.getFirst().getText()).isEqualTo("previous assistant turn");
@@ -86,7 +91,7 @@ class SpringAiPosAssistantTest {
 
     static final class PingTool {
         @org.springframework.ai.tool.annotation.Tool(description = "Health check")
-        String ping() {
+        public String ping() {
             return "pong";
         }
     }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
@@ -14,14 +15,16 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
-import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.StreamingChatModel;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.ollama.api.OllamaChatOptions;
 import reactor.core.publisher.Flux;
 
 class SpringAiStreamingPosAssistantTest {
@@ -87,13 +90,52 @@ class SpringAiStreamingPosAssistantTest {
         assertThat(secondCall.getFirst().getText()).isEqualTo("Hello");
     }
 
+    @Test
+    void chat_buildsProviderSpecificToolCallingOptionsCarryingModel() {
+        // The concrete Ollama bean implements both StreamingChatModel and ChatModel; the runtime
+        // options must copy its OllamaChatOptions default so OllamaChatModel's direct cast to
+        // OllamaChatOptions succeeds and the configured model is preserved.
+        StreamingChatModel streamingChatModel =
+                mock(StreamingChatModel.class, withSettings().extraInterfaces(ChatModel.class));
+        QueryDocumentRetriever ragRetriever = mock(QueryDocumentRetriever.class);
+        ChatMemory chatMemory = mock(ChatMemory.class);
+        OpenApiToolProvider openApiToolProvider = mock(OpenApiToolProvider.class);
+
+        when(((ChatModel) streamingChatModel).getDefaultOptions())
+                .thenReturn(OllamaChatOptions.builder().model("qwen3.5:cloud").build());
+        when(openApiToolProvider.resolveToolCallbacks(any())).thenReturn(List.of());
+        when(ragRetriever.retrieve(any())).thenReturn(List.of());
+        when(chatMemory.get(any())).thenReturn(List.of());
+        when(streamingChatModel.stream(any(Prompt.class))).thenReturn(Flux.just(chatResponse("ok")));
+
+        SpringAiStreamingPosAssistant assistant = new SpringAiStreamingPosAssistant(
+                streamingChatModel,
+                () -> "base prompt",
+                List.of(new PingTool()),
+                ragRetriever,
+                ignored -> chatMemory,
+                openApiToolProvider);
+
+        assistant
+                .chat("user-3::ROLE_TECH", "where is stock", "ctx:role=TECH")
+                .collectList()
+                .block(Duration.ofSeconds(5));
+
+        ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+        verify(streamingChatModel).stream(promptCaptor.capture());
+        assertThat(promptCaptor.getValue().getOptions()).isInstanceOf(OllamaChatOptions.class);
+        assertThat(promptCaptor.getValue().getOptions().getModel()).isEqualTo("qwen3.5:cloud");
+        assertThat(((OllamaChatOptions) promptCaptor.getValue().getOptions()).getToolCallbacks())
+                .hasSize(1);
+    }
+
     private static ChatResponse chatResponse(String token) {
         return new ChatResponse(List.of(new Generation(new AssistantMessage(token))));
     }
 
     static final class PingTool {
         @org.springframework.ai.tool.annotation.Tool(description = "Health check")
-        String ping() {
+        public String ping() {
             return "pong";
         }
     }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/RagScopeMigrationScriptsTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/RagScopeMigrationScriptsTest.java
@@ -25,6 +25,19 @@ class RagScopeMigrationScriptsTest {
     }
 
     @Test
+    void postgresMigrationRenamesEmbeddingColumnsToPgVectorSchema() throws IOException {
+        String sql = new String(
+                Objects.requireNonNull(getClass()
+                                .getResourceAsStream("/db/migration/V24__align_pgvector_document_columns.sql"))
+                        .readAllBytes(),
+                UTF_8);
+
+        assertThat(sql)
+                .contains("ALTER TABLE mcp_document_embedding RENAME COLUMN embedding_id TO id")
+                .contains("ALTER TABLE mcp_document_embedding RENAME COLUMN text TO content");
+    }
+
+    @Test
     void h2MigrationExistsForFlywayVersionAlignment() throws IOException {
         String sql = new String(
                 Objects.requireNonNull(getClass()


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:` — N/A (bug fix, no capability change)
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
N/A — this change does not touch API/event contract behavior. No controllers, DTOs, `*Request`/`*Response`, events, `openapi.yaml`, or validation/error models were modified. Only internal Spring AI `Prompt` option construction and the RAG vector-store table schema changed.

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A (no controller changed)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A

## Scope
Two independent defects surfaced in the same `MCP_CHAT_EXECUTE` request path.

### 1. HTTP 500 — tool-calling chat options (`ClassCastException`)
- **What changed:** Build the per-request tool-calling options by copying the chat model's configured default options (already the provider-specific `OllamaChatOptions`) via `mutate()` and attaching the resolved tool callbacks, in both `SpringAiPosAssistant` (blocking) and `SpringAiStreamingPosAssistant` (streaming). A generic `DefaultToolCallingChatOptions` fallback is retained for chat models whose defaults don't implement `ToolCallingChatOptions`.
- **Why:** The tool-calling path returned HTTP 500 with `java.lang.ClassCastException: DefaultToolCallingChatOptions cannot be cast to OllamaChatOptions` (from `OllamaChatModel.ollamaChatRequest`, which casts the prompt's runtime options directly to `OllamaChatOptions`). The prior fix set the model on a generic `DefaultToolCallingChatOptions`, which cleared an earlier `model cannot be null or empty` error but left the wrong runtime type. Copying the provider default keeps the correct type (cast succeeds) and preserves the configured model (null-model error stays fixed). The simple-chat path was unaffected because it sends a `Prompt` with no per-request options.

### 2. RAG retrieval silently degraded — vector-store schema mismatch
- **What changed:** `V24__align_pgvector_document_columns.sql` renames `mcp_document_embedding.embedding_id → id` and `text → content`.
- **Why:** Spring AI's `PgVectorStore` hardcodes the column names `id` / `content` / `metadata` / `embedding` (its `CREATE TABLE` and row-mapper templates), but the table created in V2 used `embedding_id` / `text`. `similaritySearch` failed with `PSQLException: The column name id was not found in this ResultSet`; the failure was swallowed by `ResilientContentRetriever` (WARN only), so every agent chat ran with **empty** retrieved context. The mismatch would likewise have broken `PgVectorStore.add()` inserts. `metadata` (jsonb) and `embedding` (vector) already match, and `rag_scope` lives inside the `metadata` jsonb, so no other change is needed. Postgres-only (the pgvector table exists only under the alpha/prod Flyway location); the H2 dev/test location never creates this table (matching the V22/V23 precedent).

## Tests
- [x] Unit tests added/updated — assistant tests assert the built `Prompt` carries an `OllamaChatOptions` with both the model (`qwen3.5:cloud`) and the tool callbacks, including the streaming bean that implements both `StreamingChatModel` and `ChatModel`; a migration-script test asserts V24 performs the two column renames.
- [ ] Integration tests added/updated — N/A
- [ ] Provider behavioral contract tests added/updated — N/A
- **How to run:**
  ```bash
  ./mvnw -pl pos-mcp-server -am -Dtest=SpringAiPosAssistantTest,SpringAiStreamingPosAssistantTest,RagScopeMigrationScriptsTest test
  ```

## Risk & Rollback
- Risk level: **Low** — the options change is narrowly scoped to per-request `Prompt` assembly and sources the model from existing chat-model defaults; the migration is a column rename on a table whose old names are referenced only by the original create migration.
- Rollback plan: revert this branch's commits. The migration rollback would be the inverse rename (`id → embedding_id`, `content → text`).

## Checklist
- [ ] Branch name matches `cap/` — N/A (fix branch)
- [ ] PR title starts with `[CAP:]` — N/A
- [ ] Links to parent + child issues are present — N/A
- [ ] Contract guide updated (when contract semantics changed) — N/A (no contract change)
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy3STGHTHWc1vYfCf5MqPy)_