### PR TITLE
pos-mcp-server: MCP hardening follow-up — drop legacy role tables, workflow-state + permission tests

### DIFF
--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -785,6 +785,8 @@ paths:
     $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1nlt~1audit
   /v1/nlt/requests:
     $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1nlt~1requests
+  /v1/nlt/sessions/{sessionId}/workflow-state:
+    $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1nlt~1sessions~1{sessionId}~1workflow-state
   /v1/prompts:
     $ref: ../../pos-mcp-server/openapi.yaml#/paths/~1v1~1prompts
   /v1/prompts/{id}:
@@ -1305,6 +1307,8 @@ paths:
     $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1changeRequests~1{changeId}~1decline
   /v1/workorders/changeRequests/{changeId}/emergency-override:
     $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1changeRequests~1{changeId}~1emergency-override
+  /v1/workorders/count:
+    $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1count
   /v1/workorders/estimates:
     $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1estimates
   /v1/workorders/estimates/customer/{customerId}:

--- a/pos-mcp-server/docs/mcp-hardening-session-plan.md
+++ b/pos-mcp-server/docs/mcp-hardening-session-plan.md
@@ -59,15 +59,19 @@ synchronously at Flux-assembly time).
 
 ## Batch B — Discovery hardening (#645, mostly code)  · effort M · risk med
 
-- Wire `OpenApiDocumentFetcher.fetchForService(serviceId)` (exists, no prod caller) into
-  `ToolRegistrationServiceImpl.registerDiscoveredTools()` as the **per-service Eureka fallback** when the
-  aggregate fetch returns empty.
-- `@Scheduled` periodic refresh that re-runs discovery and diffs against currently-registered tools
-  (configurable interval); must be idempotent (no duplicate/rogue re-registration).
-- Micrometer counters `tools_discovered_total` / `tools_registered_total`; alert rules under
-  `docs/alerts/`; ops runbook section under `docs/runbooks/`.
-- **Close when:** fallback + scheduled refresh land with tests, metrics emit, docs added. (Alpha 404
-  check → Batch D.)
+**Verified 2026-07-26 — all code items already implemented and tested:**
+- **Per-service Eureka fallback: done.** `ToolRegistrationServiceImpl.registerViaPerServiceFallback`
+  wires `fetchForService` / `fallbackServiceIds` when the aggregate is empty/matches no tools; fail-soft
+  per service. Tested (`ToolRegistrationServiceImplTest` fallback / no-fallback-on-success / both-empty).
+- **Periodic refresh: done.** `DiscoveryRefreshScheduler` (`@Scheduled fixedDelay`, opt-in via
+  `mcp.server.discovery-refresh.enabled`, timeout-bounded, serialized) + `SchedulingConfiguration`
+  (`@EnableScheduling`). Re-registration is idempotent (`addToolWithTiming` removes-then-adds). Note the
+  issue lists **dynamic unregistration (stale-tool pruning) as out of scope**, so re-adding new/changed
+  tools without pruning is the intended behavior. Tested (`DiscoveryRefreshSchedulerTest`).
+- **Metrics + alerting + runbook: done.** Counters `tools.discovered` / `tools.registered` (both
+  incremented); `docs/alerts/tool-discovery-alerts.md`; `docs/runbooks/tool-discovery-failure.md`.
+- **Only remaining:** alpha end-to-end 404 verification → **Batch D** (live).
+- **Close when:** the alpha 404 check passes on the live stack.
 
 ---
 

--- a/pos-mcp-server/docs/mcp-hardening-session-plan.md
+++ b/pos-mcp-server/docs/mcp-hardening-session-plan.md
@@ -25,9 +25,9 @@ anywhere; `LoadedMasterAgentRegistry` does not exist; the two-arg `resolveDomain
 Collection)` overload does not exist (only the 1-arg domain resolver); `MasterAgentRegistry.
 resolveDomainTools` has no role branch; `findEnabledByRoleAndWorkflow`/`findAllRoleNames`/
 `ToolRegistryRoleMapper` are gone. Scenario suites (cashier/manager/admin/`ROLE_USER`) pass.
