### PR TITLE
Fix stale pos-workorder promotion ITs broken by FI-3 declined-service lines

### DIFF
--- a/pos-workorder/src/test/java/com/positivity/workorder/contract/PartialApprovalPromotionContractBehaviorIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/contract/PartialApprovalPromotionContractBehaviorIT.java
@@ -110,10 +110,16 @@ class PartialApprovalPromotionContractBehaviorIT extends BaseContractIntegration
 
         List<WorkorderPart> partItems = workorderPartRepository.findByWorkorderId(workorderId);
 
-        int totalWorkorderItems = laborItems.size() + partItems.size();
-        assertThat(totalWorkorderItems).isEqualTo(2); // Only 2 APPROVED items should be copied
+        // Only the 2 APPROVED items become billable workorder items; the declined
+        // LABOR item is also promoted, but as a non-billable declined service line
+        // (FI-3, #1133) carrying declined=true and status CANCELLED.
+        List<com.positivity.workorder.internal.entity.WorkorderServiceLine> billableLabor = laborItems.stream()
+                .filter(ws -> !Boolean.TRUE.equals(ws.getDeclined()))
+                .toList();
 
-        // Verify declined and pending items were NOT copied
+        int totalBillableItems = billableLabor.size() + partItems.size();
+        assertThat(totalBillableItems).isEqualTo(2);
+
         List<EstimateItem> declinedItems = allItems.stream()
                 .filter(item -> item.getApprovalStatus() == ApprovalStatus.DECLINED)
                 .toList();
@@ -122,13 +128,21 @@ class PartialApprovalPromotionContractBehaviorIT extends BaseContractIntegration
                 .filter(item -> item.getApprovalStatus() == ApprovalStatus.PENDING_APPROVAL)
                 .toList();
 
