### PR TITLE
pos-mcp-server: confirm recall@k floor at production 0.55 threshold (#783 AC3)

### DIFF
--- a/pos-mcp-server/docs/mcp-hardening-session-plan.md
+++ b/pos-mcp-server/docs/mcp-hardening-session-plan.md
@@ -120,9 +120,14 @@ synchronously at Flux-assembly time).
     observed, matching the hit@5/MRR convention) in `eval_live.py` (`EVAL_MIN_RECALL`) and
     `BaselineCaptureIT` (`-Dmcp.eval.min-recall`).
   - **Corpus fix:** alpha preloaded only 6 of the 17 catalog docs (`application-alpha.yml` lagged
-    `application.yml`); synced to full parity. Baseline captured on a Python-seeded corpus
+    `application.yml`); synced to full parity. Baseline first captured on a Python-seeded corpus
     (`scripts/rag_seed.py`, faithful to `DocumentEmbeddingIngestor` chunking + metadata) to validate
-    pre-merge; matches what the preload will produce once the config change is merged and redeployed.
+    pre-merge.
+  - **Confirmed post-merge (#1117 deployed to alpha):** preload repopulated all 17 docs cleanly (each
+    once under its own scope, no `master` duplicates), and recall@k re-ran at the **production
+    similarity floor 0.55** = **0.9574** — identical to the 0.0-threshold run, so expected docs clear
+    0.55 comfortably. The **0.85 floor holds** (default made non-report-only in `eval_live.py` /
+    `BaselineCaptureIT`).
 - **Threshold gate (close item 2): scheduled runner wired (option C).** `scripts/eval-cron.sh` runs
   `eval_live.py` on a cron on the alpha host — the only place with network access to alpha's localhost
   pgvector + Ollama (GitHub-hosted runners can't reach them, and there's no self-hosted runner). Quiet
@@ -130,9 +135,9 @@ synchronously at Flux-assembly time).
   on any floor breach or forbidden leak. A per-PR blocking gate (ephemeral pgvector+Ollama services, or
   a recorded-fixture snapshot) remains a follow-up — recall@k is seedable in CI today via
   `rag_seed.py`; tool-selection needs a `mcp_tool` embedding seed first.
-- **Close when:** the config sync is merged + redeployed to alpha (preload repopulates the 17-doc
-  corpus, confirmed by re-running the eval), and the scheduled gate is installed on alpha (crontab
-  entry per `eval-cron.sh`).
+- **Close when:** ~~config sync merged + redeployed to alpha (preload repopulates the 17-doc corpus,
+  confirmed by re-running the eval)~~ **done (#1117, recall@k 0.9574 @ 0.55)** — only the scheduled
+  gate install on alpha remains (crontab entry per `eval-cron.sh`).
 
 ### #784 — Hybrid dense + BM25 retrieval  · effort L · **depends on #783** · priority low
 - Add a lexical `QueryDocumentRetriever` (Postgres FTS `tsvector` + `ts_rank` / `websearch_to_tsquery`),

--- a/pos-mcp-server/docs/mcp-hardening-session-plan.md
+++ b/pos-mcp-server/docs/mcp-hardening-session-plan.md
@@ -116,9 +116,9 @@ synchronously at Flux-assembly time).
     hard-fail (security invariant); the recall floor is report-only (`EVAL_MIN_RECALL` /
     `-Dmcp.eval.min-recall`, default 0.0) until calibrated.
   - **Captured live on alpha 2026-07-26: recall@k = 0.9574** (47 scored, forbidden_violations = 0),
