### PR TITLE
Consume frontend /sitemap.json in pos-mcp-server and wire it into ScreenLinkResolver

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/client/SiteMapClient.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/client/SiteMapClient.java
@@ -1,0 +1,202 @@
+package com.positivity.mcp.internal.client;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.positivity.mcp.internal.config.SiteMapProperties;
+import com.positivity.mcp.service.SiteMapService;
+import com.positivity.mcp.service.SiteMapUnavailableException;
+import com.positivity.mcp.service.model.SiteMap;
+import com.positivity.mcp.service.model.SiteMapSection;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Pull-only consumer of the durion-positivity-frontend {@code /sitemap.json} artifact.
+ *
+ * <p>Fetches lazily over HTTP (no auth header — the artifact is a public static asset served ahead of
+ * auth), validates against the shared contract, and caches with a TTL plus a last-known-good copy.
+ * The frontend being briefly unavailable must not break this server: on a fetch failure with a warm
+ * cache the previous copy is returned and its lifetime extended; only a cold-cache failure surfaces a
+ * {@link SiteMapUnavailableException}.
+ *
+ * <p>Decoupling: no frontend source/types are imported; the only shared contract is the JSON schema
+ * ({@code docs/sitemap/sitemap.schema.json}) and its integer {@code version}. A served {@code version}
+ * higher than {@link SiteMapProperties#expectedVersion()} is tolerated — unknown fields are ignored
+ * rather than crashing.
+ */
+@Component
+public class SiteMapClient implements SiteMapService {
+
+    private static final Logger log = LoggerFactory.getLogger(SiteMapClient.class);
+    private static final String SITEMAP_PATH = "/sitemap.json";
+    private static final String EXPECTED_APPLICATION = "durion-positivity-frontend";
+
+    // Unknown fields are ignored so a forward-compatible version bump does not break parsing.
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private final RestClient restClient;
+    private final SiteMapProperties properties;
+    private final Clock clock;
+    private final Object refreshLock = new Object();
+
+    private volatile @Nullable Cached cached;
+
+    @Autowired
+    public SiteMapClient(@NonNull SiteMapProperties properties) {
+        this(buildRestClient(properties), properties, Clock.systemUTC());
+    }
+
+    // Visible for testing: inject a pre-built RestClient (e.g. bound to MockRestServiceServer) and a
+    // controllable Clock.
+    SiteMapClient(@NonNull RestClient restClient, @NonNull SiteMapProperties properties, @NonNull Clock clock) {
+        this.restClient = restClient;
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    private static RestClient buildRestClient(SiteMapProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.fetchTimeout());
+        factory.setReadTimeout(properties.fetchTimeout());
+        // A fresh builder (not the shared/load-balanced one) guarantees no bearer-token relay: the
+        // frontend artifact is public and must be requested with no Authorization header.
+        return RestClient.builder()
+                .baseUrl(properties.baseUrl())
+                .requestFactory(factory)
+                .build();
+    }
+
+    @Override
+    public @NonNull SiteMap getSiteMap() {
+        Cached current = cached;
+        if (current != null && !isExpired(current)) {
+            return current.value();
+        }
+        synchronized (refreshLock) {
+            Cached rechecked = cached;
+            if (rechecked != null && !isExpired(rechecked)) {
+                return rechecked.value(); // another thread refreshed while we waited on the lock
+            }
+            return fetchAndCacheOrFallback();
+        }
+    }
+
+    @Override
+    public @NonNull SiteMap refresh() {
+        synchronized (refreshLock) {
+            return fetchAndCacheOrFallback();
+        }
+    }
+
+    @Override
+    public @NonNull List<SiteMapSection> visibleSections(@NonNull Collection<String> userRoles) {
+        Cached current = cached;
+        if (current == null) {
+            return List.of();
+        }
+        Set<String> roleSet = Set.copyOf(userRoles);
+        return current.value().sections().stream()
+                .filter(section -> section.isVisibleTo(roleSet))
+                .toList();
+    }
+
+    private boolean isExpired(Cached entry) {
+        return !clock.instant().isBefore(entry.expiresAt());
+    }
+
+    /** Must be called while holding {@link #refreshLock}. */
+    private SiteMap fetchAndCacheOrFallback() {
+        try {
+            SiteMap fresh = doFetch();
+            cached = new Cached(fresh, clock.instant().plus(properties.cacheTtl()));
+            return fresh;
+        } catch (RuntimeException ex) {
+            Cached fallback = cached;
+            if (fallback != null) {
+                log.warn("Site-map fetch failed; serving last-known-good copy: {}", ex.getMessage());
+                // Extend the served copy's lifetime so we don't hammer a down frontend every access.
+                cached = new Cached(fallback.value(), clock.instant().plus(properties.cacheTtl()));
+                return fallback.value();
+            }
+            log.warn("Site-map fetch failed and no cached copy is available: {}", ex.getMessage());
+            if (ex instanceof SiteMapUnavailableException unavailable) {
+                throw unavailable;
+            }
+            throw new SiteMapUnavailableException("Site map unavailable: " + ex.getMessage(), ex);
+        }
+    }
+
+    private SiteMap doFetch() {
+        ResponseEntity<String> response;
+        try {
+            response = restClient
+                    .get()
+                    .uri(SITEMAP_PATH)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .toEntity(String.class);
+        } catch (RestClientException ex) {
+            // Covers non-2xx (default error handler), connect/read timeouts, and connection errors.
+            throw new SiteMapUnavailableException("Site-map request failed: " + ex.getMessage(), ex);
+        }
+
+        if (response.getStatusCode().value() != 200) {
+            throw new SiteMapUnavailableException("Unexpected site-map status " + response.getStatusCode());
+        }
+        MediaType contentType = response.getHeaders().getContentType();
+        if (contentType == null || !contentType.getSubtype().toLowerCase().contains("json")) {
+            throw new SiteMapUnavailableException(
+                    "Unexpected site-map " + HttpHeaders.CONTENT_TYPE + ": " + contentType);
+        }
+        String body = response.getBody();
+        if (body == null || body.isBlank()) {
+            throw new SiteMapUnavailableException("Empty site-map body");
+        }
+
+        SiteMap siteMap;
+        try {
+            siteMap = MAPPER.readValue(body, SiteMap.class);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
+            throw new SiteMapUnavailableException("Malformed site-map body: " + ex.getOriginalMessage(), ex);
+        }
+
+        if (!EXPECTED_APPLICATION.equals(siteMap.application())) {
+            throw new SiteMapUnavailableException("Unexpected site-map application '" + siteMap.application() + "'");
+        }
+        assertVersion(siteMap.version());
+        log.debug(
+                "Fetched site map: version={} generatedAt={} sections={}",
+                siteMap.version(),
+                siteMap.generatedAt(),
+                siteMap.sections().size());
+        return siteMap;
+    }
+
+    private void assertVersion(int version) {
+        int expected = properties.expectedVersion();
+        if (version > expected) {
+            log.warn("Site-map version {} is newer than expected {}; using recognized fields only", version, expected);
+        } else if (version < expected) {
+            log.warn("Site-map version {} is older than expected {}; still usable", version, expected);
+        }
+    }
+
+    /** A cached site map and the instant at which it becomes stale. */
+    private record Cached(@NonNull SiteMap value, @NonNull Instant expiresAt) {}
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/client/SiteMapClient.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/client/SiteMapClient.java
@@ -11,15 +11,16 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -57,9 +58,11 @@ public class SiteMapClient implements SiteMapService {
 
     private volatile @Nullable Cached cached;
 
+    // Inject the shared Clock bean rather than Clock.systemUTC() so the accelerated-clock profile can
+    // replace application time (enforced by the pos-archunit time rule).
     @Autowired
-    public SiteMapClient(@NonNull SiteMapProperties properties) {
-        this(buildRestClient(properties), properties, Clock.systemUTC());
+    public SiteMapClient(@NonNull SiteMapProperties properties, @NonNull Clock clock) {
+        this(buildRestClient(properties), properties, clock);
     }
 
     // Visible for testing: inject a pre-built RestClient (e.g. bound to MockRestServiceServer) and a
@@ -160,7 +163,8 @@ public class SiteMapClient implements SiteMapService {
             throw new SiteMapUnavailableException("Unexpected site-map status " + response.getStatusCode());
         }
         MediaType contentType = response.getHeaders().getContentType();
-        if (contentType == null || !contentType.getSubtype().toLowerCase().contains("json")) {
+        if (contentType == null
+                || !contentType.getSubtype().toLowerCase(Locale.ROOT).contains("json")) {
             throw new SiteMapUnavailableException(
                     "Unexpected site-map " + HttpHeaders.CONTENT_TYPE + ": " + contentType);
         }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/McpServerConfiguration.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/McpServerConfiguration.java
@@ -19,7 +19,12 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
-@EnableConfigurationProperties({McpServerProperties.class, LlmApiProperties.class, HybridRetrievalProperties.class})
+@EnableConfigurationProperties({
+    McpServerProperties.class,
+    LlmApiProperties.class,
+    HybridRetrievalProperties.class,
+    SiteMapProperties.class
+})
 public class McpServerConfiguration {
 
     @Bean

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/SiteMapProperties.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/SiteMapProperties.java
@@ -1,0 +1,36 @@
+package com.positivity.mcp.internal.config;
+
+import java.time.Duration;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for the frontend site-map consumer (see {@code docs/sitemap/client-module.md} in the
+ * frontend repo).
+ *
+ * @param baseUrl origin of the frontend SSR server (NOT the API gateway); the SSR server defaults to
+ *     port 4000. Bound from {@code FRONTEND_BASE_URL} in {@code application.yml}.
+ * @param cacheTtl how long a fetched copy is served before a refresh is attempted
+ * @param fetchTimeout per-request HTTP connect/read timeout
+ * @param expectedVersion the contract {@code version} this build was written against; a higher
+ *     version served by the frontend is tolerated (known fields only), not fatal
+ */
+@ConfigurationProperties(prefix = "mcp.sitemap")
+public record SiteMapProperties(
+        @NonNull String baseUrl, Duration cacheTtl, Duration fetchTimeout, int expectedVersion) {
+
+    public SiteMapProperties {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            baseUrl = "http://localhost:4000";
+        }
+        if (cacheTtl == null) {
+            cacheTtl = Duration.ofSeconds(600);
+        }
+        if (fetchTimeout == null) {
+            fetchTimeout = Duration.ofSeconds(5);
+        }
+        if (expectedVersion < 1) {
+            expectedVersion = 1;
+        }
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImpl.java
@@ -43,13 +43,14 @@ public class AnswerResolutionLadderImpl implements AnswerResolutionLadder {
     @Override
     public @NonNull LadderResult resolveFallback(@NonNull String userMessage) {
         Set<String> permissions = callerPermissions();
+        Set<String> roles = callerRoles();
         // No structured entity extraction yet (v1): pass no params, so the screen's url_template
         // resolves to its base path with optional filters dropped.
         // Screen resolution is best-effort: this is the graceful-degradation tail, so any failure
         // (embedding-model outage, DB error) must degrade to the hand-off, never fail the chat.
         Optional<ScreenLink> link;
         try {
-            link = screenLinkResolver.resolve(userMessage, null, permissions, Map.of());
+            link = screenLinkResolver.resolve(userMessage, null, permissions, roles, Map.of());
         } catch (RuntimeException exception) {
             LOGGER.warn("Screen resolution failed; falling back to hand-off", exception);
             link = Optional.empty();
@@ -73,5 +74,12 @@ public class AnswerResolutionLadderImpl implements AnswerResolutionLadder {
                 .current()
                 .map(CurrentUserContext::permissionCodes)
                 .orElseGet(Set::of);
+    }
+
+    private @NonNull Set<String> callerRoles() {
+        if (requestScopedUserContext == null) {
+            return Set.of();
+        }
+        return requestScopedUserContext.current().map(CurrentUserContext::roles).orElseGet(Set::of);
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolver.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolver.java
@@ -11,13 +11,23 @@ import org.jspecify.annotations.Nullable;
  * Resolves the best UI screen for a request that no tool could answer (rung 3 of the answer
  * resolution ladder). Returns empty when nothing clears the similarity floor or the caller lacks
  * permission for every candidate.
+ *
+ * <p>Resolution is two-tiered: first the semantic, permission-gated screen registry; then, only when
+ * the registry surfaces nothing the caller can open, a coarse fallback over the frontend site map
+ * (gated by the caller's <em>roles</em> rather than permission codes). The registry remains the
+ * fine-grained path — the site map contributes section-level routes so a fresh frontend deployment
+ * is reachable without re-seeding the registry.
  */
 public interface ScreenLinkResolver {
 
     /**
      * @param userMessage      the original request text (embedded for the search)
      * @param domain           optional domain hint (e.g. router-classified scope); {@code null} = all
-     * @param callerPermissions the caller's permission codes, used to gate {@code required_perm}
+     * @param callerPermissions the caller's bare permission codes, used to gate the registry's
+     *     {@code required_perm}
+     * @param callerRoles      the caller's {@code ROLE_*} authorities, used to gate site-map sections
+     *     (whose access control is role-based, unlike the permission-gated registry); a section
+     *     without a {@code roles} restriction is open to any authenticated caller
      * @param params           values for filling the screen's url_template (status, locationId, …)
      */
     @NonNull
@@ -25,5 +35,6 @@ public interface ScreenLinkResolver {
             @NonNull String userMessage,
             @Nullable String domain,
             @NonNull Set<String> callerPermissions,
+            @NonNull Set<String> callerRoles,
             @NonNull Map<String, String> params);
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolverImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolverImpl.java
@@ -35,6 +35,11 @@ import org.springframework.stereotype.Service;
  * caller. This keeps top-level routes reachable across frontend deployments without re-seeding the
  * registry, while the registry stays the fine-grained path. The fallback is best-effort — a site-map
  * outage degrades to no result, never an error.
+ *
+ * <p>Section embeddings are pre-computed at startup by {@link SiteMapEmbeddingWarmupRunner} (via
+ * {@link #warmUp()}) and cached by section text, so request-time matching is a pure cache read with
+ * no embedding call on the hot path. A cache miss — warm-up never ran/failed, or a section appeared
+ * after a frontend redeploy — falls back to a lazy embed and self-heals the cache for later requests.
  */
 @Service
 @Profile({"!test", "openapi"})
@@ -145,6 +150,28 @@ public class ScreenLinkResolverImpl implements ScreenLinkResolver {
         } catch (RuntimeException exception) {
             LOGGER.debug("Site map screen fallback unavailable: {}", exception.getMessage());
             return Optional.empty();
+        }
+    }
+
+    /**
+     * Pre-embeds every current site-map section so request-time fallback matching is a pure cache
+     * read. Invoked once at startup by {@link SiteMapEmbeddingWarmupRunner}. Best-effort — a site-map
+     * outage leaves the cache to be filled lazily on first use, so warm-up never blocks startup.
+     */
+    public void warmUp() {
+        if (siteMapService == null) {
+            return;
+        }
+        try {
+            SiteMap siteMap = siteMapService.getSiteMap();
+            for (SiteMapSection section : siteMap.sections()) {
+                sectionEmbedding(section);
+            }
+            LOGGER.info(
+                    "Warmed site-map section embeddings for {} sections",
+                    siteMap.sections().size());
+        } catch (RuntimeException exception) {
+            LOGGER.warn("Site-map embedding warm-up skipped: {}", exception.getMessage());
         }
     }
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolverImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolverImpl.java
@@ -3,6 +3,10 @@ package com.positivity.mcp.internal.service;
 import com.positivity.mcp.internal.domain.ScreenCandidate;
 import com.positivity.mcp.internal.domain.ScreenLink;
 import com.positivity.mcp.internal.repository.ScreenRegistryRepository;
+import com.positivity.mcp.service.SiteMapService;
+import com.positivity.mcp.service.model.SiteMap;
+import com.positivity.mcp.service.model.SiteMapSection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -22,6 +26,14 @@ import org.springframework.stereotype.Service;
  * <p>Candidates come back ordered by descending similarity, so the first sub-floor candidate ends
  * the search (everything after it is also sub-floor). Permission-gated candidates are skipped, not
  * terminal — a lower-ranked but still-above-floor screen the caller can open still wins.
+ *
+ * <p>When the registry yields nothing the caller can open, resolution falls back to the frontend
+ * site map: a coarse, section-level index of the app's navigable areas. Site-map sections are gated
+ * by the caller's <em>roles</em> (a section with no {@code roles} is open to any authenticated
+ * caller) and matched to the request lexically. This keeps top-level routes reachable across
+ * frontend deployments without re-seeding the registry, while the registry stays the fine-grained,
+ * semantic path. The fallback is best-effort — a site-map outage degrades to no result, never an
+ * error.
  */
 @Service
 @Profile({"!test", "openapi"})
@@ -29,18 +41,29 @@ public class ScreenLinkResolverImpl implements ScreenLinkResolver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ScreenLinkResolverImpl.class);
     private static final int CANDIDATE_LIMIT = 5;
+    // Query/section tokens shorter than this are dropped as low-signal noise for the lexical fallback.
+    private static final int MIN_TOKEN_LENGTH = 3;
 
     private final EmbeddingModel embeddingModel;
     private final ScreenRegistryRepository repository;
+
+    @Nullable
+    private final SiteMapService siteMapService;
+
     private final double minScore;
+    private final double siteMapMinScore;
 
     public ScreenLinkResolverImpl(
             @NonNull EmbeddingModel embeddingModel,
             @NonNull ScreenRegistryRepository repository,
-            @Value("${mcp.screen.min-score:0.6}") double minScore) {
+            @Nullable SiteMapService siteMapService,
+            @Value("${mcp.screen.min-score:0.6}") double minScore,
+            @Value("${mcp.screen.sitemap-min-score:0.5}") double siteMapMinScore) {
         this.embeddingModel = embeddingModel;
         this.repository = repository;
+        this.siteMapService = siteMapService;
         this.minScore = minScore;
+        this.siteMapMinScore = siteMapMinScore;
     }
 
     @Override
@@ -48,11 +71,24 @@ public class ScreenLinkResolverImpl implements ScreenLinkResolver {
             @NonNull String userMessage,
             @Nullable String domain,
             @NonNull Set<String> callerPermissions,
+            @NonNull Set<String> callerRoles,
             @NonNull Map<String, String> params) {
         if (userMessage.isBlank()) {
             return Optional.empty();
         }
 
+        Optional<ScreenLink> fromRegistry = resolveFromRegistry(userMessage, domain, callerPermissions, params);
+        if (fromRegistry.isPresent()) {
+            return fromRegistry;
+        }
+        return resolveFromSiteMap(userMessage, callerRoles);
+    }
+
+    private @NonNull Optional<ScreenLink> resolveFromRegistry(
+            @NonNull String userMessage,
+            @Nullable String domain,
+            @NonNull Set<String> callerPermissions,
+            @NonNull Map<String, String> params) {
         float[] queryEmbedding = embeddingModel.embed(userMessage);
         for (ScreenCandidate candidate : repository.findNearest(queryEmbedding, domain, CANDIDATE_LIMIT)) {
             if (candidate.score() < minScore) {
@@ -70,5 +106,70 @@ public class ScreenLinkResolverImpl implements ScreenLinkResolver {
             return Optional.of(new ScreenLink(candidate.screenKey(), candidate.title(), url, candidate.score()));
         }
         return Optional.empty();
+    }
+
+    /**
+     * Coarse role-gated fallback over the frontend site map. Best-effort: a site-map outage or an
+     * empty match yields no result rather than an error.
+     */
+    private @NonNull Optional<ScreenLink> resolveFromSiteMap(
+            @NonNull String userMessage, @NonNull Set<String> callerRoles) {
+        if (siteMapService == null) {
+            return Optional.empty();
+        }
+        SiteMap siteMap;
+        try {
+            siteMap = siteMapService.getSiteMap();
+        } catch (RuntimeException exception) {
+            LOGGER.debug("Site map unavailable for screen fallback: {}", exception.getMessage());
+            return Optional.empty();
+        }
+
+        Set<String> queryTokens = tokenize(userMessage);
+        if (queryTokens.isEmpty()) {
+            return Optional.empty();
+        }
+
+        SiteMapSection best = null;
+        double bestScore = 0;
+        for (SiteMapSection section : siteMap.sections()) {
+            if (!section.isVisibleTo(callerRoles)) {
+                continue; // caller lacks a required role for this section
+            }
+            double score = lexicalScore(queryTokens, section);
+            if (score > bestScore) {
+                bestScore = score;
+                best = section;
+            }
+        }
+
+        if (best == null || bestScore < siteMapMinScore) {
+            return Optional.empty();
+        }
+        LOGGER.debug("Resolved screen link from site map route={} score={}", best.route(), bestScore);
+        // Site-map routes are static paths (no url_template placeholders); the route is the deep link.
+        return Optional.of(new ScreenLink(best.route(), best.title(), best.route(), bestScore));
+    }
+
+    /**
+     * Fraction of the request's tokens that appear in a section's searchable text (title +
+     * description + route), in {@code [0, 1]}. A coverage measure, not a similarity score — this is a
+     * deliberately simple lexical match for the section-level fallback, not the registry's semantic
+     * search.
+     */
+    private static double lexicalScore(@NonNull Set<String> queryTokens, @NonNull SiteMapSection section) {
+        Set<String> sectionTokens = tokenize(section.title() + " " + section.description() + " " + section.route());
+        long hits = queryTokens.stream().filter(sectionTokens::contains).count();
+        return (double) hits / queryTokens.size();
+    }
+
+    private static @NonNull Set<String> tokenize(@NonNull String text) {
+        Set<String> tokens = new HashSet<>();
+        for (String token : text.toLowerCase().split("[^a-z0-9]+")) {
+            if (token.length() >= MIN_TOKEN_LENGTH) {
+                tokens.add(token);
+            }
+        }
+        return tokens;
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolverImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ScreenLinkResolverImpl.java
@@ -6,10 +6,10 @@ import com.positivity.mcp.internal.repository.ScreenRegistryRepository;
 import com.positivity.mcp.service.SiteMapService;
 import com.positivity.mcp.service.model.SiteMap;
 import com.positivity.mcp.service.model.SiteMapSection;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -28,12 +28,13 @@ import org.springframework.stereotype.Service;
  * terminal — a lower-ranked but still-above-floor screen the caller can open still wins.
  *
  * <p>When the registry yields nothing the caller can open, resolution falls back to the frontend
- * site map: a coarse, section-level index of the app's navigable areas. Site-map sections are gated
- * by the caller's <em>roles</em> (a section with no {@code roles} is open to any authenticated
- * caller) and matched to the request lexically. This keeps top-level routes reachable across
- * frontend deployments without re-seeding the registry, while the registry stays the fine-grained,
- * semantic path. The fallback is best-effort — a site-map outage degrades to no result, never an
- * error.
+ * site map: a coarse, section-level index of the app's navigable areas. The request is embedded once
+ * and that same query vector is reused to rank site-map sections by cosine similarity (so the
+ * fallback is semantic, consistent with the registry, not a separate lexical scheme). Sections are
+ * gated by the caller's <em>roles</em> — a section with no {@code roles} is open to any authenticated
+ * caller. This keeps top-level routes reachable across frontend deployments without re-seeding the
+ * registry, while the registry stays the fine-grained path. The fallback is best-effort — a site-map
+ * outage degrades to no result, never an error.
  */
 @Service
 @Profile({"!test", "openapi"})
@@ -41,8 +42,6 @@ public class ScreenLinkResolverImpl implements ScreenLinkResolver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ScreenLinkResolverImpl.class);
     private static final int CANDIDATE_LIMIT = 5;
-    // Query/section tokens shorter than this are dropped as low-signal noise for the lexical fallback.
-    private static final int MIN_TOKEN_LENGTH = 3;
 
     private final EmbeddingModel embeddingModel;
     private final ScreenRegistryRepository repository;
@@ -52,6 +51,10 @@ public class ScreenLinkResolverImpl implements ScreenLinkResolver {
 
     private final double minScore;
     private final double siteMapMinScore;
+
+    // Section text → embedding. Bounded by the handful of distinct site-map section texts; keying on
+    // the text means unchanged sections are embedded once and reused across requests and rebuilds.
+    private final Map<String, float[]> sectionEmbeddingCache = new ConcurrentHashMap<>();
 
     public ScreenLinkResolverImpl(
             @NonNull EmbeddingModel embeddingModel,
@@ -77,19 +80,20 @@ public class ScreenLinkResolverImpl implements ScreenLinkResolver {
             return Optional.empty();
         }
 
-        Optional<ScreenLink> fromRegistry = resolveFromRegistry(userMessage, domain, callerPermissions, params);
+        // Embed once and reuse for both the registry search and the site-map fallback.
+        float[] queryEmbedding = embeddingModel.embed(userMessage);
+        Optional<ScreenLink> fromRegistry = resolveFromRegistry(queryEmbedding, domain, callerPermissions, params);
         if (fromRegistry.isPresent()) {
             return fromRegistry;
         }
-        return resolveFromSiteMap(userMessage, callerRoles);
+        return resolveFromSiteMap(queryEmbedding, callerRoles);
     }
 
     private @NonNull Optional<ScreenLink> resolveFromRegistry(
-            @NonNull String userMessage,
+            float @NonNull [] queryEmbedding,
             @Nullable String domain,
             @NonNull Set<String> callerPermissions,
             @NonNull Map<String, String> params) {
-        float[] queryEmbedding = embeddingModel.embed(userMessage);
         for (ScreenCandidate candidate : repository.findNearest(queryEmbedding, domain, CANDIDATE_LIMIT)) {
             if (candidate.score() < minScore) {
                 break; // ordered by descending score — nothing below this clears the floor
@@ -109,67 +113,63 @@ public class ScreenLinkResolverImpl implements ScreenLinkResolver {
     }
 
     /**
-     * Coarse role-gated fallback over the frontend site map. Best-effort: a site-map outage or an
-     * empty match yields no result rather than an error.
+     * Coarse role-gated fallback over the frontend site map, ranking visible sections by cosine
+     * similarity against the already-computed query embedding. Best-effort: a site-map outage or an
+     * embedding failure yields no result rather than an error.
      */
     private @NonNull Optional<ScreenLink> resolveFromSiteMap(
-            @NonNull String userMessage, @NonNull Set<String> callerRoles) {
+            float @NonNull [] queryEmbedding, @NonNull Set<String> callerRoles) {
         if (siteMapService == null) {
             return Optional.empty();
         }
-        SiteMap siteMap;
         try {
-            siteMap = siteMapService.getSiteMap();
+            SiteMap siteMap = siteMapService.getSiteMap();
+            SiteMapSection best = null;
+            double bestScore = 0;
+            for (SiteMapSection section : siteMap.sections()) {
+                if (!section.isVisibleTo(callerRoles)) {
+                    continue; // caller lacks a required role for this section
+                }
+                double score = cosineSimilarity(queryEmbedding, sectionEmbedding(section));
+                if (score > bestScore) {
+                    bestScore = score;
+                    best = section;
+                }
+            }
+            if (best == null || bestScore < siteMapMinScore) {
+                return Optional.empty();
+            }
+            LOGGER.debug("Resolved screen link from site map route={} score={}", best.route(), bestScore);
+            // Site-map routes are static paths (no url_template placeholders); the route is the deep link.
+            return Optional.of(new ScreenLink(best.route(), best.title(), best.route(), bestScore));
         } catch (RuntimeException exception) {
-            LOGGER.debug("Site map unavailable for screen fallback: {}", exception.getMessage());
+            LOGGER.debug("Site map screen fallback unavailable: {}", exception.getMessage());
             return Optional.empty();
         }
-
-        Set<String> queryTokens = tokenize(userMessage);
-        if (queryTokens.isEmpty()) {
-            return Optional.empty();
-        }
-
-        SiteMapSection best = null;
-        double bestScore = 0;
-        for (SiteMapSection section : siteMap.sections()) {
-            if (!section.isVisibleTo(callerRoles)) {
-                continue; // caller lacks a required role for this section
-            }
-            double score = lexicalScore(queryTokens, section);
-            if (score > bestScore) {
-                bestScore = score;
-                best = section;
-            }
-        }
-
-        if (best == null || bestScore < siteMapMinScore) {
-            return Optional.empty();
-        }
-        LOGGER.debug("Resolved screen link from site map route={} score={}", best.route(), bestScore);
-        // Site-map routes are static paths (no url_template placeholders); the route is the deep link.
-        return Optional.of(new ScreenLink(best.route(), best.title(), best.route(), bestScore));
     }
 
-    /**
-     * Fraction of the request's tokens that appear in a section's searchable text (title +
-     * description + route), in {@code [0, 1]}. A coverage measure, not a similarity score — this is a
-     * deliberately simple lexical match for the section-level fallback, not the registry's semantic
-     * search.
-     */
-    private static double lexicalScore(@NonNull Set<String> queryTokens, @NonNull SiteMapSection section) {
-        Set<String> sectionTokens = tokenize(section.title() + " " + section.description() + " " + section.route());
-        long hits = queryTokens.stream().filter(sectionTokens::contains).count();
-        return (double) hits / queryTokens.size();
+    private float @NonNull [] sectionEmbedding(@NonNull SiteMapSection section) {
+        // Embed the natural-language title + description (not the route) for a meaningful vector.
+        String text = section.title() + ". " + section.description();
+        return sectionEmbeddingCache.computeIfAbsent(text, embeddingModel::embed);
     }
 
-    private static @NonNull Set<String> tokenize(@NonNull String text) {
-        Set<String> tokens = new HashSet<>();
-        for (String token : text.toLowerCase().split("[^a-z0-9]+")) {
-            if (token.length() >= MIN_TOKEN_LENGTH) {
-                tokens.add(token);
-            }
+    /** Cosine similarity in {@code [-1, 1]}; 0 when either vector is zero or lengths differ. */
+    private static double cosineSimilarity(float @NonNull [] a, float @NonNull [] b) {
+        if (a.length != b.length) {
+            return 0;
         }
-        return tokens;
+        double dot = 0;
+        double normA = 0;
+        double normB = 0;
+        for (int i = 0; i < a.length; i++) {
+            dot += (double) a[i] * b[i];
+            normA += (double) a[i] * a[i];
+            normB += (double) b[i] * b[i];
+        }
+        if (normA == 0 || normB == 0) {
+            return 0;
+        }
+        return dot / (Math.sqrt(normA) * Math.sqrt(normB));
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SiteMapEmbeddingWarmupRunner.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SiteMapEmbeddingWarmupRunner.java
@@ -1,0 +1,35 @@
+package com.positivity.mcp.internal.service;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Startup warm-up for the site-map screen fallback: pre-embeds every site-map section so the first
+ * request that falls through to the site map does no embedding on the hot path. Mirrors
+ * {@link com.positivity.mcp.internal.config.ScreenEmbeddingInitializer}; fail-soft — {@link
+ * ScreenLinkResolverImpl#warmUp()} swallows a site-map outage so startup never blocks.
+ *
+ * <p>Deliberately lives in {@code internal.service}, not {@code internal.config}: {@code
+ * internal.service} already depends on {@code internal.config}, so a config-package runner depending
+ * on this service bean would form a package-slice cycle that the ArchUnit rules reject.
+ */
+@Component
+@Profile({"!test", "openapi"})
+@Order(22)
+public class SiteMapEmbeddingWarmupRunner implements ApplicationRunner {
+
+    private final ScreenLinkResolverImpl screenLinkResolver;
+
+    public SiteMapEmbeddingWarmupRunner(@NonNull ScreenLinkResolverImpl screenLinkResolver) {
+        this.screenLinkResolver = screenLinkResolver;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        screenLinkResolver.warmUp();
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SiteMapEmbeddingWarmupRunner.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/SiteMapEmbeddingWarmupRunner.java
@@ -1,35 +1,64 @@
 package com.positivity.mcp.internal.service;
 
+import com.positivity.mcp.internal.config.SiteMapProperties;
+import java.time.Duration;
 import org.jspecify.annotations.NonNull;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.IntervalTask;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.stereotype.Component;
 
 /**
- * Startup warm-up for the site-map screen fallback: pre-embeds every site-map section so the first
- * request that falls through to the site map does no embedding on the hot path. Mirrors
- * {@link com.positivity.mcp.internal.config.ScreenEmbeddingInitializer}; fail-soft — {@link
- * ScreenLinkResolverImpl#warmUp()} swallows a site-map outage so startup never blocks.
+ * Warm-up for the site-map screen fallback: pre-embeds every site-map section so a request that
+ * falls through to the site map does no embedding on the hot path.
+ *
+ * <p>Runs at startup ({@link ApplicationRunner}) and then periodically, on a fixed delay aligned to
+ * the site-map cache TTL ({@code mcp.sitemap.cache-ttl}). The periodic re-warm re-fetches the (by
+ * then stale) site map off the hot path so it (a) picks up sections added by a frontend redeploy and
+ * (b) self-heals a cold cache if the frontend was unreachable at startup — all without ever embedding
+ * on a request. {@link ScreenLinkResolverImpl#warmUp()} is fail-soft, so neither path blocks startup
+ * nor disrupts serving. Section embeddings are keyed by text, so an unchanged re-warm is all cache
+ * hits.
+ *
+ * <p>The periodic task is registered via {@link SchedulingConfigurer} using the bound TTL
+ * {@link Duration} directly (rather than {@code @Scheduled(fixedDelayString = ...)}), so the cadence
+ * tracks the TTL exactly with no dependence on the string's duration format.
  *
  * <p>Deliberately lives in {@code internal.service}, not {@code internal.config}: {@code
- * internal.service} already depends on {@code internal.config}, so a config-package runner depending
- * on this service bean would form a package-slice cycle that the ArchUnit rules reject.
+ * internal.service} already depends on {@code internal.config}, so a config-package bean depending on
+ * this service bean would form a package-slice cycle that the ArchUnit rules reject.
  */
 @Component
 @Profile({"!test", "openapi"})
 @Order(22)
-public class SiteMapEmbeddingWarmupRunner implements ApplicationRunner {
+public class SiteMapEmbeddingWarmupRunner implements ApplicationRunner, SchedulingConfigurer {
 
     private final ScreenLinkResolverImpl screenLinkResolver;
+    private final Duration reWarmInterval;
 
-    public SiteMapEmbeddingWarmupRunner(@NonNull ScreenLinkResolverImpl screenLinkResolver) {
+    public SiteMapEmbeddingWarmupRunner(
+            @NonNull ScreenLinkResolverImpl screenLinkResolver, @NonNull SiteMapProperties siteMapProperties) {
         this.screenLinkResolver = screenLinkResolver;
+        this.reWarmInterval = siteMapProperties.cacheTtl();
     }
 
     @Override
     public void run(ApplicationArguments args) {
+        screenLinkResolver.warmUp();
+    }
+
+    @Override
+    public void configureTasks(@NonNull ScheduledTaskRegistrar registrar) {
+        // Re-warm on the TTL cadence; first firing is one interval after startup (run() already
+        // covered boot), so the two never double up.
+        registrar.addFixedDelayTask(new IntervalTask(this::reWarm, reWarmInterval, reWarmInterval));
+    }
+
+    void reWarm() {
         screenLinkResolver.warmUp();
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/service/SiteMapService.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/service/SiteMapService.java
@@ -1,0 +1,46 @@
+package com.positivity.mcp.service;
+
+import com.positivity.mcp.service.model.SiteMap;
+import com.positivity.mcp.service.model.SiteMapSection;
+import java.util.Collection;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Read-only access to the durion-positivity-frontend site map (the frontend's {@code /sitemap.json}
+ * artifact). Implementations fetch the artifact over HTTP, validate it against the shared contract,
+ * cache it with a TTL, and keep a last-known-good copy so a brief frontend outage does not break the
+ * server.
+ *
+ * <p>This is a <strong>pull-only</strong> consumer: no frontend code/types are imported and the
+ * frontend never pushes here. The only shared contract is the JSON schema plus its integer
+ * {@code version}.
+ */
+public interface SiteMapService {
+
+    /**
+     * Returns the site map, serving the cached copy while it is fresh and otherwise fetching a new
+     * one. On a fetch failure with a warm cache the last-known-good copy is returned; on a fetch
+     * failure with a cold cache a {@link SiteMapUnavailableException} is thrown.
+     */
+    @NonNull
+    SiteMap getSiteMap();
+
+    /**
+     * Forces an HTTP fetch regardless of the cache TTL (e.g. an admin "reload" action), updating the
+     * cache on success. Falls back to last-known-good on failure with the same semantics as
+     * {@link #getSiteMap()}.
+     */
+    @NonNull
+    SiteMap refresh();
+
+    /**
+     * Filters the currently cached site map to the sections the given roles can reach. Pure and
+     * cached-only — performs no I/O; callers must ensure the cache is warm (e.g. call
+     * {@link #getSiteMap()} first). Returns an empty list when the cache is cold. A section without a
+     * {@code roles} restriction is visible to any authenticated user; otherwise the caller must hold
+     * at least one of the section's roles.
+     */
+    @NonNull
+    List<SiteMapSection> visibleSections(@NonNull Collection<String> userRoles);
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/service/SiteMapUnavailableException.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/service/SiteMapUnavailableException.java
@@ -1,0 +1,20 @@
+package com.positivity.mcp.service;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Thrown by {@link SiteMapService#getSiteMap()} / {@link SiteMapService#refresh()} only when a fetch
+ * fails <em>and</em> there is no last-known-good copy to serve (a cold cache). Once any successful
+ * fetch has been cached, later fetch failures never surface this — the cached copy is returned
+ * instead — so callers can treat this purely as a cold-start signal.
+ */
+public class SiteMapUnavailableException extends RuntimeException {
+
+    public SiteMapUnavailableException(@NonNull String message) {
+        super(message);
+    }
+
+    public SiteMapUnavailableException(@NonNull String message, @NonNull Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/service/model/SiteMap.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/service/model/SiteMap.java
@@ -1,0 +1,21 @@
+package com.positivity.mcp.service.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Parsed view of the frontend's {@code /sitemap.json} artifact — a read-only, versioned index of the
+ * application's navigable sections.
+ *
+ * <p>{@code sections} preserves the artifact's {@code (group, order)} ordering (main before admin).
+ * {@code generatedAt} is a per-build timestamp used only for change detection/telemetry and must not
+ * be treated as a stable key. Unknown fields from a newer contract version are ignored so a version
+ * bump that only adds fields does not break parsing.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SiteMap(
+        @NonNull String application,
+        int version,
+        @NonNull String generatedAt,
+        @NonNull List<SiteMapSection> sections) {}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/service/model/SiteMapSection.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/service/model/SiteMapSection.java
@@ -1,0 +1,41 @@
+package com.positivity.mcp.service.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Collection;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One navigable section of the durion-positivity-frontend, as published in the frontend's
+ * {@code /sitemap.json} artifact and governed by {@code docs/sitemap/sitemap.schema.json} in the
+ * frontend repo.
+ *
+ * <p>Forward-compatible by design: unknown JSON fields added by a newer contract version are
+ * ignored ({@link JsonIgnoreProperties}) rather than failing the parse. {@code roles} is optional —
+ * {@code null}/empty means the section is reachable by any authenticated user; otherwise the caller
+ * must hold at least one of the listed roles.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SiteMapSection(
+        @NonNull String route,
+        @NonNull String titleKey,
+        @NonNull String title,
+        @NonNull String descriptionKey,
+        @NonNull String description,
+        @Nullable List<String> roles,
+        @NonNull String group,
+        int order) {
+
+    /**
+     * Whether a caller holding {@code userRoles} may reach this section. A section without a
+     * {@code roles} restriction is open to any authenticated user; otherwise access is granted if
+     * the caller holds <em>any</em> of the listed roles.
+     */
+    public boolean isVisibleTo(@NonNull Collection<String> userRoles) {
+        if (roles == null || roles.isEmpty()) {
+            return true;
+        }
+        return roles.stream().anyMatch(userRoles::contains);
+    }
+}

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -33,6 +33,12 @@ mcp:
       - /admin/
       - /actuator/
       - /internal/
+  sitemap:
+    # Origin of the frontend SSR server (NOT the API gateway). The SSR server defaults to port 4000.
+    base-url: ${FRONTEND_BASE_URL:http://localhost:4000}
+    cache-ttl: ${SITEMAP_CACHE_TTL:600s}
+    fetch-timeout: ${SITEMAP_FETCH_TIMEOUT:5s}
+    expected-version: ${SITEMAP_EXPECTED_VERSION:1}
   security:
     permit-all-transport: false
   rag:

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/client/SiteMapClientTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/client/SiteMapClientTest.java
@@ -1,0 +1,311 @@
+package com.positivity.mcp.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.mcp.internal.config.SiteMapProperties;
+import com.positivity.mcp.service.SiteMapUnavailableException;
+import com.positivity.mcp.service.model.SiteMap;
+import com.positivity.mcp.service.model.SiteMapSection;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link SiteMapClient}, covering the reference cases from the frontend's
+ * {@code docs/sitemap/client-module.md} consumer spec against the canonical example payload.
+ */
+class SiteMapClientTest {
+
+    private static final String BASE_URL = "http://frontend";
+    private static final String SITEMAP_URL = BASE_URL + "/sitemap.json";
+    private static final Instant T0 = Instant.parse("2026-07-27T00:00:00Z");
+
+    // Canonical fixture from docs/sitemap/client-module.md — main section (no roles) before admin.
+    private static final String CANONICAL_PAYLOAD = """
+            {
+              "application": "durion-positivity-frontend",
+              "version": 1,
+              "generatedAt": "2026-07-27T00:00:00.000Z",
+              "sections": [
+                {
+                  "route": "/app/crm",
+                  "titleKey": "SHELL.NAV.CRM",
+                  "title": "Customers",
+                  "descriptionKey": "SITEMAP.SECTIONS.CRM.DESC",
+                  "description": "Manage customers, contacts, and relationships.",
+                  "group": "main",
+                  "order": 3
+                },
+                {
+                  "route": "/app/admin",
+                  "titleKey": "SHELL.NAV.ADMIN",
+                  "title": "Admin",
+                  "descriptionKey": "SITEMAP.SECTIONS.ADMIN.DESC",
+                  "description": "System administration and configuration.",
+                  "roles": ["ROLE_ADMIN"],
+                  "group": "admin",
+                  "order": 12
+                }
+              ]
+            }
+            """;
+
+    private MutableClock clock;
+
+    @BeforeEach
+    void setUp() {
+        clock = new MutableClock(T0);
+    }
+
+    @Test
+    @DisplayName("case 1: happy path returns parsed site map in (group, order) order")
+    void happyPath_returnsParsedSiteMapInOrder() {
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess(CANONICAL_PAYLOAD, MediaType.APPLICATION_JSON));
+
+        SiteMap siteMap = fixture.client().getSiteMap();
+
+        fixture.server().verify();
+        assertThat(siteMap.application()).isEqualTo("durion-positivity-frontend");
+        assertThat(siteMap.version()).isEqualTo(1);
+        assertThat(siteMap.generatedAt()).isEqualTo("2026-07-27T00:00:00.000Z");
+        assertThat(siteMap.sections()).extracting(SiteMapSection::route).containsExactly("/app/crm", "/app/admin");
+    }
+
+    @Test
+    @DisplayName("case 2: visibleSections([]) returns only sections without a roles restriction")
+    void visibleSections_noRoles_returnsOnlyUnrestricted() {
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess(CANONICAL_PAYLOAD, MediaType.APPLICATION_JSON));
+        fixture.client().getSiteMap();
+
+        List<SiteMapSection> visible = fixture.client().visibleSections(List.of());
+
+        assertThat(visible).extracting(SiteMapSection::route).containsExactly("/app/crm");
+    }
+
+    @Test
+    @DisplayName("case 3: visibleSections([ROLE_ADMIN]) includes admin-gated sections")
+    void visibleSections_admin_includesAdminSection() {
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess(CANONICAL_PAYLOAD, MediaType.APPLICATION_JSON));
+        fixture.client().getSiteMap();
+
+        List<SiteMapSection> visible = fixture.client().visibleSections(List.of("ROLE_ADMIN"));
+
+        assertThat(visible).extracting(SiteMapSection::route).containsExactly("/app/crm", "/app/admin");
+    }
+
+    @Test
+    @DisplayName("case 4: section role match is 'any of' the listed roles")
+    void visibleSections_roleMatchIsAnyOf() {
+        String payload = """
+                {
+                  "application": "durion-positivity-frontend",
+                  "version": 1,
+                  "generatedAt": "2026-07-27T00:00:00.000Z",
+                  "sections": [
+                    {
+                      "route": "/app/multi",
+                      "titleKey": "SHELL.NAV.MULTI",
+                      "title": "Multi",
+                      "descriptionKey": "SITEMAP.SECTIONS.MULTI.DESC",
+                      "description": "Requires either role.",
+                      "roles": ["ROLE_A", "ROLE_B"],
+                      "group": "main",
+                      "order": 1
+                    }
+                  ]
+                }
+                """;
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess(payload, MediaType.APPLICATION_JSON));
+        fixture.client().getSiteMap();
+
+        assertThat(fixture.client().visibleSections(List.of("ROLE_B")))
+                .extracting(SiteMapSection::route)
+                .containsExactly("/app/multi");
+        assertThat(fixture.client().visibleSections(List.of("ROLE_C"))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("case 5: HTTP 500 with a warm cache returns last-known-good and does not throw")
+    void fetchFailure_warmCache_returnsLastKnownGood() {
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess(CANONICAL_PAYLOAD, MediaType.APPLICATION_JSON));
+        expectSitemap(fixture.server()).andRespond(withServerError());
+
+        SiteMap first = fixture.client().getSiteMap();
+        clock.advance(Duration.ofSeconds(601)); // beyond the 600s TTL → next access refetches
+        SiteMap second = fixture.client().getSiteMap();
+
+        fixture.server().verify();
+        assertThat(second).isEqualTo(first);
+    }
+
+    @Test
+    @DisplayName("case 6: HTTP failure with a cold cache surfaces SiteMapUnavailableException")
+    void fetchFailure_coldCache_throwsUnavailable() {
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withServerError());
+
+        assertThatThrownBy(() -> fixture.client().getSiteMap()).isInstanceOf(SiteMapUnavailableException.class);
+        fixture.server().verify();
+    }
+
+    @Test
+    @DisplayName("case 7a: malformed JSON body is a fetch failure (cold cache → unavailable)")
+    void malformedBody_coldCache_throwsUnavailable() {
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess("{not-json", MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() -> fixture.client().getSiteMap()).isInstanceOf(SiteMapUnavailableException.class);
+    }
+
+    @Test
+    @DisplayName("case 7b: non-JSON content type is a fetch failure")
+    void nonJsonContentType_throwsUnavailable() {
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server())
+                .andRespond(withStatus(org.springframework.http.HttpStatus.OK)
+                        .body("<html></html>")
+                        .contentType(MediaType.TEXT_HTML));
+
+        assertThatThrownBy(() -> fixture.client().getSiteMap()).isInstanceOf(SiteMapUnavailableException.class);
+    }
+
+    @Test
+    @DisplayName("case 8: wrong application value is rejected as a fetch failure")
+    void wrongApplication_throwsUnavailable() {
+        String payload = """
+                {
+                  "application": "some-other-app",
+                  "version": 1,
+                  "generatedAt": "2026-07-27T00:00:00.000Z",
+                  "sections": []
+                }
+                """;
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess(payload, MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() -> fixture.client().getSiteMap()).isInstanceOf(SiteMapUnavailableException.class);
+    }
+
+    @Test
+    @DisplayName("cases 9 & 12: newer version and unknown fields are tolerated, not fatal")
+    void newerVersionAndUnknownFields_areTolerated() {
+        String payload = """
+                {
+                  "application": "durion-positivity-frontend",
+                  "version": 2,
+                  "generatedAt": "2026-07-27T00:00:00.000Z",
+                  "futureTopLevelField": {"anything": true},
+                  "sections": [
+                    {
+                      "route": "/app/crm",
+                      "titleKey": "SHELL.NAV.CRM",
+                      "title": "Customers",
+                      "descriptionKey": "SITEMAP.SECTIONS.CRM.DESC",
+                      "description": "Manage customers.",
+                      "group": "main",
+                      "order": 3,
+                      "futureSectionField": "ignored"
+                    }
+                  ]
+                }
+                """;
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess(payload, MediaType.APPLICATION_JSON));
+
+        SiteMap siteMap = fixture.client().getSiteMap();
+
+        assertThat(siteMap.version()).isEqualTo(2);
+        assertThat(siteMap.sections()).extracting(SiteMapSection::route).containsExactly("/app/crm");
+    }
+
+    @Test
+    @DisplayName("case 10: within TTL a second call is served from cache without a second HTTP request")
+    void withinTtl_secondCallUsesCache() {
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess(CANONICAL_PAYLOAD, MediaType.APPLICATION_JSON));
+
+        SiteMap first = fixture.client().getSiteMap();
+        SiteMap second = fixture.client().getSiteMap(); // no clock advance → still fresh
+
+        fixture.server().verify(); // exactly one request was expected
+        assertThat(second).isEqualTo(first);
+    }
+
+    @Test
+    @DisplayName("case 11: refresh() performs an HTTP request even within TTL")
+    void refresh_forcesFetchWithinTtl() {
+        Fixture fixture = fixture(clock);
+        expectSitemap(fixture.server()).andRespond(withSuccess(CANONICAL_PAYLOAD, MediaType.APPLICATION_JSON));
+        expectSitemap(fixture.server()).andRespond(withSuccess(CANONICAL_PAYLOAD, MediaType.APPLICATION_JSON));
+
+        fixture.client().getSiteMap();
+        fixture.client().refresh(); // within TTL, but must still hit the server
+
+        fixture.server().verify(); // two requests expected
+    }
+
+    private static org.springframework.test.web.client.ResponseActions expectSitemap(MockRestServiceServer server) {
+        return server.expect(requestTo(SITEMAP_URL)).andExpect(method(HttpMethod.GET));
+    }
+
+    private static Fixture fixture(Clock clock) {
+        RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        RestClient restClient = builder.build();
+        SiteMapProperties properties =
+                new SiteMapProperties(BASE_URL, Duration.ofSeconds(600), Duration.ofSeconds(5), 1);
+        SiteMapClient client = new SiteMapClient(restClient, properties, clock);
+        return new Fixture(client, server);
+    }
+
+    private record Fixture(SiteMapClient client, MockRestServiceServer server) {}
+
+    /** A hand-advanced {@link Clock} so TTL expiry can be driven deterministically in tests. */
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant start) {
+            this.instant = start;
+        }
+
+        void advance(Duration amount) {
+            instant = instant.plus(amount);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/AnswerResolutionLadderImplTest.java
@@ -47,7 +47,7 @@ class AnswerResolutionLadderImplTest {
     @DisplayName("a resolved screen yields a DEEP_LINK carrying its title and url")
     void deepLinkWhenScreenResolves() {
         when(requestScopedUserContext.current()).thenReturn(Optional.of(userWith(Set.of("workorder:workorder:view"))));
-        when(screenLinkResolver.resolve(any(), nullable(String.class), any(), any()))
+        when(screenLinkResolver.resolve(any(), nullable(String.class), any(), any(), any()))
                 .thenReturn(Optional.of(new ScreenLink("workorders.list", "Work Orders", "/workorders", 0.8)));
 
         LadderResult result = ladder().resolveFallback("how many workorders are open");
@@ -61,7 +61,7 @@ class AnswerResolutionLadderImplTest {
     @DisplayName("no resolvable screen yields an honest HANDOFF")
     void handoffWhenNoScreen() {
         when(requestScopedUserContext.current()).thenReturn(Optional.empty());
-        when(screenLinkResolver.resolve(any(), nullable(String.class), any(), any()))
+        when(screenLinkResolver.resolve(any(), nullable(String.class), any(), any(), any()))
                 .thenReturn(Optional.empty());
 
         LadderResult result = ladder().resolveFallback("something unanswerable");
@@ -75,7 +75,7 @@ class AnswerResolutionLadderImplTest {
     @DisplayName("a screen-resolver failure degrades to HANDOFF instead of propagating")
     void resolverFailureDegradesToHandoff() {
         when(requestScopedUserContext.current()).thenReturn(Optional.empty());
-        when(screenLinkResolver.resolve(any(), nullable(String.class), any(), any()))
+        when(screenLinkResolver.resolve(any(), nullable(String.class), any(), any(), any()))
                 .thenThrow(new RuntimeException("embedding backend down"));
 
         LadderResult result = ladder().resolveFallback("how many workorders are open");
@@ -89,7 +89,7 @@ class AnswerResolutionLadderImplTest {
     void passesCallerPermissions() {
         Set<String> perms = Set.of("workorder:workorder:view", "invoice:invoice:view");
         when(requestScopedUserContext.current()).thenReturn(Optional.of(userWith(perms)));
-        when(screenLinkResolver.resolve(any(), nullable(String.class), eq(perms), any()))
+        when(screenLinkResolver.resolve(any(), nullable(String.class), eq(perms), any(), any()))
                 .thenReturn(Optional.empty());
 
         LadderResult result = ladder().resolveFallback("q");

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenLinkResolverImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenLinkResolverImplTest.java
@@ -2,15 +2,20 @@ package com.positivity.mcp.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.positivity.mcp.internal.domain.ScreenCandidate;
 import com.positivity.mcp.internal.domain.ScreenLink;
 import com.positivity.mcp.internal.repository.ScreenRegistryRepository;
+import com.positivity.mcp.service.SiteMapService;
+import com.positivity.mcp.service.SiteMapUnavailableException;
+import com.positivity.mcp.service.model.SiteMap;
+import com.positivity.mcp.service.model.SiteMapSection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,6 +32,7 @@ import org.springframework.ai.embedding.EmbeddingModel;
 class ScreenLinkResolverImplTest {
 
     private static final Set<String> VIEW_PERM = Set.of("workorder:workorder:view");
+    private static final Set<String> NO_ROLES = Set.of();
     private final float[] embedding = {0.1f, 0.2f, 0.3f};
 
     @Mock
@@ -35,13 +41,25 @@ class ScreenLinkResolverImplTest {
     @Mock
     private ScreenRegistryRepository repository;
 
+    @Mock
+    private SiteMapService siteMapService;
+
     private ScreenLinkResolverImpl resolver() {
-        return new ScreenLinkResolverImpl(embeddingModel, repository, 0.6);
+        return new ScreenLinkResolverImpl(embeddingModel, repository, siteMapService, 0.6, 0.5);
     }
 
     private ScreenCandidate candidate(String key, String perm, double score) {
         return new ScreenCandidate(
                 key, key, "/workorders?status={status}&location={locationId}", "workorder", perm, score);
+    }
+
+    private SiteMap siteMap(SiteMapSection... sections) {
+        return new SiteMap("durion-positivity-frontend", 1, "2026-07-27T00:00:00.000Z", List.of(sections));
+    }
+
+    private SiteMapSection section(String route, String title, String description, List<String> roles) {
+        return new SiteMapSection(
+                route, "SHELL.NAV.KEY", title, "SITEMAP.SECTIONS.KEY.DESC", description, roles, "main", 1);
     }
 
     @Test
@@ -51,23 +69,27 @@ class ScreenLinkResolverImplTest {
         when(repository.findNearest(any(), nullable(String.class), anyInt()))
                 .thenReturn(List.of(candidate("workorders.list", "workorder:workorder:view", 0.82)));
 
-        Optional<ScreenLink> link =
-                resolver().resolve("how many workorders are open", "workorder", VIEW_PERM, Map.of("status", "OPEN"));
+        Optional<ScreenLink> link = resolver()
+                .resolve("how many workorders are open", "workorder", VIEW_PERM, NO_ROLES, Map.of("status", "OPEN"));
 
         assertThat(link).isPresent();
         assertThat(link.get().screenKey()).isEqualTo("workorders.list");
         assertThat(link.get().url()).isEqualTo("/workorders?status=OPEN"); // unfilled locationId dropped
         assertThat(link.get().score()).isEqualTo(0.82);
+        // Registry produced a permitted hit — the site-map fallback must not be consulted.
+        verifyNoInteractions(siteMapService);
     }
 
     @Test
-    @DisplayName("nothing above the similarity floor returns empty")
+    @DisplayName("nothing above the similarity floor, no site-map match, returns empty")
     void belowFloorReturnsEmpty() {
         when(embeddingModel.embed(anyString())).thenReturn(embedding);
         when(repository.findNearest(any(), nullable(String.class), anyInt()))
                 .thenReturn(List.of(candidate("workorders.list", null, 0.41)));
+        when(siteMapService.getSiteMap())
+                .thenReturn(siteMap(section("/app/crm", "Customers", "Manage customers.", null)));
 
-        assertThat(resolver().resolve("unrelated question", null, VIEW_PERM, Map.of()))
+        assertThat(resolver().resolve("unrelated question", null, VIEW_PERM, NO_ROLES, Map.of()))
                 .isEmpty();
     }
 
@@ -80,16 +102,65 @@ class ScreenLinkResolverImplTest {
                         candidate("admin.secret", "admin:secret:view", 0.90),
                         candidate("workorders.list", null, 0.71)));
 
-        Optional<ScreenLink> link = resolver().resolve("show me work", "workorder", VIEW_PERM, Map.of());
+        Optional<ScreenLink> link = resolver().resolve("show me work", "workorder", VIEW_PERM, NO_ROLES, Map.of());
 
         assertThat(link).isPresent();
         assertThat(link.get().screenKey()).isEqualTo("workorders.list");
     }
 
     @Test
-    @DisplayName("blank message returns empty without embedding")
+    @DisplayName("blank message returns empty without embedding or site-map lookup")
     void blankMessageReturnsEmptyWithoutEmbedding() {
-        assertThat(resolver().resolve("   ", null, VIEW_PERM, Map.of())).isEmpty();
-        verifyNoInteractions(embeddingModel, repository);
+        assertThat(resolver().resolve("   ", null, VIEW_PERM, NO_ROLES, Map.of()))
+                .isEmpty();
+        verifyNoInteractions(embeddingModel, repository, siteMapService);
+    }
+
+    @Test
+    @DisplayName("site-map fallback returns a routed link when the registry finds nothing")
+    void siteMapFallbackReturnsRoutedLink() {
+        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(repository.findNearest(any(), nullable(String.class), anyInt())).thenReturn(List.of());
+        when(siteMapService.getSiteMap())
+                .thenReturn(siteMap(
+                        section("/app/crm", "Customers", "Manage customers, contacts, and relationships.", null)));
+
+        Optional<ScreenLink> link =
+                resolver().resolve("where can I manage customers", null, VIEW_PERM, NO_ROLES, Map.of());
+
+        assertThat(link).isPresent();
+        assertThat(link.get().screenKey()).isEqualTo("/app/crm");
+        assertThat(link.get().url()).isEqualTo("/app/crm");
+        assertThat(link.get().title()).isEqualTo("Customers");
+    }
+
+    @Test
+    @DisplayName("site-map section is role-gated: hidden without the role, shown with it")
+    void siteMapSectionRoleGated() {
+        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(repository.findNearest(any(), nullable(String.class), anyInt())).thenReturn(List.of());
+        when(siteMapService.getSiteMap())
+                .thenReturn(siteMap(section(
+                        "/app/admin",
+                        "Administration",
+                        "System administration and configuration.",
+                        List.of("ROLE_ADMIN"))));
+
+        assertThat(resolver().resolve("open administration configuration", null, VIEW_PERM, NO_ROLES, Map.of()))
+                .isEmpty();
+        assertThat(resolver()
+                        .resolve("open administration configuration", null, VIEW_PERM, Set.of("ROLE_ADMIN"), Map.of()))
+                .isPresent();
+    }
+
+    @Test
+    @DisplayName("a site-map outage degrades the fallback to empty, never throwing")
+    void siteMapOutageDegradesToEmpty() {
+        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(repository.findNearest(any(), nullable(String.class), anyInt())).thenReturn(List.of());
+        lenient().when(siteMapService.getSiteMap()).thenThrow(new SiteMapUnavailableException("frontend unreachable"));
+
+        assertThat(resolver().resolve("manage customers", null, VIEW_PERM, NO_ROLES, Map.of()))
+                .isEmpty();
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenLinkResolverImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenLinkResolverImplTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -171,5 +173,28 @@ class ScreenLinkResolverImplTest {
 
         assertThat(resolver().resolve("manage customers", null, VIEW_PERM, NO_ROLES, Map.of()))
                 .isEmpty();
+    }
+
+    @Test
+    @DisplayName("warm-up pre-embeds sections so the request path reuses cached section embeddings")
+    void warmUpPreEmbedsSections() {
+        when(siteMapService.getSiteMap())
+                .thenReturn(siteMap(
+                        section("/app/crm", "Customers", "Manage customers, contacts, and relationships.", null)));
+        when(embeddingModel.embed(argThat((String text) -> text != null && text.contains("Customers"))))
+                .thenReturn(vecA);
+        when(repository.findNearest(any(), nullable(String.class), anyInt())).thenReturn(List.of());
+        when(embeddingModel.embed("where can I manage customers")).thenReturn(vecA);
+
+        ScreenLinkResolverImpl resolver = resolver();
+        resolver.warmUp(); // embeds the section once, up front
+
+        Optional<ScreenLink> link =
+                resolver.resolve("where can I manage customers", null, VIEW_PERM, NO_ROLES, Map.of());
+
+        assertThat(link).isPresent();
+        assertThat(link.get().url()).isEqualTo("/app/crm");
+        // Section embedded exactly once (during warm-up), never again on the request path.
+        verify(embeddingModel, times(1)).embed(argThat((String text) -> text != null && text.contains("Customers")));
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenLinkResolverImplTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ScreenLinkResolverImplTest.java
@@ -3,9 +3,8 @@ package com.positivity.mcp.internal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -33,7 +32,10 @@ class ScreenLinkResolverImplTest {
 
     private static final Set<String> VIEW_PERM = Set.of("workorder:workorder:view");
     private static final Set<String> NO_ROLES = Set.of();
-    private final float[] embedding = {0.1f, 0.2f, 0.3f};
+
+    // Two orthogonal query/section vectors: identical → cosine 1.0, orthogonal → cosine 0.0.
+    private final float[] vecA = {1f, 0f, 0f};
+    private final float[] vecB = {0f, 1f, 0f};
 
     @Mock
     private EmbeddingModel embeddingModel;
@@ -65,7 +67,7 @@ class ScreenLinkResolverImplTest {
     @Test
     @DisplayName("top candidate above floor returns a filled, permitted link")
     void topCandidateAboveFloorReturnsFilledUrl() {
-        when(embeddingModel.embed("how many workorders are open")).thenReturn(embedding);
+        when(embeddingModel.embed("how many workorders are open")).thenReturn(vecA);
         when(repository.findNearest(any(), nullable(String.class), anyInt()))
                 .thenReturn(List.of(candidate("workorders.list", "workorder:workorder:view", 0.82)));
 
@@ -83,11 +85,13 @@ class ScreenLinkResolverImplTest {
     @Test
     @DisplayName("nothing above the similarity floor, no site-map match, returns empty")
     void belowFloorReturnsEmpty() {
-        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(embeddingModel.embed("unrelated question")).thenReturn(vecA);
         when(repository.findNearest(any(), nullable(String.class), anyInt()))
                 .thenReturn(List.of(candidate("workorders.list", null, 0.41)));
         when(siteMapService.getSiteMap())
                 .thenReturn(siteMap(section("/app/crm", "Customers", "Manage customers.", null)));
+        when(embeddingModel.embed(argThat((String text) -> text != null && text.contains("Customers"))))
+                .thenReturn(vecB); // orthogonal to the query → cosine 0, below the floor
 
         assertThat(resolver().resolve("unrelated question", null, VIEW_PERM, NO_ROLES, Map.of()))
                 .isEmpty();
@@ -96,7 +100,7 @@ class ScreenLinkResolverImplTest {
     @Test
     @DisplayName("permission-gated top candidate is skipped for the next permitted one")
     void permissionGatedTopSkippedNextReturned() {
-        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(embeddingModel.embed("show me work")).thenReturn(vecA);
         when(repository.findNearest(any(), nullable(String.class), anyInt()))
                 .thenReturn(List.of(
                         candidate("admin.secret", "admin:secret:view", 0.90),
@@ -106,6 +110,7 @@ class ScreenLinkResolverImplTest {
 
         assertThat(link).isPresent();
         assertThat(link.get().screenKey()).isEqualTo("workorders.list");
+        verifyNoInteractions(siteMapService);
     }
 
     @Test
@@ -119,11 +124,13 @@ class ScreenLinkResolverImplTest {
     @Test
     @DisplayName("site-map fallback returns a routed link when the registry finds nothing")
     void siteMapFallbackReturnsRoutedLink() {
-        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(embeddingModel.embed("where can I manage customers")).thenReturn(vecA);
         when(repository.findNearest(any(), nullable(String.class), anyInt())).thenReturn(List.of());
         when(siteMapService.getSiteMap())
                 .thenReturn(siteMap(
                         section("/app/crm", "Customers", "Manage customers, contacts, and relationships.", null)));
+        when(embeddingModel.embed(argThat((String text) -> text != null && text.contains("Customers"))))
+                .thenReturn(vecA); // aligned with the query → cosine 1.0, clears the floor
 
         Optional<ScreenLink> link =
                 resolver().resolve("where can I manage customers", null, VIEW_PERM, NO_ROLES, Map.of());
@@ -137,7 +144,7 @@ class ScreenLinkResolverImplTest {
     @Test
     @DisplayName("site-map section is role-gated: hidden without the role, shown with it")
     void siteMapSectionRoleGated() {
-        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(embeddingModel.embed("open administration configuration")).thenReturn(vecB);
         when(repository.findNearest(any(), nullable(String.class), anyInt())).thenReturn(List.of());
         when(siteMapService.getSiteMap())
                 .thenReturn(siteMap(section(
@@ -145,6 +152,8 @@ class ScreenLinkResolverImplTest {
                         "Administration",
                         "System administration and configuration.",
                         List.of("ROLE_ADMIN"))));
+        when(embeddingModel.embed(argThat((String text) -> text != null && text.contains("Administration"))))
+                .thenReturn(vecB); // aligned with the query → cosine 1.0
 
         assertThat(resolver().resolve("open administration configuration", null, VIEW_PERM, NO_ROLES, Map.of()))
                 .isEmpty();
@@ -156,9 +165,9 @@ class ScreenLinkResolverImplTest {
     @Test
     @DisplayName("a site-map outage degrades the fallback to empty, never throwing")
     void siteMapOutageDegradesToEmpty() {
-        when(embeddingModel.embed(anyString())).thenReturn(embedding);
+        when(embeddingModel.embed("manage customers")).thenReturn(vecA);
         when(repository.findNearest(any(), nullable(String.class), anyInt())).thenReturn(List.of());
-        lenient().when(siteMapService.getSiteMap()).thenThrow(new SiteMapUnavailableException("frontend unreachable"));
+        when(siteMapService.getSiteMap()).thenThrow(new SiteMapUnavailableException("frontend unreachable"));
 
         assertThat(resolver().resolve("manage customers", null, VIEW_PERM, NO_ROLES, Map.of()))
                 .isEmpty();

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SiteMapEmbeddingWarmupRunnerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SiteMapEmbeddingWarmupRunnerTest.java
@@ -1,0 +1,21 @@
+package com.positivity.mcp.internal.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SiteMapEmbeddingWarmupRunner")
+class SiteMapEmbeddingWarmupRunnerTest {
+
+    @Test
+    @DisplayName("run() triggers the resolver's site-map embedding warm-up")
+    void runTriggersWarmUp() {
+        ScreenLinkResolverImpl resolver = mock(ScreenLinkResolverImpl.class);
+
+        new SiteMapEmbeddingWarmupRunner(resolver).run(null);
+
+        verify(resolver).warmUp();
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SiteMapEmbeddingWarmupRunnerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/SiteMapEmbeddingWarmupRunnerTest.java
@@ -3,18 +3,33 @@ package com.positivity.mcp.internal.service;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.positivity.mcp.internal.config.SiteMapProperties;
+import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("SiteMapEmbeddingWarmupRunner")
 class SiteMapEmbeddingWarmupRunnerTest {
 
+    private static final SiteMapProperties PROPERTIES =
+            new SiteMapProperties("http://frontend", Duration.ofSeconds(600), Duration.ofSeconds(5), 1);
+
     @Test
     @DisplayName("run() triggers the resolver's site-map embedding warm-up")
     void runTriggersWarmUp() {
         ScreenLinkResolverImpl resolver = mock(ScreenLinkResolverImpl.class);
 
-        new SiteMapEmbeddingWarmupRunner(resolver).run(null);
+        new SiteMapEmbeddingWarmupRunner(resolver, PROPERTIES).run(null);
+
+        verify(resolver).warmUp();
+    }
+
+    @Test
+    @DisplayName("reWarm() triggers the resolver's site-map embedding warm-up")
+    void reWarmTriggersWarmUp() {
+        ScreenLinkResolverImpl resolver = mock(ScreenLinkResolverImpl.class);
+
+        new SiteMapEmbeddingWarmupRunner(resolver, PROPERTIES).reWarm();
 
         verify(resolver).warmUp();
     }


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:287` — NLTI.
- Parent STORY (durion): louisburroughs/durion#`<parent-id>` — #1125.
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
**Not applicable — no contract-relevant files changed.** No controllers, `*Request`/`*Response` DTOs,
events, `openapi.yaml`, or validation/error models are touched. This is a **pull-only consumer** of an
artifact owned by the *frontend*; the only shared contract is the frontend's
`docs/sitemap/sitemap.schema.json` (+ its integer `version`), which lives in `durion-positivity-frontend`,
not this repo. No `BACKEND_CONTRACT_GUIDE.md` entry is required for this change.

## Contract Chain (when a Controller changed)
- N/A — no controller changed.
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope
**What changed** — `pos-mcp-server` now consumes the frontend's read-only, versioned `/sitemap.json`
build artifact (the canonical index of navigable app sections: routes, titles/descriptions, role gating)
and uses it to power screen deep-link suggestions. Delivered across five commits:

1. **Site-map consumer** (`SiteMapService` / `SiteMapClient`, `internal.client`). Fetches
   `GET ${FRONTEND_BASE_URL}/sitemap.json` over plain HTTP with **no auth header** (public static asset
   served ahead of auth), validates (HTTP 200, JSON content-type, `application` id, `version`), and
   caches with a TTL + last-known-good fallback. A brief frontend outage never breaks the server; a
   served `version` newer than expected is tolerated (unknown fields ignored) rather than crashing.
   New config `mcp.sitemap.*` (`FRONTEND_BASE_URL`, cache TTL, fetch timeout, expected version) — no
   host hardcoded.
2. **Wired into `ScreenLinkResolver`** (rung 3 of the answer-resolution ladder) as a **role-gated
   fallback**: consulted only when the semantic screen registry surfaces nothing the caller can open.
   Strictly additive — existing successful resolutions are unchanged. The registry keeps gating on
   permission codes; the site map gates on `ROLE_*` (a section with no `roles` is open to any
   authenticated caller), matching the two distinct authorization models.
3. **Semantic ranking** — the request is embedded **once** and that vector is reused to rank site-map
   sections by cosine similarity (consistent with the registry, not a separate lexical scheme).
4. **Startup warm-up runner** — `SiteMapEmbeddingWarmupRunner` pre-embeds sections at boot so the
   request path does no embedding; a request-path cache miss stays only as a cold-start safety net.
5. **TTL-aligned periodic re-warm** — re-warms section embeddings on a fixed delay equal to the
   site-map cache TTL (registered via `SchedulingConfigurer` with the bound `Duration`), so the cache
   self-heals (frontend down at startup, or sections added by a frontend redeploy) without ever
   embedding on a request.

**Why** — gives the assistant an authoritative, always-fresh view of the app's page structure for
navigation help and route suggestions, decoupled from the frontend (pull-only; no code/type import and
no reverse push, which would be a circular dependency since the frontend already calls pos-mcp-server
for chat).

**Decoupling / resilience guarantees:** pull-only; fail-soft everywhere (outage → last-known-good or a
clean "unavailable" on cold start → ladder hand-off, never a crash); forward-compatible on `version`.

**Architecture note:** the warm-up/scheduler bean lives in `internal.service`, not `internal.config`.
`internal.service` already depends on `internal.config`, so a config-package bean depending on this
service bean would form a package-slice cycle the ArchUnit rules reject; keeping it in `service` avoids
the cycle (documented in the class javadoc).

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated — none needed (no DB/controller surface changed).
- [ ] Provider behavioral contract tests added/updated — N/A (pull-only consumer of a frontend artifact).
- **How to run:**
  ```bash
  ./mvnw -pl pos-mcp-server -Dtest=SiteMapClientTest,ScreenLinkResolverImplTest,AnswerResolutionLadderImplTest,SiteMapEmbeddingWarmupRunnerTest test
  ./mvnw -pl pos-mcp-server -am test          # full module
  ./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test   # confirms no package-slice cycle
  ```
  New/updated suites: `SiteMapClientTest` (12 consumer-spec reference cases — happy path, role
  filtering, warm/cold-cache failure, malformed/non-JSON body, wrong application, version tolerance,
  TTL vs refresh), `ScreenLinkResolverImplTest` (registry-wins, semantic fallback, role gating,
  outage→empty, warm-up reuse), `AnswerResolutionLadderImplTest`, `SiteMapEmbeddingWarmupRunnerTest`.

> **CI note for reviewers:** these were developed in an environment without JDK 25 (this repo's required
> toolchain — the Maven enforcer blocks older JDKs, and a sibling module uses Java 22+ syntax). They were
> compiled and run green against an isolated Spring Boot 4.1 / Spring AI 2.0 classpath under JDK 21. The
> authoritative `./mvnw -pl pos-mcp-server -am test` + `pos-archunit` run on JDK 25 is left to CI — that
> is also the real check that the `SchedulingConfigurer` task registers cleanly in a live Spring context.

## Risk & Rollback
- **Risk level: Low.** Purely additive; the new fallback fires only where the ladder previously handed
  off, and every new path is fail-soft. No schema/DB/API changes.
- **Rollback:** revert the branch (or the individual commits). No data migration; `mcp.sitemap.*` config
  can be left in place harmlessly.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/frontend-sitemap-consumption-4pva0l` (agent
  branch convention); no cap-id provided.
- [ ] PR title starts with `[CAP:<cap-id>]` — no cap-id provided; retitle if one applies.
- [ ] Links to parent + child issues are present — unknown; author to fill.
- [x] Contract guide updated (when contract semantics changed) — N/A, no contract semantics changed.
- [ ] Required CI checks passing — to be verified by CI on JDK 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139c7Pz2bKuCgWkiqkCpKJc

---
_Generated by [Claude Code](https://claude.ai/code/session_0139c7Pz2bKuCgWkiqkCpKJc)_