### PR TITLE
pos-mcp-server: broaden RAG grounding instruction to stop workflow fabrication

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/RagGroundingInstruction.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/RagGroundingInstruction.java
@@ -1,0 +1,49 @@
+package com.positivity.mcp.internal.orchestration;
+
+/**
+ * The grounding instruction prepended to the retrieved RAG snippets in the assistant's system prompt.
+ *
+ * <p>#1124/#1125: retrieved context must carry an explicit grounding instruction. Without one, the
+ * model treats the numbered snippets as loose background rather than an authoritative source to
+ * prioritize over its own trained knowledge — observed in the gap-harness alpha eval as invented
+ * PO/GL identifier formats, and later as an entirely fabricated core-charge workflow (invented
+ * catalog flags, workorder types, events, permissions, and approval thresholds) produced <em>even
+ * though</em> the {@code order.returns-refunds} snippet — which documents core charges as NOT modeled
+ * in pos-order and forbids inventing a workflow — was in this exact block.
+ *
+ * <p>The instruction therefore does three things:
+ *
+ * <ul>
+ *   <li>requires answering from the numbered snippets when they cover the question, and forbids
+ *       stating <em>any</em> unsupported fact — not only identifier/format/ownership facts (the
+ *       original wording was scoped to those and left workflows, capabilities, fields, permissions,
+ *       events, and thresholds unguarded, which is how the core-charge workflow slipped through);
+ *   <li>makes a documented non-existence binding: when a snippet says a capability or concept is not
+ *       modeled/implemented/supported, the model must say so and must not invent a workflow,
+ *       calculation, field, or value for it, nor offer to perform an action the snippets don't
+ *       support;
+ *   <li>keeps the "say what you don't know instead of inventing" fallback for facts the snippets
+ *       don't contain.
+ * </ul>
+ *
+ * <p>Shared by {@link SpringAiPosAssistant} and {@link SpringAiStreamingPosAssistant} so the
+ * streaming and non-streaming chat paths ground identically (the streaming path previously carried
+ * only the bare "Relevant retrieved context:" header with no grounding instruction).
+ */
+final class RagGroundingInstruction {
+
+    static final String CONTEXT_PREFIX = """
+            Relevant retrieved context:
+            Ground your answer in the numbered snippets below when they cover the question, and treat \
+            them as the authoritative source — prefer them over your own trained/parametric knowledge. \
+            Do not state any workflow, capability, field, entity, permission, event, threshold, \
+            identifier format, code pattern, or service ownership that is not supported by these \
+            snippets. If a snippet says a capability or concept is not modeled, not implemented, or \
+            not supported, treat that as authoritative: say the platform does not model it, and do \
+            not invent a workflow, calculation, field, or value for it or offer to perform an action \
+            the snippets do not support. If the snippets don't contain the fact needed, say what you \
+            don't know instead of inventing or guessing a plausible-sounding answer from general \
+            knowledge.""";
+
+    private RagGroundingInstruction() {}
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
@@ -23,23 +23,9 @@ import org.springframework.ai.tool.ToolCallback;
 
 final class SpringAiPosAssistant implements PosAssistant {
 
-    /**
-     * #1124/#1125: the retrieved context must carry an explicit grounding instruction. Without one,
-     * the model treats the numbered snippets as loose background rather than an authoritative source
-     * to prioritize over its own trained knowledge — observed in the gap-harness alpha eval as
-     * contradicting facts (invented PO/GL formats) or flat refusals even when the correct
-     * `glossary.identifiers` snippet was present in this exact block. The instruction requires
-     * answering from the numbered snippets when they cover the question, and explicitly forbids
-     * silently falling back to trained/parametric knowledge for identifier/format/ownership facts.
-     */
-    private static final String RAG_CONTEXT_PREFIX =
-            """
-            Relevant retrieved context:
-            Ground your answer in the numbered snippets below when they cover the question. \
-            Do not state a specific identifier format, code pattern, or service ownership that \
-            contradicts or is not supported by these snippets — if the snippets don't contain the \
-            fact needed, say what you don't know instead of inventing or guessing a plausible-sounding \
-            answer from general knowledge.""";
+    /** Shared grounding instruction ({@link RagGroundingInstruction}) prepended to the RAG snippets. */
+    private static final String RAG_CONTEXT_PREFIX = RagGroundingInstruction.CONTEXT_PREFIX;
+
     private static final int MAX_CONTEXT_DOCS = 5;
     private static final int MAX_CONTEXT_CHARS = 4_000;
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
@@ -23,7 +23,9 @@ import reactor.core.publisher.Flux;
 
 final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
 
-    private static final String RAG_CONTEXT_PREFIX = "Relevant retrieved context:";
+    // Shared with the non-streaming assistant so both paths ground identically (previously this path
+    // carried only the bare "Relevant retrieved context:" header with no grounding instruction).
+    private static final String RAG_CONTEXT_PREFIX = RagGroundingInstruction.CONTEXT_PREFIX;
     private static final int MAX_CONTEXT_DOCS = 5;
     private static final int MAX_CONTEXT_CHARS = 4_000;
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
@@ -124,14 +124,22 @@ class SpringAiPosAssistantTest {
         ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
         verify(chatModel).call(promptCaptor.capture());
         List<Message> promptMessages = promptCaptor.getValue().getInstructions();
-        String systemMessageText =
-                promptMessages.get(promptMessages.size() - 2).getText();
+        String systemMessageText = promptMessages.get(promptMessages.size() - 2).getText();
         assertThat(systemMessageText)
                 .contains("Relevant retrieved context:")
                 .contains("Ground your answer in the numbered snippets")
                 .containsIgnoringCase("do not state")
                 .containsIgnoringCase("say what you don't know instead of inventing")
-                .contains("PO numbers are owned by pos-inventory");
+                .contains("PO numbers are owned by pos-inventory")
+                // The instruction must guard more than identifier/format facts — a fabricated workflow
+                // (the core-charge case) slipped through the original identifier-only wording.
+                .containsIgnoringCase("workflow")
+                .containsIgnoringCase("capability")
+                // A documented non-existence must be binding: say it's not modeled, don't invent it,
+                // and don't offer to perform an unsupported action.
+                .containsIgnoringCase("not modeled")
+                .containsIgnoringCase("does not model it")
+                .containsIgnoringCase("offer to perform an action");
     }
 
     @Test


### PR DESCRIPTION
## Scope
- **What changed:** The assistant's RAG grounding instruction is broadened and made binding on documented non-existence, closing a fabrication path the gap-harness caught on alpha.
  - Extract the grounding instruction into a shared `RagGroundingInstruction.CONTEXT_PREFIX` and broaden it: forbid stating **any** unsupported workflow, capability, field, entity, permission, event, threshold, identifier format, code pattern, or service ownership (the original wording was scoped to identifier/format/ownership only). Make a "not modeled / not implemented / not supported" snippet authoritative — say the platform does not model it, do not invent a workflow/calculation/field/value, and do not offer to perform an unsupported action. Keep the "say what you don't know instead of inventing" fallback.
  - Wire both `SpringAiPosAssistant` and `SpringAiStreamingPosAssistant` to the shared constant. The **streaming** path previously carried only the bare `"Relevant retrieved context:"` header with no grounding instruction at all — a latent copy of the same bug — so both chat paths now ground identically.
  - Strengthen `SpringAiPosAssistantTest` to assert the broadened categories and the not-modeled clause are present in the injected system prompt.
- **Why:** On alpha, for *"how are core charges handled when a customer returns a rebuildable part"*, the assistant fabricated an entire core-charge subsystem (invented catalog flags, workorder types, events, permissions, approval thresholds) and offered to execute it — **even though** `order.returns-refunds`, which documents core charges as NOT modeled in pos-order and forbids inventing a workflow, was in the retrieved context. Root cause: the grounding directive only guarded identifier/format/ownership facts, so a fabricated *workflow* fell outside its scope, and nothing made a documented non-existence binding.

## Contract References
- N/A — no API/event/DTO/controller behavior changes. This PR changes only the internal system-prompt text prepended to retrieved RAG context; request/response schemas are unchanged.

## Contract Chain (when a Controller changed)
- N/A — no controller changed.

## Tests
- [x] Unit tests added/updated — `SpringAiPosAssistantTest.chat_ragContextInstructsGroundingAndForbidsContradictingInventedFacts` now also asserts the broadened categories (`workflow`, `capability`) and the not-modeled clause (`not modeled`, `does not model it`, `offer to perform an action`). `SpringAiStreamingPosAssistantTest` continues to pass (still contains the `"Relevant retrieved context:"` header, now followed by the shared grounding text).
- [ ] Integration tests — N/A.
- **How to run:** `./mvnw -pl pos-mcp-server -am -Dtest=SpringAiPosAssistantTest,SpringAiStreamingPosAssistantTest -Dsurefire.failIfNoSpecifiedTests=false test` — 6/6 pass, BUILD SUCCESS.

## End-to-end regression
- The `order-core-charge-not-modeled` gap-harness fixture (added in #1160) guards this end to end: a correct run should grade it `correct` (assistant says core charges are not modeled), not `unsupported`.

## Risk & Rollback
- Risk level: **Low** — a single system-prompt string change plus a shared-constant extraction; no API/DB/event/tool-wiring changes. It tightens grounding (more likely to say "I don't know"/"not modeled", less likely to fabricate); the main downside risk is marginally more conservative answers.
- Rollback plan: revert the commit; both assistants fall back to their prior prefixes.

## Checklist
- [x] Required CI checks passing (module unit tests green locally; build clears checkstyle/spotbugs/spotless)
- [ ] Capability/contract items — N/A for an internal prompt change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BtbRyAHHFmwHE2ujGFJmq

---
_Generated by [Claude Code](https://claude.ai/code/session_012BtbRyAHHFmwHE2ujGFJmq)_