### PR TITLE
Move OWASP scan to nightly and switch NVD updates to the datafeed mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,11 +299,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [ detect-test-modules, build-test ]
     # Only run on the nightly schedule or on manual dispatch. Even with an NVD
     # API key, a cold NVD sync via the API takes hours (observed ~2.5h for 48%
     # of the DB on 2026-08-07), so the scan is kept out of the push/PR path and
-    # runs overnight against the datafeed mirror instead.
+    # runs overnight against the datafeed mirror instead. No `needs`:
+    # detect-test-modules/build-test are skipped on schedule, and a job whose
+    # needs are skipped is skipped — the reactor cache restore below (plus its
+    # cache-miss fallback install) makes this job self-sufficient anyway.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,13 +300,11 @@ jobs:
     permissions:
       contents: read
     needs: [ detect-test-modules, build-test ]
-    # Only run on main branch pushes or on PRs whose changes reach the whole
-    # reactor (root pom / BOM / .mvn — where dependency versions live). The
-    # previous gate tested contains(pull_request.changed_files, 'pom.xml'),
-    # but changed_files is a numeric count, so it never matched.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' ||
-      (github.event_name == 'pull_request' &&
-       needs.detect-test-modules.outputs.full-reactor == 'true')
+    # Only run on the nightly schedule or on manual dispatch. Even with an NVD
+    # API key, a cold NVD sync via the API takes hours (observed ~2.5h for 48%
+    # of the DB on 2026-08-07), so the scan is kept out of the push/PR path and
+    # runs overnight against the datafeed mirror instead.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout code
@@ -356,15 +354,14 @@ jobs:
             ${{ runner.os }}-owasp-nvd-
 
       - name: Run OWASP Dependency Check
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: |
-          if [ -n "${NVD_API_KEY}" ]; then
-            ./mvnw org.owasp:dependency-check-maven:check -DnvdApiKey="${NVD_API_KEY}" -B
-          else
-            echo "NVD_API_KEY is not configured; dependency-check NVD updates may be slow."
-            ./mvnw org.owasp:dependency-check-maven:check -B
-          fi
+        # The NVD API is unusably slow even with an API key (a cold sync was
+        # observed taking >2.5h for half the DB), so pull the pre-built NVD
+        # cache the dependency-check project publishes daily instead — the
+        # {0} placeholder expands to a year or "modified" per feed file.
+        run: >-
+          ./mvnw org.owasp:dependency-check-maven:check
+          -DnvdDatafeedUrl="https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/nvdcve-{0}.json.gz"
+          -B
         continue-on-error: true
 
       - name: Upload dependency check report


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (CI infrastructure follow-up to #1183/#1184)
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:ci`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- n/a — workflow-only change, no controllers/DTOs/events/openapi touched

## Contract Chain (when a Controller changed)
- n/a — no controller changed

## Scope
- What changed:
  - `security-scan` in `ci.yml` now runs only on the nightly schedule (`cron: 0 6 * * *`) and `workflow_dispatch`, instead of every main push / full-reactor PR.
  - The OWASP Dependency Check step no longer syncs via the NVD API. It pulls the pre-built NVD cache the dependency-check project publishes daily (`-DnvdDatafeedUrl=https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/nvdcve-{0}.json.gz`), which downloads the full DB in minutes and needs no API key.
  - The weekly-keyed `~/.m2/repository/org/owasp` cache is kept, so warm nightly runs only fetch the `modified` feed.
- Why: a cold NVD sync through the API takes multiple hours even with a configured API key — the 2026-08-07 main-push run reached only 48% of 374k records after ~2.5h and had to be cancelled. This restores the previous skip-except-overnight policy and makes the overnight run itself fast.

## Tests
- [ ] Unit tests added/updated — n/a (workflow-only)
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run: trigger the `Backend CI/CD` workflow manually (`workflow_dispatch`) and confirm the Security Scan job completes; the NVD update step should finish in minutes.

## Risk & Rollback
- Risk level: Low — the scan job was already `continue-on-error`; this only changes when it runs and where it fetches NVD data.
- Rollback plan: revert this commit; the previous API-based configuration returns.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, session branch `claude/backend-build-spec-lrbgnf`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a
- [x] Links to parent + child issues are present (n/a)
- [x] Contract guide updated (no contract semantics changed)
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9szbL2WrnjqWwE5wVMHhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9szbL2WrnjqWwE5wVMHhQ)_