### PR TITLE
Implement BACKEND_BUILD_SPEC phases 0–6: single-reactor CI, dependent testing, artifact promotion

### DIFF
--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -1,15 +1,15 @@
 name: Build and Push to ECR
 
+# Promotes the JARs that passed CI instead of rebuilding from source
+# (BACKEND_BUILD_SPEC.md §4.6): runs after a successful "Backend CI/CD"
+# main-push run and downloads its service-jars artifact, so the image
+# contains the tested bytes and a red CI run can never race a green ECR
+# push for the same commit.
 on:
-  push:
+  workflow_run:
+    workflows: ["Backend CI/CD"]
+    types: [completed]
     branches: [main]
-    paths:
-      - "pos-*/**"
-      - "pom.xml"
-      - "docker-compose.yml"
-      - "postgres/**"
-      - "deployment/alpha/docker-compose.prod.yml"
-      - ".github/workflows/build-push-ecr.yml"
   workflow_dispatch:
     inputs:
       deploy_alpha:
@@ -19,7 +19,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ecr-push-backend-${{ github.ref }}
+  group: ecr-push-backend-${{ github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -27,6 +27,10 @@ env:
   JAVA_VERSION: "25"
   JAVA_DISTRIBUTION: temurin
   MAVEN_OPTS: -Xmx3072m
+  # The commit being shipped: the CI run's head for workflow_run events,
+  # the current ref for manual dispatches. github.sha would be the default
+  # branch head at event time, which can race ahead of the tested commit.
+  BUILD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
@@ -35,6 +39,12 @@ jobs:
   detect-services:
     name: Detect Changed Services
     runs-on: ubuntu-latest
+    # Promote only successful CI runs for pushes to main; manual dispatch
+    # keeps working as a full rebuild-and-push.
+    if: github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main')
     outputs:
       services: ${{ steps.detect.outputs.services }}
       modules-csv: ${{ steps.detect.outputs.modules-csv }}
@@ -46,6 +56,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ env.BUILD_SHA }}
 
       - name: Detect services to build
         id: detect
@@ -76,11 +87,13 @@ jobs:
             exit 0
           fi
 
-          DIFF_BASE="${{ github.event.before }}"
-          DIFF_HEAD="${{ github.sha }}"
-          if [[ -z "${DIFF_BASE}" || "${DIFF_BASE}" == "0000000000000000000000000000000000000000" ]]; then
-            DIFF_BASE="$(git rev-parse HEAD~1)"
-          fi
+          # workflow_run events carry no push before/after pair; diff the shipped
+          # commit against its first parent. Squash-merged PRs (the norm here) are
+          # one commit, so this covers the whole change; a rare multi-commit push
+          # can under-select, and AUTO_DEPLOY_ALPHA=true or a manual dispatch
+          # forces the full set regardless.
+          DIFF_HEAD="${BUILD_SHA}"
+          DIFF_BASE="$(git rev-parse "${DIFF_HEAD}~1")"
 
           CHANGED_FILES="$(git diff --name-only "${DIFF_BASE}" "${DIFF_HEAD}" || true)"
 
@@ -123,40 +136,75 @@ jobs:
           fi
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Job 2: Build changed JARs with Maven and upload as a shared artifact
+  # Job 2: Collect the tested JARs from the triggering CI run (spec §4.6);
+  # build from source only what the artifact is missing (or on dispatch).
   # ─────────────────────────────────────────────────────────────────────────
   build-jars:
