### PR TITLE
pos-mcp-server gap-harness: surface failed ask() as ungraded transpor…

### DIFF
--- a/scripts/gap_harness/harness.py
+++ b/scripts/gap_harness/harness.py
@@ -12,9 +12,10 @@ from typing import Callable, Optional
 
 from .corpus import CorpusIndex
 from .fusion import RecoveryRecord, recovery_record
-from .judge import LLM, grade as judge_grade
+from .judge import ERR_TRANSPORT, LLM, grade as judge_grade
 from .model import (
     CAUSE_RETRIEVAL_MISS,
+    VERDICT_MISLEADING,
     Capture,
     Grade,
     Question,
@@ -45,6 +46,19 @@ def ground_truth_for(question: Question, corpus: CorpusIndex) -> list[str]:
             seen.add(f)
             out.append(f)
     return out
+
+
+def _ask_error(error: Optional[str]) -> Optional[str]:
+    """The ``ask:`` segment of a capture error, if the *answer* call itself failed. Distinct from a
+    retrieval failure (which leaves the answer intact): a failed ask means no answer was obtained, so
+    there is nothing to grade. ``capture_one`` joins segments with ``"; "`` (e.g.
+    ``"retrieve: …; ask: …"``), so split on that and match the ask segment."""
+    if not error:
+        return None
+    for segment in error.split("; "):
+        if segment.startswith("ask:"):
+            return segment
+    return None
 
 
 def capture_one(question: Question, ask: AskFn, retrieve: RetrieveFn) -> Capture:
@@ -86,8 +100,22 @@ def run(
     recoveries: list[RecoveryRecord] = []
     for q in questions:
         capture = capture_one(q, ask, retrieve)
-        gt = ground_truth_for(q, corpus)
-        grade = judge_grade(q.query, capture.answer, gt, judge_llm)
+        ask_err = _ask_error(capture.error)
+        if ask_err:
+            # The answer call itself failed (timeout / connection / non-2xx), so there is no answer
+            # to grade. Do NOT fall through to judge_grade: an empty answer trips the deterministic
+            # refusal pre-filter (refusal.py) and would be miscounted as a content `refused` with
+            # transport=0 — masking a transport/HTTP failure (e.g. a 404 from a wrong base-url) as a
+            # real refusal. Surface it as an ungraded `transport:` failure so the report keeps it out
+            # of the graded verdict + taxonomy counts, exactly as a judge transport failure is (#1130).
+            grade = Grade(
+                verdict=VERDICT_MISLEADING,  # placeholder; judge_error pulls it into the ungraded bucket
+                rationale="answer call failed; not graded",
+                judge_error=f"{ERR_TRANSPORT} {ask_err}",
+            )
+        else:
+            gt = ground_truth_for(q, corpus)
+            grade = judge_grade(q.query, capture.answer, gt, judge_llm)
         classification = classify(q, capture, grade.verdict, corpus)
         results.append(Result(question=q, capture=capture, grade=grade, classification=classification))
 

--- a/scripts/tests/test_gap_harness.py
+++ b/scripts/tests/test_gap_harness.py
@@ -11,6 +11,7 @@ import importlib.util
 import json
 import sys
 import unittest
+import urllib.error
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -240,6 +241,53 @@ class TaxonomyTest(unittest.TestCase):
         c = taxonomy.classify(q, cap, VERDICT_REFUSED, self.idx)
         self.assertEqual(c.cause, CAUSE_RETRIEVAL_MISS)
         self.assertIn("order.guide", c.covering_doc_ids)
+
+
+class HarnessRunTest(unittest.TestCase):
+    """A failed `ask` (transport/HTTP error, e.g. a 404 from a wrong base-url) must surface as an
+    ungraded transport failure — never be scored as a content `refused` off the empty answer, which
+    previously let a broken endpoint masquerade as a run full of refusals with transport=0."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.idx = corpus_mod.load_corpus()
+
+    def _retrieve(self, _q):
+        return [], []
+
+    def test_ask_failure_is_ungraded_transport_not_refused(self):
+        def ask(_q):
+            raise urllib.error.HTTPError("http://x/v1/mcp/chat", 404, "Not Found", {}, None)
+
+        q = Question("q", "what is a sku", Actor("ROLE_USER"))
+        # A judge is supplied; it must NOT be consulted for a failed ask (there is no answer to grade).
+        judge_calls = []
+        judge_llm = lambda p: judge_calls.append(p) or '{"verdict":"correct"}'
+        results, recoveries = harness.run([q], ask, self._retrieve, self.idx, judge_llm)
+
+        self.assertEqual(len(results), 1)
+        grade = results[0].grade
+        self.assertIsNotNone(grade.judge_error)
+        self.assertTrue(grade.judge_error.startswith(judge.ERR_TRANSPORT))
+        self.assertIn("404", grade.judge_error)
+        self.assertFalse(grade.deterministic)  # not a deterministic refusal
+        self.assertEqual(judge_calls, [])  # judge never called on a non-answer
+        self.assertEqual(recoveries, [])  # ungraded rows never feed the flip-threshold set
+
+        summary = report.summarize(results)
+        self.assertEqual(summary["verdicts"]["refused"], 0)  # the bug this guards against
+        self.assertEqual(summary["verdicts"]["ungraded"], 1)
+        self.assertEqual(summary["ungraded_breakdown"]["transport"], 1)
+        self.assertEqual(sum(summary["taxonomy"].values()), 0)  # taxonomy skips ungraded rows
+
+    def test_successful_ask_still_graded(self):
+        # Guard the else-branch: a clean ask is graded normally (retrieval failure alone must not
+        # divert a good answer into the ungraded bucket).
+        q = Question("q", "vin format", Actor("ROLE_USER"), expected_facts=("A VIN is 17 characters",))
+        judge_llm = lambda _p: '{"verdict":"correct"}'
+        results, _ = harness.run([q], lambda _q: "A VIN is 17 characters", self._retrieve, self.idx, judge_llm)
+        self.assertIsNone(results[0].grade.judge_error)
+        self.assertEqual(results[0].grade.verdict, VERDICT_CORRECT)
 
 
 class FusionTest(unittest.TestCase):


### PR DESCRIPTION
…t, not a refusal

A transport/HTTP failure from the chat API (e.g. a 404 from pointing --base-url at the gateway root instead of the /mcp-server route, or a 401) left the answer empty, which tripped the deterministic refusal pre-filter and was counted as a content 'refused' with ungraded_breakdown.transport=0. A fully broken endpoint could therefore masquerade as a run full of refusals, and the four-way taxonomy was computed off non-answers.

harness.run now detects a failed ask (the 'ask:' segment of the capture error) and short-circuits to an ungraded Grade tagged 'transport:', mirroring how a judge transport failure is handled (#1130): report.summarize pulls it out of the verdict histogram and taxonomy into ungraded_breakdown.transport, and it is kept out of the dense-vs-hybrid recovery set that feeds the #1124 flip-threshold. A successful ask is still graded normally; a retrieval-only failure does not divert a good answer into the ungraded bucket.

Adds HarnessRunTest covering both the failed-ask and clean-ask paths.


Claude-Session: https://claude.ai/code/session_012BtbRyAHHFmwHE2ujGFJmq

<!-- .github/pull_request_template.md -->
## Capability & Traceability
- Capability: `cap:<cap-id>`
- Parent STORY (durion): louisburroughs/durion#<parent-id>
- Child issue: louisburroughs/durion-positivity-backend#<child-id>
- Domain: `domain:<domain>`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
<!--
  The "Contract Sync Enforcement" check FAILS unless the text BACKEND_CONTRACT_GUIDE.md
  appears somewhere in this PR body whenever contract-relevant files change
  (controllers, DTOs, *Request/*Response, events, openapi.yaml, validation/error models).
  Keep the reference below and link it to the relevant domain anchor.
-->
- Contract guide entry (durion): `domains/<domain>/.business-rules/BACKEND_CONTRACT_GUIDE.md` → <link-to-anchor>
- Durion contract PR (if applicable): <link-to-durion-pr>

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope
- What changed:
- Why:

## Tests
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run:

## Risk & Rollback
- Risk level: Low / Medium / High
- Rollback plan:

## Checklist
- [ ] Branch name matches `cap/<cap-id>`
- [ ] PR title starts with `[CAP:<cap-id>]`
- [ ] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing
