### PR TITLE
fix(pos-bulk-loader): inject a Clock in unit tests (NullPointerException: clock)

### DIFF
--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/BulkLoadJobExecutionListenerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/BulkLoadJobExecutionListenerTest.java
@@ -9,12 +9,16 @@ import static org.mockito.Mockito.when;
 import com.positivity.bulkloader.internal.entity.BulkLoadJob;
 import com.positivity.bulkloader.internal.enums.JobStatus;
 import com.positivity.bulkloader.internal.repository.BulkLoadJobRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.job.JobExecution;
@@ -25,6 +29,11 @@ import org.springframework.batch.test.MetaDataInstanceFactory;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings({"java:S100", "java:S1192"})
 class BulkLoadJobExecutionListenerTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+    @Spy
+    Clock clock = TEST_CLOCK;
 
     @Mock
     BulkLoadJobRepository bulkLoadJobRepository;

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/BulkLoadJobServiceImplTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/service/BulkLoadJobServiceImplTest.java
@@ -14,6 +14,9 @@ import com.positivity.bulkloader.internal.enums.JobStatus;
 import com.positivity.bulkloader.internal.exception.JobOwnershipViolationException;
 import com.positivity.bulkloader.internal.repository.BulkLoadJobRepository;
 import com.positivity.bulkloader.service.BulkLoadBatchLauncher;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +33,10 @@ class BulkLoadJobServiceImplTest {
 
     private static final UUID JOB_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
     private static final String OPERATOR_ID = "operator-001";
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+    @Spy
+    Clock clock = TEST_CLOCK;
 
     @Mock
     BulkLoadJobRepository jobRepository;


### PR DESCRIPTION
## Capability & Traceability
- Bugfix (no capability). Pre-existing regression on `main` reddening the `Unit Tests (pos-bulk-loader)` CI job for every PR.
- Domain: `domain:bulk-loader`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- N/A — test-only change. No controllers, DTOs, `*Request`/`*Response`, events, `openapi.yaml`, or validation/error models touched.

## Contract Chain (when a Controller changed)
- N/A — no controller changed.

## Scope
**What changed:** `BulkLoadJobServiceImpl` and `BulkLoadJobExecutionListener` carry a `private final Clock clock` (from the shared-`TimeConfig` clock refactor), but `BulkLoadJobServiceImplTest` and `BulkLoadJobExecutionListenerTest` build their subjects via `@InjectMocks` without supplying a `Clock`. Mockito's constructor injection passes `null` for the Clock arg, so `Instant.now(clock)` throws:

```
java.lang.NullPointerException: clock
  at java.time.Instant.now(Instant.java:292)
  at BulkLoadJobServiceImpl.startProcessing(BulkLoadJobServiceImpl.java:172)
  at BulkLoadJobExecutionListener.afterJob(BulkLoadJobExecutionListener.java:53)
```

Three tests fail, which fails the whole reactor's **Unit Tests (pos-bulk-loader)** job on every PR.

**Fix:** supply a fixed test `Clock` via `@Spy` so `@InjectMocks` injects it, matching the established pattern already used across `pos-accounting` tests:
```java
private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);

@Spy
Clock clock = TEST_CLOCK;
```

**Why:** restore green CI on `main` (and unblock every open PR, including #1111 whose chat-fix CI is currently blocked only by this unrelated failure).

## Tests
- [x] Unit tests added/updated — fixed the two affected test classes; no new tests needed (the existing 3 now pass).
- [ ] Integration tests added/updated — N/A.
- [ ] Provider behavioral contract tests added/updated — N/A.
- **How to run:**
  ```bash
  ./mvnw -pl pos-bulk-loader test
  ```
  Full module suite: **200 tests, 0 failures**.

## Risk & Rollback
- Risk level: **Low** — test-only change; no production code touched.
- Rollback plan: revert this commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A (operational bugfix branch).
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A (no capability).
- [ ] Links to parent + child issues are present — N/A.
- [x] Contract guide updated (when contract semantics changed) — N/A, no contract change.
- [ ] Required CI checks passing — pending CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy3STGHTHWc1vYfCf5MqPy)_