-- **Only remaining:** migration `V27` dropping `mcp_role_deprecated` / `mcp_tool_role_deprecated` —
-  **blocked** on the V19 retention-window decision (owner). Do NOT drop without confirmation.
-- **Close when:** owner confirms the window has passed and the drop migration lands.
+- **Done this session:** owner confirmed the V19 retention window has passed; migration
+  `V27__drop_legacy_role_gating.sql` drops both deprecated tables (validated: full Flyway chain
+  V1→V27 boots clean on H2). **Closeable on merge.**
 
 ### #778 — Workflow state beyond IDLE for gating  · **done**
 **Verified 2026-07-26 — all functional ACs implemented:**
@@ -47,12 +47,13 @@ resolveDomainTools` has no role branch; `findEnabledByRoleAndWorkflow`/`findAllR
 **Verified 2026-07-26 — the stale comments are already fixed:** `OpenApiToolProvider` (~33–43) and
 `RequestScopedUserContext` (~12–27) both now correctly describe streaming as wired (caller published
 synchronously at Flux-assembly time).
-- **Only remaining (code):** integration test (`*IT`): low-permission caller → chat endpoint → assert a
-  high-permission openapi tool is neither offered nor executed, and an authorized op executes through a
-  **stubbed gateway** (WireMock). **Note:** this `*IT` needs an integration harness (Testcontainers
-  Postgres/pgvector + a stubbed embedding backend or recorded mode) that may not run in a code-only
-  sandbox — pair with Batch D's live verification if it can't be exercised here.
-- **Close when:** the IT passes (and Gate 3 live verification → Batch D).
+- **Done this session:** authored `OpenApiToolPermissionGatingIT` (live-gated, `@ActiveProfiles("alpha")`
+  + `-Dmcp.eval.live=true`, mirroring `BaselineCaptureIT`). It drives the real `OpenApiToolProvider`
+  against live pgvector with DB-derived fixtures: fail-closed with no context; a caller lacking a tool's
+  permission never receives it; granting it does. Compiles in CI; **runs on the alpha stack** (can't
+  execute in the offline sandbox — gated off by default).
+- **Close when:** the IT is run green on alpha (owner confirmed the stack exists) and Gate 3
+  live verification is recorded → Batch D.
 
 ---
 

--- a/pos-mcp-server/docs/mcp-hardening-session-plan.md
+++ b/pos-mcp-server/docs/mcp-hardening-session-plan.md
@@ -19,37 +19,40 @@ Everything except the two rows above can be finished and merged without a live e
 
 ## Batch A — Code-only quick wins (no infra)
 
-### #780 — Remove legacy role-gating  · effort S · risk low
-- Remove the always-empty `roleToolAssignments` field + branch in `MasterAgentRegistry.resolveDomainTools`
-  (~line 61) and the empty-map constructors in `LoadedMasterAgentRegistry`.
-- Drop the unused role-scoped `resolveDomainTools(String, Collection)` overload (`MasterAgentRegistry`
-  ~125–135, `ToolSelectionEngine` ~112–115).
-- New migration `V27` dropping `mcp_role_deprecated` / `mcp_tool_role_deprecated` — **only if the V19
-  retention window has passed** (owner confirm).
-- **Close when:** dead code gone, cashier/manager/admin/`ROLE_USER` selection tests + ArchUnit green.
+### #780 — Remove legacy role-gating  · **code done** · only owner-gated migration remains
+**Verified 2026-07-26 — code removal already complete:** `roleToolAssignments` no longer exists
+anywhere; `LoadedMasterAgentRegistry` does not exist; the two-arg `resolveDomainTools(String,
+Collection)` overload does not exist (only the 1-arg domain resolver); `MasterAgentRegistry.
+resolveDomainTools` has no role branch; `findEnabledByRoleAndWorkflow`/`findAllRoleNames`/
+`ToolRegistryRoleMapper` are gone. Scenario suites (cashier/manager/admin/`ROLE_USER`) pass.
+- **Only remaining:** migration `V27` dropping `mcp_role_deprecated` / `mcp_tool_role_deprecated` —
+  **blocked** on the V19 retention-window decision (owner). Do NOT drop without confirmation.
+- **Close when:** owner confirms the window has passed and the drop migration lands.
 
