### PR TITLE
pos-mcp-server: RAG gap-harness reliability + corpus growth + facade AUTHENTICATED gating (#1115, #1124, #1129, #1130, #1131)

### DIFF
--- a/pos-mcp-server/docs/rag-corpus-growth-and-flip-threshold-1124.md
+++ b/pos-mcp-server/docs/rag-corpus-growth-and-flip-threshold-1124.md
@@ -1,0 +1,96 @@
+# RAG corpus growth + hybrid-lexical flip threshold (#1124)
+
+Companion to `rag-hybrid-lexical-784-design.md` (the hybrid retrieval implementation, #1123) and
+`rag-corpus-gap-harness-design.md` (the gap-discovery harness, #1125). This doc records two #1124
+deliverables: the **corpus-growth plan** and the **data-driven criterion** for flipping
+`mcp.rag.hybrid.lexical-enabled` from its default `false` to `true`.
+
+## Why this exists
+
+Hybrid dense + lexical (Postgres FTS) retrieval with RRF fusion landed behind
+`mcp.rag.hybrid.lexical-enabled=false` (#1123). Live validation showed the lexical path is correct
+end-to-end but **hybrid == dense on recall** on the small (~17-doc) corpus: dense already returns the
+target at rank 1, so lexical has no headroom. Enabling it now would add an FTS query per retrieval for
+no measured benefit. Two things have to happen first: grow the corpus until dense starts missing
+exact-token queries, and define — in advance — the numeric bar that flips the flag.
+
+## Corpus-growth plan
+
+Docs live in `pos-mcp-server/src/main/resources/rag/*.md` and are declared in **three** manifests that
+must stay in lockstep (a unit test enforces the two Python copies):
+
+- `application.yml` + `application-alpha.yml` — `mcp.rag.preload.docs` (production ingest).
+- `scripts/rag_seed.py` `MANIFEST` — the Python re-embed path for alpha eval.
+- `scripts/gap_harness/corpus.py` `MANIFEST` — the offline corpus index for the harness.
+
+Every doc carries `rag_scope` + `required_permissions` frontmatter and source-verified `_Verified: …_`
+citations (the judge's ground truth). **Authoring rule (guardrail, #1125):** a doc may only be written
+from real module source — every `_Verified:` line must cite a class/field/method that exists. A topic
+with no implementation (e.g. core charges) stays a *gap*; we do not invent content to fill it.
+
+### Target scopes and doc-count target
+
+Current coverage skews to master/glossary + one doc per major scope. Under-covered scopes to grow
+(depth + noise), each doc source-verified against the owning `pos-*` module:
+
+| Scope | Owning module(s) | Candidate docs |
+|---|---|---|
+| order | pos-order | returns/refunds ✅ (this change), cart/checkout lifecycle, price-override approval |
+| pricing | pos-price | promotions/eligibility, restriction rules, normalization |
+| inventory | pos-inventory | purchase-order lifecycle, receiving/exceptions, transfers/adjustments |
+| accounting | pos-accounting | journal-entry posting/reversal, financial reporting |
+| customer | pos-customer | party/account model, vehicle fitment |
+| workorder | pos-workorder | estimate→workorder promotion, approval config |
+
+**Doc-count target: reach ~40–50 docs** (from 18 after this change), enough that dense retrieval starts
+missing exact-token / rare-identifier queries and lexical has measurable headroom. Track corpus size per
+increment; grow `rag-retrieval` (dense) and `rag-lexical` fixtures proportionally.
+
+### Initial increment (this change)
+
+`order.returns-refunds` (`returns-refunds-rag.md`) — source-verified against `pos-order`
+`ReturnOrderServiceImpl` / `ReturnOrderController` / `ReturnOrderStatus` / `RefundMethod` /
+`OrderPermissions`. Closes the planted `gap-returns-refunds` known-gap and demonstrates the phase-5
+round-trip (gap → authored+verified doc → new fixtures). Corpus: 17 → 18 docs. Core charges remain an
+intentional, documented gap (`gap-core-charge-KNOWNGAP`, no module source exists).
+
+## The flip criterion (implemented in `scripts/gap_harness/fusion.py::flip_decision`)
+
+> **Flip `mcp.rag.hybrid.lexical-enabled=true` when hybrid (dense+lexical RRF) recovers ≥ 30% of the
+> retrieval-miss failures that dense alone does not, AND the gated `rag_retrieval.recall_at_k` is known
+> and ≥ 0.85 (its #783 floor).**
+
+Details that make it honest:
+
+- Recovery rate is measured over **dense-missed misses only** — the misses lexical actually has a chance
+  to help — not diluted by misses dense already caught.
+- A **missing `recall_at_k` does not satisfy** the recall gate: without the value we cannot confirm the
+  flip is not masking a recall regression, so the conservative outcome is HOLD. Always pass
+  `--recall-at-k` from the same alpha run.
+- Defaults (`fusion.py`): `min_recovery_rate=0.30`, `recall_floor=0.85`, `rrf_k=60` (matches
+  `HybridRetrievalProperties.rrfK` and `eval_live.py`). Tunable at call time as evidence accrues.
+
+The harness emits the decision to `flip-threshold.{json,md}` on every `run`/`replay`.
+
+## Live runbook (must run against the alpha stack — not reproducible offline)
+
+The measured numbers come from the live stack; they are **not** fabricated in code review. On a host with
+line-of-sight to alpha (see `scripts/run-live-eval.sh`):
+
+1. Re-embed the grown corpus: `ENV_FILE=/opt/durion/alpha/.env python3 scripts/rag_seed.py`.
+2. Dense recall baseline + hybrid comparison: `scripts/eval_live.py` (the `rag_retrieval` and
+   `rag_lexical_hybrid_784` blocks). Record `rag_retrieval.recall_at_k`.
+3. Gap-harness recovery evidence:
+   `scripts/run-gap-harness.sh --judge ollama --judge-model llama3.1:8b --judge-timeout 300 --recall-at-k <step-2 value>`
+   (raise `--judge-timeout` on CPU-only judges, #1129). Read `flip-threshold.md` +
+   `summary.json` (check `ungraded_fraction` is low, #1130).
+4. Decision: if `recommend_flip` is true with supporting numbers, flip the flag and **re-baseline the
+   #783 floors** (the corpus grew, so recall@k must be re-measured); otherwise record the measured
+   rationale and keep the flag dormant.
+
+## Re-baseline note (#783 floors)
+
+The gated `rag_retrieval.recall_at_k` drifted 0.9574 → 0.8511 on a prior alpha redeploy (re-embedding
+wobble), leaving ~0.001 of headroom over the 0.85 floor. Growing the corpus re-embeds everything, so this
+effort is the natural point to re-measure and re-set the #783 nightly-gate floors off the new corpus, so
+the gate is not one embedding wobble from red.

--- a/pos-mcp-server/src/main/resources/application-alpha.yml
+++ b/pos-mcp-server/src/main/resources/application-alpha.yml
@@ -89,6 +89,10 @@ mcp:
           source-path: "classpath:rag/order-guide.md"
           rag-scope: "order"
           required-permissions: ["order:order:view"]
+        - id: "order.returns-refunds"
+          source-path: "classpath:rag/returns-refunds-rag.md"
+          rag-scope: "order"
+          required-permissions: ["order:order:view"]
         - id: "pricing.guide"
           source-path: "classpath:rag/pricing-guide.md"
           rag-scope: "pricing"

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -85,6 +85,10 @@ mcp:
           source-path: "classpath:rag/order-guide.md"
           rag-scope: "order"
           required-permissions: ["order:order:view"]
+        - id: "order.returns-refunds"
+          source-path: "classpath:rag/returns-refunds-rag.md"
+          rag-scope: "order"
+          required-permissions: ["order:order:view"]
         - id: "pricing.guide"
           source-path: "classpath:rag/pricing-guide.md"
           rag-scope: "pricing"

--- a/pos-mcp-server/src/main/resources/db/migration/V29__fix_facade_authenticated_gating.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V29__fix_facade_authenticated_gating.sql
@@ -1,0 +1,35 @@
+-- V29: Remove the AUTHENTICATED grant from facade tools that also bundle privileged operations.
+--
+-- Issue #1115. V18 seeds each facade the UNION of the permissions of every operation it wraps, and an
+-- operation gated only by isAuthenticated() (or ungated) contributes the pseudo-permission
+-- AUTHENTICATED. Every logged-in caller holds AUTHENTICATED, so any facade whose union includes it
+-- passes the selection-layer permission gate (findEnabledByPermissionsAndWorkflow) for EVERY
+-- authenticated user — including the facade's privileged operations.
+--
+-- Three facades in V18 carry AUTHENTICATED alongside privileged codes. Issue #1115 enumerated two;
+-- TaxFacadeTool is a third instance of the same union-floor defect, found by reading the V18 grants:
+--   * WorkorderFacadeTool  — AUTHENTICATED (from getWorkorderStatus) + workorder:workorder:view
+--   * AdminFacadeTool       — AUTHENTICATED (from getSystemStatus)   + security:{user,permission,audit}:view
+--   * TaxFacadeTool         — AUTHENTICATED (from getTaxRate/getTaxSummary, whose endpoints do not
+--                             resolve so V18 fell back to AUTHENTICATED) + tax:calculate
+--
+-- Fix (issue option 1): drop only the AUTHENTICATED row for these three, so each is gated on its
+-- privileged code(s) — workorder:workorder:view, the security:*:view set, and tax:calculate
+-- respectively. The benign single-purpose AUTHENTICATED facades (Order, Pricing, Catalog, Events) are
+-- untouched — every operation they wrap is genuinely isAuthenticated()-level, so their AUTHENTICATED
+-- grant is correct.
+--
+-- Consequence (accepted): the isAuthenticated()-level operations on these facades (getWorkorderStatus,
+-- getSystemStatus, getTaxRate/getTaxSummary) are no longer offered to a bare authenticated user
+-- through the facade. This is not a downstream authorization change — the gateway still enforces
+-- per-operation authorization on the REST call — only which facades the tool-selection layer offers
+-- the model. Splitting the low-privilege operations into their own tool (issue option 2) is a
+-- separate follow-up.
+--
+-- Idempotent: DELETE on a code that is not present is a no-op, so re-running is safe.
+
+DELETE FROM mcp_tool_permission
+WHERE permission_code = 'AUTHENTICATED'
+  AND tool_id IN (
+      SELECT id FROM mcp_tool WHERE name IN ('WorkorderFacadeTool', 'AdminFacadeTool', 'TaxFacadeTool')
+  );

--- a/pos-mcp-server/src/main/resources/rag/returns-refunds-rag.md
+++ b/pos-mcp-server/src/main/resources/rag/returns-refunds-rag.md
@@ -1,0 +1,113 @@
+# Returns and Refunds Guide
+
+## Purpose
+RAG id: `order.returns-refunds`
+RAG scope: `order`
+Required permissions: `order:order:view`
+Audience: internal staff.
+This document is reference context only and grants no access; access is enforced by permission codes at request time.
+
+This document grounds returns- and refunds-domain questions for the natural-language assistant: how a
+customer return against a completed order is created, capped, approved, refunded, and restocked. It
+describes the `pos-order` returns implementation (parity stories F1/F2, issues #1086/#1087, spec
+R5.1–R5.5). It does not define customer-facing return policy windows, restocking fees, or core charges
+— those are not modeled in `pos-order` and must not be inferred from this document.
+
+## Core concepts
+A return order is a line-by-line request to send goods back against exactly one original sales order,
+producing a refund. A return is only allowed against an original order in `COMPLETED` status; a return
+against any other status is rejected. Each return line links to one sold line on the original order and
+is capped at that sold line's un-refunded remainder.
+
+The assistant should ask for the original order number/id, the specific line(s) and return quantity, the
+condition (restock, scrap, or warranty), and the refund method when a user asks a broad question such as
+"how do I return this?"
+
+## Endpoints and permissions
+All returns endpoints live under `/v1/returns` (class-level `isAuthenticated()`, with a per-method
+permission):
+
+| Operation | Method / path | Permission |
+|---|---|---|
+| Create a return | `POST /v1/returns` | `order:return:create` |
+| Get a return by id | `GET /v1/returns/{returnOrderId}` | `order:return:view` |
+| List returns for an order | `GET /v1/returns?originalOrderId=` | `order:return:view` |
+| Per-line returnable quantities | `GET /v1/returns/returnable?orderId=` | `order:return:view` |
+| Approve a pending return | `POST /v1/returns/{id}/approve` | `order:return:approve` |
+| Reject a pending return | `POST /v1/returns/{id}/reject` | `order:return:approve` |
+| Process the saga (refund + restock signal) | `POST /v1/returns/{id}/process` | `order:return:create` |
+| Retry after a refund failure | `POST /v1/returns/{id}/retry` | `order:return:create` |
+
+Create supports an `Idempotency-Key` header: a replayed key returns the original return rather than
+creating a second one. An over-cap create returns HTTP 422 listing each line's `returnableQty`.
+
+## The return cap (per-line remainder)
+Each return line is capped at the sold line's remaining un-returned quantity:
+`returnableQty = soldQuantity − Σ returnQty of prior returns for that sold line`, where prior returns in
+`CANCELLED` or `REJECTED` status do **not** count against the cap. The sold line is row-locked at
+creation so concurrent returns of the same remainder serialize. A request exceeding the cap fails the
+whole create (no partial return). Duplicate return lines for the same sold line are rejected — the
+quantity must be combined into a single line.
+
+A line is returnable when its `returnable` flag is `TRUE`; not returnable when `FALSE`; and when the flag
+is null it is returnable unless the line was sourced from a workorder (`SourceType.WORKORDER`). A
+non-returnable line submitted with condition `WARRANTY` is routed out as a warranty claim (to
+pos-warranty), not processed as a counter return.
+
+## Refund amount
+Each line's refund is pro-rata on the sold line total (tax included):
+`lineRefund = lineTotal × returnQty ÷ soldQuantity`, rounded HALF_UP at scale 4. The return's total
+refund is the sum of its line refunds.
+
+## Refund methods
+Refund method is one of `ORIGINAL_TENDER`, `STORE_CREDIT`, or `ON_ACCOUNT_CREDIT`.
+
+- `ORIGINAL_TENDER` reverses the original order's settled tender via the invoicing service, per payment
+  intent, netting settled minus reversed amounts and refunding the largest net intents first up to the
+  return total. A missing original invoice or insufficient settled tender parks the return at
+  `REFUND_FAILED`.
+- `STORE_CREDIT` and `ON_ACCOUNT_CREDIT` require a customer on the return. The saga records the refund
+  intent; the credit-issuance artifacts (store-credit ledger / AR credit memo) are owned by pos-invoice /
+  pos-accounting as a paired follow-up.
+
+## Status lifecycle and approval
+Return status is one of `PENDING_APPROVAL`, `RETURN_REQUESTED`, `REFUND_ISSUED`, `COMPLETED`,
+`REFUND_FAILED`, `REJECTED`, `CANCELLED`.
+
+Creation lands in `RETURN_REQUESTED`, or in `PENDING_APPROVAL` when the total refund exceeds the approval
+threshold (default `$250.00`, `pos.order.return.approval-threshold`). Approving a pending return moves it
+to `RETURN_REQUESTED`; rejecting it moves it to `REJECTED` with a reason. The processing saga advances
+`RETURN_REQUESTED → REFUND_ISSUED → COMPLETED`; a refund failure parks the return at `REFUND_FAILED`
+(retryable via retry) **before any stock movement**. The refund must succeed before any stock signal is
+emitted.
+
+## Restock hand-off to inventory
+Restock is event-driven and fire-and-forget: on completion the saga emits `order.order.returned`, which
+`pos-inventory` consumes to restock. Lines with condition `RESTOCK` are restocked; `SCRAP` lines are
+skipped; there is no synchronous pos-order → pos-inventory stock call (ADR-0044). If a caller asks whether
+stock is back on hand, answer from the return's completion state and say that on-hand confirmation needs
+inventory visibility.
+
+## Not modeled here
+Core charges (a deposit on a rebuildable/exchangeable part), restocking fees, and time-boxed return
+windows are **not** implemented in `pos-order` and are not covered by this document. The assistant must
+not invent a core-charge workflow, a restocking-fee calculation, or a return-window rule; if asked, it
+should say the platform does not model these and offer the verified returns behaviour above.
+
+## Verified facts (pos-order)
+- **Returns are line-by-line against one COMPLETED sales order**, per-line capped at the un-refunded
+  remainder (row-locked at creation); prior `CANCELLED`/`REJECTED` returns do not consume the cap.
+_Verified: `pos-order` `ReturnOrderServiceImpl.createReturn`, `ReturnOrderServiceImpl.CAP_EXCLUDED_STATUSES`._
+- **Refund per line is pro-rata tax-included:** `lineTotal × returnQty ÷ soldQuantity`, HALF_UP scale 4.
+_Verified: `pos-order` `ReturnOrderServiceImpl.perLineRefund`._
+- **Return status machine** is `PENDING_APPROVAL, RETURN_REQUESTED, REFUND_ISSUED, COMPLETED, REFUND_FAILED, REJECTED, CANCELLED`; creation parks in `PENDING_APPROVAL` when the refund exceeds the approval threshold (default `$250.00`), else `RETURN_REQUESTED`.
+_Verified: `pos-order` `ReturnOrderStatus`, `ReturnOrderServiceImpl.createReturn` (`pos.order.return.approval-threshold:250.00`)._
+- **Refund methods** are `ORIGINAL_TENDER, STORE_CREDIT, ON_ACCOUNT_CREDIT`; `ORIGINAL_TENDER` reverses settled tender per payment intent (settled − reversed, largest first) and parks at `REFUND_FAILED` on missing invoice or insufficient tender.
+_Verified: `pos-order` `RefundMethod`, `ReturnOrderServiceImpl.issueRefund`, `ReturnOrderServiceImpl.reverseOriginalTender`._
+- **Restock is event-driven:** completion emits `order.order.returned`; pos-inventory restocks `RESTOCK` lines and skips `SCRAP` (ADR-0044, no synchronous stock call). Return conditions are `RESTOCK, SCRAP, WARRANTY`.
+_Verified: `pos-order` `ReturnOrderServiceImpl.runSaga`, `ReturnCondition`._
+- **Returns permissions** are `order:return:{create,view,approve}`; the returns endpoints are under `/v1/returns` and emit `ORDER_RETURN_{CREATE,GET,LIST,RETURNABLE,APPROVE,REJECT,PROCESS,RETRY}`.
+_Verified: `pos-order` `OrderPermissions`, `ReturnOrderController`, `permissions.yaml`._
+- **Core charges are NOT modeled in pos-order** — no core-charge entity, permission, or calculation exists.
+_Verified: `pos-order` source (no core-charge implementation)._
+</content>

--- a/pos-mcp-server/src/main/resources/rag/returns-refunds-rag.md
+++ b/pos-mcp-server/src/main/resources/rag/returns-refunds-rag.md
@@ -110,4 +110,3 @@ _Verified: `pos-order` `ReturnOrderServiceImpl.runSaga`, `ReturnCondition`._
 _Verified: `pos-order` `OrderPermissions`, `ReturnOrderController`, `permissions.yaml`._
 - **Core charges are NOT modeled in pos-order** — no core-charge entity, permission, or calculation exists.
 _Verified: `pos-order` source (no core-charge implementation)._
-</content>

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/FacadeToolPermissionSeedTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/repository/FacadeToolPermissionSeedTest.java
@@ -1,0 +1,120 @@
+package com.positivity.mcp.internal.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #1115 regression guard: no facade tool may be granted the {@code AUTHENTICATED} pseudo-permission
+ * alongside a privileged code. Every authenticated caller holds {@code AUTHENTICATED}, so such a
+ * facade would pass the selection-layer permission gate for everyone — offering its privileged
+ * operations to the model for any logged-in user.
+ *
+ * <p>The facade grants are Postgres-seed data ({@code V18__seed_facade_tool_permissions.sql}, fixed
+ * by {@code V29__fix_facade_authenticated_gating.sql}); there is no offline Flyway path for them, so
+ * this test asserts the invariant on the net effect of the migration SQL directly. It stays green
+ * only while the seed keeps mixed-sensitivity facades off the {@code AUTHENTICATED} floor.
+ */
+class FacadeToolPermissionSeedTest {
+
+    private static final Path MIGRATIONS = Paths.get(System.getProperty("user.dir"), "src/main/resources/db/migration");
+    private static final String AUTHENTICATED = "AUTHENTICATED";
+
+    // One INSERT block: VALUES ('code'), ('code2') ... WHERE mcp_tool.name = 'ToolName';
+    private static final Pattern TOOL_NAME = Pattern.compile("mcp_tool\\.name\\s*=\\s*'([^']+)'");
+    private static final Pattern QUOTED_CODE = Pattern.compile("\\('([^']+)'\\)");
+
+    @Test
+    @DisplayName("no facade grants AUTHENTICATED alongside a privileged permission (net of V18 + V29)")
+    void noFacadeMixesAuthenticatedWithPrivilege() throws IOException {
+        Map<String, Set<String>> grants = parseSeed(read("V18__seed_facade_tool_permissions.sql"));
+        applyAuthenticatedDeletes(grants, read("V29__fix_facade_authenticated_gating.sql"));
+
+        assertThat(grants).isNotEmpty();
+        grants.forEach((tool, codes) -> {
+            if (codes.contains(AUTHENTICATED)) {
+                assertThat(codes)
+                        .as(
+                                "%s is granted AUTHENTICATED alongside privileged codes %s; gate it on the "
+                                        + "privileged code(s) instead (see V29 / issue #1115)",
+                                tool, codes)
+                        .containsExactly(AUTHENTICATED);
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("the mixed facades no longer carry AUTHENTICATED after V29")
+    void mixedFacadesLoseAuthenticated() throws IOException {
+        Map<String, Set<String>> grants = parseSeed(read("V18__seed_facade_tool_permissions.sql"));
+        applyAuthenticatedDeletes(grants, read("V29__fix_facade_authenticated_gating.sql"));
+
+        assertThat(grants.get("WorkorderFacadeTool"))
+                .doesNotContain(AUTHENTICATED)
+                .contains("workorder:workorder:view");
+        assertThat(grants.get("AdminFacadeTool"))
+                .doesNotContain(AUTHENTICATED)
+                .contains("security:user:view", "security:permission:view", "security:audit:view");
+        // #1115 under-enumerated: TaxFacadeTool is a third mixed facade (tax:calculate + AUTHENTICATED).
+        assertThat(grants.get("TaxFacadeTool")).doesNotContain(AUTHENTICATED).contains("tax:calculate");
+    }
+
+    // ── parsing ───────────────────────────────────────────────────────────────
+
+    private static Map<String, Set<String>> parseSeed(String sql) {
+        Map<String, Set<String>> grants = new LinkedHashMap<>();
+        for (String block : sql.split("(?i)INSERT\\s+INTO\\s+mcp_tool_permission")) {
+            Matcher nameMatcher = TOOL_NAME.matcher(block);
+            if (!nameMatcher.find()) {
+                continue;
+            }
+            String tool = nameMatcher.group(1);
+            Set<String> codes = grants.computeIfAbsent(tool, t -> new LinkedHashSet<>());
+            Matcher codeMatcher = QUOTED_CODE.matcher(block);
+            while (codeMatcher.find()) {
+                codes.add(codeMatcher.group(1));
+            }
+        }
+        return grants;
+    }
+
+    /**
+     * Apply the AUTHENTICATED-removal DELETE in V29: strip AUTHENTICATED from every tool named in the
+     * migration's {@code name IN (...)} list. Parsed generically so the guard tracks the migration
+     * rather than a hardcoded tool set.
+     */
+    private static void applyAuthenticatedDeletes(Map<String, Set<String>> grants, String v29) {
+        if (!v29.toUpperCase(java.util.Locale.ROOT).contains("'" + AUTHENTICATED + "'")) {
+            return;
+        }
+        Matcher inList = Pattern.compile("name\\s+IN\\s*\\(([^)]*)\\)", Pattern.CASE_INSENSITIVE)
+                .matcher(v29);
+        if (!inList.find()) {
+            return;
+        }
+        Matcher names = Pattern.compile("'([^']+)'").matcher(inList.group(1));
+        while (names.find()) {
+            Set<String> codes = grants.get(names.group(1));
+            if (codes != null) {
+                codes.remove(AUTHENTICATED);
+            }
+        }
+    }
+
+    private static String read(String migration) throws IOException {
+        // Strip -- line comments so the executable statements are parsed, not the SQL comments that
+        // quote @PreAuthorize expressions like hasAuthority('...') / hasRole('ADMIN').
+        return Files.readString(MIGRATIONS.resolve(migration)).replaceAll("(?m)--.*$", "");
+    }
+}

--- a/pos-mcp-server/src/test/resources/eval/gap-harness/calibration.json
+++ b/pos-mcp-server/src/test/resources/eval/gap-harness/calibration.json
@@ -74,6 +74,20 @@
       "expected_facts": ["An invoice number is INV-<epochMillis>-<first 8 chars of the invoice UUID>, assigned once at draft creation."],
       "answer": "I don't have that information available.",
       "human_verdict": "refused"
+    },
+    {
+      "id": "cal-core-charge-unsupported",
+      "query": "how are core charges handled when a customer returns a rebuildable part",
+      "expected_facts": [],
+      "answer": "The platform creates a Return Request linked to the original invoice, runs the rebuild-core rule set to confirm the part is rebuildable, and a Service Rep credits the core charge back through the core-charge ledger in a five-step workflow.",
+      "human_verdict": "unsupported"
+    },
+    {
+      "id": "cal-returns-unsupported",
+      "query": "what is the policy for processing a customer return and issuing a refund on a paid invoice",
+      "expected_facts": [],
+      "answer": "Returns are processed through the Refund Authorization Center, which requires a manager PIN, automatically reverses the original journal entry, and issues store credit within 24 hours under the standard returns SLA.",
+      "human_verdict": "unsupported"
     }
   ]
 }

--- a/pos-mcp-server/src/test/resources/eval/gap-harness/questions.json
+++ b/pos-mcp-server/src/test/resources/eval/gap-harness/questions.json
@@ -92,7 +92,10 @@
       "actor": { "role": "ROLE_USER", "permission_codes": ["order:order:view"] },
       "rag_scope": "order",
       "expected_doc_ids": ["order.guide"],
-      "expected_facts": [],
+      "expected_facts": [
+        "Sales-order statuses (pos-order SalesOrderStatus) include DRAFT, QUOTED, COMPLETED, VOIDED, CANCEL_REQUESTED, and CANCELLED; read access is gated by order:order:view.",
+        "Purchase orders are NOT in pos-order — they are owned by pos-inventory (inventory:purchase_order:{create,view,approve,receive}) with PurchaseOrderStatus DRAFT, APPROVED, PARTIALLY_RECEIVED, FULLY_RECEIVED, CLOSED, CANCELLED."
+      ],
       "topic": "order lookup",
       "tags": ["scope-coverage", "positive"],
       "source": "synthetic"
@@ -103,7 +106,10 @@
       "actor": { "role": "ROLE_USER", "permission_codes": ["pricing:price_book:view", "pricing:rule:view"] },
       "rag_scope": "pricing",
       "expected_doc_ids": ["pricing.guide"],
-      "expected_facts": [],
+      "expected_facts": [
+        "Price precedence is a fixed sequential pipeline (PriceQuoteServiceImpl.calculatePrice): BASE_PRICE (MSRP, required) then LOCATION_OVERRIDE (absolute replacement) then CUSTOMER_TIER_DISCOUNT (multiplicative), with final rounding HALF_EVEN at scale 2.",
+        "effectiveFrom is inclusive and effectiveTo exclusive (NULL = open-ended/active); within one rule type the most-recently-effective active record wins. Read-level pricing permissions are pricing:price_book:view and pricing:rule:view."
+      ],
       "topic": "pricing rules",
       "tags": ["scope-coverage", "positive"],
       "source": "synthetic"
@@ -142,14 +148,17 @@
       "source": "synthetic"
     },
     {
-      "id": "gap-returns-refunds-KNOWNGAP",
+      "id": "gap-returns-refunds",
       "query": "what is the policy for processing a customer return and issuing a refund on a paid invoice",
       "actor": { "role": "ROLE_USER", "permission_codes": ["order:order:view"] },
       "rag_scope": "order",
       "expected_doc_ids": ["order.returns-refunds"],
-      "expected_facts": [],
+      "expected_facts": [
+        "Returns are line-by-line against one COMPLETED sales order, per-line capped at the un-refunded remainder; creation parks in PENDING_APPROVAL when the total refund exceeds the approval threshold (default $250.00), otherwise RETURN_REQUESTED.",
+        "Refund methods are ORIGINAL_TENDER, STORE_CREDIT, and ON_ACCOUNT_CREDIT; ORIGINAL_TENDER reverses the original settled tender and a failure parks the return at REFUND_FAILED before any stock movement."
+      ],
       "topic": "returns and refunds policy",
-      "tags": ["known-gap", "corpus-gap"],
+      "tags": ["scope-coverage", "positive", "gap-harness-roundtrip"],
       "source": "synthetic"
     },
     {
@@ -157,9 +166,9 @@
       "query": "how are core charges handled when a customer returns a rebuildable part",
       "actor": { "role": "ROLE_USER", "permission_codes": ["order:order:view"] },
       "rag_scope": "order",
-      "expected_doc_ids": ["order.returns-refunds"],
+      "expected_doc_ids": ["order.core-charges"],
       "expected_facts": [],
-      "topic": "returns and refunds policy",
+      "topic": "core charge handling",
       "tags": ["known-gap", "corpus-gap"],
       "source": "synthetic"
     }

--- a/pos-mcp-server/src/test/resources/eval/rag-lexical/returns-refunds.json
+++ b/pos-mcp-server/src/test/resources/eval/rag-lexical/returns-refunds.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "_comment": "#1124 lexical-sensitive fixtures for the authored order.returns-refunds doc. Exact status/method/event tokens (REFUND_FAILED, ORIGINAL_TENDER, order.order.returned) that dense embeddings blur but Postgres FTS recalls. Kept in the 'rag-lexical' suite so they do NOT count toward the #783 dense recall@k gate; they feed the dense-vs-hybrid recovery measurement (#1124 flip-threshold). Tokens are verbatim from rag/returns-refunds-rag.md, itself source-verified against pos-order.",
+  "fixtures": [
+    {
+      "fixture_id": "rag-lexical-returns-refund-failed",
+      "query": "REFUND_FAILED retryable return status before stock movement",
+      "actor": { "role": "ROLE_SERVICE_ADVISOR", "permission_codes": ["order:order:view"] },
+      "expected": { "doc_ids": ["order.returns-refunds"], "k": 5 },
+      "rag_scope": "order",
+      "tags": ["positive", "lexical", "exact-code"],
+      "notes": "Exact status token REFUND_FAILED; dense under-retrieves bare enum names, FTS should recall order.returns-refunds."
+    },
+    {
+      "fixture_id": "rag-lexical-returns-original-tender",
+      "query": "ORIGINAL_TENDER refund method reverse settled payment intent",
+      "actor": { "role": "ROLE_SERVICE_ADVISOR", "permission_codes": ["order:order:view"] },
+      "expected": { "doc_ids": ["order.returns-refunds"], "k": 5 },
+      "rag_scope": "order",
+      "tags": ["positive", "lexical", "exact-code"],
+      "notes": "Refund-method enum ORIGINAL_TENDER, a rare exact token verbatim in the doc."
+    },
+    {
+      "fixture_id": "rag-lexical-returns-event-name",
+      "query": "order.order.returned event restock RESTOCK SCRAP",
+      "actor": { "role": "ROLE_SERVICE_ADVISOR", "permission_codes": ["order:order:view"] },
+      "expected": { "doc_ids": ["order.returns-refunds"], "k": 5 },
+      "rag_scope": "order",
+      "tags": ["positive", "lexical", "exact-code"],
+      "notes": "Dotted event name order.order.returned + restock conditions; symbol-heavy tokens embeddings blur."
+    }
+  ]
+}

--- a/pos-mcp-server/src/test/resources/eval/rag-retrieval/seed.json
+++ b/pos-mcp-server/src/test/resources/eval/rag-retrieval/seed.json
@@ -39,6 +39,24 @@
       "rag_scope": "master",
       "tags": ["visibility-negative"],
       "notes": "Admin-only docs must not surface to a technician (permission-aware filter)."
+    },
+    {
+      "fixture_id": "returns-refund-policy-pos-1",
+      "query": "what is the policy for returning items and refunding a completed order",
+      "actor": { "role": "ROLE_SERVICE_ADVISOR", "permission_codes": ["order:order:view"] },
+      "expected": { "doc_ids": ["order.returns-refunds"], "k": 5 },
+      "rag_scope": "order",
+      "tags": ["positive", "gap-harness-roundtrip"],
+      "notes": "Round-tripped from a gap-harness corpus-gap finding (#1124/#1131): order.returns-refunds authored + source-verified against pos-order ReturnOrderServiceImpl."
+    },
+    {
+      "fixture_id": "returns-refund-method-pos-2",
+      "query": "how is a refund issued to the original tender when a return is processed",
+      "actor": { "role": "ROLE_SERVICE_ADVISOR", "permission_codes": ["order:order:view"] },
+      "expected": { "doc_ids": ["order.returns-refunds"], "k": 5 },
+      "rag_scope": "order",
+      "tags": ["positive"],
+      "notes": "ORIGINAL_TENDER refund path; should recall the authored returns-refunds doc."
     }
   ]
 }

--- a/scripts/gap_harness/api.py
+++ b/scripts/gap_harness/api.py
@@ -13,11 +13,27 @@ from __future__ import annotations
 
 import json
 import os
+import sys
+import time
 import urllib.error
 import urllib.request
 from typing import Callable, Optional
 
 from .model import Actor
+
+# Warn once a judge call spends this fraction of its timeout — a run riding the ceiling (#1129) is
+# one busy host or slightly longer prompt away from failing, and that should be visible before the
+# failures start, not only in the post-hoc tally.
+JUDGE_TIMEOUT_WARN_RATIO = 0.75
+
+
+def _warn_if_slow(model: str, elapsed: float, timeout: float) -> None:
+    if timeout > 0 and elapsed >= JUDGE_TIMEOUT_WARN_RATIO * timeout:
+        print(
+            f"WARNING: judge call ({model}) took {elapsed:.0f}s of a {timeout:.0f}s timeout "
+            f"({elapsed / timeout:.0%}); raise --judge-timeout or use a smaller judge model.",
+            file=sys.stderr,
+        )
 
 # A token provider maps an actor to the bearer token to send. Returns None if no token is known.
 TokenProvider = Callable[[Actor], Optional[str]]
@@ -83,8 +99,10 @@ def ollama_judge(base_url: str, model: str, timeout: int = 120) -> Callable[[str
             headers={"Content-Type": "application/json"},
             method="POST",
         )
+        started = time.monotonic()
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             body = json.loads(resp.read())
+        _warn_if_slow(model, time.monotonic() - started, timeout)
         return body.get("message", {}).get("content", "")
 
     return _llm
@@ -108,8 +126,10 @@ def openai_compatible_judge(
             headers=headers,
             method="POST",
         )
+        started = time.monotonic()
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             body = json.loads(resp.read())
+        _warn_if_slow(model, time.monotonic() - started, timeout)
         return body["choices"][0]["message"]["content"]
 
     return _llm

--- a/scripts/gap_harness/corpus.py
+++ b/scripts/gap_harness/corpus.py
@@ -37,6 +37,7 @@ MANIFEST: list[tuple[str, str, str, list[str]]] = [
     ("workflow.cross-domain-playbooks", "cross-domain-playbooks.md", "master", ["AUTHENTICATED"]),
     ("glossary.identifiers", "glossary-identifiers.md", "master", ["AUTHENTICATED"]),
     ("order.guide", "order-guide.md", "order", ["order:order:view"]),
+    ("order.returns-refunds", "returns-refunds-rag.md", "order", ["order:order:view"]),
     ("pricing.guide", "pricing-guide.md", "pricing", ["pricing:price_book:view", "pricing:rule:view"]),
     ("tax.guide", "tax-guide.md", "tax", ["tax:mode:view"]),
     (

--- a/scripts/gap_harness/harness.py
+++ b/scripts/gap_harness/harness.py
@@ -91,7 +91,9 @@ def run(
         classification = classify(q, capture, grade.verdict, corpus)
         results.append(Result(question=q, capture=capture, grade=grade, classification=classification))
 
-        if classification.cause == CAUSE_RETRIEVAL_MISS:
+        # An ungraded record's verdict is a placeholder, so its retrieval_miss classification is not
+        # real evidence — keep it out of the dense-vs-hybrid recovery set that feeds the #1124 flip.
+        if classification.cause == CAUSE_RETRIEVAL_MISS and not grade.judge_error:
             expected_visible = [
                 d for d in classification.covering_doc_ids if d not in classification.gated_doc_ids
             ]

--- a/scripts/gap_harness/judge.py
+++ b/scripts/gap_harness/judge.py
@@ -23,6 +23,7 @@ from .model import (
     VERDICT_CORRECT,
     VERDICT_MISLEADING,
     VERDICT_REFUSED,
+    VERDICT_UNSUPPORTED,
     VERDICTS,
     Grade,
 )
@@ -30,6 +31,7 @@ from .refusal import is_refusal, refusal_match
 
 LLM = Callable[[str], str]
 
+# Grounded grader: there IS a source of truth, so grade contradiction against it.
 _JUDGE_SYSTEM = """\
 You are a strict grader for a retrieval-augmented assistant. Grade the ANSWER against the GROUND
 TRUTH facts ONLY. Do not use outside knowledge or your own priors — if a claim is not settled by the
@@ -49,13 +51,49 @@ Definitions:
   important class to catch — a fluent wrong answer is worse than a refusal.
 """
 
+# Ungrounded grader (#1131): there is NO ground truth to contradict — a corpus gap means no doc, so
+# no expected fact can exist, and the grounded grader would fall through to "correct" on a fully
+# fabricated answer. Here the question inverts: is the answer *supported*, or is it asserting
+# specifics with no basis? That confident-invention case is the exact signal the harness exists to
+# find, so it must NOT pass as correct.
+_JUDGE_SYSTEM_UNSUPPORTED = """\
+You are a strict grader for a retrieval-augmented assistant. There is NO authoritative ground truth
+for this question — so you cannot confirm the answer is right, and you must not assume it is. Judge
+whether the answer is GROUNDED or is confidently inventing specifics with no basis.
+
+Return exactly one JSON object, no prose, with keys:
+  "verdict": one of "correct", "refused", "unsupported"
+  "rationale": one sentence explaining the verdict
+  "cited_ground_truth": "" (no ground truth is available for this question)
+
+Definitions:
+- "refused": the answer declines, says it lacks information/permission, or does not attempt an answer.
+- "unsupported": the answer is confident and specific — named entities, workflows, identifier
+  formats, owners, numbered steps — with nothing to support those specifics. Treat fluent, detailed,
+  unsourced factual claims as unsupported. This is the signal to catch: a model inventing a workflow
+  for a topic the corpus does not cover is a corpus gap, not a good answer.
+- "correct": ONLY when the answer is general and appropriately qualified, or explicitly grounded in
+  sources it cites — not when it fabricates concrete specifics.
+"""
+
 
 def build_judge_prompt(question: str, answer: str, ground_truth: Iterable[str]) -> str:
-    facts = "\n".join(f"- {f}" for f in ground_truth if f) or "- (no explicit ground-truth fact provided)"
+    """Select the grader by whether ground truth exists. With facts, grade contradiction (the
+    original behaviour). Without facts (a corpus gap), grade groundedness, so a confident fabrication
+    is caught as ``unsupported`` instead of slipping through as ``correct`` (#1131)."""
+    facts = [f for f in ground_truth if f]
+    if not facts:
+        return (
+            f"{_JUDGE_SYSTEM_UNSUPPORTED}\n"
+            f"QUESTION:\n{question}\n\n"
+            f"ANSWER:\n{answer}\n\n"
+            f"JSON:"
+        )
+    fact_lines = "\n".join(f"- {f}" for f in facts)
     return (
         f"{_JUDGE_SYSTEM}\n"
         f"QUESTION:\n{question}\n\n"
-        f"GROUND TRUTH (authoritative — grade against these only):\n{facts}\n\n"
+        f"GROUND TRUTH (authoritative — grade against these only):\n{fact_lines}\n\n"
         f"ANSWER:\n{answer}\n\n"
         f"JSON:"
     )
@@ -89,16 +127,26 @@ def _extract_json(raw: str) -> Optional[dict]:
         return None
 
 
+# judge_error prefixes distinguish the two failure kinds the report must not conflate (#1130): a
+# `parse:` error is a judge-quality signal (the model replied, but unusably), a `transport:` error is
+# retryable infrastructure noise (timeout / connection / HTTP 5xx), and `ungraded:` means no judge
+# ran at all. The aggregate keys off these prefixes so neither is counted as a real `misleading`.
+ERR_PARSE = "parse:"
+ERR_TRANSPORT = "transport:"
+ERR_UNGRADED = "ungraded:"
+
+
 def parse_verdict(raw: str) -> Grade:
     """Parse a judge reply into a Grade, defensively. An unparseable reply is surfaced as a
-    ``judge_error`` (verdict falls back to ``misleading`` — the conservative choice, since silently
-    treating a broken judge call as ``correct`` would hide real failures)."""
+    ``parse:`` ``judge_error`` (verdict falls back to ``misleading`` — the conservative choice, since
+    silently treating a broken judge call as ``correct`` would hide real failures — but the error tag
+    keeps it out of the graded ``misleading`` count)."""
     obj = _extract_json(raw)
     if obj is None:
         return Grade(
             verdict=VERDICT_MISLEADING,
             rationale="unparseable judge response",
-            judge_error=f"could not parse JSON from judge output: {raw[:200]!r}",
+            judge_error=f"{ERR_PARSE} could not parse JSON from judge output: {raw[:200]!r}",
         )
     verdict = str(obj.get("verdict", "")).strip().lower()
     if verdict not in VERDICTS:
@@ -106,7 +154,7 @@ def parse_verdict(raw: str) -> Grade:
             verdict=VERDICT_MISLEADING,
             rationale=f"judge returned unknown verdict {verdict!r}",
             cited_ground_truth=str(obj.get("cited_ground_truth", "")),
-            judge_error=f"unknown verdict: {verdict!r}",
+            judge_error=f"{ERR_PARSE} unknown verdict: {verdict!r}",
         )
     return Grade(
         verdict=verdict,
@@ -122,11 +170,17 @@ def grade(
     llm: Optional[LLM] = None,
     *,
     prefilter_refusals: bool = True,
+    transport_retries: int = 1,
 ) -> Grade:
     """Grade one answer. Deterministic refusal pre-filter first (no judge call spent); otherwise
     invoke the grounded judge. If no ``llm`` is supplied, only the refusal pre-filter runs and a
     non-refusal is returned ungraded (verdict ``correct`` is *not* assumed — an ungraded flag is set
-    via ``judge_error`` so the caller never mistakes 'not judged' for 'judged correct')."""
+    via ``judge_error`` so the caller never mistakes 'not judged' for 'judged correct').
+
+    A transport failure (timeout / connection / HTTP 5xx) is retried up to ``transport_retries``
+    times before giving up, since these are the flaky-host failures #1129 documents; a persistent
+    failure is surfaced as a ``transport:`` ``judge_error`` (not swallowed into a ``misleading``
+    verdict — the report keys off the tag to keep it out of the graded counts, #1130)."""
     if prefilter_refusals and is_refusal(answer):
         return Grade(
             verdict=VERDICT_REFUSED,
@@ -137,17 +191,20 @@ def grade(
         return Grade(
             verdict=VERDICT_CORRECT,
             rationale="no judge configured; answer not graded",
-            judge_error="ungraded: no llm supplied",
+            judge_error=f"{ERR_UNGRADED} no llm supplied",
         )
-    try:
-        raw = llm(build_judge_prompt(question, answer, list(ground_truth)))
-    except Exception as e:  # transport / model error — surface, do not swallow into a verdict
-        return Grade(
-            verdict=VERDICT_MISLEADING,
-            rationale="judge call failed",
-            judge_error=f"{type(e).__name__}: {e}",
-        )
-    return parse_verdict(raw)
+    prompt = build_judge_prompt(question, answer, list(ground_truth))
+    last_exc: Optional[Exception] = None
+    for _attempt in range(max(1, transport_retries + 1)):
+        try:
+            return parse_verdict(llm(prompt))
+        except Exception as e:  # transport / model error — surface, do not swallow into a verdict
+            last_exc = e
+    return Grade(
+        verdict=VERDICT_MISLEADING,
+        rationale="judge call failed",
+        judge_error=f"{ERR_TRANSPORT} {type(last_exc).__name__}: {last_exc}",
+    )
 
 
 # --- calibration / judge-accuracy (§4) ---------------------------------------------------------

--- a/scripts/gap_harness/model.py
+++ b/scripts/gap_harness/model.py
@@ -14,8 +14,9 @@ from typing import Any, Optional
 # --- verdict / cause vocabularies (kept as plain strings for JSON round-tripping) -------------
 VERDICT_CORRECT = "correct"
 VERDICT_REFUSED = "refused"
-VERDICT_MISLEADING = "misleading"
-VERDICTS = (VERDICT_CORRECT, VERDICT_REFUSED, VERDICT_MISLEADING)
+VERDICT_MISLEADING = "misleading"  # contradicts a supplied ground-truth fact
+VERDICT_UNSUPPORTED = "unsupported"  # confident, specific claims with no grounding to check against (#1131)
+VERDICTS = (VERDICT_CORRECT, VERDICT_REFUSED, VERDICT_MISLEADING, VERDICT_UNSUPPORTED)
 
 CAUSE_CORPUS_GAP = "corpus_gap"  # taxonomy #1 -> write a new doc (the #1124 goal)
 CAUSE_RETRIEVAL_MISS = "retrieval_miss"  # taxonomy #2 -> retrieval problem, feeds the flip-threshold

--- a/scripts/gap_harness/report.py
+++ b/scripts/gap_harness/report.py
@@ -18,17 +18,32 @@ from collections import defaultdict
 from typing import Iterable, Optional
 
 from .fusion import FlipDecision
-from .judge import JudgeAccuracy
+from .judge import ERR_PARSE, ERR_TRANSPORT, ERR_UNGRADED, JudgeAccuracy
 from .model import (
     CAUSE_CORPUS_GAP,
     CAUSE_GENERATION,
     CAUSE_PERMISSION_GATING,
     CAUSE_RETRIEVAL_MISS,
-    VERDICT_CORRECT,
-    VERDICT_MISLEADING,
-    VERDICT_REFUSED,
+    VERDICTS,
     Result,
 )
+
+# Above this ungraded fraction a run's headline numbers are not trustworthy and the summary + gap
+# report say so at the top (#1130) — half the judge calls failing must not read as a clean run.
+UNGRADED_WARN_FRACTION = 0.2
+
+
+def _ungraded_kind(judge_error: str) -> str:
+    """Bucket a ``judge_error`` by its tag prefix (see judge.py): transport failures are retryable
+    infra noise, parse failures are a judge-quality signal, no_llm means no judge ran. The two error
+    kinds mean different things for calibration, so they are reported apart (#1130)."""
+    if judge_error.startswith(ERR_TRANSPORT):
+        return "transport"
+    if judge_error.startswith(ERR_PARSE):
+        return "parse"
+    if judge_error.startswith(ERR_UNGRADED):
+        return "no_llm"
+    return "other"
 
 GUARDRAIL_BANNER = (
     "PROPOSED GAPS — DO NOT INGEST AS-IS. A human authors each doc and source-verifies it "
@@ -106,32 +121,55 @@ def _draft_outline(topic: str, scope: str, expected_docs: list[str], queries: li
 
 
 def summarize(results: list[Result]) -> dict:
-    """Top-line counts: verdict distribution + taxonomy distribution."""
-    verdicts = {VERDICT_CORRECT: 0, VERDICT_REFUSED: 0, VERDICT_MISLEADING: 0}
+    """Top-line counts: verdict distribution + taxonomy distribution.
+
+    A record carrying a ``judge_error`` was *not graded* — a transport/parse failure must not be
+    counted as a real ``misleading`` verdict (#1130). Such records are pulled out of the verdict
+    histogram into a distinct ``ungraded`` bucket, so the graded verdict counts + ``ungraded`` always
+    sum to the number of questions, and a half-broken judge can no longer masquerade as a run that
+    found many misleading answers."""
+    verdicts = {v: 0 for v in VERDICTS}
+    verdicts["ungraded"] = 0
     causes = {
         CAUSE_CORPUS_GAP: 0,
         CAUSE_RETRIEVAL_MISS: 0,
         CAUSE_GENERATION: 0,
         CAUSE_PERMISSION_GATING: 0,
     }
-    ungraded = 0
+    ungraded_breakdown = {"transport": 0, "parse": 0, "no_llm": 0, "other": 0}
+    factless_graded = 0
     for r in results:
-        verdicts[r.grade.verdict] = verdicts.get(r.grade.verdict, 0) + 1
+        if r.grade.judge_error:
+            verdicts["ungraded"] += 1
+            ungraded_breakdown[_ungraded_kind(r.grade.judge_error)] += 1
+        else:
+            verdicts[r.grade.verdict] = verdicts.get(r.grade.verdict, 0) + 1
+            if not (r.question.expected_facts or r.question.expected_doc_ids):
+                factless_graded += 1
         if r.classification.cause in causes:
             causes[r.classification.cause] += 1
-        if r.grade.judge_error and r.grade.judge_error.startswith("ungraded"):
-            ungraded += 1
     n = len(results)
-    return {
+    ungraded = verdicts["ungraded"]
+    summary = {
         "questions": n,
         "verdicts": verdicts,
         "taxonomy": causes,
         "ungraded": ungraded,
+        "ungraded_breakdown": ungraded_breakdown,
+        "ungraded_fraction": round(ungraded / n, 4) if n else 0.0,
+        "factless_graded": factless_graded,
         "honesty_note": (
             "misleading detection is partial (§4): a 0 in `misleading` does not mean all answers are "
             "correct — trust the count proportionally to the judge-accuracy report."
         ),
     }
+    if n and ungraded / n >= UNGRADED_WARN_FRACTION:
+        summary["warning"] = (
+            f"{ungraded}/{n} questions ({ungraded / n:.0%}) were UNGRADED (judge transport/parse "
+            f"failures: {ungraded_breakdown}); the verdict and taxonomy counts below rest on the "
+            "graded remainder only. Raise --judge-timeout (#1129) or use a smaller judge, then re-run."
+        )
+    return summary
 
 
 def render_gap_report_md(report: dict) -> str:

--- a/scripts/gap_harness/report.py
+++ b/scripts/gap_harness/report.py
@@ -140,12 +140,15 @@ def summarize(results: list[Result]) -> dict:
     factless_graded = 0
     for r in results:
         if r.grade.judge_error:
+            # Ungraded: the verdict is a placeholder, so its taxonomy cause is meaningless (a flaky
+            # judge would otherwise inflate the breakdown off placeholder verdicts). Keep it out of
+            # both the verdict histogram AND the taxonomy, per the warning below.
             verdicts["ungraded"] += 1
             ungraded_breakdown[_ungraded_kind(r.grade.judge_error)] += 1
-        else:
-            verdicts[r.grade.verdict] = verdicts.get(r.grade.verdict, 0) + 1
-            if not (r.question.expected_facts or r.question.expected_doc_ids):
-                factless_graded += 1
+            continue
+        verdicts[r.grade.verdict] = verdicts.get(r.grade.verdict, 0) + 1
+        if not (r.question.expected_facts or r.question.expected_doc_ids):
+            factless_graded += 1
         if r.classification.cause in causes:
             causes[r.classification.cause] += 1
     n = len(results)

--- a/scripts/rag_gap_harness.py
+++ b/scripts/rag_gap_harness.py
@@ -156,7 +156,8 @@ def cmd_replay(args):
             grade = harness.grade_only(q, cap.answer, idx, judge_llm)
         classification = classify(q, cap, grade.verdict, idx)
         results.append(Result(question=q, capture=cap, grade=grade, classification=classification))
-        if classification.cause == CAUSE_RETRIEVAL_MISS:
+        # Skip ungraded records: a placeholder verdict must not feed the flip-threshold recovery set.
+        if classification.cause == CAUSE_RETRIEVAL_MISS and not grade.judge_error:
             expected_visible = [d for d in classification.covering_doc_ids if d not in classification.gated_doc_ids]
             recoveries.append(
                 fusion.recovery_record(

--- a/scripts/rag_gap_harness.py
+++ b/scripts/rag_gap_harness.py
@@ -54,15 +54,16 @@ GAP_QUESTIONS = EVAL / "gap-harness"
 
 # --- shared wiring -----------------------------------------------------------------------------
 def build_judge(args):
+    timeout = getattr(args, "judge_timeout", 120)
     if args.judge == "none":
         return None
     if args.judge == "ollama":
         base = args.judge_base or os.environ.get("OLLAMA_CHAT_BASE_URL", "http://localhost:11434")
-        return api.ollama_judge(base, args.judge_model or "llama3.1")
+        return api.ollama_judge(base, args.judge_model or "llama3.1", timeout=timeout)
     if args.judge == "openai":
         base = args.judge_base or os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
         key = os.environ.get("OPENAI_API_KEY")
-        return api.openai_compatible_judge(base, args.judge_model or "gpt-4o-mini", key)
+        return api.openai_compatible_judge(base, args.judge_model or "gpt-4o-mini", key, timeout=timeout)
     raise SystemExit(f"unknown judge backend: {args.judge}")
 
 
@@ -235,6 +236,12 @@ def main(argv=None):
         sp.add_argument("--judge", choices=["none", "ollama", "openai"], default="none")
         sp.add_argument("--judge-base", default=None)
         sp.add_argument("--judge-model", default=None)
+        sp.add_argument(
+            "--judge-timeout",
+            type=int,
+            default=120,
+            help="per-call judge HTTP timeout in seconds (default 120; raise on CPU-hosted judges, #1129)",
+        )
 
     r = sub.add_parser("run", help="live run against the stack")
     r.add_argument("--base-url", required=True, help="MCP chat API base, e.g. http://localhost:8080")

--- a/scripts/rag_seed.py
+++ b/scripts/rag_seed.py
@@ -43,6 +43,7 @@ MANIFEST = [
     ("workflow.cross-domain-playbooks", "cross-domain-playbooks.md", "master", ["AUTHENTICATED"]),
     ("glossary.identifiers", "glossary-identifiers.md", "master", ["AUTHENTICATED"]),
     ("order.guide", "order-guide.md", "order", ["order:order:view"]),
+    ("order.returns-refunds", "returns-refunds-rag.md", "order", ["order:order:view"]),
     ("pricing.guide", "pricing-guide.md", "pricing", ["pricing:price_book:view", "pricing:rule:view"]),
     ("tax.guide", "tax-guide.md", "tax", ["tax:mode:view"]),
     ("crm.customer-vehicle", "customer-vehicle-guide.md", "customer",

--- a/scripts/tests/test_gap_harness.py
+++ b/scripts/tests/test_gap_harness.py
@@ -542,6 +542,16 @@ class JudgeReliabilityTest(unittest.TestCase):
         self.assertIn("warning", s)
         self.assertIn("UNGRADED", s["warning"])
 
+    def test_ungraded_excluded_from_taxonomy(self):
+        # An ungraded (judge_error) record's taxonomy cause is a placeholder and must not be counted,
+        # matching the summary warning that counts rest on the graded remainder only.
+        graded = self._result("g", Grade(verdict=VERDICT_MISLEADING))
+        graded.classification = Classification(cause=CAUSE_CORPUS_GAP)
+        ungraded = self._result("u", Grade(verdict=VERDICT_MISLEADING, judge_error="transport: TimeoutError"))
+        ungraded.classification = Classification(cause=CAUSE_CORPUS_GAP)
+        s = report.summarize([graded, ungraded])
+        self.assertEqual(s["taxonomy"][CAUSE_CORPUS_GAP], 1)  # only the graded one
+
     def test_summary_no_warning_when_fully_graded(self):
         results = [self._result("ok", Grade(verdict=VERDICT_CORRECT))]
         s = report.summarize(results)

--- a/scripts/tests/test_gap_harness.py
+++ b/scripts/tests/test_gap_harness.py
@@ -19,8 +19,9 @@ if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
 from gap_harness import corpus as corpus_mod  # noqa: E402
-from gap_harness import fusion, harness, judge, questions as q_mod, refusal, report  # noqa: E402
+from gap_harness import api, fusion, harness, judge, questions as q_mod, refusal, report  # noqa: E402
 from gap_harness import taxonomy  # noqa: E402
+import rag_gap_harness as harness_cli  # noqa: E402
 from gap_harness.model import (  # noqa: E402
     CAUSE_CORPUS_GAP,
     CAUSE_GENERATION,
@@ -30,9 +31,14 @@ from gap_harness.model import (  # noqa: E402
     VERDICT_CORRECT,
     VERDICT_MISLEADING,
     VERDICT_REFUSED,
+    VERDICT_UNSUPPORTED,
+    VERDICTS,
     Actor,
     Capture,
+    Classification,
+    Grade,
     Question,
+    Result,
     RetrievedDoc,
 )
 
@@ -87,9 +93,9 @@ class CorpusTest(unittest.TestCase):
         self.assertIn("glossary.identifiers", covering)
 
     def test_coverage_lookup_empty_for_uncovered_topic(self):
-        covering = self.idx.covering_docs("core charge refund policy for rebuildable parts warranty return")
-        self.assertNotIn("order.returns-refunds", covering)  # doc does not exist
-        self.assertFalse(self.idx.exists("order.returns-refunds"))
+        covering = self.idx.covering_docs("layaway installment plan scheduling and deposit forfeiture")
+        self.assertEqual(covering, [])  # no doc covers layaway
+        self.assertFalse(self.idx.exists("order.core-charges"))  # core charges are not modeled
 
 
 class RefusalTest(unittest.TestCase):
@@ -203,8 +209,8 @@ class TaxonomyTest(unittest.TestCase):
         self.assertEqual(c.cause, CAUSE_NONE)
 
     def test_corpus_gap_when_expected_doc_absent(self):
-        q = Question("q", "returns policy", Actor("ROLE_USER", ("order:order:view",)),
-                     rag_scope="order", expected_doc_ids=("order.returns-refunds",))
+        q = Question("q", "core charge policy", Actor("ROLE_USER", ("order:order:view",)),
+                     rag_scope="order", expected_doc_ids=("order.core-charges",))
         c = taxonomy.classify(q, self._cap("q", [], ["order:order:view"]), VERDICT_REFUSED, self.idx)
         self.assertEqual(c.cause, CAUSE_CORPUS_GAP)
 
@@ -357,6 +363,9 @@ class DataValidationTest(unittest.TestCase):
         self.assertIn("misleading", verdicts)
         self.assertIn("refused", verdicts)
         self.assertIn("correct", verdicts)
+        self.assertIn("unsupported", verdicts)  # #1131: ungrounded-fabrication class must be calibrated
+        # every calibration verdict is a known verdict
+        self.assertTrue(set(verdicts).issubset(set(VERDICTS)))
 
 
 class PipelineTest(unittest.TestCase):
@@ -371,9 +380,9 @@ class PipelineTest(unittest.TestCase):
             # correct: right doc retrieved, judge says correct
             Question("q-ok", "vin format", Actor("ROLE_USER"), rag_scope="master",
                      expected_doc_ids=("glossary.identifiers",), expected_facts=("17 chars",)),
-            # corpus gap: expected doc missing
-            Question("q-gap", "returns policy", Actor("ROLE_USER", ("order:order:view",)),
-                     rag_scope="order", expected_doc_ids=("order.returns-refunds",), topic="returns"),
+            # corpus gap: expected doc missing (core charges are not modeled anywhere)
+            Question("q-gap", "core charge policy", Actor("ROLE_USER", ("order:order:view",)),
+                     rag_scope="order", expected_doc_ids=("order.core-charges",), topic="core charges"),
             # retrieval miss: visible doc exists but wrong doc retrieved
             Question("q-miss", "order status", Actor("ROLE_USER", ("order:order:view",)),
                      rag_scope="order", expected_doc_ids=("order.guide",)),
@@ -416,12 +425,158 @@ class PipelineTest(unittest.TestCase):
         # reports render without error
         gap = report.build_gap_report(results)
         self.assertEqual(gap["gap_count"], 1)
-        self.assertIn("returns", gap["entries"][0]["topic"])
+        self.assertIn("core", gap["entries"][0]["topic"])
         md = report.render_gap_report_md(gap)
         self.assertIn("DO NOT INGEST", md)
         self.assertIn("Draft outline", md)
         summary = report.summarize(results)
         self.assertEqual(summary["taxonomy"][CAUSE_CORPUS_GAP], 1)
+
+
+class UnsupportedVerdictTest(unittest.TestCase):
+    """#1131: a corpus gap means no ground truth, so the grounded grader has nothing to contradict
+    and would pass a fabrication as `correct`. The judge must switch to a groundedness prompt and the
+    new `unsupported` verdict when no facts exist, and that failure must route to a corpus_gap."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.idx = corpus_mod.load_corpus()
+
+    def test_prompt_selects_grounded_grader_when_facts_present(self):
+        p = judge.build_judge_prompt("q", "a", ["fact one"])
+        self.assertIn("GROUND TRUTH", p)
+        self.assertIn("fact one", p)
+        self.assertNotIn("There is NO authoritative ground truth", p)
+
+    def test_prompt_selects_groundedness_grader_when_no_facts(self):
+        p = judge.build_judge_prompt("q", "a", [])
+        self.assertIn("There is NO authoritative ground truth", p)
+        self.assertIn("unsupported", p)
+        self.assertNotIn("GROUND TRUTH (authoritative", p)
+
+    def test_empty_string_facts_are_treated_as_no_facts(self):
+        # ground_truth_for yields [] for a factless doc; a list of empty strings must not fool it.
+        self.assertIn("There is NO authoritative ground truth", judge.build_judge_prompt("q", "a", ["", ""]))
+
+    def test_fabrication_graded_unsupported(self):
+        g = judge.grade("q", "A five-step Return Request workflow handles it.", [],
+                        lambda _: '{"verdict":"unsupported","rationale":"invented specifics"}')
+        self.assertEqual(g.verdict, VERDICT_UNSUPPORTED)
+        self.assertIsNone(g.judge_error)
+
+    def test_unsupported_routes_to_corpus_gap(self):
+        q = Question("q-gap", "how are core charges handled on a rebuildable return",
+                     Actor("ROLE_USER", ("order:order:view",)), rag_scope="order",
+                     expected_doc_ids=("order.no-such-doc",), topic="core charges")
+        cap = Capture(question_id="q-gap", answer="fabricated", permission_codes=["order:order:view"])
+        c = taxonomy.classify(q, cap, VERDICT_UNSUPPORTED, self.idx)
+        self.assertEqual(c.cause, CAUSE_CORPUS_GAP)
+
+    def test_unsupported_counts_in_summary_and_calibration(self):
+        q = Question("u", "u", Actor("ROLE_USER"))
+        r = Result(question=q, capture=Capture(question_id="u", answer="a"),
+                   grade=Grade(verdict=VERDICT_UNSUPPORTED),
+                   classification=Classification(cause=CAUSE_CORPUS_GAP))
+        s = report.summarize([r])
+        self.assertEqual(s["verdicts"][VERDICT_UNSUPPORTED], 1)
+        acc = judge.calibrate([(VERDICT_UNSUPPORTED, VERDICT_UNSUPPORTED)])
+        self.assertIn(VERDICT_UNSUPPORTED, acc.per_class)
+        self.assertAlmostEqual(acc.per_class[VERDICT_UNSUPPORTED].recall, 1.0)
+
+
+class JudgeReliabilityTest(unittest.TestCase):
+    """#1129 (configurable timeout + slow-call warning) and #1130 (transport failures must not be
+    counted as `misleading`; ungraded is derived from judge_error, not reported as 0)."""
+
+    def _result(self, qid, grade, *, expected_facts=("f",)):
+        q = Question(qid, qid, Actor("ROLE_USER"), expected_facts=expected_facts)
+        cap = Capture(question_id=qid, answer="a")
+        cls = Classification(cause=CAUSE_NONE)
+        return Result(question=q, capture=cap, grade=grade, classification=cls)
+
+    def test_transport_failure_is_tagged_and_retried(self):
+        calls = {"n": 0}
+
+        def boom(_):
+            calls["n"] += 1
+            raise TimeoutError("read timed out")
+
+        g = judge.grade("q", "a real answer", ["fact"], boom, transport_retries=2)
+        self.assertEqual(calls["n"], 3)  # initial + 2 retries
+        self.assertTrue(g.judge_error.startswith(judge.ERR_TRANSPORT))
+
+    def test_transport_retry_then_success(self):
+        calls = {"n": 0}
+
+        def flaky(_):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionError("reset")
+            return '{"verdict":"correct","rationale":"ok"}'
+
+        g = judge.grade("q", "a real answer", ["fact"], flaky, transport_retries=2)
+        self.assertEqual(g.verdict, VERDICT_CORRECT)
+        self.assertIsNone(g.judge_error)
+
+    def test_parse_failure_is_tagged_parse(self):
+        self.assertTrue(judge.parse_verdict("not json").judge_error.startswith(judge.ERR_PARSE))
+        self.assertTrue(judge.parse_verdict('{"verdict":"great"}').judge_error.startswith(judge.ERR_PARSE))
+
+    def test_summary_excludes_ungraded_from_verdicts(self):
+        results = [
+            self._result("real-mis", Grade(verdict=VERDICT_MISLEADING, cited_ground_truth="x")),
+            self._result("transport", Grade(verdict=VERDICT_MISLEADING, judge_error="transport: TimeoutError")),
+            self._result("parse", Grade(verdict=VERDICT_MISLEADING, judge_error="parse: bad json")),
+            self._result("ok", Grade(verdict=VERDICT_CORRECT)),
+        ]
+        s = report.summarize(results)
+        # only the genuinely-judged misleading is counted; the two errored ones are not
+        self.assertEqual(s["verdicts"][VERDICT_MISLEADING], 1)
+        self.assertEqual(s["verdicts"]["ungraded"], 2)
+        self.assertEqual(s["ungraded"], 2)
+        self.assertEqual(s["ungraded_breakdown"]["transport"], 1)
+        self.assertEqual(s["ungraded_breakdown"]["parse"], 1)
+        # graded verdicts + ungraded sum to the question count
+        self.assertEqual(sum(s["verdicts"].values()), s["questions"])
+        # half ungraded -> loud warning
+        self.assertIn("warning", s)
+        self.assertIn("UNGRADED", s["warning"])
+
+    def test_summary_no_warning_when_fully_graded(self):
+        results = [self._result("ok", Grade(verdict=VERDICT_CORRECT))]
+        s = report.summarize(results)
+        self.assertEqual(s["ungraded"], 0)
+        self.assertNotIn("warning", s)
+
+    def test_slow_judge_call_warns(self):
+        import io
+        from contextlib import redirect_stderr
+
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            api._warn_if_slow("judge-model", elapsed=95.0, timeout=120.0)
+            api._warn_if_slow("judge-model", elapsed=5.0, timeout=120.0)
+        out = buf.getvalue()
+        self.assertIn("WARNING", out)
+        self.assertEqual(out.count("WARNING"), 1)  # only the 95/120 call warns
+
+    def test_build_judge_threads_timeout(self):
+        import argparse
+
+        captured = {}
+
+        def fake_ollama(base, model, timeout=120):
+            captured["timeout"] = timeout
+            return lambda p: ""
+
+        orig = api.ollama_judge
+        api.ollama_judge = fake_ollama
+        try:
+            args = argparse.Namespace(judge="ollama", judge_base=None, judge_model="m", judge_timeout=300)
+            harness_cli.build_judge(args)
+        finally:
+            api.ollama_judge = orig
+        self.assertEqual(captured["timeout"], 300)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:<unknown — not supplied in the task>`
- Parent STORY (durion): _n/a_
- Child issues: louisburroughs/durion-positivity-backend#1115, #1124, #1129, #1130, #1131 (harness built in #1125)
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable — this PR changes **no** API/event contract surface: no controllers, DTOs, `*Request`/`*Response`, events, or `openapi.yaml`. Changes are limited to the Python gap-harness, RAG corpus markdown + eval fixtures, preload config, one Flyway **seed-data** migration, and tests.

## Contract Chain (when a Controller changed)
- [ ] N/A — no controller changed.

## Scope
**What changed** — two commits, two concerns:

**1. RAG gap-harness reliability + corpus growth (#1124, #1129, #1130, #1131)**
- **#1129** — add `--judge-timeout` (default 120s) to `run`/`replay`/`calibrate`, threaded into both judge clients; warn on stderr when a call exceeds 75% of the timeout. Fixes silent ~50% judge failures on CPU-only hosts.
- **#1130** — tag judge errors `transport:`/`parse:`/`ungraded:`; `report.summarize` derives `ungraded` from the tag and excludes errored records from the verdict histogram (new `verdicts.ungraded` bucket so counts sum to graded records only), reports a transport-vs-parse breakdown + `ungraded_fraction`, warns loudly above a 20% ungraded floor, and retries transport failures once. Transport failures no longer masquerade as `misleading`.
- **#1131** — add an `unsupported` verdict + a groundedness judge prompt used when a question has no ground truth, so a confident fabrication about an uncovered topic is caught instead of passing as `correct`; routes to `corpus_gap`. Populate the previously-factless coverage fixtures and surface a `factless_graded` count; add `unsupported` calibration cases.
- **#1124** — author `order.returns-refunds` (source-verified against `pos-order` `ReturnOrderServiceImpl`/`ReturnOrderController`/enums/`permissions.yaml`), wired into all three manifests (`application[-alpha].yml`, `rag_seed.py`, `gap_harness/corpus.py`). Closes the planted `gap-returns-refunds` known-gap (now a positive round-trip fixture); core charges stay an intentional documented gap (no module source exists). Add dense + lexical eval fixtures and document the flip-threshold criterion + corpus-growth plan (`docs/rag-corpus-growth-and-flip-threshold-1124.md`).

**2. Facade AUTHENTICATED gating (#1115)**
- `V29` drops the `AUTHENTICATED` grant from facades that also bundle privileged operations, so each is gated on its privileged code(s): `WorkorderFacadeTool` → `workorder:workorder:view`, `AdminFacadeTool` → `security:{user,permission,audit}:view`, **`TaxFacadeTool` → `tax:calculate`**. Benign single-purpose AUTHENTICATED facades (Order, Pricing, Catalog, Events) are untouched.
- Add `FacadeToolPermissionSeedTest` — offline guard asserting no facade grants `AUTHENTICATED` alongside a privileged code (net of V18 + V29).

> **Note — #1115 under-enumerated the affected facades.** The issue named two; reading the V18 grants showed **`TaxFacadeTool` is a third instance** of the same union-floor defect. It is fixed here and flagged in the migration comment.

**Why:** the three harness bugs made the gap-harness output untrustworthy (inflated `misleading`, hidden ungraded runs, undetectable corpus gaps), which would propagate into #1124's flip-threshold decision. #1115 leaves admin/tax facade tooling offered to any authenticated user at the selection layer.

## Tests
- [x] Unit tests added/updated — `scripts/tests/test_gap_harness.py` (55 pass, +13), `FacadeToolPermissionSeedTest` (offline seed-invariant guard).
- [ ] Integration tests — n/a (no runtime surface changed).
- [ ] Provider behavioral contract tests — n/a.
- **How to run:**
  - `python3 -m unittest scripts.tests.test_gap_harness`
  - `./mvnw -pl pos-mcp-server -am -Dtest=FacadeToolPermissionSeedTest,PermissionGatingInvariantTest,EvalFixtureValidationTest,StaticRagPreloadServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test`

**Left for a live alpha run (documented, not in this PR):** re-embed the grown corpus (`scripts/rag_seed.py`), run `eval_live.py` / `run-gap-harness.sh` to record real dense-vs-hybrid deltas, decide the `mcp.rag.hybrid.lexical-enabled` flip, and re-baseline the #783 floors. No numbers were fabricated.

## Risk & Rollback
- Risk level: **Low.** Harness changes are dev-tooling/eval-only (no runtime path). `V29` is idempotent seed data; the RAG doc adds one preload document. `V29` does not weaken security — it removes an over-broad grant (gateway authorization is unchanged).
- Rollback plan: revert the two commits; a follow-up migration re-inserting the AUTHENTICATED rows would restore prior gating if ever needed.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/plan-issues-1115-1131-1ny9zw` per the assigned task.
- [ ] PR title starts with `[CAP:<cap-id>]` — no cap-id supplied.
- [x] Links to child issues present (#1115, #1124, #1129, #1130, #1131).
- [x] Contract guide update — n/a, no contract semantics changed.
- [ ] Required CI checks passing — pending CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaZpTpNzHdi4AqAYXq4exi

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaZpTpNzHdi4AqAYXq4exi)_