### PR TITLE
pos-mcp-server: answer resolution ladder + workorder status count endpoint

### DIFF
--- a/pos-mcp-server/docs/answer-resolution-ladder-design.md
+++ b/pos-mcp-server/docs/answer-resolution-ladder-design.md
@@ -236,10 +236,15 @@ tool or screen entry.
 
 ## Rollout order
 
-1. **R1 workorder count + `getOpenStatuses()` + `CountResponse`** — makes the original question
-   answerable; smallest, highest-value slice.
+1. **[DONE] R1 workorder count + `getOpenStatuses()` + `CountResponse`** — makes the original
+   question answerable; smallest, highest-value slice. Shipped: `GET /v1/workorders/count`,
+   `WorkorderCountService`, `CountResponse` (pos-shared-dtos), `WORKORDER_COUNT` event.
 2. **RL trigger in `ChatResponseText`** → rung 4 hand-off — stops the leak immediately.
-3. **R3 screen registry + resolver** — turns misses into deep links (needs frontend route reconcile).
+3. **[DONE] R3 screen registry + resolver** — turns misses into deep links. Shipped as a
+   standalone, unit-tested component (`mcp_screen_registry` + `ScreenRegistryRepository` +
+   `ScreenLinkResolver` + `ScreenEmbeddingInitializer`); **not yet wired into orchestration** —
+   that wiring is the rung-4 trigger step (item 2). Needs frontend route reconcile before the
+   seeded `url_template`s are load-bearing.
 4. **R2 prerequisite edges** — composes `locationId`-style gaps (fixes `listwip`).
 5. **R1 remaining domains** (people, invoice, accounting) — widen coverage.
 6. Evals per rung (`reference/evaluation.md`).

--- a/pos-mcp-server/docs/answer-resolution-ladder-design.md
+++ b/pos-mcp-server/docs/answer-resolution-ladder-design.md
@@ -245,6 +245,9 @@ tool or screen entry.
    `ScreenLinkResolver` + `ScreenEmbeddingInitializer`); **not yet wired into orchestration** —
    that wiring is the rung-4 trigger step (item 2). Needs frontend route reconcile before the
    seeded `url_template`s are load-bearing.
-4. **R2 prerequisite edges** — composes `locationId`-style gaps (fixes `listwip`).
+4. **[DONE] R2 prerequisite edges** — composes `locationId`-style gaps (fixes `listwip`). Shipped
+   as a standalone, unit-tested component (`mcp_tool_prerequisite` + `ToolPrerequisiteRepository` +
+   `PrerequisiteResolver`); one-hop, **not yet wired into orchestration** (same trigger step as
+   item 2). Seeded with `workorder_listwip`/`getestimatesbylocation` → `locationId`.
 5. **R1 remaining domains** (people, invoice, accounting) — widen coverage.
 6. Evals per rung (`reference/evaluation.md`).

--- a/pos-mcp-server/docs/answer-resolution-ladder-design.md
+++ b/pos-mcp-server/docs/answer-resolution-ladder-design.md
@@ -1,0 +1,245 @@
+# Answer Resolution Ladder — implementation-ready design
+
+> **Status:** DESIGN. Replace "returned nothing / leaked reasoning" with a deterministic
+> fall-through: real answer → composed answer → deep link → honest hand-off. Scoped to
+> `pos-mcp-server` orchestration plus a shared count convention across domain services.
+
+## Why
+
+Observed failure (`How many workorders are currently open?`): the agent emitted no tool call,
+returned blank `content`, and `ChatResponseText` surfaced the model's raw planning monologue as the
+"answer" (`ChatResponseText.java:41`). Two root causes:
+
+1. **No answering capability** — there is no status-filtered count path; `workorder_getallworkorders`
+   is unbounded and `workorder_listwip` requires `locationId` and covers only WIP, not "open."
+2. **No graceful degradation** — when the agent cannot answer, it degrades to leaked reasoning
+   instead of something useful.
+
+The ladder addresses (2) structurally and adds the capability layer for (1). It is a **policy**, not a
+single feature: each rung is attempted in order; a miss falls through to the next.
+
+```
+Rung 1  Answer tool            real count/list/detail                        ← R1
+Rung 2  Composed answer        resolve missing params, then answer           ← R2
+Rung 3  Deep link              point at the correct screen + filters         ← R3
+Rung 4  Honest hand-off        "can't answer, here is where / who"           ← R4
+```
+
+Rungs 1–2 are *correctness*; rungs 3–4 are *graceful degradation*. A count always beats a link; a link
+always beats leaked reasoning.
+
+---
+
+## Components
+
+### R1 — Count convention + `CountResponse` DTO (rung 1)
+
+A uniform, discoverable count endpoint per countable resource. Because tools are OpenAPI-discovered
+(`OpenApiToolProvider`), a consistent path + operation id makes them auto-register as `*_count*` tools
+with no MCP-side wiring.
+
+**DTO** — new shared type in `pos-shared-dtos` (`com.positivity.shared.dto`), reused by every domain:
+
+```java
+package com.positivity.shared.dto;
+
+/** Aggregate count result. {@code total} is the grand total; {@code groups} is the optional
+ *  per-key breakdown (e.g. status → count). Both are server-computed via COUNT queries;
+ *  callers never page the full collection to count it. */
+public record CountResponse(long total, List<CountGroup> groups) {
+    public record CountGroup(String key, long count) {}
+
+    public static CountResponse of(long total) {
+        return new CountResponse(total, List.of());
+    }
+}
+```
+
+**Endpoint convention** (each domain service):
+
+```
+GET /{resource}/count?<domain filters>        → 200 CountResponse
+```
+
+- Backed by a repository COUNT (`countByStatusIn(...)`), **not** `findAll().size()`. The building block
+  already exists for workorder: `WorkorderRepository.findByStatusIn(...)` returns a `Page` whose
+  `getTotalElements()` is a COUNT (`WorkorderRepository.java:51`); add a dedicated
+  `long countByStatusIn(Collection<WorkorderStatus>)` to avoid fetching a page at all.
+- `@EmitEvent(id = "{DOMAIN}_COUNT", apiVersion = "1")`, threshold preset `fastRead`.
+- `@PreAuthorize` with the resource's existing `view` permission (e.g. `workorder:workorder:view`).
+- Annotate the discovered tool `readOnlyHint = true`, `idempotentHint = true`.
+
+**First-wave endpoints** (repos already carry COUNT-shaped queries — verified in workorder, invoice,
+accounting):
+
+| Domain | Endpoint | Filter → answer |
+|---|---|---|
+| workorder | `GET /v1/workorders/count?openOnly=true` | open = not `COMPLETED`/`CANCELLED` |
+| workorder | `GET /v1/workorders/count?status=WORK_IN_PROGRESS` | per-status |
+| people/hr | `GET /v1/people/count?status=ACTIVE` | active employees |
+| invoice | `GET /v1/invoices/count?status=UNPAID` | open invoices |
+| accounting | `GET /v1/accounting/journal-entries/count?period={p}` | entries in period |
+
+**"Open" is defined once, at the source of truth** — add to `WorkorderStatus`:
+
+```java
+public static Set<WorkorderStatus> getOpenStatuses() {          // non-terminal
+    return java.util.EnumSet.complementOf(EnumSet.of(COMPLETED, CANCELLED));
+}
+```
+
+so the set stays correct if a status is added later (mirrors the existing
+`getInProgressSubStatuses()`, `WorkorderStatus.java:46`).
+
+### R2 — Prerequisite edges + composition (rung 2)
+
+Many count/list tools need a parameter the user did not supply (`listWip` needs `locationId`). Today
+that dependency is implicit, so the model guesses or stalls. Model it explicitly and let the ladder
+resolve one hop before giving up.
+
+**Edge model** — metadata attached to discovered operations (no new datastore; a table beside the
+existing tool registry):
+
+```sql
+CREATE TABLE mcp_tool_prerequisite (
+    tool_name        text NOT NULL,   -- e.g. 'workorder_listwip'
+    required_param    text NOT NULL,   -- e.g. 'locationId'
+    producing_tool    text NOT NULL,   -- e.g. 'location_getcurrentuserprimarylocation'
+    producing_field   text NOT NULL,   -- field on the producer's result to bind
+    PRIMARY KEY (tool_name, required_param)
+);
+```
+
+**Resolver** (orchestration):
+
+```java
+public interface PrerequisiteResolver {
+    /** Params the tool needs that are absent from the request context, each with the tool that
+     *  can produce them. Empty when the tool is directly callable. */
+    List<MissingParam> missingFor(String toolName, RequestContext ctx);
+
+    record MissingParam(String param, String producingTool, String producingField) {}
+}
+```
+
+Composition is **bounded to one hop** in v1 (resolve producers that are themselves directly callable);
+deeper chains fall through to rung 3. This is the point where a graph engine *would* help — deferred:
+one-hop edges in Postgres cover the current needs; revisit only if multi-hop composition becomes core.
+
+### R3 — Screen registry + deep-link resolver (rung 3)
+
+When no tool (composed or not) can answer, return a link to the screen where a human can. Resolution is
+**semantic**, mirroring how tools are embedded (`ToolEmbeddingInitializer`, pgvector store) — so it
+generalizes to unseen phrasings instead of needing a question→URL table.
+
+```sql
+CREATE TABLE mcp_screen_registry (
+    id             uuid PRIMARY KEY,
+    screen_key      text NOT NULL UNIQUE,      -- 'workorders.list'
+    title           text NOT NULL,             -- 'Work Orders'
+    description     text NOT NULL,             -- embedded; 'open/closed work orders, filter by status/location'
+    domain          text NOT NULL,             -- rag scope, aligns with RouterClassification.domain
+    url_template    text NOT NULL,             -- '/workorders?status={status}&location={locationId}'
+    required_perm   text,                      -- gate a link the caller can't open
+    embedding       vector(768)                -- nomic-embed-text, matches tool embeddings
+);
+```
+
+```java
+public interface ScreenLinkResolver {
+    /** Best screen for an unanswered request, or empty if nothing clears the similarity floor.
+     *  Fills url_template placeholders from resolved context params (status, locationId, …). */
+    Optional<ScreenLink> resolve(String userMessage, String domain, RequestContext ctx);
+
+    record ScreenLink(String title, String url, String screenKey) {}
+}
+```
+
+- Similarity floor (config `mcp.screen.min-score`, default 0.6) — below it, no link; fall to rung 4.
+- Permission-gated: never surface a link to a screen the caller lacks `required_perm` for.
+- **Frontend contract dependency:** URLs must be stable, linkable routes that accept filter params.
+  Reconcile `url_template`s against `docs/frontend-audit-route-reconciliation.md`; a screen with no
+  real route is not registered.
+
+### R4 — Honest hand-off (rung 4)
+
+Nothing matched. Return a truthful "I can't answer this" carried in the existing guided-error channel
+rather than blank content or leaked reasoning.
+
+- Reuse `ApiError.guided(...)` (`com.positivity.shared.error.ApiError`) — populate `nextAction`
+  (what the user can do) and `supportAction` (who to ask). No new envelope.
+- Never echo the model's `thinking` channel to the user in this state; the ladder owns the response.
+
+### RL — Ladder orchestrator + fallback trigger points
+
+The ladder wraps the existing chat path in `SessionAgentManager.chat` (`SessionAgentManager.java:230`).
+
+```java
+public interface AnswerResolutionLadder {
+    LadderResult resolve(CurrentUserContext user, String message, AgentTurn turn);
+
+    /** turn = the outcome of the normal agent().chat() call: model content, tool calls made,
+     *  and tool-selection confidence — so the ladder decides on structural signals, not on the
+     *  model self-reporting "I don't know." */
+    record AgentTurn(String content, List<String> toolsInvoked, double topToolScore, boolean blankContent) {}
+
+    record LadderResult(String text, Rung rung, @Nullable String screenUrl) {}
+    enum Rung { ANSWER_TOOL, COMPOSED, DEEP_LINK, HANDOFF }
+}
+```
+
+**Trigger points — the miss is detected structurally, never from model self-report:**
+
+| Signal | Source | Meaning |
+|---|---|---|
+| `blankContent` after tool phase | `ChatResponseText.extract` returns fallback / recovers from `thinking` | model produced no real answer → **do not surface `thinking`; enter ladder** |
+| `toolsInvoked.isEmpty()` and message is a data question | router `intentType == QUERY` (`NltiRouter`) with no tool call | model answered from prior knowledge or stalled → verify via ladder |
+| `topToolScore < mcp.tool.min-score` | `ToolSelectionEngine` / `OpenApiToolProvider.resolveToolCallbacks` | no confidently-relevant tool was offered → rungs 2–3 |
+| tool call returned 4xx "missing required param" | tool execution | → rung 2 (resolve the param), then retry once |
+
+The cleanest single hook is `ChatResponseText`: today it silently recovers the `thinking` channel
+(the exact bug). Change that recovery to instead hand control to the ladder, which decides rung 2/3/4.
+That one change removes the leak even before rungs 1–3 land (it degrades straight to rung 4).
+
+---
+
+## Data & config summary
+
+- New shared DTO: `CountResponse` (`pos-shared-dtos`).
+- New tables (pos-mcp-server schema, Flyway): `mcp_tool_prerequisite`, `mcp_screen_registry`.
+- New config: `mcp.tool.min-score` (default 0.6), `mcp.screen.min-score` (0.6),
+  `mcp.ladder.enabled` (feature flag, default true in `alpha`).
+- Reused: pgvector store + `nomic-embed-text` (screen embeddings), `ApiError.guided`, `@EmitEvent`
+  registries, per-resource `view` permissions.
+
+## Telemetry
+
+Extend the existing `nlti.request.telemetry` (`NltiRequestTelemetryFactory`) with a `resolution` block:
+`{ rung: ANSWER_TOOL|COMPOSED|DEEP_LINK|HANDOFF, screenKey?, composedProducer? }`. This makes the
+degradation rate observable — rising `DEEP_LINK`/`HANDOFF` share is the signal to add the next count
+tool or screen entry.
+
+## Drift guards / non-goals
+
+- **Rung 1 beats rung 3 always.** A deep link is never returned when a count/list tool could answer —
+  the ladder only falls through on a *structural* miss.
+- **No question→answer table.** Pre-seeding enumerated natural-language questions is out of scope;
+  canonical questions live only in the eval suite (`reference/evaluation.md` format). Capabilities are
+  seeded, questions are not.
+- **No graph DB in v1.** Prerequisite edges are one-hop rows in Postgres; a graph engine is deferred
+  until multi-hop composition is load-bearing.
+- **Never surface the `thinking` channel to end users.** The ladder owns the unanswered-state
+  response.
+- **Operational note (out of band):** set `OLLAMA_CHAT_THINK=false` for the reasoning chat model.
+  With thinking enabled, the model routes planning into `thinking` and returns blank `content`; the
+  ladder makes the miss safe, but disabling think removes the miss at the source.
+
+## Rollout order
+
+1. **R1 workorder count + `getOpenStatuses()` + `CountResponse`** — makes the original question
+   answerable; smallest, highest-value slice.
+2. **RL trigger in `ChatResponseText`** → rung 4 hand-off — stops the leak immediately.
+3. **R3 screen registry + resolver** — turns misses into deep links (needs frontend route reconcile).
+4. **R2 prerequisite edges** — composes `locationId`-style gaps (fixes `listwip`).
+5. **R1 remaining domains** (people, invoice, accounting) — widen coverage.
+6. Evals per rung (`reference/evaluation.md`).

