### PR TITLE
pos-mcp-server: gateway-routing IT + route check for OpenAPI tools (#645)

### DIFF
--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolGatewayRoutingIT.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolGatewayRoutingIT.java
@@ -34,7 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
  *
  * <p>A gateway that matched the route but rejected auth returns 401/403; a matched route with missing
  * query params returns 400; a healthy call returns 2xx. All of those prove the route resolved — only
- * an unmatched route 404s. So a bearer token is <em>optional</em>: supply {@code -Dmcp.eval.bearer=<jwt>}
+ * an unmatched route 404s. So a bearer token is <em>optional</em>: supply {@code -Dmcp.eval.bearer=&lt;jwt&gt;}
  * (or {@code MCP_EVAL_BEARER}) to additionally exercise the downstream service (expect 2xx); without
  * it the 401/403 still proves routing.
  *
@@ -46,7 +46,7 @@ import org.springframework.test.context.ActiveProfiles;
  * <pre>
  *   POS_MCP_DB_HOST=... POS_MCP_DB_PASSWORD=... OLLAMA_EMBEDDING_BASE_URL=... \
  *   ./mvnw -pl pos-mcp-server test -Dtest=OpenApiToolGatewayRoutingIT \
- *       -Dmcp.eval.live=true -Dspring.profiles.active=alpha [-Dmcp.eval.bearer=<jwt>]
+ *       -Dmcp.eval.live=true -Dspring.profiles.active=alpha [-Dmcp.eval.bearer=&lt;jwt&gt;]
  * </pre>
  */
 @SpringBootTest(
@@ -136,11 +136,13 @@ class OpenApiToolGatewayRoutingIT {
                         || lower.contains("no instance available")),
                 "gateway not reachable from this host (infra, not a #645 routing failure): " + result);
 
-        // The #645 assertion: the discovered path resolved through the gateway (no 404 Not Found).
+        // The #645 assertion: the discovered path resolved through the gateway (no 404).
         // A 2xx body, or a routed 400/401/403/5xx, all pass; only an unmatched route surfaces a 404.
-        assertThat(result)
+        // Match the status token, not the reason phrase — the WebClient error message renders the
+        // reason case-variantly ("404 Not Found" vs "404 NOT_FOUND"), so key off the lowercased "404".
+        assertThat(lower)
                 .as("#645: discovered op %s [GET %s] must route through the gateway without a 404", toolName, httpPath)
-                .doesNotContain("404 Not Found");
+                .doesNotContain("404");
     }
 
     private static String bearerHeader() {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolGatewayRoutingIT.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolGatewayRoutingIT.java
@@ -1,0 +1,162 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.positivity.mcp.service.CurrentUserContext;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * #645: end-to-end verification that an OpenAPI-discovered tool invokes <em>through the gateway</em>
+ * with no routing 404 — the failure mode #645 exists to rule out (a discovered op whose persisted
+ * execution coordinates don't line up with a live gateway route). Drives the real
+ * {@link OpenApiToolProvider} → {@code OpenApiOperationExecutor} → {@code OperationProxyFactory}
+ * against the live gateway, so it exercises exactly the production invocation path.
+ *
+ * <p><strong>Read-only / side-effect-free:</strong> only a discovered <em>GET</em> op with no path
+ * parameters is selected (a collection/list/count endpoint), so the call mutates nothing and a
+ * healthy route returns 2xx rather than a legitimate resource-level 404 — making a {@code 404 Not
+ * Found} an unambiguous routing miss.
+ *
+ * <p>A gateway that matched the route but rejected auth returns 401/403; a matched route with missing
+ * query params returns 400; a healthy call returns 2xx. All of those prove the route resolved — only
+ * an unmatched route 404s. So a bearer token is <em>optional</em>: supply {@code -Dmcp.eval.bearer=<jwt>}
+ * (or {@code MCP_EVAL_BEARER}) to additionally exercise the downstream service (expect 2xx); without
+ * it the 401/403 still proves routing.
+ *
+ * <p>Requires the live alpha stack (Postgres + pgvector with discovered tools + embeddings, and a
+ * reachable gateway at the discovered {@code service_id} base URI). Disabled by default; starts a
+ * context only with {@code -Dmcp.eval.live=true}. Boots lean + read-only (Flyway/web/Eureka/permission
+ * registration off), same as {@link OpenApiToolPermissionGatingIT}.
+ *
+ * <pre>
+ *   POS_MCP_DB_HOST=... POS_MCP_DB_PASSWORD=... OLLAMA_EMBEDDING_BASE_URL=... \
+ *   ./mvnw -pl pos-mcp-server test -Dtest=OpenApiToolGatewayRoutingIT \
+ *       -Dmcp.eval.live=true -Dspring.profiles.active=alpha [-Dmcp.eval.bearer=<jwt>]
+ * </pre>
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {
+            "spring.flyway.enabled=false",
+            "pos.security.permission-registration.enabled=false",
+            "eureka.client.enabled=false"
+        })
+@ActiveProfiles("alpha")
+@EnabledIfSystemProperty(named = "mcp.eval.live", matches = "true")
+class OpenApiToolGatewayRoutingIT {
+
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-7000-8000-000000000645");
+
+    @Autowired
+    private OpenApiToolProvider openApiToolProvider;
+
+    @Autowired
+    private RequestScopedUserContext requestScopedUserContext;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void clearContext() {
+        requestScopedUserContext.clear();
+    }
+
+    @Test
+    @DisplayName("a discovered GET op invokes through the gateway with no routing 404 (#645)")
+    void discoveredGetOpRoutesThroughGatewayWithoutNotFound() {
+        // Pick a real discovered, embedded GET op with NO path parameters (a collection/list/count
+        // endpoint), so the call is side-effect-free and a healthy route returns 2xx — making any
+        // 404 an unambiguous routing miss rather than a legitimate "resource not found". Requires a
+        // grantable permission so the provider will surface it. Skip cleanly if none is seeded.
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList("""
+                SELECT t.id AS id, t.name AS name, t.description AS description,
+                       t.http_path AS http_path, t.service_id AS service_id
+                FROM mcp_tool t
+                WHERE t.source = 'openapi' AND t.enabled AND t.embedding IS NOT NULL
+                  AND t.http_method = 'GET'
+                  AND t.http_path NOT LIKE '%{%'
+                  AND t.service_id IS NOT NULL
+                  AND EXISTS (SELECT 1 FROM mcp_tool_permission tp WHERE tp.tool_id = t.id)
+                ORDER BY t.name
+                LIMIT 1
+                """);
+        assumeTrue(!rows.isEmpty(), "no parameter-free GET OpenAPI tool discovered on the live stack");
+
+        Map<String, Object> op = rows.getFirst();
+        UUID toolId = (UUID) op.get("id");
+        String toolName = (String) op.get("name");
+        String description = (String) op.get("description");
+        String httpPath = (String) op.get("http_path");
+
+        // Grant exactly the op's required permissions (∪ AUTHENTICATED) so the provider offers it, and
+        // relay a bearer token if one was supplied (lets the gateway execute the op as the caller).
+        Set<String> perms = new HashSet<>(jdbcTemplate.queryForList(
+                "SELECT permission_code FROM mcp_tool_permission WHERE tool_id = ?", String.class, toolId));
+        perms.add("AUTHENTICATED");
+        requestScopedUserContext.set(callerWith(perms), bearerHeader());
+
+        // Query with the op's own description so semantic retrieval ranks it among the candidates.
+        ToolCallback callback = openApiToolProvider.resolveToolCallbacks(description).stream()
+                .filter(cb -> cb.getToolDefinition().name().equals(toolName))
+                .findFirst()
+                .orElse(null);
+        assumeTrue(
+                callback != null,
+                "discovered GET op '" + toolName + "' not surfaced for its own description; cannot drive routing");
+
+        // Invoke through the real executor → OperationProxyFactory → gateway. Empty args: a param-free
+        // GET needs none, and any missing query params yield a downstream 400 (still a routed response).
+        String result = callback.call("{}");
+        String lower = result.toLowerCase(Locale.ROOT);
+
+        // Distinguish an infra problem (gateway unreachable from this host) from a #645 routing miss —
+        // the former is not what this test asserts, so skip rather than fail.
+        assumeTrue(
+                !(lower.contains("connection")
+                        || lower.contains("timed out")
+                        || lower.contains("timeout")
+                        || lower.contains("unknownhost")
+                        || lower.contains("unable to resolve")
+                        || lower.contains("i/o error")
+                        || lower.contains("no instance available")),
+                "gateway not reachable from this host (infra, not a #645 routing failure): " + result);
+
+        // The #645 assertion: the discovered path resolved through the gateway (no 404 Not Found).
+        // A 2xx body, or a routed 400/401/403/5xx, all pass; only an unmatched route surfaces a 404.
+        assertThat(result)
+                .as("#645: discovered op %s [GET %s] must route through the gateway without a 404", toolName, httpPath)
+                .doesNotContain("404 Not Found");
+    }
+
+    private static String bearerHeader() {
+        String raw = System.getProperty("mcp.eval.bearer", System.getenv("MCP_EVAL_BEARER"));
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        String trimmed = raw.trim();
+        return trimmed.regionMatches(true, 0, "Bearer ", 0, "Bearer ".length()) ? trimmed : "Bearer " + trimmed;
+    }
+
+    private static CurrentUserContext callerWith(Set<String> permissionCodes) {
+        Set<String> roles = Set.of("ROLE_ADMIN");
+        // authorities = roles ∪ permission codes, matching the production CurrentUserContext shape.
+        Set<String> authorities = new HashSet<>(permissionCodes);
+        authorities.addAll(roles);
+        return new CurrentUserContext("it-user", USER_ID, "ROLE_ADMIN", roles, authorities, permissionCodes);
+    }
+}

