### PR TITLE
[FI-3] Workorder → CRM service-completion + declined-service feed (#1133)

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/domain/PartyAttributes.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/domain/PartyAttributes.java
@@ -15,6 +15,11 @@ import org.jspecify.annotations.Nullable;
  * @param vehicleMakes distinct makes across the party's active vehicles — a predicate on
  *     {@code vehicle.make} matches if <em>any</em> vehicle matches, which is what a marketer
  *     targeting "customers with a Ford" means
+ * @param monthsSinceLastService whole months since the most recent completed service, or null
+ *     when the party has no service history (FI-3, #1133)
+ * @param hasServiceHistory whether the party has any completed-service history
+ * @param daysSinceDeclinedService whole days since the most recent declined recommendation, or
+ *     null when the party has never declined one (FI-3, #1133)
  */
 public record PartyAttributes(
         UUID partyId,
@@ -34,4 +39,7 @@ public record PartyAttributes(
         Set<Integer> vehicleYears,
         boolean hasActiveVehicle,
         long vehicleCount,
-        @Nullable String displayLabel) {}
+        @Nullable String displayLabel,
+        @Nullable Integer monthsSinceLastService,
+        boolean hasServiceHistory,
+        @Nullable Integer daysSinceDeclinedService) {}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/domain/SegmentAttribute.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/domain/SegmentAttribute.java
@@ -15,9 +15,9 @@ import java.util.Set;
  * operators it accepts; anything outside the enum is rejected at save time. That keeps the
  * resolver's query surface fixed and auditable no matter what a stored predicate contains.
  *
- * <p>Service-history and geography attributes are absent by design: they need the workorder
- * fact feed (FI-3) and structured addresses (FI-4), which are not yet available. They join
- * this catalog in story A-follow.
+ * <p>Service-history attributes (FI-3, #1133) are fed by the workorder fact feed via the CRM
+ * service-history read model. Geography attributes remain absent by design: they need structured
+ * addresses (FI-4), which are not yet available.
  */
 public enum SegmentAttribute {
 
@@ -44,7 +44,15 @@ public enum SegmentAttribute {
     VEHICLE_MODEL("vehicle.model", OperandKind.TEXT, equality()),
     VEHICLE_YEAR("vehicle.year", OperandKind.NUMBER, numeric()),
     HAS_ACTIVE_VEHICLE("vehicle.hasActive", OperandKind.BOOLEAN, booleanOps()),
-    VEHICLE_COUNT("vehicle.count", OperandKind.NUMBER, numeric());
+    VEHICLE_COUNT("vehicle.count", OperandKind.NUMBER, numeric()),
+
+    // --- Service history, from the workorder fact feed (FI-3, #1133) ---
+    /** Whole months since the party's most recent completed service; unset when no history. */
+    MONTHS_SINCE_LAST_SERVICE("service.monthsSinceLast", OperandKind.NUMBER, numeric()),
+    /** Whether the party has any completed-service history at all. */
+    HAS_SERVICE_HISTORY("service.hasHistory", OperandKind.BOOLEAN, booleanOps()),
+    /** Whole days since the party's most recent declined recommendation; unset when none. */
+    DAYS_SINCE_DECLINED_SERVICE("service.daysSinceDeclined", OperandKind.NUMBER, numeric());
 
     /** What shape of operand the attribute compares against. */
     public enum OperandKind {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/domain/SegmentPredicateEvaluator.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/domain/SegmentPredicateEvaluator.java
@@ -59,6 +59,9 @@ public final class SegmentPredicateEvaluator {
             case VEHICLE_YEAR -> yearMatch(party.vehicleYears(), operator, values);
             case HAS_ACTIVE_VEHICLE -> booleanMatch(party.hasActiveVehicle(), operator);
             case VEHICLE_COUNT -> numberMatch(party.vehicleCount(), operator, values);
+            case MONTHS_SINCE_LAST_SERVICE -> nullableNumberMatch(party.monthsSinceLastService(), operator, values);
+            case HAS_SERVICE_HISTORY -> booleanMatch(party.hasServiceHistory(), operator);
+            case DAYS_SINCE_DECLINED_SERVICE -> nullableNumberMatch(party.daysSinceDeclinedService(), operator, values);
         };
     }
 
@@ -95,6 +98,20 @@ public final class SegmentPredicateEvaluator {
 
     private static boolean numberMatch(long actual, SegmentOperator operator, List<String> values) {
         return compare(actual, operator, Long.parseLong(values.get(0).trim()));
+    }
+
+    /**
+     * A null value is unknown, not zero: a party with no service history has not "had its last
+     * service 0 months ago", so a "months since last service &gt; 6" predicate must not match it.
+     * Missing data evaluates to non-match, consistent with the rest of the catalog.
+     */
+    private static boolean nullableNumberMatch(
+            @Nullable Integer actual, SegmentOperator operator, List<String> values) {
+        if (actual == null) {
+            return false;
+        }
+        return compare(
+                actual.longValue(), operator, Long.parseLong(values.get(0).trim()));
     }
 
     private static boolean compare(long actual, SegmentOperator operator, long operand) {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/entity/ServiceHistory.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/entity/ServiceHistory.java
@@ -1,0 +1,75 @@
+package com.positivity.customer.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A completed service on a party's vehicle, projected from {@code workorder.events.v1} (FI-3,
+ * #1133). One row per completed workorder.
+ *
+ * <p>This is a read model owned entirely by the {@code WorkorderEventsListener}; pos-workorder owns
+ * the underlying fact (ADR-0044 R6). It gives CRM the service-history signal it previously lacked —
+ * the resolver reads the most recent completion per party for last-service-age and service-due
+ * predicates. {@code sourceEventId} carries a unique index so a replayed fact cannot duplicate a
+ * row, independent of the {@code processed_events} log.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "service_history",
+        indexes = {
+            @Index(name = "idx_service_history_party", columnList = "party_id, completed_at DESC"),
+            @Index(name = "idx_service_history_vehicle", columnList = "vehicle_id, completed_at DESC")
+        })
+public class ServiceHistory {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "service_history_id", columnDefinition = "UUID", nullable = false, updatable = false)
+    private UUID serviceHistoryId;
+
+    @Column(name = "party_id", columnDefinition = "UUID", nullable = false)
+    private UUID partyId;
+
+    @Column(name = "vehicle_id", columnDefinition = "UUID")
+    @Nullable
+    private UUID vehicleId;
+
+    @Column(name = "source_workorder_id", columnDefinition = "UUID", nullable = false)
+    private UUID sourceWorkorderId;
+
+    @Column(name = "workorder_number", length = 64)
+    @Nullable
+    private String workorderNumber;
+
+    @Column(name = "completed_at", nullable = false)
+    private Instant completedAt;
+
+    @Column(name = "amount", precision = 19, scale = 2)
+    @Nullable
+    private BigDecimal amount;
+
+    /** Originating event envelope id; the ingestion idempotency key. */
+    @Column(name = "source_event_id", length = 64, nullable = false, updatable = false)
+    private String sourceEventId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/FollowUpTaskRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/FollowUpTaskRepository.java
@@ -3,6 +3,9 @@ package com.positivity.customer.internal.repository;
 import com.positivity.customer.internal.entity.FollowUpTask;
 import com.positivity.customer.internal.enums.FollowUpStatus;
 import com.positivity.customer.internal.enums.FollowUpType;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -39,4 +42,22 @@ public interface FollowUpTaskRepository extends JpaRepository<FollowUpTask, UUID
             @Param("assignedTo") String assignedTo,
             @Param("type") FollowUpType type,
             Pageable pageable);
+
+    /**
+     * Most recent declined-service follow-up per party for the given candidates — the batch query
+     * the segment resolver uses to derive the "declined service in last N days" predicate (FI-3,
+     * #1133). A declined follow-up is not removed when closed, so it remains the record that a
+     * decline occurred regardless of whether it was later worked.
+     */
+    @Query("select t.partyId as partyId, max(t.createdAt) as lastDeclinedAt from FollowUpTask t"
+            + " where t.type = com.positivity.customer.internal.enums.FollowUpType.DECLINED_SERVICE_FOLLOWUP"
+            + " and t.partyId in :partyIds group by t.partyId")
+    List<PartyLastDecline> findLastDeclinedByParty(@Param("partyIds") Collection<UUID> partyIds);
+
+    /** Projection: a party and the timestamp of its most recent declined-service follow-up. */
+    interface PartyLastDecline {
+        UUID getPartyId();
+
+        Instant getLastDeclinedAt();
+    }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/ServiceHistoryRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/ServiceHistoryRepository.java
@@ -1,0 +1,35 @@
+package com.positivity.customer.internal.repository;
+
+import com.positivity.customer.internal.entity.ServiceHistory;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ServiceHistoryRepository extends JpaRepository<ServiceHistory, UUID> {
+
+    /** Idempotency backstop for the event-fed path (FI-3, #1133), independent of processed_events. */
+    boolean existsBySourceEventId(String sourceEventId);
+
+    /**
+     * Most recent completion per party for the given candidates — the single batch query the
+     * segment resolver uses to derive last-service age and service-due (FI-3, #1133).
+     */
+    @Query("select sh.partyId as partyId, max(sh.completedAt) as lastCompletedAt"
+            + " from ServiceHistory sh where sh.partyId in :partyIds group by sh.partyId")
+    @NonNull
+    List<PartyLastServiceView> findLastServiceByParty(@Param("partyIds") @NonNull Collection<UUID> partyIds);
+
+    /** Projection: a party and its most recent service-completion timestamp. */
+    interface PartyLastServiceView {
+        UUID getPartyId();
+
+        Instant getLastCompletedAt();
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/SegmentResolutionService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/SegmentResolutionService.java
@@ -15,9 +15,16 @@ import com.positivity.customer.internal.enums.SegmentType;
 import com.positivity.customer.internal.repository.CommercialPartyRepository;
 import com.positivity.customer.internal.repository.CommunicationPreferenceRepository;
 import com.positivity.customer.internal.repository.ExtVehicleRepository;
+import com.positivity.customer.internal.repository.FollowUpTaskRepository;
 import com.positivity.customer.internal.repository.PartyTagAssignmentRepository;
 import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.customer.internal.repository.SegmentMemberRepository;
+import com.positivity.customer.internal.repository.ServiceHistoryRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -30,6 +37,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,6 +71,9 @@ public class SegmentResolutionService {
     private final ExtVehicleRepository extVehicleRepository;
     private final PartyTagAssignmentRepository tagAssignmentRepository;
     private final SegmentMemberRepository segmentMemberRepository;
+    private final ServiceHistoryRepository serviceHistoryRepository;
+    private final FollowUpTaskRepository followUpTaskRepository;
+    private final Clock clock;
 
     /** Matched party ids plus whether the candidate scan hit the ceiling. */
     public record Resolution(List<UUID> partyIds, boolean truncated) {}
@@ -141,6 +152,8 @@ public class SegmentResolutionService {
         Map<UUID, CommunicationPreference> preferences = preferencesByParty(ids);
         Map<UUID, Set<UUID>> tags = tagsByParty(ids);
         Map<UUID, List<ExtVehicle>> vehicles = vehiclesByAccount(ids);
+        Map<UUID, Instant> lastService = lastServiceByParty(ids);
+        Map<UUID, Instant> lastDeclined = lastDeclinedByParty(ids);
 
         return accounts.stream()
                 .map(account -> {
@@ -177,7 +190,10 @@ public class SegmentResolutionService {
                                     .collect(Collectors.toSet()),
                             owned.stream().anyMatch(ExtVehicle::isActive),
                             owned.size(),
-                            account.getDisplayName() != null ? account.getDisplayName() : account.getLegalName());
+                            account.getDisplayName() != null ? account.getDisplayName() : account.getLegalName(),
+                            monthsSince(lastService.get(account.getPartyId())),
+                            lastService.containsKey(account.getPartyId()),
+                            daysSince(lastDeclined.get(account.getPartyId())));
                 })
                 .toList();
     }
@@ -189,6 +205,8 @@ public class SegmentResolutionService {
         Map<UUID, CommunicationPreference> preferences = preferencesByParty(ids);
         Map<UUID, Set<UUID>> tags = tagsByParty(ids);
         Map<UUID, List<ExtVehicle>> vehicles = vehiclesByAccount(ids);
+        Map<UUID, Instant> lastService = lastServiceByParty(ids);
+        Map<UUID, Instant> lastDeclined = lastDeclinedByParty(ids);
 
         return people.stream()
                 .map(person -> {
@@ -217,7 +235,10 @@ public class SegmentResolutionService {
                             owned.size(),
                             // Person names live in pos-people-contact (ADR-0015); the customer
                             // number is the only local label, and it is already non-identifying.
-                            person.getCustomerNumber());
+                            person.getCustomerNumber(),
+                            monthsSince(lastService.get(person.getPartyId())),
+                            lastService.containsKey(person.getPartyId()),
+                            daysSince(lastDeclined.get(person.getPartyId())));
                 })
                 .toList();
     }
@@ -262,6 +283,50 @@ public class SegmentResolutionService {
         }
         return extVehicleRepository.findByAccountIdIn(partyIds).stream()
                 .collect(Collectors.groupingBy(ExtVehicle::getAccountId));
+    }
+
+    private Map<UUID, Instant> lastServiceByParty(List<UUID> partyIds) {
+        if (partyIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<UUID, Instant> byParty = new HashMap<>();
+        for (var row : serviceHistoryRepository.findLastServiceByParty(partyIds)) {
+            if (row.getLastCompletedAt() != null) {
+                byParty.put(row.getPartyId(), row.getLastCompletedAt());
+            }
+        }
+        return byParty;
+    }
+
+    private Map<UUID, Instant> lastDeclinedByParty(List<UUID> partyIds) {
+        if (partyIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<UUID, Instant> byParty = new HashMap<>();
+        for (var row : followUpTaskRepository.findLastDeclinedByParty(partyIds)) {
+            if (row.getLastDeclinedAt() != null) {
+                byParty.put(row.getPartyId(), row.getLastDeclinedAt());
+            }
+        }
+        return byParty;
+    }
+
+    /** Whole months elapsed since {@code since} (UTC calendar), or null when absent; floored at 0. */
+    private @Nullable Integer monthsSince(@Nullable Instant since) {
+        if (since == null) {
+            return null;
+        }
+        long months = ChronoUnit.MONTHS.between(LocalDate.ofInstant(since, ZoneOffset.UTC), LocalDate.now(clock));
+        return (int) Math.max(0, months);
+    }
+
+    /** Whole days elapsed since {@code since} (UTC calendar), or null when absent; floored at 0. */
+    private @Nullable Integer daysSince(@Nullable Instant since) {
+        if (since == null) {
+            return null;
+        }
+        long days = ChronoUnit.DAYS.between(LocalDate.ofInstant(since, ZoneOffset.UTC), LocalDate.now(clock));
+        return (int) Math.max(0, days);
     }
 
     private static String consent(CommunicationPreference preference, boolean email) {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventsListener.java
@@ -1,0 +1,168 @@
+package com.positivity.customer.internal.service;
+
+import com.positivity.customer.internal.entity.FollowUpTask;
+import com.positivity.customer.internal.entity.ProcessedEvent;
+import com.positivity.customer.internal.entity.ServiceHistory;
+import com.positivity.customer.internal.enums.FollowUpStatus;
+import com.positivity.customer.internal.enums.FollowUpType;
+import com.positivity.customer.internal.repository.FollowUpTaskRepository;
+import com.positivity.customer.internal.repository.ProcessedEventRepository;
+import com.positivity.customer.internal.repository.ServiceHistoryRepository;
+import com.positivity.domainevents.workorder.WorkorderServiceCompletedV1;
+import com.positivity.domainevents.workorder.WorkorderServiceLineDeclinedV1;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Consumes {@code workorder.events.v1} for the CRM service-history feed (FI-3, #1133, resolves spec
+ * O-4 + O-7).
+ *
+ * <p>pos-workorder owns the workorder facts (ADR-0044 R6); this listener projects two of them into
+ * CRM-local read models:
+ *
+ * <ul>
+ *   <li>{@code workorder.service.completed.v1} → a {@link ServiceHistory} row, powering
+ *       last-service-age and service-due segment predicates.
+ *   <li>{@code workorder.service_line.declined.v1} → exactly one {@code DECLINED_SERVICE_FOLLOWUP}
+ *       {@link FollowUpTask}, and the declined-service segment predicate.
+ * </ul>
+ *
+ * <p>Same contract as {@link VehicleEventsListener}: idempotent via {@code processed_events} in the
+ * write transaction (a per-write {@code source_event_id} unique guard backs it up), transient DB
+ * errors rethrown for container retry/DLQ, malformed payloads logged and skipped. All other
+ * workorder fact types on the topic are ignored.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
+public class WorkorderEventsListener {
+
+    static final String OWNER = "workorder";
+    private static final String SYSTEM_ACTOR = "workorder-events";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final ServiceHistoryRepository serviceHistoryRepository;
+    private final FollowUpTaskRepository followUpTaskRepository;
+
+    @KafkaListener(
+            topics = "${pos.customer.kafka.workorder-facts-topic:workorder.events.v1}",
+            groupId = "${pos.customer.kafka.workorder-facts-consumer-group:pos-customer-workorder-facts}")
+    @Transactional
+    public void onWorkorderEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable workorder event: {}", message, e);
+            return;
+        }
+        String eventType = envelope.path("eventType").stringValue(null);
+        boolean handled = WorkorderServiceCompletedV1.EVENT_TYPE.equals(eventType)
+                || WorkorderServiceLineDeclinedV1.EVENT_TYPE.equals(eventType);
+        if (!handled) {
+            log.debug("Ignoring workorder event type={}", eventType);
+            return;
+        }
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping workorder event without eventId: {}", message);
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            log.debug("Skipping duplicate workorder event eventId={}", eventId);
+            return;
+        }
+
+        try {
+            if (WorkorderServiceCompletedV1.EVENT_TYPE.equals(eventType)) {
+                applyServiceCompleted(envelope, eventId);
+            } else {
+                applyServiceLineDeclined(envelope, eventId);
+            }
+        } catch (TransientDataAccessException e) {
+            // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed workorder event eventId={} type={}", eventId, eventType, e);
+        }
+        processedEventRepository.save(ProcessedEvent.builder()
+                .eventId(eventId)
+                .owner(OWNER)
+                .processedAt(Instant.now(clock))
+                .build());
+    }
+
+    private void applyServiceCompleted(JsonNode envelope, String eventId) {
+        WorkorderServiceCompletedV1 payload =
+                objectMapper.treeToValue(envelope.path("payload"), WorkorderServiceCompletedV1.class);
+        if (payload.partyId() == null) {
+            log.debug("Workorder {} completion has no party; no service-history row", payload.workorderId());
+            return;
+        }
+        if (serviceHistoryRepository.existsBySourceEventId(eventId)) {
+            log.debug("Service-history row already exists for eventId={}", eventId);
+            return;
+        }
+        serviceHistoryRepository.save(ServiceHistory.builder()
+                .partyId(payload.partyId())
+                .vehicleId(payload.vehicleId())
+                .sourceWorkorderId(payload.workorderId())
+                .workorderNumber(payload.workorderNumber())
+                .completedAt(payload.completedAt())
+                .amount(payload.totalAmount())
+                .sourceEventId(eventId)
+                .createdAt(Instant.now(clock))
+                .build());
+        log.info(
+                "Projected service_history partyId={} workorderId={} amount={}",
+                payload.partyId(),
+                payload.workorderId(),
+                payload.totalAmount());
+    }
+
+    private void applyServiceLineDeclined(JsonNode envelope, String eventId) {
+        WorkorderServiceLineDeclinedV1 payload =
+                objectMapper.treeToValue(envelope.path("payload"), WorkorderServiceLineDeclinedV1.class);
+        if (payload.partyId() == null) {
+            log.debug("Declined service line {} has no party; no follow-up task", payload.workorderLineId());
+            return;
+        }
+        // Exactly one follow-up per originating fact (spec §6.1): the unique source_event_id backs
+        // this up, but checking first avoids a constraint-violation round-trip on redelivery.
+        if (followUpTaskRepository.existsBySourceEventId(eventId)) {
+            log.debug("Declined-service follow-up already exists for eventId={}", eventId);
+            return;
+        }
+        UUID workorderId = payload.workorderId();
+        followUpTaskRepository.save(FollowUpTask.builder()
+                .partyId(payload.partyId())
+                .vehicleId(payload.vehicleId())
+                .type(FollowUpType.DECLINED_SERVICE_FOLLOWUP)
+                .status(FollowUpStatus.OPEN)
+                .sourceWorkorderId(workorderId.toString())
+                .sourceEventId(eventId)
+                .reason(payload.description())
+                .notes(payload.declineReason())
+                .createdBy(SYSTEM_ACTOR)
+                .build());
+        log.info(
+                "Created DECLINED_SERVICE_FOLLOWUP partyId={} workorderId={} line={}",
+                payload.partyId(),
+                workorderId,
+                payload.workorderLineId());
+    }
+}

--- a/pos-customer/src/main/resources/application.yml
+++ b/pos-customer/src/main/resources/application.yml
@@ -84,6 +84,10 @@ pos:
         max-submissions-per-hour: ${POS_CUSTOMER_PUBLIC_INQUIRY_MAX_PER_HOUR:5}
     kafka:
       workorder-events-topic: workorder-events
+      # Service-history fact feed (FI-3, #1133): service-completion + declined-service facts
+      # projected into the CRM service-history read model and declined-service follow-ups.
+      workorder-facts-topic: ${POS_CUSTOMER_WORKORDER_FACTS_TOPIC:workorder.events.v1}
+      workorder-facts-consumer-group: ${POS_CUSTOMER_WORKORDER_FACTS_CONSUMER_GROUP:pos-customer-workorder-facts}
       # Reconciliation manifests + drift-repair commands (ADR-0044)
       workorder-manifest-topic: ${POS_CUSTOMER_WORKORDER_MANIFEST_TOPIC:workorder.manifest.v1}
       workorder-commands-topic: ${POS_CUSTOMER_WORKORDER_COMMANDS_TOPIC:workorder.commands.v1}

--- a/pos-customer/src/main/resources/db/migration/V26__service_history.sql
+++ b/pos-customer/src/main/resources/db/migration/V26__service_history.sql
@@ -1,0 +1,23 @@
+-- FI-3 (#1133): CRM service-history read model, fed by workorder.events.v1.
+-- pos-workorder owns the workorder facts (ADR-0044 R6); nothing here writes this table except the
+-- WorkorderEventsListener. One row per completed workorder gives CRM the service-history signal it
+-- lacked, powering win-back / service-due segmentation without a synchronous call to pos-workorder.
+CREATE TABLE service_history (
+    service_history_id uuid NOT NULL,
+    party_id uuid NOT NULL,
+    vehicle_id uuid,
+    source_workorder_id uuid NOT NULL,
+    workorder_number character varying(64),
+    completed_at timestamp(6) with time zone NOT NULL,
+    amount numeric(19, 2),
+    -- Originating envelope id; the ingestion idempotency backstop independent of processed_events,
+    -- so a replayed completion fact cannot create a second history row.
+    source_event_id character varying(64) NOT NULL,
+    created_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT service_history_pkey PRIMARY KEY (service_history_id)
+);
+
+-- Segment resolution reads the most recent completion per party (last-service age, service-due).
+CREATE INDEX idx_service_history_party ON service_history (party_id, completed_at DESC);
+CREATE INDEX idx_service_history_vehicle ON service_history (vehicle_id, completed_at DESC);
+CREATE UNIQUE INDEX uq_service_history_source_event ON service_history (source_event_id);

--- a/pos-customer/src/test/java/com/positivity/customer/internal/domain/SegmentPredicateEvaluatorTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/domain/SegmentPredicateEvaluatorTest.java
@@ -36,7 +36,70 @@ class SegmentPredicateEvaluatorTest {
                 Set.of(2019),
                 true,
                 vehicleCount,
-                "Acme Towing");
+                "Acme Towing",
+                null,
+                false,
+                null);
+    }
+
+    private static PartyAttributes serviceParty(
+            Integer monthsSinceLastService, boolean hasServiceHistory, Integer daysSinceDeclinedService) {
+        return new PartyAttributes(
+                PARTY,
+                "COMMERCIAL",
+                "GOLD",
+                "ACTIVE",
+                false,
+                Map.of(),
+                Set.of(),
+                Boolean.FALSE,
+                Boolean.FALSE,
+                "NET30",
+                "OPT_IN",
+                "UNSET",
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                true,
+                1,
+                "Acme Towing",
+                monthsSinceLastService,
+                hasServiceHistory,
+                daysSinceDeclinedService);
+    }
+
+    @Test
+    @DisplayName("months-since-last-service matches a numeric predicate; unknown never matches")
+    void matchesServiceAgePredicate() {
+        assertThat(SegmentPredicateEvaluator.matches(
+                        comparison("service.monthsSinceLast", SegmentOperator.GREATER_THAN, "6"),
+                        serviceParty(8, true, null)))
+                .isTrue();
+        assertThat(SegmentPredicateEvaluator.matches(
+                        comparison("service.monthsSinceLast", SegmentOperator.GREATER_THAN, "6"),
+                        serviceParty(3, true, null)))
+                .isFalse();
+        // No service history: unknown, not zero — a "> 6 months" win-back predicate must not match.
+        assertThat(SegmentPredicateEvaluator.matches(
+                        comparison("service.monthsSinceLast", SegmentOperator.GREATER_THAN, "6"),
+                        serviceParty(null, false, null)))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("has-service-history and declined-recency predicates evaluate")
+    void matchesServiceHistoryAndDeclinePredicates() {
+        assertThat(SegmentPredicateEvaluator.matches(
+                        comparison("service.hasHistory", SegmentOperator.IS_TRUE), serviceParty(2, true, null)))
+                .isTrue();
+        assertThat(SegmentPredicateEvaluator.matches(
+                        comparison("service.daysSinceDeclined", SegmentOperator.LESS_THAN_OR_EQUAL, "30"),
+                        serviceParty(2, true, 10)))
+                .isTrue();
+        assertThat(SegmentPredicateEvaluator.matches(
+                        comparison("service.daysSinceDeclined", SegmentOperator.LESS_THAN_OR_EQUAL, "30"),
+                        serviceParty(2, true, null)))
+                .isFalse();
     }
 
     private static SegmentPredicate.Comparison comparison(

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderEventsListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderEventsListenerTest.java
@@ -1,0 +1,147 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.entity.FollowUpTask;
+import com.positivity.customer.internal.entity.ProcessedEvent;
+import com.positivity.customer.internal.entity.ServiceHistory;
+import com.positivity.customer.internal.enums.FollowUpStatus;
+import com.positivity.customer.internal.enums.FollowUpType;
+import com.positivity.customer.internal.repository.FollowUpTaskRepository;
+import com.positivity.customer.internal.repository.ProcessedEventRepository;
+import com.positivity.customer.internal.repository.ServiceHistoryRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Unit tests for {@link WorkorderEventsListener} (FI-3, #1133): completion facts project into
+ * {@code service_history}, declined facts raise exactly one {@code DECLINED_SERVICE_FOLLOWUP}
+ * task, both idempotent, and unrelated workorder fact types are ignored.
+ */
+class WorkorderEventsListenerTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-20T12:00:00Z"), ZoneOffset.UTC);
+    private static final ObjectMapper MAPPER =
+            JsonMapper.builder().findAndAddModules().build();
+    private static final UUID WORKORDER_ID = UUID.fromString("01980a58-0000-7000-8000-000000000001");
+    private static final UUID PARTY_ID = UUID.fromString("01980a58-0000-7000-8000-000000000002");
+    private static final UUID VEHICLE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000003");
+    private static final UUID LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000004");
+
+    private final ProcessedEventRepository processedEvents = mock(ProcessedEventRepository.class);
+    private final ServiceHistoryRepository serviceHistory = mock(ServiceHistoryRepository.class);
+    private final FollowUpTaskRepository followUps = mock(FollowUpTaskRepository.class);
+
+    private WorkorderEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new WorkorderEventsListener(TEST_CLOCK, MAPPER, processedEvents, serviceHistory, followUps);
+    }
+
+    private String completedEvent(String eventId) {
+        return """
+                {"eventId":"%s","eventType":"workorder.service.completed.v1","sourceService":"pos-workorder",
+                 "payload":{"workorderId":"%s","workorderNumber":"WO-2026-1001","partyId":"%s","vehicleId":"%s",
+                            "completedAt":"2026-07-20T10:00:00Z","totalAmount":149.99,
+                            "services":[{"workorderLineId":"%s","description":"Oil change","lineTotal":149.99}]}}
+                """.formatted(eventId, WORKORDER_ID, PARTY_ID, VEHICLE_ID, LINE_ID);
+    }
+
+    private String declinedEvent(String eventId) {
+        return """
+                {"eventId":"%s","eventType":"workorder.service_line.declined.v1","sourceService":"pos-workorder",
+                 "payload":{"workorderId":"%s","workorderNumber":"WO-2026-1001","workorderLineId":"%s",
+                            "partyId":"%s","vehicleId":"%s","description":"Brake pads",
+                            "declineReason":"Defer to next visit","declinedAt":"2026-07-20T10:00:00Z"}}
+                """.formatted(eventId, WORKORDER_ID, LINE_ID, PARTY_ID, VEHICLE_ID);
+    }
+
+    @Test
+    @DisplayName("Completion fact projects a service_history row and records the eventId")
+    void projectsServiceHistory() {
+        when(processedEvents.existsById("e-1")).thenReturn(false);
+        when(serviceHistory.existsBySourceEventId("e-1")).thenReturn(false);
+
+        listener.onWorkorderEvent(completedEvent("e-1"));
+
+        ArgumentCaptor<ServiceHistory> saved = ArgumentCaptor.forClass(ServiceHistory.class);
+        verify(serviceHistory).save(saved.capture());
+        assertThat(saved.getValue().getPartyId()).isEqualTo(PARTY_ID);
+        assertThat(saved.getValue().getVehicleId()).isEqualTo(VEHICLE_ID);
+        assertThat(saved.getValue().getSourceWorkorderId()).isEqualTo(WORKORDER_ID);
+        assertThat(saved.getValue().getAmount()).isEqualByComparingTo("149.99");
+        assertThat(saved.getValue().getSourceEventId()).isEqualTo("e-1");
+        verify(processedEvents).save(any(ProcessedEvent.class));
+    }
+
+    @Test
+    @DisplayName("Declined fact raises exactly one DECLINED_SERVICE_FOLLOWUP task")
+    void raisesDeclinedFollowUp() {
+        when(processedEvents.existsById("e-2")).thenReturn(false);
+        when(followUps.existsBySourceEventId("e-2")).thenReturn(false);
+
+        listener.onWorkorderEvent(declinedEvent("e-2"));
+
+        ArgumentCaptor<FollowUpTask> saved = ArgumentCaptor.forClass(FollowUpTask.class);
+        verify(followUps).save(saved.capture());
+        FollowUpTask task = saved.getValue();
+        assertThat(task.getType()).isEqualTo(FollowUpType.DECLINED_SERVICE_FOLLOWUP);
+        assertThat(task.getStatus()).isEqualTo(FollowUpStatus.OPEN);
+        assertThat(task.getPartyId()).isEqualTo(PARTY_ID);
+        assertThat(task.getVehicleId()).isEqualTo(VEHICLE_ID);
+        assertThat(task.getSourceWorkorderId()).isEqualTo(WORKORDER_ID.toString());
+        assertThat(task.getSourceEventId()).isEqualTo("e-2");
+        assertThat(task.getReason()).isEqualTo("Brake pads");
+        assertThat(task.getNotes()).isEqualTo("Defer to next visit");
+    }
+
+    @Test
+    @DisplayName("Duplicate envelope is skipped via processed_events")
+    void skipsDuplicate() {
+        when(processedEvents.existsById("e-1")).thenReturn(true);
+
+        listener.onWorkorderEvent(completedEvent("e-1"));
+
+        verify(serviceHistory, never()).save(any());
+        verify(processedEvents, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("A replayed declined fact does not create a second task")
+    void deduplicatesDeclinedFollowUp() {
+        when(processedEvents.existsById("e-2")).thenReturn(false);
+        when(followUps.existsBySourceEventId("e-2")).thenReturn(true);
+
+        listener.onWorkorderEvent(declinedEvent("e-2"));
+
+        verify(followUps, never()).save(any());
+        // Still recorded as processed so the offset advances.
+        verify(processedEvents).save(any(ProcessedEvent.class));
+    }
+
+    @Test
+    @DisplayName("Unrelated workorder fact types are ignored")
+    void ignoresOtherEventTypes() {
+        listener.onWorkorderEvent("""
+                {"eventId":"e-9","eventType":"workorder.workorder.updated","payload":{}}
+                """);
+
+        verify(serviceHistory, never()).save(any());
+        verify(followUps, never()).save(any());
+        verify(processedEvents, never()).save(any());
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/WorkorderServiceCompletedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/WorkorderServiceCompletedV1.java
@@ -1,0 +1,77 @@
+package com.positivity.domainevents.workorder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: a workorder was completed (closed) — the service-history signal for CRM (FI-3, issue
+ * #1133, resolves spec open question O-4).
+ *
+ * <p>Published by pos-workorder on {@code workorder.events.v1} with
+ * {@code eventType = "workorder.service.completed.v1"} once, at workorder completion. pos-customer
+ * projects it into a local service-history read model that powers segment predicates
+ * (last-service age, service-due) and win-back campaigns; the workorder owns the fact and no
+ * consumer re-fetches to process it.
+ *
+ * <p>PII-minimal by design: the customer and vehicle ride as ids only. {@code totalAmount} is the
+ * sum of the completed (non-declined) service and part line totals — no monetary total is
+ * persisted on the workorder itself, so it is computed at emit time.
+ *
+ * @param workorderId completed workorder (also the envelope aggregateId and record key)
+ * @param workorderNumber human-readable workorder number (null until assigned)
+ * @param partyId owning customer party (null for a no-customer job)
+ * @param vehicleId serviced vehicle (null for a no-vehicle job)
+ * @param shopId shop location the workorder executed at
+ * @param invoiceId generated invoice back-reference (null until invoiced)
+ * @param completedAt when the workorder was completed
+ * @param totalAmount Σ line totals of the performed (non-declined) service and part lines
+ * @param services the services performed on this workorder
+ */
+public record WorkorderServiceCompletedV1(
+        @NonNull UUID workorderId,
+        @Nullable String workorderNumber,
+        @Nullable UUID partyId,
+        @Nullable UUID vehicleId,
+        @Nullable UUID shopId,
+        @Nullable UUID invoiceId,
+        @NonNull Instant completedAt,
+        @Nullable BigDecimal totalAmount,
+        @NonNull List<PerformedService> services) {
+
+    public static final String EVENT_TYPE = "workorder.service.completed.v1";
+    public static final int SCHEMA_VERSION = 1;
+
+    /**
+     * One performed (non-declined) service line.
+     *
+     * @param workorderLineId service line identifier
+     * @param serviceEntityId pos-catalog service reference (null for ad-hoc labor)
+     * @param description snapshotted line description
+     * @param quantity snapshotted quantity (hours for labor)
+     * @param unitPrice snapshotted unit price (hourly rate for labor)
+     * @param lineTotal snapshotted line total = quantity × unitPrice
+     */
+    public record PerformedService(
+            @NonNull UUID workorderLineId,
+            @Nullable UUID serviceEntityId,
+            @Nullable String description,
+            @Nullable BigDecimal quantity,
+            @Nullable BigDecimal unitPrice,
+            @Nullable BigDecimal lineTotal) {}
+
+    public WorkorderServiceCompletedV1 {
+        if (workorderId == null) {
+            throw new IllegalArgumentException("workorderId must not be null");
+        }
+        if (completedAt == null) {
+            throw new IllegalArgumentException("completedAt must not be null");
+        }
+        if (services == null) {
+            throw new IllegalArgumentException("services must not be null");
+        }
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/WorkorderServiceLineDeclinedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/WorkorderServiceLineDeclinedV1.java
@@ -1,0 +1,56 @@
+package com.positivity.domainevents.workorder;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: a recommended service line was declined on a workorder (FI-3, issue #1133, resolves spec
+ * open question O-7).
+ *
+ * <p>Published by pos-workorder on {@code workorder.events.v1} with
+ * {@code eventType = "workorder.service_line.declined.v1"} — one fact per declined service line,
+ * emitted at workorder completion (a declined recommendation, promoted onto the workorder from
+ * the estimate, carries its rejection reason). pos-customer raises exactly one
+ * {@code DECLINED_SERVICE_FOLLOWUP} task per fact and exposes a "declined service in last N days"
+ * segment predicate.
+ *
+ * <p>PII-minimal by design: the customer and vehicle ride as ids only.
+ *
+ * @param workorderId source workorder (also the envelope aggregateId and record key)
+ * @param workorderNumber human-readable workorder number (null until assigned)
+ * @param workorderLineId the declined service line
+ * @param partyId owning customer party (null for a no-customer job)
+ * @param vehicleId serviced vehicle (null for a no-vehicle job)
+ * @param serviceEntityId pos-catalog service reference (null for ad-hoc labor)
+ * @param description snapshotted line description of the declined service
+ * @param declineReason why the customer declined the recommendation (null if not recorded)
+ * @param declinedAt when the decline was recorded (the workorder completion time)
+ */
+public record WorkorderServiceLineDeclinedV1(
+        @NonNull UUID workorderId,
+        @Nullable String workorderNumber,
+        @NonNull UUID workorderLineId,
+        @Nullable UUID partyId,
+        @Nullable UUID vehicleId,
+        @Nullable UUID serviceEntityId,
+        @Nullable String description,
+        @Nullable String declineReason,
+        @NonNull Instant declinedAt) {
+
+    public static final String EVENT_TYPE = "workorder.service_line.declined.v1";
+    public static final int SCHEMA_VERSION = 1;
+
+    public WorkorderServiceLineDeclinedV1 {
+        if (workorderId == null) {
+            throw new IllegalArgumentException("workorderId must not be null");
+        }
+        if (workorderLineId == null) {
+            throw new IllegalArgumentException("workorderLineId must not be null");
+        }
+        if (declinedAt == null) {
+            throw new IllegalArgumentException("declinedAt must not be null");
+        }
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderServiceCompletedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderServiceCompletedV1Test.java
@@ -1,0 +1,69 @@
+package com.positivity.domainevents.workorder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class WorkorderServiceCompletedV1Test {
+
+    private static final ObjectMapper MAPPER =
+            JsonMapper.builder().findAndAddModules().build();
+
+    private static final UUID WORKORDER_ID = UUID.fromString("01980a58-0000-7000-8000-000000000010");
+    private static final UUID PARTY_ID = UUID.fromString("01980a58-0000-7000-8000-000000000011");
+    private static final UUID VEHICLE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000012");
+    private static final UUID LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000013");
+    private static final UUID SERVICE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000014");
+
+    private static WorkorderServiceCompletedV1 event() {
+        return new WorkorderServiceCompletedV1(
+                WORKORDER_ID,
+                "WO-2026-1001",
+                PARTY_ID,
+                VEHICLE_ID,
+                null,
+                null,
+                Instant.parse("2026-07-20T10:00:00Z"),
+                new BigDecimal("149.99"),
+                List.of(new WorkorderServiceCompletedV1.PerformedService(
+                        LINE_ID,
+                        SERVICE_ID,
+                        "Oil change",
+                        new BigDecimal("1.0"),
+                        new BigDecimal("149.99"),
+                        new BigDecimal("149.99"))));
+    }
+
+    @Test
+    void roundTripPreservesFields() {
+        WorkorderServiceCompletedV1 evt = event();
+
+        String json = MAPPER.writeValueAsString(evt);
+        WorkorderServiceCompletedV1 back = MAPPER.readValue(json, WorkorderServiceCompletedV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(back.services()).hasSize(1);
+        assertThat(back.services().get(0).description()).isEqualTo("Oil change");
+        assertThat(WorkorderServiceCompletedV1.EVENT_TYPE).isEqualTo("workorder.service.completed.v1");
+    }
+
+    @Test
+    void rejectsNullRequiredFields() {
+        assertThatThrownBy(() -> new WorkorderServiceCompletedV1(
+                        null, null, PARTY_ID, VEHICLE_ID, null, null, Instant.now(), null, List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new WorkorderServiceCompletedV1(
+                        WORKORDER_ID, null, PARTY_ID, VEHICLE_ID, null, null, null, null, List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new WorkorderServiceCompletedV1(
+                        WORKORDER_ID, null, PARTY_ID, VEHICLE_ID, null, null, Instant.now(), null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderServiceLineDeclinedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderServiceLineDeclinedV1Test.java
@@ -1,0 +1,60 @@
+package com.positivity.domainevents.workorder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class WorkorderServiceLineDeclinedV1Test {
+
+    private static final ObjectMapper MAPPER =
+            JsonMapper.builder().findAndAddModules().build();
+
+    private static final UUID WORKORDER_ID = UUID.fromString("01980a58-0000-7000-8000-000000000020");
+    private static final UUID LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000021");
+    private static final UUID PARTY_ID = UUID.fromString("01980a58-0000-7000-8000-000000000022");
+    private static final UUID VEHICLE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000023");
+    private static final UUID SERVICE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000024");
+
+    private static WorkorderServiceLineDeclinedV1 event() {
+        return new WorkorderServiceLineDeclinedV1(
+                WORKORDER_ID,
+                "WO-2026-1001",
+                LINE_ID,
+                PARTY_ID,
+                VEHICLE_ID,
+                SERVICE_ID,
+                "Brake pad replacement",
+                "Customer will defer to next visit",
+                Instant.parse("2026-07-20T10:00:00Z"));
+    }
+
+    @Test
+    void roundTripPreservesFields() {
+        WorkorderServiceLineDeclinedV1 evt = event();
+
+        String json = MAPPER.writeValueAsString(evt);
+        WorkorderServiceLineDeclinedV1 back = MAPPER.readValue(json, WorkorderServiceLineDeclinedV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(back.declineReason()).isEqualTo("Customer will defer to next visit");
+        assertThat(WorkorderServiceLineDeclinedV1.EVENT_TYPE).isEqualTo("workorder.service_line.declined.v1");
+    }
+
+    @Test
+    void rejectsNullRequiredFields() {
+        assertThatThrownBy(() -> new WorkorderServiceLineDeclinedV1(
+                        null, null, LINE_ID, PARTY_ID, VEHICLE_ID, SERVICE_ID, null, null, Instant.now()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new WorkorderServiceLineDeclinedV1(
+                        WORKORDER_ID, null, null, PARTY_ID, VEHICLE_ID, SERVICE_ID, null, null, Instant.now()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new WorkorderServiceLineDeclinedV1(
+                        WORKORDER_ID, null, LINE_ID, PARTY_ID, VEHICLE_ID, SERVICE_ID, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/WorkorderServiceLine.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/WorkorderServiceLine.java
@@ -90,6 +90,12 @@ public class WorkorderServiceLine {
     @Builder.Default
     private Boolean declined = false;
 
+    // Reason the customer declined the recommendation (FI-3, #1133). Snapshotted from the source
+    // EstimateItem's rejectionReason when a declined recommendation is promoted onto the workorder.
+    @Column(name = "decline_reason", length = 500)
+    @Nullable
+    private String declineReason;
+
     // Status of the work order item
     @Enumerated(EnumType.STRING)
     @Builder.Default

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/ServiceCompletionFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/ServiceCompletionFactPublisher.java
@@ -1,0 +1,167 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.domainevents.workorder.WorkorderServiceCompletedV1;
+import com.positivity.domainevents.workorder.WorkorderServiceLineDeclinedV1;
+import com.positivity.workorder.internal.config.OutboxEventWriter;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Publishes the CRM service-history facts (FI-3, issue #1133) to the transactional outbox at
+ * workorder completion: one {@link WorkorderServiceCompletedV1} for the workorder, plus one
+ * {@link WorkorderServiceLineDeclinedV1} per declined service line.
+ *
+ * <p>The completion path calls {@link #markCompleted(UUID)} after saving; this publisher emits the
+ * facts once at {@code beforeCommit}, built from the final persisted state (COMPLETED status,
+ * completedAt, the full service/part line set). When Kafka publishing is disabled the outbox
+ * writer bean is absent and every call is a no-op, mirroring {@link WorkorderFactPublisher}, so
+ * callers never need their own guard.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ServiceCompletionFactPublisher {
+
+    private static final Object TX_RESOURCE_KEY = ServiceCompletionFactPublisher.class;
+
+    private final Clock clock;
+    private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+    private final WorkorderRepository workorderRepository;
+    private final WorkorderPartRepository workorderPartRepository;
+    private final WorkorderServiceRepository workorderServiceRepository;
+
+    /** Mark a workorder as completed in the current transaction; facts are emitted at commit. */
+    public void markCompleted(@NonNull UUID workorderId) {
+        if (outboxEventWriter.getIfAvailable() == null
+                || !TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+        @SuppressWarnings("unchecked")
+        Set<UUID> pending = (Set<UUID>) TransactionSynchronizationManager.getResource(TX_RESOURCE_KEY);
+        if (pending == null) {
+            pending = new LinkedHashSet<>();
+            TransactionSynchronizationManager.bindResource(TX_RESOURCE_KEY, pending);
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void beforeCommit(boolean readOnly) {
+                    if (!readOnly) {
+                        publishPending();
+                    }
+                }
+
+                @Override
+                public void afterCompletion(int status) {
+                    TransactionSynchronizationManager.unbindResourceIfPossible(TX_RESOURCE_KEY);
+                }
+            });
+        }
+        pending.add(workorderId);
+    }
+
+    private void publishPending() {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        @SuppressWarnings("unchecked")
+        Set<UUID> pending = (Set<UUID>) TransactionSynchronizationManager.getResource(TX_RESOURCE_KEY);
+        if (writer == null || pending == null) {
+            return;
+        }
+        for (UUID workorderId : pending) {
+            Workorder workorder = workorderRepository.findById(workorderId).orElse(null);
+            if (workorder == null) {
+                log.warn("Skipping service-completion fact for {}: row not found at commit", workorderId);
+                continue;
+            }
+            List<WorkorderServiceLine> services = workorderServiceRepository.findByWorkOrder_Id(workorderId);
+            List<WorkorderPart> parts = workorderPartRepository.findByWorkorderId(workorderId);
+            Instant completedAt = workorder.getCompletedAt() != null ? workorder.getCompletedAt() : Instant.now(clock);
+
+            publishCompleted(writer, workorder, services, parts, completedAt);
+            publishDeclines(writer, workorder, services, completedAt);
+        }
+    }
+
+    private void publishCompleted(
+            OutboxEventWriter writer,
+            Workorder workorder,
+            List<WorkorderServiceLine> services,
+            List<WorkorderPart> parts,
+            Instant completedAt) {
+        List<WorkorderServiceCompletedV1.PerformedService> performed = services.stream()
+                .filter(line -> !isDeclined(line.getDeclined()))
+                .map(line -> new WorkorderServiceCompletedV1.PerformedService(
+                        line.getId(),
+                        line.getServiceEntityId(),
+                        line.getDescription(),
+                        line.getQuantity(),
+                        line.getUnitPrice(),
+                        line.getLineTotal()))
+                .toList();
+
+        BigDecimal serviceTotal = services.stream()
+                .filter(line -> !isDeclined(line.getDeclined()))
+                .map(WorkorderServiceLine::getLineTotal)
+                .filter(java.util.Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal partTotal = parts.stream()
+                .filter(part -> !isDeclined(part.getDeclined()))
+                .map(WorkorderPart::getLineTotal)
+                .filter(java.util.Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        WorkorderServiceCompletedV1 payload = new WorkorderServiceCompletedV1(
+                workorder.getId(),
+                workorder.getWorkorderNumber(),
+                workorder.getCustomerId(),
+                workorder.getVehicleId(),
+                workorder.getShopId(),
+                workorder.getInvoiceId(),
+                completedAt,
+                serviceTotal.add(partTotal),
+                performed);
+        writer.publish(WorkorderServiceCompletedV1.EVENT_TYPE, workorder.getId().toString(), payload);
+    }
+
+    private void publishDeclines(
+            OutboxEventWriter writer, Workorder workorder, List<WorkorderServiceLine> services, Instant completedAt) {
+        for (WorkorderServiceLine line : services) {
+            if (!isDeclined(line.getDeclined())) {
+                continue;
+            }
+            WorkorderServiceLineDeclinedV1 payload = new WorkorderServiceLineDeclinedV1(
+                    workorder.getId(),
+                    workorder.getWorkorderNumber(),
+                    line.getId(),
+                    workorder.getCustomerId(),
+                    workorder.getVehicleId(),
+                    line.getServiceEntityId(),
+                    line.getDescription(),
+                    line.getDeclineReason(),
+                    completedAt);
+            // Keyed by the workorder id so a workorder's facts stay ordered on one partition.
+            writer.publish(
+                    WorkorderServiceLineDeclinedV1.EVENT_TYPE, workorder.getId().toString(), payload);
+        }
+    }
+
+    private static boolean isDeclined(Boolean declined) {
+        return Boolean.TRUE.equals(declined);
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/ServiceCompletionFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/ServiceCompletionFactPublisher.java
@@ -6,12 +6,15 @@ import com.positivity.workorder.internal.config.OutboxEventWriter;
 import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.entity.WorkorderPart;
 import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.enums.WorkorderItemStatus;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -90,7 +93,7 @@ public class ServiceCompletionFactPublisher {
                 continue;
             }
             List<WorkorderServiceLine> services = workorderServiceRepository.findByWorkOrder_Id(workorderId);
-            List<WorkorderPart> parts = workorderPartRepository.findByWorkorderId(workorderId);
+            List<WorkorderPart> parts = loadParts(workorderId);
             Instant completedAt = workorder.getCompletedAt() != null ? workorder.getCompletedAt() : Instant.now(clock);
 
             publishCompleted(writer, workorder, services, parts, completedAt);
@@ -105,7 +108,7 @@ public class ServiceCompletionFactPublisher {
             List<WorkorderPart> parts,
             Instant completedAt) {
         List<WorkorderServiceCompletedV1.PerformedService> performed = services.stream()
-                .filter(line -> !isDeclined(line.getDeclined()))
+                .filter(line -> isPerformed(line.getDeclined(), line.getStatus()))
                 .map(line -> new WorkorderServiceCompletedV1.PerformedService(
                         line.getId(),
                         line.getServiceEntityId(),
@@ -116,12 +119,12 @@ public class ServiceCompletionFactPublisher {
                 .toList();
 
         BigDecimal serviceTotal = services.stream()
-                .filter(line -> !isDeclined(line.getDeclined()))
+                .filter(line -> isPerformed(line.getDeclined(), line.getStatus()))
                 .map(WorkorderServiceLine::getLineTotal)
                 .filter(java.util.Objects::nonNull)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
         BigDecimal partTotal = parts.stream()
-                .filter(part -> !isDeclined(part.getDeclined()))
+                .filter(part -> isPerformed(part.getDeclined(), part.getStatus()))
                 .map(WorkorderPart::getLineTotal)
                 .filter(java.util.Objects::nonNull)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
@@ -159,6 +162,31 @@ public class ServiceCompletionFactPublisher {
             writer.publish(
                     WorkorderServiceLineDeclinedV1.EVENT_TYPE, workorder.getId().toString(), payload);
         }
+    }
+
+    /**
+     * The full part set for the workorder, deduped by id — parts hang off either the workorder
+     * directly or a service line, and completion totals must count both to stay consistent with
+     * invoice / billable-scope totals (mirrors WorkorderInvoiceServiceImpl).
+     */
+    private List<WorkorderPart> loadParts(UUID workorderId) {
+        List<WorkorderPart> parts = new ArrayList<>();
+        parts.addAll(workorderPartRepository.findByWorkOrderService_WorkOrder_Id(workorderId));
+        parts.addAll(workorderPartRepository.findByWorkorderIdAndWorkOrderServiceIsNull(workorderId));
+        Set<UUID> seen = new HashSet<>();
+        return parts.stream()
+                .filter(part -> part.getId() == null || seen.add(part.getId()))
+                .toList();
+    }
+
+    /**
+     * A line counts toward the completed-service snapshot only when it was actually performed:
+     * not declined and not CANCELLED. Workorder billable totals exclude CANCELLED (see
+     * WorkorderInvoiceServiceImpl), so the emitted completion facts must too, or CRM's amount
+     * would diverge from the invoice.
+     */
+    private static boolean isPerformed(Boolean declined, WorkorderItemStatus status) {
+        return !isDeclined(declined) && status != WorkorderItemStatus.CANCELLED;
     }
 
     private static boolean isDeclined(Boolean declined) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
@@ -285,9 +285,62 @@ public class WorkorderServiceImpl implements WorkorderService {
                     savedWorkorder.getEstimateId(),
                     savedWorkorder.getId());
             copyEstimateItemsToWorkorder(savedWorkorder);
+            // FI-3 (#1133): retain declined recommendations on the workorder so the decline has a
+            // source workorder and its reason survives to the service-completion fact feed.
+            copyDeclinedEstimateServicesToWorkorder(savedWorkorder);
         }
 
         return savedWorkorder;
+    }
+
+    /**
+     * Promote DECLINED estimate LABOR items onto the workorder as declined service lines (FI-3,
+     * #1133). These are not billable work — they carry {@code declined = true} and the customer's
+     * rejection reason so pos-workorder can emit a {@code WorkorderServiceLineDeclinedV1} fact at
+     * completion, which CRM turns into a declined-service follow-up. Only LABOR items are
+     * promoted; a declined part is not a declined "recommended service".
+     *
+     * @param workorder the workorder promoted from an estimate
+     */
+    private void copyDeclinedEstimateServicesToWorkorder(Workorder workorder) {
+        UUID estimateId = workorder.getEstimateId();
+        if (estimateId == null) {
+            return;
+        }
+
+        List<EstimateItem> declinedItems = estimateItemRepository.findByEstimate_IdAndApprovalStatusAndDeletedFalse(
+                estimateId, ApprovalStatus.DECLINED);
+        if (declinedItems.isEmpty()) {
+            return;
+        }
+
+        List<com.positivity.workorder.internal.entity.WorkorderServiceLine> declinedLines = declinedItems.stream()
+                .filter(item -> item.getItemType() == EstimateItemType.LABOR)
+                .map(item -> com.positivity.workorder.internal.entity.WorkorderServiceLine.builder()
+                        .workOrder(workorder)
+                        .description(item.getDescription())
+                        .quantity(item.getQuantity())
+                        .unitPrice(item.getUnitPrice())
+                        .lineTotal(item.getLineTotal())
+                        .taxCode(item.getTaxCode())
+                        .originEstimateItem(item)
+                        .serviceEntityId(item.getServiceId())
+                        .status(WorkorderItemStatus.CANCELLED)
+                        .declined(true)
+                        .declineReason(item.getRejectionReason())
+                        .isEmergencySafety(false)
+                        .photoNotPossible(false)
+                        .build())
+                .toList();
+
+        if (!declinedLines.isEmpty()) {
+            workorderServiceRepository.saveAll(declinedLines);
+            workorderFactPublisher.markChanged(workorder.getId());
+            log.info(
+                    "Promoted {} declined estimate service items onto workorder {}",
+                    declinedLines.size(),
+                    workorder.getId());
+        }
     }
 
     /**

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderStateMachine.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderStateMachine.java
@@ -40,6 +40,7 @@ public class WorkorderStateMachine {
 
     private final WorkorderRepository workorderRepository;
     private final WorkorderFactPublisher workorderFactPublisher;
+    private final ServiceCompletionFactPublisher serviceCompletionFactPublisher;
     private final WorkorderStateTransitionRepository transitionRepository;
     private final WorkorderSnapshotRepository snapshotRepository;
     private final WorkorderServiceRepository workorderServiceRepository;
@@ -339,6 +340,9 @@ public class WorkorderStateMachine {
         workorder.setReopenReason(null);
         workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(workorderId);
+        // FI-3 (#1133): emit the CRM service-history facts (service-completion + declined-service)
+        // from the final committed state.
+        serviceCompletionFactPublisher.markCompleted(workorderId);
 
         // Transition to COMPLETED state
         transitionWorkorder(workorderId, WorkorderStatus.COMPLETED, actorId, "Work Order Completed");

--- a/pos-workorder/src/main/resources/db/migration/V14__workorder_service_decline_reason.sql
+++ b/pos-workorder/src/main/resources/db/migration/V14__workorder_service_decline_reason.sql
@@ -1,0 +1,5 @@
+-- FI-3 (#1133): declined-recommendation service-history feed.
+-- Declined estimate recommendations are now promoted onto the workorder as declined service
+-- lines so the decline has a source workorder and its reason is retained. Null means "not
+-- declined" or "no reason recorded"; the WorkorderServiceLineDeclinedV1 fact carries it to CRM.
+ALTER TABLE workorder_service ADD COLUMN decline_reason VARCHAR(500);

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/ServiceCompletionFactPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/ServiceCompletionFactPublisherTest.java
@@ -13,7 +13,9 @@ import com.positivity.domainevents.workorder.WorkorderServiceCompletedV1;
 import com.positivity.domainevents.workorder.WorkorderServiceLineDeclinedV1;
 import com.positivity.workorder.internal.config.OutboxEventWriter;
 import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderPart;
 import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.enums.WorkorderItemStatus;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
@@ -74,6 +76,11 @@ class ServiceCompletionFactPublisherTest {
     }
 
     private WorkorderServiceLine serviceLine(String description, BigDecimal total, boolean declined, String reason) {
+        return serviceLine(description, total, declined, reason, WorkorderItemStatus.COMPLETED);
+    }
+
+    private WorkorderServiceLine serviceLine(
+            String description, BigDecimal total, boolean declined, String reason, WorkorderItemStatus status) {
         return WorkorderServiceLine.builder()
                 .id(UUID.randomUUID())
                 .serviceEntityId(UUID.randomUUID())
@@ -83,6 +90,18 @@ class ServiceCompletionFactPublisherTest {
                 .lineTotal(total)
                 .declined(declined)
                 .declineReason(reason)
+                .status(status)
+                .build();
+    }
+
+    private WorkorderPart part(BigDecimal total, WorkorderItemStatus status) {
+        return WorkorderPart.builder()
+                .id(UUID.randomUUID())
+                .quantity(BigDecimal.ONE)
+                .unitPrice(total)
+                .lineTotal(total)
+                .declined(false)
+                .status(status)
                 .build();
     }
 
@@ -102,10 +121,18 @@ class ServiceCompletionFactPublisherTest {
         WorkorderServiceLine performed = serviceLine("Oil change", new BigDecimal("100.00"), false, null);
         WorkorderServiceLine declined =
                 serviceLine("Brake pads", new BigDecimal("300.00"), true, "Defer to next visit");
+        // A non-declined CANCELLED line must not count as performed nor into the amount.
+        WorkorderServiceLine cancelled =
+                serviceLine("Tire rotation", new BigDecimal("40.00"), false, null, WorkorderItemStatus.CANCELLED);
 
         when(workorderRepository.findById(workorderId)).thenReturn(Optional.of(workorder));
-        when(workorderServiceRepository.findByWorkOrder_Id(workorderId)).thenReturn(List.of(performed, declined));
-        when(workorderPartRepository.findByWorkorderId(workorderId)).thenReturn(List.of());
+        when(workorderServiceRepository.findByWorkOrder_Id(workorderId))
+                .thenReturn(List.of(performed, declined, cancelled));
+        // A part attached to a service line (not the workorder directly) must still be counted.
+        when(workorderPartRepository.findByWorkOrderService_WorkOrder_Id(workorderId))
+                .thenReturn(List.of(part(new BigDecimal("50.00"), WorkorderItemStatus.COMPLETED)));
+        when(workorderPartRepository.findByWorkorderIdAndWorkOrderServiceIsNull(workorderId))
+                .thenReturn(List.of());
 
         publisher.markCompleted(workorderId);
         publisher.markCompleted(workorderId);
@@ -119,8 +146,8 @@ class ServiceCompletionFactPublisherTest {
         assertThat(completionFact.vehicleId()).isEqualTo(vehicleId);
         assertThat(completionFact.services()).hasSize(1);
         assertThat(completionFact.services().get(0).description()).isEqualTo("Oil change");
-        // Only the performed line contributes to the amount; the declined line is excluded.
-        assertThat(completionFact.totalAmount()).isEqualByComparingTo("100.00");
+        // Performed service (100) + service-line part (50); declined (300) and CANCELLED (40) excluded.
+        assertThat(completionFact.totalAmount()).isEqualByComparingTo("150.00");
 
         ArgumentCaptor<Object> declinedFact = ArgumentCaptor.forClass(Object.class);
         verify(writer, times(1))
@@ -145,7 +172,10 @@ class ServiceCompletionFactPublisherTest {
         when(workorderRepository.findById(workorderId)).thenReturn(Optional.of(workorder));
         when(workorderServiceRepository.findByWorkOrder_Id(workorderId))
                 .thenReturn(List.of(serviceLine("Oil change", new BigDecimal("100.00"), false, null)));
-        when(workorderPartRepository.findByWorkorderId(workorderId)).thenReturn(List.of());
+        when(workorderPartRepository.findByWorkOrderService_WorkOrder_Id(workorderId))
+                .thenReturn(List.of());
+        when(workorderPartRepository.findByWorkorderIdAndWorkOrderServiceIsNull(workorderId))
+                .thenReturn(List.of());
 
         publisher.markCompleted(workorderId);
         fireBeforeCommit();

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/ServiceCompletionFactPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/ServiceCompletionFactPublisherTest.java
@@ -1,0 +1,167 @@
+package com.positivity.workorder.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.workorder.WorkorderServiceCompletedV1;
+import com.positivity.domainevents.workorder.WorkorderServiceLineDeclinedV1;
+import com.positivity.workorder.internal.config.OutboxEventWriter;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import com.positivity.workorder.internal.service.ServiceCompletionFactPublisher;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Unit tests for {@link ServiceCompletionFactPublisher} (FI-3, #1133): one service-completion fact
+ * plus one declined fact per declined service line, emitted at beforeCommit from persisted state.
+ */
+class ServiceCompletionFactPublisherTest {
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<OutboxEventWriter> writerProvider = mock(ObjectProvider.class);
+
+    private final OutboxEventWriter writer = mock(OutboxEventWriter.class);
+    private final WorkorderRepository workorderRepository = mock(WorkorderRepository.class);
+    private final WorkorderPartRepository workorderPartRepository = mock(WorkorderPartRepository.class);
+    private final WorkorderServiceRepository workorderServiceRepository = mock(WorkorderServiceRepository.class);
+    private final Clock clock = Clock.fixed(Instant.parse("2026-07-20T10:00:00Z"), ZoneOffset.UTC);
+
+    private ServiceCompletionFactPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        when(writerProvider.getIfAvailable()).thenReturn(writer);
+        publisher = new ServiceCompletionFactPublisher(
+                clock, writerProvider, workorderRepository, workorderPartRepository, workorderServiceRepository);
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+        TransactionSynchronizationManager.unbindResourceIfPossible(ServiceCompletionFactPublisher.class);
+    }
+
+    private void fireBeforeCommit() {
+        for (TransactionSynchronization synchronization : TransactionSynchronizationManager.getSynchronizations()) {
+            synchronization.beforeCommit(false);
+        }
+    }
+
+    private WorkorderServiceLine serviceLine(String description, BigDecimal total, boolean declined, String reason) {
+        return WorkorderServiceLine.builder()
+                .id(UUID.randomUUID())
+                .serviceEntityId(UUID.randomUUID())
+                .description(description)
+                .quantity(BigDecimal.ONE)
+                .unitPrice(total)
+                .lineTotal(total)
+                .declined(declined)
+                .declineReason(reason)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Completion emits one service-completion fact and one declined fact per declined line")
+    void emitsCompletionAndDeclineFacts() {
+        UUID workorderId = UUID.randomUUID();
+        UUID partyId = UUID.randomUUID();
+        UUID vehicleId = UUID.randomUUID();
+        Workorder workorder = Workorder.builder()
+                .id(workorderId)
+                .workorderNumber("WO-2026-1001")
+                .customerId(partyId)
+                .vehicleId(vehicleId)
+                .completedAt(Instant.parse("2026-07-20T10:00:00Z"))
+                .build();
+        WorkorderServiceLine performed = serviceLine("Oil change", new BigDecimal("100.00"), false, null);
+        WorkorderServiceLine declined =
+                serviceLine("Brake pads", new BigDecimal("300.00"), true, "Defer to next visit");
+
+        when(workorderRepository.findById(workorderId)).thenReturn(Optional.of(workorder));
+        when(workorderServiceRepository.findByWorkOrder_Id(workorderId)).thenReturn(List.of(performed, declined));
+        when(workorderPartRepository.findByWorkorderId(workorderId)).thenReturn(List.of());
+
+        publisher.markCompleted(workorderId);
+        publisher.markCompleted(workorderId);
+        fireBeforeCommit();
+
+        ArgumentCaptor<Object> completed = ArgumentCaptor.forClass(Object.class);
+        verify(writer, times(1))
+                .publish(eq(WorkorderServiceCompletedV1.EVENT_TYPE), eq(workorderId.toString()), completed.capture());
+        WorkorderServiceCompletedV1 completionFact = (WorkorderServiceCompletedV1) completed.getValue();
+        assertThat(completionFact.partyId()).isEqualTo(partyId);
+        assertThat(completionFact.vehicleId()).isEqualTo(vehicleId);
+        assertThat(completionFact.services()).hasSize(1);
+        assertThat(completionFact.services().get(0).description()).isEqualTo("Oil change");
+        // Only the performed line contributes to the amount; the declined line is excluded.
+        assertThat(completionFact.totalAmount()).isEqualByComparingTo("100.00");
+
+        ArgumentCaptor<Object> declinedFact = ArgumentCaptor.forClass(Object.class);
+        verify(writer, times(1))
+                .publish(
+                        eq(WorkorderServiceLineDeclinedV1.EVENT_TYPE),
+                        eq(workorderId.toString()),
+                        declinedFact.capture());
+        WorkorderServiceLineDeclinedV1 fact = (WorkorderServiceLineDeclinedV1) declinedFact.getValue();
+        assertThat(fact.description()).isEqualTo("Brake pads");
+        assertThat(fact.declineReason()).isEqualTo("Defer to next visit");
+        assertThat(fact.workorderLineId()).isEqualTo(declined.getId());
+    }
+
+    @Test
+    @DisplayName("No declined lines means no declined facts")
+    void noDeclinedLinesNoDeclineFacts() {
+        UUID workorderId = UUID.randomUUID();
+        Workorder workorder = Workorder.builder()
+                .id(workorderId)
+                .completedAt(Instant.parse("2026-07-20T10:00:00Z"))
+                .build();
+        when(workorderRepository.findById(workorderId)).thenReturn(Optional.of(workorder));
+        when(workorderServiceRepository.findByWorkOrder_Id(workorderId))
+                .thenReturn(List.of(serviceLine("Oil change", new BigDecimal("100.00"), false, null)));
+        when(workorderPartRepository.findByWorkorderId(workorderId)).thenReturn(List.of());
+
+        publisher.markCompleted(workorderId);
+        fireBeforeCommit();
+
+        verify(writer, times(1)).publish(eq(WorkorderServiceCompletedV1.EVENT_TYPE), any(), any());
+        verify(writer, never()).publish(eq(WorkorderServiceLineDeclinedV1.EVENT_TYPE), any(), any());
+    }
+
+    @Test
+    @DisplayName("No-op when Kafka publishing is disabled")
+    void noopWhenWriterAbsent() {
+        when(writerProvider.getIfAvailable()).thenReturn(null);
+
+        publisher.markCompleted(UUID.randomUUID());
+        fireBeforeCommit();
+
+        verify(writer, never()).publish(any(), any(), any());
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderCompletionTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderCompletionTest.java
@@ -112,6 +112,9 @@ class WorkorderCompletionTest {
     @Mock
     private com.positivity.workorder.internal.service.WorkorderFactPublisher workorderFactPublisher;
 
+    @Mock
+    private com.positivity.workorder.internal.service.ServiceCompletionFactPublisher serviceCompletionFactPublisher;
+
     @InjectMocks
     private WorkorderStateMachine stateMachine;
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderStateMachineTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderStateMachineTest.java
@@ -68,6 +68,9 @@ class WorkorderStateMachineTest {
     @org.mockito.Mock
     private com.positivity.workorder.internal.service.WorkorderFactPublisher workorderFactPublisher;
 
+    @org.mockito.Mock
+    private com.positivity.workorder.internal.service.ServiceCompletionFactPublisher serviceCompletionFactPublisher;
+
     @InjectMocks
     private WorkorderStateMachine stateMachine;
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:<unknown — FI-3 workorder-events workstream>`
- Parent STORY (durion): louisburroughs/durion#<parent-id>
- Child issue: louisburroughs/durion-positivity-backend#1133
- Domain: `domain:workorder`, `domain:crm` (pos-customer)

Resolves spec open questions **O-4** (service-history data feed) and **O-7** (declined-service event).

## Contract References (REQUIRED for backend PRs touching API/event behavior)
This PR introduces two new cross-module domain **event** contracts (no REST/controller changes), so it is contract-relevant. Contract guide entry (durion): `domains/crm/.business-rules/BACKEND_CONTRACT_GUIDE.md` → workorder-events / service-history feed anchor.

New event contracts (owned by pos-workorder, published on `workorder.events.v1` per ADR-0044):
- `WorkorderServiceCompletedV1` — `workorder.service.completed.v1`
- `WorkorderServiceLineDeclinedV1` — `workorder.service_line.declined.v1`

Both are additive, versioned records in `pos-domain-events`; existing consumers of `workorder.events.v1` (pos-inventory, pos-invoice, pos-warranty) ignore unrecognised event types.

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A (no controller changed)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A
- [ ] Angular SDK regenerated — N/A

## Scope
**What changed:**

_Shared contract (`pos-domain-events`)_
- `WorkorderServiceCompletedV1` (party, vehicle, performed services, completedAt, total amount).
- `WorkorderServiceLineDeclinedV1` (party, vehicle, service, decline reason, source workorder).

_Emit (`pos-workorder`)_
- Declined estimate service items are promoted onto the workorder as declined service lines (`declined=true` + reason) so the decline has a source workorder and its reason survives; new `decline_reason` column (`V14`).
- `ServiceCompletionFactPublisher` emits one completion fact plus one declined fact per declined line to the ADR-0044 transactional outbox at workorder completion, built from the final committed state.

_Consume (`pos-customer`)_
- `WorkorderEventsListener` consumes `workorder.events.v1` idempotently (`processed_events`, owner `workorder`), projecting completions into a new `service_history` read model (`V26`) and raising exactly one `DECLINED_SERVICE_FOLLOWUP` follow-up per declined fact (`source_event_id` unique-index guard).
- Segment catalog gains `service.monthsSinceLast`, `service.hasHistory`, `service.daysSinceDeclined`, resolved from `service_history` and declined follow-ups; missing history evaluates to non-match.

**Why:** pos-customer previously had no service-history signal, blocking CRM segmentation (win-back, service-due, declined-service) and declined-service follow-up tasks. This feeds those facts across the pos-workorder → pos-customer wall via events only (ADR-0044), with no synchronous cross-service call.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run:
  ```bash
  ./mvnw -pl pos-domain-events,pos-workorder,pos-customer -am test
  ./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test
  ```
  New coverage: DTO round-trips (`WorkorderServiceCompletedV1Test`, `WorkorderServiceLineDeclinedV1Test`), emit path (`ServiceCompletionFactPublisherTest`), idempotent consume + follow-up creation (`WorkorderEventsListenerTest`), and the new segment predicates (`SegmentPredicateEvaluatorTest`). pos-workorder (369) and pos-customer full suites and cross-module ArchUnit (12) all green; spotless clean.

## Risk & Rollback
- Risk level: Medium
- Rollback plan: Both listeners and the outbox writer are gated behind `pos.customer.kafka.enabled` / `workorder.kafka.enabled` (default false), so the feed is inert until enabled. Revert the commit to remove the facts; the additive `V14`/`V26` migrations leave an unused column/table if left in place and can be dropped in a follow-up.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/issue-1133-bhi877` (issue-scoped)
- [ ] PR title starts with `[CAP:<cap-id>]` — title is FI-3/issue-scoped
- [x] Links to parent + child issues are present (child #1133)
- [x] Contract guide updated (when contract semantics changed) — referenced above
- [ ] Required CI checks passing — pending CI

---
_Generated by [Claude Code](https://claude.ai/code/session_015JcbpXCo9VYVVUoAzkktCu)_