### PR TITLE
fix(pos-mcp-server): OR-semantics lexical query so identifier questions match (#1124 item 4 residual)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/rag/LexicalDocumentRetriever.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/rag/LexicalDocumentRetriever.java
@@ -29,28 +29,34 @@ final class LexicalDocumentRetriever implements QueryDocumentRetriever {
     private static final Logger LOGGER = LoggerFactory.getLogger(LexicalDocumentRetriever.class);
     private static final TypeReference<Map<String, Object>> METADATA_TYPE = new TypeReference<>() {};
 
-    // websearch_to_tsquery parses free text and quoted phrases safely (input is data, never SQL) and
-    // yields an empty query — zero rows, not an error — on unparseable input. The query term binds
-    // twice: once for the @@ match, once for ts_rank_cd ordering.
-    private static final String SQL_SCOPED = """
-            SELECT id, content, metadata::text AS metadata
-            FROM mcp_document_embedding
-            WHERE content_tsv @@ websearch_to_tsquery('english', ?)
-              AND metadata ->> 'rag_scope' = ?
-            ORDER BY ts_rank_cd(content_tsv, websearch_to_tsquery('english', ?)) DESC, id
-            LIMIT ?
-            """;
+    // #1124 item 4 (residual): websearch_to_tsquery parses free text and quoted phrases safely (input
+    // is data, never SQL), but it joins the terms with AND. For a natural-language question that merely
+    // CONTAINS an identifier ("what is the exact format of a VIN and which characters are not allowed"),
+    // AND requires one chunk to hold every lexeme (exact & format & vin & …) and matches nothing — on
+    // alpha the bare token `VIN` matched 9 chunks while the full question matched 0. We therefore switch
+    // the parsed query to OR by swapping its `&` operators for `|` in the tsquery's text form. The raw
+    // user text still passes ONLY through websearch_to_tsquery (safe parsing); the ::text/replace/
+    // ::tsquery runs on the already-parsed query, so there is no injection surface. Phrase (<->) and
+    // negation (!) operators are left intact, a bare token (no `&`) is unaffected, and an empty parse
+    // stays empty (zero rows). ts_rank_cd still ranks the OR matches so the best chunk sorts first.
+    // The tsquery term binds twice: once for the @@ match, once for ts_rank_cd ordering.
+    private static final String OR_TSQUERY = "replace(websearch_to_tsquery('english', ?)::text, ' & ', ' | ')::tsquery";
+
+    private static final String SQL_SCOPED = "SELECT id, content, metadata::text AS metadata\n"
+            + "FROM mcp_document_embedding\n"
+            + "WHERE content_tsv @@ " + OR_TSQUERY + "\n"
+            + "  AND metadata ->> 'rag_scope' = ?\n"
+            + "ORDER BY ts_rank_cd(content_tsv, " + OR_TSQUERY + ") DESC, id\n"
+            + "LIMIT ?";
 
     // #1124 item 4: the `master` scope is the catch-all agent, not a literal doc scope, so it must
     // search all scopes (mirrors the dense path in ScopedContentRetrieverFactory#create). Permission
     // gating is applied downstream by PermissionAwareMetadataFilter, not here.
-    private static final String SQL_ALL_SCOPES = """
-            SELECT id, content, metadata::text AS metadata
-            FROM mcp_document_embedding
-            WHERE content_tsv @@ websearch_to_tsquery('english', ?)
-            ORDER BY ts_rank_cd(content_tsv, websearch_to_tsquery('english', ?)) DESC, id
-            LIMIT ?
-            """;
+    private static final String SQL_ALL_SCOPES = "SELECT id, content, metadata::text AS metadata\n"
+            + "FROM mcp_document_embedding\n"
+            + "WHERE content_tsv @@ " + OR_TSQUERY + "\n"
+            + "ORDER BY ts_rank_cd(content_tsv, " + OR_TSQUERY + ") DESC, id\n"
+            + "LIMIT ?";
 
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/rag/ScopedContentRetrieverFactoryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/rag/ScopedContentRetrieverFactoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -138,10 +137,17 @@ class ScopedContentRetrieverFactoryTest {
         assertThat(lexical).isPresent();
         lexical.orElseThrow().retrieve("stock levels");
 
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Object[]> argsCaptor = ArgumentCaptor.forClass(Object[].class);
-        verify(jdbcTemplate).query(contains("websearch_to_tsquery"), any(RowMapper.class), argsCaptor.capture());
+        verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), argsCaptor.capture());
         // Bound params: query (match), normalized scope, query (rank), maxResults.
         assertThat(argsCaptor.getValue()).containsExactly("stock levels", "inventory", "stock levels", 7);
+        // #1124 residual: the parsed tsquery must be transformed to OR semantics (& -> |) so a
+        // natural-language question that merely contains an identifier still matches.
+        assertThat(sqlCaptor.getValue())
+                .contains("websearch_to_tsquery")
+                .contains("replace(")
+                .contains("' & '", "' | '");
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Parent issue: louisburroughs/durion-positivity-backend#1124 (item 4 — generation failures, final residual)
- Domain: `domain:mcp` (pos-mcp-server lexical RAG retrieval)
- Follows #1169 (master scope searches all scopes + permission gating) and #1167 (lexical FTS default-on).

## Contract References
- N/A — no API/event/contract surface. One SQL query-construction change + a test assertion.

## Scope
- **What changed:** Makes the lexical (Postgres FTS) retriever use **OR** semantics so a natural-language question that merely *contains* an identifier matches the identifier doc.
- **Why:** After #1169 + #1167, 5 of 7 item-4 questions recovered, but VIN-format and invoice-number-format still failed — both answered from `glossary.identifiers`. Live DB diagnosis on alpha found the cause: `LexicalDocumentRetriever` passed the raw question to `websearch_to_tsquery('english', ?)`, which **ANDs every term**:

  | Query form | Matching chunks (alpha) |
  |---|---|
  | bare `VIN` | 9 |
  | `VIN format` (2 terms) | 2 |
  | full question (all ANDed) | **0** |
  | full question, OR semantics | 47 |

  A question requiring `exact & format & vin & character & allow` in one chunk matches nothing, so lexical only ever fired for bare-token queries (why the original eval fixtures passed but live questions didn't). Dense also misses (`glossary.identifiers` 0.58 < 0.60), so neither path surfaced the doc → the assistant refused.
- **The fix:** transform the parsed tsquery to OR — `replace(websearch_to_tsquery('english', ?)::text, ' & ', ' | ')::tsquery`. The raw user text still passes **only** through `websearch_to_tsquery` (safe parsing); the `::text`/`replace`/`::tsquery` runs on the already-parsed query, so there is **no injection surface**. Phrase (`<->`) and negation (`!`) operators are left intact; a bare token is unaffected; an empty parse stays empty. `ts_rank_cd` still ranks OR matches, so the best chunk sorts first. Applied to both the scoped and all-scopes (master) SQL paths.

## Tests
- [x] Unit — `ScopedContentRetrieverFactoryTest` asserts the issued SQL contains the OR transform (`replace(` … `' & '` → `' | '`) and that bound params are unchanged. `LexicalDocumentRetrieverTest` still green.
- [x] **Live SQL validation on alpha** — with OR, `glossary.identifiers` is the **top-ranked** lexical hit for the VIN question (rank 1.2) and top-2 for the invoice question, so it now enters RRF fusion + rerank instead of being absent.
- **How to run:** `./mvnw -pl pos-mcp-server test` (full module suite: **553 pass**, BUILD SUCCESS).

## Risk & Rollback
- **Risk level:** Low — one SQL query-construction change on the lexical path only. OR broadens lexical candidates (more recall); RRF + top-5 rerank + the existing permission filter (#1169) bound what reaches the model, and dense-only behavior is unchanged when `MCP_RAG_LEXICAL_ENABLED=false`.
- **Rollback plan:** revert the commit, or set `MCP_RAG_LEXICAL_ENABLED=false` for an immediate dense-only fallback.

## Verification (acceptance gate, post-merge)
After the normal main → CI build → alpha redeploy, re-run the 2-question probe (VIN, invoice-number). Expected: both surface `glossary.identifiers` and answer with the VIN regex / invoice-number format, completing item 4 (7/7). Also re-check `eval_live` `rag_forbidden_violations` stays 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146AcnAPgXdc57esJBM6DvX