--- a/scripts/gateway_route_check.py
+++ b/scripts/gateway_route_check.py
@@ -18,6 +18,7 @@ Config (reuses eval_live's DB/.env resolution):
                 stored service_id is a docker-internal host (http://pos-api-gateway:8080) the Python
                 host can't resolve. If unset, each op's own service_id is used.
   MCP_EVAL_BEARER  optional bearer token relayed as Authorization (get a full 2xx instead of 401).
+  GATEWAY_TIMEOUT  per-request timeout in seconds (default 20); raise it for slow/remote gateways.
 
 Usage:
   ENV_FILE=/opt/durion/alpha/.env GATEWAY_URL=http://localhost:8080 \

--- a/scripts/gateway_route_check.py
+++ b/scripts/gateway_route_check.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""#645 live check without the JVM: verify OpenAPI-discovered tools invoke through the gateway with
+zero routing 404s. Python-only alternative to OpenApiToolGatewayRoutingIT for hosts with Python but
+no JDK. More thorough than the IT — it checks *every* eligible discovered op, not just one.
+
+What it does (mirrors OperationProxyFactory.executeRequest for a param-free GET): for each discovered
+op (`mcp_tool.source='openapi'`) that is a GET with no path parameters, it issues
+`GET {service_id}{http_path}` relaying only the Authorization header (no X-Authorities etc.), and
+records the status. A gateway that matched the route returns 2xx (healthy), or 400/401/403 (routed but
+rejected) — only an *unmatched* route 404s. So any 404 is a #645 routing miss.
+
+Read-only / side-effect-free: only GETs with no `{path params}` are called (collection/list/count
+endpoints), so nothing is mutated and a healthy route returns 2xx rather than a legitimate resource
+404 — making a 404 unambiguous. Non-GET and parameterised ops are skipped and reported.
+
+Config (reuses eval_live's DB/.env resolution):
+  GATEWAY_URL   override the base to a host-reachable gateway (e.g. http://localhost:8080) when the
+                stored service_id is a docker-internal host (http://pos-api-gateway:8080) the Python
+                host can't resolve. If unset, each op's own service_id is used.
+  MCP_EVAL_BEARER  optional bearer token relayed as Authorization (get a full 2xx instead of 401).
+
+Usage:
+  ENV_FILE=/opt/durion/alpha/.env GATEWAY_URL=http://localhost:8080 \
+      MCP_EVAL_BEARER=<jwt> python3 scripts/gateway_route_check.py
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+import eval_live as E  # reuse DB_* config + .env resolution
+
+GATEWAY_URL = os.environ.get("GATEWAY_URL", "").rstrip("/")
+TIMEOUT = int(os.environ.get("GATEWAY_TIMEOUT", "20"))
+
+
+def bearer():
+    raw = os.environ.get("MCP_EVAL_BEARER") or E.env_file("MCP_EVAL_BEARER")
+    if not raw:
+        return None
+    raw = raw.strip()
+    return raw if raw.lower().startswith("bearer ") else "Bearer " + raw
+
+
+def probe(base, path, token):
+    """GET base+path relaying only Authorization. Returns (status|None, url, error|None)."""
+    url = base.rstrip("/") + path
+    req = urllib.request.Request(url, method="GET")
+    if token:
+        req.add_header("Authorization", token)
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return resp.status, url, None
+    except urllib.error.HTTPError as e:
+        return e.code, url, None  # 4xx/5xx: the route resolved and the service/gateway answered
+    except Exception as e:  # URLError, timeout, DNS — infra, not a routing verdict
+        return None, url, f"{type(e).__name__}: {e}"
+
+
+def main():
+    try:
+        import pg8000.native
+    except ImportError:
+        sys.exit("Missing driver. Run:  pip install --user pg8000")
+    if not E.DB_USER or not E.DB_PASS:
+        sys.exit("Could not resolve DB user/password (env or .env). Set ENV_FILE=/opt/durion/alpha/.env")
+
+    con = pg8000.native.Connection(
+        user=E.DB_USER, password=E.DB_PASS, host=E.DB_HOST, port=E.DB_PORT, database=E.DB_NAME
+    )
+    token = bearer()
+    print(f"DB={E.DB_USER}@{E.DB_HOST}:{E.DB_PORT}/{E.DB_NAME}  "
+          f"gateway_override={GATEWAY_URL or '(use each op service_id)'}  bearer={'yes' if token else 'no'}\n")
+
+    rows = con.run(
+        """
+        SELECT name, http_method, http_path, service_id
+        FROM mcp_tool
+        WHERE source = 'openapi' AND enabled
+          AND http_path IS NOT NULL AND service_id IS NOT NULL
+        ORDER BY name
+        """
+    )
+    con.close()
+
+    routed, not_found, unreachable = [], [], []
+    skipped_write, skipped_params = 0, 0
+
+    for name, method, path, service_id in rows:
+        if (method or "").upper() != "GET":
+            skipped_write += 1           # never call write ops against a live gateway
+            continue
+        if "{" in path:
+            skipped_params += 1          # needs path values; skip for an unambiguous signal
+            continue
+        base = GATEWAY_URL or service_id
+        status, url, err = probe(base, path, token)
+        entry = {"name": name, "path": path, "url": url, "status": status}
+        if err is not None:
+            unreachable.append({**entry, "error": err})
+        elif status == 404:
+            not_found.append(entry)
+        else:
+            routed.append(entry)
+
+    result = {
+        "checked": len(routed) + len(not_found),
+        "routed_ok": len(routed),
+        "not_found_violations": not_found,     # the #645 failures
+        "unreachable": unreachable,
+        "skipped_write_ops": skipped_write,
+        "skipped_path_param_ops": skipped_params,
+        "status_breakdown": _breakdown(routed),
+    }
+    out = E.ROOT / "pos-mcp-server/target/eval/gateway-route-check.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))
+    print(f"\nwrote {out}")
+
+    if not_found:
+        print(f"\n#645 FAIL: {len(not_found)} discovered op(s) 404'd through the gateway "
+              f"(routing miss): {[v['name'] for v in not_found]}")
+        sys.exit(1)
+    if result["checked"] == 0 and unreachable:
+        print("\nINCONCLUSIVE: gateway unreachable from this host — set GATEWAY_URL to a reachable "
+              "gateway (e.g. http://localhost:8080).")
+        sys.exit(2)
+    if result["checked"] == 0:
+        print("\nINCONCLUSIVE: no param-free GET openapi ops discovered to check.")
+        sys.exit(2)
+    print(f"\n#645 OK: {result['checked']} discovered op(s) routed through the gateway, zero 404s.")
+
+
+def _breakdown(routed):
+    counts = {}
+    for e in routed:
+        counts[str(e["status"])] = counts.get(str(e["status"]), 0) + 1
+    return counts
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Capability & Traceability
- Capability: MCP hardening (OpenAPI tool gateway-routing verification; no single `cap:` id)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#645
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not contract-relevant: adds a disabled-by-default integration test and a standalone ops script only. No controllers, DTOs, `*Request`/`*Response`, events, `openapi.yaml`, or schema/validation models change.

## Contract Chain (when a Controller changed)
- N/A — no controller changed.

## Scope
- **What changed:** end-to-end verification that an OpenAPI-discovered MCP tool invokes **through the gateway** without a routing 404 — the failure mode #645 exists to rule out (a discovered op whose persisted execution coordinates don't line up with a live gateway route).
  - `OpenApiToolGatewayRoutingIT` (`pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/`): drives the real `OpenApiToolProvider` → `OpenApiOperationExecutor` → `OperationProxyFactory` against the live gateway. Selects a discovered, embedded, **parameter-free GET** op so the call is side-effect-free and a healthy route returns 2xx — making any `404 Not Found` an unambiguous routing miss rather than a legitimate resource-level 404. Disabled by default; boots a lean, read-only context (Flyway/web/Eureka/permission-registration off) only under `-Dmcp.eval.live=true`, matching the sibling `OpenApiToolPermissionGatingIT`. A bearer token is optional — a matched-but-unauthenticated route still returns 401/403, which proves routing; supply `-Dmcp.eval.bearer=<jwt>` to additionally exercise the downstream service (expect 2xx).
  - `scripts/gateway_route_check.py`: standalone operational check that each persisted OpenAPI tool's `(service_id, http_path)` resolves to a live gateway route, for use outside the JVM/test harness.
- **Why:** give #645 a repeatable, side-effect-free routing check at both layers (in-JVM IT + out-of-band script), so a discovered-op/route mismatch is caught rather than surfacing as a runtime 404.

## Tests
- [ ] Unit tests added/updated — n/a
- [x] Integration tests added/updated — `OpenApiToolGatewayRoutingIT` (live-gated, disabled by default; compiles into the build)
- [ ] Provider behavioral contract tests added/updated — n/a
- **How to run (live, alpha):**
  ```
  POS_MCP_DB_HOST=... POS_MCP_DB_PASSWORD=... OLLAMA_EMBEDDING_BASE_URL=... \
    ./mvnw -pl pos-mcp-server test -Dtest=OpenApiToolGatewayRoutingIT \
        -Dmcp.eval.live=true -Dspring.profiles.active=alpha [-Dmcp.eval.bearer=<jwt>]
  ```

## Risk & Rollback
- **Risk level:** Low — a disabled-by-default test and a standalone script; no production or default-CI behavior changes.
- **Rollback plan:** revert the branch.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no (agent branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — no CAP id for this hardening work
- [x] Links to related issues are present (Refs #645)
- [x] Contract guide updated — n/a (no contract semantics changed)
- [ ] Required CI checks passing — pending CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9hcDusfL8raMjfb8mosnG)_