### PR TITLE
enable lexical retrieval for exact identifiers in pos-mcp-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -833,6 +833,7 @@ services:
       MCP_RAG_CHUNKING_ENABLED: ${MCP_RAG_CHUNKING_ENABLED:-true}
       MCP_RAG_MAX_SEGMENT_SIZE: ${MCP_RAG_MAX_SEGMENT_SIZE:-2000}
       MCP_RAG_MAX_OVERLAP_SIZE: ${MCP_RAG_MAX_OVERLAP_SIZE:-200}
+      MCP_RAG_LEXICAL_ENABLED: ${MCP_RAG_LEXICAL_ENABLED:-true}
       # Origin of the frontend SSR server that serves /sitemap.json (NOT the API gateway).
       # Must be listed here to be passed into the container; values come from the
       # docker compose process environment and/or the .env file during ${...} substitution.

--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -134,11 +134,34 @@ Both session managers use a Tier-2 retrieval chain:
 
 1. Baseline semantic retriever (`maxResults=10`, `minScore=0.6`).
 2. Query-expanded retriever (`maxResults=20`, `minScore=0.55`) using deterministic paraphrases.
-3. Hybrid merge + de-duplication across both retrievers.
+3. PostgreSQL full-text retrieval for literal identifiers (enabled by default), followed by reciprocal-rank fusion and de-duplication across all retrievers.
 4. Final lexical-aware re-ranking to the top-5 contexts before prompt injection.
 
 Retrieval is role-aware (`RoleAwareMetadataFilter`, `ScopedContentRetrieverFactory`) and chat memory is persisted via
 `SemanticChatMemoryStore` with session summarization (`SessionSummary`).
+
+### Troubleshooting identifier misses
+
+Treat a missing VIN, SKU, event name, or permission code as a candidate-pipeline problem before
+changing the answer prompt:
+
+1. Run the same query against dense retrieval at both score floors and against PostgreSQL FTS;
+   record document IDs at every stage (source retrieval, RRF, de-duplication, and final top-5).
+2. Confirm the expected chunk has the selected tool's RAG scope and that its
+   `required-permissions` are satisfied. A correct lexical match must never bypass scope or
+   permission filtering.
+3. Inspect the stored `search_vector` and query produced by `websearch_to_tsquery`. Punctuation in
+   VINs, SKUs, and colon/dot-delimited codes can change lexemes; use a normalized exact-token
+   fallback when PostgreSQL tokenization removes the distinguishing characters.
+4. Compare the covering chunk's rank before and after `RerankedContentRetriever`. If it enters the
+   candidate pool but misses the top-5, tune or diversify the final selection rather than lowering
+   the dense threshold.
+5. Check ingestion and chunking: verify the current source revision was embedded, the literal token
+   was not split across chunks, and dense/lexical copies share a stable document ID for de-duplication.
+
+Keep exact-identifier fixtures in `src/test/resources/eval/rag-lexical` and compare dense-only with
+hybrid recall, hit@5, MRR, forbidden-document violations, and latency before changing fusion weights
+or similarity floors.
 
 ## Configuration
 
@@ -153,6 +176,7 @@ Retrieval is role-aware (`RoleAwareMetadataFilter`, `ScopedContentRetrieverFacto
 | `mcp.rag.chunking.enabled`                 | `MCP_RAG_CHUNKING_ENABLED` `true`           | Chunk documents before embedding                                                          |
 | `mcp.rag.chunking.max-segment-size`        | `MCP_RAG_MAX_SEGMENT_SIZE`                  | Max chunk size                                                                            |
 | `mcp.rag.chunking.max-overlap-size`        | `MCP_RAG_MAX_OVERLAP_SIZE`                  | Chunk overlap                                                                             |
+| `mcp.rag.hybrid.lexical-enabled`           | `MCP_RAG_LEXICAL_ENABLED` `true`            | Include scoped PostgreSQL full-text hits in RRF fusion; set `false` for immediate rollback |
 | `mcp.rag.preload.docs`                     | `[]`                                        | Static classpath documents to preload                                                     |
 | `mcp.tuning.enabled`                       | `MCP_TUNING_ENABLED` `false`                | Adaptive tool priority tuning (disabled until regression harness exists — Gate 0)         |
 | `mcp.tuning.cron`                          | `0 0 2 * * ?`                               | Tuning schedule (daily 02:00)                                                             |

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/HybridRetrievalProperties.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/HybridRetrievalProperties.java
@@ -5,10 +5,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * #784: configuration for hybrid dense + lexical (Postgres FTS) RAG retrieval.
  *
- * <p>Lexical retrieval is <strong>off by default</strong> so the FTS migration and code can ship
- * decoupled from the behavior change; enabling it is a one-line, instantly reversible flip. When
- * disabled, retrieval stays exactly as before (dense + query-expansion fused in insertion order).
- * When enabled, the lexical path joins the source set and fusion switches to Reciprocal Rank Fusion.
+ * <p>The application configuration enables lexical retrieval by default because literal identifiers
+ * can fall below the dense similarity floor. It remains an instantly reversible feature flag. When
+ * disabled, retrieval uses dense + query-expansion fused in insertion order. When enabled, the
+ * lexical path joins the source set and fusion switches to Reciprocal Rank Fusion.
  */
 @ConfigurationProperties(prefix = "mcp.rag.hybrid")
 public record HybridRetrievalProperties(boolean lexicalEnabled, int rrfK, int lexicalMaxResults) {

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -45,6 +45,11 @@ mcp:
     table-name: mcp_document_embedding
     dimension: 768
     index-type: ivfflat
+    hybrid:
+      # Exact identifiers (VINs, SKUs, permission/event codes) routinely score below the dense
+      # tier-1 floor. Keep the literal FTS source in the live candidate set; operators can disable
+      # it immediately if the retrieval-quality gate detects a regression.
+      lexical-enabled: ${MCP_RAG_LEXICAL_ENABLED:true}
     preload:
       docs:
         - id: "accounting.de-bookkeeping"


### PR DESCRIPTION
### Motivation

- Exact-token queries (VINs, SKUs, permission/event codes) were being dropped by the dense-tier similarity floor (0.55–0.60) and never reached the answer-writing stage.
- The real fix is in retrieval: ensure a scoped PostgreSQL FTS (lexical) source participates in fusion so literal identifiers survive the first-pass filter and can be surfaced to the assistant.
- Make the change reversible and observable so operators can flip the behavior off immediately if it causes regressions.

### Description

- Enabled a lexical (PostgreSQL FTS) path by default in the RAG configuration via `mcp.rag.hybrid.lexical-enabled` and documented the reason for enabling it. (configuration file change)
- Exposed `MCP_RAG_LEXICAL_ENABLED` in `docker-compose.yml` so deployments can disable the lexical path at runtime without code changes. (deployment env change)
- Updated `HybridRetrievalProperties` Javadoc to reflect the new default and the rollback story. (code comment/documentation change)
- Expanded `pos-mcp-server/README.md` to describe the live Tier-2 retrieval pipeline (dense at 0.6, expanded dense at 0.55, lexical FTS, RRF fusion, de-dup, rerank) and added a concise troubleshooting checklist for identifier-miss cases. (docs change)

### Testing

- ✅ Ran `git diff --check` to verify no whitespace/patch issues were introduced and it passed.
- ✅ Validated the modified `application.yml` with Ruby YAML loader (`ruby -e

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a7d2a4f58832e8ea9fd6cc27eab5c)