### PR TITLE
[CRM] Scheduled SERVICE_DUE_REMINDER follow-up generation (#1153)

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/ServiceHistoryRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/ServiceHistoryRepository.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -35,4 +36,28 @@ public interface ServiceHistoryRepository extends JpaRepository<ServiceHistory, 
 
         Instant getLastCompletedAt();
     }
+
+    /**
+     * Service-due candidates for the reminder job (Story #1153): the most recent completion
+     * per (party, vehicle) that is older than {@code cutoff} and does not yet have a follow-up
+     * task keyed {@code sourcePrefix + serviceHistoryId}. The not-exists runs here rather than
+     * in Java so already-reminded rows never occupy batch slots and starve newer candidates.
+     */
+    @Query("""
+            select sh from ServiceHistory sh
+            where sh.completedAt < :cutoff
+              and sh.completedAt = (
+                  select max(sh2.completedAt) from ServiceHistory sh2
+                  where sh2.partyId = sh.partyId
+                    and ((sh2.vehicleId is null and sh.vehicleId is null) or sh2.vehicleId = sh.vehicleId))
+              and not exists (
+                  select t.taskId from FollowUpTask t
+                  where t.sourceEventId = concat(:sourcePrefix, cast(sh.serviceHistoryId as string)))
+            order by sh.completedAt asc, sh.serviceHistoryId asc
+            """)
+    @NonNull
+    List<ServiceHistory> findServiceDueCandidates(
+            @Param("cutoff") @NonNull Instant cutoff,
+            @Param("sourcePrefix") @NonNull String sourcePrefix,
+            @NonNull Pageable pageable);
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/ServiceDueReminderJob.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/ServiceDueReminderJob.java
@@ -1,0 +1,109 @@
+package com.positivity.customer.internal.service;
+
+import com.positivity.customer.internal.entity.FollowUpTask;
+import com.positivity.customer.internal.entity.ServiceHistory;
+import com.positivity.customer.internal.enums.FollowUpStatus;
+import com.positivity.customer.internal.enums.FollowUpType;
+import com.positivity.customer.internal.repository.FollowUpTaskRepository;
+import com.positivity.customer.internal.repository.ServiceHistoryRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Raises {@code SERVICE_DUE_REMINDER} follow-up tasks from the service-history read model
+ * (Story #1153) — the second automatic feed alongside the declined-service listener.
+ *
+ * <p>A party/vehicle becomes due once its most recent completed service is at least
+ * {@code pos.customer.crm.service-due-months} old — the same module-wide interval the
+ * {@code service.due} segment attribute uses (#1144). pos-vehicle-inventory owns per-vehicle
+ * care-preference intervals but does not yet emit them; when that feed lands, it replaces this
+ * interval, not this job.
+ *
+ * <p>Idempotency has no event envelope to key on, so the task's {@code source_event_id} is the
+ * deterministic {@code service-due:<serviceHistoryId>} of the completion the reminder chases.
+ * The unique index makes a rerun, an overlapping instance, or a still-open prior reminder a
+ * no-op; a new reminder can only appear after a newer completion starts the next cycle.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        prefix = "pos.customer.crm",
+        name = "service-due-reminders-enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class ServiceDueReminderJob {
+
+    /** Prefix of the deterministic {@code source_event_id} idempotency key. */
+    static final String SOURCE_PREFIX = "service-due:";
+
+    private static final String SYSTEM_ACTOR = "service-due-reminder";
+
+    private final Clock clock;
+    private final ServiceHistoryRepository serviceHistoryRepository;
+    private final FollowUpTaskRepository followUpTaskRepository;
+
+    @Value("${pos.customer.crm.service-due-months:6}")
+    private int serviceDueMonths = 6;
+
+    /** Per-run ceiling; anything beyond it is picked up by the next run, never lost. */
+    @Value("${pos.customer.crm.service-due-reminder-batch-size:500}")
+    private int batchSize = 500;
+
+    @Scheduled(cron = "${pos.customer.crm.service-due-reminder-cron:0 0 5 * * *}")
+    public void generateReminders() {
+        ZonedDateTime now = ZonedDateTime.now(clock.withZone(ZoneOffset.UTC));
+        List<ServiceHistory> candidates = serviceHistoryRepository.findServiceDueCandidates(
+                now.minusMonths(serviceDueMonths).toInstant(), SOURCE_PREFIX, PageRequest.of(0, batchSize));
+
+        // Two completions at the same max timestamp both satisfy the latest-row query; one
+        // reminder per party/vehicle per run is enough.
+        Set<String> seenScopes = new HashSet<>();
+        int created = 0;
+        for (ServiceHistory history : candidates) {
+            if (!seenScopes.add(history.getPartyId() + ":" + history.getVehicleId())) {
+                continue;
+            }
+            try {
+                followUpTaskRepository.save(toReminder(history));
+                created++;
+            } catch (DataIntegrityViolationException e) {
+                // Another instance won the race on the unique source_event_id; their task is ours.
+                log.debug("Service-due reminder already exists for serviceHistoryId={}", history.getServiceHistoryId());
+            }
+        }
+        if (created > 0 || !candidates.isEmpty()) {
+            log.info("Service-due reminder run created {} task(s) from {} candidate(s)", created, candidates.size());
+        }
+    }
+
+    private FollowUpTask toReminder(ServiceHistory history) {
+        LocalDate lastServiceDate = LocalDate.ofInstant(history.getCompletedAt(), ZoneOffset.UTC);
+        String reason = "Vehicle service due — last service completed " + lastServiceDate
+                + (history.getWorkorderNumber() != null ? " (workorder " + history.getWorkorderNumber() + ")" : "");
+        return FollowUpTask.builder()
+                .partyId(history.getPartyId())
+                .vehicleId(history.getVehicleId())
+                .type(FollowUpType.SERVICE_DUE_REMINDER)
+                .status(FollowUpStatus.OPEN)
+                .dueDate(lastServiceDate.plusMonths(serviceDueMonths))
+                .sourceWorkorderId(history.getSourceWorkorderId().toString())
+                .sourceEventId(SOURCE_PREFIX + history.getServiceHistoryId())
+                .reason(reason)
+                .createdBy(SYSTEM_ACTOR)
+                .build();
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/ServiceDueReminderJob.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/ServiceDueReminderJob.java
@@ -7,9 +7,9 @@ import com.positivity.customer.internal.enums.FollowUpType;
 import com.positivity.customer.internal.repository.FollowUpTaskRepository;
 import com.positivity.customer.internal.repository.ServiceHistoryRepository;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -65,9 +65,17 @@ public class ServiceDueReminderJob {
 
     @Scheduled(cron = "${pos.customer.crm.service-due-reminder-cron:0 0 5 * * *}")
     public void generateReminders() {
-        ZonedDateTime now = ZonedDateTime.now(clock.withZone(ZoneOffset.UTC));
-        List<ServiceHistory> candidates = serviceHistoryRepository.findServiceDueCandidates(
-                now.minusMonths(serviceDueMonths).toInstant(), SOURCE_PREFIX, PageRequest.of(0, batchSize));
+        // Whole UTC calendar months, same as the service.due segment attribute
+        // (SegmentResolutionService.monthsSince, #1144): a completion is due once its date is
+        // serviceDueMonths old, regardless of time of day — so the cutoff is the start of the
+        // day after the anniversary date, not an instant offset.
+        Instant cutoff = LocalDate.now(clock)
+                .minusMonths(serviceDueMonths)
+                .plusDays(1)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant();
+        List<ServiceHistory> candidates =
+                serviceHistoryRepository.findServiceDueCandidates(cutoff, SOURCE_PREFIX, PageRequest.of(0, batchSize));
 
         // Two completions at the same max timestamp both satisfy the latest-row query; one
         // reminder per party/vehicle per run is enough.
@@ -77,12 +85,24 @@ public class ServiceDueReminderJob {
             if (!seenScopes.add(history.getPartyId() + ":" + history.getVehicleId())) {
                 continue;
             }
+            FollowUpTask reminder = toReminder(history);
             try {
-                followUpTaskRepository.save(toReminder(history));
+                followUpTaskRepository.save(reminder);
                 created++;
             } catch (DataIntegrityViolationException e) {
-                // Another instance won the race on the unique source_event_id; their task is ours.
-                log.debug("Service-due reminder already exists for serviceHistoryId={}", history.getServiceHistoryId());
+                if (followUpTaskRepository.existsBySourceEventId(reminder.getSourceEventId())) {
+                    // Another instance won the race on the unique source_event_id; their task is ours.
+                    log.debug(
+                            "Service-due reminder already exists for serviceHistoryId={}",
+                            history.getServiceHistoryId());
+                } else {
+                    // Some other integrity problem — surface it, but let the rest of the batch run;
+                    // the row stays a candidate and is retried next run.
+                    log.warn(
+                            "Failed to create service-due reminder for serviceHistoryId={}",
+                            history.getServiceHistoryId(),
+                            e);
+                }
             }
         }
         if (created > 0 || !candidates.isEmpty()) {

--- a/pos-customer/src/main/resources/application.yml
+++ b/pos-customer/src/main/resources/application.yml
@@ -78,6 +78,13 @@ pos:
       # service is at least this many whole months old. Module-wide interval until per-vehicle
       # care-preference intervals are fed from pos-vehicle-inventory.
       service-due-months: ${POS_CUSTOMER_SERVICE_DUE_MONTHS:6}
+      # Service-due reminder feed (#1153): raises one SERVICE_DUE_REMINDER follow-up task per
+      # party/vehicle service cycle once its latest completion is service-due-months old.
+      # Idempotent via a deterministic source_event_id, so reruns and concurrent instances
+      # cannot duplicate a task.
+      service-due-reminders-enabled: ${POS_CUSTOMER_SERVICE_DUE_REMINDERS_ENABLED:true}
+      service-due-reminder-cron: ${POS_CUSTOMER_SERVICE_DUE_REMINDER_CRON:0 0 5 * * *}
+      service-due-reminder-batch-size: ${POS_CUSTOMER_SERVICE_DUE_REMINDER_BATCH_SIZE:500}
     inquiry:
       public:
         # Story #1154: the only unauthenticated write surface in pos-customer. OFF by default.

--- a/pos-customer/src/test/java/com/positivity/customer/internal/repository/ServiceHistoryRepositoryTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/repository/ServiceHistoryRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.positivity.customer.internal.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.customer.internal.entity.FollowUpTask;
+import com.positivity.customer.internal.entity.ServiceHistory;
+import com.positivity.customer.internal.enums.FollowUpStatus;
+import com.positivity.customer.internal.enums.FollowUpType;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Query semantics of {@link ServiceHistoryRepository#findServiceDueCandidates} (Story #1153):
+ * only the latest completion per party/vehicle qualifies, only past the cutoff, and never once
+ * a reminder keyed to that completion exists.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class ServiceHistoryRepositoryTest {
+
+    private static final String SOURCE_PREFIX = "service-due:";
+    private static final Instant CUTOFF = Instant.parse("2026-01-20T12:00:00Z");
+    private static final Instant STALE = Instant.parse("2025-11-01T10:00:00Z");
+    private static final Instant RECENT = Instant.parse("2026-06-01T10:00:00Z");
+
+    @Autowired
+    private ServiceHistoryRepository serviceHistoryRepository;
+
+    @Autowired
+    private FollowUpTaskRepository followUpTaskRepository;
+
+    @BeforeEach
+    void setUp() {
+        followUpTaskRepository.deleteAll();
+        serviceHistoryRepository.deleteAll();
+    }
+
+    private ServiceHistory saveHistory(UUID partyId, UUID vehicleId, Instant completedAt) {
+        return serviceHistoryRepository.saveAndFlush(ServiceHistory.builder()
+                .partyId(partyId)
+                .vehicleId(vehicleId)
+                .sourceWorkorderId(UUID.randomUUID())
+                .completedAt(completedAt)
+                .sourceEventId(UUID.randomUUID().toString())
+                .createdAt(completedAt)
+                .build());
+    }
+
+    @Test
+    @DisplayName("Only stale latest completions per party/vehicle are candidates")
+    void selectsOnlyStaleLatestCompletions() {
+        UUID servicedAgainParty = UUID.randomUUID();
+        UUID dueParty = UUID.randomUUID();
+        UUID vehicle = UUID.randomUUID();
+        // Serviced again recently: the stale row is no longer the latest, so not due.
+        saveHistory(servicedAgainParty, vehicle, STALE);
+        saveHistory(servicedAgainParty, vehicle, RECENT);
+        ServiceHistory due = saveHistory(dueParty, UUID.randomUUID(), STALE);
+        ServiceHistory dueNoVehicle = saveHistory(dueParty, null, STALE);
+
+        List<ServiceHistory> candidates =
+                serviceHistoryRepository.findServiceDueCandidates(CUTOFF, SOURCE_PREFIX, PageRequest.of(0, 10));
+
+        assertThat(candidates)
+                .extracting(ServiceHistory::getServiceHistoryId)
+                .containsExactlyInAnyOrder(due.getServiceHistoryId(), dueNoVehicle.getServiceHistoryId());
+    }
+
+    @Test
+    @DisplayName("A completion with an existing keyed reminder is excluded, open or closed")
+    void excludesAlreadyRemindedCompletions() {
+        ServiceHistory reminded = saveHistory(UUID.randomUUID(), UUID.randomUUID(), STALE);
+        ServiceHistory unreminded = saveHistory(UUID.randomUUID(), UUID.randomUUID(), STALE);
+        followUpTaskRepository.saveAndFlush(FollowUpTask.builder()
+                .partyId(reminded.getPartyId())
+                .vehicleId(reminded.getVehicleId())
+                .type(FollowUpType.SERVICE_DUE_REMINDER)
+                .status(FollowUpStatus.OPEN)
+                .sourceEventId(SOURCE_PREFIX + reminded.getServiceHistoryId())
+                .build());
+
+        List<ServiceHistory> candidates =
+                serviceHistoryRepository.findServiceDueCandidates(CUTOFF, SOURCE_PREFIX, PageRequest.of(0, 10));
+
+        assertThat(candidates)
+                .extracting(ServiceHistory::getServiceHistoryId)
+                .containsExactly(unreminded.getServiceHistoryId());
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/ServiceDueReminderJobTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/ServiceDueReminderJobTest.java
@@ -88,16 +88,19 @@ class ServiceDueReminderJobTest {
     }
 
     @Test
-    @DisplayName("Candidates are queried with the configured interval as the cutoff")
+    @DisplayName("Cutoff is whole calendar months: any time of day on the anniversary date is due")
     void queriesWithConfiguredCutoff() {
         when(serviceHistory.findServiceDueCandidates(any(), anyString(), any(Pageable.class)))
                 .thenReturn(List.of());
 
         job.generateReminders();
 
+        // Same whole-UTC-month semantics as the service.due segment attribute (#1144): a
+        // completion anywhere on 2026-01-20 is six months old on 2026-07-20, so the cutoff is
+        // the start of the following day, not now-minus-six-months as an instant.
         verify(serviceHistory)
                 .findServiceDueCandidates(
-                        eq(Instant.parse("2026-01-20T12:00:00Z")),
+                        eq(Instant.parse("2026-01-21T00:00:00Z")),
                         eq(ServiceDueReminderJob.SOURCE_PREFIX),
                         any(Pageable.class));
     }
@@ -130,6 +133,31 @@ class ServiceDueReminderJobTest {
         when(followUps.save(any(FollowUpTask.class)))
                 .thenThrow(new DataIntegrityViolationException("duplicate source_event_id"))
                 .thenAnswer(invocation -> invocation.getArgument(0));
+        // The lost race is confirmed by the winner's row existing.
+        when(followUps.existsBySourceEventId("service-due:" + HISTORY_ID)).thenReturn(true);
+
+        job.generateReminders();
+
+        ArgumentCaptor<FollowUpTask> saved = ArgumentCaptor.forClass(FollowUpTask.class);
+        verify(followUps, times(2)).save(saved.capture());
+        assertThat(saved.getAllValues().get(1).getPartyId()).isEqualTo(otherParty);
+    }
+
+    @Test
+    @DisplayName("An integrity failure that is not the unique-key race still lets the batch finish")
+    void continuesAfterNonRaceIntegrityFailure() {
+        Instant completedAt = Instant.parse("2026-01-05T10:00:00Z");
+        UUID otherParty = UUID.fromString("01980a58-0000-7000-8000-000000000006");
+        UUID otherHistoryId = UUID.fromString("01980a58-0000-7000-8000-000000000007");
+        when(serviceHistory.findServiceDueCandidates(any(), anyString(), any(Pageable.class)))
+                .thenReturn(List.of(
+                        history(HISTORY_ID, PARTY_ID, VEHICLE_ID, completedAt),
+                        history(otherHistoryId, otherParty, VEHICLE_ID, completedAt)));
+        when(followUps.save(any(FollowUpTask.class)))
+                .thenThrow(new DataIntegrityViolationException("outcome check violated"))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        // No row with the key exists, so this was not the race — warned, row retried next run.
+        when(followUps.existsBySourceEventId("service-due:" + HISTORY_ID)).thenReturn(false);
 
         job.generateReminders();
 

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/ServiceDueReminderJobTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/ServiceDueReminderJobTest.java
@@ -1,0 +1,140 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.entity.FollowUpTask;
+import com.positivity.customer.internal.entity.ServiceHistory;
+import com.positivity.customer.internal.enums.FollowUpStatus;
+import com.positivity.customer.internal.enums.FollowUpType;
+import com.positivity.customer.internal.repository.FollowUpTaskRepository;
+import com.positivity.customer.internal.repository.ServiceHistoryRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Unit tests for {@link ServiceDueReminderJob} (Story #1153): stale latest completions become
+ * exactly one {@code SERVICE_DUE_REMINDER} each, keyed deterministically so reruns and racing
+ * instances cannot duplicate a task.
+ */
+class ServiceDueReminderJobTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-20T12:00:00Z"), ZoneOffset.UTC);
+    private static final UUID PARTY_ID = UUID.fromString("01980a58-0000-7000-8000-000000000001");
+    private static final UUID VEHICLE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000002");
+    private static final UUID HISTORY_ID = UUID.fromString("01980a58-0000-7000-8000-000000000003");
+    private static final UUID WORKORDER_ID = UUID.fromString("01980a58-0000-7000-8000-000000000004");
+
+    private final ServiceHistoryRepository serviceHistory = mock(ServiceHistoryRepository.class);
+    private final FollowUpTaskRepository followUps = mock(FollowUpTaskRepository.class);
+
+    private ServiceDueReminderJob job;
+
+    @BeforeEach
+    void setUp() {
+        job = new ServiceDueReminderJob(TEST_CLOCK, serviceHistory, followUps);
+    }
+
+    private ServiceHistory history(UUID historyId, UUID partyId, UUID vehicleId, Instant completedAt) {
+        return ServiceHistory.builder()
+                .serviceHistoryId(historyId)
+                .partyId(partyId)
+                .vehicleId(vehicleId)
+                .sourceWorkorderId(WORKORDER_ID)
+                .workorderNumber("WO-2026-1001")
+                .completedAt(completedAt)
+                .sourceEventId("e-1")
+                .createdAt(completedAt)
+                .build();
+    }
+
+    @Test
+    @DisplayName("A stale latest completion becomes one SERVICE_DUE_REMINDER with a deterministic key")
+    void createsReminder() {
+        Instant completedAt = Instant.parse("2026-01-05T10:00:00Z");
+        when(serviceHistory.findServiceDueCandidates(any(), anyString(), any(Pageable.class)))
+                .thenReturn(List.of(history(HISTORY_ID, PARTY_ID, VEHICLE_ID, completedAt)));
+
+        job.generateReminders();
+
+        ArgumentCaptor<FollowUpTask> saved = ArgumentCaptor.forClass(FollowUpTask.class);
+        verify(followUps).save(saved.capture());
+        FollowUpTask task = saved.getValue();
+        assertThat(task.getType()).isEqualTo(FollowUpType.SERVICE_DUE_REMINDER);
+        assertThat(task.getStatus()).isEqualTo(FollowUpStatus.OPEN);
+        assertThat(task.getPartyId()).isEqualTo(PARTY_ID);
+        assertThat(task.getVehicleId()).isEqualTo(VEHICLE_ID);
+        assertThat(task.getDueDate()).isEqualTo(LocalDate.of(2026, 7, 5));
+        assertThat(task.getSourceWorkorderId()).isEqualTo(WORKORDER_ID.toString());
+        assertThat(task.getSourceEventId()).isEqualTo("service-due:" + HISTORY_ID);
+        assertThat(task.getReason()).contains("2026-01-05").contains("WO-2026-1001");
+        assertThat(task.getCreatedBy()).isEqualTo("service-due-reminder");
+    }
+
+    @Test
+    @DisplayName("Candidates are queried with the configured interval as the cutoff")
+    void queriesWithConfiguredCutoff() {
+        when(serviceHistory.findServiceDueCandidates(any(), anyString(), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        job.generateReminders();
+
+        verify(serviceHistory)
+                .findServiceDueCandidates(
+                        eq(Instant.parse("2026-01-20T12:00:00Z")),
+                        eq(ServiceDueReminderJob.SOURCE_PREFIX),
+                        any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("Two candidates for the same party/vehicle in one run yield a single reminder")
+    void dedupesSamePartyAndVehicleWithinRun() {
+        Instant completedAt = Instant.parse("2026-01-05T10:00:00Z");
+        UUID otherHistoryId = UUID.fromString("01980a58-0000-7000-8000-000000000005");
+        when(serviceHistory.findServiceDueCandidates(any(), anyString(), any(Pageable.class)))
+                .thenReturn(List.of(
+                        history(HISTORY_ID, PARTY_ID, VEHICLE_ID, completedAt),
+                        history(otherHistoryId, PARTY_ID, VEHICLE_ID, completedAt)));
+
+        job.generateReminders();
+
+        verify(followUps, times(1)).save(any(FollowUpTask.class));
+    }
+
+    @Test
+    @DisplayName("Losing the unique-key race on one reminder does not stop the rest of the batch")
+    void continuesAfterUniqueKeyRace() {
+        Instant completedAt = Instant.parse("2026-01-05T10:00:00Z");
+        UUID otherParty = UUID.fromString("01980a58-0000-7000-8000-000000000006");
+        UUID otherHistoryId = UUID.fromString("01980a58-0000-7000-8000-000000000007");
+        when(serviceHistory.findServiceDueCandidates(any(), anyString(), any(Pageable.class)))
+                .thenReturn(List.of(
+                        history(HISTORY_ID, PARTY_ID, VEHICLE_ID, completedAt),
+                        history(otherHistoryId, otherParty, VEHICLE_ID, completedAt)));
+        when(followUps.save(any(FollowUpTask.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate source_event_id"))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        job.generateReminders();
+
+        ArgumentCaptor<FollowUpTask> saved = ArgumentCaptor.forClass(FollowUpTask.class);
+        verify(followUps, times(2)).save(saved.capture());
+        assertThat(saved.getAllValues().get(1).getPartyId()).isEqualTo(otherParty);
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (Odoo-parity plan `durion/domains/crm/plan-odoo-parity-pos-customer.md` §5, WS-D Wave 4)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1153
- Domain: `domain:crm`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/crm/.business-rules/BACKEND_CONTRACT_GUIDE.md` → not applicable — no controllers, DTOs, events, or OpenAPI files change in this PR; it adds an internal scheduled job, a repository query, config defaults, and tests.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — not needed
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — not needed

## Scope
- What changed:
  - `ServiceDueReminderJob` (pos-customer): daily cron (default 05:00 UTC, toggleable via `pos.customer.crm.service-due-reminders-enabled`) that raises one `SERVICE_DUE_REMINDER` follow-up task per party/vehicle once its latest completed service is `pos.customer.crm.service-due-months` (default 6) old.
  - `ServiceHistoryRepository.findServiceDueCandidates`: batched candidate query — latest completion per party/vehicle, past the cutoff, with the "not yet reminded" filter pushed into SQL so already-reminded rows never occupy batch slots.
  - Idempotency without an event envelope: each task's `source_event_id` is the deterministic `service-due:<serviceHistoryId>`, so the existing unique index makes reruns, overlapping instances, and replays no-ops; a new reminder can only follow a newer completion.
  - New config defaults in `application.yml` (`service-due-reminders-enabled`, `service-due-reminder-cron`, `service-due-reminder-batch-size`).
- Why: closes the last gap in #1153. The follow-up task model, endpoints, permissions, and the declined-service listener already landed (#1158, #1165), but nothing raised `SERVICE_DUE_REMINDER` tasks automatically. The job reuses the module-wide service-due interval from the #1144 segment attribute; per-vehicle care-preference intervals stay a future pos-vehicle-inventory feed (its `VehicleCarePreference` is an unstructured JSONB blob with no feed today), and that feed will replace the interval, not this job.

## Tests
- [x] Unit tests added/updated — `ServiceDueReminderJobTest` (4 tests: field mapping + deterministic key, configured cutoff, per-run party/vehicle dedupe, unique-key race continues the batch)
- [x] Integration tests added/updated — `ServiceHistoryRepositoryTest` (H2-backed query semantics: latest-only, cutoff, keyed-reminder exclusion open or closed)
- [ ] Provider behavioral contract tests added/updated — n/a, no API/event contract change
- How to run: `./mvnw -pl pos-customer -Dtest=ServiceDueReminderJobTest,ServiceHistoryRepositoryTest test` (full module suite: 246 tests, 0 failures)

## Risk & Rollback
- Risk level: Low — additive; no schema change (reuses `follow_up_task` and its `uq_follow_up_task_source_event` index), no endpoint change; job is a no-op until service-history rows age past the interval.
- Rollback plan: set `POS_CUSTOMER_SERVICE_DUE_REMINDERS_ENABLED=false` (bean not created) or revert the commit; generated tasks are ordinary follow-ups a CSR can dismiss.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/issue-1153-m07l3d` per the issue workflow
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id for this story; titled with the `[CRM]` module tag instead
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [x] Required CI checks passing — pos-customer suite green locally; CI pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpAtLNFqnkokVdbKNieaXZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpAtLNFqnkokVdbKNieaXZ)_