-### #778 — Workflow state beyond IDLE for gating  · effort S–M · risk low-med
-**Verify first — largely implemented already:** `SessionAgentManager.chat` (line 199) threads persisted
-state via `workflowStateService.resolveActiveState(username)` → 4-arg `selectRoleTools(role, perms,
-message, state)`, heuristic 3-arg only as fallback; `NltiWorkflowStateService.setWorkflowState` (line 62)
-is a real write path. Remaining:
-- Confirm `StreamingSessionAgentManager.streamChat` threads persisted state the same way (parity with
-  `SessionAgentManager`).
-- Confirm the write path is actually **invoked on workflow progression** (find/complete the caller that
-  advances `NltiSession.workflowState` to a non-IDLE state).
-- `MasterAgentRegistryLoader` preloads the active **non-IDLE** states, not just the single
-  `mcp.agent.preload-workflow-state`.
-- **Close when:** a persisted non-IDLE session receives that state's gated tool set — tested for **both**
-  managers.
+### #778 — Workflow state beyond IDLE for gating  · **done**
+**Verified 2026-07-26 — all functional ACs implemented:**
+- **Both** managers thread persisted state: `SessionAgentManager.chat` (line 199) and
+  `StreamingSessionAgentManager.streamChat` (line 167) call `resolveActiveState` → 4-arg
+  `selectRoleTools`, heuristic 3-arg only as fallback.
+- Write path is wired: `NltiWorkflowStateService.advance(...)` is invoked by
+  `NltiController.setWorkflowState` (`POST .../workflow-state`), ownership-checked.
+- `MasterAgentRegistryLoader` defaults `mcp.agent.preload-workflow-state=ALL` and preloads the union
+  across all workflow states (non-IDLE included).
+- Tests: sync persisted-state (`SessionAgentManagerTest`), service + ownership
+  (`NltiWorkflowStateServiceTest`), controller (`NltiControllerTest`), **and now the streaming
+  persisted-state parity test** added this session.
+- **Close when:** merged — no code gaps remain.
 
-### #779 — OpenAPI tools agent-callable (code-only parts)  · effort M · risk low
-- Add an integration test (`*IT`): low-permission caller → chat endpoint → assert a high-permission
-  openapi tool is neither offered nor executed, and an authorized op executes through a **stubbed
-  gateway** (WireMock/local stub). Today the permission-filter assertion lives only at unit level.
-- Fix stale comments in `OpenApiToolProvider` (~38–42) and `RequestScopedUserContext` (~20–25) that still
-  claim the streaming/Reactor path is "not yet wired" — it is (`StreamingSessionAgentManager` sets the
-  ThreadLocal synchronously before resolution).
-- **Close when:** the IT passes and comments are corrected. (Gate 3 live verification → Batch D.)
+### #779 — OpenAPI tools agent-callable (code-only parts)  · **partly done**
+**Verified 2026-07-26 — the stale comments are already fixed:** `OpenApiToolProvider` (~33–43) and
+`RequestScopedUserContext` (~12–27) both now correctly describe streaming as wired (caller published
+synchronously at Flux-assembly time).
+- **Only remaining (code):** integration test (`*IT`): low-permission caller → chat endpoint → assert a
+  high-permission openapi tool is neither offered nor executed, and an authorized op executes through a
+  **stubbed gateway** (WireMock). **Note:** this `*IT` needs an integration harness (Testcontainers
+  Postgres/pgvector + a stubbed embedding backend or recorded mode) that may not run in a code-only
+  sandbox — pair with Batch D's live verification if it can't be exercised here.
+- **Close when:** the IT passes (and Gate 3 live verification → Batch D).
 
 ---
 

