### PR TITLE
fix(pos-archunit): honor -DskipTests so reactor bootstrap skips arch tests (#909)

### DIFF
--- a/pos-archunit/pom.xml
+++ b/pos-archunit/pom.xml
@@ -16,15 +16,23 @@
         <!--
             Module-scoped switch to skip this module's ArchUnit tests without disabling tests
             reactor-wide. The cross-module rules (and ClasspathVisibilityGuardTest) only work when
-            sibling modules resolve to target/classes; a full-reactor `verify` first repackages the
-            domain modules into Spring Boot fat jars (classes under BOOT-INF/classes) where ArchUnit
-            cannot see them, so the guard fails vacuous-pass detection (#909). The nightly
-            "Full Coverage SonarCloud Analysis" job runs exactly such a `-pl pos-coverage-aggregate
-            -am verify`, so it sets -Darchunit.skipTests=true. pos-archunit has no production code,
-            so skipping its tests there costs no coverage; the rules stay enforced in the per-module
-            unit/integration jobs, which run pos-archunit at the `test` phase.
+            sibling modules resolve to target/classes; a full-reactor `verify`/`install` first
+            repackages the domain modules into Spring Boot fat jars (classes under BOOT-INF/classes)
+            where ArchUnit cannot see them, so the guard fails vacuous-pass detection (#909).
+
+            It defaults to the standard ${skipTests} so that any reactor bootstrap that already
+            passes -DskipTests (e.g. the CI "Install all modules" step,
+            `./mvnw install -DskipTests -T 1C`) also skips pos-archunit and avoids the fat-jar
+            visibility failure — a plugin-level <skipTests> otherwise wins over the -DskipTests
+            user property. The nightly "Full Coverage SonarCloud Analysis" job runs a
+            `-pl pos-coverage-aggregate -am verify` without -DskipTests, so it still sets
+            -Darchunit.skipTests=true explicitly to opt out. pos-archunit has no production code, so
+            skipping its tests in those aggregate builds costs no coverage; the rules stay enforced
+            in the dedicated per-module unit/integration jobs, which run pos-archunit at the `test`
+            phase (no -DskipTests) as an isolated `-pl pos-archunit -am` reactor.
         -->
-        <archunit.skipTests>false</archunit.skipTests>
+        <skipTests>false</skipTests>
+        <archunit.skipTests>${skipTests}</archunit.skipTests>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Scope

Every build on `main` is red at the very first CI step — the `build-reactor` bootstrap `./mvnw install -DskipTests -DskipITs -T 1C -B -q` (`.github/workflows/ci.yml:143`, and the equivalent bootstrap steps at lines 202/294/355). It fails in `pos-archunit`'s `ClasspathVisibilityGuardTest`:

```
No classes imported from module dependencies: pos-accounting, pos-catalog, ...
— ArchUnit cannot see application classes inside Spring Boot repackaged fat jars
(BOOT-INF/classes). Run pos-archunit as a reactor build ... (see issue #909)
```

## Root cause

`pos-archunit`'s tests are meant to be **skipped** during any full-reactor `install`/`verify`, because there the sibling domain modules are already repackaged into Spring Boot fat jars (classes under `BOOT-INF/classes`) that ArchUnit cannot see — the guard's vacuous-pass detection then fails (#909). They only run correctly as an isolated `-pl pos-archunit -am` reactor where dependencies resolve to `target/classes`.

The module-scoped `archunit.skipTests` knob (added so the nightly Full-Coverage Sonar `verify` could opt out via `-Darchunit.skipTests=true`) was wired as an explicit maven-surefire `<skipTests>${archunit.skipTests}</skipTests>` with a hardcoded default of `false`. A **plugin-level `<skipTests>` overrides the `-DskipTests` user property**, so the standard `-DskipTests` flag passed by every reactor bootstrap step no longer skipped this module — its arch tests started running inside the full reactor and failing.

This is not a missing `-am`; the bootstrap step is a whole-reactor `install` (no `-pl`, so `-am` doesn't apply). The regression is purely the surefire skip binding.

## Fix

Default `archunit.skipTests` to the standard `${skipTests}` (itself defaulting to `false`):

```xml
<skipTests>false</skipTests>
<archunit.skipTests>${skipTests}</archunit.skipTests>
```

Behavior after the fix (verified via `help:evaluate` on the effective property):

| Invocation | `archunit.skipTests` | Effect |
|---|---|---|
| `-DskipTests` (every reactor bootstrap) | `true` | pos-archunit skipped → #909 avoided |
| no flag (`-pl pos-archunit -am test` enforcement job) | `false` | architecture rules still enforced |
| `-Darchunit.skipTests=true` (nightly Sonar `verify`) | `true` | explicit opt-out preserved |

## Tests

- [x] Verified the three property-resolution scenarios above with `./mvnw -pl pos-archunit help:evaluate -Dexpression=archunit.skipTests ...`.
- The dedicated `-pl pos-archunit -am test` enforcement path is unchanged (no `-DskipTests` → runs).
- **How to run:**
  ```bash
  ./mvnw -pl pos-archunit -am test          # rules still enforced (thin jars)
  ./mvnw install -DskipTests -DskipITs -T 1C # reactor bootstrap now green
  ```

## Risk & Rollback

- Risk level: **Low** — one-module POM property change; no production code, no other module affected.
- Rollback: revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy3STGHTHWc1vYfCf5MqPy)_