--- a/pos-mcp-server/docs/answer-resolution-ladder-design.md
+++ b/pos-mcp-server/docs/answer-resolution-ladder-design.md
@@ -239,7 +239,13 @@ tool or screen entry.
 1. **[DONE] R1 workorder count + `getOpenStatuses()` + `CountResponse`** — makes the original
    question answerable; smallest, highest-value slice. Shipped: `GET /v1/workorders/count`,
    `WorkorderCountService`, `CountResponse` (pos-shared-dtos), `WORKORDER_COUNT` event.
-2. **RL trigger in `ChatResponseText`** → rung 4 hand-off — stops the leak immediately.
+2. **[DONE] RL orchestrator + trigger** — `AnswerResolutionLadder(+Impl)` wired into
+   `SpringAiPosAssistant`. Trigger is structural: when the model's `content` is blank (the leak
+   scenario), the ladder owns the response (rung 3 deep link → rung 4 hand-off) instead of
+   surfacing the thinking channel. Feature-flagged via bean presence (`mcp.ladder.enabled`,
+   default true); with it off, behaviour is exactly as before. A non-blank `content` answer never
+   triggers the ladder — no regression. Structured entity extraction for url_template params is a
+   follow-up (v1 passes no params → screens resolve to their base path).
 3. **[DONE] R3 screen registry + resolver** — turns misses into deep links. Shipped as a
    standalone, unit-tested component (`mcp_screen_registry` + `ScreenRegistryRepository` +
    `ScreenLinkResolver` + `ScreenEmbeddingInitializer`); **not yet wired into orchestration** —