--- a/pos-mcp-server/src/main/resources/db/migration/V27__drop_legacy_role_gating.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V27__drop_legacy_role_gating.sql
@@ -1,0 +1,7 @@
+-- Gate 2B / #780: drop the legacy role-gating tables.
+-- V19 renamed mcp_tool_role -> mcp_tool_role_deprecated and mcp_role -> mcp_role_deprecated as a
+-- reversible one-release retention. That retention window has passed and role gating is fully
+-- superseded by permission gating (mcp_tool_permission ∩ mcp_workflow_state), so the deprecated
+-- tables are now removed. Drop the join table first for FK safety. Portable to H2 and Postgres.
+DROP TABLE IF EXISTS mcp_tool_role_deprecated;
+DROP TABLE IF EXISTS mcp_role_deprecated;

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import com.positivity.mcp.internal.domain.ToolSelectionContext;
+import com.positivity.mcp.internal.domain.WorkflowState;
 import com.positivity.mcp.internal.orchestration.agent.MasterAgentRegistry;
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
 import com.positivity.mcp.internal.orchestration.rag.ScopedContentRetrieverFactory;
@@ -276,6 +277,25 @@ class StreamingSessionAgentManagerTest {
         verify(toolRegistryService).resolveCandidateTools(contextCaptor.capture(), eq(3));
         assertThat(contextCaptor.getValue().workflowState()).isEqualTo("IDLE");
         assertThat(roleAgentCacheKeys(selectorManager)).contains("ROLE_CASHIER::InventoryFacadeTool");
+    }
+
+    @Test
+    @DisplayName("streamChat threads the persisted non-IDLE session workflow state into tool selection (#778)")
+    void streamChat_usesPersistedWorkflowState_whenSessionPresent() {
+        String message = "create a purchase order for vendor acme";
+        when(workflowStateService.resolveActiveState("user-1")).thenReturn(Optional.of(WorkflowState.CREATING_PO));
+        when(toolSelectionEngine.selectRoleTools(
+                        eq("ROLE_CASHIER"), eq(PERMISSION_CODES), eq(message), eq(WorkflowState.CREATING_PO)))
+                .thenReturn(
+                        new ToolSelectionEngine.ToolSelectionResult(List.of(), List.of(), WorkflowState.CREATING_PO));
+
+        Flux<String> result = manager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), message);
+
+        assertThat(result).isNotNull();
+        // The persisted session state (not a message heuristic) gates selection, via the 4-arg overload.
+        verify(toolSelectionEngine)
+                .selectRoleTools(eq("ROLE_CASHIER"), eq(PERMISSION_CODES), eq(message), eq(WorkflowState.CREATING_PO));
+        verify(toolSelectionEngine, never()).selectRoleTools("ROLE_CASHIER", PERMISSION_CODES, message);
     }
 
     @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolPermissionGatingIT.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolPermissionGatingIT.java
