### PR TITLE
fix(openapi): publish workorder count `status` filter as a repeatable enum array

### DIFF
--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -3840,7 +3840,19 @@ paths:
         description: Exact statuses to count; repeatable. Takes precedence over 'openOnly'.
         required: false
         schema:
-          type: string
+          type: array
+          items:
+            type: string
+            enum:
+            - DRAFT
+            - APPROVED
+            - ASSIGNED
+            - WORK_IN_PROGRESS
+            - AWAITING_PARTS
+            - AWAITING_APPROVAL
+            - READY_FOR_PICKUP
+            - COMPLETED
+            - CANCELLED
       responses:
         '200':
           description: Count returned successfully.

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
@@ -22,6 +22,7 @@ import com.positivity.workorder.service.WorkorderInvoiceService;
 import com.positivity.workorder.service.WorkorderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -83,7 +84,9 @@ public class WorkorderController {
                             schema = @Schema(type = "boolean", defaultValue = "false"))
                     @RequestParam(defaultValue = "false")
                     boolean openOnly,
-            @Parameter(description = "Exact statuses to count; repeatable. Takes precedence over 'openOnly'.")
+            @Parameter(
+                            description = "Exact statuses to count; repeatable. Takes precedence over 'openOnly'.",
+                            array = @ArraySchema(schema = @Schema(implementation = WorkorderStatus.class)))
                     @RequestParam(required = false)
                     @Nullable
                     Set<WorkorderStatus> status) {


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (follow-up to #1116)
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:workorder`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/workorder/.business-rules/BACKEND_CONTRACT_GUIDE.md` → work order count filters. No behavioural change: Spring already binds repeated `status=` parameters into `Set<WorkorderStatus>`; only the published parameter schema is corrected.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` regenerated (aggregate indexes module specs by `$ref`, unchanged)
- [x] Angular SDK regenerated — already merged as louisburroughs/durion-positivity-sdk-angular#30

## Scope
- What changed: `WorkorderController.countWorkorders` pins the `status` parameter with `@ArraySchema(schema = @Schema(implementation = WorkorderStatus.class))`; `pos-workorder/openapi.yaml` regenerated so `status` emits `type: array` with the status enum as `items`.
- Why: this commit was pushed to the #1116 branch after that PR's merge commit was created, so it did not land. Backend `main` currently publishes `status` as a scalar `string` while the merged SDK (`durion-positivity-sdk-angular` `b54c550`) types it as `Array<'DRAFT' | ... | 'CANCELLED'>`. This PR closes that gap.

Original review context: louisburroughs/durion-positivity-sdk-angular#30 (review comment on `workOrderAPI.service.ts`).

## Tests
- [ ] Unit tests added/updated (annotation + regenerated spec only, no behavioural change)
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run:
  - `./mvnw -pl pos-workorder -am -DskipTests compile` — clean
  - `./mvnw -pl pos-workorder -am -DskipTests=false test` — 366 + 37 tests passed on the identical change before the #1116 merge
  - `scripts/generate-openapi.sh --no-permissions --no-aggregate pos-workorder` — spec regenerates cleanly

## Risk & Rollback
- Risk level: Low
- Rollback plan: revert the commit; the spec reverts with it.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` (not a capability run)
- [ ] PR title starts with `[CAP:<cap-id>]` (not a capability run)
- [ ] Links to parent + child issues are present (follow-up to #1116)
- [x] Contract guide updated (no semantic change)
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCuQzpQRrmXm4WdARBMaZL