### PR TITLE
gap-harness: split chat vs judge transport failures + chat preflight guard

### DIFF
--- a/scripts/gap_harness/report.py
+++ b/scripts/gap_harness/report.py
@@ -45,6 +45,14 @@ def _ungraded_kind(judge_error: str) -> str:
         return "no_llm"
     return "other"
 
+
+def _is_ask_transport(judge_error: str) -> bool:
+    """True if a ``transport:`` failure originated in the *chat* (answer) call rather than the judge.
+    ``harness.run`` tags a failed ask as ``"transport: ask: …"`` (see harness._ask_error), so a
+    transport error whose payload starts with ``ask:`` is a chat-endpoint problem (base-url / token),
+    not a judge problem (timeout / judge model)."""
+    return judge_error.startswith(f"{ERR_TRANSPORT} ask:")
+
 GUARDRAIL_BANNER = (
     "PROPOSED GAPS — DO NOT INGEST AS-IS. A human authors each doc and source-verifies it "
     "(the `_Verified: …_` convention). A model authoring docs to answer its own questions injects "
@@ -137,6 +145,11 @@ def summarize(results: list[Result]) -> dict:
         CAUSE_PERMISSION_GATING: 0,
     }
     ungraded_breakdown = {"transport": 0, "parse": 0, "no_llm": 0, "other": 0}
+    # A transport failure can come from the *chat* call (the answer never arrived — wrong base-url,
+    # expired token) or from the *judge* call. They share the `transport` bucket but need opposite
+    # fixes, so split them for the warning's remedy (#1157-followup).
+    ask_transport = 0
+    judge_transport = 0
     factless_graded = 0
     for r in results:
         if r.grade.judge_error:
@@ -144,7 +157,13 @@ def summarize(results: list[Result]) -> dict:
             # judge would otherwise inflate the breakdown off placeholder verdicts). Keep it out of
             # both the verdict histogram AND the taxonomy, per the warning below.
             verdicts["ungraded"] += 1
-            ungraded_breakdown[_ungraded_kind(r.grade.judge_error)] += 1
+            kind = _ungraded_kind(r.grade.judge_error)
+            ungraded_breakdown[kind] += 1
+            if kind == "transport":
+                if _is_ask_transport(r.grade.judge_error):
+                    ask_transport += 1
+                else:
+                    judge_transport += 1
             continue
         verdicts[r.grade.verdict] = verdicts.get(r.grade.verdict, 0) + 1
         if not (r.question.expected_facts or r.question.expected_doc_ids):
@@ -167,10 +186,33 @@ def summarize(results: list[Result]) -> dict:
         ),
     }
     if n and ungraded / n >= UNGRADED_WARN_FRACTION:
+        # Tailor the remedy to what actually failed: a chat-endpoint failure needs the base-url/token
+        # fixed, a judge failure needs the judge timeout/model changed. Conflating them (the old text
+        # always blamed the judge) sends people chasing --judge-timeout when the real fault is a 404
+        # from a wrong base-url or a 401 from an expired token.
+        hints = []
+        if ask_transport:
+            hints.append(
+                f"{ask_transport} were CHAT-ENDPOINT failures (the answer call itself failed — e.g. a "
+                "404 from a --base-url missing the gateway service route like `/mcp-server`, or a 401 "
+                "from an expired/invalid token) — fix the endpoint/token, not the judge"
+            )
+        if judge_transport:
+            hints.append(
+                f"{judge_transport} were JUDGE transport failures — raise --judge-timeout (#1129) or "
+                "use a smaller judge model"
+            )
+        if ungraded_breakdown["parse"]:
+            hints.append(
+                f"{ungraded_breakdown['parse']} were judge PARSE failures (a judge-quality signal)"
+            )
+        if ungraded_breakdown["no_llm"]:
+            hints.append(f"{ungraded_breakdown['no_llm']} ran with no judge configured (--judge none)")
+        remedy = "; ".join(hints) if hints else "raise --judge-timeout (#1129) or use a smaller judge"
         summary["warning"] = (
-            f"{ungraded}/{n} questions ({ungraded / n:.0%}) were UNGRADED (judge transport/parse "
-            f"failures: {ungraded_breakdown}); the verdict and taxonomy counts below rest on the "
-            "graded remainder only. Raise --judge-timeout (#1129) or use a smaller judge, then re-run."
+            f"{ungraded}/{n} questions ({ungraded / n:.0%}) were UNGRADED "
+            f"(breakdown: {ungraded_breakdown}); the verdict and taxonomy counts below rest on the "
+            f"graded remainder only. {remedy}. Then re-run."
         )
     return summary
 