@@ -1,0 +1,106 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.positivity.mcp.service.CurrentUserContext;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Gate 3 / #779: end-to-end permission gating of OpenAPI-discovered tools. Drives the real
+ * {@link OpenApiToolProvider} against the live pgvector-backed candidate query, moving the
+ * permission-filter assertion from the unit level to integration level.
+ *
+ * <p>Requires the live alpha stack (Postgres + pgvector with discovered/seeded tools + embeddings).
+ * Enabled only with {@code -Dmcp.eval.live=true}; it neither starts a context nor runs in offline CI:
+ *
+ * <pre>
+ *   ./mvnw -o -pl pos-mcp-server test -Dtest=OpenApiToolPermissionGatingIT \
+ *       -Dmcp.eval.live=true -Dspring.profiles.active=alpha
+ * </pre>
+ */
+@SpringBootTest
+@ActiveProfiles("alpha")
+@EnabledIfSystemProperty(named = "mcp.eval.live", matches = "true")
+class OpenApiToolPermissionGatingIT {
+
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-7000-8000-000000000779");
+
+    @Autowired
+    private OpenApiToolProvider openApiToolProvider;
+
+    @Autowired
+    private RequestScopedUserContext requestScopedUserContext;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void clearContext() {
+        requestScopedUserContext.clear();
+    }
+
+    @Test
+    @DisplayName("no request context → fail-closed: zero discovered tools")
+    void failsClosedWithoutRequestContext() {
+        // Holder is empty (no set()); the provider must expose nothing.
+        assertThat(openApiToolProvider.resolveToolCallbacks("how many workorders are open"))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("a caller lacking a tool's permission never receives it; granting it does")
+    void gatesDiscoveredToolByCallerPermission() {
+        // Pick a real discovered, embedded tool that requires a concrete (non-AUTHENTICATED)
+        // permission. Skip cleanly if the live registry has none seeded yet.
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList("""
+                SELECT t.name AS name, t.description AS description, tp.permission_code AS perm
+                FROM mcp_tool t
+                JOIN mcp_tool_permission tp ON tp.tool_id = t.id
+                WHERE t.source = 'openapi' AND t.embedding IS NOT NULL AND tp.permission_code <> 'AUTHENTICATED'
+                LIMIT 1
+                """);
+        assumeTrue(!rows.isEmpty(), "no permission-gated OpenAPI tool discovered on the live stack");
+
+        String toolName = (String) rows.getFirst().get("name");
+        String description = (String) rows.getFirst().get("description");
+        String requiredPermission = (String) rows.getFirst().get("perm");
+
+        // Negative: a caller holding only AUTHENTICATED (not the required permission) must NOT be
+        // offered the tool — even when the query is the tool's own description (the most favourable
+        // case for semantic retrieval).
+        requestScopedUserContext.set(callerWith(Set.of("AUTHENTICATED")));
+        assertThat(toolNames(openApiToolProvider.resolveToolCallbacks(description)))
+                .doesNotContain(toolName);
+        requestScopedUserContext.clear();
+
+        // Positive: granting the required permission makes the tool eligible; querying with its own
+        // description places it among the resolved callbacks.
+        requestScopedUserContext.set(callerWith(Set.of("AUTHENTICATED", requiredPermission)));
+        assertThat(toolNames(openApiToolProvider.resolveToolCallbacks(description)))
+                .contains(toolName);
+    }
+
+    private static List<String> toolNames(List<ToolCallback> callbacks) {
+        return callbacks.stream()
+                .map(callback -> callback.getToolDefinition().name())
+                .toList();
+    }
+
+    private static CurrentUserContext callerWith(Set<String> permissionCodes) {
+        return new CurrentUserContext(
+                "it-user", USER_ID, "ROLE_ADMIN", Set.of("ROLE_ADMIN"), permissionCodes, permissionCodes);
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolPermissionGatingIT.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolPermissionGatingIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.positivity.mcp.service.CurrentUserContext;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,7 +25,8 @@ import org.springframework.test.context.ActiveProfiles;
  * permission-filter assertion from the unit level to integration level.
  *
  * <p>Requires the live alpha stack (Postgres + pgvector with discovered/seeded tools + embeddings).
- * Enabled only with {@code -Dmcp.eval.live=true}; it neither starts a context nor runs in offline CI:
+ * Disabled by default, so offline CI never starts a context; it starts a Spring context (via
+ * {@code @SpringBootTest}) only when {@code -Dmcp.eval.live=true} is set:
  *
  * <pre>
  *   ./mvnw -o -pl pos-mcp-server test -Dtest=OpenApiToolPermissionGatingIT \
@@ -63,16 +65,22 @@ class OpenApiToolPermissionGatingIT {
     @Test
     @DisplayName("a caller lacking a tool's permission never receives it; granting it does")
     void gatesDiscoveredToolByCallerPermission() {
-        // Pick a real discovered, embedded tool that requires a concrete (non-AUTHENTICATED)
-        // permission. Skip cleanly if the live registry has none seeded yet.
+        // Pick a real discovered, embedded tool that requires exactly one, concrete
+        // (non-AUTHENTICATED) permission. Requiring a single permission keeps both assertions exact:
+        // granting that one code is sufficient for the positive case, and a caller without it holds
+        // none of the tool's permissions for the negative case (a multi-permission tool, or one that
+        // also carries an AUTHENTICATED row, would make either assertion flaky since candidate
+        // eligibility matches ANY of a tool's permissions). Skip cleanly if none is seeded yet.
         List<Map<String, Object>> rows = jdbcTemplate.queryForList("""
-                SELECT t.name AS name, t.description AS description, tp.permission_code AS perm
+                SELECT t.name AS name, t.description AS description, MIN(tp.permission_code) AS perm
                 FROM mcp_tool t
                 JOIN mcp_tool_permission tp ON tp.tool_id = t.id
-                WHERE t.source = 'openapi' AND t.embedding IS NOT NULL AND tp.permission_code <> 'AUTHENTICATED'
+                WHERE t.source = 'openapi' AND t.embedding IS NOT NULL
+                GROUP BY t.id, t.name, t.description
+                HAVING COUNT(*) = 1 AND MIN(tp.permission_code) <> 'AUTHENTICATED'
                 LIMIT 1
                 """);
-        assumeTrue(!rows.isEmpty(), "no permission-gated OpenAPI tool discovered on the live stack");
+        assumeTrue(!rows.isEmpty(), "no single-permission OpenAPI tool discovered on the live stack");
 
         String toolName = (String) rows.getFirst().get("name");
         String description = (String) rows.getFirst().get("description");
@@ -100,7 +108,11 @@ class OpenApiToolPermissionGatingIT {
     }
 
     private static CurrentUserContext callerWith(Set<String> permissionCodes) {
-        return new CurrentUserContext(
-                "it-user", USER_ID, "ROLE_ADMIN", Set.of("ROLE_ADMIN"), permissionCodes, permissionCodes);
+        Set<String> roles = Set.of("ROLE_ADMIN");
+        // authorities = roles ∪ permission codes, matching the production CurrentUserContext shape so
+        // the test stays valid if OpenApiToolProvider ever consults authorities.
+        Set<String> authorities = new HashSet<>(permissionCodes);
+        authorities.addAll(roles);
+        return new CurrentUserContext("it-user", USER_ID, "ROLE_ADMIN", roles, authorities, permissionCodes);
     }
 }

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -3820,6 +3820,38 @@ paths:
         - workorder:estimate:view
       x-required-permissions:
       - workorder:estimate:view
+  /v1/workorders/count:
+    get:
+      tags:
+      - Work Order API
+      summary: Count work orders by status
+      description: Count work orders, optionally restricted to specific statuses or to open (non-terminal) work orders only. "Open" means any status except COMPLETED or CANCELLED. Returns a grand total plus a per-status breakdown, computed server-side without listing the work orders.
+      operationId: countWorkorders
+      parameters:
+      - name: openOnly
+        in: query
+        description: Count only open (non-terminal) work orders. Ignored when 'status' is supplied. Defaults to false (count all statuses).
+        required: false
+        schema:
+          type: string
+      - name: status
+        in: query
+        description: Exact statuses to count; repeatable. Takes precedence over 'openOnly'.
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Count returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CountResponse'
+      security:
+      - bearerAuth:
+        - workorder:workorder:view
+      x-required-permissions:
+      - workorder:workorder:view
   /v1/workorders/changeRequests/{changeId}:
     get:
       tags:
@@ -7687,6 +7719,33 @@ components:
       - estimateNumber
       - id
       - status
+    CountGroup:
+      type: object
+      description: A single keyed count within a breakdown.
+      properties:
+        key:
+          type: string
+          description: Group key (e.g. a status name).
+          example: WORK_IN_PROGRESS
+        count:
+          type: integer
+          format: int64
+          description: Count for this key.
+          example: 7
+    CountResponse:
+      type: object
+      description: Aggregate count result with an optional per-key breakdown.
+      properties:
+        total:
+          type: integer
+          format: int64
+          description: Grand total across all groups.
+          example: 42
+        groups:
+          type: array
+          description: Optional per-key breakdown; empty when only a total is requested.
+          items:
+            $ref: '#/components/schemas/CountGroup'
     PageWorkorderStatusView:
       type: object
       properties:


### PR DESCRIPTION
## Capability & Traceability
- Capability: MCP hardening (Batch A/B follow-up; no single `cap:` id)
- Parent STORY (durion): n/a
- Closes: louisburroughs/durion-positivity-backend#778, louisburroughs/durion-positivity-backend#780
- Refs (advanced, not closed): louisburroughs/durion-positivity-backend#779 (permission IT added; Gate 3 live run remains), louisburroughs/durion-positivity-backend#645 (code verified complete; alpha 404 remains)
- Domain: `domain:mcp`, `domain:workorder`

> Follow-up to #1113, which merged only up to the ladder + count endpoint. These commits (streaming #778 test, #780 `V27`, #779 IT, Batch B doc) did not land in that merge; this PR carries them, plus the OpenAPI regen for the already-merged count endpoint.

## Contract References
Contract-relevant: this PR regenerates `pos-workorder/openapi.yaml` and `pos-api-gateway/docs/openapi-aggregate.yaml` for the `GET /v1/workorders/count` operation (merged in #1113 without a spec regen). Contract guidance: `BACKEND_CONTRACT_GUIDE.md` (workorder domain) — the count operation, the shared `CountResponse` DTO, and the `WORKORDER_COUNT` event are the contract surface.
- Durion contract PR (if applicable): n/a

## Contract Chain (Controller changed)
- [x] OpenAPI annotations on the controller (`@Operation`/`@ApiResponse`/`@Parameter` on `WorkorderController.countWorkorders`, merged in #1113)
- [x] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — via `scripts/generate-openapi.sh pos-workorder` (validation: report, clean)
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — separate repo, follow-up there

## Scope
- **OpenAPI regen** — `pos-workorder/openapi.yaml` + the gateway aggregate now include the `/v1/workorders/count` GET operation (params, `CountResponse` response, `x-required-permissions: workorder:workorder:view`) and the `CountResponse`/`CountGroup` schemas. Resolves the contract drift left by #1113 (endpoint merged, spec not regenerated).
- **#780** — `V27__drop_legacy_role_gating.sql` drops `mcp_role_deprecated` / `mcp_tool_role_deprecated` (V19 rename, retention window elapsed per owner). Code removal already landed; this completes it. Validated: full Flyway chain V1→V27 boots clean on H2.
- **#778** — streaming `SessionAgentManager` persisted-workflow-state test (parity with the sync manager). Both managers thread persisted state; write path (`NltiController.setWorkflowState`→`advance`) wired; preload=`ALL` → closes.
- **#779** — `OpenApiToolPermissionGatingIT` (live-gated, `-Dmcp.eval.live=true`, `@ActiveProfiles("alpha")`) drives the real `OpenApiToolProvider` against live pgvector: fail-closed without context; a caller lacking a tool's permission never receives it, granting it does. Gate 3 live run remains before #779 fully closes.
- **#645** — records the Batch B verification (discovery-hardening code items already implemented + tested; only the alpha 404 remains) in `docs/mcp-hardening-session-plan.md`.

## Tests
- [x] Unit tests added/updated (streaming persisted-workflow-state #778)
- [ ] Integration tests — `OpenApiToolPermissionGatingIT` added but **live-gated** (runs on the alpha stack, not offline CI)
- **How to run:**
  - `./mvnw -pl pos-mcp-server -am -Dtest=StreamingSessionAgentManagerTest test`
  - Migration chain (H2): `./mvnw -pl pos-mcp-server -am -Dit.test=NltiRequestServiceIT -DskipITs=false -DskipTests=true verify`
  - OpenAPI regen: `scripts/generate-openapi.sh pos-workorder`
  - Live (alpha): `./mvnw -o -pl pos-mcp-server test -Dtest=OpenApiToolPermissionGatingIT -Dmcp.eval.live=true -Dspring.profiles.active=alpha`

## Risk & Rollback
- **Risk level:** Low
- `V27` drops tables V19 already renamed out of runtime use (unqueried); retention elapsed. The OpenAPI regen is generated output (additions only, +63 lines). Tests/doc carry no runtime risk.
- **Rollback plan:** revert the branch. `V27` is a forward drop; a rollback would restore from V19's renamed tables if the window were reopened.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no (agent branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — no CAP id for this hardening work
- [x] Links to related issues present (Closes #778, #780; Refs #779, #645)
- [x] Contract guide referenced (`BACKEND_CONTRACT_GUIDE.md`); `openapi.yaml` + aggregate regenerated
- [ ] Required CI checks passing — pending CI