-    name: Maven Package (selected modules)
+    name: Collect tested JARs
     needs: detect-services
     if: needs.detect-services.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read # cross-run artifact download from the CI workflow run
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ env.BUILD_SHA }}
+
+      - name: Download tested JARs from CI run
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: service-jars
+          path: ci-jars
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Stage tested JARs, list missing services
+        id: stage
+        run: |
+          set -euo pipefail
+          rm -rf artifact-jars
+          MISSING=()
+          for service in $(jq -r '.[]' <<< '${{ needs.detect-services.outputs.services }}'); do
+            JAR_PATH="$(find ci-jars -type f -path "*/${service}/target/*.jar" 2>/dev/null | head -n 1 || true)"
+            if [[ -n "${JAR_PATH}" ]]; then
+              mkdir -p "artifact-jars/${service}/target"
+              cp "${JAR_PATH}" "artifact-jars/${service}/target/"
+              echo "tested JAR: ${service}"
+            else
+              MISSING+=("${service}")
+              echo "missing from CI artifact: ${service}"
+            fi
+          done
+          MISSING_CSV="$(IFS=,; echo "${MISSING[*]-}")"
+          echo "missing-csv=${MISSING_CSV}" >> "$GITHUB_OUTPUT"
 
       - name: Set Maven revision
+        if: steps.stage.outputs.missing-csv != ''
         run: printf -- "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT\n-Dmaven.build.cache.enabled=false\n" > .mvn/maven.config
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
+        if: steps.stage.outputs.missing-csv != ''
         uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           cache: maven
 
-      - name: Build selected JARs (skip tests — tested separately in ci.yml)
-        run: ./mvnw -pl ${{ needs.detect-services.outputs.modules-csv }} -am package -B -DskipTests -q
-
-      - name: Stage JAR artifacts
+      - name: Build missing JARs from source (fallback)
+        if: steps.stage.outputs.missing-csv != ''
         run: |
           set -euo pipefail
-          rm -rf artifact-jars
-          jq -r '.[]' <<< '${{ needs.detect-services.outputs.services }}' | while read -r service; do
+          ./mvnw -pl "${{ steps.stage.outputs.missing-csv }}" -am package -B -DskipTests -T 1C -q
+          for service in $(tr ',' ' ' <<< "${{ steps.stage.outputs.missing-csv }}"); do
             mkdir -p "artifact-jars/${service}/target"
-            cp "${service}"/target/*.jar "artifact-jars/${service}/target/"
+            find "${service}/target" -maxdepth 1 -name '*.jar' ! -name '*.jar.original' \
+              -exec cp {} "artifact-jars/${service}/target/" \;
           done
 
       - name: Store JAR artifacts
@@ -187,6 +235,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ env.BUILD_SHA }}
 
       - name: Download JAR artifacts
         uses: actions/download-artifact@v5
@@ -226,7 +276,7 @@ jobs:
       - name: Set image metadata
         id: meta
         run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
+          SHORT_SHA="${BUILD_SHA::7}"
           IMAGE_TAG="sha-${SHORT_SHA}"
           SERVICE="${{ matrix.service }}"
           # Some services publish to repository names that differ from the module directory.
@@ -275,7 +325,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SHORT_SHA="${GITHUB_SHA::7}"
+          SHORT_SHA="${BUILD_SHA::7}"
           IMAGE_TAG="sha-${SHORT_SHA}"
           SERVICE_COUNT="$(jq 'length' <<< '${{ needs.detect-services.outputs.services }}')"
           # Derived from the canonical list in detect-services so it can't go stale
@@ -306,7 +356,7 @@ jobs:
             echo "This run published only changed services. Unchanged services were not retagged to \`${IMAGE_TAG}\`, so this tag is not valid for whole-stack deployment." >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Commit: \`${GITHUB_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Commit: \`${BUILD_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
 
   deploy-alpha:
     name: Deploy Backend to Alpha
@@ -325,6 +375,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ env.BUILD_SHA }}
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
@@ -361,7 +413,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "${{ vars.ALPHA_EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
-            --parameters "{\"commands\":[\"SECURITY_SEED_ADMIN_PASSWORD_HASH='${SECURITY_SEED_ADMIN_PASSWORD_HASH}' bash /opt/durion/alpha/scripts/deploy-backend.sh '${{ github.sha }}'\"]}" \
+            --parameters "{\"commands\":[\"SECURITY_SEED_ADMIN_PASSWORD_HASH='${SECURITY_SEED_ADMIN_PASSWORD_HASH}' bash /opt/durion/alpha/scripts/deploy-backend.sh '${{ env.BUILD_SHA }}'\"]}" \
             --timeout-seconds 2700 \
             --query "Command.CommandId" --output text)
           echo "SSM Command ID: $COMMAND_ID"

--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -138,7 +138,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
+        run: printf -- "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT\n-Dmaven.build.cache.enabled=false\n" > .mvn/maven.config
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,8 @@ jobs:
         # every cache key, and nothing downstream consumes PR artifacts by version.
         # (The pilot's first run exposed pos-archunit's 2.4 GB fat jar, which the
         # extension's output hashing cannot read — fixed in pos-archunit/pom.xml.)
+        # The ArchUnit step below opts back out of the cache: restored modules
+        # resolve as fat JARs, not target/classes, which blinds the rules (#909).
         if: github.event_name == 'pull_request'
         run: echo "-Dmaven.build.cache.enabled=true" > .mvn/maven.config
 
@@ -226,10 +228,15 @@ jobs:
             -T 1C -B -ntp
 
       - name: Run ArchUnit rules
+        # Cache opt-out: a build-cache hit restores sibling modules as their
+        # repackaged fat JARs instead of materializing target/classes, hiding
+        # every application class under BOOT-INF/classes — the exact #909
+        # failure mode ClasspathVisibilityGuardTest exists to catch.
         run: |
           ./mvnw -pl pos-archunit -am -DskipTests=false test \
             -Dtest='com/positivity/archunit/*' \
             -Dsurefire.failIfNoSpecifiedTests=false \
+            -Dmaven.build.cache.enabled=false \
             -DskipITs -T 1C -B -ntp -q
 
       - name: Save reactor build to cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
     if: github.event_name != 'schedule'
     outputs:
       modules: ${{ steps.detect.outputs.modules }}
+      changed-modules: ${{ steps.detect.outputs.changed-modules }}
+      full-reactor: ${{ steps.detect.outputs.full-reactor }}
       has-changes: ${{ steps.detect.outputs.has-changes }}
 
     steps:
@@ -60,53 +62,42 @@ jobs:
         run: |
           set -euo pipefail
 
-          ARCHUNIT_MODULE="pos-archunit"
-          NON_TEST_MODULES_JSON='["pos-dependencies","pos-coverage-aggregate"]'
-          ALL_MODULES_JSON=$(ls -d pos-* | jq -R -s -c --argjson excluded "${NON_TEST_MODULES_JSON}" 'split("\n")[:-1] | map(select((. as $module | $excluded | index($module)) | not))')
-
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "modules=${ALL_MODULES_JSON}" >> "$GITHUB_OUTPUT"
-            echo "has-changes=true" >> "$GITHUB_OUTPUT"
-            echo "workflow_dispatch: testing all modules"
-            exit 0
-          fi
-
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1
-            DIFF_BASE="origin/${{ github.base_ref }}"
-            DIFF_HEAD="${{ github.sha }}"
+            DETECTION="$(./scripts/ci/detect-modules.sh --full)"
           else
-            DIFF_BASE="${{ github.event.before }}"
-            DIFF_HEAD="${{ github.sha }}"
-            if [[ -z "${DIFF_BASE}" || "${DIFF_BASE}" == "0000000000000000000000000000000000000000" ]]; then
-              DIFF_BASE="$(git rev-parse HEAD~1)"
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              git fetch origin "${{ github.base_ref }}" --depth=1
+              DIFF_BASE="origin/${{ github.base_ref }}"
+              DIFF_HEAD="${{ github.sha }}"
+            else
+              DIFF_BASE="${{ github.event.before }}"
+              DIFF_HEAD="${{ github.sha }}"
+              if [[ -z "${DIFF_BASE}" || "${DIFF_BASE}" == "0000000000000000000000000000000000000000" ]]; then
+                DIFF_BASE="$(git rev-parse HEAD~1)"
+              fi
             fi
+            DETECTION="$(./scripts/ci/detect-modules.sh "${DIFF_BASE}" "${DIFF_HEAD}")"
           fi
 
-          CHANGED_FILES=$(git diff --name-only "${DIFF_BASE}" "${DIFF_HEAD}" || true)
+          echo "Detection: ${DETECTION}"
+          FULL_REACTOR="$(jq -r '.full_reactor' <<< "${DETECTION}")"
+          CHANGED_JSON="$(jq -c '.modules' <<< "${DETECTION}")"
 
-          if echo "${CHANGED_FILES}" | grep -Eq '^(pom\.xml|\.github/workflows/ci\.yml|docker-compose\.yml)$'; then
-            echo "modules=${ALL_MODULES_JSON}" >> "$GITHUB_OUTPUT"
-            echo "has-changes=true" >> "$GITHUB_OUTPUT"
-            echo "Core CI/build file changed: testing all modules"
-            exit 0
-          fi
-
-          CHANGED_MODULES_JSON=$(echo "${CHANGED_FILES}" | grep '^pos-' | cut -d'/' -f1 | sort -u | jq -R -s -c --argjson excluded "${NON_TEST_MODULES_JSON}" 'split("\n")[:-1] | map(select((. as $module | $excluded | index($module)) | not))')
-          MATRIX_MODULES_JSON=$(jq -cn \
-            --argjson changed "${CHANGED_MODULES_JSON}" \
-            --arg archunit "${ARCHUNIT_MODULE}" \
-            '$changed + [$archunit] | unique')
-
-          if [[ "${CHANGED_MODULES_JSON}" == "[]" ]]; then
-            echo "modules=${MATRIX_MODULES_JSON}" >> "$GITHUB_OUTPUT"
-            echo "has-changes=true" >> "$GITHUB_OUTPUT"
-            echo "No pos-* module changes detected; running ${ARCHUNIT_MODULE}"
+          # Matrix view of the detection: every selectable module when the whole
+          # reactor is affected, otherwise the changed modules plus pos-archunit
+          # (current behaviour, preserved — a CI-triggering change that maps to
+          # no module still runs pos-archunit, so has-changes is always true).
+          NON_TEST_MODULES_JSON='["pos-dependencies","pos-coverage-aggregate"]'
+          if [[ "${FULL_REACTOR}" == "true" ]]; then
+            MATRIX_JSON=$(ls -d pos-* | jq -R -s -c --argjson excluded "${NON_TEST_MODULES_JSON}" 'split("\n")[:-1] | map(select((. as $module | $excluded | index($module)) | not))')
           else
-            echo "modules=${MATRIX_MODULES_JSON}" >> "$GITHUB_OUTPUT"
-            echo "has-changes=true" >> "$GITHUB_OUTPUT"
-            echo "Changed modules (+${ARCHUNIT_MODULE}): ${MATRIX_MODULES_JSON}"
+            MATRIX_JSON=$(jq -c '. + ["pos-archunit"] | unique' <<< "${CHANGED_JSON}")
           fi
+
+          echo "full-reactor=${FULL_REACTOR}" >> "$GITHUB_OUTPUT"
+          echo "changed-modules=${CHANGED_JSON}" >> "$GITHUB_OUTPUT"
+          echo "modules=${MATRIX_JSON}" >> "$GITHUB_OUTPUT"
+          echo "has-changes=true" >> "$GITHUB_OUTPUT"
 
   build-reactor:
     name: Build Reactor (install all)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,30 @@ jobs:
           echo "modules=${MATRIX_JSON}" >> "$GITHUB_OUTPUT"
           echo "has-changes=true" >> "$GITHUB_OUTPUT"
 
-  build-reactor:
-    name: Build Reactor (install all)
+  build-test:
+    # One job, three reactor invocations (BACKEND_BUILD_SPEC.md §4.2/§4.3, adapted):
+    #
+    #  1. install -DskipTests        — full reactor, ~2 min warm. Needed because
+    #     Maven's -amd includes dependents of the selection but NOT the dependents'
+    #     own upstream dependencies, so a purely selective build cannot resolve on
+    #     a clean runner; and pos-archunit depends on nearly every module anyway.
+    #     This also populates ~/.m2 with every internal artifact for the SHA-keyed
+    #     reactor cache and packages every service JAR for downstream jobs.
+    #  2. selective tests            — -pl <changed> -amd runs the changed modules'
+    #     tests plus every dependent's tests (gap G1): PRs stop at `test` (ITs
+    #     skipped), main pushes run `verify` (failsafe ITs included). Dependencies
+    #     absent from the -amd reactor resolve from the step-1 install.
+    #  3. pos-archunit rules         — its own -am reactor stopped at the `test`
+    #     phase, where sibling classes resolve from target/classes. Running the
+    #     rules past `package` lets spring-boot:repackage swap siblings for fat
+    #     JARs whose classes hide under BOOT-INF/classes, and every rule passes
+    #     vacuously (#909) — which is also why -Darchunit.skipTests=true is set on
+    #     invocations 1 and 2.
+    #
+    # Replaces the former build-reactor job and both per-module test matrices:
+    # same three build shapes, minus ~70s×N of per-job setup/cache-restore
+    # overhead and the inter-job queue gaps (docs/build-timings-baseline.md).
+    name: Build & Test (reactor)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -130,193 +152,129 @@ jobs:
           key: ${{ runner.os }}-maven-wrapper-${{
             hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
 
-      - name: Install all modules (skip tests)
-        run: ./mvnw install -DskipTests -DskipITs -T 1C -B -q
-
-      - name: Warm up test-execution infrastructure for offline jobs
-        # Run a real test on the smallest module so Maven downloads all Surefire /
-        # JUnit Platform runtime artifacts (surefire-junit-platform, junit-platform-launcher,
-        # etc.) before they are needed by the offline matrix jobs.
-        run: ./mvnw -pl pos-events test -DskipITs -T 1C -B -q
-
-      - name: Save reactor build to cache
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-reactor-${{ github.sha }}
-
-  unit-tests:
-    name: Unit Tests (${{ matrix.module }})
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs: [ detect-test-modules, build-reactor ]
-    if: needs.detect-test-modules.outputs.has-changes == 'true'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        module: ${{ fromJson(needs.detect-test-modules.outputs.modules) }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0 # Full history for better change detection
-
-      - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-
-      - name: Cache Maven wrapper binary
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/wrapper
-          key: ${{ runner.os }}-maven-wrapper-${{
-            hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
-
-      - name: Restore reactor build cache
-        id: restore-reactor-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-reactor-${{ github.sha }}
-
-      - name: Bootstrap local Maven repo on cache miss
-        if: steps.restore-reactor-cache.outputs.cache-hit != 'true'
-        run: |
-          ./mvnw install -DskipTests -DskipITs -T 1C -B -q
-          ./mvnw -pl pos-events test -DskipITs -T 1C -B -q
-
       - name: Enforce no-arg now() policy
         run: ./scripts/check-noarg-now.sh
 
       - name: Enforce Flyway migration hygiene
         run: ./scripts/check-flyway-hygiene.sh
 
-      - name: Run unit tests
-        # pos-archunit's cross-module rules need sibling modules' target/classes on the
-        # classpath: the installed Spring Boot fat jars hide application classes under
-        # BOOT-INF/classes and every rule passes vacuously (#909). Build it as a reactor
-        # (-am) while running only its own tests in the upstream modules' place.
+      - name: Install reactor (skip tests)
+        run: ./mvnw install -DskipTests -DskipITs -Darchunit.skipTests=true -T 1C -B -ntp -q
+
+      - name: Compute test selection
+        id: selection
+        env:
+          FULL_REACTOR: ${{ needs.detect-test-modules.outputs.full-reactor }}
+          CHANGED_MODULES: ${{ needs.detect-test-modules.outputs.changed-modules }}
         run: |
-          if [[ "${{ matrix.module }}" == "pos-archunit" ]]; then
-            ./mvnw -pl pos-archunit -am test \
-              org.jacoco:jacoco-maven-plugin:0.8.14:report \
-              -Dtest='com/positivity/archunit/*' \
-              -Dsurefire.failIfNoSpecifiedTests=false \
-              -DskipITs -T 1C -B -q -o
+          set -euo pipefail
+          if [[ "${FULL_REACTOR}" == "true" ]]; then
+            # Whole reactor affected: no -pl, every module's tests run.
+            echo "args=" >> "$GITHUB_OUTPUT"
+            echo "run-tests=true" >> "$GITHUB_OUTPUT"
           else
-            ./mvnw -pl ${{ matrix.module }} test \
-              org.jacoco:jacoco-maven-plugin:0.8.14:report -DskipITs -T 1C -B -q -o
+            CSV="$(jq -r 'join(",")' <<< "${CHANGED_MODULES}")"
+            if [[ -z "${CSV}" ]]; then
+              # No module changed (e.g. root Dockerfile): archunit still runs below.
+              echo "args=" >> "$GITHUB_OUTPUT"
+              echo "run-tests=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "args=-pl ${CSV} -amd" >> "$GITHUB_OUTPUT"
+              echo "run-tests=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
+
+      - name: Test changed modules and dependents (PR)
+        if: github.event_name == 'pull_request' && steps.selection.outputs.run-tests == 'true'
+        # lowResourceTests bounds each Surefire fork to 1 GiB: with -T 1C up to four
+        # module builds fork test JVMs concurrently, and default heap sizing would
+        # overcommit the 16 GB runner.
+        run: |
+          ./mvnw ${{ steps.selection.outputs.args }} \
+            -DskipTests=false test \
+            org.jacoco:jacoco-maven-plugin:0.8.14:report \
+            -Darchunit.skipTests=true \
+            -DlowResourceTests=true \
+            -DskipITs -T 1C -B -ntp
+
+      - name: Test changed modules and dependents incl. ITs (main)
+        if: github.event_name != 'pull_request' && steps.selection.outputs.run-tests == 'true'
+        run: |
+          ./mvnw ${{ steps.selection.outputs.args }} \
+            -DskipTests=false verify \
+            org.jacoco:jacoco-maven-plugin:0.8.14:report \
+            -Darchunit.skipTests=true \
+            -DlowResourceTests=true \
+            -T 1C -B -ntp
+
+      - name: Run ArchUnit rules
+        run: |
+          ./mvnw -pl pos-archunit -am -DskipTests=false test \
+            -Dtest='com/positivity/archunit/*' \
+            -Dsurefire.failIfNoSpecifiedTests=false \
+            -DskipITs -T 1C -B -ntp -q
+
+      - name: Save reactor build to cache
+        if: github.event_name != 'pull_request'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-reactor-${{ github.sha }}
+
+      - name: Stage service JARs
+        if: github.event_name != 'pull_request'
+        # The bytes downstream Docker/ECR jobs ship (spec §4.6): one JAR per
+        # containerized module, all packaged by the step-1 install.
+        run: |
+          set -euo pipefail
+          rm -rf artifact-jars
+          for dockerfile in pos-*/Dockerfile; do
+            service="${dockerfile%%/*}"
+            jar="$(find "${service}/target" -maxdepth 1 -name '*.jar' ! -name '*.jar.original' 2>/dev/null | head -n 1 || true)"
+            if [[ -n "${jar}" ]]; then
+              mkdir -p "artifact-jars/${service}/target"
+              cp "${jar}" "artifact-jars/${service}/target/"
+            fi
+          done
+          find artifact-jars -maxdepth 2 -print | sort
+
+      - name: Upload service JARs
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v6
+        with:
+          name: service-jars
+          path: artifact-jars
+          retention-days: 3
+          if-no-files-found: error
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: unit-test-results-${{ matrix.module }}
+          name: test-results-reactor
           path: |
             **/target/surefire-reports/*.xml
+            **/target/failsafe-reports/*.xml
+          if-no-files-found: ignore
           retention-days: 30
 
       - name: Upload JaCoCo coverage report
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: jacoco-coverage-${{ matrix.module }}
+          name: jacoco-coverage-reactor
           path: |
             **/target/site/jacoco/jacoco.xml
           if-no-files-found: ignore
           retention-days: 7
 
