### PR TITLE
[CAP:316] Complete Labor & Overhead GL mapping + currency/location enrichment (#731)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,15 +191,24 @@ jobs:
           if [[ "${FULL_REACTOR}" == "true" ]]; then
             # Whole reactor affected: no -pl, every module's tests run.
             echo "args=" >> "$GITHUB_OUTPUT"
+            echo "args-pr=" >> "$GITHUB_OUTPUT"
             echo "run-tests=true" >> "$GITHUB_OUTPUT"
           else
             CSV="$(jq -r 'join(",")' <<< "${CHANGED_MODULES}")"
             if [[ -z "${CSV}" ]]; then
               # No module changed (e.g. root Dockerfile): archunit still runs below.
               echo "args=" >> "$GITHUB_OUTPUT"
+              echo "args-pr=" >> "$GITHUB_OUTPUT"
               echo "run-tests=false" >> "$GITHUB_OUTPUT"
             else
               echo "args=-pl ${CSV} -amd" >> "$GITHUB_OUTPUT"
+              # PR variant adds -am: with the build-cache pilot enabled, a cache
+              # hit on the install step skips installing sibling snapshots into
+              # ~/.m2, so the test session must materialize upstream modules in
+              # its own reactor (cache restores them cheaply). Without this, any
+              # re-run that hits the restored cache fails dependency resolution
+              # ("Could not find artifact com.positivity:pos-events:...").
+              echo "args-pr=-pl ${CSV} -amd -am" >> "$GITHUB_OUTPUT"
               echo "run-tests=true" >> "$GITHUB_OUTPUT"
             fi
           fi
@@ -210,7 +219,7 @@ jobs:
         # module builds fork test JVMs concurrently, and default heap sizing would
         # overcommit the 16 GB runner.
         run: |
-          ./mvnw ${{ steps.selection.outputs.args }} \
+          ./mvnw ${{ steps.selection.outputs.args-pr }} \
             -DskipTests=false test \
             org.jacoco:jacoco-maven-plugin:0.8.14:report \
             -Darchunit.skipTests=true \

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/LocationFxRate.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/LocationFxRate.java
@@ -1,0 +1,85 @@
+package com.positivity.accounting.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Configured FX rates for a location and fiscal year (issue #731, CAP-316 enrichment).
+ *
+ * <p>{@code localCurrencyPerUsd} is the period-end local-currency-per-USD rate;
+ * {@code averageRate} is the average conversion rate used for the year's P&amp;L flows (both
+ * {@code 1.00} for US plants — locations without a configured row fall back to that default).
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "accounting_location_fx_rate",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uq_accounting_location_fx_rate",
+                        columnNames = {"location_code", "fiscal_year"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class LocationFxRate {
+
+    @EqualsAndHashCode.Include
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "fx_rate_id", columnDefinition = "UUID")
+    private UUID fxRateId;
+
+    /** Accounting {@code locationId} dimension value this rate applies to. */
+    @NonNull
+    @Column(name = "location_code", length = 100, nullable = false)
+    private String locationCode;
+
+    @Column(name = "fiscal_year", nullable = false)
+    private int fiscalYear;
+
+    /** Local currency units per USD (e.g. {@code 17.150000} for MXN). */
+    @NonNull
+    @Column(name = "local_currency_per_usd", nullable = false, precision = 12, scale = 6)
+    private BigDecimal localCurrencyPerUsd;
+
+    /** Average conversion rate used for the year's flows. */
+    @NonNull
+    @Column(name = "average_rate", nullable = false, precision = 12, scale = 6)
+    private BigDecimal averageRate;
+
+    @Version
+    @Column(name = "version")
+    private Integer version;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/LocationProfile.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/LocationProfile.java
@@ -1,0 +1,76 @@
+package com.positivity.accounting.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Accounting-side location dimension master data (issue #731, CAP-316 enrichment).
+ *
+ * <p>Keyed by {@code locationCode} — the value carried in the journal-entry-line
+ * {@code locationId} dimension. Supplies the human-readable label and reporting currency for
+ * location-scoped reports. Locations without a profile are treated as US plants
+ * ({@code USD}, label = echoed location code).
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "accounting_location_profile")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class LocationProfile {
+
+    @EqualsAndHashCode.Include
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "profile_id", columnDefinition = "UUID")
+    private UUID profileId;
+
+    /** Accounting {@code locationId} dimension value (e.g. {@code LOC-107}). Unique. */
+    @NonNull
+    @Column(name = "location_code", length = 100, nullable = false, unique = true)
+    private String locationCode;
+
+    /** Human-readable location label shown on reports. */
+    @NonNull
+    @Column(name = "location_label", length = 255, nullable = false)
+    private String locationLabel;
+
+    /** ISO-4217 reporting currency of the plant (e.g. {@code USD}, {@code MXN}). */
+    @NonNull
+    @Column(name = "currency_code", length = 3, nullable = false)
+    private String currencyCode;
+
+    @Version
+    @Column(name = "version")
+    private Integer version;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/StatementLineMapping.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/entity/StatementLineMapping.java
@@ -119,6 +119,14 @@ public class StatementLineMapping {
     @Column(name = "operation", length = 50, nullable = false)
     private OperationType operation;
 
+    /**
+     * Optional location scope (accounting {@code locationId} dimension value). {@code null} rows are
+     * the global default for a statement line; rows carrying a location override the global rows for
+     * that line at that location (per-location-overridable master data, issue #731).
+     */
+    @Column(name = "location_id", length = 100)
+    private String locationId;
+
     @Transient
     public UUID getGlAccountId() {
         return glAccount != null ? glAccount.getGlAccountId() : null;

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationFxRateRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationFxRateRepository.java
@@ -1,0 +1,23 @@
+package com.positivity.accounting.internal.repository;
+
+import com.positivity.accounting.internal.entity.LocationFxRate;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Repository for configured location/fiscal-year FX rates (issue #731). */
+@Repository
+public interface LocationFxRateRepository extends JpaRepository<LocationFxRate, UUID> {
+
+    /**
+     * Find the configured FX rate for a location and fiscal year.
+     *
+     * @param locationCode the accounting {@code locationId} dimension value
+     * @param fiscalYear the fiscal year the rate applies to
+     * @return the configured rate, or empty when the location defaults to a US plant (1.00)
+     */
+    @NonNull
+    Optional<LocationFxRate> findByLocationCodeAndFiscalYear(@NonNull String locationCode, int fiscalYear);
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationFxRateRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationFxRateRepository.java
@@ -18,6 +18,5 @@ public interface LocationFxRateRepository extends JpaRepository<LocationFxRate, 
      * @param fiscalYear the fiscal year the rate applies to
      * @return the configured rate, or empty when the location defaults to a US plant (1.00)
      */
-    @NonNull
     Optional<LocationFxRate> findByLocationCodeAndFiscalYear(@NonNull String locationCode, int fiscalYear);
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationProfileRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationProfileRepository.java
@@ -1,0 +1,22 @@
+package com.positivity.accounting.internal.repository;
+
+import com.positivity.accounting.internal.entity.LocationProfile;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Repository for the accounting-side location dimension (issue #731). */
+@Repository
+public interface LocationProfileRepository extends JpaRepository<LocationProfile, UUID> {
+
+    /**
+     * Find the profile for an accounting {@code locationId} dimension value.
+     *
+     * @param locationCode the location code (e.g. {@code LOC-107})
+     * @return the profile, or empty when the location has no accounting-side master data
+     */
+    @NonNull
+    Optional<LocationProfile> findByLocationCode(@NonNull String locationCode);
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationProfileRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationProfileRepository.java
@@ -17,6 +17,5 @@ public interface LocationProfileRepository extends JpaRepository<LocationProfile
      * @param locationCode the location code (e.g. {@code LOC-107})
      * @return the profile, or empty when the location has no accounting-side master data
      */
-    @NonNull
     Optional<LocationProfile> findByLocationCode(@NonNull String locationCode);
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
@@ -3,14 +3,19 @@ package com.positivity.accounting.internal.service;
 import com.positivity.accounting.internal.dto.LaborOverheadCostReport;
 import com.positivity.accounting.internal.dto.LaborOverheadReportLine;
 import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.entity.LocationFxRate;
+import com.positivity.accounting.internal.entity.LocationProfile;
 import com.positivity.accounting.internal.enums.StatementType;
 import com.positivity.accounting.internal.report.LaborOverheadTaxonomy;
 import com.positivity.accounting.internal.report.LaborOverheadTaxonomy.LineDef;
 import com.positivity.accounting.internal.repository.JournalEntryLineRepository;
+import com.positivity.accounting.internal.repository.LocationFxRateRepository;
+import com.positivity.accounting.internal.repository.LocationProfileRepository;
 import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
 import com.positivity.accounting.service.LaborOverheadReportService;
 import com.positivity.security.common.LogSanitizer;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -37,6 +42,12 @@ import org.springframework.transaction.annotation.Transactional;
  * (debit − credit) by month for the requested {@code locationId} dimension, computes subtotal rows
  * column-wise from the taxonomy, and derives YTD over the elapsed months. Mirrors the posted-state
  * semantic ({@code je.status = 'POSTED'}) used by the existing financial reporting.
+ *
+ * <p>Issue #731 enrichment: mappings are per-location-overridable (location rows replace global
+ * rows per line code); the report header resolves {@code locationLabel}/{@code currency} from the
+ * accounting-side {@link LocationProfile} and the FX rates from {@link LocationFxRate}, both
+ * defaulting to a US plant (USD, 1.00) when unconfigured. The {@code usdOnly} line (2.11.4) is
+ * presented in USD on local-currency plants via the year's average rate.
  */
 @Service
 @Transactional(readOnly = true)
@@ -51,12 +62,18 @@ public class LaborOverheadReportServiceImpl implements LaborOverheadReportServic
 
     private final StatementLineMappingRepository statementLineMappingRepository;
     private final JournalEntryLineRepository journalEntryLineRepository;
+    private final LocationProfileRepository locationProfileRepository;
+    private final LocationFxRateRepository locationFxRateRepository;
 
     public LaborOverheadReportServiceImpl(
             StatementLineMappingRepository statementLineMappingRepository,
-            JournalEntryLineRepository journalEntryLineRepository) {
+            JournalEntryLineRepository journalEntryLineRepository,
+            LocationProfileRepository locationProfileRepository,
+            LocationFxRateRepository locationFxRateRepository) {
         this.statementLineMappingRepository = statementLineMappingRepository;
         this.journalEntryLineRepository = journalEntryLineRepository;
+        this.locationProfileRepository = locationProfileRepository;
+        this.locationFxRateRepository = locationFxRateRepository;
     }
 
     @Override
@@ -70,41 +87,69 @@ public class LaborOverheadReportServiceImpl implements LaborOverheadReportServic
                 fiscalYear,
                 resolvedAsOfMonth);
 
-        Map<String, Set<UUID>> leafToAccounts = resolveLeafToAccounts();
+        Map<String, Set<UUID>> leafToAccounts = resolveLeafToAccounts(locationId);
         Map<String, BigDecimal[]> leafMonthly = aggregateLeafMonthly(leafToAccounts, locationId, fiscalYear);
+
+        LocationProfile profile =
+                locationProfileRepository.findByLocationCode(locationId).orElse(null);
+        LocationFxRate fxRate = locationFxRateRepository
+                .findByLocationCodeAndFiscalYear(locationId, fiscalYear)
+                .orElse(null);
+        BigDecimal averageRate = fxRate != null ? fxRate.getAverageRate() : RATE_US_PLANT;
 
         Map<String, BigDecimal[]> monthlyByCode = new HashMap<>();
         List<LaborOverheadReportLine> reportLines = new ArrayList<>();
         for (LineDef def : LaborOverheadTaxonomy.lines()) {
             BigDecimal[] monthly = computeMonthly(def, leafMonthly, monthlyByCode);
+            if (def.usdOnly()) {
+                monthly = toUsd(monthly, averageRate);
+            }
             reportLines.add(toReportLine(def, monthly, resolvedAsOfMonth));
         }
 
         return LaborOverheadCostReport.builder()
                 .locationId(locationId)
-                .locationLabel(locationId)
+                .locationLabel(profile != null ? profile.getLocationLabel() : locationId)
                 .fiscalYear(fiscalYear)
                 .asOfMonth(resolvedAsOfMonth)
-                .currency(CURRENCY_USD)
-                .localCurrencyPerUsd(RATE_US_PLANT)
-                .averageRate(RATE_US_PLANT)
+                .currency(profile != null ? profile.getCurrencyCode() : CURRENCY_USD)
+                .localCurrencyPerUsd(fxRate != null ? fxRate.getLocalCurrencyPerUsd() : RATE_US_PLANT)
+                .averageRate(averageRate)
                 .lines(reportLines)
                 .build();
     }
 
-    /** Group LABOR_OVERHEAD mappings by line code into the set of contributing GL account ids. */
-    private Map<String, Set<UUID>> resolveLeafToAccounts() {
-        Map<String, Set<UUID>> leafToAccounts = new HashMap<>();
+    /**
+     * Group LABOR_OVERHEAD mappings by line code into the set of contributing GL account ids.
+     *
+     * <p>Rows with a {@code null} location are the global default; rows carrying the requested
+     * location <b>replace</b> the global rows for that line code. Rows scoped to other locations are
+     * ignored.
+     */
+    private Map<String, Set<UUID>> resolveLeafToAccounts(String locationId) {
+        Map<String, Set<UUID>> globalAccounts = new HashMap<>();
+        Map<String, Set<UUID>> overrideAccounts = new HashMap<>();
         statementLineMappingRepository
                 .findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(StatementType.LABOR_OVERHEAD)
                 .forEach(mapping -> {
                     UUID accountId = mapping.getGlAccountId();
-                    if (accountId != null && mapping.getStatementLineCode() != null) {
-                        leafToAccounts
-                                .computeIfAbsent(mapping.getStatementLineCode(), key -> new LinkedHashSet<>())
-                                .add(accountId);
+                    if (accountId == null || mapping.getStatementLineCode() == null) {
+                        return;
                     }
+                    String mappingLocation = mapping.getLocationId();
+                    Map<String, Set<UUID>> target;
+                    if (mappingLocation == null) {
+                        target = globalAccounts;
+                    } else if (mappingLocation.equals(locationId)) {
+                        target = overrideAccounts;
+                    } else {
+                        return;
+                    }
+                    target.computeIfAbsent(mapping.getStatementLineCode(), key -> new LinkedHashSet<>())
+                            .add(accountId);
                 });
+        Map<String, Set<UUID>> leafToAccounts = new HashMap<>(globalAccounts);
+        leafToAccounts.putAll(overrideAccounts);
         return leafToAccounts;
     }
 
@@ -199,6 +244,24 @@ public class LaborOverheadReportServiceImpl implements LaborOverheadReportServic
                 .monthly(List.of(monthly))
                 .ytd(ytd)
                 .build();
+    }
+
+    /**
+     * Convert a monthly array from local currency to USD using the year's average rate
+     * ({@code usd = local / averageRate}). Applied only to {@code usdOnly} lines (2.11.4) on
+     * local-currency plants; subtotals are computed from the unconverted local amounts, so a
+     * local-currency subtotal is not the arithmetic sum of a converted USD child (source-form
+     * behavior). Returns a new array — the memoized subtotal inputs are never mutated.
+     */
+    private static BigDecimal[] toUsd(BigDecimal[] monthly, BigDecimal averageRate) {
+        if (BigDecimal.ONE.compareTo(averageRate) == 0) {
+            return monthly;
+        }
+        BigDecimal[] converted = new BigDecimal[MONTHS];
+        for (int m = 0; m < MONTHS; m++) {
+            converted[m] = monthly[m].divide(averageRate, 2, RoundingMode.HALF_UP);
+        }
+        return converted;
     }
 
     private boolean matchesLocation(JournalEntryLine line, String locationId) {

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImpl.java
@@ -45,9 +45,10 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * <p>Issue #731 enrichment: mappings are per-location-overridable (location rows replace global
  * rows per line code); the report header resolves {@code locationLabel}/{@code currency} from the
- * accounting-side {@link LocationProfile} and the FX rates from {@link LocationFxRate}, both
- * defaulting to a US plant (USD, 1.00) when unconfigured. The {@code usdOnly} line (2.11.4) is
- * presented in USD on local-currency plants via the year's average rate.
+ * accounting-side {@link LocationProfile}, defaulting to a US plant (USD, 1.00) when unconfigured.
+ * FX ({@link LocationFxRate}) is consulted only for a profiled non-USD plant — an orphaned FX row
+ * never skews a USD report — and only then is the {@code usdOnly} line (2.11.4) presented in USD
+ * via the year's average rate.
  */
 @Service
 @Transactional(readOnly = true)
@@ -92,16 +93,21 @@ public class LaborOverheadReportServiceImpl implements LaborOverheadReportServic
 
         LocationProfile profile =
                 locationProfileRepository.findByLocationCode(locationId).orElse(null);
-        LocationFxRate fxRate = locationFxRateRepository
-                .findByLocationCodeAndFiscalYear(locationId, fiscalYear)
-                .orElse(null);
+        // FX is active only for a profiled local-currency plant; a partial FX config without a
+        // profile (or for a USD plant) must not skew the header rates or convert any line.
+        boolean localCurrencyPlant = profile != null && !CURRENCY_USD.equals(profile.getCurrencyCode());
+        LocationFxRate fxRate = localCurrencyPlant
+                ? locationFxRateRepository
+                        .findByLocationCodeAndFiscalYear(locationId, fiscalYear)
+                        .orElse(null)
+                : null;
         BigDecimal averageRate = fxRate != null ? fxRate.getAverageRate() : RATE_US_PLANT;
 
         Map<String, BigDecimal[]> monthlyByCode = new HashMap<>();
         List<LaborOverheadReportLine> reportLines = new ArrayList<>();
         for (LineDef def : LaborOverheadTaxonomy.lines()) {
             BigDecimal[] monthly = computeMonthly(def, leafMonthly, monthlyByCode);
-            if (def.usdOnly()) {
+            if (def.usdOnly() && localCurrencyPlant) {
                 monthly = toUsd(monthly, averageRate);
             }
             reportLines.add(toReportLine(def, monthly, resolvedAsOfMonth));

--- a/pos-accounting/src/main/resources/db/migration/V25__labor_overhead_full_mapping_and_location_enrichment.sql
+++ b/pos-accounting/src/main/resources/db/migration/V25__labor_overhead_full_mapping_and_location_enrichment.sql
@@ -1,0 +1,154 @@
+-- Issue #731 (CAP-316 follow-up): complete the Labor & Overhead report-line -> GL-account mapping
+-- and add location currency/FX enrichment master data.
+--
+-- 1. statement_line_mappings gains a nullable location_id: a NULL row is the global default for a
+--    line; rows carrying a location_id override the global rows for that line at that location
+--    (persisted, per-location-overridable master data — the decision recorded on #731).
+-- 2. Every canonical CAP-316 leaf line (Labor 1.1.1–1.5, Overhead 2.1.1–2.15.2) now has an
+--    authoritative global mapping against the retread-plant chart of accounts (6xxx expense series;
+--    2.14 rubber-dust income stays on revenue account 6900). The five representative V3 rows are
+--    re-asserted here with their canonical display order.
+-- 3. accounting_location_profile / accounting_location_fx_rate hold the location dimension used to
+--    resolve locationLabel + currency and the per-fiscal-year FX rates (localCurrencyPerUsd,
+--    averageRate). Locations absent from these tables are treated as US plants (USD, 1.00).
+--
+-- FLYWAY COLLISION NOTE: numbered V25 as the next contiguous version after V24. Unmerged
+-- accounting branches may also claim a V2x; renumber on rebase if one merges first.
+
+-- ---------------------------------------------------------------- 1. location override column
+ALTER TABLE statement_line_mappings
+    ADD COLUMN location_id character varying(100);
+
+CREATE INDEX idx_statement_line_mapping_line_location
+    ON statement_line_mappings (statement_type, statement_line_code, location_id);
+
+-- ---------------------------------------------------------------- 3. location enrichment tables
+CREATE TABLE accounting_location_profile (
+    profile_id uuid NOT NULL,
+    location_code character varying(100) NOT NULL,
+    location_label character varying(255) NOT NULL,
+    currency_code character varying(3) NOT NULL,
+    version integer,
+    created_at timestamp(6) with time zone NOT NULL,
+    modified_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT accounting_location_profile_pkey PRIMARY KEY (profile_id),
+    CONSTRAINT uq_accounting_location_profile_code UNIQUE (location_code)
+);
+
+CREATE TABLE accounting_location_fx_rate (
+    fx_rate_id uuid NOT NULL,
+    location_code character varying(100) NOT NULL,
+    fiscal_year integer NOT NULL,
+    local_currency_per_usd numeric(12, 6) NOT NULL,
+    average_rate numeric(12, 6) NOT NULL,
+    version integer,
+    created_at timestamp(6) with time zone NOT NULL,
+    modified_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT accounting_location_fx_rate_pkey PRIMARY KEY (fx_rate_id),
+    CONSTRAINT uq_accounting_location_fx_rate UNIQUE (location_code, fiscal_year),
+    CONSTRAINT accounting_location_fx_rate_per_usd_check CHECK (local_currency_per_usd > 0),
+    CONSTRAINT accounting_location_fx_rate_average_check CHECK (average_rate > 0)
+);
+
+-- ---------------------------------------------------------------- 2. full chart + mapping seed
+-- Retread-plant chart of accounts (existing: 6010, 6110, 6400, 6450, 6900 from V3).
+INSERT INTO gl_account (gl_account_id, account_code, account_name, account_type, version, created_at, created_by, modified_at, modified_by)
+VALUES
+    ('a1000000-0000-7000-8000-000000000006'::uuid, '6015', 'Retread Plant Management Salaries', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000007'::uuid, '6025', 'Retread Plant Contract & Temp Labor', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000008'::uuid, '6120', 'Retread Plant Federal Unemployment Tax', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000009'::uuid, '6130', 'Retread Plant State Unemployment Tax', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000010'::uuid, '6140', 'Retread Plant Medical & Life Insurance', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000011'::uuid, '6150', 'Retread Plant Retirement Contributions', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000012'::uuid, '6160', 'Retread Plant Workers Comp Insurance', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000013'::uuid, '6170', 'Retread Plant Uniforms & Laundry', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000014'::uuid, '6200', 'Retread Building Depreciation', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000015'::uuid, '6210', 'Retread Building Maintenance', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000016'::uuid, '6220', 'Retread Building Rent', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000017'::uuid, '6230', 'Retread Plant Training Costs', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000018'::uuid, '6240', 'Retread Plant Recruiting & Employment Advertising', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000019'::uuid, '6250', 'Retread Plant Vehicle Gas & Oil', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000020'::uuid, '6255', 'Retread Plant Vehicle Maintenance', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000021'::uuid, '6260', 'Retread Plant Vehicle Taxes', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000022'::uuid, '6265', 'Retread Plant Vehicle Depreciation', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000023'::uuid, '6270', 'Retread Plant Vehicle Rent', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000024'::uuid, '6280', 'Retread Plant Telephone', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000025'::uuid, '6290', 'Retread Plant Travel & Entertainment', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000026'::uuid, '6300', 'Retread Plant Fire Insurance', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000027'::uuid, '6310', 'Retread Plant Theft Insurance', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000028'::uuid, '6320', 'Retread Plant Liability Insurance', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000029'::uuid, '6330', 'Retread Plant Property Taxes', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000030'::uuid, '6340', 'Retread Shop Consumables', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000031'::uuid, '6350', 'Retread Curing Consumables', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000032'::uuid, '6360', 'Retread Plant Miscellaneous Supplies', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000033'::uuid, '6370', 'Retread Plant Office Supplies', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000034'::uuid, '6410', 'Retread Equipment Maintenance', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000035'::uuid, '6420', 'Retread Equipment Rental', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000036'::uuid, '6430', 'Retread Small Tools & Equipment', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000037'::uuid, '6460', 'Retread Other Shop Equipment Depreciation', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000038'::uuid, '6470', 'MRTI Equipment Leases & Software', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000039'::uuid, '6500', 'Retread Plant Administration Fees', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000040'::uuid, '6510', 'Retread Inventory Charge', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000041'::uuid, '6520', 'Casings Scrapped In Production', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator'),
+    ('a1000000-0000-7000-8000-000000000042'::uuid, '6530', 'Retread Production Adjustments', 'EXPENSE', 0, NOW(), 'seed-generator', NOW(), 'seed-generator')
+ON CONFLICT (account_code) DO UPDATE SET
+    account_name = EXCLUDED.account_name,
+    account_type = EXCLUDED.account_type,
+    modified_at = NOW(),
+    modified_by = 'seed-generator';
+
+-- Global (location_id NULL) mapping for every canonical leaf line, canonical display order.
+-- Rows b...01–05 re-assert the V3 representative rows with their canonical positions.
+INSERT INTO statement_line_mappings (mapping_id, gl_account_id, account_name, statement_type, statement_line_code, parent_line_code, line_description, display_order, operation)
+VALUES
+    ('b1000000-0000-7000-8000-000000000001'::uuid, 'a1000000-0000-7000-8000-000000000001'::uuid, '6010', 'LABOR_OVERHEAD', '1.1.1', '1.1', 'Hourly wages and bonuses', 1, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000006'::uuid, 'a1000000-0000-7000-8000-000000000006'::uuid, '6015', 'LABOR_OVERHEAD', '1.1.2', '1.1', 'Management salaries', 2, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000007'::uuid, 'a1000000-0000-7000-8000-000000000007'::uuid, '6025', 'LABOR_OVERHEAD', '1.2', NULL, 'Misc Labor (contract and temp production employees)', 3, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000002'::uuid, 'a1000000-0000-7000-8000-000000000002'::uuid, '6110', 'LABOR_OVERHEAD', '1.3.1', '1.3', 'FICA', 4, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000008'::uuid, 'a1000000-0000-7000-8000-000000000008'::uuid, '6120', 'LABOR_OVERHEAD', '1.3.2', '1.3', 'Fed Unemployment', 5, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000009'::uuid, 'a1000000-0000-7000-8000-000000000009'::uuid, '6130', 'LABOR_OVERHEAD', '1.3.3', '1.3', 'State Unemployment', 6, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000010'::uuid, 'a1000000-0000-7000-8000-000000000010'::uuid, '6140', 'LABOR_OVERHEAD', '1.3.4', '1.3', 'Medical/dental insurance, life, health, disability', 7, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000011'::uuid, 'a1000000-0000-7000-8000-000000000011'::uuid, '6150', 'LABOR_OVERHEAD', '1.3.5', '1.3', 'Retirement plan contributions', 8, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000012'::uuid, 'a1000000-0000-7000-8000-000000000012'::uuid, '6160', 'LABOR_OVERHEAD', '1.3.6', '1.3', 'Employee Insurance - workers'' comp', 9, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000013'::uuid, 'a1000000-0000-7000-8000-000000000013'::uuid, '6170', 'LABOR_OVERHEAD', '1.5', NULL, 'Uniforms rental / laundry', 10, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000014'::uuid, 'a1000000-0000-7000-8000-000000000014'::uuid, '6200', 'LABOR_OVERHEAD', '2.1.1', '2.1', 'Building depreciation', 11, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000015'::uuid, 'a1000000-0000-7000-8000-000000000015'::uuid, '6210', 'LABOR_OVERHEAD', '2.1.2', '2.1', 'Building maintenance', 12, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000016'::uuid, 'a1000000-0000-7000-8000-000000000016'::uuid, '6220', 'LABOR_OVERHEAD', '2.1.3', '2.1', 'Building rent', 13, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000017'::uuid, 'a1000000-0000-7000-8000-000000000017'::uuid, '6230', 'LABOR_OVERHEAD', '2.2', NULL, 'Training Costs', 14, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000018'::uuid, 'a1000000-0000-7000-8000-000000000018'::uuid, '6240', 'LABOR_OVERHEAD', '2.3', NULL, 'Employment advertising / recruiting costs', 15, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000019'::uuid, 'a1000000-0000-7000-8000-000000000019'::uuid, '6250', 'LABOR_OVERHEAD', '2.4.1', '2.4', 'Vehicle Gas & Oil', 16, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000020'::uuid, 'a1000000-0000-7000-8000-000000000020'::uuid, '6255', 'LABOR_OVERHEAD', '2.4.2', '2.4', 'Vehicle Maintenance', 17, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000021'::uuid, 'a1000000-0000-7000-8000-000000000021'::uuid, '6260', 'LABOR_OVERHEAD', '2.4.3', '2.4', 'Vehicle Taxes', 18, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000022'::uuid, 'a1000000-0000-7000-8000-000000000022'::uuid, '6265', 'LABOR_OVERHEAD', '2.4.4', '2.4', 'Vehicle Depreciation', 19, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000023'::uuid, 'a1000000-0000-7000-8000-000000000023'::uuid, '6270', 'LABOR_OVERHEAD', '2.4.5', '2.4', 'Vehicle Rent', 20, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000024'::uuid, 'a1000000-0000-7000-8000-000000000024'::uuid, '6280', 'LABOR_OVERHEAD', '2.5', NULL, 'Telephone', 21, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000025'::uuid, 'a1000000-0000-7000-8000-000000000025'::uuid, '6290', 'LABOR_OVERHEAD', '2.6', NULL, 'Travel and Entertainment', 22, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000026'::uuid, 'a1000000-0000-7000-8000-000000000026'::uuid, '6300', 'LABOR_OVERHEAD', '2.7.1', '2.7', 'Fire insurance', 23, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000027'::uuid, 'a1000000-0000-7000-8000-000000000027'::uuid, '6310', 'LABOR_OVERHEAD', '2.7.2', '2.7', 'Theft insurance', 24, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000028'::uuid, 'a1000000-0000-7000-8000-000000000028'::uuid, '6320', 'LABOR_OVERHEAD', '2.7.3', '2.7', 'Liability insurance', 25, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000029'::uuid, 'a1000000-0000-7000-8000-000000000029'::uuid, '6330', 'LABOR_OVERHEAD', '2.8', NULL, 'Property Taxes', 26, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000030'::uuid, 'a1000000-0000-7000-8000-000000000030'::uuid, '6340', 'LABOR_OVERHEAD', '2.9.1', '2.9', 'Shop Consumables (rasps, grinding wheels, brushes)', 27, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000031'::uuid, 'a1000000-0000-7000-8000-000000000031'::uuid, '6350', 'LABOR_OVERHEAD', '2.9.2', '2.9', 'Curing Consumables (envelopes, lube, wicks, poly)', 28, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000032'::uuid, 'a1000000-0000-7000-8000-000000000032'::uuid, '6360', 'LABOR_OVERHEAD', '2.9.3', '2.9', 'Miscellaneous supplies', 29, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000033'::uuid, 'a1000000-0000-7000-8000-000000000033'::uuid, '6370', 'LABOR_OVERHEAD', '2.9.4', '2.9', 'Office supplies', 30, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000003'::uuid, 'a1000000-0000-7000-8000-000000000003'::uuid, '6400', 'LABOR_OVERHEAD', '2.10', NULL, 'Utilities - gas, electric, water', 31, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000034'::uuid, 'a1000000-0000-7000-8000-000000000034'::uuid, '6410', 'LABOR_OVERHEAD', '2.11.1', '2.11', 'Equipment maintenance', 32, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000035'::uuid, 'a1000000-0000-7000-8000-000000000035'::uuid, '6420', 'LABOR_OVERHEAD', '2.11.2', '2.11', 'Equipment rental', 33, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000036'::uuid, 'a1000000-0000-7000-8000-000000000036'::uuid, '6430', 'LABOR_OVERHEAD', '2.11.3', '2.11', 'Small tools and equipment', 34, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000004'::uuid, 'a1000000-0000-7000-8000-000000000004'::uuid, '6450', 'LABOR_OVERHEAD', '2.11.4', '2.11', 'Depreciation - MRT process equipment ($US only)', 35, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000037'::uuid, 'a1000000-0000-7000-8000-000000000037'::uuid, '6460', 'LABOR_OVERHEAD', '2.11.5', '2.11', 'Depreciation - Other shop equipment', 36, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000038'::uuid, 'a1000000-0000-7000-8000-000000000038'::uuid, '6470', 'LABOR_OVERHEAD', '2.11.6', '2.11', 'MRTI equipment leases or rent', 37, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000039'::uuid, 'a1000000-0000-7000-8000-000000000039'::uuid, '6500', 'LABOR_OVERHEAD', '2.12', NULL, 'Administration fees', 38, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000040'::uuid, 'a1000000-0000-7000-8000-000000000040'::uuid, '6510', 'LABOR_OVERHEAD', '2.13', NULL, 'Inventory charge', 39, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000005'::uuid, 'a1000000-0000-7000-8000-000000000005'::uuid, '6900', 'LABOR_OVERHEAD', '2.14', NULL, 'Income from rubber dust sales', 40, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000041'::uuid, 'a1000000-0000-7000-8000-000000000041'::uuid, '6520', 'LABOR_OVERHEAD', '2.15.1', '2.15', 'Casings scrapped in production', 41, 'SUM'),
+    ('b1000000-0000-7000-8000-000000000042'::uuid, 'a1000000-0000-7000-8000-000000000042'::uuid, '6530', 'LABOR_OVERHEAD', '2.15.2', '2.15', 'Adjustments (customer returns)', 42, 'SUM')
+ON CONFLICT (mapping_id) DO UPDATE SET
+    gl_account_id = EXCLUDED.gl_account_id,
+    account_name = EXCLUDED.account_name,
+    statement_type = EXCLUDED.statement_type,
+    statement_line_code = EXCLUDED.statement_line_code,
+    parent_line_code = EXCLUDED.parent_line_code,
+    line_description = EXCLUDED.line_description,
+    display_order = EXCLUDED.display_order,
+    operation = EXCLUDED.operation;

--- a/pos-accounting/src/test/java/com/positivity/accounting/contract/LaborOverheadReportContractBehaviorIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/contract/LaborOverheadReportContractBehaviorIT.java
@@ -10,6 +10,8 @@ import com.positivity.accounting.internal.dto.LaborOverheadReportLine;
 import com.positivity.accounting.internal.entity.GLAccount;
 import com.positivity.accounting.internal.entity.JournalEntry;
 import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.entity.LocationFxRate;
+import com.positivity.accounting.internal.entity.LocationProfile;
 import com.positivity.accounting.internal.entity.StatementLineMapping;
 import com.positivity.accounting.internal.enums.AccountType;
 import com.positivity.accounting.internal.enums.JournalEntryStatus;
@@ -18,6 +20,8 @@ import com.positivity.accounting.internal.enums.StatementType;
 import com.positivity.accounting.internal.report.LaborOverheadTaxonomy;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.repository.LocationFxRateRepository;
+import com.positivity.accounting.internal.repository.LocationProfileRepository;
 import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -47,6 +51,12 @@ class LaborOverheadReportContractBehaviorIT extends BaseContractIntegrationTest 
 
     @Autowired
     private JournalEntryRepository journalEntryRepository;
+
+    @Autowired
+    private LocationProfileRepository locationProfileRepository;
+
+    @Autowired
+    private LocationFxRateRepository locationFxRateRepository;
 
     @Test
     @DisplayName("Report leaf + subtotal amounts trace to a posted journal entry for the location")
@@ -111,6 +121,70 @@ class LaborOverheadReportContractBehaviorIT extends BaseContractIntegrationTest 
         assertThat(wages.getYtd()).isEqualByComparingTo("1000.00");
     }
 
+    @Test
+    @DisplayName("Header enrichment: locationLabel/currency from the location profile, rates from the FX config,"
+            + " and line 2.11.4 reported in USD on a local-currency plant")
+    void enrichesHeaderAndReportsUsdOnlyLineInUsd() throws Exception {
+        String location = "LOC-IT-316-MX";
+        LocationProfile profile = new LocationProfile();
+        profile.setLocationCode(location);
+        profile.setLocationLabel("Planta Monterrey");
+        profile.setCurrencyCode("MXN");
+        locationProfileRepository.save(profile);
+        LocationFxRate fxRate = new LocationFxRate();
+        fxRate.setLocationCode(location);
+        fxRate.setFiscalYear(FISCAL_YEAR);
+        fxRate.setLocalCurrencyPerUsd(new BigDecimal("17.500000"));
+        fxRate.setAverageRate(new BigDecimal("2.000000"));
+        locationFxRateRepository.save(fxRate);
+
+        GLAccount mrtDepreciation = seedAccount("6450-IT", "Retread MRT Equipment Depreciation (IT)");
+        seedMapping("2.11.4", mrtDepreciation);
+        seedPostedExpense(mrtDepreciation, 5, location, new BigDecimal("100.00")); // MXN in GL
+
+        String json = mockMvc.perform(withAuth(get(PATH)
+                        .param("locationId", location)
+                        .param("fiscalYear", String.valueOf(FISCAL_YEAR))
+                        .param("asOfMonth", "12")))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        LaborOverheadCostReport report = objectMapper.readValue(json, LaborOverheadCostReport.class);
+        assertThat(report.getLocationLabel()).isEqualTo("Planta Monterrey");
+        assertThat(report.getCurrency()).isEqualTo("MXN");
+        assertThat(report.getLocalCurrencyPerUsd()).isEqualByComparingTo("17.5");
+        assertThat(report.getAverageRate()).isEqualByComparingTo("2");
+        // 100 MXN / 2.0 average rate -> 50 USD on the usdOnly line.
+        assertThat(line(report, "2.11.4").getMonthly().get(4)).isEqualByComparingTo("50.00");
+        assertThat(line(report, "2.11.4").getYtd()).isEqualByComparingTo("50.00");
+    }
+
+    @Test
+    @DisplayName("A location-scoped mapping overrides the global mapping for that line")
+    void locationScopedMappingOverridesGlobal() throws Exception {
+        String location = "LOC-IT-316-OVR";
+        GLAccount globalAccount = seedAccount("6010-IT3", "Retread Plant Hourly Wages (IT3)");
+        GLAccount overrideAccount = seedAccount("6011-IT3", "Retread Plant Hourly Wages Override (IT3)");
+        seedMapping("1.1.1", globalAccount);
+        seedMapping("1.1.1", overrideAccount, location);
+        seedPostedExpense(globalAccount, 3, location, new BigDecimal("1000.00"));
+        seedPostedExpense(overrideAccount, 3, location, new BigDecimal("400.00"));
+
+        String json = mockMvc.perform(withAuth(get(PATH)
+                        .param("locationId", location)
+                        .param("fiscalYear", String.valueOf(FISCAL_YEAR))
+                        .param("asOfMonth", "12")))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        LaborOverheadReportLine wages = line(objectMapper.readValue(json, LaborOverheadCostReport.class), "1.1.1");
+        assertThat(wages.getMonthly().get(2)).isEqualByComparingTo("400.00"); // override replaces global
+    }
+
     private GLAccount seedAccount(String code, String name) {
         GLAccount account = new GLAccount();
         account.setAccountCode(code);
@@ -122,6 +196,10 @@ class LaborOverheadReportContractBehaviorIT extends BaseContractIntegrationTest 
     }
 
     private void seedMapping(String lineCode, GLAccount account) {
+        seedMapping(lineCode, account, null);
+    }
+
+    private void seedMapping(String lineCode, GLAccount account, String locationId) {
         StatementLineMapping mapping = new StatementLineMapping();
         mapping.setStatementType(StatementType.LABOR_OVERHEAD);
         mapping.setStatementLineCode(lineCode);
@@ -129,6 +207,7 @@ class LaborOverheadReportContractBehaviorIT extends BaseContractIntegrationTest 
         mapping.setAccountName(account.getAccountCode());
         mapping.setOperation(OperationType.SUM);
         mapping.setDisplayOrder(1);
+        mapping.setLocationId(locationId);
         statementLineMappingRepository.save(mapping);
     }
 

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/report/LaborOverheadMappingSeedTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/report/LaborOverheadMappingSeedTest.java
@@ -1,0 +1,46 @@
+package com.positivity.accounting.internal.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the issue #731 acceptance criterion that <b>every</b> canonical CAP-316 leaf line carries
+ * an authoritative GL-account mapping: parses the V25 seed migration and cross-checks its
+ * LABOR_OVERHEAD line codes against {@link LaborOverheadTaxonomy#leafCodes()}. Contract ITs run on
+ * H2 without Flyway, so the seed content is verified statically here.
+ */
+class LaborOverheadMappingSeedTest {
+
+    private static final String MIGRATION =
+            "/db/migration/V25__labor_overhead_full_mapping_and_location_enrichment.sql";
+
+    private static final Pattern MAPPING_ROW = Pattern.compile("'LABOR_OVERHEAD',\\s*'([^']+)'");
+
+    @Test
+    void v25SeedsAGlobalMappingForEveryCanonicalLeafLine() throws IOException {
+        String sql = readMigration();
+
+        Set<String> seededCodes = new LinkedHashSet<>();
+        Matcher matcher = MAPPING_ROW.matcher(sql);
+        while (matcher.find()) {
+            seededCodes.add(matcher.group(1));
+        }
+
+        assertThat(seededCodes).containsExactlyInAnyOrderElementsOf(LaborOverheadTaxonomy.leafCodes());
+    }
+
+    private static String readMigration() throws IOException {
+        try (InputStream stream = LaborOverheadMappingSeedTest.class.getResourceAsStream(MIGRATION)) {
+            assertThat(stream).as("migration %s on classpath", MIGRATION).isNotNull();
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
@@ -2,23 +2,30 @@ package com.positivity.accounting.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.positivity.accounting.internal.dto.LaborOverheadCostReport;
 import com.positivity.accounting.internal.dto.LaborOverheadReportLine;
 import com.positivity.accounting.internal.entity.JournalEntry;
 import com.positivity.accounting.internal.entity.JournalEntryLine;
+import com.positivity.accounting.internal.entity.LocationFxRate;
+import com.positivity.accounting.internal.entity.LocationProfile;
 import com.positivity.accounting.internal.entity.StatementLineMapping;
 import com.positivity.accounting.internal.enums.StatementType;
 import com.positivity.accounting.internal.report.LaborOverheadTaxonomy;
 import com.positivity.accounting.internal.repository.JournalEntryLineRepository;
+import com.positivity.accounting.internal.repository.LocationFxRateRepository;
+import com.positivity.accounting.internal.repository.LocationProfileRepository;
 import com.positivity.accounting.internal.repository.StatementLineMappingRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,11 +57,25 @@ class LaborOverheadReportServiceImplTest {
     @Mock
     private JournalEntryLineRepository journalEntryLineRepository;
 
+    @Mock
+    private LocationProfileRepository locationProfileRepository;
+
+    @Mock
+    private LocationFxRateRepository locationFxRateRepository;
+
     private LaborOverheadReportServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        service = new LaborOverheadReportServiceImpl(statementLineMappingRepository, journalEntryLineRepository);
+        service = new LaborOverheadReportServiceImpl(
+                statementLineMappingRepository,
+                journalEntryLineRepository,
+                locationProfileRepository,
+                locationFxRateRepository);
+        lenient().when(locationProfileRepository.findByLocationCode(any())).thenReturn(Optional.empty());
+        lenient()
+                .when(locationFxRateRepository.findByLocationCodeAndFiscalYear(any(), anyInt()))
+                .thenReturn(Optional.empty());
     }
 
     private void mappings(StatementLineMapping... mappings) {
@@ -300,6 +321,85 @@ class LaborOverheadReportServiceImplTest {
         LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, 12), "1.1.1");
 
         assertThat(wages.getMonthly().get(0)).isEqualByComparingTo("5"); // only the matching-location line counts
+    }
+
+    private static StatementLineMapping mapping(String lineCode, UUID accountId, String locationId) {
+        StatementLineMapping mapping = mapping(lineCode, accountId);
+        mapping.setLocationId(locationId);
+        return mapping;
+    }
+
+    @Test
+    void generate_locationOverrideReplacesGlobalMappingForLine() {
+        mappings(mapping("1.1.1", ACCT_WAGES), mapping("1.1.1", ACCT_WAGES_2, LOCATION));
+        postedLines(
+                line(ACCT_WAGES, 1, LOCATION, money("1000"), BigDecimal.ZERO),
+                line(ACCT_WAGES_2, 1, LOCATION, money("400"), BigDecimal.ZERO));
+
+        LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, 12), "1.1.1");
+
+        assertThat(wages.getMonthly().get(0)).isEqualByComparingTo("400"); // override replaces global
+    }
+
+    @Test
+    void generate_ignoresOverridesScopedToOtherLocations() {
+        mappings(mapping("1.1.1", ACCT_WAGES), mapping("1.1.1", ACCT_WAGES_2, OTHER_LOCATION));
+        postedLines(
+                line(ACCT_WAGES, 1, LOCATION, money("1000"), BigDecimal.ZERO),
+                line(ACCT_WAGES_2, 1, LOCATION, money("400"), BigDecimal.ZERO));
+
+        LaborOverheadReportLine wages = find(service.generate(LOCATION, FISCAL_YEAR, 12), "1.1.1");
+
+        assertThat(wages.getMonthly().get(0)).isEqualByComparingTo("1000"); // global mapping still in force
+    }
+
+    @Test
+    void generate_enrichesHeaderFromProfileAndFxRate() {
+        when(statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(any()))
+                .thenReturn(List.of());
+        LocationProfile profile = new LocationProfile();
+        profile.setLocationCode(LOCATION);
+        profile.setLocationLabel("Planta Monterrey");
+        profile.setCurrencyCode("MXN");
+        when(locationProfileRepository.findByLocationCode(eq(LOCATION))).thenReturn(Optional.of(profile));
+        LocationFxRate fxRate = new LocationFxRate();
+        fxRate.setLocationCode(LOCATION);
+        fxRate.setFiscalYear(FISCAL_YEAR);
+        fxRate.setLocalCurrencyPerUsd(money("17.500000"));
+        fxRate.setAverageRate(money("17.000000"));
+        when(locationFxRateRepository.findByLocationCodeAndFiscalYear(eq(LOCATION), eq(FISCAL_YEAR)))
+                .thenReturn(Optional.of(fxRate));
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        assertThat(report.getLocationLabel()).isEqualTo("Planta Monterrey");
+        assertThat(report.getCurrency()).isEqualTo("MXN");
+        assertThat(report.getLocalCurrencyPerUsd()).isEqualByComparingTo("17.5");
+        assertThat(report.getAverageRate()).isEqualByComparingTo("17");
+    }
+
+    @Test
+    void generate_convertsUsdOnlyLineUsingAverageRateOnLocalCurrencyPlant() {
+        mappings(mapping("2.11.4", ACCT_INV), mapping("2.11.1", ACCT_UTIL));
+        postedLines(
+                line(ACCT_INV, 1, LOCATION, money("100"), BigDecimal.ZERO),
+                line(ACCT_UTIL, 1, LOCATION, money("34"), BigDecimal.ZERO));
+        LocationFxRate fxRate = new LocationFxRate();
+        fxRate.setLocationCode(LOCATION);
+        fxRate.setFiscalYear(FISCAL_YEAR);
+        fxRate.setLocalCurrencyPerUsd(money("2.000000"));
+        fxRate.setAverageRate(money("2.000000"));
+        when(locationFxRateRepository.findByLocationCodeAndFiscalYear(eq(LOCATION), eq(FISCAL_YEAR)))
+                .thenReturn(Optional.of(fxRate));
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        LaborOverheadReportLine mrtDepreciation = find(report, "2.11.4");
+        assertThat(mrtDepreciation.getMonthly().get(0)).isEqualByComparingTo("50.00"); // 100 MXN / 2.0 -> USD
+        assertThat(mrtDepreciation.getYtd()).isEqualByComparingTo("50.00");
+        // Other lines and the 2.11 subtotal stay in local currency (subtotal uses unconverted child).
+        assertThat(find(report, "2.11.1").getMonthly().get(0)).isEqualByComparingTo("34");
+        assertThat(find(report, "2.11").getMonthly().get(0)).isEqualByComparingTo("134");
     }
 
     @Test

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/LaborOverheadReportServiceImplTest.java
@@ -378,19 +378,29 @@ class LaborOverheadReportServiceImplTest {
         assertThat(report.getAverageRate()).isEqualByComparingTo("17");
     }
 
+    private void localCurrencyPlant(String currency, String perUsd, String averageRate) {
+        LocationProfile profile = new LocationProfile();
+        profile.setLocationCode(LOCATION);
+        profile.setLocationLabel("Local Plant");
+        profile.setCurrencyCode(currency);
+        when(locationProfileRepository.findByLocationCode(eq(LOCATION))).thenReturn(Optional.of(profile));
+        LocationFxRate fxRate = new LocationFxRate();
+        fxRate.setLocationCode(LOCATION);
+        fxRate.setFiscalYear(FISCAL_YEAR);
+        fxRate.setLocalCurrencyPerUsd(money(perUsd));
+        fxRate.setAverageRate(money(averageRate));
+        lenient()
+                .when(locationFxRateRepository.findByLocationCodeAndFiscalYear(eq(LOCATION), eq(FISCAL_YEAR)))
+                .thenReturn(Optional.of(fxRate));
+    }
+
     @Test
     void generate_convertsUsdOnlyLineUsingAverageRateOnLocalCurrencyPlant() {
         mappings(mapping("2.11.4", ACCT_INV), mapping("2.11.1", ACCT_UTIL));
         postedLines(
                 line(ACCT_INV, 1, LOCATION, money("100"), BigDecimal.ZERO),
                 line(ACCT_UTIL, 1, LOCATION, money("34"), BigDecimal.ZERO));
-        LocationFxRate fxRate = new LocationFxRate();
-        fxRate.setLocationCode(LOCATION);
-        fxRate.setFiscalYear(FISCAL_YEAR);
-        fxRate.setLocalCurrencyPerUsd(money("2.000000"));
-        fxRate.setAverageRate(money("2.000000"));
-        when(locationFxRateRepository.findByLocationCodeAndFiscalYear(eq(LOCATION), eq(FISCAL_YEAR)))
-                .thenReturn(Optional.of(fxRate));
+        localCurrencyPlant("MXN", "2.000000", "2.000000");
 
         LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
 
@@ -400,6 +410,43 @@ class LaborOverheadReportServiceImplTest {
         // Other lines and the 2.11 subtotal stay in local currency (subtotal uses unconverted child).
         assertThat(find(report, "2.11.1").getMonthly().get(0)).isEqualByComparingTo("34");
         assertThat(find(report, "2.11").getMonthly().get(0)).isEqualByComparingTo("134");
+    }
+
+    @Test
+    void generate_ignoresFxConfigWithoutLocationProfile() {
+        mappings(mapping("2.11.4", ACCT_INV));
+        postedLines(line(ACCT_INV, 1, LOCATION, money("100"), BigDecimal.ZERO));
+        LocationFxRate fxRate = new LocationFxRate();
+        fxRate.setLocationCode(LOCATION);
+        fxRate.setFiscalYear(FISCAL_YEAR);
+        fxRate.setLocalCurrencyPerUsd(money("2.000000"));
+        fxRate.setAverageRate(money("2.000000"));
+        lenient()
+                .when(locationFxRateRepository.findByLocationCodeAndFiscalYear(eq(LOCATION), eq(FISCAL_YEAR)))
+                .thenReturn(Optional.of(fxRate));
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        // No profile -> US plant defaults; the orphaned FX row must not skew rates or convert.
+        assertThat(report.getCurrency()).isEqualTo("USD");
+        assertThat(report.getLocalCurrencyPerUsd()).isEqualByComparingTo("1.00");
+        assertThat(report.getAverageRate()).isEqualByComparingTo("1.00");
+        assertThat(find(report, "2.11.4").getMonthly().get(0)).isEqualByComparingTo("100");
+    }
+
+    @Test
+    void generate_usdProfilePlantIgnoresFxConfig() {
+        mappings(mapping("2.11.4", ACCT_INV));
+        postedLines(line(ACCT_INV, 1, LOCATION, money("100"), BigDecimal.ZERO));
+        localCurrencyPlant("USD", "2.000000", "2.000000");
+
+        LaborOverheadCostReport report = service.generate(LOCATION, FISCAL_YEAR, 12);
+
+        // USD plant: FX config (even if present) is inactive; no conversion, rates stay 1.00.
+        assertThat(report.getCurrency()).isEqualTo("USD");
+        assertThat(report.getLocalCurrencyPerUsd()).isEqualByComparingTo("1.00");
+        assertThat(report.getAverageRate()).isEqualByComparingTo("1.00");
+        assertThat(find(report, "2.11.4").getMonthly().get(0)).isEqualByComparingTo("100");
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:316`
- Parent STORY (durion): louisburroughs/durion#328
- Child issue: louisburroughs/durion-positivity-backend#731
- Domain: `domain:accounting`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` → CAP-316 Labor & Overhead Cost Report section (behavior notes: header enrichment + per-location mapping overrides; endpoint contract shape unchanged — OpenAPI/SDK already cover all fields)
- Durion contract PR (if applicable): n/a (no shape change)

## Contract Chain (when a Controller changed)
- [x] No controller/DTO shape change — `openapi.yaml` and the Angular SDK already cover every field; regeneration not required

## Scope
- What changed:
  - **Full report-line → GL-account mapping (per-location-overridable master data, per the decision on #731):**
    - Migration `V25` adds nullable `statement_line_mappings.location_id` (NULL = global default; rows carrying a location **replace** the global rows for that line code at that location) plus a supporting index.
    - Seeds an authoritative global mapping for **every** canonical CAP-316 leaf line (Labor §1.1.1–§1.5, Overhead §2.1.1–§2.15.2) against a retread-plant 6xxx chart of accounts; V3's five representative rows are re-asserted with canonical display order and parent line codes.
    - `LaborOverheadReportServiceImpl` resolves mappings with location overrides.
  - **Currency / location enrichment:**
    - New accounting-side location dimension master data: `accounting_location_profile` (`locationLabel`, ISO currency) and `accounting_location_fx_rate` (`localCurrencyPerUsd`, `averageRate` per location/fiscal year), with entities (`LocationProfile`, `LocationFxRate`) and repositories. Locations without configuration default to a US plant (USD, 1.00) — existing behavior preserved.
    - Report header now resolves `locationLabel`/`currency` from the profile and the rates from the FX config.
    - `usdOnly` line **2.11.4** is presented in USD on local-currency plants (`usd = local / averageRate`, HALF_UP to 2dp). Subtotals stay in local currency and are computed from unconverted child amounts (source-form behavior), so header `currency` remains the plant currency.
- Why: #731 closes the two deliberate v1 simplifications deferred from story #724 / PR #728 — unmapped lines rendering 0, and the hard-coded US-plant currency context.

## Tests
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Provider behavioral contract tests added/updated
- How to run:
  - `./mvnw -pl pos-accounting -Dtest=LaborOverheadReportServiceImplTest,LaborOverheadMappingSeedTest,LaborOverheadTaxonomyTest test`
  - `./mvnw -pl pos-accounting test-compile failsafe:integration-test failsafe:verify -Dit.test=LaborOverheadReportContractBehaviorIT`
  - `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests,EntityStandardsArchitectureTest,ClasspathVisibilityGuardTest,DomainWallsTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - New coverage: `LaborOverheadMappingSeedTest` statically guards that the V25 seed covers every taxonomy leaf code (contract ITs run on H2 without Flyway, so seed completeness is verified against the migration file); IT cases for header enrichment + 2.11.4 USD conversion and for location-scoped mapping override; unit cases for override resolution, other-location isolation, FX enrichment, and USD conversion leaving subtotals in local currency.
- Verified locally: full `pos-accounting` unit suite (109 test classes) green; `LaborOverheadReportContractBehaviorIT` 4/4 green; full `pos-archunit` suite (20 tests) green.

## Risk & Rollback
- Risk level: Low — read-only report endpoint; unconfigured locations keep the exact v1 behavior (USD/1.00, echoed label); mapping seed is additive upsert master data.
- Rollback plan: revert the PR; V25 is additive (new nullable column, new tables, upserted seed rows) so a follow-up down-migration can drop the tables/column if ever needed.

## Checklist
- [x] Links to parent + child issues are present
- [ ] Branch name matches `cap/<cap-id>` (follow-up story branch named `feature/731-...` after the issue)
- [x] PR title starts with `[CAP:<cap-id>]`

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kgTHMwCpztZwhJghUCsre