### PR TITLE
feat(pos-marketing): shared sender adapter + delivery outcome feedback (#1150)

### DIFF
--- a/docs/PLATFORM_SENDER_CONTRACT.md
+++ b/docs/PLATFORM_SENDER_CONTRACT.md
@@ -54,8 +54,10 @@ stores it on the send record for bounce correlation.
 ## 2. Outcome feedback (Kafka)
 
 Topic `sender.outcomes.v1` (`pos.marketing.kafka.sender-outcomes-topic`), standard domain
-envelope (`eventId`, `eventType`, `occurredAt`, `payload`), at-least-once, keyed by
-`providerMessageId`.
+envelope (`eventId`, `eventType`, `payload`), at-least-once, keyed by `providerMessageId`.
+The `occurredAt` timestamp (ISO-8601 instant) lives **inside `payload`**, next to
+`providerMessageId`; a missing or malformed value makes pos-marketing fall back to its own
+clock.
 
 Event types and payload:
 

--- a/docs/PLATFORM_SENDER_CONTRACT.md
+++ b/docs/PLATFORM_SENDER_CONTRACT.md
@@ -1,0 +1,113 @@
+# Platform Sender Contract (FI-2)
+
+Contract between `pos-marketing` and the **shared platform sender** for campaign email/SMS
+delivery and outcome feedback. Defines what `pos-marketing` builds against (durion#369,
+plan decision O-1, stories #1149/#1150). The sender owns provider credentials, address
+resolution, wire-level retries, and provider webhooks; `pos-marketing` owns orchestration
+only — audience, consent/suppression gating, batching, per-recipient state.
+
+## 1. Send API
+
+`POST {pos.marketing.sender.base-url}/platform-sender/v1/messages`
+
+Headers:
+
+| Header | Value |
+| --- | --- |
+| `Content-Type` | `application/json` |
+| `X-Pos-Sender-Secret` | shared secret (`pos.marketing.sender.api-secret`); same pattern as `X-Pos-Events-Secret` |
+
+Request body:
+
+```json
+{
+  "messageId": "0198c2f0-…",          // campaignSendId — idempotency key
+  "channel": "EMAIL",                  // EMAIL | SMS
+  "recipientPartyId": "0198c2f0-…",
+  "contactId": "0198c2f0-…",           // optional; the contact audience resolution picked
+  "campaignCode": "SPRING24",          // sender-side metadata / provider tagging
+  "subject": "…",                      // null for SMS
+  "body": "…"                          // fully rendered; sender does no templating
+}
+```
+
+Semantics:
+
+- **Address resolution belongs to the sender.** `pos-marketing` never sends or stores a raw
+  address; the sender resolves the recipient's address from `recipientPartyId`/`contactId`
+  (via pos-people-contact) at delivery time.
+- **Idempotency:** a replayed `messageId` MUST NOT produce a second delivery; the sender
+  answers `200` with the original response instead of `202`.
+
+Responses:
+
+| Status | Meaning | Body |
+| --- | --- | --- |
+| `202` (or `200` on idempotent replay) | accepted for delivery | `{"providerMessageId": "…", "addressHash": "…"}` |
+| `4xx` | permanent refusal (malformed, unknown party, no resolvable address) — caller marks the send `FAILED` | `ApiError` |
+| `5xx` | transient — caller retries with backoff up to `pos.marketing.send.max-attempts` | `ApiError` |
+
+`providerMessageId` is required on acceptance — it is the only correlation key for outcomes.
+`addressHash` (SHA-256 of the normalized address) is optional; when present `pos-marketing`
+stores it on the send record for bounce correlation.
+
+## 2. Outcome feedback (Kafka)
+
+Topic `sender.outcomes.v1` (`pos.marketing.kafka.sender-outcomes-topic`), standard domain
+envelope (`eventId`, `eventType`, `occurredAt`, `payload`), at-least-once, keyed by
+`providerMessageId`.
+
+Event types and payload:
+
+| `eventType` | Payload fields | Effect in pos-marketing |
+| --- | --- | --- |
+| `sender.message.delivered` | `providerMessageId`, `occurredAt` | send → `DELIVERED` |
+| `sender.message.bounced` | `providerMessageId`, `reason`, `permanent` (bool, default `true`), `address`, `occurredAt` | send → `BOUNCED`; hard bounce → CRM suppression |
+| `sender.message.complained` | `providerMessageId`, `reason`, `address`, `occurredAt` | send → `COMPLAINED`; always → CRM suppression |
+| `sender.message.opened` | `providerMessageId`, `occurredAt` | stamps `openedAt` (first only) |
+| `sender.message.clicked` | `providerMessageId`, `occurredAt` | stamps `clickedAt` (+ implies open) |
+
+Open/click support is **optional** per channel/provider; consumers degrade gracefully when
+these never arrive. `address` (raw, normalized) is REQUIRED on bounce/complaint so the
+suppression hand-off can identify what to block; it is relayed to pos-customer and never
+persisted by pos-marketing.
+
+## 3. Suppression feedback (pos-marketing → pos-customer)
+
+On hard bounce or complaint, `pos-marketing` queues a command on `customer.commands.v1`
+(transactional outbox, same transaction as the send-state change):
+
+```json
+{
+  "commandType": "customer.suppression.add-requested",
+  "eventId": "…",                      // reuses the sender outcome eventId → replay-safe
+  "payload": {
+    "channel": "EMAIL",
+    "address": "jane@example.com",
+    "partyId": "0198c2f0-…",
+    "reason": "HARD_BOUNCE"            // HARD_BOUNCE | SPAM_COMPLAINT
+  }
+}
+```
+
+`pos-customer` applies it via `SuppressionService.add` (idempotent; stores only a normalized
+hash + masked hint; source recorded as `SYSTEM`) and republishes
+`customer.suppression.changed`, which flows back into pos-marketing's `ext_suppression`
+replica — closing the loop so the next audience build and send-time re-check both exclude
+the address.
+
+## 4. Facts published by pos-marketing
+
+On each applied terminal outcome, `marketing.events.v1` carries
+`marketing.campaign.send.delivered|bounced|complained`
+(`MarketingCampaignSendOutcomeV1`; aggregateId = recipient party).
+
+## 5. Config reference (pos-marketing)
+
+| Property | Default | Purpose |
+| --- | --- | --- |
+| `pos.marketing.send.transport` | `stub` | `stub` logs sends; `platform-sender` activates the adapter |
+| `pos.marketing.sender.base-url` | `http://localhost:8085` | sender endpoint |
+| `pos.marketing.sender.api-secret` | _(empty)_ | shared secret header |
+| `pos.marketing.kafka.sender-outcomes-topic` | `sender.outcomes.v1` | outcome feed |
+| `pos.marketing.kafka.customer-commands-topic` | `customer.commands.v1` | suppression hand-off |

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/CustomerCommandListener.java
@@ -1,7 +1,12 @@
 package com.positivity.customer.internal.config;
 
+import com.positivity.customer.internal.dto.AddSuppressionRequest;
+import com.positivity.customer.internal.enums.ConsentChangeSource;
+import com.positivity.customer.internal.enums.MarketingChannel;
+import com.positivity.customer.internal.enums.SuppressionReason;
 import com.positivity.customer.service.OutboxReplayService;
 import com.positivity.customer.service.SegmentService;
+import com.positivity.customer.service.SuppressionService;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -28,6 +33,10 @@ import tools.jackson.databind.ObjectMapper;
  * <li>{@code customer.outbox.replay-requested} — consumer-initiated drift repair and replica
  * bootstrap: re-queues published outbox events created in the requested window for
  * re-publication; consumers dedupe by eventId so replay is idempotent.</li>
+ * <li>{@code customer.segment.resolve-requested} — asynchronous segment membership resolution
+ * answered with a {@code customer.segment.resolved} fact (Story #1137).</li>
+ * <li>{@code customer.suppression.add-requested} — provider bounce/complaint feedback relayed
+ * by pos-marketing into the hard suppression list (Story #1150).</li>
  * </ul>
  */
 @Slf4j
@@ -46,6 +55,13 @@ public class CustomerCommandListener {
      */
     private static final String COMMAND_SEGMENT_RESOLVE_REQUESTED = "CUSTOMER_SEGMENT_RESOLVE_REQUESTED";
 
+    /**
+     * Hard-block an address from marketing on provider feedback (Story #1150). Sent by
+     * pos-marketing when the shared platform sender reports a hard bounce or a spam complaint;
+     * {@link SuppressionService#add} is idempotent, so command replay is harmless.
+     */
+    private static final String COMMAND_SUPPRESSION_ADD_REQUESTED = "CUSTOMER_SUPPRESSION_ADD_REQUESTED";
+
     /** Covers the sub-millisecond skew between outbox createdAt and the eventId timestamp. */
     private static final Duration REPLAY_WINDOW_SLACK = Duration.ofSeconds(1);
 
@@ -57,6 +73,7 @@ public class CustomerCommandListener {
     private final ObjectMapper objectMapper;
     private final OutboxReplayService outboxReplayService;
     private final SegmentService segmentService;
+    private final SuppressionService suppressionService;
 
     @KafkaListener(
             topics = "${pos.customer.kafka.commands-topic:customer.commands.v1}",
@@ -79,6 +96,10 @@ public class CustomerCommandListener {
             }
             if (COMMAND_SEGMENT_RESOLVE_REQUESTED.equals(commandType)) {
                 handleSegmentResolveRequested(root);
+                return;
+            }
+            if (COMMAND_SUPPRESSION_ADD_REQUESTED.equals(commandType)) {
+                handleSuppressionAddRequested(root);
                 return;
             }
             log.debug("Ignoring unsupported commandType={} message={}", commandType, message);
@@ -161,6 +182,48 @@ public class CustomerCommandListener {
             throw e;
         } catch (RuntimeException e) {
             log.warn("Segment {} could not be resolved for request {}: {}", segmentId, requestId, e.getMessage());
+        }
+    }
+
+    /**
+     * Apply a provider-feedback suppression (Story #1150): pos-marketing relays a hard bounce
+     * or spam complaint from the shared platform sender, and the address gets hard-blocked
+     * here — suppression outranks whatever consent the party may still hold.
+     *
+     * <p>The raw address exists only inside this command; {@link SuppressionService#add} stores
+     * a normalized hash plus a masked hint. Malformed commands are dropped, not retried:
+     * redelivery cannot repair a missing address or an unknown enum value.
+     */
+    @Transactional
+    void handleSuppressionAddRequested(JsonNode root) {
+        JsonNode payload = root.path("payload");
+        String address = payload.path("address").stringValue(null);
+        MarketingChannel channel = enumOrNull(MarketingChannel.class, payload, "channel");
+        SuppressionReason reason = enumOrNull(SuppressionReason.class, payload, "reason");
+        if (address == null || address.isBlank() || channel == null || reason == null) {
+            log.warn("Ignoring suppression-add command missing address, channel, or reason");
+            return;
+        }
+        UUID partyId = uuidOrNull(payload, "partyId");
+        var entry = suppressionService.add(
+                new AddSuppressionRequest(channel, address, partyId, reason, ConsentChangeSource.SYSTEM));
+        log.info(
+                "Provider feedback suppressed {} address for party {} (reason {}, suppressionId {})",
+                channel,
+                partyId,
+                reason,
+                entry.suppressionId());
+    }
+
+    private static <E extends Enum<E>> @Nullable E enumOrNull(Class<E> type, JsonNode node, String field) {
+        String value = node.path(field).stringValue(null);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Enum.valueOf(type, value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/FollowUpTaskRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/FollowUpTaskRepository.java
@@ -15,55 +15,55 @@ import org.springframework.data.repository.query.Param;
 
 public interface FollowUpTaskRepository extends JpaRepository<FollowUpTask, UUID> {
 
-        Page<FollowUpTask> findByPartyIdOrderByDueDateAscCreatedAtAsc(UUID partyId, Pageable pageable);
+    Page<FollowUpTask> findByPartyIdOrderByDueDateAscCreatedAtAsc(UUID partyId, Pageable pageable);
 
-        Page<FollowUpTask> findByPartyIdAndStatusOrderByDueDateAscCreatedAtAsc(
-                        UUID partyId, FollowUpStatus status, Pageable pageable);
+    Page<FollowUpTask> findByPartyIdAndStatusOrderByDueDateAscCreatedAtAsc(
+            UUID partyId, FollowUpStatus status, Pageable pageable);
 
-        /** Idempotency guard for the event-fed path (FI-3, #1133). */
-        boolean existsBySourceEventId(String sourceEventId);
+    /** Idempotency guard for the event-fed path (FI-3, #1133). */
+    boolean existsBySourceEventId(String sourceEventId);
 
-        /**
-         * The CSR queue. Every filter is optional so one query backs "my open tasks",
-         * "everything
-         * overdue", and "all declined-service chases" without three near-identical
-         * methods drifting
-         * apart.
-         */
-        @Query("""
+    /**
+     * The CSR queue. Every filter is optional so one query backs "my open tasks",
+     * "everything
+     * overdue", and "all declined-service chases" without three near-identical
+     * methods drifting
+     * apart.
+     */
+    @Query("""
                         SELECT t FROM FollowUpTask t
                         WHERE (:status IS NULL OR t.status = :status)
                           AND (:assignedTo IS NULL OR t.assignedTo = :assignedTo)
                           AND (:type IS NULL OR t.type = :type)
                         ORDER BY t.dueDate ASC NULLS LAST, t.createdAt ASC
                         """)
-        Page<FollowUpTask> findQueue(
-                        @Param("status") FollowUpStatus status,
-                        @Param("assignedTo") String assignedTo,
-                        @Param("type") FollowUpType type,
-                        Pageable pageable);
+    Page<FollowUpTask> findQueue(
+            @Param("status") FollowUpStatus status,
+            @Param("assignedTo") String assignedTo,
+            @Param("type") FollowUpType type,
+            Pageable pageable);
 
-        /**
-         * Most recent declined-service follow-up per party for the given candidates —
-         * the batch query
-         * the segment resolver uses to derive the "declined service in last N days"
-         * predicate (FI-3,
-         * #1133). A declined follow-up is not removed when closed, so it remains the
-         * record that a
-         * decline occurred regardless of whether it was later worked.
-         */
-        @Query("select t.partyId as partyId, max(t.createdAt) as lastDeclinedAt from FollowUpTask t"
-                        + " where t.type = com.positivity.customer.internal.enums.FollowUpType.DECLINED_SERVICE_FOLLOWUP"
-                        + " and t.partyId in :partyIds group by t.partyId")
-        List<PartyLastDecline> findLastDeclinedByParty(@Param("partyIds") Collection<UUID> partyIds);
+    /**
+     * Most recent declined-service follow-up per party for the given candidates —
+     * the batch query
+     * the segment resolver uses to derive the "declined service in last N days"
+     * predicate (FI-3,
+     * #1133). A declined follow-up is not removed when closed, so it remains the
+     * record that a
+     * decline occurred regardless of whether it was later worked.
+     */
+    @Query("select t.partyId as partyId, max(t.createdAt) as lastDeclinedAt from FollowUpTask t"
+            + " where t.type = com.positivity.customer.internal.enums.FollowUpType.DECLINED_SERVICE_FOLLOWUP"
+            + " and t.partyId in :partyIds group by t.partyId")
+    List<PartyLastDecline> findLastDeclinedByParty(@Param("partyIds") Collection<UUID> partyIds);
 
-        /**
-         * Projection: a party and the timestamp of its most recent declined-service
-         * follow-up.
-         */
-        interface PartyLastDecline {
-                UUID getPartyId();
+    /**
+     * Projection: a party and the timestamp of its most recent declined-service
+     * follow-up.
+     */
+    interface PartyLastDecline {
+        UUID getPartyId();
 
-                Instant getLastDeclinedAt();
-        }
+        Instant getLastDeclinedAt();
+    }
 }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/CustomerCommandListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/CustomerCommandListenerTest.java
@@ -9,7 +9,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.positivity.customer.internal.dto.AddSuppressionRequest;
+import com.positivity.customer.internal.dto.SuppressionEntryResponse;
+import com.positivity.customer.internal.enums.ConsentChangeSource;
+import com.positivity.customer.internal.enums.MarketingChannel;
+import com.positivity.customer.internal.enums.SuppressionReason;
 import com.positivity.customer.service.OutboxReplayService;
+import com.positivity.customer.service.SuppressionService;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -32,12 +38,14 @@ class CustomerCommandListenerTest {
     private final OutboxReplayService replayService = mock(OutboxReplayService.class);
     private final com.positivity.customer.service.SegmentService segmentService =
             mock(com.positivity.customer.service.SegmentService.class);
+    private final SuppressionService suppressionService = mock(SuppressionService.class);
 
     private CustomerCommandListener listener;
 
     @BeforeEach
     void setUp() {
-        listener = new CustomerCommandListener(TEST_CLOCK, new ObjectMapper(), replayService, segmentService);
+        listener = new CustomerCommandListener(
+                TEST_CLOCK, new ObjectMapper(), replayService, segmentService, suppressionService);
         ReflectionTestUtils.setField(listener, "replayMaxLookback", Duration.ofDays(30));
     }
 
@@ -86,6 +94,44 @@ class CustomerCommandListenerTest {
         assertThatCode(() -> listener.onCommand("{\"commandType\":\"something.else\"}"))
                 .doesNotThrowAnyException();
         verify(replayService, never()).replayBetween(any(), any());
+    }
+
+    @Test
+    @DisplayName("Suppression-add command from provider feedback lands in SuppressionService (#1150)")
+    void appliesSuppressionAddCommand() {
+        when(suppressionService.add(any()))
+                .thenReturn(new SuppressionEntryResponse(
+                        java.util.UUID.fromString("01960006-0000-7000-8000-000000000080"),
+                        "EMAIL",
+                        "j***@example.com",
+                        java.util.UUID.fromString("01960006-0000-7000-8000-000000000081"),
+                        "HARD_BOUNCE",
+                        "SYSTEM",
+                        null,
+                        Instant.parse("2026-07-13T12:00:00Z")));
+
+        listener.onCommand("""
+                {"commandType":"customer.suppression.add-requested","eventId":"evt-1",
+                 "payload":{"channel":"EMAIL","address":"jane@example.com",
+                            "partyId":"01960006-0000-7000-8000-000000000081","reason":"HARD_BOUNCE"}}
+                """);
+
+        ArgumentCaptor<AddSuppressionRequest> request = ArgumentCaptor.forClass(AddSuppressionRequest.class);
+        verify(suppressionService).add(request.capture());
+        assertThat(request.getValue().getChannel()).isEqualTo(MarketingChannel.EMAIL);
+        assertThat(request.getValue().getAddress()).isEqualTo("jane@example.com");
+        assertThat(request.getValue().getReason()).isEqualTo(SuppressionReason.HARD_BOUNCE);
+        assertThat(request.getValue().getSource()).isEqualTo(ConsentChangeSource.SYSTEM);
+    }
+
+    @Test
+    @DisplayName("Suppression-add command missing the address is dropped, not retried")
+    void dropsSuppressionCommandWithoutAddress() {
+        assertThatCode(() -> listener.onCommand("""
+                        {"commandType":"customer.suppression.add-requested",
+                         "payload":{"channel":"EMAIL","reason":"HARD_BOUNCE"}}
+                        """)).doesNotThrowAnyException();
+        verify(suppressionService, never()).add(any());
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/marketing/MarketingCampaignSendOutcomeV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/marketing/MarketingCampaignSendOutcomeV1.java
@@ -1,0 +1,59 @@
+package com.positivity.domainevents.marketing;
+
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: the shared platform sender reported a terminal outcome for one campaign send
+ * (Story #1150).
+ *
+ * <p>Published by pos-marketing on {@code marketing.events.v1} with one of three event types —
+ * {@link #EVENT_TYPE_DELIVERED}, {@link #EVENT_TYPE_BOUNCED}, {@link #EVENT_TYPE_COMPLAINED} —
+ * mirroring the send-state transition applied to {@code CampaignSend}. The payload shape is
+ * identical across the three so consumers can share one deserializer; {@code outcome} repeats
+ * the discriminator for consumers that route on payload alone.
+ *
+ * <p>The envelope's aggregateId is the recipient party (matching
+ * {@link MarketingCampaignSentV1}): per-party ordering is what a timeline or a suppression
+ * decision needs.
+ *
+ * @param campaignSendId the send record — consumers' idempotency key alongside the envelope id
+ * @param campaignId campaign that produced the send
+ * @param campaignCode stable campaign code, so consumers need no lookup
+ * @param recipientPartyId party contacted (also the envelope aggregateId)
+ * @param channel EMAIL or SMS
+ * @param outcome DELIVERED, BOUNCED, or COMPLAINED
+ * @param reason provider's reason for a bounce or complaint, when it gave one
+ */
+public record MarketingCampaignSendOutcomeV1(
+        @NonNull UUID campaignSendId,
+        @NonNull UUID campaignId,
+        @NonNull String campaignCode,
+        @NonNull UUID recipientPartyId,
+        @NonNull String channel,
+        @NonNull String outcome,
+        @Nullable String reason) {
+
+    public static final String EVENT_TYPE_DELIVERED = "marketing.campaign.send.delivered";
+    public static final String EVENT_TYPE_BOUNCED = "marketing.campaign.send.bounced";
+    public static final String EVENT_TYPE_COMPLAINED = "marketing.campaign.send.complained";
+
+    public MarketingCampaignSendOutcomeV1 {
+        if (campaignSendId == null) {
+            throw new IllegalArgumentException("campaignSendId must not be null");
+        }
+        if (campaignId == null) {
+            throw new IllegalArgumentException("campaignId must not be null");
+        }
+        if (recipientPartyId == null) {
+            throw new IllegalArgumentException("recipientPartyId must not be null");
+        }
+        if (channel == null || channel.isBlank()) {
+            throw new IllegalArgumentException("channel must not be blank");
+        }
+        if (outcome == null || outcome.isBlank()) {
+            throw new IllegalArgumentException("outcome must not be blank");
+        }
+    }
+}

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/client/PlatformSenderClient.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/client/PlatformSenderClient.java
@@ -1,0 +1,105 @@
+package com.positivity.marketing.internal.client;
+
+import com.positivity.marketing.internal.service.MessageChannelPort;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * Adapter to the shared platform sender (Story #1150, FI-2 contract — durion#369,
+ * {@code docs/PLATFORM_SENDER_CONTRACT.md}).
+ *
+ * <p>The sender owns provider credentials, address resolution, wire-level retries, and the
+ * bounce/complaint webhooks (decision O-1); this adapter only hands over one rendered message
+ * and reports whether it was accepted. Outcomes come back asynchronously on
+ * {@code sender.outcomes.v1} and are applied by
+ * {@link com.positivity.marketing.internal.service.DeliveryOutcomeListener}.
+ *
+ * <p>{@code campaignSendId} travels as the {@code messageId} idempotency key, so the send
+ * worker retrying a transient failure can never produce a duplicate email: the sender answers
+ * a replayed key with the original {@code providerMessageId} (HTTP 200 instead of 202).
+ *
+ * <p>Failure mapping follows the port's retry semantics: a 4xx is a permanent refusal
+ * (malformed message, unknown party, no resolvable address — retrying cannot fix it), while a
+ * 5xx or an I/O failure is transient and left to the worker's bounded retry.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "pos.marketing.send", name = "transport", havingValue = "platform-sender")
+public class PlatformSenderClient implements MessageChannelPort {
+
+    private final RestClient restClient;
+
+    public PlatformSenderClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${pos.marketing.sender.base-url}") String baseUrl,
+            @Value("${pos.marketing.sender.api-secret:}") String apiSecret) {
+        RestClient.Builder builder = restClientBuilder.clone().baseUrl(baseUrl);
+        if (!apiSecret.isBlank()) {
+            builder.defaultHeader("X-Pos-Sender-Secret", apiSecret);
+        }
+        this.restClient = builder.build();
+    }
+
+    @Override
+    public @NonNull SendOutcome send(@NonNull OutboundMessage message) {
+        SendMessageRequest request = new SendMessageRequest(
+                message.campaignSendId(),
+                message.channel().name(),
+                message.recipientPartyId(),
+                message.contactId(),
+                message.campaignCode(),
+                message.subject(),
+                message.body());
+        try {
+            SendMessageResponse response = restClient
+                    .post()
+                    .uri("/platform-sender/v1/messages")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .body(SendMessageResponse.class);
+            if (response == null || response.providerMessageId() == null) {
+                // An accepting sender that returns no correlation id leaves every later
+                // outcome unmatchable — treat it as a contract violation worth retrying.
+                return SendOutcome.transientFailure("Sender returned no providerMessageId");
+            }
+            return SendOutcome.accepted(response.providerMessageId(), response.addressHash());
+        } catch (RestClientResponseException e) {
+            String reason = "Sender rejected message: HTTP " + e.getStatusCode().value();
+            if (e.getStatusCode().is5xxServerError()) {
+                return SendOutcome.transientFailure(reason);
+            }
+            log.warn(
+                    "Platform sender permanently refused send {} ({}): {}",
+                    message.campaignSendId(),
+                    e.getStatusCode().value(),
+                    e.getResponseBodyAsString());
+            return SendOutcome.permanentFailure(reason);
+        } catch (ResourceAccessException e) {
+            return SendOutcome.transientFailure("Sender unreachable: " + e.getMessage());
+        }
+    }
+
+    /** FI-2 send request; {@code messageId} is the idempotency key (= campaignSendId). */
+    record SendMessageRequest(
+            @NonNull UUID messageId,
+            @NonNull String channel,
+            @NonNull UUID recipientPartyId,
+            @Nullable UUID contactId,
+            @NonNull String campaignCode,
+            @Nullable String subject,
+            @NonNull String body) {}
+
+    /** FI-2 send response; {@code addressHash} is optional — not every channel shares it. */
+    record SendMessageResponse(
+            @Nullable String providerMessageId, @Nullable String addressHash) {}
+}

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/entity/CampaignSend.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/entity/CampaignSend.java
@@ -96,6 +96,14 @@ public class CampaignSend {
     @Column(name = "delivered_at")
     private Instant deliveredAt;
 
+    /** First open reported by the sender; stays null when the channel can't track opens. */
+    @Column(name = "opened_at")
+    private Instant openedAt;
+
+    /** First click reported by the sender; stays null when the channel can't track clicks. */
+    @Column(name = "clicked_at")
+    private Instant clickedAt;
+
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 }

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/repository/CampaignSendRepository.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/repository/CampaignSendRepository.java
@@ -14,29 +14,29 @@ import org.springframework.data.repository.query.Param;
 
 public interface CampaignSendRepository extends JpaRepository<CampaignSend, UUID> {
 
-        Optional<CampaignSend> findByCampaignIdAndRecipientPartyIdAndChannel(
-                        UUID campaignId, UUID recipientPartyId, CampaignChannel channel);
+    Optional<CampaignSend> findByCampaignIdAndRecipientPartyIdAndChannel(
+            UUID campaignId, UUID recipientPartyId, CampaignChannel channel);
 
-        Optional<CampaignSend> findByProviderMessageId(String providerMessageId);
+    Optional<CampaignSend> findByProviderMessageId(String providerMessageId);
 
-        Page<CampaignSend> findByCampaignId(UUID campaignId, Pageable pageable);
+    Page<CampaignSend> findByCampaignId(UUID campaignId, Pageable pageable);
 
-        List<CampaignSend> findByCampaignIdAndStatus(UUID campaignId, SendStatus status);
+    List<CampaignSend> findByCampaignIdAndStatus(UUID campaignId, SendStatus status);
 
-        /**
-         * One drain's worth of queued recipients, oldest first so a campaign progresses
-         * in order.
-         */
-        List<CampaignSend> findByStatusOrderByQueuedAtAsc(SendStatus status, Pageable pageable);
+    /**
+     * One drain's worth of queued recipients, oldest first so a campaign progresses
+     * in order.
+     */
+    List<CampaignSend> findByStatusOrderByQueuedAtAsc(SendStatus status, Pageable pageable);
 
-        long countByCampaignIdAndStatus(UUID campaignId, SendStatus status);
+    long countByCampaignIdAndStatus(UUID campaignId, SendStatus status);
 
-        long countByCampaignId(UUID campaignId);
+    long countByCampaignId(UUID campaignId);
 
-        /**
-         * Per-status totals for one campaign in a single query, for the stats funnel.
-         */
-        @Query("SELECT s.channel, s.status, COUNT(s) FROM CampaignSend s WHERE s.campaignId = :campaignId "
-                        + "GROUP BY s.channel, s.status")
-        List<Object[]> countByChannelAndStatus(@Param("campaignId") UUID campaignId);
+    /**
+     * Per-status totals for one campaign in a single query, for the stats funnel.
+     */
+    @Query("SELECT s.channel, s.status, COUNT(s) FROM CampaignSend s WHERE s.campaignId = :campaignId "
+            + "GROUP BY s.channel, s.status")
+    List<Object[]> countByChannelAndStatus(@Param("campaignId") UUID campaignId);
 }

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/repository/SegmentReplicaRepository.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/repository/SegmentReplicaRepository.java
@@ -4,5 +4,4 @@ import com.positivity.marketing.internal.entity.SegmentReplica;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SegmentReplicaRepository extends JpaRepository<SegmentReplica, UUID> {
-}
+public interface SegmentReplicaRepository extends JpaRepository<SegmentReplica, UUID> {}

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignSendWorker.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignSendWorker.java
@@ -124,12 +124,21 @@ public class CampaignSendWorker {
         String body = renderService.render(template.get().getBody(), tokens);
 
         send.setAttempts(send.getAttempts() + 1);
-        MessageChannelPort.SendOutcome outcome =
-                messageChannel.send(send.getChannel(), send.getRecipientPartyId(), subject, body);
+        MessageChannelPort.SendOutcome outcome = messageChannel.send(new MessageChannelPort.OutboundMessage(
+                send.getCampaignSendId(),
+                send.getChannel(),
+                send.getRecipientPartyId(),
+                send.getContactId(),
+                campaign.getCode(),
+                subject,
+                body));
 
         if (outcome.accepted()) {
             send.setStatus(SendStatus.SENT);
             send.setProviderMessageId(outcome.providerMessageId());
+            if (outcome.addressHash() != null) {
+                send.setAddressHash(outcome.addressHash());
+            }
             send.setSentAt(Instant.now(clock));
             send.setFailureReason(null);
             touch(send);

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/DeliveryOutcomeListener.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/DeliveryOutcomeListener.java
@@ -1,0 +1,266 @@
+package com.positivity.marketing.internal.service;
+
+import com.positivity.domainevents.marketing.MarketingCampaignSendOutcomeV1;
+import com.positivity.marketing.internal.config.OutboxEventWriter;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.entity.CampaignSend;
+import com.positivity.marketing.internal.entity.ProcessedEvent;
+import com.positivity.marketing.internal.enums.SendStatus;
+import com.positivity.marketing.internal.repository.CampaignRepository;
+import com.positivity.marketing.internal.repository.CampaignSendRepository;
+import com.positivity.marketing.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Consumes {@code sender.outcomes.v1} — the shared platform sender's delivery, bounce,
+ * complaint, open, and click reports (Story #1150, FI-2 contract — durion#369,
+ * {@code docs/PLATFORM_SENDER_CONTRACT.md}).
+ *
+ * <p>Each outcome correlates back to a {@code CampaignSend} row via the
+ * {@code providerMessageId} returned at send time. An outcome for an id this module has never
+ * seen is thrown back to the container: the send worker's transaction may simply not have
+ * committed yet, so the record retries with backoff and lands on the DLQ only if it stays
+ * unmatched — silently dropping it would leave the send stuck in {@code SENT} forever.
+ *
+ * <p>Hard bounces and complaints additionally feed the CRM suppression list (spec §4.3): a
+ * {@code customer.suppression.add-requested} command goes to {@code customer.commands.v1}
+ * through the outbox, in the same transaction as the status change. The raw address rides only
+ * inside that command — it is never persisted here (the send table keeps a hash at most). The
+ * command reuses the sender envelope's eventId, so a redelivered outcome produces the same
+ * command, and pos-customer's idempotent add makes the replay harmless.
+ *
+ * <p>Opens and clicks are best-effort engagement signals: first occurrence stamps
+ * {@code openedAt}/{@code clickedAt}, later ones are ignored, and a sender that never reports
+ * them (SMS, privacy-proxied email) costs nothing — the funnel just shows the columns as
+ * untracked. Delivery is at-least-once, so everything here is idempotent via
+ * {@code processed_events}.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "pos.marketing.kafka", name = "enabled", havingValue = "true")
+public class DeliveryOutcomeListener {
+
+    private static final String OWNER = "platform-sender";
+
+    static final String OUTCOME_DELIVERED = "sender.message.delivered";
+    static final String OUTCOME_BOUNCED = "sender.message.bounced";
+    static final String OUTCOME_COMPLAINED = "sender.message.complained";
+    static final String OUTCOME_OPENED = "sender.message.opened";
+    static final String OUTCOME_CLICKED = "sender.message.clicked";
+
+    private static final String SUPPRESSION_COMMAND_TYPE = "customer.suppression.add-requested";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final CampaignSendRepository sendRepository;
+    private final CampaignRepository campaignRepository;
+    private final MarketingFactPublisher factPublisher;
+    private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+    private final String customerCommandsTopic;
+
+    public DeliveryOutcomeListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            CampaignSendRepository sendRepository,
+            CampaignRepository campaignRepository,
+            MarketingFactPublisher factPublisher,
+            ObjectProvider<OutboxEventWriter> outboxEventWriter,
+            @Value("${pos.marketing.kafka.customer-commands-topic:customer.commands.v1}")
+                    String customerCommandsTopic) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.sendRepository = sendRepository;
+        this.campaignRepository = campaignRepository;
+        this.factPublisher = factPublisher;
+        this.outboxEventWriter = outboxEventWriter;
+        this.customerCommandsTopic = customerCommandsTopic;
+    }
+
+    @KafkaListener(
+            topics = "${pos.marketing.kafka.sender-outcomes-topic:sender.outcomes.v1}",
+            groupId = "${pos.marketing.kafka.sender-outcomes-consumer-group:pos-marketing-sender-outcomes}")
+    @Transactional
+    public void onSenderOutcome(@NonNull String message) {
+        JsonNode envelope = objectMapper.readTree(message);
+        String eventId = envelope.path("eventId").asString("");
+        String eventType = envelope.path("eventType").asString("");
+        if (eventId.isBlank() || processedEventRepository.existsById(eventId)) {
+            log.debug("Skipping duplicate or unidentified sender outcome type={} id={}", eventType, eventId);
+            return;
+        }
+        boolean relevant =
+                switch (eventType) {
+                    case OUTCOME_DELIVERED, OUTCOME_BOUNCED, OUTCOME_COMPLAINED, OUTCOME_OPENED, OUTCOME_CLICKED ->
+                        true;
+                    default -> false;
+                };
+        if (!relevant) {
+            // The sender may add outcome kinds this module doesn't consume; skip without
+            // recording them so the processed log stays scoped to what was actually applied.
+            return;
+        }
+
+        JsonNode payload = envelope.path("payload");
+        String providerMessageId = payload.path("providerMessageId").asString("");
+        if (providerMessageId.isBlank()) {
+            log.warn("Ignoring sender outcome {} without providerMessageId: {}", eventType, eventId);
+            return;
+        }
+        CampaignSend send = sendRepository
+                .findByProviderMessageId(providerMessageId)
+                // Retryable on purpose: the outcome may have raced the send worker's commit.
+                .orElseThrow(() -> new IllegalStateException("No campaign send for providerMessageId="
+                        + providerMessageId + " (outcome " + eventType + ")"));
+
+        switch (eventType) {
+            case OUTCOME_DELIVERED -> applyDelivered(send, payload);
+            case OUTCOME_BOUNCED -> applyRejection(send, payload, SendStatus.BOUNCED, eventId);
+            case OUTCOME_COMPLAINED -> applyRejection(send, payload, SendStatus.COMPLAINED, eventId);
+            case OUTCOME_OPENED -> applyEngagement(send, payload, true);
+            case OUTCOME_CLICKED -> applyEngagement(send, payload, false);
+            default -> throw new IllegalStateException("Unhandled outcome type " + eventType);
+        }
+
+        processedEventRepository.save(ProcessedEvent.builder()
+                .eventId(eventId)
+                .owner(OWNER)
+                .processedAt(Instant.now(clock))
+                .build());
+    }
+
+    private void applyDelivered(CampaignSend send, JsonNode payload) {
+        // A bounce or complaint outranks delivery; out-of-order or duplicate delivery
+        // reports must not resurrect the send.
+        if (send.getStatus() != SendStatus.SENT) {
+            log.debug("Ignoring delivery report for send {} in status {}", send.getCampaignSendId(), send.getStatus());
+            return;
+        }
+        send.setStatus(SendStatus.DELIVERED);
+        send.setDeliveredAt(occurredAt(payload));
+        touch(send);
+        sendRepository.save(send);
+        factPublisher.sendOutcome(send, campaignCode(send), MarketingCampaignSendOutcomeV1.EVENT_TYPE_DELIVERED);
+    }
+
+    /** Bounce and complaint share a shape: terminal status, optional reason, suppression feed. */
+    private void applyRejection(CampaignSend send, JsonNode payload, SendStatus newStatus, String eventId) {
+        // A complaint can follow a delivery (the customer read it, then hit "spam"); anything
+        // already bounced/complained/failed stays as-is.
+        if (send.getStatus() != SendStatus.SENT && send.getStatus() != SendStatus.DELIVERED) {
+            log.debug(
+                    "Ignoring {} report for send {} in status {}",
+                    newStatus,
+                    send.getCampaignSendId(),
+                    send.getStatus());
+            return;
+        }
+        send.setStatus(newStatus);
+        send.setFailureReason(payload.path("reason").asString(null));
+        touch(send);
+        sendRepository.save(send);
+
+        String eventType = newStatus == SendStatus.BOUNCED
+                ? MarketingCampaignSendOutcomeV1.EVENT_TYPE_BOUNCED
+                : MarketingCampaignSendOutcomeV1.EVENT_TYPE_COMPLAINED;
+        factPublisher.sendOutcome(send, campaignCode(send), eventType);
+
+        // Only a hard bounce protects deliverability by suppressing the address; a soft
+        // bounce (full mailbox, greylisting) must not hard-block someone forever. The
+        // sender says which it was; absence of the flag is treated as hard — failing
+        // toward suppression is the safe direction for reputation and compliance.
+        boolean permanent = payload.path("permanent").asBoolean(true);
+        if (newStatus == SendStatus.COMPLAINED || permanent) {
+            requestSuppression(send, payload, newStatus, eventId);
+        }
+    }
+
+    private void applyEngagement(CampaignSend send, JsonNode payload, boolean opened) {
+        Instant at = occurredAt(payload);
+        boolean changed = false;
+        if (opened && send.getOpenedAt() == null) {
+            send.setOpenedAt(at);
+            changed = true;
+        }
+        // A click implies an open even when the open pixel was blocked.
+        if (!opened && send.getClickedAt() == null) {
+            send.setClickedAt(at);
+            if (send.getOpenedAt() == null) {
+                send.setOpenedAt(at);
+            }
+            changed = true;
+        }
+        if (changed) {
+            touch(send);
+            sendRepository.save(send);
+        }
+    }
+
+    /**
+     * Queue {@code customer.suppression.add-requested} on {@code customer.commands.v1}. The raw
+     * address arrives in the outcome payload solely for this hand-off; when the sender omitted
+     * it there is nothing to suppress by and the outcome is only recorded locally.
+     */
+    private void requestSuppression(CampaignSend send, JsonNode payload, SendStatus newStatus, String eventId) {
+        String address = payload.path("address").asString("");
+        if (address.isBlank()) {
+            log.warn(
+                    "Sender {} outcome for send {} carried no address; CRM suppression skipped",
+                    newStatus,
+                    send.getCampaignSendId());
+            return;
+        }
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        ObjectNode command = objectMapper.createObjectNode();
+        command.put("commandType", SUPPRESSION_COMMAND_TYPE);
+        command.put("eventId", eventId);
+        ObjectNode commandPayload = command.putObject("payload");
+        commandPayload.put("channel", send.getChannel().name());
+        commandPayload.put("address", address);
+        commandPayload.put("partyId", send.getRecipientPartyId().toString());
+        commandPayload.put("reason", newStatus == SendStatus.COMPLAINED ? "SPAM_COMPLAINT" : "HARD_BOUNCE");
+        writer.publishRaw(
+                customerCommandsTopic, send.getRecipientPartyId().toString(), objectMapper.writeValueAsString(command));
+    }
+
+    private @NonNull String campaignCode(CampaignSend send) {
+        return campaignRepository
+                .findById(send.getCampaignId())
+                .map(Campaign::getCode)
+                .orElse("UNKNOWN");
+    }
+
+    private @NonNull Instant occurredAt(@Nullable JsonNode payload) {
+        String value = payload == null ? null : payload.path("occurredAt").asString(null);
+        if (value != null && !value.isBlank()) {
+            try {
+                return Instant.parse(value);
+            } catch (Exception _) {
+                log.debug("Malformed occurredAt '{}' on sender outcome; using now", value);
+            }
+        }
+        return Instant.now(clock);
+    }
+
+    private void touch(CampaignSend send) {
+        send.setUpdatedAt(Instant.now(clock));
+    }
+}

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/LoggingMessageChannel.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/LoggingMessageChannel.java
@@ -1,28 +1,25 @@
 package com.positivity.marketing.internal.service;
 
-import com.positivity.marketing.internal.enums.CampaignChannel;
 import java.util.Locale;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 /**
  * Stand-in transport that records what <em>would</em> have been sent (Story #1149).
  *
- * <p>The real adapter is Story #1150, which is blocked on the shared sender contract
- * (FI-2, durion#369). Until it exists, this implementation lets the whole orchestration path —
- * audience materialization, idempotency, the send-time consent and suppression re-check, status
- * transitions, and the {@code marketing.campaign.sent} fact — run and be tested end to end
+ * <p>The real adapter is {@link com.positivity.marketing.internal.client.PlatformSenderClient}
+ * (Story #1150), active on {@code pos.marketing.send.transport=platform-sender}. This stub stays
+ * the default so environments without a deployed shared sender still exercise the whole
+ * orchestration path — audience materialization, idempotency, the send-time consent and
+ * suppression re-check, status transitions, and the {@code marketing.campaign.sent} fact —
  * without contacting a single real customer.
  *
  * <p>Selection is by explicit property rather than {@code @ConditionalOnMissingBean}: that
  * annotation is only evaluated for {@code @Bean} methods in auto-configuration, so on a plain
- * component it silently registers nothing and the context fails to start. {@code transport}
- * defaults to {@code stub}; the FI-2 adapter will activate on {@code platform-sender}, and the
- * mutually exclusive conditions make it impossible to have both or neither.
+ * component it silently registers nothing and the context fails to start. The mutually exclusive
+ * conditions make it impossible to have both or neither implementation.
  */
 @Slf4j
 @Component
@@ -30,18 +27,16 @@ import org.springframework.stereotype.Component;
 public class LoggingMessageChannel implements MessageChannelPort {
 
     @Override
-    public @NonNull SendOutcome send(
-            @NonNull CampaignChannel channel,
-            @NonNull UUID recipientPartyId,
-            @Nullable String subject,
-            @NonNull String body) {
+    public @NonNull SendOutcome send(@NonNull OutboundMessage message) {
         // Logs the party id and a length only, never the rendered body: the body is the
         // customer's message, and log aggregation is not where it belongs.
         log.info(
-                "[stub sender] would deliver {} to party {} ({} chars); real transport arrives with FI-2 (durion#369)",
-                channel,
-                recipientPartyId,
-                body.length());
-        return SendOutcome.accepted("stub-" + channel.name().toLowerCase(Locale.ROOT) + "-" + recipientPartyId);
+                "[stub sender] would deliver {} to party {} for campaign {} ({} chars)",
+                message.channel(),
+                message.recipientPartyId(),
+                message.campaignCode(),
+                message.body().length());
+        return SendOutcome.accepted(
+                "stub-" + message.channel().name().toLowerCase(Locale.ROOT) + "-" + message.recipientPartyId());
     }
 }

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/MarketingFactPublisher.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/MarketingFactPublisher.java
@@ -2,6 +2,7 @@ package com.positivity.marketing.internal.service;
 
 import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.marketing.MarketingCampaignScheduledV1;
+import com.positivity.domainevents.marketing.MarketingCampaignSendOutcomeV1;
 import com.positivity.domainevents.marketing.MarketingCampaignSentV1;
 import com.positivity.marketing.internal.config.OutboxEventWriter;
 import com.positivity.marketing.internal.entity.Campaign;
@@ -78,6 +79,26 @@ public class MarketingFactPublisher {
                 send.getChannel().name(),
                 renderedSubject);
         publish(writer, MarketingCampaignSentV1.EVENT_TYPE, send.getRecipientPartyId(), payload);
+    }
+
+    /**
+     * Emit {@code marketing.campaign.send.delivered/bounced/complained} for one sender outcome
+     * (Story #1150). The event type mirrors the status transition just applied to the send.
+     */
+    public void sendOutcome(@NonNull CampaignSend send, @NonNull String campaignCode, @NonNull String eventType) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        MarketingCampaignSendOutcomeV1 payload = new MarketingCampaignSendOutcomeV1(
+                send.getCampaignSendId(),
+                send.getCampaignId(),
+                campaignCode,
+                send.getRecipientPartyId(),
+                send.getChannel().name(),
+                send.getStatus().name(),
+                send.getFailureReason());
+        publish(writer, eventType, send.getRecipientPartyId(), payload);
     }
 
     private void publish(

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/MessageChannelPort.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/MessageChannelPort.java
@@ -11,31 +11,48 @@ import org.jspecify.annotations.Nullable;
  * <p>pos-marketing owns orchestration only (decision O-1): who to contact, in what order, and
  * whether they may be contacted at all. The transport itself — provider credentials, retries at
  * the wire level, bounce and complaint webhooks — belongs to the shared platform sender, and
- * reaches this module through the FI-2 contract (durion#369).
+ * reaches this module through the FI-2 contract (durion#369, {@code docs/PLATFORM_SENDER_CONTRACT.md}).
  *
- * <p>Until that contract lands, {@link LoggingMessageChannel} stands in. Keeping the port
- * defined now means the orchestrator, the idempotency guarantees, and the send-time consent
- * re-check are all exercised and testable; only the final hop is stubbed.
+ * <p>Two implementations exist, selected by {@code pos.marketing.send.transport}:
+ * {@link LoggingMessageChannel} ({@code stub}, the default) and
+ * {@link com.positivity.marketing.internal.client.PlatformSenderClient} ({@code platform-sender}).
  */
 public interface MessageChannelPort {
 
     /**
      * Deliver one rendered message.
      *
-     * @param recipientPartyId party to contact; the sender resolves the address under FI-2, so
-     *     this module never holds one
      * @return the outcome, including a provider message id to correlate later delivery events
      */
     @NonNull
-    SendOutcome send(
+    SendOutcome send(@NonNull OutboundMessage message);
+
+    /**
+     * Everything the transport needs for one recipient.
+     *
+     * @param campaignSendId the send record's id — doubles as the client-side idempotency key
+     *     under FI-2, so a retried HTTP call can never become a second email
+     * @param recipientPartyId party to contact; the sender resolves the address under FI-2, so
+     *     this module never holds one
+     * @param contactId specific contact within the party, when audience resolution picked one
+     * @param campaignCode stable campaign code, carried as sender metadata so outcomes and
+     *     provider-side logs can name the campaign without a lookup
+     */
+    record OutboundMessage(
+            @NonNull UUID campaignSendId,
             @NonNull CampaignChannel channel,
             @NonNull UUID recipientPartyId,
+            @Nullable UUID contactId,
+            @NonNull String campaignCode,
             @Nullable String subject,
-            @NonNull String body);
+            @NonNull String body) {}
 
     /**
      * @param accepted whether the provider took the message
      * @param providerMessageId correlation id for delivery, bounce, and complaint callbacks
+     * @param addressHash SHA-256 of the normalized address the sender resolved, when it shares
+     *     one — stored on the send record so a later bounce can be correlated without this
+     *     module ever holding the raw address
      * @param failureReason why the provider refused, when it did
      * @param retryable whether a later attempt could succeed — a throttle is retryable, a
      *     malformed address is not, and retrying the latter forever just burns quota
@@ -43,19 +60,24 @@ public interface MessageChannelPort {
     record SendOutcome(
             boolean accepted,
             @Nullable String providerMessageId,
+            @Nullable String addressHash,
             @Nullable String failureReason,
             boolean retryable) {
 
         public static SendOutcome accepted(String providerMessageId) {
-            return new SendOutcome(true, providerMessageId, null, false);
+            return accepted(providerMessageId, null);
+        }
+
+        public static SendOutcome accepted(String providerMessageId, @Nullable String addressHash) {
+            return new SendOutcome(true, providerMessageId, addressHash, null, false);
         }
 
         public static SendOutcome permanentFailure(String reason) {
-            return new SendOutcome(false, null, reason, false);
+            return new SendOutcome(false, null, null, reason, false);
         }
 
         public static SendOutcome transientFailure(String reason) {
-            return new SendOutcome(false, null, reason, true);
+            return new SendOutcome(false, null, null, reason, true);
         }
     }
 }

--- a/pos-marketing/src/main/resources/application.yml
+++ b/pos-marketing/src/main/resources/application.yml
@@ -82,26 +82,20 @@ pos:
       # (FI-2, docs/PLATFORM_SENDER_CONTRACT.md).
       sender-outcomes-topic: ${POS_MARKETING_SENDER_OUTCOMES_TOPIC:sender.outcomes.v1}
       sender-outcomes-consumer-group: ${POS_MARKETING_SENDER_OUTCOMES_CONSUMER_GROUP:pos-marketing-sender-outcomes}
-      # Bounce/complaint suppression feedback commands aimed at pos-customer (spec §4.3).
+      # Outbound commands to pos-customer: asynchronous segment-membership resolution
+      # (Story #1137) and bounce/complaint suppression feedback (Story #1150, spec §4.3).
       customer-commands-topic: ${POS_MARKETING_CUSTOMER_COMMANDS_TOPIC:customer.commands.v1}
-    send:
-      # Transport behind MessageChannelPort: `stub` logs instead of sending (safe default);
-      # `platform-sender` calls the shared platform sender under the FI-2 contract.
-      transport: ${POS_MARKETING_SEND_TRANSPORT:stub}
     sender:
       # Shared platform sender endpoint + shared secret; only read when transport=platform-sender.
       base-url: ${POS_MARKETING_SENDER_BASE_URL:http://localhost:8085}
       api-secret: ${POS_MARKETING_SENDER_API_SECRET:}
-      # Outbound: asks pos-customer to resolve a segment's membership. Membership is derived
-      # from party data and has no event boundary, so it cannot be replicated continuously.
-      customer-commands-topic: ${POS_MARKETING_CUSTOMER_COMMANDS_TOPIC:customer.commands.v1}
     send:
       # Send-worker pacing (Story #1149). The batch size bounds how many recipients one
       # drain locks; the delay paces the provider so a large campaign does not burst.
       enabled: ${POS_MARKETING_SEND_ENABLED:true}
-      # Transport selection: 'stub' logs what would be sent and contacts nobody. The real
-      # platform-sender adapter arrives with FI-2 (durion#369) and activates on
-      # 'platform-sender'. The two are mutually exclusive by construction.
+      # Transport selection: 'stub' logs what would be sent and contacts nobody;
+      # 'platform-sender' activates the FI-2 adapter (PlatformSenderClient, Story #1150).
+      # The two are mutually exclusive by construction.
       transport: ${POS_MARKETING_SEND_TRANSPORT:stub}
       batch-size: ${POS_MARKETING_SEND_BATCH_SIZE:100}
       poll-delay-ms: ${POS_MARKETING_SEND_POLL_DELAY_MS:5000}

--- a/pos-marketing/src/main/resources/application.yml
+++ b/pos-marketing/src/main/resources/application.yml
@@ -78,6 +78,20 @@ pos:
       # redemption facts — all owned by pos-customer (ADR-0044 R3).
       customer-events-topic: ${POS_MARKETING_CUSTOMER_EVENTS_TOPIC:customer.events.v1}
       customer-events-consumer-group: ${POS_MARKETING_CUSTOMER_EVENTS_CONSUMER_GROUP:pos-marketing-customer-events}
+      # Delivery/bounce/complaint/open/click reports from the shared platform sender
+      # (FI-2, docs/PLATFORM_SENDER_CONTRACT.md).
+      sender-outcomes-topic: ${POS_MARKETING_SENDER_OUTCOMES_TOPIC:sender.outcomes.v1}
+      sender-outcomes-consumer-group: ${POS_MARKETING_SENDER_OUTCOMES_CONSUMER_GROUP:pos-marketing-sender-outcomes}
+      # Bounce/complaint suppression feedback commands aimed at pos-customer (spec §4.3).
+      customer-commands-topic: ${POS_MARKETING_CUSTOMER_COMMANDS_TOPIC:customer.commands.v1}
+    send:
+      # Transport behind MessageChannelPort: `stub` logs instead of sending (safe default);
+      # `platform-sender` calls the shared platform sender under the FI-2 contract.
+      transport: ${POS_MARKETING_SEND_TRANSPORT:stub}
+    sender:
+      # Shared platform sender endpoint + shared secret; only read when transport=platform-sender.
+      base-url: ${POS_MARKETING_SENDER_BASE_URL:http://localhost:8085}
+      api-secret: ${POS_MARKETING_SENDER_API_SECRET:}
       # Outbound: asks pos-customer to resolve a segment's membership. Membership is derived
       # from party data and has no event boundary, so it cannot be replicated continuously.
       customer-commands-topic: ${POS_MARKETING_CUSTOMER_COMMANDS_TOPIC:customer.commands.v1}

--- a/pos-marketing/src/main/resources/db/migration/V7__campaign_send_open_click.sql
+++ b/pos-marketing/src/main/resources/db/migration/V7__campaign_send_open_click.sql
@@ -1,0 +1,7 @@
+-- Story #1150: engagement timestamps from the shared platform sender.
+-- Opens and clicks are best-effort — SMS and some email providers never report them — so both
+-- columns are nullable and the funnel (Story #1152) treats null as "not tracked", never as
+-- "not opened". Only the first open/click is kept; per-event analytics stay with the sender.
+ALTER TABLE campaign_send
+    ADD COLUMN opened_at timestamp(6) with time zone,
+    ADD COLUMN clicked_at timestamp(6) with time zone;

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/client/PlatformSenderClientTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/client/PlatformSenderClientTest.java
@@ -69,7 +69,7 @@ class PlatformSenderClientTest {
     @DisplayName("a 4xx is a permanent refusal — retrying cannot fix it")
     void clientErrorIsPermanent() {
         server.expect(requestTo("http://sender/platform-sender/v1/messages"))
-                .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                .andRespond(withStatus(HttpStatus.UNPROCESSABLE_CONTENT)
                         .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"code\":\"NO_RESOLVABLE_ADDRESS\"}"));
 

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/client/PlatformSenderClientTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/client/PlatformSenderClientTest.java
@@ -1,0 +1,120 @@
+package com.positivity.marketing.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import com.positivity.marketing.internal.enums.CampaignChannel;
+import com.positivity.marketing.internal.service.MessageChannelPort;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Pins the FI-2 adapter's failure mapping (Story #1150): the send worker's retry policy is
+ * only as good as the adapter's transient/permanent classification, and misclassifying a 4xx
+ * as retryable would hammer the sender with a message it will never accept.
+ */
+class PlatformSenderClientTest {
+
+    private static final UUID SEND_ID = UUID.fromString("01960005-0000-7000-8000-000000000070");
+    private static final UUID PARTY = UUID.fromString("01960005-0000-7000-8000-000000000071");
+
+    private MockRestServiceServer server;
+    private PlatformSenderClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new PlatformSenderClient(builder, "http://sender", "secret-1");
+    }
+
+    private static MessageChannelPort.OutboundMessage message() {
+        return new MessageChannelPort.OutboundMessage(
+                SEND_ID, CampaignChannel.EMAIL, PARTY, null, "SPRING-2026", "Hello", "Body");
+    }
+
+    @Test
+    @DisplayName("an accepted message carries the idempotency key and returns the provider id")
+    void acceptedSend() {
+        server.expect(requestTo("http://sender/platform-sender/v1/messages"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("X-Pos-Sender-Secret", "secret-1"))
+                .andExpect(jsonPath("$.messageId").value(SEND_ID.toString()))
+                .andExpect(jsonPath("$.campaignCode").value("SPRING-2026"))
+                .andRespond(withStatus(HttpStatus.ACCEPTED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"providerMessageId\":\"prov-1\",\"addressHash\":\"hash-1\"}"));
+
+        MessageChannelPort.SendOutcome outcome = client.send(message());
+
+        assertThat(outcome.accepted()).isTrue();
+        assertThat(outcome.providerMessageId()).isEqualTo("prov-1");
+        assertThat(outcome.addressHash()).isEqualTo("hash-1");
+    }
+
+    @Test
+    @DisplayName("a 4xx is a permanent refusal — retrying cannot fix it")
+    void clientErrorIsPermanent() {
+        server.expect(requestTo("http://sender/platform-sender/v1/messages"))
+                .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"code\":\"NO_RESOLVABLE_ADDRESS\"}"));
+
+        MessageChannelPort.SendOutcome outcome = client.send(message());
+
+        assertThat(outcome.accepted()).isFalse();
+        assertThat(outcome.retryable()).isFalse();
+        assertThat(outcome.failureReason()).contains("422");
+    }
+
+    @Test
+    @DisplayName("a 5xx is transient and left to the worker's bounded retry")
+    void serverErrorIsTransient() {
+        server.expect(requestTo("http://sender/platform-sender/v1/messages"))
+                .andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE));
+
+        MessageChannelPort.SendOutcome outcome = client.send(message());
+
+        assertThat(outcome.accepted()).isFalse();
+        assertThat(outcome.retryable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("an unreachable sender is transient")
+    void ioErrorIsTransient() {
+        server.expect(requestTo("http://sender/platform-sender/v1/messages"))
+                .andRespond(withException(new IOException("connection refused")));
+
+        MessageChannelPort.SendOutcome outcome = client.send(message());
+
+        assertThat(outcome.accepted()).isFalse();
+        assertThat(outcome.retryable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("acceptance without a providerMessageId is a contract violation worth retrying")
+    void missingProviderMessageIdIsTransient() {
+        server.expect(requestTo("http://sender/platform-sender/v1/messages"))
+                .andRespond(withStatus(HttpStatus.ACCEPTED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{}"));
+
+        MessageChannelPort.SendOutcome outcome = client.send(message());
+
+        assertThat(outcome.accepted()).isFalse();
+        assertThat(outcome.retryable()).isTrue();
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignSendWorkerTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignSendWorkerTest.java
@@ -178,15 +178,23 @@ class CampaignSendWorkerTest {
         givenOneQueuedSend();
         when(eligibilityService.decide(PARTY, CampaignChannel.EMAIL))
                 .thenReturn(new AudienceEligibilityService.Decision(true, "OPT_IN"));
-        when(messageChannel.send(any(), any(), any(), anyString()))
-                .thenReturn(MessageChannelPort.SendOutcome.accepted("provider-1"));
+        when(messageChannel.send(any())).thenReturn(MessageChannelPort.SendOutcome.accepted("provider-1", "hash-1"));
 
         worker().drain();
+
+        ArgumentCaptor<MessageChannelPort.OutboundMessage> outbound =
+                ArgumentCaptor.forClass(MessageChannelPort.OutboundMessage.class);
+        verify(messageChannel).send(outbound.capture());
+        // The send record's id is the FI-2 idempotency key; losing it would let a retried
+        // HTTP call become a second email.
+        assertThat(outbound.getValue().campaignSendId()).isEqualTo(pendingSend().getCampaignSendId());
+        assertThat(outbound.getValue().campaignCode()).isEqualTo("SPRING-2026");
 
         ArgumentCaptor<CampaignSend> saved = ArgumentCaptor.forClass(CampaignSend.class);
         verify(sendRepository).save(saved.capture());
         assertThat(saved.getValue().getStatus()).isEqualTo(SendStatus.SENT);
         assertThat(saved.getValue().getProviderMessageId()).isEqualTo("provider-1");
+        assertThat(saved.getValue().getAddressHash()).isEqualTo("hash-1");
         verify(factPublisher).campaignSent(any(), anyString(), any());
     }
 

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/DeliveryOutcomeListenerTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/DeliveryOutcomeListenerTest.java
@@ -1,0 +1,301 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.marketing.MarketingCampaignSendOutcomeV1;
+import com.positivity.marketing.internal.config.OutboxEventWriter;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.entity.CampaignSend;
+import com.positivity.marketing.internal.entity.ProcessedEvent;
+import com.positivity.marketing.internal.enums.AudienceType;
+import com.positivity.marketing.internal.enums.CampaignChannel;
+import com.positivity.marketing.internal.enums.CampaignStatus;
+import com.positivity.marketing.internal.enums.SendStatus;
+import com.positivity.marketing.internal.repository.CampaignRepository;
+import com.positivity.marketing.internal.repository.CampaignSendRepository;
+import com.positivity.marketing.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Pins the outcome listener's three obligations (Story #1150): send state reflects what the
+ * provider reported, bounces and complaints feed CRM suppression, and none of it double-applies
+ * under at-least-once delivery.
+ */
+@ExtendWith(MockitoExtension.class)
+class DeliveryOutcomeListenerTest {
+
+    private static final UUID CAMPAIGN_ID = UUID.fromString("01960004-0000-7000-8000-000000000060");
+    private static final UUID SEND_ID = UUID.fromString("01960004-0000-7000-8000-000000000061");
+    private static final UUID PARTY = UUID.fromString("01960004-0000-7000-8000-000000000062");
+    private static final String PROVIDER_MESSAGE_ID = "prov-123";
+
+    private final Clock clock = Clock.fixed(Instant.parse("2026-07-30T12:00:00Z"), ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private CampaignSendRepository sendRepository;
+
+    @Mock
+    private CampaignRepository campaignRepository;
+
+    @Mock
+    private MarketingFactPublisher factPublisher;
+
+    @Mock
+    private ObjectProvider<OutboxEventWriter> outboxProvider;
+
+    @Mock
+    private OutboxEventWriter outboxWriter;
+
+    private DeliveryOutcomeListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new DeliveryOutcomeListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                sendRepository,
+                campaignRepository,
+                factPublisher,
+                outboxProvider,
+                "customer.commands.v1");
+    }
+
+    private static CampaignSend sentSend() {
+        return CampaignSend.builder()
+                .campaignSendId(SEND_ID)
+                .campaignId(CAMPAIGN_ID)
+                .recipientPartyId(PARTY)
+                .channel(CampaignChannel.EMAIL)
+                .status(SendStatus.SENT)
+                .providerMessageId(PROVIDER_MESSAGE_ID)
+                .queuedAt(Instant.parse("2026-07-30T10:00:00Z"))
+                .sentAt(Instant.parse("2026-07-30T11:00:00Z"))
+                .updatedAt(Instant.parse("2026-07-30T11:00:00Z"))
+                .build();
+    }
+
+    private void givenSend(CampaignSend send) {
+        when(processedEventRepository.existsById(anyString())).thenReturn(false);
+        when(sendRepository.findByProviderMessageId(PROVIDER_MESSAGE_ID)).thenReturn(Optional.of(send));
+    }
+
+    /** Only outcomes that emit a fact look the campaign up for its code. */
+    private void givenCampaign() {
+        when(campaignRepository.findById(CAMPAIGN_ID))
+                .thenReturn(Optional.of(Campaign.builder()
+                        .campaignId(CAMPAIGN_ID)
+                        .code("SPRING-2026")
+                        .name("Spring")
+                        .audienceType(AudienceType.INDIVIDUAL)
+                        .status(CampaignStatus.SENDING)
+                        .build()));
+    }
+
+    private static String envelope(String eventId, String eventType, String payloadJson) {
+        return "{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":" + payloadJson + "}";
+    }
+
+    @Test
+    @DisplayName("a delivery report moves SENT to DELIVERED and emits the delivered fact")
+    void deliveredUpdatesSend() {
+        CampaignSend send = sentSend();
+        givenCampaign();
+        givenSend(send);
+
+        listener.onSenderOutcome(envelope(
+                "evt-1",
+                DeliveryOutcomeListener.OUTCOME_DELIVERED,
+                "{\"providerMessageId\":\"prov-123\",\"occurredAt\":\"2026-07-30T11:30:00Z\"}"));
+
+        assertThat(send.getStatus()).isEqualTo(SendStatus.DELIVERED);
+        assertThat(send.getDeliveredAt()).isEqualTo(Instant.parse("2026-07-30T11:30:00Z"));
+        verify(sendRepository).save(send);
+        verify(factPublisher)
+                .sendOutcome(eq(send), eq("SPRING-2026"), eq(MarketingCampaignSendOutcomeV1.EVENT_TYPE_DELIVERED));
+        verify(processedEventRepository).save(any(ProcessedEvent.class));
+    }
+
+    @Test
+    @DisplayName("a duplicate eventId is skipped entirely")
+    void duplicateEventIsSkipped() {
+        when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+
+        listener.onSenderOutcome(
+                envelope("evt-1", DeliveryOutcomeListener.OUTCOME_DELIVERED, "{\"providerMessageId\":\"prov-123\"}"));
+
+        verifyNoInteractions(sendRepository, factPublisher);
+    }
+
+    @Test
+    @DisplayName("a hard bounce suppresses the address in CRM and emits the bounced fact")
+    void hardBounceFeedsSuppression() {
+        CampaignSend send = sentSend();
+        givenCampaign();
+        givenSend(send);
+        when(outboxProvider.getIfAvailable()).thenReturn(outboxWriter);
+
+        listener.onSenderOutcome(envelope(
+                "evt-2",
+                DeliveryOutcomeListener.OUTCOME_BOUNCED,
+                "{\"providerMessageId\":\"prov-123\",\"reason\":\"mailbox does not exist\","
+                        + "\"permanent\":true,\"address\":\"jane@example.com\"}"));
+
+        assertThat(send.getStatus()).isEqualTo(SendStatus.BOUNCED);
+        assertThat(send.getFailureReason()).isEqualTo("mailbox does not exist");
+        verify(factPublisher)
+                .sendOutcome(eq(send), eq("SPRING-2026"), eq(MarketingCampaignSendOutcomeV1.EVENT_TYPE_BOUNCED));
+
+        ArgumentCaptor<String> command = ArgumentCaptor.forClass(String.class);
+        verify(outboxWriter).publishRaw(eq("customer.commands.v1"), eq(PARTY.toString()), command.capture());
+        JsonNode json = objectMapper.readTree(command.getValue());
+        assertThat(json.path("commandType").asString()).isEqualTo("customer.suppression.add-requested");
+        // Reusing the outcome eventId makes the command replay-identical under redelivery.
+        assertThat(json.path("eventId").asString()).isEqualTo("evt-2");
+        assertThat(json.path("payload").path("channel").asString()).isEqualTo("EMAIL");
+        assertThat(json.path("payload").path("address").asString()).isEqualTo("jane@example.com");
+        assertThat(json.path("payload").path("partyId").asString()).isEqualTo(PARTY.toString());
+        assertThat(json.path("payload").path("reason").asString()).isEqualTo("HARD_BOUNCE");
+    }
+
+    @Test
+    @DisplayName("a soft bounce records BOUNCED but must not hard-block the address")
+    void softBounceDoesNotSuppress() {
+        CampaignSend send = sentSend();
+        givenCampaign();
+        givenSend(send);
+
+        listener.onSenderOutcome(envelope(
+                "evt-3",
+                DeliveryOutcomeListener.OUTCOME_BOUNCED,
+                "{\"providerMessageId\":\"prov-123\",\"reason\":\"mailbox full\","
+                        + "\"permanent\":false,\"address\":\"jane@example.com\"}"));
+
+        assertThat(send.getStatus()).isEqualTo(SendStatus.BOUNCED);
+        verifyNoInteractions(outboxWriter);
+    }
+
+    @Test
+    @DisplayName("a complaint after delivery still lands, and always suppresses")
+    void complaintAfterDeliverySuppresses() {
+        CampaignSend send = sentSend();
+        givenCampaign();
+        send.setStatus(SendStatus.DELIVERED);
+        givenSend(send);
+        when(outboxProvider.getIfAvailable()).thenReturn(outboxWriter);
+
+        listener.onSenderOutcome(envelope(
+                "evt-4",
+                DeliveryOutcomeListener.OUTCOME_COMPLAINED,
+                "{\"providerMessageId\":\"prov-123\",\"address\":\"jane@example.com\"}"));
+
+        assertThat(send.getStatus()).isEqualTo(SendStatus.COMPLAINED);
+        ArgumentCaptor<String> command = ArgumentCaptor.forClass(String.class);
+        verify(outboxWriter).publishRaw(anyString(), anyString(), command.capture());
+        assertThat(objectMapper
+                        .readTree(command.getValue())
+                        .path("payload")
+                        .path("reason")
+                        .asString())
+                .isEqualTo("SPAM_COMPLAINT");
+    }
+
+    @Test
+    @DisplayName("a bounce without an address updates state but skips the suppression hand-off")
+    void bounceWithoutAddressSkipsSuppression() {
+        CampaignSend send = sentSend();
+        givenCampaign();
+        givenSend(send);
+
+        listener.onSenderOutcome(
+                envelope("evt-5", DeliveryOutcomeListener.OUTCOME_BOUNCED, "{\"providerMessageId\":\"prov-123\"}"));
+
+        assertThat(send.getStatus()).isEqualTo(SendStatus.BOUNCED);
+        verifyNoInteractions(outboxWriter);
+        verify(processedEventRepository).save(any(ProcessedEvent.class));
+    }
+
+    @Test
+    @DisplayName("a delivery report cannot resurrect a bounced send")
+    void deliveryDoesNotDowngradeBounce() {
+        CampaignSend send = sentSend();
+        send.setStatus(SendStatus.BOUNCED);
+        givenSend(send);
+
+        listener.onSenderOutcome(
+                envelope("evt-6", DeliveryOutcomeListener.OUTCOME_DELIVERED, "{\"providerMessageId\":\"prov-123\"}"));
+
+        assertThat(send.getStatus()).isEqualTo(SendStatus.BOUNCED);
+        verify(sendRepository, never()).save(any());
+        // Still recorded as processed: the outcome was seen and deliberately ignored.
+        verify(processedEventRepository).save(any(ProcessedEvent.class));
+    }
+
+    @Test
+    @DisplayName("an outcome for an unknown providerMessageId is retried, not dropped")
+    void unknownProviderMessageIdThrows() {
+        when(processedEventRepository.existsById(anyString())).thenReturn(false);
+        when(sendRepository.findByProviderMessageId("prov-999")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> listener.onSenderOutcome(envelope(
+                        "evt-7", DeliveryOutcomeListener.OUTCOME_DELIVERED, "{\"providerMessageId\":\"prov-999\"}")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("prov-999");
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("opens and clicks stamp first-engagement timestamps; a click implies an open")
+    void engagementStampsTimestamps() {
+        CampaignSend send = sentSend();
+        send.setStatus(SendStatus.DELIVERED);
+        givenSend(send);
+
+        listener.onSenderOutcome(envelope(
+                "evt-8",
+                DeliveryOutcomeListener.OUTCOME_CLICKED,
+                "{\"providerMessageId\":\"prov-123\",\"occurredAt\":\"2026-07-30T11:45:00Z\"}"));
+
+        assertThat(send.getClickedAt()).isEqualTo(Instant.parse("2026-07-30T11:45:00Z"));
+        assertThat(send.getOpenedAt()).isEqualTo(Instant.parse("2026-07-30T11:45:00Z"));
+        assertThat(send.getStatus()).isEqualTo(SendStatus.DELIVERED);
+        verifyNoInteractions(factPublisher);
+    }
+
+    @Test
+    @DisplayName("outcome kinds this module doesn't consume are skipped without a processed row")
+    void irrelevantOutcomeIsSkipped() {
+        when(processedEventRepository.existsById(anyString())).thenReturn(false);
+
+        listener.onSenderOutcome(envelope("evt-9", "sender.message.queued", "{\"providerMessageId\":\"prov-123\"}"));
+
+        verifyNoInteractions(sendRepository, factPublisher);
+        verify(processedEventRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:C2` (CRM Odoo-parity plan, WS-C Wave 3, decision O-1)
- Parent STORY (durion): plan `durion/domains/crm/plan-odoo-parity-pos-customer.md` §4; builds against FI-2 shared platform sender contract (durion#369)
- Child issue: louisburroughs/durion-positivity-backend#1150
- Domain: `domain:marketing` (with suppression command handling in `domain:crm`)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/crm/.business-rules/BACKEND_CONTRACT_GUIDE.md` — new events/commands (`marketing.campaign.send.delivered/bounced/complained` on `marketing.events.v1`, `customer.suppression.add-requested` on `customer.commands.v1`, inbound `sender.outcomes.v1`) described below; guide anchor to be added alongside the durion contract PR (BACKEND_CONTRACT_GUIDE.md)
- Durion contract PR (if applicable): none yet — the FI-2 sender contract (durion#369) had no documented contract, so this PR documents it in `docs/PLATFORM_SENDER_CONTRACT.md`

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controllers changed (Kafka listener, outbound client, config only)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
- What changed:
  Implements Story C2 of the CRM Odoo-parity plan (`durion/domains/crm/plan-odoo-parity-pos-customer.md` §4, Wave 3). Builds against the FI-2 shared platform sender contract (durion#369), which this PR documents in `docs/PLATFORM_SENDER_CONTRACT.md` since no documented contract existed yet.
  - **pos-marketing**: `MessageChannelPort` extended with `OutboundMessage` (`campaignSendId` as FI-2 idempotency key, `campaignCode` metadata) and `SendOutcome.addressHash`; `LoggingMessageChannel` and `CampaignSendWorker` adapted.
  - New `internal/client/PlatformSenderClient` (active on `pos.marketing.send.transport=platform-sender`): POSTs rendered messages to the shared sender (`pos.marketing.sender.base-url`, `X-Pos-Sender-Secret`); 4xx → permanent FAILED, 5xx/IO → transient with bounded worker retry.
  - New `internal/service/DeliveryOutcomeListener` on `sender.outcomes.v1`: delivered/bounced/complained update `CampaignSend` state (idempotent via `processed_events`, correlated by `providerMessageId`, unknown ids retried then DLQ'd); opened/clicked stamp first-engagement timestamps (`V7__campaign_send_open_click.sql`) and degrade gracefully when unsupported by the sender.
  - **Suppression feedback** (AC, spec §4.3): hard bounces and complaints queue `customer.suppression.add-requested` on `customer.commands.v1` via the transactional outbox (raw address relayed only, never persisted; command reuses the outcome eventId so replay is idempotent). Soft bounces (`permanent=false`) never hard-block an address.
  - **pos-customer**: `CustomerCommandListener` handles `customer.suppression.add-requested` → idempotent `SuppressionService.add` (reason HARD_BOUNCE/SPAM_COMPLAINT, source SYSTEM); the resulting `customer.suppression.changed` fact flows back into pos-marketing's `ext_suppression` replica, closing the loop for the next send-time re-check.
  - **pos-domain-events**: `MarketingCampaignSendOutcomeV1` with event types `marketing.campaign.send.delivered/bounced/complained`, published on `marketing.events.v1` per applied terminal outcome.
  - **Config**: `sender-outcomes-topic` (`sender.outcomes.v1`), `customer-commands-topic`, `pos.marketing.send.transport` (default `stub`), `pos.marketing.sender.base-url`/`api-secret`.
- Why: Campaign sends need a real transport to the shared platform sender and a feedback loop so delivery outcomes update send state and hard bounces/complaints reach CRM suppression (acceptance criteria of #1150; A5 #1140 dependency).

Acceptance criteria mapping:
- Outcomes update send state → `DeliveryOutcomeListener` + `DeliveryOutcomeListenerTest` (10 tests).
- Bounces/complaints reach CRM suppression (A5, #1140) → outbox command + `CustomerCommandListener` handler + tests.
- Open/click tracked when supported, degrade gracefully otherwise → nullable `opened_at`/`clicked_at`, first-only stamping, unknown outcome kinds skipped.

Note for reviewers: `FollowUpTaskRepository`/`SegmentReplicaRepository`/`CampaignSendRepository` diffs are spotless formatting normalization only.

## Tests
- [x] Unit tests added/updated (new `PlatformSenderClientTest`, `DeliveryOutcomeListenerTest`; updated `CampaignSendWorkerTest`)
- [ ] Integration tests added/updated — none new in this PR
- [ ] Provider behavioral contract tests added/updated — none; FI-2 sender contract documented in `docs/PLATFORM_SENDER_CONTRACT.md`, contract tests to follow
- How to run:
  - `./mvnw -pl pos-marketing -am test` (49 tests green)
  - `./mvnw -pl pos-customer -am test` (235 tests green)
  - `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test` (12 green)
  - `./mvnw spotless:apply` applied

## Risk & Rollback
- Risk level: Medium — new Kafka listener and outbound transport are additive; default transport remains `stub`, so the platform-sender path is opt-in via config. Suppression commands are idempotent (reuse outcome eventId).
- Rollback plan: revert the commit. `V7__campaign_send_open_click.sql` adds nullable columns only, so rollback leaves harmless unused schema; new event/command types are ignored by consumers running older code.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` (branch is `feature/1150-sender-adapter-outcome-feedback` per the issue-numbered convention)
- [ ] PR title starts with `[CAP:<cap-id>]` (uses the repo's `feat(module): ... (#issue)` convention, matching recent merged PRs)
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed) — pending durion-side PR; sender contract documented in `docs/PLATFORM_SENDER_CONTRACT.md`
- [ ] Required CI checks passing

Closes #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBHu6Gyt1RxBKr2BxS3PF6