--- a/scripts/rag_gap_harness.py
+++ b/scripts/rag_gap_harness.py
@@ -22,7 +22,7 @@ logic lives in the `gap_harness` package and is unit-tested (scripts/tests/test_
 Usage:
     # Phase 1 capture + phases 2-4 in one live pass:
     POS_MCP_TOKEN_ROLE_ADMIN=... python3 scripts/rag_gap_harness.py run \\
-        --base-url http://localhost:8080 --judge ollama --judge-model llama3.1 \\
+        --base-url http://localhost:8080/mcp-server --judge ollama --judge-model llama3.1:8b \\
         --out pos-mcp-server/target/gap-harness
 
     # Iterate the judge/taxonomy offline on a captured dump:
@@ -108,6 +108,32 @@ def write_outputs(out_dir: Path, results: list[Result], recoveries, recall_at_k,
 
 
 # --- subcommand: run ---------------------------------------------------------------------------
+def preflight_chat(chat, actor, base_url):
+    """Fail fast if the chat endpoint is unreachable/unauthorized, instead of letting every question
+    fail one at a time (which — since a failed ask is now an ungraded transport row — surfaces only
+    at the end as a 100%-ungraded run). A 404 almost always means ``--base-url`` is missing the
+    gateway service route (e.g. ``/mcp-server``); a 401 means the token is missing/expired."""
+    import urllib.error
+
+    try:
+        chat.ask(actor, "ping")
+    except urllib.error.HTTPError as e:
+        hint = ""
+        if e.code == 404:
+            hint = (
+                " — path 404s: is --base-url missing the gateway service route? "
+                "e.g. http://localhost:8080/mcp-server, not bare http://localhost:8080"
+            )
+        elif e.code in (401, 403):
+            hint = " — auth rejected: the bearer token is missing, expired, or lacks mcp:chat:execute"
+        raise SystemExit(f"chat preflight to {base_url}/v1/mcp/chat failed: HTTP {e.code}{hint}")
+    except urllib.error.URLError as e:
+        raise SystemExit(
+            f"chat preflight to {base_url}/v1/mcp/chat failed: {e.reason} "
+            "(is the stack up and --base-url reachable?)"
+        )
+
+
 def cmd_run(args):
     from gap_harness.retrieval import DbRetriever
 
@@ -119,6 +145,8 @@ def cmd_run(args):
     if args.token:
         token_provider = api.static_token_provider(args.token)
     chat = api.ChatClient(args.base_url, token_provider)
+    if not args.no_preflight:
+        preflight_chat(chat, qs[0].actor, args.base_url)
     retriever = DbRetriever.connect()
     judge_llm = build_judge(args)
 
@@ -245,7 +273,16 @@ def main(argv=None):
         )
 
     r = sub.add_parser("run", help="live run against the stack")
-    r.add_argument("--base-url", required=True, help="MCP chat API base, e.g. http://localhost:8080")
+    r.add_argument(
+        "--base-url",
+        required=True,
+        help="MCP chat API base incl. the gateway service route, e.g. http://localhost:8080/mcp-server",
+    )
+    r.add_argument(
+        "--no-preflight",
+        action="store_true",
+        help="skip the one-shot chat preflight that fails fast on a 404/401 before running the batch",
+    )
     r.add_argument("--out", default=str(ROOT / "pos-mcp-server/target/gap-harness"))
     r.add_argument("--token", default=None, help="single bearer token (else POS_MCP_TOKEN_<ROLE> env)")
     r.add_argument("--include-fixtures", action="store_true", help="also draw questions from eval fixtures")

--- a/scripts/run-gap-harness.sh
+++ b/scripts/run-gap-harness.sh
@@ -8,7 +8,9 @@
 #
 # Prereqs (a host with line-of-sight to the stack — see scripts/run-live-eval.sh for the DB/embed setup):
 #   - python3 + pg8000            (pip install --user pg8000)
-#   - MCP chat API reachable      (--base-url, default http://localhost:8080)
+#   - MCP chat API reachable      (GAP_HARNESS_BASE_URL, default http://localhost:8080/mcp-server —
+#                                  the gateway route; a bare http://localhost:8080 404s, since the
+#                                  chat path lives behind the /mcp-server gateway route)
 #   - alpha Postgres reachable    (POS_MCP_DB_* / .env, for retrieved-context capture)
 #   - local Ollama embedding      (OLLAMA_EMBEDDING_BASE_URL, nomic-embed-text)
 #   - a judge chat model          (--judge ollama|openai; ungraded refusal-only pass with --judge none)
@@ -23,7 +25,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-BASE_URL="${GAP_HARNESS_BASE_URL:-http://localhost:8080}"
+# The chat endpoint lives behind the gateway's /mcp-server route (Path=/mcp-server/** + StripPrefix=1);
+# the gateway validates the JWT and injects the X-Authorities headers the service trusts. A bare
+# http://localhost:8080 has no such route and 404s — the CLI preflight now catches that early.
+BASE_URL="${GAP_HARNESS_BASE_URL:-http://localhost:8080/mcp-server}"
 OUT="${GAP_HARNESS_OUT:-pos-mcp-server/target/gap-harness}"
 
 # Pass-through: everything after the known --base-url/--out defaults goes straight to the CLI, so

--- a/scripts/tests/test_gap_harness.py
+++ b/scripts/tests/test_gap_harness.py
@@ -290,6 +290,73 @@ class HarnessRunTest(unittest.TestCase):
         self.assertEqual(results[0].grade.verdict, VERDICT_CORRECT)
 
 
+class WarningRemedyTest(unittest.TestCase):
+    """The ungraded warning must name the right fix: chat-endpoint (ask) transport failures need the
+    base-url/token fixed, judge transport failures need the judge timeout/model changed. They share
+    the `transport` bucket, so the message keys off the `ask:` tag harness.run stamps on a failed ask."""
+
+    def _res(self, judge_error):
+        q = Question("q", "x", Actor("ROLE_USER"))
+        cap = Capture(question_id="q", answer="", dense_docs=[], permission_codes=[])
+        grade = Grade(verdict=VERDICT_MISLEADING, judge_error=judge_error)
+        return Result(question=q, capture=cap, grade=grade, classification=Classification(cause=CAUSE_NONE))
+
+    def test_chat_endpoint_transport_blames_endpoint_not_judge(self):
+        results = [self._res("transport: ask: HTTPError: HTTP Error 404: Not Found") for _ in range(3)]
+        w = report.summarize(results)["warning"]
+        self.assertIn("CHAT-ENDPOINT", w)
+        self.assertIn("--base-url", w)
+        self.assertNotIn("--judge-timeout", w)  # do NOT send them at the judge
+
+    def test_judge_transport_blames_judge(self):
+        results = [self._res("transport: RuntimeError: timeout") for _ in range(3)]
+        w = report.summarize(results)["warning"]
+        self.assertIn("JUDGE", w)
+        self.assertIn("--judge-timeout", w)
+        self.assertNotIn("CHAT-ENDPOINT", w)
+
+    def test_mixed_transport_names_both(self):
+        results = [
+            self._res("transport: ask: HTTPError: HTTP Error 401: Unauthorized"),
+            self._res("transport: RuntimeError: timeout"),
+            self._res("transport: ask: HTTPError: HTTP Error 404: Not Found"),
+        ]
+        w = report.summarize(results)["warning"]
+        self.assertIn("CHAT-ENDPOINT", w)
+        self.assertIn("JUDGE", w)
+
+
+class PreflightTest(unittest.TestCase):
+    """The run preflight fails fast with an actionable message on a 404/401 rather than letting all N
+    questions fail one at a time and surface only as a 100%-ungraded run at the end."""
+
+    class _Chat:
+        def __init__(self, exc):
+            self._exc = exc
+
+        def ask(self, _actor, _msg):
+            if self._exc:
+                raise self._exc
+            return "ok"
+
+    def test_404_aborts_with_base_url_hint(self):
+        exc = urllib.error.HTTPError("http://x/v1/mcp/chat", 404, "Not Found", {}, None)
+        with self.assertRaises(SystemExit) as cm:
+            harness_cli.preflight_chat(self._Chat(exc), Actor("ROLE_USER"), "http://localhost:8080")
+        msg = str(cm.exception)
+        self.assertIn("404", msg)
+        self.assertIn("/mcp-server", msg)
+
+    def test_401_aborts_with_token_hint(self):
+        exc = urllib.error.HTTPError("http://x/v1/mcp/chat", 401, "Unauthorized", {}, None)
+        with self.assertRaises(SystemExit) as cm:
+            harness_cli.preflight_chat(self._Chat(exc), Actor("ROLE_USER"), "http://localhost:8080/mcp-server")
+        self.assertIn("token", str(cm.exception).lower())
+
+    def test_success_is_silent(self):
+        harness_cli.preflight_chat(self._Chat(None), Actor("ROLE_USER"), "http://x/mcp-server")  # no raise
+
+
 class FusionTest(unittest.TestCase):
     def test_rrf_fuse_orders_by_reciprocal_rank(self):
         fused = fusion.rrf_fuse([["a", "b", "c"], ["c", "d"]], k=60)


### PR DESCRIPTION
## Scope
- **What changed:** Two ergonomics/reliability follow-ups to #1157 so a misconfigured gap-harness run is diagnosed up front and points at the right fix.
  1. **Warning distinguishes chat-endpoint vs judge transport failures.** After #1157 a failed `ask()` (chat call) is surfaced as an ungraded `transport:` row — the same bucket as a judge transport failure. `report.summarize()` now splits them (keying off the `ask:` tag `harness.run` stamps on a failed ask) and tailors the remedy: a chat failure says "fix the base-url/token, not the judge"; a judge failure says "raise `--judge-timeout` / use a smaller model." The old text always blamed the judge.
  2. **Chat preflight guard.** `cmd_run` fires one chat request before the batch and aborts with an actionable message on 404 (base-url likely missing the `/mcp-server` gateway route) or 401 (missing/expired token), instead of letting all N questions fail and surface only as a 100%-ungraded run. Opt out with `--no-preflight`.
  3. **Runner default fixed.** `run-gap-harness.sh` now defaults the base-url to `http://localhost:8080/mcp-server` (the canonical gateway route: `Path=/mcp-server/**` + `StripPrefix=1`) rather than a bare `:8080` that 404s. Docstring examples updated to match and to use an exact judge model tag.
- **Why:** A bare-`:8080` base-url 404s silently; pre-#1157 that masqueraded as refusals, and even after #1157 the generic "raise --judge-timeout" warning sent operators chasing the judge when the real fault was the endpoint or an expired token. Observed live on the alpha stack.

## Contract References
- N/A — no API/event/DTO/controller behavior changes. This PR only touches the Python gap-harness tooling under `scripts/`.

## Contract Chain (when a Controller changed)
- N/A — no controller changed.

## Tests
- [x] Unit tests added/updated — `WarningRemedyTest` (chat vs judge vs mixed transport remedy) and `PreflightTest` (404 → base-url hint, 401 → token hint, success silent) in `scripts/tests/test_gap_harness.py`.
- [ ] Integration tests — N/A (offline decision logic).
- **How to run:** `cd scripts && python3 -m unittest tests.test_gap_harness` (64/64 pass).

## Risk & Rollback
- Risk level: **Low** — test-and-tooling only; no production/service code, no API/DB/event changes. The preflight adds one chat call per run (opt out with `--no-preflight`).
- Rollback plan: revert the commit; the harness reverts to the prior warning text and no preflight.

## Checklist
- [x] Required CI checks passing (Python unit suite green locally)
- [ ] Capability/contract items — N/A for tooling-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BtbRyAHHFmwHE2ujGFJmq

---
_Generated by [Claude Code](https://claude.ai/code/session_012BtbRyAHHFmwHE2ujGFJmq)_