--- a/pos-mcp-server/docs/mcp-hardening-session-plan.md
+++ b/pos-mcp-server/docs/mcp-hardening-session-plan.md
@@ -1,0 +1,129 @@
+# MCP Hardening — Working Session Plan
+
+> **Status:** PLAN. Bundles the remaining `pos-mcp-server` hardening into one working session and
+> defines what closes #645, #778, #779, #780, #783, #784. Grounded in a current-state read of the
+> code (2026-07-26); several issues are further along than their text implies — verify before
+> building.
+
+## Environment prerequisites (what gates the "live" items)
+
+| Need | Unblocks |
+|---|---|
+| Live alpha stack (gateway + model backend + pgvector) | #645 alpha 404 check, #779 Gate 3 |
+| CI-reachable embedding backend (Ollama + pgvector) **or** recorded-fixture mode | #783 threshold-in-CI, #784 validation |
+| None (code-only, unit/ArchUnit testable) | #780, #778, #779 (IT + comments), #645 (fallback/refresh/metrics) |
+
+Everything except the two rows above can be finished and merged without a live environment.
+
+---
+
+## Batch A — Code-only quick wins (no infra)
+
+### #780 — Remove legacy role-gating  · effort S · risk low
+- Remove the always-empty `roleToolAssignments` field + branch in `MasterAgentRegistry.resolveDomainTools`
+  (~line 61) and the empty-map constructors in `LoadedMasterAgentRegistry`.
+- Drop the unused role-scoped `resolveDomainTools(String, Collection)` overload (`MasterAgentRegistry`
+  ~125–135, `ToolSelectionEngine` ~112–115).
+- New migration `V27` dropping `mcp_role_deprecated` / `mcp_tool_role_deprecated` — **only if the V19
+  retention window has passed** (owner confirm).
+- **Close when:** dead code gone, cashier/manager/admin/`ROLE_USER` selection tests + ArchUnit green.
+
+### #778 — Workflow state beyond IDLE for gating  · effort S–M · risk low-med
+**Verify first — largely implemented already:** `SessionAgentManager.chat` (line 199) threads persisted
+state via `workflowStateService.resolveActiveState(username)` → 4-arg `selectRoleTools(role, perms,
+message, state)`, heuristic 3-arg only as fallback; `NltiWorkflowStateService.setWorkflowState` (line 62)
+is a real write path. Remaining:
+- Confirm `StreamingSessionAgentManager.streamChat` threads persisted state the same way (parity with
+  `SessionAgentManager`).
+- Confirm the write path is actually **invoked on workflow progression** (find/complete the caller that
+  advances `NltiSession.workflowState` to a non-IDLE state).
+- `MasterAgentRegistryLoader` preloads the active **non-IDLE** states, not just the single
+  `mcp.agent.preload-workflow-state`.
+- **Close when:** a persisted non-IDLE session receives that state's gated tool set — tested for **both**
+  managers.
+
+### #779 — OpenAPI tools agent-callable (code-only parts)  · effort M · risk low
+- Add an integration test (`*IT`): low-permission caller → chat endpoint → assert a high-permission
+  openapi tool is neither offered nor executed, and an authorized op executes through a **stubbed
+  gateway** (WireMock/local stub). Today the permission-filter assertion lives only at unit level.
+- Fix stale comments in `OpenApiToolProvider` (~38–42) and `RequestScopedUserContext` (~20–25) that still
+  claim the streaming/Reactor path is "not yet wired" — it is (`StreamingSessionAgentManager` sets the
+  ThreadLocal synchronously before resolution).
+- **Close when:** the IT passes and comments are corrected. (Gate 3 live verification → Batch D.)
+
+---
+
+## Batch B — Discovery hardening (#645, mostly code)  · effort M · risk med
+
+- Wire `OpenApiDocumentFetcher.fetchForService(serviceId)` (exists, no prod caller) into
+  `ToolRegistrationServiceImpl.registerDiscoveredTools()` as the **per-service Eureka fallback** when the
+  aggregate fetch returns empty.
+- `@Scheduled` periodic refresh that re-runs discovery and diffs against currently-registered tools
+  (configurable interval); must be idempotent (no duplicate/rogue re-registration).
+- Micrometer counters `tools_discovered_total` / `tools_registered_total`; alert rules under
+  `docs/alerts/`; ops runbook section under `docs/runbooks/`.
+- **Close when:** fallback + scheduled refresh land with tests, metrics emit, docs added. (Alpha 404
+  check → Batch D.)
+
+---
+
+## Batch C — Retrieval eval, then hybrid (ordered: #783 → #784)
+
+### #783 — Retrieval-quality regression (hit@5, MRR)  · effort M–L
+- Author fixtures to volume (≥100 tool-selection / ≥50 rag / ≥30 write-safety); enable the `@Disabled`
+  `minimumFixtureCountsMet` gate.
+- Retarget seed fixtures to the **live facade tool names** (current mismatch → `baseline.json` hit@5 = 0).
+- Implement RAG **recall@k live capture** in `BaselineCaptureIT` (`rag_recall_at_k` currently null).
+- Threshold assertions (hit@5 / MRR / recall@k floors) wired into CI — **needs the embedding backend or a
+  recorded-fixture mode**.
+- **Close when:** fixtures at volume, hit@5 > 0 on retargeted names, recall@k captured, thresholds
+  asserted in CI.
+
+### #784 — Hybrid dense + BM25 retrieval  · effort L · **depends on #783** · priority low
+- Add a lexical `QueryDocumentRetriever` (Postgres FTS `tsvector` + `ts_rank` / `websearch_to_tsquery`),
+  scope-filtered like the dense path.
+- Migration: `tsvector` column + index (on `mcp_document_embedding` or a companion table).
+- Fuse dense + lexical in `HybridContentRetriever` via Reciprocal Rank Fusion; keep
+  `RerankedContentRetriever` as the re-rank stage.
+- **Close when:** the fusion is validated by the #783 recall@k harness (measurable recall gain).
+
+---
+
+## Batch D — Live-stack verification (blocked on environment)  · effort M (ops-heavy)
+
+- #645: alpha end-to-end — discovered tools invoke through the gateway with **zero 404s**.
+- #779: Gate 3 live-stack verification per `docs/gate3-openapi-bridge-design.md`.
+- Run these **together** in one live session (shared gateway + model + pgvector setup).
+
+---
+
+## Sequencing
+
+```
+Batch A (#780, #778, #779-code)  ──►  Batch B (#645-code)  ──►  Batch C (#783 ──► #784)
+        (parallel-safe, merge first)                                   │
+Batch D (#645-live, #779-live)  ── run whenever a live stack exists ───┘ (independent)
+```
+
+- Do **A** first: smallest, unblocks nothing else but retires risk and dead code cheaply.
+- **C** and **D** share the "needs a backend" blocker — schedule them with whoever owns the CI/live infra.
+- **#784** is gated on **#783** and is low priority; defer if the session runs short.
+
+## Per-issue close conditions
+
+| Issue | Blocked by infra? | Closes when |
+|---|---|---|
+| #780 | No | Dead role-gating code removed; deprecated tables dropped (if window passed); selection tests green |
+| #778 | No | Persisted non-IDLE state gates tools in **both** managers, with a test; verify write path is invoked |
+| #779 | Partly (Gate 3 live) | Permission IT via stubbed gateway passes; stale comments fixed; Gate 3 done in Batch D |
+| #645 | Partly (alpha 404) | Eureka fallback + scheduled refresh + metrics/alerts/runbook; 404 check in Batch D |
+| #783 | Yes (CI backend) | Fixtures at volume, retargeted names (hit@5 > 0), recall@k captured, CI thresholds |
+| #784 | Yes (via #783) | Lexical + RRF fusion validated by recall@k harness |
+
+## Open questions for the owner
+
+1. **#780:** has the `V19` retention window passed — safe to drop `*_deprecated` tables now?
+2. **#783 / #784 / Batch D:** is a CI-reachable Ollama + pgvector available, or should #783 land in
+   recorded-fixture mode and defer live thresholds?
+3. **Ladder follow-ups** (from PR #1113 — structured entity extraction for deep-link filters, a telemetry
+   `resolution` block): fold into this session, or track separately?

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/ScreenEmbeddingInitializer.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/ScreenEmbeddingInitializer.java
@@ -1,0 +1,87 @@
+package com.positivity.mcp.internal.config;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.postgresql.util.PGobject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Backfills {@code mcp_screen_registry.embedding} for rows seeded without one (rung 3 of the answer
+ * resolution ladder). Mirrors {@link ToolEmbeddingInitializer}. Fail-soft — a per-row embedding
+ * failure is logged and skipped so startup never blocks.
+ */
+@Component
+@Profile("!test")
+@Order(21)
+public class ScreenEmbeddingInitializer implements ApplicationRunner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScreenEmbeddingInitializer.class);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final EmbeddingModel embeddingModel;
+
+    public ScreenEmbeddingInitializer(@NonNull JdbcTemplate jdbcTemplate, @NonNull EmbeddingModel embeddingModel) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.embeddingModel = embeddingModel;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        List<ScreenDescriptionRow> rows = jdbcTemplate.query(
+                "SELECT id, screen_key, description FROM mcp_screen_registry WHERE embedding IS NULL",
+                (resultSet, rowNum) -> new ScreenDescriptionRow(
+                        resultSet.getObject("id", UUID.class),
+                        resultSet.getString("screen_key"),
+                        resultSet.getString("description")));
+
+        LOGGER.info("Screen embedding initialization found {} screens missing embeddings", rows.size());
+        int populated = 0;
+        for (ScreenDescriptionRow row : rows) {
+            try {
+                float[] vector = embeddingModel.embed(row.description());
+                jdbcTemplate.update(
+                        "UPDATE mcp_screen_registry SET embedding = ?::vector WHERE id = ?",
+                        toVectorPGobject(vector),
+                        row.id());
+                populated++;
+            } catch (RuntimeException exception) {
+                LOGGER.warn("Failed to populate embedding for screen {} ({})", row.screenKey(), row.id(), exception);
+            }
+        }
+        LOGGER.info("Populated embeddings for {} screens", populated);
+    }
+
+    private static PGobject toVectorPGobject(float[] embedding) {
+        StringBuilder value = new StringBuilder("[");
+        for (int i = 0; i < embedding.length; i++) {
+            if (i > 0) {
+                value.append(',');
+            }
+            value.append(embedding[i]);
+        }
+        value.append(']');
+        PGobject object = new PGobject();
+        object.setType("vector");
+        try {
+            object.setValue(value.toString());
+        } catch (SQLException exception) {
+            throw new IllegalArgumentException("Failed to build vector PGobject", exception);
+        }
+        return object;
+    }
+
+    private record ScreenDescriptionRow(
+            @NonNull UUID id,
+            @NonNull String screenKey,
+            @NonNull String description) {}
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ScreenCandidate.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ScreenCandidate.java
@@ -5,8 +5,9 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * A screen-registry row returned by a semantic nearest-neighbour search (rung 3 of the answer
- * resolution ladder). {@code score} is cosine similarity in {@code [0,1]} (1 = identical);
- * {@code requiredPerm} gates whether the caller may be shown the screen.
+ * resolution ladder). {@code score} is cosine similarity in {@code [-1, 1]} (1 = identical, and
+ * negative for unrelated text) computed as {@code 1 - cosineDistance}; {@code requiredPerm} gates
+ * whether the caller may be shown the screen.
  */
 public record ScreenCandidate(
         @NonNull String screenKey,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ScreenCandidate.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ScreenCandidate.java
@@ -1,0 +1,17 @@
+package com.positivity.mcp.internal.domain;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A screen-registry row returned by a semantic nearest-neighbour search (rung 3 of the answer
+ * resolution ladder). {@code score} is cosine similarity in {@code [0,1]} (1 = identical);
+ * {@code requiredPerm} gates whether the caller may be shown the screen.
+ */
+public record ScreenCandidate(
+        @NonNull String screenKey,
+        @NonNull String title,
+        @NonNull String urlTemplate,
+        @NonNull String domain,
+        @Nullable String requiredPerm,
+        double score) {}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ScreenLink.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ScreenLink.java
@@ -1,0 +1,13 @@
+package com.positivity.mcp.internal.domain;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * A resolved deep link to a UI screen — the rung-3 answer when no tool can satisfy the request.
+ * {@code url} has had its template placeholders filled from the request context.
+ */
+public record ScreenLink(
+        @NonNull String screenKey,
+        @NonNull String title,
+        @NonNull String url,
+        double score) {}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ToolPrerequisite.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/domain/ToolPrerequisite.java
@@ -1,0 +1,14 @@
+package com.positivity.mcp.internal.domain;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * A one-hop prerequisite edge (rung 2 of the answer resolution ladder): {@code toolName} needs
+ * {@code requiredParam}, which {@code producingTool} can supply via {@code producingField} on its
+ * result.
+ */
+public record ToolPrerequisite(
+        @NonNull String toolName,
+        @NonNull String requiredParam,
+        @NonNull String producingTool,
+        @NonNull String producingField) {}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ChatResponseText.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/ChatResponseText.java
@@ -26,24 +26,46 @@ final class ChatResponseText {
 
     private ChatResponseText() {}
 
+    /** Where the extracted text came from — lets callers detect a turn that produced no direct answer. */
+    enum Source {
+        /** The model's {@code content} field — a genuine direct answer. */
+        CONTENT,
+        /** Recovered from the {@code thinking} channel because {@code content} was blank. */
+        THINKING,
+        /** Neither channel had text; the fixed fallback string is used. */
+        BLANK
+    }
+
+    /** The extracted user-facing text plus its {@link Source}. */
+    record Extracted(@NonNull String text, @NonNull Source source) {}
+
     static @NonNull String extract(@Nullable AssistantMessage message) {
+        return extractDetailed(message).text();
+    }
+
+    /**
+     * Like {@link #extract} but reports the {@link Source}. A source other than {@link Source#CONTENT}
+     * means the model did not produce a direct answer — the caller (e.g. the answer resolution ladder)
+     * may choose a fallback rather than surface the thinking channel.
+     */
+    static @NonNull Extracted extractDetailed(@Nullable AssistantMessage message) {
         if (message == null) {
             LOGGER.warn("Chat model returned no assistant message; using blank-response fallback");
-            return BLANK_RESPONSE_FALLBACK;
+            return new Extracted(BLANK_RESPONSE_FALLBACK, Source.BLANK);
         }
         String content = stripThinkBlocks(message.getText());
         if (!content.isBlank()) {
-            return content;
+            return new Extracted(content, Source.CONTENT);
         }
         // content was empty: the model routed its answer into the reasoning channel.
         String thinking = stripThinkBlocks(thinkingChannel(message));
         if (!thinking.isBlank()) {
             LOGGER.warn("Chat model returned blank content; recovered answer from thinking channel. "
                     + "Set OLLAMA_CHAT_THINK=false for reasoning models to return the answer in content.");
-            return thinking;
+            return new Extracted(thinking, Source.THINKING);
         }
         LOGGER.warn("Chat model returned blank content and no thinking channel; using blank-response fallback");
-        return BLANK_RESPONSE_FALLBACK;
+        return new Extracted(BLANK_RESPONSE_FALLBACK, Source.BLANK);
     }
 
     private static @NonNull String stripThinkBlocks(@Nullable String text) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -11,6 +11,7 @@ import com.positivity.mcp.internal.orchestration.memory.SemanticChatMemoryStore;
 import com.positivity.mcp.internal.orchestration.memory.SessionSummary;
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
+import com.positivity.mcp.internal.service.AnswerResolutionLadder;
 import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import com.positivity.mcp.internal.service.PermissionCodes;
@@ -84,6 +85,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
     private final SimpleChatClassifier simpleChatClassifier;
     private final @Nullable NltiTelemetryEmitter telemetryEmitter;
     private final @Nullable OpenApiToolProvider openApiToolProvider;
+    private final @Nullable AnswerResolutionLadder answerResolutionLadder;
     private final @Nullable RequestScopedUserContext requestScopedUserContext;
     private final @Nullable RoleDefaultPermissionsClient roleDefaultPermissionsClient;
     private final NltiWorkflowStateService workflowStateService;
@@ -106,6 +108,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             @NonNull SimpleChatClassifier simpleChatClassifier,
             @Nullable NltiTelemetryEmitter telemetryEmitter,
             @Nullable OpenApiToolProvider openApiToolProvider,
+            @Nullable AnswerResolutionLadder answerResolutionLadder,
             @Nullable RequestScopedUserContext requestScopedUserContext,
             @Nullable RoleDefaultPermissionsClient roleDefaultPermissionsClient,
             @NonNull NltiWorkflowStateService workflowStateService,
@@ -127,6 +130,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         this.simpleChatClassifier = simpleChatClassifier;
         this.telemetryEmitter = telemetryEmitter;
         this.openApiToolProvider = openApiToolProvider;
+        this.answerResolutionLadder = answerResolutionLadder;
         this.requestScopedUserContext = requestScopedUserContext;
         this.roleDefaultPermissionsClient = roleDefaultPermissionsClient;
         this.workflowStateService = workflowStateService;
@@ -333,7 +337,8 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                 tools,
                 resilientContentRetriever,
                 this::chatMemoryFor,
-                openApiToolProvider);
+                openApiToolProvider,
+                answerResolutionLadder);
         LOGGER.debug(
                 "Built MCP role agent role={} promptName={} ragScope={} toolNames={}",
                 role,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
@@ -1,6 +1,7 @@
 package com.positivity.mcp.internal.orchestration;
 
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
+import com.positivity.mcp.internal.service.AnswerResolutionLadder;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,7 @@ final class SpringAiPosAssistant implements PosAssistant {
     private final QueryDocumentRetriever ragRetriever;
     private final Function<String, ChatMemory> chatMemoryProvider;
     private final @Nullable OpenApiToolProvider openApiToolProvider;
+    private final @Nullable AnswerResolutionLadder answerResolutionLadder;
 
     SpringAiPosAssistant(
             @NonNull ChatModel chatModel,
@@ -39,13 +41,15 @@ final class SpringAiPosAssistant implements PosAssistant {
             @NonNull List<Object> staticTools,
             @NonNull QueryDocumentRetriever ragRetriever,
             @NonNull Function<String, ChatMemory> chatMemoryProvider,
-            @Nullable OpenApiToolProvider openApiToolProvider) {
+            @Nullable OpenApiToolProvider openApiToolProvider,
+            @Nullable AnswerResolutionLadder answerResolutionLadder) {
         this.chatModel = chatModel;
         this.systemPromptSupplier = systemPromptSupplier;
         this.staticToolCallbacks = SpringAiToolCallbackResolver.fromObjects(staticTools);
         this.ragRetriever = ragRetriever;
         this.chatMemoryProvider = chatMemoryProvider;
         this.openApiToolProvider = openApiToolProvider;
+        this.answerResolutionLadder = answerResolutionLadder;
     }
 
     @Override
@@ -65,9 +69,24 @@ final class SpringAiPosAssistant implements PosAssistant {
                 .call(new Prompt(promptMessages, toolCallingOptions(chatModel.getDefaultOptions(), toolCallbacks)))
                 .getResult()
                 .getOutput();
-        String response = ChatResponseText.extract(output);
+        ChatResponseText.Extracted extracted = ChatResponseText.extractDetailed(output);
+        String response = resolveResponse(userMessage, extracted);
         chatMemory.add(memoryId, List.of(new UserMessage(userMessage), new AssistantMessage(response)));
         return response;
+    }
+
+    /**
+     * Returns the model's direct answer when it produced one. When it did not (blank {@code content},
+     * so the text would otherwise be recovered thinking or the blank fallback) and a ladder is wired,
+     * hand off to the ladder rather than surface the reasoning channel. With no ladder, behaviour is
+     * unchanged — the extracted text (including thinking recovery) is returned.
+     */
+    private @NonNull String resolveResponse(
+            @NonNull String userMessage, ChatResponseText.@NonNull Extracted extracted) {
+        if (answerResolutionLadder != null && extracted.source() != ChatResponseText.Source.CONTENT) {
+            return answerResolutionLadder.resolveFallback(userMessage).text();
+        }
+        return extracted.text();
     }
 
     private @NonNull String buildSystemPrompt(@NonNull String userMessage, @NonNull String userContext) {

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ScreenRegistryRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ScreenRegistryRepository.java
@@ -1,0 +1,21 @@
+package com.positivity.mcp.internal.repository;
+
+import com.positivity.mcp.internal.domain.ScreenCandidate;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/** Nearest-neighbour lookup over the screen registry (rung 3 of the answer resolution ladder). */
+public interface ScreenRegistryRepository {
+
+    /**
+     * Return up to {@code limit} screens whose embedding is closest to {@code queryEmbedding},
+     * ordered by descending cosine similarity. Rows without an embedding are ignored.
+     *
+     * @param queryEmbedding the embedded user message
+     * @param domain         optional exact-domain restriction; {@code null} searches all domains
+     * @param limit          maximum candidates to return
+     */
+    @NonNull
+    List<ScreenCandidate> findNearest(float @NonNull [] queryEmbedding, @Nullable String domain, int limit);
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ScreenRegistryRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ScreenRegistryRepositoryImpl.java
@@ -1,0 +1,79 @@
+package com.positivity.mcp.internal.repository;
+
+import com.positivity.mcp.internal.domain.ScreenCandidate;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.postgresql.util.PGobject;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * pgvector-backed screen lookup. Mirrors {@link ToolMetadataRepositoryImpl}'s cosine-distance
+ * search (the {@code <=>} operator); {@code 1 - distance} is projected as the similarity score.
+ */
+@Repository
+@Profile({"!test", "openapi"})
+public class ScreenRegistryRepositoryImpl implements ScreenRegistryRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ScreenRegistryRepositoryImpl(@NonNull JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public @NonNull List<ScreenCandidate> findNearest(
+            float @NonNull [] queryEmbedding, @Nullable String domain, int limit) {
+        StringBuilder sql = new StringBuilder("""
+                SELECT screen_key, title, url_template, domain, required_perm,
+                       1 - (embedding <=> ?::vector) AS score
+                FROM mcp_screen_registry
+                WHERE embedding IS NOT NULL
+                """);
+        if (domain != null) {
+            sql.append("  AND domain = ?\n");
+        }
+        sql.append("ORDER BY embedding <=> ?::vector\nLIMIT ?\n");
+
+        PGobject vector = toVectorPGobject(queryEmbedding);
+        return jdbcTemplate.query(
+                sql.toString(),
+                ps -> {
+                    int i = 1;
+                    ps.setObject(i++, vector);
+                    if (domain != null) {
+                        ps.setString(i++, domain);
+                    }
+                    ps.setObject(i++, vector);
+                    ps.setInt(i, limit);
+                },
+                (rs, rowNum) -> new ScreenCandidate(
+                        rs.getString("screen_key"),
+                        rs.getString("title"),
+                        rs.getString("url_template"),
+                        rs.getString("domain"),
+                        rs.getString("required_perm"),
+                        rs.getDouble("score")));
+    }
+
+    private static PGobject toVectorPGobject(float[] embedding) {
+        StringBuilder value = new StringBuilder("[");
+        for (int i = 0; i < embedding.length; i++) {
+            if (i > 0) {
+                value.append(',');
+            }
+            value.append(embedding[i]);
+        }
+        value.append(']');
+        PGobject object = new PGobject();
+        object.setType("vector");
+        try {
+            object.setValue(value.toString());
+        } catch (java.sql.SQLException exception) {
+            throw new IllegalArgumentException("Failed to build vector PGobject", exception);
+        }
+        return object;
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolPrerequisiteRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolPrerequisiteRepository.java
@@ -1,0 +1,13 @@
+package com.positivity.mcp.internal.repository;
+
+import com.positivity.mcp.internal.domain.ToolPrerequisite;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+
+/** Lookup of prerequisite edges for a tool (rung 2 of the answer resolution ladder). */
+public interface ToolPrerequisiteRepository {
+
+    /** All prerequisite edges declared for {@code toolName}; empty when the tool has none. */
+    @NonNull
+    List<ToolPrerequisite> findByToolName(@NonNull String toolName);
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolPrerequisiteRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolPrerequisiteRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.positivity.mcp.internal.repository;
+
+import com.positivity.mcp.internal.domain.ToolPrerequisite;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** JdbcTemplate-backed prerequisite lookup over {@code mcp_tool_prerequisite}. */
+@Repository
+@Profile({"!test", "openapi"})
+public class ToolPrerequisiteRepositoryImpl implements ToolPrerequisiteRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ToolPrerequisiteRepositoryImpl(@NonNull JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public @NonNull List<ToolPrerequisite> findByToolName(@NonNull String toolName) {
+        return jdbcTemplate.query(
+                """
+                SELECT tool_name, required_param, producing_tool, producing_field
+                FROM mcp_tool_prerequisite
+                WHERE tool_name = ?
+                """,
+                (rs, rowNum) -> new ToolPrerequisite(
+                        rs.getString("tool_name"),
+                        rs.getString("required_param"),
+                        rs.getString("producing_tool"),
+                        rs.getString("producing_field")),
+                toolName);
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/AnswerResolutionLadder.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/AnswerResolutionLadder.java
@@ -1,0 +1,30 @@
+package com.positivity.mcp.internal.service;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Owns the response for a turn that produced no direct answer (the model's {@code content} was
+ * blank). Instead of surfacing the raw thinking channel, it falls through the answer resolution
+ * ladder: a deep link to the right screen (rung 3), else an honest hand-off (rung 4).
+ *
+ * <p>Rungs 1–2 (answer tools, prerequisite composition) run earlier, inside the model's tool loop;
+ * this entry point is the graceful-degradation tail invoked only when that loop yielded nothing.
+ */
+public interface AnswerResolutionLadder {
+
+    /** Resolve a fallback response for {@code userMessage}. Never returns null. */
+    @NonNull
+    LadderResult resolveFallback(@NonNull String userMessage);
+
+    /** The chosen fallback: user-facing text, which rung produced it, and any deep-link URL. */
+    record LadderResult(
+            @NonNull String text,
+            @NonNull Rung rung,
+            @Nullable String screenUrl) {}
+
+    enum Rung {
+        DEEP_LINK,
+        HANDOFF
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImpl.java
@@ -1,0 +1,69 @@
+package com.positivity.mcp.internal.service;
+
+import com.positivity.mcp.internal.domain.ScreenLink;
+import com.positivity.mcp.service.CurrentUserContext;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * Default ladder tail. Tries a semantic screen deep link (rung 3), falling back to an honest
+ * hand-off (rung 4). Disabled by setting {@code mcp.ladder.enabled=false}, which removes the bean so
+ * callers keep their prior behaviour (surfacing the thinking channel).
+ */
+@Service
+@Profile({"!test", "openapi"})
+@ConditionalOnProperty(name = "mcp.ladder.enabled", havingValue = "true", matchIfMissing = true)
+public class AnswerResolutionLadderImpl implements AnswerResolutionLadder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AnswerResolutionLadderImpl.class);
+
+    static final String HANDOFF_MESSAGE = "I couldn't find a way to answer that from the available tools or screens. "
+            + "Try rephrasing, or contact your administrator if you expect this to be supported.";
+
+    private final ScreenLinkResolver screenLinkResolver;
+
+    @Nullable
+    private final RequestScopedUserContext requestScopedUserContext;
+
+    public AnswerResolutionLadderImpl(
+            @NonNull ScreenLinkResolver screenLinkResolver,
+            @Nullable RequestScopedUserContext requestScopedUserContext) {
+        this.screenLinkResolver = screenLinkResolver;
+        this.requestScopedUserContext = requestScopedUserContext;
+    }
+
+    @Override
+    public @NonNull LadderResult resolveFallback(@NonNull String userMessage) {
+        Set<String> permissions = callerPermissions();
+        // No structured entity extraction yet (v1): pass no params, so the screen's url_template
+        // resolves to its base path with optional filters dropped.
+        Optional<ScreenLink> link = screenLinkResolver.resolve(userMessage, null, permissions, Map.of());
+        if (link.isPresent()) {
+            ScreenLink resolved = link.get();
+            LOGGER.debug("Ladder rung=DEEP_LINK screenKey={} score={}", resolved.screenKey(), resolved.score());
+            String text = "I can't compute that directly, but you can view it here — " + resolved.title() + ": "
+                    + resolved.url();
+            return new LadderResult(text, Rung.DEEP_LINK, resolved.url());
+        }
+        LOGGER.debug("Ladder rung=HANDOFF (no screen cleared the similarity floor)");
+        return new LadderResult(HANDOFF_MESSAGE, Rung.HANDOFF, null);
+    }
+
+    private @NonNull Set<String> callerPermissions() {
+        if (requestScopedUserContext == null) {
+            return Set.of();
+        }
+        return requestScopedUserContext
+                .current()
+                .map(CurrentUserContext::permissionCodes)
+                .orElseGet(Set::of);
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImpl.java
@@ -45,7 +45,15 @@ public class AnswerResolutionLadderImpl implements AnswerResolutionLadder {
         Set<String> permissions = callerPermissions();
         // No structured entity extraction yet (v1): pass no params, so the screen's url_template
         // resolves to its base path with optional filters dropped.
-        Optional<ScreenLink> link = screenLinkResolver.resolve(userMessage, null, permissions, Map.of());
+        // Screen resolution is best-effort: this is the graceful-degradation tail, so any failure
+        // (embedding-model outage, DB error) must degrade to the hand-off, never fail the chat.
+        Optional<ScreenLink> link;
+        try {
+            link = screenLinkResolver.resolve(userMessage, null, permissions, Map.of());
+        } catch (RuntimeException exception) {
+            LOGGER.warn("Screen resolution failed; falling back to hand-off", exception);
+            link = Optional.empty();
+        }
         if (link.isPresent()) {
             ScreenLink resolved = link.get();
             LOGGER.debug("Ladder rung=DEEP_LINK screenKey={} score={}", resolved.screenKey(), resolved.score());

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/PrerequisiteResolver.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/PrerequisiteResolver.java
@@ -1,0 +1,28 @@
+package com.positivity.mcp.internal.service;
+
+import java.util.List;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Resolves the missing prerequisites of a tool the agent wants to call (rung 2 of the answer
+ * resolution ladder). For each required param absent from the known request context, returns the
+ * tool that can produce it. Resolution is bounded to a single hop — deeper chains fall through to
+ * rung 3.
+ */
+public interface PrerequisiteResolver {
+
+    /**
+     * @param toolName    the tool the agent intends to call
+     * @param knownParams param names already available from the request context
+     * @return one entry per required param that is missing, each with its producing tool
+     */
+    @NonNull
+    List<MissingParam> missingFor(@NonNull String toolName, @NonNull Set<String> knownParams);
+
+    /** A required param the tool lacks, and the tool that can supply it. */
+    record MissingParam(
+            @NonNull String param,
+            @NonNull String producingTool,
+            @NonNull String producingField) {}
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/PrerequisiteResolverImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/PrerequisiteResolverImpl.java
@@ -1,0 +1,31 @@
+package com.positivity.mcp.internal.service;
+
+import com.positivity.mcp.internal.repository.ToolPrerequisiteRepository;
+import java.util.List;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * Default one-hop prerequisite resolver. Looks up the tool's declared edges and keeps only those
+ * whose required param is not already known.
+ */
+@Service
+@Profile({"!test", "openapi"})
+public class PrerequisiteResolverImpl implements PrerequisiteResolver {
+
+    private final ToolPrerequisiteRepository repository;
+
+    public PrerequisiteResolverImpl(@NonNull ToolPrerequisiteRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public @NonNull List<MissingParam> missingFor(@NonNull String toolName, @NonNull Set<String> knownParams) {
+        return repository.findByToolName(toolName).stream()
+                .filter(edge -> !knownParams.contains(edge.requiredParam()))
+                .map(edge -> new MissingParam(edge.requiredParam(), edge.producingTool(), edge.producingField()))
+                .toList();
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolver.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolver.java
@@ -1,0 +1,29 @@
+package com.positivity.mcp.internal.service;
+
+import com.positivity.mcp.internal.domain.ScreenLink;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Resolves the best UI screen for a request that no tool could answer (rung 3 of the answer
+ * resolution ladder). Returns empty when nothing clears the similarity floor or the caller lacks
+ * permission for every candidate.
+ */
+public interface ScreenLinkResolver {
+
+    /**
+     * @param userMessage      the original request text (embedded for the search)
+     * @param domain           optional domain hint (e.g. router-classified scope); {@code null} = all
+     * @param callerPermissions the caller's permission codes, used to gate {@code required_perm}
+     * @param params           values for filling the screen's url_template (status, locationId, …)
+     */
+    @NonNull
+    Optional<ScreenLink> resolve(
+            @NonNull String userMessage,
+            @Nullable String domain,
+            @NonNull Set<String> callerPermissions,
+            @NonNull Map<String, String> params);
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolverImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolverImpl.java
@@ -1,0 +1,74 @@
+package com.positivity.mcp.internal.service;
+
+import com.positivity.mcp.internal.domain.ScreenCandidate;
+import com.positivity.mcp.internal.domain.ScreenLink;
+import com.positivity.mcp.internal.repository.ScreenRegistryRepository;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * Semantic screen resolver. Embeds the request, finds the nearest registered screens, and returns
+ * the highest-scoring one that clears the similarity floor and that the caller is permitted to see.
+ *
+ * <p>Candidates come back ordered by descending similarity, so the first sub-floor candidate ends
+ * the search (everything after it is also sub-floor). Permission-gated candidates are skipped, not
+ * terminal — a lower-ranked but still-above-floor screen the caller can open still wins.
+ */
+@Service
+@Profile({"!test", "openapi"})
+public class ScreenLinkResolverImpl implements ScreenLinkResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScreenLinkResolverImpl.class);
+    private static final int CANDIDATE_LIMIT = 5;
+
+    private final EmbeddingModel embeddingModel;
+    private final ScreenRegistryRepository repository;
+    private final double minScore;
+
+    public ScreenLinkResolverImpl(
+            @NonNull EmbeddingModel embeddingModel,
+            @NonNull ScreenRegistryRepository repository,
+            @Value("${mcp.screen.min-score:0.6}") double minScore) {
+        this.embeddingModel = embeddingModel;
+        this.repository = repository;
+        this.minScore = minScore;
+    }
+
+    @Override
+    public @NonNull Optional<ScreenLink> resolve(
+            @NonNull String userMessage,
+            @Nullable String domain,
+            @NonNull Set<String> callerPermissions,
+            @NonNull Map<String, String> params) {
+        if (userMessage.isBlank()) {
+            return Optional.empty();
+        }
+
+        float[] queryEmbedding = embeddingModel.embed(userMessage);
+        for (ScreenCandidate candidate : repository.findNearest(queryEmbedding, domain, CANDIDATE_LIMIT)) {
+            if (candidate.score() < minScore) {
+                break; // ordered by descending score — nothing below this clears the floor
+            }
+            if (candidate.requiredPerm() != null && !callerPermissions.contains(candidate.requiredPerm())) {
+                continue; // caller can't open this screen; try the next best
+            }
+            String url = ScreenUrlTemplate.fill(candidate.urlTemplate(), params);
+            LOGGER.debug(
+                    "Resolved screen link screenKey={} score={} domain={}",
+                    candidate.screenKey(),
+                    candidate.score(),
+                    domain);
+            return Optional.of(new ScreenLink(candidate.screenKey(), candidate.title(), url, candidate.score()));
+        }
+        return Optional.empty();
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenUrlTemplate.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenUrlTemplate.java
@@ -1,0 +1,45 @@
+package com.positivity.mcp.internal.service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Fills {@code {placeholder}} tokens in a screen {@code url_template} from resolved request params.
+ *
+ * <p>Provided params are substituted (URL-encoded). Any query-string parameter whose placeholder is
+ * still unresolved is dropped, so {@code /workorders?status={status}&location={locationId}} with only
+ * {@code status=OPEN} becomes {@code /workorders?status=OPEN}. Unresolved placeholders in the path
+ * portion are left as-is (there are none in the seeded templates).
+ */
+final class ScreenUrlTemplate {
+
+    private ScreenUrlTemplate() {}
+
+    static @NonNull String fill(@NonNull String template, @NonNull Map<String, String> params) {
+        String result = template;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (entry.getValue() != null) {
+                result = result.replace("{" + entry.getKey() + "}", encode(entry.getValue()));
+            }
+        }
+
+        int queryStart = result.indexOf('?');
+        if (queryStart < 0) {
+            return result;
+        }
+        String base = result.substring(0, queryStart);
+        String kept = Arrays.stream(result.substring(queryStart + 1).split("&"))
+                .filter(pair -> !pair.isBlank())
+                .filter(pair -> !pair.contains("{")) // unresolved placeholder → drop the pair
+                .collect(Collectors.joining("&"));
+        return kept.isEmpty() ? base : base + "?" + kept;
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -115,6 +115,13 @@ mcp:
     cache-ttl-minutes: 30
     max-cached-agents: 500
     memory-max-messages: 50
+  # Answer resolution ladder: on a turn that produced no direct answer, fall through to a
+  # deep link (rung 3) or an honest hand-off (rung 4) instead of surfacing the thinking channel.
+  ladder:
+    enabled: ${MCP_LADDER_ENABLED:true}
+  screen:
+    # Minimum cosine similarity for a screen to be offered as a deep link.
+    min-score: ${MCP_SCREEN_MIN_SCORE:0.6}
   tuning:
     # Gate 0 (NL-interface plan): adaptive tuning disabled until the retrieval-quality
     # regression harness exists. Re-enable only via shadow→controlled-live promotion (Gate 7).

--- a/pos-mcp-server/src/main/resources/db/migration/V25__mcp_screen_registry.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V25__mcp_screen_registry.sql
@@ -1,0 +1,35 @@
+-- Answer resolution ladder, rung 3: screen registry for deep-link fallback.
+-- When no tool can answer a request, the assistant points at the correct UI screen
+-- (with filters) instead of returning nothing. Screens are matched semantically —
+-- `description` is embedded (nomic-embed-text, 768 dims) and searched by cosine
+-- distance, mirroring the mcp_tool embedding approach.
+
+CREATE TABLE IF NOT EXISTS mcp_screen_registry (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    screen_key    VARCHAR(120) NOT NULL UNIQUE,
+    title         VARCHAR(200) NOT NULL,
+    description   TEXT NOT NULL,
+    domain        VARCHAR(80) NOT NULL,
+    url_template  TEXT NOT NULL,
+    required_perm VARCHAR(120),
+    embedding     vector(768),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_screen_registry_domain ON mcp_screen_registry (domain);
+
+-- Seed screens. Embeddings are left NULL and backfilled at startup by
+-- ScreenEmbeddingInitializer. url_template placeholders ({status}, {locationId}, …)
+-- are filled from resolved request params; unresolved query params are dropped.
+INSERT INTO mcp_screen_registry (screen_key, title, description, domain, url_template, required_perm)
+VALUES
+    ('workorders.list', 'Work Orders',
+     'Browse and filter work orders by status (open, in progress, awaiting parts, completed, cancelled) and by location. Use to see how many work orders are open or to find a specific work order.',
+     'workorder', '/workorders?status={status}&location={locationId}', 'workorder:workorder:view'),
+    ('workorders.wip', 'Work In Progress',
+     'Live board of active work-in-progress work orders for a location, including assigned technician and current status.',
+     'workorder', '/workorders/wip?location={locationId}', 'workorder:wip:view'),
+    ('invoices.list', 'Invoices',
+     'Browse invoices and filter by payment status such as open, unpaid, paid, or overdue balances.',
+     'invoice', '/invoices?status={status}', 'invoice:invoice:view')
+ON CONFLICT (screen_key) DO NOTHING;

--- a/pos-mcp-server/src/main/resources/db/migration/V26__mcp_tool_prerequisite.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V26__mcp_tool_prerequisite.sql
@@ -1,0 +1,21 @@
+-- Answer resolution ladder, rung 2: tool prerequisite edges.
+-- Some tools need a parameter the user did not supply (e.g. workorder_listwip needs
+-- locationId). Today that dependency is implicit, so the model guesses or stalls.
+-- These edges make it explicit: a required_param can be produced by calling producing_tool
+-- and reading producing_field off its result. Resolution is bounded to one hop.
+
+CREATE TABLE IF NOT EXISTS mcp_tool_prerequisite (
+    tool_name       VARCHAR(150) NOT NULL,   -- consuming tool, e.g. 'workorder_listwip'
+    required_param  VARCHAR(120) NOT NULL,   -- param it needs, e.g. 'locationId'
+    producing_tool  VARCHAR(150) NOT NULL,   -- tool that can supply it
+    producing_field VARCHAR(120) NOT NULL,   -- field on the producer's result to bind
+    PRIMARY KEY (tool_name, required_param)
+);
+
+-- Seed edges. Tool names are real discovered OpenAPI operations; producing_field is the
+-- result field carrying the value. Extend as more location/entity-scoped tools are added.
+INSERT INTO mcp_tool_prerequisite (tool_name, required_param, producing_tool, producing_field)
+VALUES
+    ('workorder_listwip', 'locationId', 'location_getcurrentuserprimarylocation', 'id'),
+    ('workorder_getestimatesbylocation', 'locationId', 'location_getcurrentuserprimarylocation', 'id')
+ON CONFLICT (tool_name, required_param) DO NOTHING;

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -185,8 +185,9 @@ class SessionAgentManagerTest {
                 rolePromptResolver,
                 simpleChatClassifier,
                 telemetryEmitter,
-                null,
-                null,
+                null, // openApiToolProvider
+                null, // answerResolutionLadder
+                null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
                 workflowStateService,
                 FIXED_CLOCK,
@@ -389,8 +390,9 @@ class SessionAgentManagerTest {
                 rolePromptResolver,
                 simpleChatClassifier,
                 telemetryEmitter,
-                null,
-                null,
+                null, // openApiToolProvider
+                null, // answerResolutionLadder
+                null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
                 workflowStateService,
                 FIXED_CLOCK,
@@ -430,8 +432,9 @@ class SessionAgentManagerTest {
                 rolePromptResolver,
                 simpleChatClassifier,
                 telemetryEmitter,
-                null,
-                null,
+                null, // openApiToolProvider
+                null, // answerResolutionLadder
+                null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
                 workflowStateService,
                 FIXED_CLOCK,

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
@@ -5,11 +5,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
+import com.positivity.mcp.internal.service.AnswerResolutionLadder;
+import com.positivity.mcp.internal.service.AnswerResolutionLadder.LadderResult;
+import com.positivity.mcp.internal.service.AnswerResolutionLadder.Rung;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.ai.chat.memory.ChatMemory;
@@ -49,7 +54,8 @@ class SpringAiPosAssistantTest {
                 List.of(new PingTool()),
                 ragRetriever,
                 ignored -> chatMemory,
-                openApiToolProvider);
+                openApiToolProvider,
+                null);
 
         String response = assistant.chat("user-1::ROLE_TECH", "where is stock", "ctx:role=TECH");
 
@@ -85,8 +91,65 @@ class SpringAiPosAssistantTest {
         assertThat(persistedMessages.getValue().get(1).getText()).isEqualTo("resolved answer");
     }
 
+    @Test
+    void chat_handsOffToLadderWhenContentBlank() {
+        ChatModel chatModel = mock(ChatModel.class);
+        QueryDocumentRetriever ragRetriever = mock(QueryDocumentRetriever.class);
+        ChatMemory chatMemory = mock(ChatMemory.class);
+        AnswerResolutionLadder ladder = mock(AnswerResolutionLadder.class);
+        when(chatModel.getDefaultOptions())
+                .thenReturn(OllamaChatOptions.builder().model("gpt-oss:120b").build());
+        when(ragRetriever.retrieve(any())).thenReturn(List.of());
+        when(chatMemory.get(any())).thenReturn(List.of());
+        // Blank content, answer routed to the thinking channel — the leak scenario.
+        when(chatModel.call(any(Prompt.class))).thenReturn(chatResponseWithThinking("", "We should call some tool..."));
+        when(ladder.resolveFallback("how many workorders are open"))
+                .thenReturn(
+                        new LadderResult("View them here — Work Orders: /workorders", Rung.DEEP_LINK, "/workorders"));
+
+        SpringAiPosAssistant assistant = new SpringAiPosAssistant(
+                chatModel, () -> "base prompt", List.of(), ragRetriever, ignored -> chatMemory, null, ladder);
+
+        String response = assistant.chat("user-1::ROLE_ADMIN", "how many workorders are open", "ctx");
+
+        // The reasoning monologue is never surfaced; the ladder result is returned and persisted.
+        assertThat(response).isEqualTo("View them here — Work Orders: /workorders");
+        ArgumentCaptor<List<Message>> persisted = messageListCaptor();
+        verify(chatMemory).add(eq("user-1::ROLE_ADMIN"), persisted.capture());
+        assertThat(persisted.getValue().get(1).getText()).isEqualTo("View them here — Work Orders: /workorders");
+    }
+
+    @Test
+    void chat_returnsDirectContentWithoutConsultingLadder() {
+        ChatModel chatModel = mock(ChatModel.class);
+        QueryDocumentRetriever ragRetriever = mock(QueryDocumentRetriever.class);
+        ChatMemory chatMemory = mock(ChatMemory.class);
+        AnswerResolutionLadder ladder = mock(AnswerResolutionLadder.class);
+        when(chatModel.getDefaultOptions())
+                .thenReturn(OllamaChatOptions.builder().model("gpt-oss:120b").build());
+        when(ragRetriever.retrieve(any())).thenReturn(List.of());
+        when(chatMemory.get(any())).thenReturn(List.of());
+        when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse("There are 12 open work orders."));
+
+        SpringAiPosAssistant assistant = new SpringAiPosAssistant(
+                chatModel, () -> "base prompt", List.of(), ragRetriever, ignored -> chatMemory, null, ladder);
+
+        String response = assistant.chat("user-1::ROLE_ADMIN", "how many workorders are open", "ctx");
+
+        assertThat(response).isEqualTo("There are 12 open work orders.");
+        verifyNoInteractions(ladder); // a direct answer must never trigger the fallback
+    }
+
     private static ChatResponse chatResponse(String text) {
         return new ChatResponse(List.of(new Generation(new AssistantMessage(text))));
+    }
+
+    private static ChatResponse chatResponseWithThinking(String content, String thinking) {
+        AssistantMessage message = AssistantMessage.builder()
+                .content(content)
+                .properties(Map.of("thinking", thinking))
+                .build();
+        return new ChatResponse(List.of(new Generation(message)));
     }
 
     static final class PingTool {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImplTest.java
@@ -72,6 +72,19 @@ class AnswerResolutionLadderImplTest {
     }
 
     @Test
+    @DisplayName("a screen-resolver failure degrades to HANDOFF instead of propagating")
+    void resolverFailureDegradesToHandoff() {
+        when(requestScopedUserContext.current()).thenReturn(Optional.empty());
+        when(screenLinkResolver.resolve(any(), nullable(String.class), any(), any()))
+                .thenThrow(new RuntimeException("embedding backend down"));
+
+        LadderResult result = ladder().resolveFallback("how many workorders are open");
+
+        assertThat(result.rung()).isEqualTo(Rung.HANDOFF);
+        assertThat(result.text()).isEqualTo(AnswerResolutionLadderImpl.HANDOFF_MESSAGE);
+    }
+
+    @Test
     @DisplayName("caller permissions from the request context are passed to the screen resolver")
     void passesCallerPermissions() {
         Set<String> perms = Set.of("workorder:workorder:view", "invoice:invoice:view");

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImplTest.java
@@ -1,0 +1,86 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.domain.ScreenLink;
+import com.positivity.mcp.internal.service.AnswerResolutionLadder.LadderResult;
+import com.positivity.mcp.internal.service.AnswerResolutionLadder.Rung;
+import com.positivity.mcp.service.CurrentUserContext;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnswerResolutionLadderImpl — rung 3/4 fallback")
+class AnswerResolutionLadderImplTest {
+
+    @Mock
+    private ScreenLinkResolver screenLinkResolver;
+
+    @Mock
+    private RequestScopedUserContext requestScopedUserContext;
+
+    private AnswerResolutionLadderImpl ladder() {
+        return new AnswerResolutionLadderImpl(screenLinkResolver, requestScopedUserContext);
+    }
+
+    private CurrentUserContext userWith(Set<String> permissions) {
+        return new CurrentUserContext(
+                "user",
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                "ROLE_ADMIN",
+                Set.of(),
+                Set.of(),
+                permissions);
+    }
+
+    @Test
+    @DisplayName("a resolved screen yields a DEEP_LINK carrying its title and url")
+    void deepLinkWhenScreenResolves() {
+        when(requestScopedUserContext.current()).thenReturn(Optional.of(userWith(Set.of("workorder:workorder:view"))));
+        when(screenLinkResolver.resolve(any(), nullable(String.class), any(), any()))
+                .thenReturn(Optional.of(new ScreenLink("workorders.list", "Work Orders", "/workorders", 0.8)));
+
+        LadderResult result = ladder().resolveFallback("how many workorders are open");
+
+        assertThat(result.rung()).isEqualTo(Rung.DEEP_LINK);
+        assertThat(result.screenUrl()).isEqualTo("/workorders");
+        assertThat(result.text()).contains("Work Orders").contains("/workorders");
+    }
+
+    @Test
+    @DisplayName("no resolvable screen yields an honest HANDOFF")
+    void handoffWhenNoScreen() {
+        when(requestScopedUserContext.current()).thenReturn(Optional.empty());
+        when(screenLinkResolver.resolve(any(), nullable(String.class), any(), any()))
+                .thenReturn(Optional.empty());
+
+        LadderResult result = ladder().resolveFallback("something unanswerable");
+
+        assertThat(result.rung()).isEqualTo(Rung.HANDOFF);
+        assertThat(result.screenUrl()).isNull();
+        assertThat(result.text()).isEqualTo(AnswerResolutionLadderImpl.HANDOFF_MESSAGE);
+    }
+
+    @Test
+    @DisplayName("caller permissions from the request context are passed to the screen resolver")
+    void passesCallerPermissions() {
+        Set<String> perms = Set.of("workorder:workorder:view", "invoice:invoice:view");
+        when(requestScopedUserContext.current()).thenReturn(Optional.of(userWith(perms)));
+        when(screenLinkResolver.resolve(any(), nullable(String.class), eq(perms), any()))
+                .thenReturn(Optional.empty());
+
+        LadderResult result = ladder().resolveFallback("q");
+
+        assertThat(result.rung()).isEqualTo(Rung.HANDOFF); // resolver returned empty for these perms
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/PrerequisiteResolverImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/PrerequisiteResolverImplTest.java
@@ -1,0 +1,74 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.domain.ToolPrerequisite;
+import com.positivity.mcp.internal.repository.ToolPrerequisiteRepository;
+import com.positivity.mcp.internal.service.PrerequisiteResolver.MissingParam;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PrerequisiteResolverImpl — one-hop missing-param resolution (rung 2)")
+class PrerequisiteResolverImplTest {
+
+    private static final ToolPrerequisite LOCATION_EDGE =
+            new ToolPrerequisite("workorder_listwip", "locationId", "location_getcurrentuserprimarylocation", "id");
+
+    @Mock
+    private ToolPrerequisiteRepository repository;
+
+    private PrerequisiteResolverImpl resolver() {
+        return new PrerequisiteResolverImpl(repository);
+    }
+
+    @Test
+    @DisplayName("a required param absent from context is reported with its producing tool")
+    void missingParamReported() {
+        when(repository.findByToolName("workorder_listwip")).thenReturn(List.of(LOCATION_EDGE));
+
+        List<MissingParam> missing = resolver().missingFor("workorder_listwip", Set.of());
+
+        assertThat(missing).singleElement().satisfies(m -> {
+            assertThat(m.param()).isEqualTo("locationId");
+            assertThat(m.producingTool()).isEqualTo("location_getcurrentuserprimarylocation");
+            assertThat(m.producingField()).isEqualTo("id");
+        });
+    }
+
+    @Test
+    @DisplayName("a required param already known is not reported")
+    void knownParamNotReported() {
+        when(repository.findByToolName("workorder_listwip")).thenReturn(List.of(LOCATION_EDGE));
+
+        List<MissingParam> missing = resolver().missingFor("workorder_listwip", Set.of("locationId"));
+
+        assertThat(missing).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a tool with no declared edges yields no missing params")
+    void toolWithoutEdgesYieldsEmpty() {
+        when(repository.findByToolName("workorder_countworkorders")).thenReturn(List.of());
+
+        assertThat(resolver().missingFor("workorder_countworkorders", Set.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("only the absent params are reported when context is partial")
+    void partialContextReportsOnlyAbsent() {
+        ToolPrerequisite secondEdge =
+                new ToolPrerequisite("workorder_listwip", "customerId", "location_resolvepartynames", "partyId");
+        when(repository.findByToolName("workorder_listwip")).thenReturn(List.of(LOCATION_EDGE, secondEdge));
+
+        List<MissingParam> missing = resolver().missingFor("workorder_listwip", Set.of("locationId"));
+
+        assertThat(missing).extracting(MissingParam::param).containsExactly("customerId");
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenLinkResolverImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenLinkResolverImplTest.java
@@ -1,0 +1,95 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.domain.ScreenCandidate;
+import com.positivity.mcp.internal.domain.ScreenLink;
+import com.positivity.mcp.internal.repository.ScreenRegistryRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.embedding.EmbeddingModel;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ScreenLinkResolverImpl — semantic deep-link resolution (rung 3)")
+class ScreenLinkResolverImplTest {
+
+    private static final Set<String> VIEW_PERM = Set.of("workorder:workorder:view");
+    private final float[] embedding = {0.1f, 0.2f, 0.3f};
+
+    @Mock
+    private EmbeddingModel embeddingModel;
+
+    @Mock
+    private ScreenRegistryRepository repository;
+
+    private ScreenLinkResolverImpl resolver() {
+        return new ScreenLinkResolverImpl(embeddingModel, repository, 0.6);
+    }
+
+    private ScreenCandidate candidate(String key, String perm, double score) {
+        return new ScreenCandidate(
+                key, key, "/workorders?status={status}&location={locationId}", "workorder", perm, score);
+    }
+
+    @Test
+    @DisplayName("top candidate above floor returns a filled, permitted link")
+    void topCandidateAboveFloorReturnsFilledUrl() {
+        when(embeddingModel.embed("how many workorders are open")).thenReturn(embedding);
+        when(repository.findNearest(any(), nullable(String.class), anyInt()))
+                .thenReturn(List.of(candidate("workorders.list", "workorder:workorder:view", 0.82)));
+
+        Optional<ScreenLink> link =
+                resolver().resolve("how many workorders are open", "workorder", VIEW_PERM, Map.of("status", "OPEN"));
+
+        assertThat(link).isPresent();
+        assertThat(link.get().screenKey()).isEqualTo("workorders.list");
+        assertThat(link.get().url()).isEqualTo("/workorders?status=OPEN"); // unfilled locationId dropped
+        assertThat(link.get().score()).isEqualTo(0.82);
+    }
+
+    @Test
+    @DisplayName("nothing above the similarity floor returns empty")
+    void belowFloorReturnsEmpty() {
+        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(repository.findNearest(any(), nullable(String.class), anyInt()))
+                .thenReturn(List.of(candidate("workorders.list", null, 0.41)));
+
+        assertThat(resolver().resolve("unrelated question", null, VIEW_PERM, Map.of()))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("permission-gated top candidate is skipped for the next permitted one")
+    void permissionGatedTopSkippedNextReturned() {
+        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(repository.findNearest(any(), nullable(String.class), anyInt()))
+                .thenReturn(List.of(
+                        candidate("admin.secret", "admin:secret:view", 0.90),
+                        candidate("workorders.list", null, 0.71)));
+
+        Optional<ScreenLink> link = resolver().resolve("show me work", "workorder", VIEW_PERM, Map.of());
+
+        assertThat(link).isPresent();
+        assertThat(link.get().screenKey()).isEqualTo("workorders.list");
+    }
+
+    @Test
+    @DisplayName("blank message returns empty without embedding")
+    void blankMessageReturnsEmptyWithoutEmbedding() {
+        assertThat(resolver().resolve("   ", null, VIEW_PERM, Map.of())).isEmpty();
+        verifyNoInteractions(embeddingModel, repository);
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenUrlTemplateTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenUrlTemplateTest.java
@@ -1,0 +1,48 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ScreenUrlTemplate — placeholder filling")
+class ScreenUrlTemplateTest {
+
+    private static final String TEMPLATE = "/workorders?status={status}&location={locationId}";
+
+    @Test
+    @DisplayName("all placeholders filled")
+    void allPlaceholdersFilled() {
+        String url = ScreenUrlTemplate.fill(TEMPLATE, Map.of("status", "OPEN", "locationId", "LOC1"));
+        assertThat(url).isEqualTo("/workorders?status=OPEN&location=LOC1");
+    }
+
+    @Test
+    @DisplayName("unresolved query param is dropped")
+    void unresolvedQueryParamDropped() {
+        String url = ScreenUrlTemplate.fill(TEMPLATE, Map.of("status", "OPEN"));
+        assertThat(url).isEqualTo("/workorders?status=OPEN");
+    }
+
+    @Test
+    @DisplayName("all query params unresolved collapses to the base path")
+    void allUnresolvedCollapsesToBase() {
+        String url = ScreenUrlTemplate.fill(TEMPLATE, Map.of());
+        assertThat(url).isEqualTo("/workorders");
+    }
+
+    @Test
+    @DisplayName("values are URL-encoded")
+    void valuesAreUrlEncoded() {
+        String url = ScreenUrlTemplate.fill("/invoices?status={status}", Map.of("status", "past due"));
+        assertThat(url).isEqualTo("/invoices?status=past+due");
+    }
+
+    @Test
+    @DisplayName("template without a query string is returned unchanged")
+    void noQueryStringReturnedAsIs() {
+        String url = ScreenUrlTemplate.fill("/dashboard", Map.of("status", "OPEN"));
+        assertThat(url).isEqualTo("/dashboard");
+    }
+}

--- a/pos-shared-dtos/src/main/java/com/positivity/shared/dto/CountResponse.java
+++ b/pos-shared-dtos/src/main/java/com/positivity/shared/dto/CountResponse.java
@@ -1,0 +1,36 @@
+package com.positivity.shared.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Aggregate count result shared across domain services (the rung-1 "count convention" of the
+ * answer resolution ladder — see {@code pos-mcp-server/docs/answer-resolution-ladder-design.md}).
+ *
+ * <p>{@code total} is the grand total; {@code groups} is the optional per-key breakdown (e.g.
+ * status &rarr; count). Both are server-computed via COUNT queries — callers never page a full
+ * collection to count it.
+ */
+@Schema(description = "Aggregate count result with an optional per-key breakdown.")
+public record CountResponse(
+        @Schema(description = "Grand total across all groups.", example = "42")
+        long total,
+
+        @Schema(description = "Optional per-key breakdown; empty when only a total is requested.") @NonNull
+        List<CountGroup> groups) {
+
+    @Schema(description = "A single keyed count within a breakdown.")
+    public record CountGroup(
+            @Schema(description = "Group key (e.g. a status name).", example = "WORK_IN_PROGRESS") @NonNull
+            String key,
+
+            @Schema(description = "Count for this key.", example = "7")
+            long count) {}
+
+    /** A total-only result with no breakdown. */
+    @NonNull
+    public static CountResponse of(long total) {
+        return new CountResponse(total, List.of());
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
@@ -28,6 +28,12 @@ public final class EventTypes {
             .apiVersion("1")
             .build();
 
+    /** Count workorders by status (open / specific statuses / all) */
+    public static final EventTypeRegistration WORKORDER_COUNT = EventTypeRegistration.fastRead(
+                    "WORKORDER_COUNT", "Count workorders by status (open, specific statuses, or all)")
+            .apiVersion("1")
+            .build();
+
     /** Batch-resolve workorder ids to human workorder numbers */
     public static final EventTypeRegistration WORKORDER_NUMBER_RESOLVE = EventTypeRegistration.fastRead(
                     "WORKORDER_NUMBER_RESOLVE", "Batch-resolve workorder ids to human workorder numbers")
@@ -514,6 +520,7 @@ public final class EventTypes {
             // Workorder events
             WORKORDER_LIST,
             WORKORDER_SEARCH,
+            WORKORDER_COUNT,
             WORKORDER_NUMBER_RESOLVE,
             WORKORDER_CREATE,
             WORKORDER_OUTBOX_REPLAY,

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
@@ -2,6 +2,7 @@ package com.positivity.workorder.internal.controller;
 
 import com.positivity.events.EmitEvent;
 import com.positivity.security.common.SecurityContextHelper;
+import com.positivity.shared.dto.CountResponse;
 import com.positivity.shared.dto.InvoiceGenerationResponse;
 import com.positivity.workorder.internal.dto.ApproveWorkorderRequest;
 import com.positivity.workorder.internal.dto.CompleteWorkorderRequest;
@@ -14,7 +15,9 @@ import com.positivity.workorder.internal.dto.WorkorderItemCompletionResponse;
 import com.positivity.workorder.internal.dto.WorkorderResponse;
 import com.positivity.workorder.internal.dto.WorkorderSnapshotResponse;
 import com.positivity.workorder.internal.dto.WorkorderStateTransitionResponse;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
 import com.positivity.workorder.internal.service.WorkorderStateMachine;
+import com.positivity.workorder.service.WorkorderCountService;
 import com.positivity.workorder.service.WorkorderInvoiceService;
 import com.positivity.workorder.service.WorkorderService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,9 +29,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +48,7 @@ public class WorkorderController {
 
     private final WorkorderService workorderService;
     private final WorkorderInvoiceService workorderInvoiceService;
+    private final WorkorderCountService workorderCountService;
 
     @Operation(summary = "Get all work orders", description = "Retrieve a list of all work orders.")
     @ApiResponse(responseCode = "200", description = "List of work orders returned successfully.")
@@ -56,6 +62,39 @@ public class WorkorderController {
         return workorderService.getAllWorkorders().stream()
                 .map(WorkorderResponse::fromEntity)
                 .toList();
+    }
+
+    @Operation(
+            summary = "Count work orders by status",
+            description = "Count work orders, optionally restricted to specific statuses or to open (non-terminal) "
+                    + "work orders only. \"Open\" means any status except COMPLETED or CANCELLED. Returns a grand "
+                    + "total plus a per-status breakdown, computed server-side without listing the work orders.")
+    @ApiResponse(responseCode = "200", description = "Count returned successfully.")
+    @GetMapping("/count")
+    @EmitEvent(id = "WORKORDER_COUNT", apiVersion = "1")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:workorder:view"})
+    @PreAuthorize("hasAuthority('workorder:workorder:view')")
+    public CountResponse countWorkorders(
+            @Parameter(
+                            description = "Count only open (non-terminal) work orders. Ignored when 'status' is "
+                                    + "supplied. Defaults to false (count all statuses).")
+                    @RequestParam(defaultValue = "false")
+                    boolean openOnly,
+            @Parameter(description = "Exact statuses to count; repeatable. Takes precedence over 'openOnly'.")
+                    @RequestParam(required = false)
+                    @Nullable
+                    Set<WorkorderStatus> status) {
+        Set<WorkorderStatus> statuses;
+        if (status != null && !status.isEmpty()) {
+            statuses = status;
+        } else if (openOnly) {
+            statuses = WorkorderStatus.getOpenStatuses();
+        } else {
+            statuses = null; // count every status
+        }
+        return workorderCountService.countByStatuses(statuses);
     }
 
     @Operation(summary = "Get work order by ID", description = "Retrieve a work order by its unique ID.")

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/enums/WorkorderStatus.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/enums/WorkorderStatus.java
@@ -1,5 +1,6 @@
 package com.positivity.workorder.internal.enums;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -45,5 +46,18 @@ public enum WorkorderStatus {
 
     public static Set<WorkorderStatus> getInProgressSubStatuses() {
         return Set.of(WORK_IN_PROGRESS, AWAITING_PARTS, AWAITING_APPROVAL);
+    }
+
+    /** Terminal statuses — a workorder in one of these is finished and no longer "open". */
+    public static Set<WorkorderStatus> getTerminalStatuses() {
+        return Set.of(COMPLETED, CANCELLED);
+    }
+
+    /**
+     * "Open" workorders — every non-terminal status. Derived as the complement of
+     * {@link #getTerminalStatuses()} so it stays correct if a new status is added.
+     */
+    public static Set<WorkorderStatus> getOpenStatuses() {
+        return EnumSet.complementOf(EnumSet.copyOf(getTerminalStatuses()));
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderRepository.java
@@ -50,6 +50,26 @@ public interface WorkorderRepository extends JpaRepository<Workorder, UUID> {
     @NonNull
     Page<Workorder> findByStatusIn(@NonNull Collection<WorkorderStatus> statuses, @NonNull Pageable pageable);
 
+    /** Projection row for {@link #countGroupedByStatus(Collection)} — one status and its count. */
+    interface StatusCount {
+        WorkorderStatus getStatus();
+
+        long getCount();
+    }
+
+    /**
+     * Server-side grouped count of workorders whose status is in {@code statuses}. Returns one row
+     * per status that actually has matching rows (statuses with zero matches are absent). Backs the
+     * {@code GET /v1/workorders/count} endpoint without loading any workorder rows.
+     *
+     * @param statuses statuses to include (must be non-empty for the JPQL {@code IN} clause)
+     * @return per-status counts for the matching statuses
+     */
+    @Query("SELECT w.status AS status, COUNT(w) AS count FROM Workorder w "
+            + "WHERE w.status IN :statuses GROUP BY w.status")
+    @NonNull
+    List<StatusCount> countGroupedByStatus(@Param("statuses") @NonNull Collection<WorkorderStatus> statuses);
+
     /**
      * Find all workorders for a given scheduled date and location.
      * Used by the Daily Dispatch Board Dashboard (CAP-142) to populate the day

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderCountServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderCountServiceImpl.java
@@ -1,0 +1,38 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.shared.dto.CountResponse;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.service.WorkorderCountService;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WorkorderCountServiceImpl implements WorkorderCountService {
+
+    private final WorkorderRepository workorderRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public @NonNull CountResponse countByStatuses(@Nullable Set<WorkorderStatus> statuses) {
+        Set<WorkorderStatus> target = (statuses == null || statuses.isEmpty())
+                ? EnumSet.allOf(WorkorderStatus.class)
+                : EnumSet.copyOf(statuses);
+
+        List<CountResponse.CountGroup> groups = workorderRepository.countGroupedByStatus(target).stream()
+                .map(row -> new CountResponse.CountGroup(row.getStatus().name(), row.getCount()))
+                .sorted(Comparator.comparing(CountResponse.CountGroup::key))
+                .toList();
+
+        long total = groups.stream().mapToLong(CountResponse.CountGroup::count).sum();
+        return new CountResponse(total, groups);
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/WorkorderCountService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/WorkorderCountService.java
@@ -1,0 +1,29 @@
+package com.positivity.workorder.service;
+
+import com.positivity.shared.dto.CountResponse;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Aggregate workorder counts (rung 1 of the answer resolution ladder). Computes counts server-side
+ * via COUNT queries — never by loading and sizing a collection.
+ */
+public interface WorkorderCountService {
+
+    /**
+     * Count workorders grouped by status.
+     *
+     * @param statuses the statuses to include; when {@code null} or empty, every status is counted
+     * @return the total and a per-status breakdown (statuses with zero matches are omitted)
+     */
+    @NonNull
+    CountResponse countByStatuses(@Nullable Set<WorkorderStatus> statuses);
+
+    /** Convenience for the common question "how many workorders are open?" (non-terminal statuses). */
+    @NonNull
+    default CountResponse countOpen() {
+        return countByStatuses(WorkorderStatus.getOpenStatuses());
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderCountServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderCountServiceImplTest.java
@@ -1,0 +1,106 @@
+package com.positivity.workorder.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.positivity.shared.dto.CountResponse;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository.StatusCount;
+import com.positivity.workorder.internal.service.WorkorderCountServiceImpl;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WorkorderCountServiceImpl — rung-1 aggregate counts")
+class WorkorderCountServiceImplTest {
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @InjectMocks
+    private WorkorderCountServiceImpl service;
+
+    private static StatusCount row(WorkorderStatus status, long count) {
+        return new StatusCount() {
+            @Override
+            public WorkorderStatus getStatus() {
+                return status;
+            }
+
+            @Override
+            public long getCount() {
+                return count;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("countOpen sums non-terminal statuses and excludes COMPLETED/CANCELLED")
+    void countOpenSumsNonTerminalStatuses() {
+        when(workorderRepository.countGroupedByStatus(WorkorderStatus.getOpenStatuses()))
+                .thenReturn(List.of(
+                        row(WorkorderStatus.WORK_IN_PROGRESS, 7),
+                        row(WorkorderStatus.DRAFT, 3),
+                        row(WorkorderStatus.READY_FOR_PICKUP, 2)));
+
+        CountResponse result = service.countOpen();
+
+        assertThat(result.total()).isEqualTo(12);
+        assertThat(result.groups())
+                .extracting(CountResponse.CountGroup::key)
+                .containsExactly("DRAFT", "READY_FOR_PICKUP", "WORK_IN_PROGRESS"); // sorted by key
+        assertThat(WorkorderStatus.getOpenStatuses())
+                .doesNotContain(WorkorderStatus.COMPLETED, WorkorderStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("null/empty statuses count every status")
+    void nullStatusesCountAllStatuses() {
+        ArgumentCaptor<Collection<WorkorderStatus>> captor = ArgumentCaptor.forClass(Collection.class);
+        when(workorderRepository.countGroupedByStatus(captor.capture()))
+                .thenReturn(List.of(row(WorkorderStatus.COMPLETED, 5)));
+
+        CountResponse result = service.countByStatuses(null);
+
+        assertThat(captor.getValue()).containsExactlyInAnyOrderElementsOf(EnumSet.allOf(WorkorderStatus.class));
+        assertThat(result.total()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("explicit status set is passed through and totalled")
+    void explicitStatusSetIsCounted() {
+        Set<WorkorderStatus> requested = Set.of(WorkorderStatus.AWAITING_PARTS);
+        when(workorderRepository.countGroupedByStatus(requested))
+                .thenReturn(List.of(row(WorkorderStatus.AWAITING_PARTS, 4)));
+
+        CountResponse result = service.countByStatuses(requested);
+
+        assertThat(result.total()).isEqualTo(4);
+        assertThat(result.groups()).singleElement().satisfies(group -> {
+            assertThat(group.key()).isEqualTo("AWAITING_PARTS");
+            assertThat(group.count()).isEqualTo(4);
+        });
+    }
+
+    @Test
+    @DisplayName("no matching rows yields zero total and empty breakdown")
+    void noRowsYieldsZeroTotal() {
+        when(workorderRepository.countGroupedByStatus(WorkorderStatus.getOpenStatuses()))
+                .thenReturn(List.of());
+
+        CountResponse result = service.countOpen();
+
+        assertThat(result.total()).isZero();
+        assertThat(result.groups()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: MCP hardening (no single `cap:` id — infrastructure work reducing the "assistant returns nothing / leaks reasoning" failure class, plus Batch A hardening)
- Parent STORY (durion): n/a
- Closes: louisburroughs/durion-positivity-backend#778, louisburroughs/durion-positivity-backend#780
- Refs (advanced, not closed): louisburroughs/durion-positivity-backend#779 (permission IT added; Gate 3 live verification remains), louisburroughs/durion-positivity-backend#645
- Domain: `domain:mcp`, `domain:workorder`

## Contract References
This PR adds a new backend endpoint and DTO, so it is contract-relevant. Contract guidance: `BACKEND_CONTRACT_GUIDE.md` (workorder domain) — the new `GET /v1/workorders/count` operation, the shared `CountResponse` DTO, and the `WORKORDER_COUNT` event type are the contract surface added here.
- Durion contract PR (if applicable): n/a

## Contract Chain (Controller changed)
- [x] OpenAPI annotations updated on the controller (`@Operation` / `@ApiResponse` / `@Parameter` on `WorkorderController.countWorkorders`)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — **NOT done in this PR; required follow-up before merge**
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — follow-up, gated on the aggregate regen above

## Scope
- **Answer resolution ladder** in `pos-mcp-server` — deterministic fall-through for turns that produce no direct answer: real count tool (rung 1) → one-hop prerequisite composition (rung 2) → semantic screen deep link (rung 3) → honest hand-off (rung 4). Wires rungs 3–4 into the hot path so the model's `thinking` channel is never surfaced as an answer. Adds `GET /v1/workorders/count` (rung 1). Review fixes: ladder screen resolution is best-effort (degrades to HANDOFF on failure); `ScreenCandidate.score` doc corrected to `[-1, 1]`.
- **Batch A MCP hardening** (per `docs/mcp-hardening-session-plan.md`):
  - **#778** — streaming persisted-workflow-state gating test (parity with the sync manager); verified both managers thread persisted state, the write path (`NltiController.setWorkflowState`→`advance`) is wired, and preload defaults to `ALL`. Functionally complete → closes.
  - **#780** — `V27__drop_legacy_role_gating.sql` drops `mcp_role_deprecated` / `mcp_tool_role_deprecated` (V19 rename, retention window elapsed per owner). Role gating fully superseded by permission gating; code removal was already complete → closes.
  - **#779** — `OpenApiToolPermissionGatingIT` (live-gated, `-Dmcp.eval.live=true`, `@ActiveProfiles("alpha")`) drives the real `OpenApiToolProvider` against live pgvector: fail-closed without context; a caller lacking a tool's permission never receives it, granting it does. Moves the permission-filter assertion from unit to integration level. Gate 3 live run remains before #779 fully closes.
- **Why:** A live query ("How many workorders are currently open?") returned the model's planning monologue instead of an answer. This makes the question answerable, degrades every no-answer turn gracefully, and clears the code-only Batch A hardening.

## Tests
- [x] Unit tests added/updated (rung 1 count service; rungs 2/3 resolvers; ladder rung 3/4 incl. resolver-failure→HANDOFF; `ChatResponseText` source detection; `SpringAiPosAssistant` blank-content→ladder / direct-content→no-ladder; streaming persisted-workflow-state #778)
- [ ] Integration tests — `OpenApiToolPermissionGatingIT` added but **live-gated** (runs on the alpha stack, not offline CI); a stubbed-gateway execution path for #779 remains
- **How to run:**
  - `./mvnw -pl pos-workorder -am -Dtest=WorkorderCountServiceImplTest test`
  - `./mvnw -pl pos-mcp-server -am -Dtest='SpringAiPosAssistantTest,AnswerResolutionLadderImplTest,ScreenLinkResolverImplTest,PrerequisiteResolverImplTest,ScreenUrlTemplateTest,SessionAgentManagerTest,StreamingSessionAgentManagerTest,ChatResponseTextTest' test`
  - Live (alpha): `./mvnw -o -pl pos-mcp-server test -Dtest=OpenApiToolPermissionGatingIT -Dmcp.eval.live=true -Dspring.profiles.active=alpha`
  - ArchUnit: `./mvnw -pl pos-workorder,pos-mcp-server -am -Dtest=ArchitectureTest test`

## Risk & Rollback
- **Risk level:** Low
- Ladder is feature-flagged by bean presence (`mcp.ladder.enabled`, default true); `MCP_LADDER_ENABLED=false` reverts to prior behaviour. New tables (V25/V26) and the count endpoint are additive/read-only. `V27` drops tables that were already renamed-out-of-use in V19 and are unqueried at runtime.
- **Rollback plan:** disable the ladder via `MCP_LADDER_ENABLED=false`, or revert the branch. `V27` is a forward drop; a rollback would restore from V19's renamed tables if needed (data was retained through the window, now elapsed).

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no (agent branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — no CAP id for this hardening work
- [x] Links to related issues present (Closes #778, #780; Refs #779, #645)
- [x] Contract guide referenced (`BACKEND_CONTRACT_GUIDE.md`) for the new endpoint/DTO/event
- [ ] Required CI checks passing — pending (OpenAPI-regen contract-chain item above)