### PR TITLE
Add sitemap configuration to docker-compose environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -833,6 +833,13 @@ services:
       MCP_RAG_CHUNKING_ENABLED: ${MCP_RAG_CHUNKING_ENABLED:-true}
       MCP_RAG_MAX_SEGMENT_SIZE: ${MCP_RAG_MAX_SEGMENT_SIZE:-2000}
       MCP_RAG_MAX_OVERLAP_SIZE: ${MCP_RAG_MAX_OVERLAP_SIZE:-200}
+      # Origin of the frontend SSR server that serves /sitemap.json (NOT the API gateway).
+      # Must be passed through explicitly; compose only reads .env for ${..} substitution,
+      # it does not inject host env into the container.
+      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://pos-frontend:4000}
+      SITEMAP_CACHE_TTL: ${SITEMAP_CACHE_TTL:-600s}
+      SITEMAP_FETCH_TIMEOUT: ${SITEMAP_FETCH_TIMEOUT:-5s}
+      SITEMAP_EXPECTED_VERSION: ${SITEMAP_EXPECTED_VERSION:-1}
       EXA_API_KEY: ${EXA_API_KEY:-}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
       OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -834,8 +834,8 @@ services:
       MCP_RAG_MAX_SEGMENT_SIZE: ${MCP_RAG_MAX_SEGMENT_SIZE:-2000}
       MCP_RAG_MAX_OVERLAP_SIZE: ${MCP_RAG_MAX_OVERLAP_SIZE:-200}
       # Origin of the frontend SSR server that serves /sitemap.json (NOT the API gateway).
-      # Must be passed through explicitly; compose only reads .env for ${..} substitution,
-      # it does not inject host env into the container.
+      # Must be listed here to be passed into the container; values come from the
+      # docker compose process environment and/or the .env file during ${...} substitution.
       FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://pos-frontend:4000}
       SITEMAP_CACHE_TTL: ${SITEMAP_CACHE_TTL:-600s}
       SITEMAP_FETCH_TIMEOUT: ${SITEMAP_FETCH_TIMEOUT:-5s}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:<cap-id>`
- Parent STORY (durion): louisburroughs/durion#<parent-id>
- Child issue: louisburroughs/durion-positivity-backend#<child-id>
- Domain: `domain:<domain>`

## Scope
- **What changed:** Added four new environment variables to the docker-compose service configuration:
  - `FRONTEND_BASE_URL`: Origin of the frontend SSR server serving `/sitemap.json` (defaults to `http://pos-frontend:4000`)
  - `SITEMAP_CACHE_TTL`: Cache time-to-live for sitemap data (defaults to `600s`)
  - `SITEMAP_FETCH_TIMEOUT`: Timeout for fetching sitemap (defaults to `5s`)
  - `SITEMAP_EXPECTED_VERSION`: Expected sitemap version (defaults to `1`)

- **Why:** Enables the backend service to fetch and cache sitemap data from the frontend SSR server. These configuration parameters allow runtime tuning of sitemap fetch behavior without code changes. The `FRONTEND_BASE_URL` must be explicitly passed through compose (not injected from host env) since compose only substitutes `${...}` variables from `.env`.

## Tests
- No testing needed. Configuration-only change; behavior is controlled by consuming code.

## Risk & Rollback
- Risk level: **Low**
- Rollback plan: Remove the four new environment variable lines from docker-compose.yml.

## Checklist
- [ ] Branch name matches `cap/<cap-id>`
- [ ] PR title starts with `[CAP:<cap-id>]`
- [ ] Links to parent + child issues are present
- [ ] Required CI checks passing

https://claude.ai/code/session_0195a1qKnYWEmGXSQpENdS4v