-  integration-tests-modules:
-    name: Integration Tests (${{ matrix.module }})
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs: [ detect-test-modules, build-reactor ]
-    if: needs.detect-test-modules.outputs.has-changes == 'true' &&
-      (github.event_name == 'workflow_dispatch' || (github.event_name == 'push'
-      && github.ref == 'refs/heads/main'))
-
-    strategy:
-      fail-fast: false
-      matrix:
-        module: ${{ fromJson(needs.detect-test-modules.outputs.modules) }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-
-      - name: Cache Maven wrapper binary
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/wrapper
-          key: ${{ runner.os }}-maven-wrapper-${{
-            hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
-
-      - name: Restore reactor build cache
-        id: restore-reactor-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-reactor-${{ github.sha }}
-
-      - name: Bootstrap local Maven repo on cache miss
-        if: steps.restore-reactor-cache.outputs.cache-hit != 'true'
-        run: |
-          ./mvnw install -DskipTests -DskipITs -T 1C -B -q
-          ./mvnw -pl pos-events test -DskipITs -T 1C -B -q
-
-      - name: Run integration tests
-        # pos-archunit has no failsafe ITs, and running `verify` on the -am reactor
-        # takes the upstream modules through package, where spring-boot:repackage
-        # swaps their jars for fat jars whose classes hide under BOOT-INF/classes —
-        # ArchUnit then sees nothing and ClasspathVisibilityGuardTest fails (#909).
-        # Stop at the test phase so siblings resolve to target/classes, exactly as
-        # in the unit-tests job.
-        run: |
-          if [[ "${{ matrix.module }}" == "pos-archunit" ]]; then
-            ./mvnw -pl pos-archunit -am -DskipTests=false test \
-              -Dtest='com/positivity/archunit/*' \
-              -Dsurefire.failIfNoSpecifiedTests=false \
-              -DskipITs -T 1C -B -q -o
-          else
-            ./mvnw -pl ${{ matrix.module }} -DskipTests=false verify -T 1C -B -q -o
-          fi
-
-      - name: Upload integration test results
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: integration-test-results-${{ matrix.module }}
-          path: |
-            **/target/failsafe-reports/*.xml
-          retention-days: 30
 
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [ unit-tests ]
+    needs: [ build-test ]
     # Only run on main branch pushes or when pom.xml files change (dependency updates)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' ||
       contains(github.event.pull_request.changed_files, 'pom.xml')
@@ -333,7 +291,6 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-          cache: maven
 
       - name: Cache Maven wrapper binary
         uses: actions/cache@v5
@@ -342,8 +299,18 @@ jobs:
           key: ${{ runner.os }}-maven-wrapper-${{
             hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
 
-      - name: Install internal snapshot artifacts
-        run: ./mvnw install -DskipTests -DskipITs -B -q
+      - name: Restore reactor build cache
+        id: restore-reactor-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-reactor-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-maven-reactor-
+
+      - name: Install internal snapshot artifacts (cache-miss fallback)
+        if: steps.restore-reactor-cache.outputs.cache-hit != 'true'
+        run: ./mvnw install -DskipTests -DskipITs -T 1C -B -q
 
       - name: Get current week for cache key
         id: date
@@ -384,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [ unit-tests ]
+    needs: [ build-test ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     outputs:
       services: ${{ steps.detect-services.outputs.services }}
@@ -443,7 +410,6 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-          cache: maven
 
       - name: Cache Maven wrapper binary
         uses: actions/cache@v5
@@ -452,9 +418,29 @@ jobs:
           key: ${{ runner.os }}-maven-wrapper-${{
             hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
 
-      - name: Build service JAR
-        run: ./mvnw clean package -pl ${{ matrix.service }} -am -DskipTests -DskipITs -T
-          1C -B
+      - name: Download tested service JAR
+        id: tested-jar
+        # Prefer the JAR that passed build-test (spec §4.6). Fall back to a scoped
+        # Maven build only if this service wasn't part of the tested artifact.
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: service-jars
+          path: downloaded-jars
+
+      - name: Restore tested JAR or build from source
+        run: |
+          set -euo pipefail
+          JAR_PATH="$(find downloaded-jars -type f \
+            -path "*/${{ matrix.service }}/target/*.jar" 2>/dev/null | head -n 1 || true)"
+          if [[ -n "${JAR_PATH}" ]]; then
+            mkdir -p "${{ matrix.service }}/target"
+            cp "${JAR_PATH}" "${{ matrix.service }}/target/"
+            echo "Using tested JAR from build-test: ${JAR_PATH}"
+          else
+            echo "No tested JAR for ${{ matrix.service }}; building from source"
+            ./mvnw package -pl ${{ matrix.service }} -am -DskipTests -DskipITs -T 1C -B
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -498,7 +484,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    needs: [ unit-tests ]
+    needs: [ build-test ]
     if: github.event_name != 'schedule'
 
     steps:
@@ -525,10 +511,15 @@ jobs:
             hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
 
       - name: Restore reactor build cache
+        # Only populated on main pushes (build-test saves it after `install`);
+        # a PR-run miss is expected and harmless.
+        if: github.event_name != 'pull_request'
         uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-reactor-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-maven-reactor-
 
       - name: Run Checkstyle
         if: github.event_name != 'pull_request'
@@ -662,7 +653,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [ unit-tests ]
+    needs: [ build-test ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     env:
@@ -697,7 +688,6 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-          cache: maven
 
       - name: Cache Maven wrapper binary
         uses: actions/cache@v5
@@ -706,8 +696,24 @@ jobs:
           key: ${{ runner.os }}-maven-wrapper-${{
             hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
 
-      - name: Build all modules
-        run: ./mvnw clean package -DskipTests -DskipITs -B
+      - name: Restore reactor build cache
+        # Supersedes setup-java's dependency cache here: it contains the external
+        # dependencies plus the internal modules build-test installed.
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-reactor-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-maven-reactor-
+
+      - name: Package smoke-test services
+        # Only the services this smoke test actually starts (plus their in-repo
+        # dependencies via -am) — not the whole reactor (G3). Internal deps build
+        # from source in-reactor, so this is correct even when build-test's
+        # selective install didn't cover these modules.
+        run: ./mvnw package -pl
+          pos-service-discovery,pos-security-service,pos-api-gateway -am -DskipTests
+          -DskipITs -T 1C -B
 
       - name: Detect Docker Compose command
         run: |
@@ -759,7 +765,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       [
-        unit-tests,
+        build-test,
         security-scan,
         docker-build,
         docker-build-matrix,
@@ -771,7 +777,7 @@ jobs:
     steps:
       - name: Check build status
         run: |
-          if [ "${{ needs.unit-tests.result }}" != "success" ]; then
+          if [ "${{ needs.build-test.result }}" != "success" ]; then
             echo "Build failed!"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
+        run: printf -- "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT\n-Dmaven.build.cache.enabled=false\n" > .mvn/maven.config
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
@@ -157,6 +157,24 @@ jobs:
 
       - name: Enforce Flyway migration hygiene
         run: ./scripts/check-flyway-hygiene.sh
+
+      - name: Configure build cache (PR pilot)
+        # Build Cache Extension pilot, PR builds only (spec §4.5). PRs skip the
+        # run-number revision stamp: a version that changes every run would poison
+        # every cache key, and nothing downstream consumes PR artifacts by version.
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "-Dmaven.build.cache.enabled=true" > .mvn/maven.config
+          fi
+
+      - name: Restore build cache (PR pilot)
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/build-cache
+          key: ${{ runner.os }}-mvn-build-cache-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-build-cache-
 
       - name: Install reactor (skip tests)
         run: ./mvnw install -DskipTests -DskipITs -Darchunit.skipTests=true -T 1C -B -ntp -q
@@ -284,7 +302,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
+        run: printf -- "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT\n-Dmaven.build.cache.enabled=false\n" > .mvn/maven.config
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
@@ -494,7 +512,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
+        run: printf -- "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT\n-Dmaven.build.cache.enabled=false\n" > .mvn/maven.config
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
@@ -597,7 +615,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
+        run: printf -- "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT\n-Dmaven.build.cache.enabled=false\n" > .mvn/maven.config
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
@@ -681,7 +699,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
+        run: printf -- "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT\n-Dmaven.build.cache.enabled=false\n" > .mvn/maven.config
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,10 +292,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [ build-test ]
-    # Only run on main branch pushes or when pom.xml files change (dependency updates)
+    needs: [ detect-test-modules, build-test ]
+    # Only run on main branch pushes or on PRs whose changes reach the whole
+    # reactor (root pom / BOM / .mvn — where dependency versions live). The
+    # previous gate tested contains(pull_request.changed_files, 'pom.xml'),
+    # but changed_files is a numeric count, so it never matched.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' ||
-      contains(github.event.pull_request.changed_files, 'pom.xml')
+      (github.event_name == 'pull_request' &&
+       needs.detect-test-modules.outputs.full-reactor == 'true')
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,10 @@ jobs:
         # Build Cache Extension pilot, PR builds only (spec §4.5). PRs skip the
         # run-number revision stamp: a version that changes every run would poison
         # every cache key, and nothing downstream consumes PR artifacts by version.
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "-Dmaven.build.cache.enabled=true" > .mvn/maven.config
-          fi
+        # (The pilot's first run exposed pos-archunit's 2.4 GB fat jar, which the
+        # extension's output hashing cannot read — fixed in pos-archunit/pom.xml.)
+        if: github.event_name == 'pull_request'
+        run: echo "-Dmaven.build.cache.enabled=true" > .mvn/maven.config
 
       - name: Restore build cache (PR pilot)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
+        run: printf -- "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT\n-Dmaven.build.cache.enabled=false\n" > .mvn/maven.config
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5

--- a/.github/workflows/nightly-full-stack-compose.yml
+++ b/.github/workflows/nightly-full-stack-compose.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set Maven revision
-        run: echo "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT" > .mvn/maven.config
+        run: printf -- "-Drevision=0.1.${{ github.run_number }}-SNAPSHOT\n-Dmaven.build.cache.enabled=false\n" > .mvn/maven.config
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -27,14 +27,15 @@ jobs:
       - name: Detect changed modules
         id: changed
         run: |
-          # Get changed files between base and head
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-          
-          # Extract unique module names
-          CHANGED_MODULES=$(echo "$CHANGED_FILES" | grep '^pos-' | cut -d'/' -f1 | sort -u | tr '\n' ',' | sed 's/,$//')
-          
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          DETECTION="$(./scripts/ci/detect-modules.sh "origin/${{ github.base_ref }}" HEAD)"
+          echo "Detection: ${DETECTION}"
+
+          # This workflow only lints per-module Dockerfiles, so the full-reactor
+          # flag is irrelevant here — only the concrete changed-module list matters.
+          CHANGED_MODULES="$(jq -r '.modules | join(",")' <<< "${DETECTION}")"
+
           if [ -z "$CHANGED_MODULES" ]; then
             echo "has-changes=false" >> $GITHUB_OUTPUT
             echo "modules=" >> $GITHUB_OUTPUT
@@ -42,7 +43,7 @@ jobs:
             echo "has-changes=true" >> $GITHUB_OUTPUT
             echo "modules=$CHANGED_MODULES" >> $GITHUB_OUTPUT
           fi
-          
+
           echo "Changed modules: $CHANGED_MODULES"
 
   # Note: Build and test are now handled by ci.yml to avoid duplication.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,13 +17,14 @@ jobs:
     outputs:
       modules: ${{ steps.changed.outputs.modules }}
       has-changes: ${{ steps.changed.outputs.has-changes }}
-    
+      full-reactor: ${{ steps.changed.outputs.full-reactor }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      
+
       - name: Detect changed modules
         id: changed
         run: |
@@ -32,10 +33,17 @@ jobs:
           DETECTION="$(./scripts/ci/detect-modules.sh "origin/${{ github.base_ref }}" HEAD)"
           echo "Detection: ${DETECTION}"
 
-          # This workflow only lints per-module Dockerfiles, so the full-reactor
-          # flag is irrelevant here — only the concrete changed-module list matters.
-          CHANGED_MODULES="$(jq -r '.modules | join(",")' <<< "${DETECTION}")"
+          FULL_REACTOR="$(jq -r '.full_reactor' <<< "${DETECTION}")"
+          if [[ "${FULL_REACTOR}" == "true" ]]; then
+            # A full-reactor change (root pom, .mvn/**, BOM, ci.yml, compose)
+            # affects every module: the detection's module list is empty by
+            # contract, so lint every containerized module's Dockerfile.
+            CHANGED_MODULES="$(ls -d pos-*/ | cut -d'/' -f1 | paste -sd, -)"
+          else
+            CHANGED_MODULES="$(jq -r '.modules | join(",")' <<< "${DETECTION}")"
+          fi
 
+          echo "full-reactor=${FULL_REACTOR}" >> $GITHUB_OUTPUT
           if [ -z "$CHANGED_MODULES" ]; then
             echo "has-changes=false" >> $GITHUB_OUTPUT
             echo "modules=" >> $GITHUB_OUTPUT
@@ -121,10 +129,13 @@ jobs:
         with:
           script: |
             const modules = '${{ needs.detect-changes.outputs.modules }}';
-            
+            const fullReactor = '${{ needs.detect-changes.outputs.full-reactor }}' === 'true';
+
             let comment = '## 🔍 PR Analysis\n\n';
-            
-            if (!modules) {
+
+            if (fullReactor) {
+              comment += '🔄 Build-wide change (root pom / `.mvn` / BOM / CI config): **all modules** are affected and the full reactor will be tested.\n';
+            } else if (!modules) {
               comment += '✅ No backend modules were modified in this PR.\n';
             } else {
               comment += '### Changed Modules\n';

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <!-- Maven Build Cache Extension pilot (docs/BACKEND_BUILD_SPEC.md section 4.5).
+         Disabled by default via .mvn/maven.config; CI enables it on pull-request
+         builds only. Release/ECR builds and main stay uncached until the pilot
+         passes the validation gate. -->
+    <extension>
+        <groupId>org.apache.maven.extensions</groupId>
+        <artifactId>maven-build-cache-extension</artifactId>
+        <version>1.2.3</version>
+    </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dmaven.build.cache.enabled=false

--- a/docs/BACKEND_BUILD_SPEC.md
+++ b/docs/BACKEND_BUILD_SPEC.md
@@ -121,8 +121,10 @@ its fields into `$GITHUB_OUTPUT`):
 
 `modules` is the deduplicated list of changed `pos-*` module directories, empty when
 `full_reactor` is `true` (the whole reactor builds, so no selection is meaningful). Consumers
-must branch on `full_reactor`, never on whether `modules` is empty — an empty list with
-`full_reactor: false` means "nothing to build" (docs-only change) and skips the build entirely.
+must check `full_reactor` before interpreting `modules` — an empty list never implies a full
+build. An empty list with `full_reactor: false` (a CI-triggering change that maps to no module,
+e.g. the root `Dockerfile`) skips the selective test pass; the build job still runs its install
+and ArchUnit invocations, preserving the pre-existing "always run pos-archunit" behaviour.
 
 **Full-reactor triggers** (any changed path matching):
 

--- a/docs/BACKEND_BUILD_SPEC.md
+++ b/docs/BACKEND_BUILD_SPEC.md
@@ -158,49 +158,52 @@ build-and-unit-test          ONE job, one reactor invocation
 quality gates (Sonar PR scan)  [unchanged]
 ```
 
-The single job runs:
+The single job runs the lint/policy checks once (not per matrix leg — closes G5), then **three
+reactor invocations**:
 
 ```bash
-# Lint/policy checks once, not per matrix leg (closes G5)
 ./scripts/check-noarg-now.sh
 ./scripts/check-flyway-hygiene.sh
-```
 
-then one reactor invocation, stopped at `test`, in the form selected by the detect-modules
-output (§4.1):
+# 1. Full-reactor install, tests skipped (~2 min warm — measured baseline).
+./mvnw -B -ntp -T 1C install -DskipTests -DskipITs -Darchunit.skipTests=true
 
-```bash
-# full_reactor=false, modules non-empty — selective build.
-# ("pos-archunit" is appended by the workflow, so the -pl list is never empty here.)
+# 2. Selective tests: changed modules plus every dependent (closes G1).
+#    full_reactor=true → same command without -pl/-amd; empty selection → skipped.
 ./mvnw -B -ntp -T 1C \
-  -pl "$CHANGED_MODULES,pos-archunit" \
-  -am -amd \
-  test \
+  -pl "$CHANGED_MODULES" -amd \
+  -DskipTests=false test \
   org.jacoco:jacoco-maven-plugin:0.8.14:report \
+  -Darchunit.skipTests=true \
   -DskipITs
 
-# full_reactor=true — no -pl at all; every module (incl. pos-archunit) is in the reactor.
-./mvnw -B -ntp -T 1C \
-  test \
-  org.jacoco:jacoco-maven-plugin:0.8.14:report \
-  -DskipITs
+# 3. ArchUnit rules: -am reactor stopped at the test phase (#909-safe).
+./mvnw -B -ntp -T 1C -pl pos-archunit -am -DskipTests=false test \
+  -Dtest='com/positivity/archunit/*' -Dsurefire.failIfNoSpecifiedTests=false -DskipITs
 ```
 
-(`full_reactor=false` with an empty `modules` list skips the build job entirely — §4.1.)
+**Why three invocations and not the single selective one originally sketched here** (implementation
+finding, phase 2): Maven's `-amd` adds the *dependents* of the selection to the reactor but not
+those dependents' own upstream dependencies, so a purely selective `-pl <changed> -am -amd` build
+cannot resolve on a clean runner (verified: `-pl pos-shared-dtos -am -amd` yields a 29-project
+reactor that contains `pos-order` but not `pos-order`'s dependency `pos-events`). And
+`pos-archunit` declares dependencies on ~22 modules, so any dependent-closure that includes it is
+the full reactor anyway. The cheap full `install -DskipTests` (step 1) makes every internal
+artifact resolvable from `~/.m2`, after which the selective `-amd` test pass and the archunit
+reactor are both correct. Step 1 is the same build the old `build-reactor` job ran — the savings
+come from eliminating the per-module matrix jobs, not from skipping compilation.
 
 Design notes:
 
 - **`test`, not `verify`, on PRs — deliberately.** Failsafe ITs already run only on `main`
-  push / dispatch (current policy, kept). Stopping before `package` also means
-  `spring-boot:repackage` never runs, sibling modules resolve to `target/classes`, and
-  **pos-archunit can run inside the same reactor invocation** with no special-casing — the #909
-  hazard only exists past the `package` phase. The two workarounds in today's unit-test and
-  integration-test jobs collapse into nothing.
+  push / dispatch (current policy, kept). `-Darchunit.skipTests=true` is set on invocations 1
+  and 2: past the `package` phase (and against installed fat JARs) the ArchUnit rules pass
+  vacuously (#909), so they run only in invocation 3 where siblings resolve to `target/classes`.
 - `-amd` may pull in a large dependent set for shared-library changes. That is the point (G1).
   For a full-reactor trigger, `-pl` is omitted entirely.
-- The `build-reactor` install job and SHA-keyed reactor cache are **no longer needed on the PR
-  path** (nothing runs offline in a separate job). `setup-java`'s `cache: maven` keeps external
-  dependencies cached, keyed on `**/pom.xml`.
+- The separate `build-reactor` job disappears (its install moved into this job); the SHA-keyed
+  reactor cache is **not saved on the PR path** (no separate job consumes it). `setup-java`'s
+  `cache: maven` keeps external dependencies cached, keyed on `**/pom.xml`.
 - Checkout uses `fetch-depth: 0` only in `detect-modules`; the build job checks out at depth 1.
 - Memory budget: `-T 1C` on a 4-vCPU runner = up to 4 concurrent module builds, each with
   `forkCount=1` reused test JVM. `MAVEN_OPTS: -Xmx3072m` for the reactor JVM; test JVMs inherit
@@ -219,28 +222,24 @@ module count. This is a measured exception, not the default shape.
 detect-modules
       │
       ▼
-build-install                ONE reactor invocation to `install` (unit + failsafe ITs + package
-      │                       + install to ~/.m2 — see note below on why not `verify`)
-      │        ├─ upload service JARs as workflow artifact (tested bytes)
+build-install                same job shape as the PR path (§4.2), three invocations:
+      │                       1. full-reactor `install -DskipTests` (populates ~/.m2,
+      │                          packages every service JAR)
+      │                       2. `-pl <changed> -amd verify` — unit + failsafe ITs for
+      │                          changed modules and dependents
+      │                       3. pos-archunit rules at the test phase (#909-safe)
+      │        ├─ upload service JARs as workflow artifact (tested bytes, all services)
       │        ├─ save ~/.m2/repository to SHA-keyed reactor cache
       │        └─ upload surefire/failsafe/jacoco reports
-      ▼
-archunit                     ./mvnw -pl pos-archunit -am test -o   (test phase; #909-safe)
       ▼
 compose-smoke │ security-scan │ sonar    — all consume the build-install output; none re-run
       ▼                                    package/install from scratch (closes G3)
 docker-build-and-push        matrix over changed services, consuming the JAR artifact (§4.6)
 ```
 
-`build-install` command:
-
-```bash
-./mvnw -B -ntp -T 1C \
-  -pl "$CHANGED_MODULES" \
-  -am -amd \
-  install \
-  -Darchunit.skipTests=true
-```
+The full-reactor step-1 install (see §4.2 for why it is required) has a main-path bonus: every
+service JAR exists for every main commit, so whole-stack deploy tags (ECR `BACKEND_TAG`) can
+always be satisfied from the artifact regardless of how narrow the triggering change was.
 
 - **`install`, not `verify`, on `main` — deliberately.** `verify` runs every test and packages
   the JARs but stops one phase short of copying reactor artifacts into `~/.m2/repository`, so an
@@ -252,10 +251,10 @@ docker-build-and-push        matrix over changed services, consuming the JAR art
   `target/` trees or the internal `com/positivity` subtree of `~/.m2` as workflow artifacts — is
   rejected as a second transport mechanism with no benefit over the cache.)
 - On `main` the full lifecycle is required (failsafe ITs, packaged JARs). Because packaging
-  repackages siblings into fat JARs, **pos-archunit runs as its own downstream step** at the
-  `test` phase (`-am` builds siblings from source, so their classes resolve from
-  `target/classes`; `-o` works because `install` populated the local repo) — the one place the
-  #909 special case survives, matching today's proven pattern.
+  repackages siblings into fat JARs, **pos-archunit runs as invocation 3 inside the same job**
+  at the `test` phase (`-am` builds siblings from source, so their classes resolve from
+  `target/classes`) — the one place the #909 special case survives, matching today's proven
+  pattern without paying a separate job's overhead.
 - Jobs that only need compiled/packaged output (Sonar, compose smoke test, OWASP) restore the
   SHA-keyed reactor cache written by `build-install` instead of rebuilding (the cache mechanism
   from §1.1 stays, relocated to the main path where multiple consumers still exist).

--- a/docs/BACKEND_BUILD_SPEC.md
+++ b/docs/BACKEND_BUILD_SPEC.md
@@ -307,6 +307,16 @@ flakiness appears.
 </extensions>
 ```
 
+**Pilot status (2026-08-06):** the first enabled run failed with
+`OutOfMemoryError: Required array size too large` in the extension's output hashing. Root
+cause (reproduced and fixed locally): `pos-archunit` carried a no-op-looking
+`spring-boot-maven-plugin` declaration whose repackage embedded its ~22 sibling fat-JAR
+dependencies into a **2.4 GB** `pos-archunit.jar` — unreadable into a byte array (2 GiB
+limit), and silently bloating every SHA-keyed reactor cache before this. With the repackage
+removed (the module is test-only; nothing consumes its jar, now 4.8 KB) the full-reactor
+`install` passes with the cache enabled and a same-inputs second run restores all modules
+from cache — the validation gate's first two checks, verified locally.
+
 Rollout policy — the pilot scope is **PR builds only** (matching the §3 disposition); `main`
 stays uncached until the pilot passes its validation gate:
 

--- a/docs/build-timings-baseline.md
+++ b/docs/build-timings-baseline.md
@@ -1,0 +1,69 @@
+# CI Build Timings — Baseline (pre-optimisation)
+
+Snapshot taken 2026-08-06 from the GitHub Actions API, before implementing the phases of
+`docs/BACKEND_BUILD_SPEC.md`. This is the phase-0 reference the §6.4 acceptance measurements
+compare against.
+
+## Wall-clock per run — Backend CI/CD (`ci.yml`), last 20 completed runs
+
+| Run | Event | Conclusion | Wall clock |
+|---|---|---|---|
+| 31078920629 | schedule | success | 16m 36s |
+| 30982969915 | schedule | success | 16m 25s |
+| 30885604530 | schedule | success | 16m 18s |
+| 30792523080 | schedule | success | 14m 56s |
+| 30736747332 | schedule | success | 15m 47s |
+| 30688520005 | schedule | success | 16m 08s |
+| 30611317239 | schedule | success | 13m 26s |
+| 30586145382 | push (main) | success | 13m 31s |
+| 30585031095 | pull_request | success | 15m 01s |
+| 30583669351 | pull_request | success | 9m 55s |
+| 30578660422 | push (main) | success | 100m 51s |
+| 30578406109 | push (main) | cancelled | (superseded) |
+| 30577361121 | pull_request | success | 9m 58s |
+| 30576408352 | pull_request | success | 8m 44s |
+| 30576334950 | pull_request | success | 9m 11s |
+| 30573443679 | push (main) | failure | 33m 45s |
+| 30571615501 | push (main) | cancelled | (superseded) |
+| 30571337886 | push (main) | cancelled | (superseded) |
+| 30570892756 | pull_request | success | 8m 55s |
+| 30570326263 | pull_request | success | 9m 53s |
+
+Medians: **pull_request ≈ 9m 55s** (n=7, range 8m 44s – 15m 01s, typically 1–2 changed modules);
+**push to main** is bimodal — ~13m for narrow changes, 30–100m when the integration-test /
+docker matrices fan out. Scheduled (full-coverage Sonar) runs cluster at ~16m.
+
+## Job-level dissection — PR run 30585031095 (changed: `pos-mcp-server`; 15m 01s total)
+
+| Job | Duration | Fixed overhead* | Useful work |
+|---|---|---|---|
+| Detect Test Modules | 0m 06s | 6s | diff + jq |
+| Build Reactor (install all) | 2m 29s | ~10s | install 1m 44s, test-infra warmup 9s, cache save 28s |
+| Unit Tests (pos-mcp-server) | 1m 50s | **1m 12s** | tests **0m 38s** |
+| Unit Tests (pos-archunit) | 3m 16s | **1m 16s** | tests 1m 48s |
+| Incremental Code Quality | 3m 11s | ~1m 10s | Sonar scan 1m 56s |
+| Notify Build Status | 0m 03s (started after a 5m 42s queue gap) | — | — |
+
+\* Fixed overhead = job setup + checkout + JDK + wrapper cache + `~/.m2` reactor-cache restore
+(the restore alone is ~58–68s per job) + report uploads.
+
+Key baseline facts the spec's phases target:
+
+- **Per-matrix-job overhead (G2):** each Unit Tests job pays ~70s of setup/restore before any
+  test runs; for `pos-mcp-server` that is 2× the actual test time. Every additional changed
+  module adds one such job.
+- **Repeated lint scripts (G5):** `check-noarg-now.sh` + `check-flyway-hygiene.sh` ran in both
+  matrix jobs (~2s each — small, but N×).
+- **Queue gaps between dependent jobs:** the Notify job sat queued 5m 42s after its
+  dependencies finished; every job boundary risks such a gap, so fewer jobs = fewer gaps.
+- **Push-run totals:** run 30578660422 (wide change) accumulated **100.9 minutes** of run
+  duration across 13 jobs; run 30586145382 (narrow change) 13.5 minutes across 13 jobs.
+- **Downstream dependents (G1):** no baseline number possible — dependent modules simply do not
+  run today; the synthetic `pos-shared-dtos` PR check in §6.4 starts failing-by-design here.
+
+## Comparison protocol (post-phase)
+
+For each landed phase, re-sample the most recent 20 completed `ci.yml` runs and recompute the
+medians above, split by event type and by changed-module count (1, 2–3, shared-lib). Runner-cost
+comparisons use summed job durations (billable minutes are all zero on this repo's plan, so wall
+time per job is the proxy).

--- a/pos-archunit/pom.xml
+++ b/pos-archunit/pom.xml
@@ -198,13 +198,12 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
+            <!-- No spring-boot-maven-plugin here: repackaging this test-only module
+                 embedded the ~22 sibling fat JARs it depends on into a 2.4 GB
+                 pos-archunit.jar that nothing consumes. It bloated the CI reactor
+                 cache on every save and crashed the Maven Build Cache Extension,
+                 whose output hashing cannot read a file above the 2 GiB array
+                 limit (OutOfMemoryError: Required array size too large). -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/pos-events/src/test/resources/junit-platform.properties
+++ b/pos-events/src/test/resources/junit-platform.properties
@@ -1,0 +1,10 @@
+# JUnit class-level parallelism pilot (docs/BACKEND_BUILD_SPEC.md section 4.4).
+# Classes run concurrently; methods within a class stay sequential. Tests that
+# share mutable state across classes must use @ResourceLock or
+# @Execution(SAME_THREAD) before this module keeps the opt-in.
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=2
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=2

--- a/pos-invoice/src/test/resources/junit-platform.properties
+++ b/pos-invoice/src/test/resources/junit-platform.properties
@@ -1,0 +1,10 @@
+# JUnit class-level parallelism pilot (docs/BACKEND_BUILD_SPEC.md section 4.4).
+# Classes run concurrently; methods within a class stay sequential. Tests that
+# share mutable state across classes must use @ResourceLock or
+# @Execution(SAME_THREAD) before this module keeps the opt-in.
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=2
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=2

--- a/pos-warranty/src/test/resources/junit-platform.properties
+++ b/pos-warranty/src/test/resources/junit-platform.properties
@@ -1,0 +1,10 @@
+# JUnit class-level parallelism pilot (docs/BACKEND_BUILD_SPEC.md section 4.4).
+# Classes run concurrently; methods within a class stay sequential. Tests that
+# share mutable state across classes must use @ResourceLock or
+# @Execution(SAME_THREAD) before this module keeps the opt-in.
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=2
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=2

--- a/scripts/check-noarg-now.sh
+++ b/scripts/check-noarg-now.sh
@@ -6,7 +6,13 @@ cd "$ROOT_DIR"
 
 PATTERN='\b(Instant\.now|LocalDateTime\.now|LocalDate\.now|Year\.now)\(\s*\)'
 
-matches=$(rg -n --no-heading "$PATTERN" --glob "**/src/main/**" . || true)
+# CI runners have no ripgrep: `rg` used to fail with exit 127, `|| true`
+# swallowed it, and the check passed vacuously. Fall back to GNU grep.
+if command -v rg >/dev/null 2>&1; then
+  matches=$(rg -n --no-heading "$PATTERN" --glob "**/src/main/**" . || true)
+else
+  matches=$(grep -rEn "$PATTERN" --include='*.java' ./*/src/main 2>/dev/null || true)
+fi
 
 if [[ -n "$matches" ]]; then
   echo "ERROR: Found forbidden no-arg time calls in src/main:"

--- a/scripts/ci/detect-modules.sh
+++ b/scripts/ci/detect-modules.sh
@@ -6,17 +6,14 @@
 #   {"full_reactor": true,  "modules": []}
 #
 # modules is the deduplicated list of changed pos-* module directories, empty
-# when full_reactor is true. Consumers must branch on full_reactor, never on
-# whether modules is empty: an empty list with full_reactor=false means
-# "nothing to build".
+# when full_reactor is true. Consumers must check full_reactor before looking
+# at modules — an empty list only means "no module selection" when
+# full_reactor is false (ci.yml then runs its ArchUnit-only fallback rather
+# than a selective test pass; it never means the whole reactor is affected).
 #
 # Usage:
 #   detect-modules.sh --full                    # unconditional full reactor
 #   detect-modules.sh <diff-base> <diff-head>   # diff-driven detection
-#
-# Extra full-reactor trigger paths (regexes, one per line) can be appended via
-# the EXTRA_FULL_REACTOR_TRIGGERS environment variable — build-push-ecr.yml
-# uses this for its deploy-file triggers.
 
 set -euo pipefail
 
@@ -51,12 +48,6 @@ CHANGED_FILES="$(git diff --name-only "${DIFF_BASE}" "${DIFF_HEAD}")"
 FULL_REACTOR_TRIGGERS='^(pom\.xml|\.mvn/|pos-dependencies/|build-tools/|\.github/workflows/ci\.yml|docker-compose\.yml)'
 
 if echo "${CHANGED_FILES}" | grep -Eq "${FULL_REACTOR_TRIGGERS}"; then
-  emit true '[]'
-  exit 0
-fi
-
-if [[ -n "${EXTRA_FULL_REACTOR_TRIGGERS:-}" ]] \
-  && echo "${CHANGED_FILES}" | grep -Eq "${EXTRA_FULL_REACTOR_TRIGGERS}"; then
   emit true '[]'
   exit 0
 fi

--- a/scripts/ci/detect-modules.sh
+++ b/scripts/ci/detect-modules.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Single source of truth for CI change detection (BACKEND_BUILD_SPEC.md §4.1).
+#
+# Emits one JSON object on stdout:
+#   {"full_reactor": false, "modules": ["pos-order", "pos-price"]}
+#   {"full_reactor": true,  "modules": []}
+#
+# modules is the deduplicated list of changed pos-* module directories, empty
+# when full_reactor is true. Consumers must branch on full_reactor, never on
+# whether modules is empty: an empty list with full_reactor=false means
+# "nothing to build".
+#
+# Usage:
+#   detect-modules.sh --full                    # unconditional full reactor
+#   detect-modules.sh <diff-base> <diff-head>   # diff-driven detection
+#
+# Extra full-reactor trigger paths (regexes, one per line) can be appended via
+# the EXTRA_FULL_REACTOR_TRIGGERS environment variable — build-push-ecr.yml
+# uses this for its deploy-file triggers.
+
+set -euo pipefail
+
+# Modules that exist in the reactor but are never selected for testing/building
+# on their own: the BOM has no code, the coverage aggregator only aggregates.
+NON_SELECTABLE_MODULES='["pos-dependencies","pos-coverage-aggregate"]'
+
+emit() {
+  local full_reactor="$1" modules_json="$2"
+  jq -cn --argjson full "${full_reactor}" --argjson modules "${modules_json}" \
+    '{full_reactor: $full, modules: $modules}'
+}
+
+if [[ "${1:-}" == "--full" ]]; then
+  emit true '[]'
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 --full | <diff-base> <diff-head>" >&2
+  exit 2
+fi
+
+DIFF_BASE="$1"
+DIFF_HEAD="$2"
+
+CHANGED_FILES="$(git diff --name-only "${DIFF_BASE}" "${DIFF_HEAD}")"
+
+# Full-reactor triggers: files whose changes can affect how every module
+# builds. Shared libraries are NOT listed — Maven's -amd flag rebuilds their
+# dependents from the module selection instead (spec §4.1).
+FULL_REACTOR_TRIGGERS='^(pom\.xml|\.mvn/|pos-dependencies/|build-tools/|\.github/workflows/ci\.yml|docker-compose\.yml)'
+
+if echo "${CHANGED_FILES}" | grep -Eq "${FULL_REACTOR_TRIGGERS}"; then
+  emit true '[]'
+  exit 0
+fi
+
+if [[ -n "${EXTRA_FULL_REACTOR_TRIGGERS:-}" ]] \
+  && echo "${CHANGED_FILES}" | grep -Eq "${EXTRA_FULL_REACTOR_TRIGGERS}"; then
+  emit true '[]'
+  exit 0
+fi
+
+MODULES_JSON="$(
+  echo "${CHANGED_FILES}" \
+    | { grep -E '^pos-[^/]+/' || true; } \
+    | cut -d'/' -f1 \
+    | sort -u \
+    | while read -r module; do
+        [[ -n "${module}" && -f "${module}/pom.xml" ]] && echo "${module}"
+      done \
+    | jq -R -s -c --argjson excluded "${NON_SELECTABLE_MODULES}" \
+        'split("\n")[:-1] | map(select((. as $m | $excluded | index($m)) | not))'
+)"
+
+emit false "${MODULES_JSON}"


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (build infrastructure — implements `docs/BACKEND_BUILD_SPEC.md`)
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:build-ci`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Not applicable: no controllers, DTOs, events, or `openapi.yaml` files change in this PR (CI workflows, build config, and docs only).

## Contract Chain (when a Controller changed)
- Not applicable — no controller changes.

## Scope
- What changed:
  - **Phase 0**: `docs/build-timings-baseline.md` — job-level timings from the Actions API (median PR run ~10 min; ~70s fixed overhead per matrix job).
  - **Phase 1**: `scripts/ci/detect-modules.sh` — single change-detection source for `ci.yml` and `pr-checks.yml`; full-reactor triggers now include `.mvn/**`, `pos-dependencies/**`, `build-tools/**`.
  - **Phases 2–3**: `ci.yml` — `build-reactor` + per-module unit/IT matrices collapsed into one `build-test` job running three reactor invocations (full `install -DskipTests` → selective `-pl <changed> -amd` tests → ArchUnit rules at the test phase). Changed modules' **dependents now run their tests** (gap G1). Main pushes run `verify`-with-ITs selectively, save the SHA-keyed `~/.m2` cache, and upload a `service-jars` artifact; Sonar/OWASP/compose-smoke/docker jobs consume that output instead of rebuilding.
  - **Phase 4**: `build-push-ecr.yml` — triggers via `workflow_run` on successful CI main-push runs, downloads the tested `service-jars` artifact (source build only as fallback), and uses the CI run's `head_sha` for checkouts, image tags, and the alpha deploy.
  - **Phase 5**: JUnit class-level parallelism (fixed 2) opt-in for `pos-warranty`, `pos-invoice`, `pos-events`.
  - **Phase 6**: Maven Build Cache Extension 1.2.3, default-disabled via `.mvn/maven.config`, enabled on PR builds only.
- Why: implements the phased plan in `docs/BACKEND_BUILD_SPEC.md` — fixes the untested-dependents correctness gap, removes per-module matrix overhead and duplicate rebuilds, and makes deployed images carry the tested bytes.

Implementation finding recorded in the spec (§4.2): Maven's `-amd` does not add a dependent's own upstream dependencies to the reactor, and `pos-archunit` depends on ~22 modules — so the cheap full `install -DskipTests` precedes the selective test pass rather than the originally sketched single selective invocation.

## Tests
- [ ] Unit tests added/updated — n/a (no production code)
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run: this PR's own CI run exercises the new PR path end-to-end (`ci.yml` is a full-reactor trigger here, so every module's tests run). `actionlint` passes on all modified workflows; `scripts/ci/detect-modules.sh` validated against repo history (module, multi-module, docs-only, and `--full` cases). The main path and ECR `workflow_run` flow can only execute after merge — first post-merge push should be watched.

## Risk & Rollback
- Risk level: Medium — CI topology change; PR path is validated by this PR's own run, the main/ECR path only after merge.
- Rollback plan: `git revert` the phase commits individually (each phase is one commit and independently revertible). The build cache pilot is neutralized by deleting `.mvn/extensions.xml`; JUnit parallelism by deleting the three `junit-platform.properties` files.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a (infra branch `claude/backend-build-spec-lrbgnf`)
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a
- [x] Links to parent + child issues are present — n/a, spec is in-repo
- [ ] Contract guide updated — n/a (no contract semantics changed)
- [ ] Required CI checks passing — pending this PR's run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9szbL2WrnjqWwE5wVMHhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9szbL2WrnjqWwE5wVMHhQ)_