### PR TITLE
pos-mcp-server: prune orphaned OpenAPI tools during discovery (#1121)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
@@ -2,6 +2,7 @@ package com.positivity.mcp.internal.repository;
 
 import com.positivity.mcp.internal.domain.DiscoveredOperation;
 import com.positivity.mcp.internal.domain.ToolMetadata;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -32,6 +33,19 @@ public interface ToolMetadataRepository {
      */
     @NonNull
     UUID upsertDiscoveredOperation(@NonNull DiscoveredOperation operation, @NonNull String domain);
+
+    /**
+     * #1121: reconciles the discovered-tool set to the current run. Deletes every
+     * {@code source='openapi'} {@code mcp_tool} row whose name is NOT in {@code keptNames} (and its FK
+     * children), removing orphans left behind by a spec change or discovery-mode switch — discovery is
+     * otherwise upsert-only and never prunes. Scoped strictly to {@code source='openapi'} so
+     * hand-seeded/admin tools are never touched. Returns the number of orphan rows deleted.
+     *
+     * <p><strong>Safety:</strong> an empty {@code keptNames} is a no-op (returns 0) — the caller must
+     * only prune after a successful, non-empty discovery run so a transient empty/failed fetch can
+     * never wipe the catalog.
+     */
+    int pruneDiscoveredOperationsExcept(@NonNull Collection<String> keptNames);
 
     /** Gate 3 (G3.1): maps a tool to a workflow state (by name) so it is selectable there. Idempotent. */
     void linkToolToWorkflow(@NonNull UUID toolId, @NonNull String workflowState);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -4,16 +4,19 @@ import com.positivity.mcp.internal.domain.DiscoveredOperation;
 import com.positivity.mcp.internal.domain.ToolMetadata;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 import org.postgresql.util.PGobject;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @Profile({"!test", "openapi"})
@@ -187,6 +190,35 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
                 operation.serviceId(),
                 operation.inputSchema());
         return Objects.requireNonNull(id, "upsertDiscoveredOperation returned no id");
+    }
+
+    @Override
+    @Transactional
+    public int pruneDiscoveredOperationsExcept(@NonNull Collection<String> keptNames) {
+        // Safety: never prune against an empty keep-set — that would delete the entire discovered
+        // catalog. The caller only invokes this after a successful, non-empty discovery run.
+        if (keptNames.isEmpty()) {
+            return 0;
+        }
+        String keptPlaceholders = keptNames.stream().map(name -> "?").collect(Collectors.joining(", "));
+        Object[] keptArgs = keptNames.toArray();
+        List<UUID> orphanIds = jdbcTemplate.query(
+                "SELECT id FROM mcp_tool WHERE source = 'openapi' AND name NOT IN (" + keptPlaceholders + ")",
+                (rs, rowNum) -> rs.getObject("id", UUID.class),
+                keptArgs);
+        if (orphanIds.isEmpty()) {
+            return 0;
+        }
+        String idPlaceholders = orphanIds.stream().map(id -> "?").collect(Collectors.joining(", "));
+        Object[] idArgs = orphanIds.toArray();
+        // Clear FK children explicitly (portable across Postgres and the H2 test schema, which may not
+        // declare ON DELETE CASCADE): permission grants and workflow links are deleted; the nullable
+        // invocation log's tool_id is nulled so historical audit rows survive the tool's removal.
+        jdbcTemplate.update("DELETE FROM mcp_tool_permission WHERE tool_id IN (" + idPlaceholders + ")", idArgs);
+        jdbcTemplate.update("DELETE FROM mcp_tool_workflow WHERE tool_id IN (" + idPlaceholders + ")", idArgs);
+        jdbcTemplate.update(
+                "UPDATE mcp_tool_invocation_log SET tool_id = NULL WHERE tool_id IN (" + idPlaceholders + ")", idArgs);
+        return jdbcTemplate.update("DELETE FROM mcp_tool WHERE id IN (" + idPlaceholders + ")", idArgs);
     }
 
     @Override

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
@@ -184,9 +184,9 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
         return Mono.fromRunnable(() -> {
                     List<DiscoveredOperation> operations =
                             openApiToolMapper.toDiscoveredOperations(gatewayBaseUrl, openApi);
-                    // Names of every op discovered this run — the desired persisted set. Collected for the
-                    // #1121 prune below; includes ops with a null path (skipped from persist) so a skipped
-                    // op is never mistaken for an orphan and deleted.
+                    // Names of every op discovered this run — the desired persisted set for the #1121 prune
+                    // below. name is @NonNull by contract; the filter is a defensive guard so a stray null
+                    // can never enter the keep-set and turn the prune's NOT IN (...) into a silent no-op.
                     Set<String> discoveredNames = operations.stream()
                             .map(DiscoveredOperation::name)
                             .filter(java.util.Objects::nonNull)

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImpl.java
@@ -12,6 +12,7 @@ import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
@@ -40,6 +41,8 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
     // tools_discovered_total / tools_registered_total.
     private final Counter toolsDiscoveredTotal;
     private final Counter toolsRegisteredTotal;
+    // #1121: orphan openapi rows pruned to reconcile the persisted set with the current spec.
+    private final Counter toolsPrunedTotal;
 
     public ToolRegistrationServiceImpl(
             @NonNull McpServerProperties properties,
@@ -63,6 +66,9 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
                 .register(meterRegistry);
         this.toolsRegisteredTotal = Counter.builder("tools.registered")
                 .description("MCP tools successfully registered from discovery")
+                .register(meterRegistry);
+        this.toolsPrunedTotal = Counter.builder("tools.pruned")
+                .description("Stale openapi-discovered mcp_tool rows pruned to match the current spec (#1121)")
                 .register(meterRegistry);
     }
 
@@ -178,6 +184,13 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
         return Mono.fromRunnable(() -> {
                     List<DiscoveredOperation> operations =
                             openApiToolMapper.toDiscoveredOperations(gatewayBaseUrl, openApi);
+                    // Names of every op discovered this run — the desired persisted set. Collected for the
+                    // #1121 prune below; includes ops with a null path (skipped from persist) so a skipped
+                    // op is never mistaken for an orphan and deleted.
+                    Set<String> discoveredNames = operations.stream()
+                            .map(DiscoveredOperation::name)
+                            .filter(java.util.Objects::nonNull)
+                            .collect(Collectors.toSet());
                     int persisted = 0;
                     for (DiscoveredOperation operation : operations) {
                         String path = operation.httpPath();
@@ -207,6 +220,17 @@ public class ToolRegistrationServiceImpl implements ToolRegistrationService {
                                     + "x-required-permissions (fail-closed when absent)",
                             persisted,
                             DISCOVERED_WORKFLOW_STATE);
+                    // #1121: reconcile — delete any source='openapi' row absent from this run (orphans left
+                    // by a spec change or discovery-mode switch, since persistence is otherwise upsert-only).
+                    // Guarded on persisted > 0 so a run that wrote nothing (bad/empty spec, DB trouble) can
+                    // never wipe the catalog; pruneDiscoveredOperationsExcept also no-ops on an empty set.
+                    if (persisted > 0 && !discoveredNames.isEmpty()) {
+                        int pruned = toolMetadataRepository.pruneDiscoveredOperationsExcept(discoveredNames);
+                        if (pruned > 0) {
+                            toolsPrunedTotal.increment(pruned);
+                            log.info("Pruned {} stale openapi mcp_tool row(s) not in the current spec (#1121)", pruned);
+                        }
+                    }
                 })
                 .subscribeOn(Schedulers.boundedElastic())
                 .then();

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
@@ -90,6 +90,11 @@ public class SessionAgentManagerTestConfiguration {
             }
 
             @Override
+            public int pruneDiscoveredOperationsExcept(java.util.Collection<String> keptNames) {
+                return 0;
+            }
+
+            @Override
             public void linkToolToWorkflow(java.util.UUID toolId, String workflowState) {
                 // no-op stub
             }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImplTest.java
@@ -3,7 +3,11 @@ package com.positivity.mcp.internal.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.postgresql.util.PGobject;
@@ -139,5 +144,52 @@ class ToolMetadataRepositoryImplTest {
 
         assertThat(result).isEmpty();
         verifyNoInteractions(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("pruneDiscoveredOperationsExcept short-circuits to 0 without querying when keptNames is empty")
+    void pruneDiscoveredOperationsExcept_withEmptyKept_shortCircuits() {
+        int pruned = repository.pruneDiscoveredOperationsExcept(Set.of());
+
+        assertThat(pruned).isZero();
+        verifyNoInteractions(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("pruneDiscoveredOperationsExcept returns 0 and issues no deletes when no orphans exist")
+    @SuppressWarnings("unchecked")
+    void pruneDiscoveredOperationsExcept_noOrphans_returnsZero() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of());
+
+        int pruned = repository.pruneDiscoveredOperationsExcept(Set.of("customer_getall"));
+
+        assertThat(pruned).isZero();
+        verify(jdbcTemplate, never()).update(anyString(), any(Object[].class));
+    }
+
+    @Test
+    @DisplayName("pruneDiscoveredOperationsExcept clears FK children before deleting parents, scoped to openapi")
+    @SuppressWarnings("unchecked")
+    void pruneDiscoveredOperationsExcept_deletesOrphansAndClearsChildrenInOrder() {
+        UUID orphanA = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
+        UUID orphanB = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of(orphanA, orphanB));
+        // parent DELETE (the value prune returns); child clears also return via this stub — value unused.
+        when(jdbcTemplate.update(anyString(), any(Object[].class))).thenReturn(2);
+
+        int pruned = repository.pruneDiscoveredOperationsExcept(Set.of("customer_getall", "order_list"));
+
+        assertThat(pruned).isEqualTo(2);
+        // The orphan lookup is scoped to source='openapi' and excludes the kept names.
+        verify(jdbcTemplate)
+                .query(contains("source = 'openapi' AND name NOT IN"), any(RowMapper.class), any(Object[].class));
+        // Children must be cleared before the parent rows are deleted (FK-safe order).
+        InOrder inOrder = inOrder(jdbcTemplate);
+        inOrder.verify(jdbcTemplate).update(contains("DELETE FROM mcp_tool_permission"), any(Object[].class));
+        inOrder.verify(jdbcTemplate).update(contains("DELETE FROM mcp_tool_workflow"), any(Object[].class));
+        inOrder.verify(jdbcTemplate).update(contains("UPDATE mcp_tool_invocation_log"), any(Object[].class));
+        inOrder.verify(jdbcTemplate).update(contains("DELETE FROM mcp_tool WHERE id IN"), any(Object[].class));
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolRegistrationServiceImplTest.java
@@ -13,6 +13,7 @@ import ch.qos.logback.core.read.ListAppender;
 import com.positivity.mcp.internal.config.McpServerProperties;
 import com.positivity.mcp.internal.discovery.OpenApiDocumentFetcher;
 import com.positivity.mcp.internal.discovery.OpenApiToolMapper;
+import com.positivity.mcp.internal.domain.DiscoveredOperation;
 import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.modelcontextprotocol.server.McpAsyncServer;
@@ -22,6 +23,8 @@ import io.swagger.v3.oas.models.OpenAPI;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -199,9 +202,74 @@ class ToolRegistrationServiceImplTest {
         verify(mcpAsyncServer, never()).notifyToolsListChanged();
     }
 
+    @Test
+    @DisplayName("registerDiscoveredTools prunes stale openapi rows absent from the current spec after persisting "
+            + "(#1121)")
+    void registerDiscoveredTools_prunesOrphans_afterPersistingAggregate() {
+        McpServerFeatures.AsyncToolSpecification spec = toolSpec("accounting_listinvoices");
+        OpenApiDocumentFetcher.DiscoveredOpenApi discovered =
+                new OpenApiDocumentFetcher.DiscoveredOpenApi("aggregate", GATEWAY_BASE_URI, new OpenAPI());
+        DiscoveredOperation op = new DiscoveredOperation(
+                "accounting_listinvoices",
+                "List invoices",
+                "GET",
+                "/accounting/v1/invoices",
+                "http://api-gateway:8080",
+                null,
+                List.of());
+
+        when(openApiDocumentFetcher.fetchAggregateSpec()).thenReturn(Mono.just(discovered));
+        when(openApiToolMapper.toAggregateToolSpecifications(GATEWAY_BASE_URI, discovered.openApi()))
+                .thenReturn(List.of(spec));
+        when(openApiToolMapper.toDiscoveredOperations("http://api-gateway:8080", discovered.openApi()))
+                .thenReturn(List.of(op));
+        when(mcpAsyncServer.removeTool(any())).thenReturn(Mono.empty());
+        when(mcpAsyncServer.addTool(spec)).thenReturn(Mono.empty());
+        when(mcpAsyncServer.notifyToolsListChanged()).thenReturn(Mono.empty());
+
+        ToolMetadataRepository repo = mock(ToolMetadataRepository.class);
+        when(repo.upsertDiscoveredOperation(any(), any()))
+                .thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+        when(repo.pruneDiscoveredOperationsExcept(any())).thenReturn(3);
+
+        serviceUnderTest(repo).registerDiscoveredTools().block(Duration.ofSeconds(5));
+
+        // Reconciliation runs with exactly the names discovered this run, and the counter reflects the deletes.
+        verify(repo).pruneDiscoveredOperationsExcept(Set.of("accounting_listinvoices"));
+        assertThat(meterRegistry.get("tools.pruned").counter().count()).isEqualTo(3.0);
+    }
+
+    @Test
+    @DisplayName("registerDiscoveredTools does not prune when the aggregate persists no ops (#1121 safety guard)")
+    void registerDiscoveredTools_doesNotPrune_whenNothingPersisted() {
+        McpServerFeatures.AsyncToolSpecification spec = toolSpec("accounting_listinvoices");
+        OpenApiDocumentFetcher.DiscoveredOpenApi discovered =
+                new OpenApiDocumentFetcher.DiscoveredOpenApi("aggregate", GATEWAY_BASE_URI, new OpenAPI());
+
+        when(openApiDocumentFetcher.fetchAggregateSpec()).thenReturn(Mono.just(discovered));
+        when(openApiToolMapper.toAggregateToolSpecifications(GATEWAY_BASE_URI, discovered.openApi()))
+                .thenReturn(List.of(spec));
+        // No discovered operations persisted this run → the guard must skip pruning so a bad/empty run
+        // can never wipe the catalog.
+        when(openApiToolMapper.toDiscoveredOperations("http://api-gateway:8080", discovered.openApi()))
+                .thenReturn(List.of());
+        when(mcpAsyncServer.removeTool(any())).thenReturn(Mono.empty());
+        when(mcpAsyncServer.addTool(spec)).thenReturn(Mono.empty());
+        when(mcpAsyncServer.notifyToolsListChanged()).thenReturn(Mono.empty());
+
+        ToolMetadataRepository repo = mock(ToolMetadataRepository.class);
+        serviceUnderTest(repo).registerDiscoveredTools().block(Duration.ofSeconds(5));
+
+        verify(repo, never()).pruneDiscoveredOperationsExcept(any());
+    }
+
     // --- helpers ---
 
     private ToolRegistrationServiceImpl serviceUnderTest() {
+        return serviceUnderTest(mock(ToolMetadataRepository.class));
+    }
+
+    private ToolRegistrationServiceImpl serviceUnderTest(ToolMetadataRepository toolMetadataRepository) {
         McpServerProperties properties = new McpServerProperties(
                 "http://localhost:8086",
                 "/mcp/message",
@@ -217,7 +285,7 @@ class ToolRegistrationServiceImplTest {
                 openApiDocumentFetcher,
                 openApiToolMapper,
                 mcpAsyncServer,
-                mock(ToolMetadataRepository.class),
+                toolMetadataRepository,
                 "http://api-gateway:8080",
                 meterRegistry);
     }


### PR DESCRIPTION
## Capability & Traceability
- Capability: MCP hardening (discovery reconciliation; no single `cap:` id)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1121
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not contract-relevant: internal discovery/persistence behavior only. No controllers, DTOs, `*Request`/`*Response`, events, `openapi.yaml`, or schema/validation models change. (No `BACKEND_CONTRACT_GUIDE.md` reference needed.)

## Contract Chain (when a Controller changed)
- N/A — no controller changed.

## Scope
- **What changed:** OpenAPI tool discovery persisted rows via an upsert (`INSERT … ON CONFLICT (name) DO UPDATE`) and **never pruned**. When the gateway's merged OpenAPI spec changed — or discovery switched modes — operations that vanished from the spec were left behind as permanent **orphan `mcp_tool` rows**. Since each op's `http_path` carries a service routing prefix, an orphan whose prefix no longer matches the service that owns the path routes to a service that **404s** it (#1121: 125 such rows observed on alpha, all 404ing through the gateway).
  - `ToolMetadataRepository.pruneDiscoveredOperationsExcept(keptNames)` — deletes every `source='openapi'` row whose name is not in the current run's set, plus its FK children. Children are cleared **explicitly** (portable across Postgres and the H2 test schema, which may not declare `ON DELETE CASCADE`): permission grants and workflow links are deleted; the nullable invocation-log `tool_id` is nulled so audit history survives. An empty keep-set is a **no-op**.
  - `ToolRegistrationServiceImpl` — after persisting the aggregate spec, prunes with the names discovered this run. **Guarded on `persisted > 0`** so a bad/empty/failed fetch can never wipe the catalog; emits a `tools.pruned` counter and logs the count.
- **Why:** reconcile the persisted discovered-tool set to the live spec so stale/mis-homed tools can't linger and 404. This is the durable root-cause fix for #1121; it also closes the loop with the #645 gateway-routing check by construction — an op absent from the current spec can no longer survive to 404.

## Tests
- [x] Unit tests added/updated — `ToolMetadataRepositoryImplTest` (empty keep-set short-circuits; no-orphans no-ops; orphans delete with FK children cleared **before** parents, scoped to `source='openapi'`); `ToolRegistrationServiceImplTest` (prunes with the run's discovered names + `tools.pruned` counter; **does not** prune when nothing was persisted — the safety guard).
- [ ] Integration tests added/updated — n/a (repo tests mock `JdbcTemplate`, matching the module's existing repo-test style).
- [ ] Provider behavioral contract tests added/updated — n/a
- **How to run:** `./mvnw -pl pos-mcp-server -am test -Dtest=ToolMetadataRepositoryImplTest,ToolRegistrationServiceImplTest` (20 tests, green).

## Risk & Rollback
- **Risk level:** Medium — introduces a **destructive delete** in the discovery path. Mitigated by: strict `source='openapi'` scoping (hand-seeded/admin tools untouched), the `persisted > 0` guard and empty-keep-set no-op (a failed/empty fetch cannot wipe the catalog), and a single `@Transactional` unit of work.
- **Rollback plan:** revert the branch. No schema migration is involved.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no (agent branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — no CAP id for this hardening work
- [x] Links to related issue present (#1121)
- [x] Contract guide updated — n/a (no contract semantics changed)
- [ ] Required CI checks passing — pending CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9hcDusfL8raMjfb8mosnG)_