### PR TITLE
fix(pos-mcp-server): stop RAG grounding prompt over-refusing on covered snippets (#1124 item 4)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/RagGroundingInstruction.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/RagGroundingInstruction.java
@@ -11,19 +11,30 @@ package com.positivity.mcp.internal.orchestration;
  * though</em> the {@code order.returns-refunds} snippet — which documents core charges as NOT modeled
  * in pos-order and forbids inventing a workflow — was in this exact block.
  *
- * <p>The instruction therefore does three things:
+ * <p>The instruction therefore does four things:
  *
  * <ul>
- *   <li>requires answering from the numbered snippets when they cover the question, and forbids
- *       stating <em>any</em> unsupported fact — not only identifier/format/ownership facts (the
- *       original wording was scoped to those and left workflows, capabilities, fields, permissions,
- *       events, and thresholds unguarded, which is how the core-charge workflow slipped through);
+ *   <li>requires answering directly and completely from the numbered snippets when they cover the
+ *       question — the model must not claim it lacks a reference, ask the user for more detail, or
+ *       defer to an external doc / another system / a UI link when the snippet already states the
+ *       fact. #1124 item 4: the gap-harness alpha eval showed 6 of 7 generation failures were this
+ *       over-refusal — e.g. the {@code glossary.identifiers} snippet (VIN regex) and the
+ *       {@code order.returns-refunds} snippet were retrieved into this exact block, yet the model
+ *       answered "I don't have a reference in the current knowledge base." The original wording led
+ *       with prohibitions and buried the positive obligation, so the model treated "when in doubt,
+ *       refuse" as the safe default even with the answer in front of it;
+ *   <li>forbids stating <em>any</em> unsupported fact — not only identifier/format/ownership facts
+ *       (the original wording was scoped to those and left workflows, capabilities, fields,
+ *       permissions, events, and thresholds unguarded, which is how the core-charge workflow slipped
+ *       through) — and constrains answers to the entities, fields, names, and values that actually
+ *       appear in the snippets (the 7th failure fabricated a {@code PriceBook} entity and field set
+ *       absent from the retrieved pricing snippets);
  *   <li>makes a documented non-existence binding: when a snippet says a capability or concept is not
  *       modeled/implemented/supported, the model must say so and must not invent a workflow,
  *       calculation, field, or value for it, nor offer to perform an action the snippets don't
  *       support;
- *   <li>keeps the "say what you don't know instead of inventing" fallback for facts the snippets
- *       don't contain.
+ *   <li>keeps the "say what you don't know instead of inventing" fallback, scoped to when the
+ *       snippets genuinely do not contain the fact.
  * </ul>
  *
  * <p>Shared by {@link SpringAiPosAssistant} and {@link SpringAiStreamingPosAssistant} so the
@@ -36,14 +47,18 @@ final class RagGroundingInstruction {
             Relevant retrieved context:
             Ground your answer in the numbered snippets below when they cover the question, and treat \
             them as the authoritative source — prefer them over your own trained/parametric knowledge. \
-            Do not state any workflow, capability, field, entity, permission, event, threshold, \
-            identifier format, code pattern, or service ownership that is not supported by these \
-            snippets. If a snippet says a capability or concept is not modeled, not implemented, or \
-            not supported, treat that as authoritative: say the platform does not model it, and do \
-            not invent a workflow, calculation, field, or value for it or offer to perform an action \
-            the snippets do not support. If the snippets don't contain the fact needed, say what you \
-            don't know instead of inventing or guessing a plausible-sounding answer from general \
-            knowledge.""";
+            When the snippets do contain the answer, answer directly and completely from them: do not \
+            claim you lack a reference or that it is not in the knowledge base, do not ask the user for \
+            more detail, and do not defer to an external document, another system, or a UI link when \
+            the snippets already state the fact. Use only the entities, fields, names, and values that \
+            appear in the snippets. Do not state any workflow, capability, field, entity, permission, \
+            event, threshold, identifier format, code pattern, or service ownership that is not \
+            supported by these snippets. If a snippet says a capability or concept is not modeled, not \
+            implemented, or not supported, treat that as authoritative: say the platform does not model \
+            it, and do not invent a workflow, calculation, field, or value for it or offer to perform \
+            an action the snippets do not support. Only when the snippets genuinely do not contain the \
+            fact needed, say what you don't know instead of inventing or guessing a plausible-sounding \
+            answer from general knowledge.""";
 
     private RagGroundingInstruction() {}
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
@@ -139,7 +139,15 @@ class SpringAiPosAssistantTest {
                 // and don't offer to perform an unsupported action.
                 .containsIgnoringCase("not modeled")
                 .containsIgnoringCase("does not model it")
-                .containsIgnoringCase("offer to perform an action");
+                .containsIgnoringCase("offer to perform an action")
+                // #1124 item 4: the positive obligation must be explicit so the model answers from a
+                // covering snippet instead of over-refusing ("I don't have a reference"). It must also
+                // forbid deferring to a UI link / another system and constrain answers to snippet names.
+                .containsIgnoringCase("answer directly and completely")
+                .containsIgnoringCase("do not claim you lack a reference")
+                .containsIgnoringCase("do not ask the user for more detail")
+                .containsIgnoringCase("UI link")
+                .containsIgnoringCase("use only the entities, fields, names, and values");
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Parent issue: louisburroughs/durion-positivity-backend#1124 (item 4 — generation failures)
- Domain: `domain:mcp` (pos-mcp-server RAG assistant orchestration)

## Contract References
- N/A — no API/event/contract surface changes. This edits an internal system-prompt string constant (`RagGroundingInstruction.CONTEXT_PREFIX`) shared by the two chat assistants; no controller, DTO, `*Request`/`*Response`, event, or `openapi.yaml` is touched.

## Contract Chain (when a Controller changed)
- N/A — no controller changed.

## Scope
- **What changed:** Rebalanced the RAG grounding instruction so the assistant answers directly from a retrieved snippet that covers the question instead of over-refusing.
- **Why:** The 2026-07-29 gap-harness alpha run classified **7 of 16** answers as generation failures (right doc retrieved into the prompt, answer still wrong). Reading the transcripts split them into two opposite modes, both traceable to `RagGroundingInstruction.CONTEXT_PREFIX`:
  - **6 of 7 — over-refusal.** The snippet contained the answer, yet the model replied "I don't have a reference in the current knowledge base," asked the user for more detail, or deferred to a UI link. E.g. `glossary.identifiers` (VIN regex) retrieved → "I don't have a reference for the VIN format"; `order.returns-refunds` retrieved → "I don't have a stored policy."
  - **1 of 7 — fabrication.** With `pricing.guide`/`pricing.restrictions` retrieved, the model invented a `PriceBook` entity and field set that do not exist.
  - Root cause: the prompt led with one weak positive clause followed by four "do not invent" prohibitions, so the model defaulted to "when in doubt, refuse" even with the answer in front of it — while still fabricating where the snippets were thin.
- **The fix:**
  - Adds an explicit positive obligation: when the snippets contain the answer, answer directly and completely; do not claim to lack a reference, ask for more detail, or defer to an external doc / another system / a UI link.
  - Constrains answers to the entities, fields, names, and values that appear in the snippets (targets the `PriceBook` fabrication).
  - Scopes the "say what you don't know" fallback to when the snippets genuinely do not cover the question.
  - Anti-fabrication and documented-non-existence clauses are unchanged.

## Tests
- [x] Unit tests added/updated — `SpringAiPosAssistantTest` now asserts the new positive directives ("answer directly and completely", "do not claim you lack a reference", "do not ask the user for more detail", "UI link", "use only the entities, fields, names, and values") so they cannot silently regress. Existing anti-fabrication assertions retained.
- [ ] Integration tests added/updated — N/A (behavioral change is verified live on alpha, below).
- **How to run:** `./mvnw -pl pos-mcp-server -Dtest=SpringAiPosAssistantTest,SpringAiStreamingPosAssistantTest test` (full module suite: 551 pass, BUILD SUCCESS).

## Risk & Rollback
- **Risk level:** Low — single internal prompt-string constant; no schema, API, or data change. Both chat paths share the constant so they stay in sync.
- **Rollback plan:** Revert this commit; the previous `CONTEXT_PREFIX` wording is restored with no migration.

## Verification (post-merge)
Prompt is compiled into the pos-mcp-server image, so live proof requires the **normal main → CI build → alpha redeploy** path. After redeploy, re-run the gap harness (`scripts/run-gap-harness.sh --judge ollama --judge-model llama3.1:8b --recall-at-k <eval_live value>`) and confirm the 6 over-refusal questions (`gap-vin-format`, `gap-po-number-owner`, `gap-invoice-number-format`, `gap-tax-mode`, `gap-returns-refunds`, `order-core-charge-not-modeled`) now grade `correct`/`not-modeled` and the `gap-pricing-rules` fabrication is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146AcnAPgXdc57esJBM6DvX