-    alongside hit@5 0.84 / MRR 0.77 / permission_gating_779 PASS. Floor set to **0.85** (~10% below
-    observed, matching the hit@5/MRR convention) in `eval_live.py` (`EVAL_MIN_RECALL`) and
-    `BaselineCaptureIT` (`-Dmcp.eval.min-recall`).
+    alongside hit@5 0.84 / MRR 0.77 / permission_gating_779 PASS. Floor set to **0.85** (~11% below the
+    observed 0.9574 — same margin as hit@5 0.84→0.75; MRR uses a wider 0.77→0.65 as it's rank-sensitive)
+    in `eval_live.py` (`EVAL_MIN_RECALL`) and `BaselineCaptureIT` (`-Dmcp.eval.min-recall`).
   - **Corpus fix:** alpha preloaded only 6 of the 17 catalog docs (`application-alpha.yml` lagged
     `application.yml`); synced to full parity. Baseline first captured on a Python-seeded corpus
     (`scripts/rag_seed.py`, faithful to `DocumentEmbeddingIngestor` chunking + metadata) to validate

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/eval/BaselineCaptureIT.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/eval/BaselineCaptureIT.java
@@ -211,7 +211,7 @@ class BaselineCaptureIT {
                 .as("forbidden (permission-negative) RAG docs must never be visible")
                 .isEmpty();
 
-        // AC3 (#783) recall floor — 0.85, ~10% below the live baseline recall@k 0.9574. Confirmed at
+        // AC3 (#783) recall floor — 0.85, ~11% below the live baseline recall@k 0.9574. Confirmed at
         // the production similarity floor (0.55, above) on the preload-repopulated corpus: identical to
         // the 0.0-threshold run, so the floor holds. Override with -Dmcp.eval.min-recall.
         double minRecall = Double.parseDouble(System.getProperty("mcp.eval.min-recall", "0.85"));

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/eval/BaselineCaptureIT.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/eval/BaselineCaptureIT.java
@@ -211,9 +211,9 @@ class BaselineCaptureIT {
                 .as("forbidden (permission-negative) RAG docs must never be visible")
                 .isEmpty();
 
-        // AC3 (#783) recall floor. NOTE: 0.85 was measured at similarity 0.0; re-confirm against a
-        // fresh live run now that the retriever scores at the production floor (0.55, above).
-        // Override with -Dmcp.eval.min-recall.
+        // AC3 (#783) recall floor — 0.85, ~10% below the live baseline recall@k 0.9574. Confirmed at
+        // the production similarity floor (0.55, above) on the preload-repopulated corpus: identical to
+        // the 0.0-threshold run, so the floor holds. Override with -Dmcp.eval.min-recall.
         double minRecall = Double.parseDouble(System.getProperty("mcp.eval.min-recall", "0.85"));
         assertThat(recallAtK).as("RAG recall@k floor").isGreaterThanOrEqualTo(minRecall);
     }

--- a/scripts/eval_live.py
+++ b/scripts/eval_live.py
@@ -266,11 +266,12 @@ def main():
 
     # AC4 (#783) thresholds — calibrated from the live baseline (hit@5 0.84 / MRR 0.77),
     # set with margin below observed. Override with EVAL_MIN_HIT5 / EVAL_MIN_MRR.
-    # Floors calibrated from the live alpha baseline (17-doc corpus): hit@5 0.84, MRR 0.77, recall@k
-    # 0.9574 — each set ~10% below observed. Recall confirmed at the production RAG_MIN_SCORE=0.55 floor
-    # on the preload-repopulated corpus (identical to the 0.0-threshold run: expected docs clear 0.55
-    # comfortably). RAG forbidden leaks are always a hard fail. Override with EVAL_MIN_HIT5 /
-    # EVAL_MIN_MRR / EVAL_MIN_RECALL.
+    # Floors calibrated with margin below the live alpha baseline (17-doc corpus):
+    #   hit@5   0.84 -> 0.75  (~11%),  recall@k 0.9574 -> 0.85 (~11%),  MRR 0.77 -> 0.65 (~16%, wider —
+    #   MRR is rank-sensitive so it gets more headroom). Recall confirmed at the production
+    #   RAG_MIN_SCORE=0.55 floor on the preload-repopulated corpus (identical to the 0.0-threshold run:
+    #   expected docs clear 0.55 comfortably). RAG forbidden leaks are always a hard fail.
+    # Override with EVAL_MIN_HIT5 / EVAL_MIN_MRR / EVAL_MIN_RECALL.
     floor_hit5 = float(os.environ.get("EVAL_MIN_HIT5", "0.75"))
     floor_mrr = float(os.environ.get("EVAL_MIN_MRR", "0.65"))
     floor_recall = float(os.environ.get("EVAL_MIN_RECALL", "0.85"))

--- a/scripts/eval_live.py
+++ b/scripts/eval_live.py
@@ -266,10 +266,11 @@ def main():
 
     # AC4 (#783) thresholds — calibrated from the live baseline (hit@5 0.84 / MRR 0.77),
     # set with margin below observed. Override with EVAL_MIN_HIT5 / EVAL_MIN_MRR.
-    # Floors calibrated from the live alpha baseline (17-doc corpus): hit@5 0.84, MRR 0.77 — each set
-    # ~10% below observed. RAG forbidden leaks are always a hard fail. Override with EVAL_MIN_HIT5 /
-    # EVAL_MIN_MRR / EVAL_MIN_RECALL. NOTE: the recall floor (0.85) was measured at similarity 0.0;
-    # re-confirm it against a fresh live run now that RAG_MIN_SCORE defaults to the production 0.55.
+    # Floors calibrated from the live alpha baseline (17-doc corpus): hit@5 0.84, MRR 0.77, recall@k
+    # 0.9574 — each set ~10% below observed. Recall confirmed at the production RAG_MIN_SCORE=0.55 floor
+    # on the preload-repopulated corpus (identical to the 0.0-threshold run: expected docs clear 0.55
+    # comfortably). RAG forbidden leaks are always a hard fail. Override with EVAL_MIN_HIT5 /
+    # EVAL_MIN_MRR / EVAL_MIN_RECALL.
     floor_hit5 = float(os.environ.get("EVAL_MIN_HIT5", "0.75"))
     floor_mrr = float(os.environ.get("EVAL_MIN_MRR", "0.65"))
     floor_recall = float(os.environ.get("EVAL_MIN_RECALL", "0.85"))


### PR DESCRIPTION
## Capability & Traceability
- Capability: MCP hardening (retrieval-quality eval; no single `cap:` id)
- Parent STORY (durion): n/a
- Refs (advanced, not closed): louisburroughs/durion-positivity-backend#783 (AC1–AC4 done + live-confirmed; only the scheduled cron gate install on alpha remains)
- Domain: `domain:mcp`

## Contract References
Not contract-relevant: docs- and test-comment-only. No controllers, DTOs, `*Request`/`*Response`, events, `openapi.yaml`, or schema files change.

## Contract Chain (when a Controller changed)
- N/A — no controller changed.

## Scope
- **What changed:** records the post-deploy confirmation of #783 AC3, following #1117's merge and the alpha redeploy.
  - After the redeploy, the static preload repopulated all 17 catalog docs cleanly — each once under its own `rag_scope`, no `master` duplicates (verified via `rag_diag.py`).
  - `eval_live.py` re-ran at the **production similarity floor `RAG_MIN_SCORE=0.55`**: **recall@k = 0.9574** (47 scored, 0 forbidden violations) — identical to the earlier 0.0-threshold run, i.e. every expected doc clears 0.55 comfortably. The provisional **0.85 floor holds**.
  - Updates the now-stale "re-confirm against a fresh live run" notes in `eval_live.py` and `BaselineCaptureIT` to record the confirmation, and marks the redeploy close-item done in `docs/mcp-hardening-session-plan.md`.
- **Why:** close the loop on the recall floor calibration; the threshold change landed in #1117 with a hedge to re-confirm, and the live run has now confirmed it.

## Tests
- [ ] Unit tests added/updated — n/a (comment/doc only)
- [ ] Integration tests added/updated — n/a; `BaselineCaptureIT` behavior unchanged (comment only). Live re-run evidence: `eval_live.py` `rag_retrieval.recall_at_k = 0.9574` at `RAG_MIN_SCORE=0.55` on alpha.
- **How to run (live, alpha):** `ENV_FILE=/path/.env OLLAMA_EMBEDDING_BASE_URL=… python3 scripts/eval_live.py`

## Risk & Rollback
- **Risk level:** Low — comments and a planning doc only; no production or test behavior changes.
- **Rollback plan:** revert the branch.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no (agent branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — no CAP id for this hardening work
- [x] Links to related issues present (Refs #783)
- [x] Contract guide updated — n/a (no contract semantics changed)
- [ ] Required CI checks passing — pending CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9hcDusfL8raMjfb8mosnG)_