+        // Verify the declined LABOR item was promoted as a declined service line,
+        // never as a billable item
         for (EstimateItem declinedItem : declinedItems) {
-            boolean foundInWorkorder = laborItems.stream()
+            boolean foundAsBillable = billableLabor.stream()
                             .anyMatch(ws -> ws.getOriginEstimateItemId().equals(declinedItem.getId()))
                     || partItems.stream()
                             .anyMatch(wp -> wp.getOriginEstimateItemId().equals(declinedItem.getId()));
+            assertThat(foundAsBillable).isFalse();
 
-            assertThat(foundInWorkorder).isFalse();
+            com.positivity.workorder.internal.entity.WorkorderServiceLine declinedLine = laborItems.stream()
+                    .filter(ws -> ws.getOriginEstimateItemId().equals(declinedItem.getId()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(declinedLine.getDeclined()).isTrue();
+            assertThat(declinedLine.getStatus()).isEqualTo(WorkorderItemStatus.CANCELLED);
         }
 
         for (EstimateItem pendingItem : pendingItems) {
@@ -222,15 +236,18 @@ class PartialApprovalPromotionContractBehaviorIT extends BaseContractIntegration
 
         UUID workorderId = UUID.fromString(workorderIdStr);
 
-        // Then: Verify financial snapshot matches approved items only
+        // Then: Verify financial snapshot matches approved items only. Declined
+        // LABOR items are promoted separately as non-billable declined service
+        // lines (FI-3, #1133), so they are excluded from this billable check.
         List<com.positivity.workorder.internal.entity.WorkorderServiceLine> laborItems =
                 workorderServiceRepository.findAll().stream()
                         .filter(ws -> ws.getWorkOrder().getId().equals(workorderId))
+                        .filter(ws -> !Boolean.TRUE.equals(ws.getDeclined()))
                         .toList();
 
         List<WorkorderPart> partItems = workorderPartRepository.findByWorkorderId(workorderId);
 
-        // Verify each workorder item corresponds to an approved estimate item
+        // Verify each billable workorder item corresponds to an approved estimate item
         for (com.positivity.workorder.internal.entity.WorkorderServiceLine laborItem : laborItems) {
             EstimateItem sourceItem = approvedItems.stream()
                     .filter(ei -> ei.getId().equals(laborItem.getOriginEstimateItemId()))
@@ -282,7 +299,15 @@ class PartialApprovalPromotionContractBehaviorIT extends BaseContractIntegration
 
         UUID workorderId = UUID.fromString(workorderIdStr);
 
-        // Then: Verify all workorder items trace back to approved estimate items only
+        // Then: billable workorder items trace back to approved estimate items;
+        // declined service lines (FI-3, #1133) trace back to declined LABOR items
+        List<UUID> declinedItemIds =
+                estimateItemRepository
+                        .findByEstimate_IdAndApprovalStatusAndDeletedFalse(estimateId, ApprovalStatus.DECLINED)
+                        .stream()
+                        .map(EstimateItem::getId)
+                        .toList();
+
         List<com.positivity.workorder.internal.entity.WorkorderServiceLine> laborItems =
                 workorderServiceRepository.findAll().stream()
                         .filter(ws -> ws.getWorkOrder().getId().equals(workorderId))
@@ -291,7 +316,11 @@ class PartialApprovalPromotionContractBehaviorIT extends BaseContractIntegration
         List<WorkorderPart> partItems = workorderPartRepository.findByWorkorderId(workorderId);
 
         for (com.positivity.workorder.internal.entity.WorkorderServiceLine laborItem : laborItems) {
-            assertThat(approvedItemIds).contains(laborItem.getOriginEstimateItemId());
+            if (Boolean.TRUE.equals(laborItem.getDeclined())) {
+                assertThat(declinedItemIds).contains(laborItem.getOriginEstimateItemId());
+            } else {
+                assertThat(approvedItemIds).contains(laborItem.getOriginEstimateItemId());
+            }
         }
 
         for (WorkorderPart partItem : partItems) {

--- a/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkorderItemGenerationContractBehaviorIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkorderItemGenerationContractBehaviorIT.java
@@ -369,32 +369,39 @@ class WorkorderItemGenerationContractBehaviorIT extends BaseContractIntegrationT
 
         List<WorkorderPart> partItems = workorderPartRepository.findByWorkorderId(workorderId);
 
-        int totalWorkorderItems = laborItems.size() + partItems.size();
-        assertThat(totalWorkorderItems).isEqualTo(2); // Only 2 APPROVED items should be copied
+        // Only the 2 APPROVED items become billable workorder items; the declined
+        // LABOR item is also promoted, but as a non-billable declined service line
+        // (FI-3, #1133) with declined=true.
+        List<com.positivity.workorder.internal.entity.WorkorderServiceLine> billableLabor = laborItems.stream()
+                .filter(ws -> !Boolean.TRUE.equals(ws.getDeclined()))
+                .toList();
 
-        // Verify each workorder item traces back to an APPROVED estimate item
+        int totalBillableItems = billableLabor.size() + partItems.size();
+        assertThat(totalBillableItems).isEqualTo(2);
+
+        // Verify each billable workorder item traces back to an APPROVED estimate item
         List<UUID> approvedItemIds =
                 approvedItems.stream().map(EstimateItem::getId).toList();
-        for (com.positivity.workorder.internal.entity.WorkorderServiceLine laborItem : laborItems) {
+        for (com.positivity.workorder.internal.entity.WorkorderServiceLine laborItem : billableLabor) {
             assertThat(approvedItemIds).contains(laborItem.getOriginEstimateItemId());
         }
         for (WorkorderPart partItem : partItems) {
             assertThat(approvedItemIds).contains(partItem.getOriginEstimateItemId());
         }
 
-        // Verify declined and pending items were NOT copied
+        // Verify declined and pending items were NOT copied as billable items
         List<EstimateItem> nonApprovedItems = allItems.stream()
                 .filter(item -> item.getApprovalStatus() != ApprovalStatus.APPROVED)
                 .toList();
 
         for (EstimateItem nonApprovedItem : nonApprovedItems) {
-            boolean foundInWorkorder = laborItems.stream()
+            boolean foundAsBillable = billableLabor.stream()
                             .anyMatch(ws -> ws.getOriginEstimateItemId().equals(nonApprovedItem.getId()))
                     || partItems.stream()
                             .anyMatch(wp -> wp.getOriginEstimateItemId().equals(nonApprovedItem.getId()));
 
-            assertThat(foundInWorkorder)
-                    .as("Non-approved item %s should not be in workorder", nonApprovedItem.getId())
+            assertThat(foundAsBillable)
+                    .as("Non-approved item %s should not be a billable workorder item", nonApprovedItem.getId())
                     .isFalse();
         }
     }

--- a/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkorderItemGenerationContractBehaviorIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/contract/WorkorderItemGenerationContractBehaviorIT.java
@@ -404,6 +404,23 @@ class WorkorderItemGenerationContractBehaviorIT extends BaseContractIntegrationT
                     .as("Non-approved item %s should not be a billable workorder item", nonApprovedItem.getId())
                     .isFalse();
         }
+
+        // Verify the DECLINED LABOR item WAS promoted as a non-billable declined
+        // service line (FI-3, #1133) with declined=true and status CANCELLED
+        List<EstimateItem> declinedItems = allItems.stream()
+                .filter(item -> item.getApprovalStatus() == ApprovalStatus.DECLINED)
+                .toList();
+        assertThat(declinedItems).hasSize(1);
+
+        for (EstimateItem declinedItem : declinedItems) {
+            com.positivity.workorder.internal.entity.WorkorderServiceLine declinedLine = laborItems.stream()
+                    .filter(ws -> ws.getOriginEstimateItemId().equals(declinedItem.getId()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                            "Declined LABOR item " + declinedItem.getId() + " was not promoted as a service line"));
+            assertThat(declinedLine.getDeclined()).isTrue();
+            assertThat(declinedLine.getStatus()).isEqualTo(WorkorderItemStatus.CANCELLED);
+        }
     }
 
     private UUID seedEstimateWithMixedApprovalStatuses() {


### PR DESCRIPTION
## Capability &amp; Traceability
- Capability: n/a (test-only fix; unblocks the main CI path introduced by #1183)
- Parent STORY (durion): n/a (behavior under test was introduced by FI-3, #1133 / #1165)
- Child issue: n/a
- Domain: `domain:workorder`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Not applicable: no production code changes — only integration-test assertions are updated to match the already-merged FI-3 promotion contract.

## Contract Chain (when a Controller changed)
- Not applicable — no controller changes.

## Scope
- What changed: four assertions across two pos-workorder contract ITs (`PartialApprovalPromotionContractBehaviorIT` PA-001/PA-004/PA-005, `WorkorderItemGenerationContractBehaviorIT` WI-006).
- Why: the first post-merge main run of the new single-reactor CI (#1183, run 31138888212) ran pos-workorder's failsafe ITs for the first time since FI-3 (#1165) changed estimate promotion to also copy DECLINED LABOR items onto the workorder as non-billable declined service lines (`declined=true`, status `CANCELLED`) for the CRM declined-service feed. The old per-module IT matrix only ran ITs for changed modules, so these tests kept asserting the pre-FI-3 "approved items only" contract and rotted unnoticed. The tests now assert: only APPROVED items become billable lines; the declined LABOR item is present as a declined service line (and never as billable); billable lines trace to APPROVED estimate items and declined lines to DECLINED ones.

## Tests
- [x] Integration tests updated (the fix itself)
- How to run: `./mvnw -pl pos-workorder -am install -DskipTests` then `./mvnw -pl pos-workorder -DskipTests=false verify -DlowResourceTests=true`. Reproduced all four CI failures locally at `b5b9ec4` (deterministic — no `-T` parallelism involvement), then verified BUILD SUCCESS with this change (560 tests, 0 failures; `FlywayMigrationIT` excluded locally as it needs Docker, unavailable in the sandbox — it is unrelated to the failing assertions).

## Risk &amp; Rollback
- Risk level: Low — test-only; encodes the contract that shipped with FI-3.
- Rollback plan: `git revert` the single commit.

## Checklist
- [ ] Branch name matches `cap/` — n/a (infra follow-up branch `claude/backend-build-spec-lrbgnf`)
- [ ] PR title starts with `[CAP:]` — n/a
- [x] Links to parent + child issues are present — FI-3 references above
- [ ] Contract guide updated — n/a
- [ ] Required CI checks passing — pending this PR's run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9szbL2WrnjqWwE5wVMHhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9szbL2WrnjqWwE5wVMHhQ)_