### PR TITLE
[CRM] Per-vehicle care-preference service-interval feed (pos-vehicle-inventory → pos-customer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,17 @@ jobs:
             ${{ runner.os }}-mvn-build-cache-
 
       - name: Install reactor (skip tests)
-        run: ./mvnw install -DskipTests -DskipITs -Darchunit.skipTests=true -T 1C -B -ntp -q
+        # alwaysRunPlugins: on a build-cache hit the extension skips the install
+        # goal, so sibling snapshots never reach ~/.m2 and the selective test
+        # reactor below fails resolution on any module outside its own graph
+        # (first pos-shared-dtos, then pos-tax-common via an -amd dependent —
+        # the -am band-aid can't cover dependents' own upstreams). Forcing the
+        # install plugin to run installs the restored artifacts without
+        # rebuilding them, keeping the cache's compile/test savings.
+        run: >-
+          ./mvnw install -DskipTests -DskipITs -Darchunit.skipTests=true
+          -Dmaven.build.cache.alwaysRunPlugins=maven-install-plugin:install
+          -T 1C -B -ntp -q
 
       - name: Compute test selection
         id: selection

--- a/pos-customer/README.md
+++ b/pos-customer/README.md
@@ -10,6 +10,7 @@ CRM service for the Durion Positivity ETSMS platform. Manages the customer party
 - Assign and query account tiers for loyalty programs
 - Record and validate promotion redemptions
 - Maintain customer-linked vehicle associations (CRM vehicles); the vehicle records themselves are a read-only `ext_vehicle` replica fed by `vehicle.events.v1` from pos-vehicle-inventory (ADR-0044 §6, #843) — vehicle registry writes go directly to pos-vehicle-inventory through the gateway
+- Project `vehicle.care-preference.updated` facts into a read-only `ext_vehicle_care_preference` replica (#1175); the `service.due` segment attribute and the `SERVICE_DUE_REMINDER` job resolve each vehicle's effective service interval as its replicated care-preference override, falling back to `pos.customer.crm.service-due-months`
 - Handle workorder event-driven customer updates via `WorkorderEventHandler`
 - Consume `vehicle.events.v1` (`VehicleEventsListener`, idempotent via `processed_events`) and reconcile the replica against `vehicle.manifest.v1` manifests (`VehicleManifestListener`)
 - Support bulk customer import via `POST /v1/customer/bulk-ingest`

--- a/pos-customer/src/main/java/com/positivity/customer/internal/domain/PartyAttributes.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/domain/PartyAttributes.java
@@ -20,9 +20,10 @@ import org.jspecify.annotations.Nullable;
  * @param hasServiceHistory whether the party has any completed-service history
  * @param daysSinceDeclinedService whole days since the most recent declined recommendation, or
  *     null when the party has never declined one (FI-3, #1133)
- * @param serviceDue true only when the party has a completed service at least the configured
- *     service-due interval old (#1144); false when the interval has not elapsed and also when
- *     the party has no service history at all
+ * @param serviceDue true only when the party has a completed service at least the effective
+ *     service-due interval old (#1144) — the vehicle's replicated care-preference interval where
+ *     one exists, the configured default otherwise (#1175); false when no scope's interval has
+ *     elapsed and also when the party has no service history at all
  * @param addressCountry ISO 3166-1 alpha-2 country code of the party's structured postal
  *     address, or null when none is on file (FI-4, #1135) — individuals read the
  *     ext_people_contact_person replica, commercial parties ext_organization_postal_address

--- a/pos-customer/src/main/java/com/positivity/customer/internal/domain/SegmentAttribute.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/domain/SegmentAttribute.java
@@ -110,9 +110,10 @@ public enum SegmentAttribute {
             numeric(),
             "Whole days since the most recent declined service recommendation; unknown when none"),
     /**
-     * The care interval has elapsed since the last completed service (#1144). Until per-vehicle
-     * care-preference intervals are replicated from pos-vehicle-inventory, the interval is the
-     * module-wide {@code pos.customer.crm.service-due-months} setting. A party with no service
+     * The care interval has elapsed since the last completed service (#1144). The interval is
+     * resolved per vehicle (#1175): a vehicle's care-preference override replicated from
+     * pos-vehicle-inventory ({@code ext_vehicle_care_preference}) where one exists, the
+     * module-wide {@code pos.customer.crm.service-due-months} setting otherwise. A party with no service
      * history projects false — never-served customers are targeted via
      * {@link #HAS_SERVICE_HISTORY} / {@link #MONTHS_SINCE_LAST_SERVICE} instead.
      */

--- a/pos-customer/src/main/java/com/positivity/customer/internal/entity/ExtVehicleCarePreference.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/entity/ExtVehicleCarePreference.java
@@ -1,0 +1,62 @@
+package com.positivity.customer.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Generator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Read-only per-vehicle care-preference replica owned by pos-vehicle-inventory, populated
+ * exclusively by the {@code vehicle.care-preference.updated} consumer on {@code vehicle.events.v1}
+ * (#1175). Nothing else may write it.
+ *
+ * <p>{@code serviceIntervalMonths} is nullable: null means "no per-vehicle override" and CRM
+ * service-due consumers fall back to the module-wide {@code pos.customer.crm.service-due-months}
+ * default. A care-preference delete lands as a versioned tombstone (interval null,
+ * {@code aggregateVersion} advanced) rather than a hard delete, so a replayed older fact can never
+ * resurrect a removed override.
+ *
+ * <p>{@code aggregateVersion} is the owner's last-writer-wins epoch-millis stamp — care
+ * preferences are hard-deleted and re-created upstream, so it is not a JPA row version and the
+ * consumer's stale guard uses {@code >} (the people-contact replica precedent), not {@code >=}.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "ext_vehicle_care_preference")
+public class ExtVehicleCarePreference {
+
+    @Id
+    @Column(name = "vehicle_id", columnDefinition = "UUID", nullable = false, updatable = false)
+    private UUID vehicleId;
+
+    @Column(name = "service_interval_months")
+    private Integer serviceIntervalMonths;
+
+    @Column(name = "preference_updated_at")
+    private Instant preferenceUpdatedAt;
+
+    @Column(name = "aggregate_version", nullable = false)
+    private long aggregateVersion;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /**
+     * Explicit dependency hook for ArchUnit UUIDv7 rule.
+     */
+    @Transient
+    public Class<?> uuidv7Dependency() {
+        return UUIDv7Generator.class;
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/ExtVehicleCarePreferenceRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/ExtVehicleCarePreferenceRepository.java
@@ -1,0 +1,21 @@
+package com.positivity.customer.internal.repository;
+
+import com.positivity.customer.internal.entity.ExtVehicleCarePreference;
+import java.util.UUID;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ExtVehicleCarePreferenceRepository extends JpaRepository<ExtVehicleCarePreference, UUID> {
+
+    /**
+     * Smallest per-vehicle override on record, or null when no vehicle carries one (#1175). The
+     * reminder job queries candidates at the loosest interval in effect (the smaller of this and
+     * the module default) and then filters per candidate in Java, so a tight per-vehicle interval
+     * can never be missed by the SQL cutoff.
+     */
+    @Query("select min(p.serviceIntervalMonths) from ExtVehicleCarePreference p"
+            + " where p.serviceIntervalMonths is not null")
+    @Nullable
+    Integer findMinServiceIntervalMonths();
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/ServiceHistoryRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/ServiceHistoryRepository.java
@@ -20,19 +20,23 @@ public interface ServiceHistoryRepository extends JpaRepository<ServiceHistory, 
     boolean existsBySourceEventId(String sourceEventId);
 
     /**
-     * Most recent completion per party for the given candidates — the single batch
-     * query the
-     * segment resolver uses to derive last-service age and service-due (FI-3,
-     * #1133).
+     * Most recent completion per (party, vehicle) for the given candidates — the single batch
+     * query the segment resolver uses to derive last-service age (max across scopes) and to
+     * evaluate service-due against the effective per-vehicle interval (FI-3, #1133, #1175).
+     * Vehicle-less history rows group under a null vehicleId and are judged against the module
+     * default.
      */
-    @Query("select sh.partyId as partyId, max(sh.completedAt) as lastCompletedAt"
-            + " from ServiceHistory sh where sh.partyId in :partyIds group by sh.partyId")
+    @Query("select sh.partyId as partyId, sh.vehicleId as vehicleId, max(sh.completedAt) as lastCompletedAt"
+            + " from ServiceHistory sh where sh.partyId in :partyIds group by sh.partyId, sh.vehicleId")
     @NonNull
-    List<PartyLastServiceView> findLastServiceByParty(@Param("partyIds") @NonNull Collection<UUID> partyIds);
+    List<PartyVehicleLastServiceView> findLastServiceByPartyAndVehicle(
+            @Param("partyIds") @NonNull Collection<UUID> partyIds);
 
-    /** Projection: a party and its most recent service-completion timestamp. */
-    interface PartyLastServiceView {
+    /** Projection: a (party, vehicle) scope and its most recent service-completion timestamp. */
+    interface PartyVehicleLastServiceView {
         UUID getPartyId();
+
+        UUID getVehicleId();
 
         Instant getLastCompletedAt();
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/SegmentResolutionService.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/SegmentResolutionService.java
@@ -18,12 +18,14 @@ import com.positivity.customer.internal.repository.CommercialPartyRepository;
 import com.positivity.customer.internal.repository.CommunicationPreferenceRepository;
 import com.positivity.customer.internal.repository.ExtOrganizationPostalAddressRepository;
 import com.positivity.customer.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.customer.internal.repository.ExtVehicleCarePreferenceRepository;
 import com.positivity.customer.internal.repository.ExtVehicleRepository;
 import com.positivity.customer.internal.repository.FollowUpTaskRepository;
 import com.positivity.customer.internal.repository.PartyTagAssignmentRepository;
 import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.customer.internal.repository.SegmentMemberRepository;
 import com.positivity.customer.internal.repository.ServiceHistoryRepository;
+import com.positivity.customer.internal.repository.ServiceHistoryRepository.PartyVehicleLastServiceView;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -80,12 +82,14 @@ public class SegmentResolutionService {
     private final FollowUpTaskRepository followUpTaskRepository;
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
     private final ExtOrganizationPostalAddressRepository extOrganizationPostalAddressRepository;
+    private final ExtVehicleCarePreferenceRepository extVehicleCarePreferenceRepository;
     private final Clock clock;
 
     /**
-     * Service-due interval in whole months (#1144). pos-vehicle-inventory owns per-vehicle
-     * care-preference intervals but does not yet emit them, so until that feed exists the
-     * catalog's {@code service.due} attribute uses this module-wide interval.
+     * Fallback service-due interval in whole months (#1144). Per-vehicle care-preference
+     * intervals replicate from pos-vehicle-inventory into {@code ext_vehicle_care_preference}
+     * (#1175) and take precedence where vehicle-scoped history exists; this module-wide interval
+     * covers vehicles without an override and vehicle-less service history.
      */
     @Value("${pos.customer.crm.service-due-months:6}")
     private int serviceDueMonths = 6;
@@ -167,7 +171,9 @@ public class SegmentResolutionService {
         Map<UUID, CommunicationPreference> preferences = preferencesByParty(ids);
         Map<UUID, Set<UUID>> tags = tagsByParty(ids);
         Map<UUID, List<ExtVehicle>> vehicles = vehiclesByAccount(ids);
-        Map<UUID, Instant> lastService = lastServiceByParty(ids);
+        Map<UUID, List<PartyVehicleLastServiceView>> lastServiceRows = lastServiceByPartyVehicle(ids);
+        Map<UUID, Instant> lastService = latestByParty(lastServiceRows);
+        Map<UUID, Integer> intervalOverrides = intervalOverridesByVehicle(lastServiceRows);
         Map<UUID, Instant> lastDeclined = lastDeclinedByParty(ids);
         // FI-4 (#1135): organization addresses replicate from pos-people-contact keyed by the
         // commercial party id this module minted.
@@ -214,7 +220,8 @@ public class SegmentResolutionService {
                             monthsSinceService,
                             lastService.containsKey(account.getPartyId()),
                             daysSince(lastDeclined.get(account.getPartyId())),
-                            serviceDue(monthsSinceService),
+                            serviceDue(
+                                    lastServiceRows.getOrDefault(account.getPartyId(), List.of()), intervalOverrides),
                             address != null ? address.getCountryCode() : null,
                             address != null ? address.getRegion() : null,
                             address != null ? address.getCity() : null,
@@ -230,7 +237,9 @@ public class SegmentResolutionService {
         Map<UUID, CommunicationPreference> preferences = preferencesByParty(ids);
         Map<UUID, Set<UUID>> tags = tagsByParty(ids);
         Map<UUID, List<ExtVehicle>> vehicles = vehiclesByAccount(ids);
-        Map<UUID, Instant> lastService = lastServiceByParty(ids);
+        Map<UUID, List<PartyVehicleLastServiceView>> lastServiceRows = lastServiceByPartyVehicle(ids);
+        Map<UUID, Instant> lastService = latestByParty(lastServiceRows);
+        Map<UUID, Integer> intervalOverrides = intervalOverridesByVehicle(lastServiceRows);
         Map<UUID, Instant> lastDeclined = lastDeclinedByParty(ids);
         // FI-4 (#1135): individual addresses live on the person identity replica, keyed by the
         // people-contact person id, not the local party id.
@@ -269,7 +278,7 @@ public class SegmentResolutionService {
                             monthsSinceService,
                             lastService.containsKey(person.getPartyId()),
                             daysSince(lastDeclined.get(person.getPartyId())),
-                            serviceDue(monthsSinceService),
+                            serviceDue(lastServiceRows.getOrDefault(person.getPartyId(), List.of()), intervalOverrides),
                             replica != null ? replica.getAddressCountryCode() : null,
                             replica != null ? replica.getAddressRegion() : null,
                             replica != null ? replica.getAddressCity() : null,
@@ -346,17 +355,47 @@ public class SegmentResolutionService {
                 .collect(Collectors.groupingBy(ExtVehicle::getAccountId));
     }
 
-    private Map<UUID, Instant> lastServiceByParty(List<UUID> partyIds) {
+    private Map<UUID, List<PartyVehicleLastServiceView>> lastServiceByPartyVehicle(List<UUID> partyIds) {
         if (partyIds.isEmpty()) {
             return Map.of();
         }
+        return serviceHistoryRepository.findLastServiceByPartyAndVehicle(partyIds).stream()
+                .filter(row -> row.getLastCompletedAt() != null)
+                .collect(Collectors.groupingBy(PartyVehicleLastServiceView::getPartyId));
+    }
+
+    /** Party-level last completion: the max across the party's per-vehicle scopes. */
+    private static Map<UUID, Instant> latestByParty(Map<UUID, List<PartyVehicleLastServiceView>> rowsByParty) {
         Map<UUID, Instant> byParty = new HashMap<>();
-        for (var row : serviceHistoryRepository.findLastServiceByParty(partyIds)) {
-            if (row.getLastCompletedAt() != null) {
-                byParty.put(row.getPartyId(), row.getLastCompletedAt());
-            }
-        }
+        rowsByParty.forEach((partyId, rows) -> rows.stream()
+                .map(PartyVehicleLastServiceView::getLastCompletedAt)
+                .max(Instant::compareTo)
+                .ifPresent(last -> byParty.put(partyId, last)));
         return byParty;
+    }
+
+    /**
+     * Per-vehicle interval overrides for every vehicle appearing in the candidates' service
+     * history, batch-loaded from the {@code ext_vehicle_care_preference} replica in one query
+     * (#1175). Vehicles without an override (or with a tombstoned one) are simply absent.
+     */
+    private Map<UUID, Integer> intervalOverridesByVehicle(Map<UUID, List<PartyVehicleLastServiceView>> rowsByParty) {
+        Set<UUID> vehicleIds = rowsByParty.values().stream()
+                .flatMap(List::stream)
+                .map(PartyVehicleLastServiceView::getVehicleId)
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toSet());
+        if (vehicleIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<UUID, Integer> byVehicle = new HashMap<>();
+        extVehicleCarePreferenceRepository.findAllById(vehicleIds).forEach(preference -> {
+            // A non-positive replica value can only be corrupt data; fall back to the default.
+            if (preference.getServiceIntervalMonths() != null && preference.getServiceIntervalMonths() >= 1) {
+                byVehicle.put(preference.getVehicleId(), preference.getServiceIntervalMonths());
+            }
+        });
+        return byVehicle;
     }
 
     private Map<UUID, Instant> lastDeclinedByParty(List<UUID> partyIds) {
@@ -382,13 +421,28 @@ public class SegmentResolutionService {
     }
 
     /**
-     * Care-preference interval elapsed (#1144): true only when the party has a completed service
-     * and it is at least the configured interval old. A party with no service history projects
-     * false — never-served customers are targeted via {@code service.hasHistory} /
+     * Care-preference interval elapsed (#1144, #1175): true when any of the party's service
+     * scopes — a vehicle with history, or the vehicle-less scope — has its most recent completion
+     * at least the effective interval old. The effective interval is the vehicle's replicated
+     * care-preference override where one exists, the module-wide default otherwise (vehicle-less
+     * history always uses the default). A party with no service history projects false —
+     * never-served customers are targeted via {@code service.hasHistory} /
      * {@code service.monthsSinceLast}, not lumped into service-due reminders.
      */
-    private boolean serviceDue(@Nullable Integer monthsSinceLastService) {
-        return monthsSinceLastService != null && monthsSinceLastService >= serviceDueMonths;
+    private boolean serviceDue(
+            List<PartyVehicleLastServiceView> lastServiceRows, Map<UUID, Integer> intervalOverrides) {
+        for (PartyVehicleLastServiceView row : lastServiceRows) {
+            Integer months = monthsSince(row.getLastCompletedAt());
+            if (months == null) {
+                continue;
+            }
+            Integer override = row.getVehicleId() != null ? intervalOverrides.get(row.getVehicleId()) : null;
+            int interval = override != null ? override : serviceDueMonths;
+            if (months >= interval) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Whole days elapsed since {@code since} (UTC calendar), or null when absent; floored at 0. */

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/ServiceDueReminderJob.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/ServiceDueReminderJob.java
@@ -4,15 +4,21 @@ import com.positivity.customer.internal.entity.FollowUpTask;
 import com.positivity.customer.internal.entity.ServiceHistory;
 import com.positivity.customer.internal.enums.FollowUpStatus;
 import com.positivity.customer.internal.enums.FollowUpType;
+import com.positivity.customer.internal.repository.ExtVehicleCarePreferenceRepository;
 import com.positivity.customer.internal.repository.FollowUpTaskRepository;
 import com.positivity.customer.internal.repository.ServiceHistoryRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,11 +32,14 @@ import org.springframework.stereotype.Component;
  * Raises {@code SERVICE_DUE_REMINDER} follow-up tasks from the service-history read model
  * (Story #1153) — the second automatic feed alongside the declined-service listener.
  *
- * <p>A party/vehicle becomes due once its most recent completed service is at least
- * {@code pos.customer.crm.service-due-months} old — the same module-wide interval the
- * {@code service.due} segment attribute uses (#1144). pos-vehicle-inventory owns per-vehicle
- * care-preference intervals but does not yet emit them; when that feed lands, it replaces this
- * interval, not this job.
+ * <p>A party/vehicle becomes due once its most recent completed service is at least the
+ * effective interval old: the vehicle's care-preference override replicated from
+ * pos-vehicle-inventory into {@code ext_vehicle_care_preference} (#1175) where one exists, the
+ * module-wide {@code pos.customer.crm.service-due-months} otherwise — the same resolution the
+ * {@code service.due} segment attribute uses (#1144). Candidates are queried at the loosest
+ * interval in effect (the smallest override or the default, whichever is smaller) and filtered
+ * per candidate in Java against one batch replica load, so the query stays fixed-count — never
+ * N+1 — and a tight per-vehicle interval is never missed by the SQL cutoff.
  *
  * <p>Idempotency has no event envelope to key on, so the task's {@code source_event_id} is the
  * deterministic {@code service-due:<serviceHistoryId>} of the completion the reminder chases.
@@ -55,6 +64,7 @@ public class ServiceDueReminderJob {
     private final Clock clock;
     private final ServiceHistoryRepository serviceHistoryRepository;
     private final FollowUpTaskRepository followUpTaskRepository;
+    private final ExtVehicleCarePreferenceRepository extVehicleCarePreferenceRepository;
 
     @Value("${pos.customer.crm.service-due-months:6}")
     private int serviceDueMonths = 6;
@@ -65,27 +75,33 @@ public class ServiceDueReminderJob {
 
     @Scheduled(cron = "${pos.customer.crm.service-due-reminder-cron:0 0 5 * * *}")
     public void generateReminders() {
-        // Whole UTC calendar months, same as the service.due segment attribute
-        // (SegmentResolutionService.monthsSince, #1144): a completion is due once its date is
-        // serviceDueMonths old, regardless of time of day — so the cutoff is the start of the
-        // day after the anniversary date, not an instant offset.
-        Instant cutoff = LocalDate.now(clock)
-                .minusMonths(serviceDueMonths)
-                .plusDays(1)
-                .atStartOfDay(ZoneOffset.UTC)
-                .toInstant();
+        // The SQL cutoff must be loose enough for the tightest interval in effect anywhere, so
+        // a vehicle with a shorter care-preference override still surfaces as a candidate; each
+        // candidate is then judged against its own effective interval below (#1175).
+        Integer minOverride = extVehicleCarePreferenceRepository.findMinServiceIntervalMonths();
+        // A non-positive replica value can only be corrupt data; never let it widen the scan.
+        int loosestIntervalMonths =
+                minOverride != null && minOverride >= 1 ? Math.min(minOverride, serviceDueMonths) : serviceDueMonths;
+        Instant cutoff = cutoffFor(loosestIntervalMonths);
         List<ServiceHistory> candidates =
                 serviceHistoryRepository.findServiceDueCandidates(cutoff, SOURCE_PREFIX, PageRequest.of(0, batchSize));
+        Map<UUID, Integer> intervalOverrides = intervalOverridesFor(candidates);
 
         // Two completions at the same max timestamp both satisfy the latest-row query; one
         // reminder per party/vehicle per run is enough.
         Set<String> seenScopes = new HashSet<>();
         int created = 0;
         for (ServiceHistory history : candidates) {
+            int intervalMonths = effectiveIntervalMonths(history.getVehicleId(), intervalOverrides);
+            if (history.getCompletedAt().compareTo(cutoffFor(intervalMonths)) >= 0) {
+                // Candidate under the loosest cutoff but not yet due at its own effective
+                // interval; it stays a candidate and is re-judged next run.
+                continue;
+            }
             if (!seenScopes.add(history.getPartyId() + ":" + history.getVehicleId())) {
                 continue;
             }
-            FollowUpTask reminder = toReminder(history);
+            FollowUpTask reminder = toReminder(history, intervalMonths);
             try {
                 followUpTaskRepository.save(reminder);
                 created++;
@@ -110,7 +126,7 @@ public class ServiceDueReminderJob {
         }
     }
 
-    private FollowUpTask toReminder(ServiceHistory history) {
+    private FollowUpTask toReminder(ServiceHistory history, int intervalMonths) {
         LocalDate lastServiceDate = LocalDate.ofInstant(history.getCompletedAt(), ZoneOffset.UTC);
         String reason = "Vehicle service due — last service completed " + lastServiceDate
                 + (history.getWorkorderNumber() != null ? " (workorder " + history.getWorkorderNumber() + ")" : "");
@@ -119,11 +135,52 @@ public class ServiceDueReminderJob {
                 .vehicleId(history.getVehicleId())
                 .type(FollowUpType.SERVICE_DUE_REMINDER)
                 .status(FollowUpStatus.OPEN)
-                .dueDate(lastServiceDate.plusMonths(serviceDueMonths))
+                .dueDate(lastServiceDate.plusMonths(intervalMonths))
                 .sourceWorkorderId(history.getSourceWorkorderId().toString())
                 .sourceEventId(SOURCE_PREFIX + history.getServiceHistoryId())
                 .reason(reason)
                 .createdBy(SYSTEM_ACTOR)
                 .build();
+    }
+
+    /**
+     * Whole UTC calendar months, same as the service.due segment attribute
+     * (SegmentResolutionService.monthsSince, #1144): a completion is due once its date is
+     * intervalMonths old, regardless of time of day — so the cutoff is the start of the day
+     * after the anniversary date, not an instant offset.
+     */
+    private Instant cutoffFor(int intervalMonths) {
+        return LocalDate.now(clock)
+                .minusMonths(intervalMonths)
+                .plusDays(1)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant();
+    }
+
+    /**
+     * Care-preference interval overrides for the candidates' vehicles, batch-loaded from the
+     * {@code ext_vehicle_care_preference} replica in one query (#1175) so the run never goes
+     * N+1. Vehicles without an override (or with a tombstoned one) are absent.
+     */
+    private Map<UUID, Integer> intervalOverridesFor(List<ServiceHistory> candidates) {
+        Set<UUID> vehicleIds = candidates.stream()
+                .map(ServiceHistory::getVehicleId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        if (vehicleIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<UUID, Integer> byVehicle = new HashMap<>();
+        extVehicleCarePreferenceRepository.findAllById(vehicleIds).forEach(preference -> {
+            if (preference.getServiceIntervalMonths() != null && preference.getServiceIntervalMonths() >= 1) {
+                byVehicle.put(preference.getVehicleId(), preference.getServiceIntervalMonths());
+            }
+        });
+        return byVehicle;
+    }
+
+    private int effectiveIntervalMonths(UUID vehicleId, Map<UUID, Integer> intervalOverrides) {
+        Integer override = vehicleId != null ? intervalOverrides.get(vehicleId) : null;
+        return override != null ? override : serviceDueMonths;
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/VehicleEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/VehicleEventsListener.java
@@ -3,12 +3,15 @@ package com.positivity.customer.internal.service;
 import com.positivity.customer.internal.entity.AbstractParty;
 import com.positivity.customer.internal.entity.CommercialParty;
 import com.positivity.customer.internal.entity.ExtVehicle;
+import com.positivity.customer.internal.entity.ExtVehicleCarePreference;
 import com.positivity.customer.internal.entity.PersonParty;
 import com.positivity.customer.internal.entity.ProcessedEvent;
 import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import com.positivity.customer.internal.repository.ExtVehicleCarePreferenceRepository;
 import com.positivity.customer.internal.repository.ExtVehicleRepository;
 import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.customer.internal.repository.ProcessedEventRepository;
+import com.positivity.domainevents.vehicle.VehicleCarePreferenceUpdatedV1;
 import com.positivity.domainevents.vehicle.VehicleUpdatedV1;
 import java.time.Clock;
 import java.time.Instant;
@@ -27,11 +30,15 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 /**
- * Consumes {@code vehicle.events.v1} into the {@code ext_vehicle} replica (ADR-0044 §6, #843).
+ * Consumes {@code vehicle.events.v1} into the {@code ext_vehicle} and
+ * {@code ext_vehicle_care_preference} replicas (ADR-0044 §6, #843, #1175).
  *
  * <p>Same contract as pos-accounting's replica listeners: idempotent via {@code processed_events}
- * in the upsert transaction, stale envelopes (aggregateVersion at or below the replica's) skipped,
- * transient DB errors rethrown for container retry/DLQ, malformed payloads logged and skipped.
+ * in the upsert transaction, stale envelopes skipped, transient DB errors rethrown for container
+ * retry/DLQ, malformed payloads logged and skipped. Every parsed envelope with an eventId is
+ * recorded in {@code processed_events} — including event types this module ignores — because the
+ * owner's reconciliation manifest counts every event on the topic and an unrecorded eventId would
+ * read as drift (#1175).
  *
  * <p>Beyond the replica, this listener maintains the vehicle-party association pos-customer owns
  * (ADR-0012): the event's {@code accountId} is the owning party, so the VIN is added to that
@@ -50,6 +57,7 @@ public class VehicleEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtVehicleRepository extVehicleRepository;
+    private final ExtVehicleCarePreferenceRepository extVehicleCarePreferenceRepository;
     private final PersonPartyRepository personPartyRepository;
     private final CommercialPartyRepository commercialPartyRepository;
 
@@ -65,11 +73,6 @@ public class VehicleEventsListener {
             log.warn("Skipping unparsable vehicle event: {}", message, e);
             return;
         }
-        String eventType = envelope.path("eventType").stringValue(null);
-        if (!VehicleUpdatedV1.EVENT_TYPE.equals(eventType)) {
-            log.debug("Ignoring vehicle event type={}", eventType);
-            return;
-        }
         String eventId = envelope.path("eventId").stringValue(null);
         if (eventId == null || eventId.isBlank()) {
             log.warn("Skipping vehicle event without eventId: {}", message);
@@ -80,8 +83,17 @@ public class VehicleEventsListener {
             return;
         }
 
+        String eventType = envelope.path("eventType").stringValue(null);
         try {
-            applyVehicleUpdate(envelope);
+            if (VehicleUpdatedV1.EVENT_TYPE.equals(eventType)) {
+                applyVehicleUpdate(envelope);
+            } else if (VehicleCarePreferenceUpdatedV1.EVENT_TYPE.equals(eventType)) {
+                applyCarePreferenceUpdate(envelope);
+            } else {
+                // Recorded below anyway: the owner's manifest counts every event on the topic,
+                // so an ignored-but-unrecorded eventId would read as drift every window (#1175).
+                log.debug("Ignoring vehicle event type={}", eventType);
+            }
         } catch (TransientDataAccessException e) {
             // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
             throw e;
@@ -140,6 +152,43 @@ public class VehicleEventsListener {
                 payload.accountId(),
                 payload.active(),
                 aggregateVersion);
+    }
+
+    private void applyCarePreferenceUpdate(JsonNode envelope) {
+        VehicleCarePreferenceUpdatedV1 payload =
+                objectMapper.treeToValue(envelope.path("payload"), VehicleCarePreferenceUpdatedV1.class);
+        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+        UUID vehicleId = payload.vehicleId();
+
+        ExtVehicleCarePreference existing =
+                extVehicleCarePreferenceRepository.findById(vehicleId).orElse(null);
+        // The care-preference aggregateVersion is a last-writer-wins epoch-millis stamp, not a
+        // JPA row version (the row is hard-deleted and re-created upstream), so the guard is
+        // strictly-greater — an equal stamp applies (people-contact replica precedent).
+        if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
+            log.debug(
+                    "Skipping stale care-preference event vehicleId={} eventVersion={} replicaVersion={}",
+                    vehicleId,
+                    aggregateVersion,
+                    existing.getAggregateVersion());
+            return;
+        }
+
+        // A delete is a versioned tombstone (interval null, version advanced), never a hard
+        // delete: a surviving row is what lets this guard reject a replayed older update after
+        // the removal was applied.
+        extVehicleCarePreferenceRepository.save(ExtVehicleCarePreference.builder()
+                .vehicleId(vehicleId)
+                .serviceIntervalMonths(payload.deleted() ? null : payload.serviceIntervalMonths())
+                .preferenceUpdatedAt(payload.updatedAt())
+                .aggregateVersion(aggregateVersion)
+                .updatedAt(Instant.now(clock))
+                .build());
+        log.info(
+                "Updated ext_vehicle_care_preference replica vehicleId={} serviceIntervalMonths={} deleted={}",
+                vehicleId,
+                payload.serviceIntervalMonths(),
+                payload.deleted());
     }
 
     /**

--- a/pos-customer/src/main/resources/application.yml
+++ b/pos-customer/src/main/resources/application.yml
@@ -75,8 +75,10 @@ pos:
   customer:
     crm:
       # Service-due segment attribute (#1144): a party is `service.due` once its last completed
-      # service is at least this many whole months old. Module-wide interval until per-vehicle
-      # care-preference intervals are fed from pos-vehicle-inventory.
+      # service is at least this many whole months old. Fallback interval only (#1175): a
+      # vehicle's care-preference interval replicated from pos-vehicle-inventory
+      # (ext_vehicle_care_preference) takes precedence; this default covers vehicles without an
+      # override and vehicle-less service history.
       service-due-months: ${POS_CUSTOMER_SERVICE_DUE_MONTHS:6}
       # Service-due reminder feed (#1153): raises one SERVICE_DUE_REMINDER follow-up task per
       # party/vehicle service cycle once its latest completion is service-due-months old.

--- a/pos-customer/src/main/resources/db/migration/V28__ext_vehicle_care_preference_replica.sql
+++ b/pos-customer/src/main/resources/db/migration/V28__ext_vehicle_care_preference_replica.sql
@@ -1,0 +1,19 @@
+-- #1175: read-only per-vehicle care-preference replica fed by vehicle.care-preference.updated
+-- facts on vehicle.events.v1. pos-vehicle-inventory owns these facts; nothing in this module may
+-- write the table except the event consumer.
+--
+-- service_interval_months is nullable: null means "no per-vehicle override — use the module-wide
+-- pos.customer.crm.service-due-months default". A care-preference delete is a versioned tombstone
+-- (interval null, aggregate_version advanced) rather than a hard delete, so the stale-version
+-- guard keeps rejecting replayed older facts after a removal. aggregate_version is the owner's
+-- last-writer-wins epoch-millis stamp (care preferences are hard-deleted and re-created upstream,
+-- so it is not a JPA row version); preference_updated_at carries the owner's row timestamp,
+-- updated_at is when this replica row was written.
+CREATE TABLE ext_vehicle_care_preference (
+    vehicle_id uuid NOT NULL,
+    service_interval_months integer,
+    preference_updated_at timestamp(6) with time zone,
+    aggregate_version bigint NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT ext_vehicle_care_preference_pkey PRIMARY KEY (vehicle_id)
+);

--- a/pos-customer/src/test/java/com/positivity/customer/internal/repository/ServiceHistoryRepositoryTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/repository/ServiceHistoryRepositoryTest.java
@@ -75,6 +75,35 @@ class ServiceHistoryRepositoryTest {
     }
 
     @Test
+    @DisplayName("Latest completion is grouped per (party, vehicle), with a null-vehicle scope of its own (#1175)")
+    void groupsLatestCompletionPerPartyAndVehicle() {
+        UUID party = UUID.randomUUID();
+        UUID vehicleA = UUID.randomUUID();
+        UUID vehicleB = UUID.randomUUID();
+        saveHistory(party, vehicleA, STALE);
+        saveHistory(party, vehicleA, RECENT);
+        saveHistory(party, vehicleB, STALE);
+        saveHistory(party, null, RECENT);
+
+        var rows = serviceHistoryRepository.findLastServiceByPartyAndVehicle(List.of(party));
+
+        assertThat(rows).hasSize(3);
+        assertThat(rows)
+                .anySatisfy(row -> {
+                    assertThat(row.getVehicleId()).isEqualTo(vehicleA);
+                    assertThat(row.getLastCompletedAt()).isEqualTo(RECENT);
+                })
+                .anySatisfy(row -> {
+                    assertThat(row.getVehicleId()).isEqualTo(vehicleB);
+                    assertThat(row.getLastCompletedAt()).isEqualTo(STALE);
+                })
+                .anySatisfy(row -> {
+                    assertThat(row.getVehicleId()).isNull();
+                    assertThat(row.getLastCompletedAt()).isEqualTo(RECENT);
+                });
+    }
+
+    @Test
     @DisplayName("A completion with an existing keyed reminder is excluded, open or closed")
     void excludesAlreadyRemindedCompletions() {
         ServiceHistory reminded = saveHistory(UUID.randomUUID(), UUID.randomUUID(), STALE);

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/SegmentResolutionServiceTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/SegmentResolutionServiceTest.java
@@ -1,0 +1,186 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.domain.PartyAttributes;
+import com.positivity.customer.internal.entity.ExtVehicleCarePreference;
+import com.positivity.customer.internal.entity.PersonParty;
+import com.positivity.customer.internal.enums.AudienceType;
+import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import com.positivity.customer.internal.repository.CommunicationPreferenceRepository;
+import com.positivity.customer.internal.repository.ExtOrganizationPostalAddressRepository;
+import com.positivity.customer.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.customer.internal.repository.ExtVehicleCarePreferenceRepository;
+import com.positivity.customer.internal.repository.ExtVehicleRepository;
+import com.positivity.customer.internal.repository.FollowUpTaskRepository;
+import com.positivity.customer.internal.repository.PartyTagAssignmentRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.customer.internal.repository.SegmentMemberRepository;
+import com.positivity.customer.internal.repository.ServiceHistoryRepository;
+import com.positivity.customer.internal.repository.ServiceHistoryRepository.PartyVehicleLastServiceView;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SegmentResolutionService}'s effective per-vehicle service-due resolution
+ * (#1144, #1175): the vehicle's replicated care-preference interval takes precedence over the
+ * module-wide default, and vehicle-less history keeps using the default.
+ */
+class SegmentResolutionServiceTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-20T12:00:00Z"), ZoneOffset.UTC);
+    private static final UUID PARTY_ID = UUID.fromString("01980a58-0000-7000-8000-000000000001");
+    private static final UUID VEHICLE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000002");
+
+    private final CommercialPartyRepository commercialParties = mock(CommercialPartyRepository.class);
+    private final PersonPartyRepository personParties = mock(PersonPartyRepository.class);
+    private final CommunicationPreferenceRepository preferences = mock(CommunicationPreferenceRepository.class);
+    private final ExtVehicleRepository vehicles = mock(ExtVehicleRepository.class);
+    private final PartyTagAssignmentRepository tags = mock(PartyTagAssignmentRepository.class);
+    private final SegmentMemberRepository segmentMembers = mock(SegmentMemberRepository.class);
+    private final ServiceHistoryRepository serviceHistory = mock(ServiceHistoryRepository.class);
+    private final FollowUpTaskRepository followUps = mock(FollowUpTaskRepository.class);
+    private final ExtPersonReplicaRepository personReplicas = mock(ExtPersonReplicaRepository.class);
+    private final ExtOrganizationPostalAddressRepository orgAddresses =
+            mock(ExtOrganizationPostalAddressRepository.class);
+    private final ExtVehicleCarePreferenceRepository carePreferences = mock(ExtVehicleCarePreferenceRepository.class);
+
+    private SegmentResolutionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SegmentResolutionService(
+                commercialParties,
+                personParties,
+                preferences,
+                vehicles,
+                tags,
+                segmentMembers,
+                serviceHistory,
+                followUps,
+                personReplicas,
+                orgAddresses,
+                carePreferences,
+                TEST_CLOCK);
+        PersonParty person = new PersonParty();
+        person.setPartyId(PARTY_ID);
+        person.setPersonId(UUID.fromString("01980a58-0000-7000-8000-000000000009"));
+        when(personParties.findAll()).thenReturn(List.of(person));
+        when(personReplicas.findAllById(any())).thenReturn(List.of());
+        when(preferences.findByPartyIdIn(any())).thenReturn(List.of());
+        when(tags.findByPartyIdIn(any())).thenReturn(List.of());
+        when(vehicles.findByAccountIdIn(anyCollection())).thenReturn(List.of());
+        when(followUps.findLastDeclinedByParty(any())).thenReturn(List.of());
+        when(carePreferences.findAllById(any())).thenReturn(List.of());
+    }
+
+    private static PartyVehicleLastServiceView lastService(UUID vehicleId, Instant completedAt) {
+        return new PartyVehicleLastServiceView() {
+            @Override
+            public UUID getPartyId() {
+                return PARTY_ID;
+            }
+
+            @Override
+            public UUID getVehicleId() {
+                return vehicleId;
+            }
+
+            @Override
+            public Instant getLastCompletedAt() {
+                return completedAt;
+            }
+        };
+    }
+
+    private void stubIntervalOverride(int months) {
+        when(carePreferences.findAllById(any()))
+                .thenReturn(List.of(ExtVehicleCarePreference.builder()
+                        .vehicleId(VEHICLE_ID)
+                        .serviceIntervalMonths(months)
+                        .aggregateVersion(1000L)
+                        .updatedAt(Instant.now(TEST_CLOCK))
+                        .build()));
+    }
+
+    private PartyAttributes soleCandidate() {
+        List<PartyAttributes> candidates = service.loadCandidates(AudienceType.INDIVIDUAL);
+        assertThat(candidates).hasSize(1);
+        return candidates.get(0);
+    }
+
+    @Test
+    @DisplayName("A tighter per-vehicle interval makes the party service-due before the module default (#1175)")
+    void tighterOverrideMakesDueEarlier() {
+        // Four months old: not due at the 6-month default, due at the vehicle's 3-month interval.
+        when(serviceHistory.findLastServiceByPartyAndVehicle(anyCollection()))
+                .thenReturn(List.of(lastService(VEHICLE_ID, Instant.parse("2026-03-15T10:00:00Z"))));
+        stubIntervalOverride(3);
+
+        PartyAttributes party = soleCandidate();
+
+        assertThat(party.serviceDue()).isTrue();
+        assertThat(party.monthsSinceLastService()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("A looser per-vehicle interval keeps the party not-due past the module default (#1175)")
+    void looserOverrideDefersDue() {
+        // Seven months old: due at the 6-month default, not due at the vehicle's 12-month interval.
+        when(serviceHistory.findLastServiceByPartyAndVehicle(anyCollection()))
+                .thenReturn(List.of(lastService(VEHICLE_ID, Instant.parse("2025-12-15T10:00:00Z"))));
+        stubIntervalOverride(12);
+
+        assertThat(soleCandidate().serviceDue()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Without an override the module default applies, and vehicle-less history uses it too")
+    void defaultAppliesWithoutOverride() {
+        when(serviceHistory.findLastServiceByPartyAndVehicle(anyCollection()))
+                .thenReturn(List.of(lastService(null, Instant.parse("2025-12-15T10:00:00Z"))));
+
+        assertThat(soleCandidate().serviceDue()).isTrue();
+    }
+
+    @Test
+    @DisplayName("The party is due when any owned vehicle's effective interval has elapsed")
+    void anyDueVehicleMakesPartyDue() {
+        UUID otherVehicle = UUID.fromString("01980a58-0000-7000-8000-000000000003");
+        when(serviceHistory.findLastServiceByPartyAndVehicle(anyCollection()))
+                .thenReturn(List.of(
+                        // 2 months old on the overridden 3-month vehicle: not due.
+                        lastService(VEHICLE_ID, Instant.parse("2026-05-15T10:00:00Z")),
+                        // 7 months old on a default-interval vehicle: due.
+                        lastService(otherVehicle, Instant.parse("2025-12-15T10:00:00Z"))));
+        stubIntervalOverride(3);
+
+        PartyAttributes party = soleCandidate();
+
+        assertThat(party.serviceDue()).isTrue();
+        // monthsSinceLastService stays the max across scopes — the freshest completion.
+        assertThat(party.monthsSinceLastService()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("A party with no service history is never service-due")
+    void noHistoryNeverDue() {
+        when(serviceHistory.findLastServiceByPartyAndVehicle(anyCollection())).thenReturn(List.of());
+
+        PartyAttributes party = soleCandidate();
+
+        assertThat(party.serviceDue()).isFalse();
+        assertThat(party.monthsSinceLastService()).isNull();
+        assertThat(party.hasServiceHistory()).isFalse();
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/ServiceDueReminderJobTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/ServiceDueReminderJobTest.java
@@ -5,14 +5,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.positivity.customer.internal.entity.ExtVehicleCarePreference;
 import com.positivity.customer.internal.entity.FollowUpTask;
 import com.positivity.customer.internal.entity.ServiceHistory;
 import com.positivity.customer.internal.enums.FollowUpStatus;
 import com.positivity.customer.internal.enums.FollowUpType;
+import com.positivity.customer.internal.repository.ExtVehicleCarePreferenceRepository;
 import com.positivity.customer.internal.repository.FollowUpTaskRepository;
 import com.positivity.customer.internal.repository.ServiceHistoryRepository;
 import java.time.Clock;
@@ -43,12 +46,24 @@ class ServiceDueReminderJobTest {
 
     private final ServiceHistoryRepository serviceHistory = mock(ServiceHistoryRepository.class);
     private final FollowUpTaskRepository followUps = mock(FollowUpTaskRepository.class);
+    private final ExtVehicleCarePreferenceRepository carePreferences = mock(ExtVehicleCarePreferenceRepository.class);
 
     private ServiceDueReminderJob job;
 
     @BeforeEach
     void setUp() {
-        job = new ServiceDueReminderJob(TEST_CLOCK, serviceHistory, followUps);
+        job = new ServiceDueReminderJob(TEST_CLOCK, serviceHistory, followUps, carePreferences);
+        when(carePreferences.findAllById(any())).thenReturn(List.of());
+    }
+
+    private void stubIntervalOverride(UUID vehicleId, int months) {
+        when(carePreferences.findAllById(any()))
+                .thenReturn(List.of(ExtVehicleCarePreference.builder()
+                        .vehicleId(vehicleId)
+                        .serviceIntervalMonths(months)
+                        .aggregateVersion(1000L)
+                        .updatedAt(Instant.now(TEST_CLOCK))
+                        .build()));
     }
 
     private ServiceHistory history(UUID historyId, UUID partyId, UUID vehicleId, Instant completedAt) {
@@ -103,6 +118,58 @@ class ServiceDueReminderJobTest {
                         eq(Instant.parse("2026-01-21T00:00:00Z")),
                         eq(ServiceDueReminderJob.SOURCE_PREFIX),
                         any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("A tighter per-vehicle interval widens the SQL cutoff and drives the reminder's dueDate (#1175)")
+    void tighterPerVehicleIntervalAppliesEarlier() {
+        when(carePreferences.findMinServiceIntervalMonths()).thenReturn(3);
+        stubIntervalOverride(VEHICLE_ID, 3);
+        Instant completedAt = Instant.parse("2026-02-05T10:00:00Z");
+        when(serviceHistory.findServiceDueCandidates(any(), anyString(), any(Pageable.class)))
+                .thenReturn(List.of(history(HISTORY_ID, PARTY_ID, VEHICLE_ID, completedAt)));
+
+        job.generateReminders();
+
+        // The SQL cutoff is the loosest interval in effect — min(3, 6) = 3 months.
+        verify(serviceHistory)
+                .findServiceDueCandidates(
+                        eq(Instant.parse("2026-04-21T00:00:00Z")),
+                        eq(ServiceDueReminderJob.SOURCE_PREFIX),
+                        any(Pageable.class));
+        ArgumentCaptor<FollowUpTask> saved = ArgumentCaptor.forClass(FollowUpTask.class);
+        verify(followUps).save(saved.capture());
+        // dueDate uses the vehicle's own interval, not the module default.
+        assertThat(saved.getValue().getDueDate()).isEqualTo(LocalDate.of(2026, 5, 5));
+    }
+
+    @Test
+    @DisplayName("A looser per-vehicle interval defers the reminder past the module default (#1175)")
+    void looserPerVehicleIntervalDefers() {
+        stubIntervalOverride(VEHICLE_ID, 12);
+        // Six months old — due at the module default, but the vehicle's interval is 12 months.
+        Instant completedAt = Instant.parse("2026-01-05T10:00:00Z");
+        when(serviceHistory.findServiceDueCandidates(any(), anyString(), any(Pageable.class)))
+                .thenReturn(List.of(history(HISTORY_ID, PARTY_ID, VEHICLE_ID, completedAt)));
+
+        job.generateReminders();
+
+        verify(followUps, never()).save(any(FollowUpTask.class));
+    }
+
+    @Test
+    @DisplayName("A vehicle-less candidate is judged against the module default even when overrides exist")
+    void vehicleLessCandidateUsesDefault() {
+        when(carePreferences.findMinServiceIntervalMonths()).thenReturn(3);
+        Instant completedAt = Instant.parse("2026-01-05T10:00:00Z");
+        when(serviceHistory.findServiceDueCandidates(any(), anyString(), any(Pageable.class)))
+                .thenReturn(List.of(history(HISTORY_ID, PARTY_ID, null, completedAt)));
+
+        job.generateReminders();
+
+        ArgumentCaptor<FollowUpTask> saved = ArgumentCaptor.forClass(FollowUpTask.class);
+        verify(followUps).save(saved.capture());
+        assertThat(saved.getValue().getDueDate()).isEqualTo(LocalDate.of(2026, 7, 5));
     }
 
     @Test

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/VehicleEventsListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/VehicleEventsListenerTest.java
@@ -10,8 +10,10 @@ import static org.mockito.Mockito.when;
 
 import com.positivity.customer.internal.entity.CommercialParty;
 import com.positivity.customer.internal.entity.ExtVehicle;
+import com.positivity.customer.internal.entity.ExtVehicleCarePreference;
 import com.positivity.customer.internal.entity.PersonParty;
 import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import com.positivity.customer.internal.repository.ExtVehicleCarePreferenceRepository;
 import com.positivity.customer.internal.repository.ExtVehicleRepository;
 import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.customer.internal.repository.ProcessedEventRepository;
@@ -42,6 +44,8 @@ class VehicleEventsListenerTest {
 
     private final ProcessedEventRepository processedEvents = mock(ProcessedEventRepository.class);
     private final ExtVehicleRepository replica = mock(ExtVehicleRepository.class);
+    private final ExtVehicleCarePreferenceRepository carePreferenceReplica =
+            mock(ExtVehicleCarePreferenceRepository.class);
     private final PersonPartyRepository personParties = mock(PersonPartyRepository.class);
     private final CommercialPartyRepository commercialParties = mock(CommercialPartyRepository.class);
 
@@ -50,7 +54,22 @@ class VehicleEventsListenerTest {
     @BeforeEach
     void setUp() {
         listener = new VehicleEventsListener(
-                TEST_CLOCK, new ObjectMapper(), processedEvents, replica, personParties, commercialParties);
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                replica,
+                carePreferenceReplica,
+                personParties,
+                commercialParties);
+    }
+
+    private String carePreferenceEvent(String eventId, long version, Integer intervalMonths, boolean deleted) {
+        return """
+                {"eventId":"%s","eventType":"vehicle.care-preference.updated","schemaVersion":1,
+                 "aggregateId":"%s","aggregateVersion":%d,
+                 "payload":{"vehicleId":"%s","serviceIntervalMonths":%s,"deleted":%b,
+                            "updatedAt":"2026-07-12T11:00:00Z"}}
+                """.formatted(eventId, VEHICLE_ID, version, VEHICLE_ID, intervalMonths, deleted);
     }
 
     private String event(String eventId, long version, UUID accountId, boolean active) {
@@ -183,14 +202,96 @@ class VehicleEventsListenerTest {
     }
 
     @Test
-    @DisplayName("Ignores other event types")
+    @DisplayName("Ignores other event types but still records their eventId for manifest reconciliation (#1175)")
     void ignoresOtherEventTypes() {
+        when(processedEvents.existsById("e-x")).thenReturn(false);
+
         listener.onVehicleEvent("""
-                {"eventId":"e-x","eventType":"vehicle.manifest.published","payload":{}}
+                {"eventId":"e-x","eventType":"vehicle.future.event","payload":{}}
                 """);
 
         verify(replica, never()).save(any());
-        verify(processedEvents, never()).save(any());
+        verify(carePreferenceReplica, never()).save(any());
+        // The owner's manifest counts every event on the topic; an unrecorded eventId would
+        // read as drift every window.
+        verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Materializes care-preference event into the interval replica and records the eventId (#1175)")
+    void upsertsCarePreferenceReplica() {
+        when(processedEvents.existsById("cp-1")).thenReturn(false);
+        when(carePreferenceReplica.findById(VEHICLE_ID)).thenReturn(Optional.empty());
+
+        listener.onVehicleEvent(carePreferenceEvent("cp-1", 1000L, 4, false));
+
+        ArgumentCaptor<ExtVehicleCarePreference> saved = ArgumentCaptor.forClass(ExtVehicleCarePreference.class);
+        verify(carePreferenceReplica).save(saved.capture());
+        assertThat(saved.getValue().getVehicleId()).isEqualTo(VEHICLE_ID);
+        assertThat(saved.getValue().getServiceIntervalMonths()).isEqualTo(4);
+        assertThat(saved.getValue().getAggregateVersion()).isEqualTo(1000L);
+        assertThat(saved.getValue().getPreferenceUpdatedAt()).isEqualTo(Instant.parse("2026-07-12T11:00:00Z"));
+        verify(replica, never()).save(any());
+        verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Care-preference delete lands as a versioned tombstone, not a hard delete (#1175)")
+    void carePreferenceDeleteWritesTombstone() {
+        when(processedEvents.existsById("cp-del")).thenReturn(false);
+        when(carePreferenceReplica.findById(VEHICLE_ID))
+                .thenReturn(Optional.of(ExtVehicleCarePreference.builder()
+                        .vehicleId(VEHICLE_ID)
+                        .serviceIntervalMonths(4)
+                        .aggregateVersion(1000L)
+                        .updatedAt(Instant.now(TEST_CLOCK))
+                        .build()));
+
+        listener.onVehicleEvent(carePreferenceEvent("cp-del", 2000L, null, true));
+
+        ArgumentCaptor<ExtVehicleCarePreference> saved = ArgumentCaptor.forClass(ExtVehicleCarePreference.class);
+        verify(carePreferenceReplica).save(saved.capture());
+        assertThat(saved.getValue().getServiceIntervalMonths()).isNull();
+        assertThat(saved.getValue().getAggregateVersion()).isEqualTo(2000L);
+        verify(carePreferenceReplica, never()).delete(any());
+        verify(carePreferenceReplica, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("Skips stale care-preference events by the last-writer-wins guard, but records them (#1175)")
+    void skipsStaleCarePreferenceVersions() {
+        when(processedEvents.existsById("cp-old")).thenReturn(false);
+        when(carePreferenceReplica.findById(VEHICLE_ID))
+                .thenReturn(Optional.of(ExtVehicleCarePreference.builder()
+                        .vehicleId(VEHICLE_ID)
+                        .serviceIntervalMonths(4)
+                        .aggregateVersion(3000L)
+                        .updatedAt(Instant.now(TEST_CLOCK))
+                        .build()));
+
+        listener.onVehicleEvent(carePreferenceEvent("cp-old", 2000L, 9, false));
+
+        verify(carePreferenceReplica, never()).save(any());
+        verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("Applies a care-preference event with an equal version stamp (LWW '>' guard, re-created row)")
+    void appliesEqualCarePreferenceVersion() {
+        when(processedEvents.existsById("cp-eq")).thenReturn(false);
+        when(carePreferenceReplica.findById(VEHICLE_ID))
+                .thenReturn(Optional.of(ExtVehicleCarePreference.builder()
+                        .vehicleId(VEHICLE_ID)
+                        .serviceIntervalMonths(4)
+                        .aggregateVersion(2000L)
+                        .updatedAt(Instant.now(TEST_CLOCK))
+                        .build()));
+
+        listener.onVehicleEvent(carePreferenceEvent("cp-eq", 2000L, 9, false));
+
+        ArgumentCaptor<ExtVehicleCarePreference> saved = ArgumentCaptor.forClass(ExtVehicleCarePreference.class);
+        verify(carePreferenceReplica).save(saved.capture());
+        assertThat(saved.getValue().getServiceIntervalMonths()).isEqualTo(9);
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/vehicle/VehicleCarePreferenceUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/vehicle/VehicleCarePreferenceUpdatedV1.java
@@ -28,7 +28,8 @@ import org.jspecify.annotations.Nullable;
  * (and therefore ordering) with the vehicle's registry facts.
  *
  * @param vehicleId owning vehicle (also the envelope aggregateId and record key)
- * @param serviceIntervalMonths structured service interval in whole months; null = use CRM default
+ * @param serviceIntervalMonths structured service interval in whole months (1–120); null = use
+ *     CRM default
  * @param deleted true when the care-preference row was deleted (tombstone)
  * @param updatedAt when the owner last modified the preference; null on deletes
  */
@@ -41,13 +42,21 @@ public record VehicleCarePreferenceUpdatedV1(
     public static final String EVENT_TYPE = "vehicle.care-preference.updated";
     public static final int SCHEMA_VERSION = 1;
 
+    /** Interval bounds, matching the owner's API validation and DB CHECK constraint. */
+    public static final int MIN_SERVICE_INTERVAL_MONTHS = 1;
+
+    public static final int MAX_SERVICE_INTERVAL_MONTHS = 120;
+
     public VehicleCarePreferenceUpdatedV1 {
         if (vehicleId == null) {
             throw new IllegalArgumentException("vehicleId must not be null");
         }
-        if (serviceIntervalMonths != null && serviceIntervalMonths < 1) {
-            throw new IllegalArgumentException(
-                    "serviceIntervalMonths must be >= 1 when present but was: " + serviceIntervalMonths);
+        if (serviceIntervalMonths != null
+                && (serviceIntervalMonths < MIN_SERVICE_INTERVAL_MONTHS
+                        || serviceIntervalMonths > MAX_SERVICE_INTERVAL_MONTHS)) {
+            throw new IllegalArgumentException("serviceIntervalMonths must be between "
+                    + MIN_SERVICE_INTERVAL_MONTHS + " and " + MAX_SERVICE_INTERVAL_MONTHS
+                    + " when present but was: " + serviceIntervalMonths);
         }
         if (deleted && serviceIntervalMonths != null) {
             throw new IllegalArgumentException("a deleted care preference must not carry an interval");

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/vehicle/VehicleCarePreferenceUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/vehicle/VehicleCarePreferenceUpdatedV1.java
@@ -1,0 +1,56 @@
+package com.positivity.domainevents.vehicle;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Payload for {@code vehicle.care-preference.updated} v1 on {@code vehicle.events.v1} (#1175).
+ *
+ * <p>Published by pos-vehicle-inventory after every care-preference mutation (upsert, merge,
+ * delete). Carries the structured service-interval fact pos-vehicle-inventory owns; pos-customer
+ * projects it into an {@code ext_vehicle_care_preference} replica so CRM service-due consumers
+ * (the {@code service.due} segment attribute and {@code SERVICE_DUE_REMINDER} generation) can
+ * resolve a per-vehicle interval instead of the module-wide default.
+ *
+ * <p>{@code serviceIntervalMonths} is nullable: null means "no per-vehicle override — use the
+ * CRM default". A deleted preference is emitted with {@code deleted=true} and a null interval
+ * (a tombstone), never as a separate event type, mirroring {@link VehicleUpdatedV1}'s
+ * no-separate-deleted-event convention.
+ *
+ * <p>Unlike {@code vehicle.vehicle.updated}, the envelope's {@code aggregateVersion} for this
+ * fact is <em>not</em> a JPA optimistic-lock version: care preferences are hard-deleted and may
+ * be re-created, which would restart a row version at 0 and wedge a version-based stale guard.
+ * Producers instead stamp the mutation's epoch-millis, and consumers apply a last-writer-wins
+ * {@code >} guard (the {@code people-contact} replica precedent). The envelope's
+ * {@code aggregateId} is the {@code vehicleId} so care-preference facts share a Kafka partition
+ * (and therefore ordering) with the vehicle's registry facts.
+ *
+ * @param vehicleId owning vehicle (also the envelope aggregateId and record key)
+ * @param serviceIntervalMonths structured service interval in whole months; null = use CRM default
+ * @param deleted true when the care-preference row was deleted (tombstone)
+ * @param updatedAt when the owner last modified the preference; null on deletes
+ */
+public record VehicleCarePreferenceUpdatedV1(
+        @NonNull UUID vehicleId,
+        @Nullable Integer serviceIntervalMonths,
+        boolean deleted,
+        @Nullable Instant updatedAt) {
+
+    public static final String EVENT_TYPE = "vehicle.care-preference.updated";
+    public static final int SCHEMA_VERSION = 1;
+
+    public VehicleCarePreferenceUpdatedV1 {
+        if (vehicleId == null) {
+            throw new IllegalArgumentException("vehicleId must not be null");
+        }
+        if (serviceIntervalMonths != null && serviceIntervalMonths < 1) {
+            throw new IllegalArgumentException(
+                    "serviceIntervalMonths must be >= 1 when present but was: " + serviceIntervalMonths);
+        }
+        if (deleted && serviceIntervalMonths != null) {
+            throw new IllegalArgumentException("a deleted care preference must not carry an interval");
+        }
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/vehicle/VehicleCarePreferenceUpdatedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/vehicle/VehicleCarePreferenceUpdatedV1Test.java
@@ -48,6 +48,8 @@ class VehicleCarePreferenceUpdatedV1Test {
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new VehicleCarePreferenceUpdatedV1(VEHICLE_ID, 0, false, null))
                 .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new VehicleCarePreferenceUpdatedV1(VEHICLE_ID, 121, false, null))
+                .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new VehicleCarePreferenceUpdatedV1(VEHICLE_ID, 4, true, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/vehicle/VehicleCarePreferenceUpdatedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/vehicle/VehicleCarePreferenceUpdatedV1Test.java
@@ -1,0 +1,54 @@
+package com.positivity.domainevents.vehicle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class VehicleCarePreferenceUpdatedV1Test {
+
+    private static final ObjectMapper MAPPER =
+            JsonMapper.builder().findAndAddModules().build();
+
+    private static final UUID VEHICLE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000021");
+
+    @Test
+    void roundTripPreservesFields() {
+        VehicleCarePreferenceUpdatedV1 evt =
+                new VehicleCarePreferenceUpdatedV1(VEHICLE_ID, 4, false, Instant.parse("2026-07-20T10:00:00Z"));
+
+        String json = MAPPER.writeValueAsString(evt);
+        VehicleCarePreferenceUpdatedV1 back = MAPPER.readValue(json, VehicleCarePreferenceUpdatedV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(VehicleCarePreferenceUpdatedV1.EVENT_TYPE).isEqualTo("vehicle.care-preference.updated");
+        assertThat(VehicleCarePreferenceUpdatedV1.SCHEMA_VERSION).isEqualTo(1);
+    }
+
+    @Test
+    void allowsNullIntervalAsUseDefault() {
+        VehicleCarePreferenceUpdatedV1 evt =
+                new VehicleCarePreferenceUpdatedV1(VEHICLE_ID, null, false, Instant.parse("2026-07-20T10:00:00Z"));
+        assertThat(evt.serviceIntervalMonths()).isNull();
+    }
+
+    @Test
+    void allowsDeletedTombstone() {
+        VehicleCarePreferenceUpdatedV1 evt = new VehicleCarePreferenceUpdatedV1(VEHICLE_ID, null, true, null);
+        assertThat(evt.deleted()).isTrue();
+    }
+
+    @Test
+    void rejectsInvalidConstruction() {
+        assertThatThrownBy(() -> new VehicleCarePreferenceUpdatedV1(null, 4, false, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new VehicleCarePreferenceUpdatedV1(VEHICLE_ID, 0, false, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new VehicleCarePreferenceUpdatedV1(VEHICLE_ID, 4, true, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/pos-vehicle-inventory/README.md
+++ b/pos-vehicle-inventory/README.md
@@ -8,6 +8,7 @@ Vehicle registry and inventory service for the Durion Positivity ETSMS platform.
 - Search vehicles by VIN, account, or full-text criteria
 - Manage customer care preferences per vehicle
 - Publish `vehicle.vehicle.updated` events on `vehicle.events.v1` via a transactional outbox (ADR-0044 §6, #843); frontends write vehicles here directly through the gateway, and pos-customer keeps a read-only `ext_vehicle` replica fed by these events
+- Publish `vehicle.care-preference.updated` events on the same topic after care-preference mutations (#1175); pos-customer projects the structured `serviceIntervalMonths` into an `ext_vehicle_care_preference` replica that drives per-vehicle CRM service-due resolution
 - Serve replay/bootstrap commands on `vehicle.commands.v1` and publish reconciliation manifests on `vehicle.manifest.v1`
 - Support legacy vehicle data migration (`VehicleLegacyService`)
 - Expose bulk vehicle import via `POST /v1/vehicles/bulk-ingest`

--- a/pos-vehicle-inventory/docs/pos-vehicle-inventory-erd.md
+++ b/pos-vehicle-inventory/docs/pos-vehicle-inventory-erd.md
@@ -23,6 +23,7 @@ erDiagram
 		UUID id
 		UUID vehicle_id
 		jsonb preferences
+		Integer service_interval_months
 		TEXT service_notes
 		UUID created_by_user_id
 		UUID updated_by_user_id

--- a/pos-vehicle-inventory/openapi.json
+++ b/pos-vehicle-inventory/openapi.json
@@ -825,6 +825,13 @@
             "additionalProperties": true,
             "description": "Complete preference map (replaces existing preferences)"
           },
+          "serviceIntervalMonths": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 120,
+            "description": "Structured service interval in whole months; null clears the per-vehicle override (#1175)"
+          },
           "serviceNotes": {
             "type": "string",
             "description": "Service notes"
@@ -853,6 +860,13 @@
             "type": "object",
             "additionalProperties": true,
             "description": "Partial preference map to merge (does not replace existing keys)"
+          },
+          "serviceIntervalMonths": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 120,
+            "description": "Structured service interval in whole months; null leaves the current value unchanged (#1175)"
           },
           "updatedByUserId": {
             "type": "string",

--- a/pos-vehicle-inventory/openapi.yaml
+++ b/pos-vehicle-inventory/openapi.yaml
@@ -695,6 +695,14 @@ components:
           example:
             preferredOil: 5W-30
             tireRotationInterval: 5000
+        serviceIntervalMonths:
+          type: integer
+          format: int32
+          description: Structured service interval in whole months; null clears the
+            per-vehicle override so CRM falls back to its default (#1175)
+          example: 6
+          maximum: 120
+          minimum: 1
         serviceNotes:
           type: string
           description: Optional free-text service notes
@@ -731,6 +739,12 @@ components:
           example:
             oilType: synthetic
             washPreference: hand
+        serviceIntervalMonths:
+          type: integer
+          format: int32
+          description: Structured service interval in whole months; null means use
+            the CRM default (#1175)
+          example: 6
         serviceNotes:
           type: string
           description: Service notes for technicians
@@ -1309,6 +1323,14 @@ components:
           description: Subset of preference fields to merge into existing preferences
           example:
             tireRotationInterval: 7500
+        serviceIntervalMonths:
+          type: integer
+          format: int32
+          description: Structured service interval in whole months; null leaves the
+            current value unchanged (#1175)
+          example: 6
+          maximum: 120
+          minimum: 1
         updatedByUserId:
           type: string
           format: uuid

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/config/CarePreferenceEventPublisher.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/config/CarePreferenceEventPublisher.java
@@ -1,0 +1,94 @@
+package com.positivity.vehicle.internal.config;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.vehicle.VehicleCarePreferenceUpdatedV1;
+import com.positivity.vehicle.internal.entity.VehicleCarePreference;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Emits {@code vehicle.care-preference.updated} to the vehicle outbox after care-preference
+ * mutations (#1175), mirroring {@link VehicleEventPublisher}.
+ *
+ * <p>No-op when the Kafka feature flag ({@code pos.vehicle-inventory.kafka.enabled}) is off — the
+ * {@link OutboxEventWriter} bean is conditional, so this publisher degrades gracefully. Must be
+ * called inside the mutating transaction (the writer requires {@code MANDATORY} propagation).
+ *
+ * <p>The envelope's {@code aggregateId} is the vehicle id, keeping care-preference facts on the
+ * same Kafka partition (and in order with) the vehicle's registry facts. {@code aggregateVersion}
+ * is a last-writer-wins epoch-millis stamp, <em>not</em> the row's JPA {@code @Version}: care
+ * preferences are hard-deleted and may be re-created, which would restart a row version at 0 and
+ * wedge a version-based consumer stale guard. Consumers order these facts with a {@code >} guard
+ * (the people-contact replica precedent).
+ */
+@Slf4j
+@Component
+public class CarePreferenceEventPublisher {
+
+    private final Clock clock;
+    private final EntityManager entityManager;
+    private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+    private final String eventsTopic;
+
+    public CarePreferenceEventPublisher(
+            Clock clock,
+            EntityManager entityManager,
+            ObjectProvider<OutboxEventWriter> outboxEventWriter,
+            // Same property ManifestPublisher scans event_outbox by, so an override can never
+            // desync the outbox rows from the manifest computation (PR #865 review).
+            @Value("${pos.vehicle-inventory.kafka.events-topic:vehicle.events.v1}") String eventsTopic) {
+        this.clock = clock;
+        this.entityManager = entityManager;
+        this.outboxEventWriter = outboxEventWriter;
+        this.eventsTopic = eventsTopic;
+    }
+
+    /** Queue the fact for a created or updated care preference. */
+    public void publishCarePreferenceUpserted(@NonNull VehicleCarePreference preference) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        // Flush so auditing (@LastModifiedDate) has stamped the row before we snapshot it.
+        entityManager.flush();
+        UUID vehicleId = preference.getVehicleId();
+        VehicleCarePreferenceUpdatedV1 payload = new VehicleCarePreferenceUpdatedV1(
+                vehicleId, preference.getServiceIntervalMonths(), false, preference.getUpdatedAt());
+        publish(writer, vehicleId, payload);
+        log.debug(
+                "Queued vehicle.care-preference.updated vehicleId={} serviceIntervalMonths={}",
+                vehicleId,
+                preference.getServiceIntervalMonths());
+    }
+
+    /** Queue the tombstone fact for a deleted care preference. */
+    public void publishCarePreferenceDeleted(@NonNull UUID vehicleId) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        publish(writer, vehicleId, new VehicleCarePreferenceUpdatedV1(vehicleId, null, true, null));
+        log.debug("Queued vehicle.care-preference.updated tombstone vehicleId={}", vehicleId);
+    }
+
+    private void publish(OutboxEventWriter writer, UUID vehicleId, VehicleCarePreferenceUpdatedV1 payload) {
+        DomainEventEnvelope<VehicleCarePreferenceUpdatedV1> envelope = DomainEventEnvelope.of(
+                VehicleCarePreferenceUpdatedV1.EVENT_TYPE,
+                VehicleCarePreferenceUpdatedV1.SCHEMA_VERSION,
+                vehicleId,
+                Instant.now(clock).toEpochMilli(),
+                "pos-vehicle-inventory",
+                null,
+                null,
+                payload,
+                clock);
+        writer.publish(eventsTopic, envelope);
+    }
+}

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -117,13 +118,13 @@ public class VehiclePreferencesController {
             @Parameter(description = "Vehicle ID") @PathVariable UUID vehicleId,
             @Valid @RequestBody PreferencesMergeDto request) {
 
-        log.info(
-                "PATCH /v1/vehicles/{}/preferences - merging keys={}",
-                vehicleId,
-                request.partialPreferences().keySet());
+        // partialPreferences is optional: a PATCH may update only serviceIntervalMonths.
+        Map<String, Object> partialPreferences =
+                request.partialPreferences() != null ? request.partialPreferences() : new HashMap<>();
+        log.info("PATCH /v1/vehicles/{}/preferences - merging keys={}", vehicleId, partialPreferences.keySet());
 
         var preference = preferencesService.mergePreferences(
-                vehicleId, request.partialPreferences(), request.serviceIntervalMonths(), request.updatedByUserId());
+                vehicleId, partialPreferences, request.serviceIntervalMonths(), request.updatedByUserId());
         return ResponseEntity.ok(VehicleCarePreferenceMapper.toResponse(preference));
     }
 

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.UUID;
@@ -91,6 +93,7 @@ public class VehiclePreferencesController {
         var serviceRequest = new UpsertPreferencesRequest(
                 vehicleId,
                 request.preferences(),
+                request.serviceIntervalMonths(),
                 request.serviceNotes(),
                 request.createdByUserId(),
                 request.updatedByUserId());
@@ -112,15 +115,15 @@ public class VehiclePreferencesController {
     @EmitEvent(id = "VEHICLE_PREFERENCES_MERGE", apiVersion = "1")
     public ResponseEntity<VehicleCarePreferenceResponse> mergePreferences(
             @Parameter(description = "Vehicle ID") @PathVariable UUID vehicleId,
-            @RequestBody PreferencesMergeDto request) {
+            @Valid @RequestBody PreferencesMergeDto request) {
 
         log.info(
                 "PATCH /v1/vehicles/{}/preferences - merging keys={}",
                 vehicleId,
                 request.partialPreferences().keySet());
 
-        var preference =
-                preferencesService.mergePreferences(vehicleId, request.partialPreferences(), request.updatedByUserId());
+        var preference = preferencesService.mergePreferences(
+                vehicleId, request.partialPreferences(), request.serviceIntervalMonths(), request.updatedByUserId());
         return ResponseEntity.ok(VehicleCarePreferenceMapper.toResponse(preference));
     }
 
@@ -147,6 +150,15 @@ public class VehiclePreferencesController {
                     example = "{\"preferredOil\":\"5W-30\",\"tireRotationInterval\":5000}",
                     requiredMode = Schema.RequiredMode.REQUIRED)
             Map<String, Object> preferences,
+
+            @Min(1)
+            @Max(120)
+            @Schema(
+                    description =
+                            "Structured service interval in whole months; null clears the per-vehicle override so CRM falls back to its default (#1175)",
+                    example = "6",
+                    requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+            Integer serviceIntervalMonths,
 
             @Schema(
                     description = "Optional free-text service notes",
@@ -176,6 +188,15 @@ public class VehiclePreferencesController {
                     example = "{\"tireRotationInterval\":7500}",
                     requiredMode = Schema.RequiredMode.NOT_REQUIRED)
             Map<String, Object> partialPreferences,
+
+            @Min(1)
+            @Max(120)
+            @Schema(
+                    description =
+                            "Structured service interval in whole months; null leaves the current value unchanged (#1175)",
+                    example = "6",
+                    requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+            Integer serviceIntervalMonths,
 
             @Schema(
                     description = "Identifier of the user updating the preferences",

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/dto/UpsertPreferencesRequest.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/dto/UpsertPreferencesRequest.java
@@ -4,6 +4,8 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.UUID;
@@ -33,6 +35,14 @@ public class UpsertPreferencesRequest {
             example = "{\"oilType\":\"synthetic\",\"washPreference\":\"hand\"}")
     @NotNull
     private Map<String, Object> preferences;
+
+    @Schema(
+            description = "Structured service interval in whole months; null means use the CRM default (#1175)",
+            example = "6",
+            requiredMode = NOT_REQUIRED)
+    @Min(1)
+    @Max(120)
+    private Integer serviceIntervalMonths;
 
     @Schema(
             description = "Optional service notes for technicians",

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/dto/VehicleCarePreferenceMapper.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/dto/VehicleCarePreferenceMapper.java
@@ -10,6 +10,7 @@ public final class VehicleCarePreferenceMapper {
                 .id(preference.getId())
                 .vehicleId(preference.getVehicleId())
                 .preferences(preference.getPreferences())
+                .serviceIntervalMonths(preference.getServiceIntervalMonths())
                 .serviceNotes(preference.getServiceNotes())
                 .createdByUserId(preference.getCreatedByUserId())
                 .updatedByUserId(preference.getUpdatedByUserId())

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/dto/VehicleCarePreferenceResponse.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/dto/VehicleCarePreferenceResponse.java
@@ -34,6 +34,12 @@ public class VehicleCarePreferenceResponse {
     Map<String, Object> preferences;
 
     @Schema(
+            description = "Structured service interval in whole months; null means use the CRM default (#1175)",
+            example = "6",
+            requiredMode = NOT_REQUIRED)
+    Integer serviceIntervalMonths;
+
+    @Schema(
             description = "Service notes for technicians",
             example = "Customer prefers synthetic oil only",
             requiredMode = NOT_REQUIRED)

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/entity/VehicleCarePreference.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/entity/VehicleCarePreference.java
@@ -64,6 +64,14 @@ public class VehicleCarePreference {
     @Column(name = "preferences", columnDefinition = "jsonb", nullable = false)
     private Map<String, Object> preferences;
 
+    /**
+     * Structured service interval in whole months, promoted out of the JSONB blob (#1175) so it
+     * can be validated and fed to CRM as a {@code vehicle.care-preference.updated} fact. Null
+     * means "no per-vehicle override" — CRM consumers fall back to their module-wide default.
+     */
+    @Column(name = "service_interval_months")
+    private Integer serviceIntervalMonths;
+
     @Column(name = "service_notes", columnDefinition = "TEXT")
     private String serviceNotes;
 

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/service/VehiclePreferencesServiceImpl.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/service/VehiclePreferencesServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.vehicle.internal.service;
 
+import com.positivity.vehicle.internal.config.CarePreferenceEventPublisher;
 import com.positivity.vehicle.internal.dto.UpsertPreferencesRequest;
 import com.positivity.vehicle.internal.entity.VehicleCarePreference;
 import com.positivity.vehicle.internal.repository.VehicleCarePreferenceRepository;
@@ -12,6 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,14 +21,26 @@ import org.springframework.transaction.annotation.Transactional;
  * Service for managing vehicle care preferences (CAP:091 Story #102).
  * Handles flexible JSONB preference storage with validation.
  * PUBLIC API for preferences management.
+ *
+ * <p>The service interval is a structured column, not a blob key (#1175): a legacy
+ * {@code serviceIntervalMonths} key arriving inside the preferences map is promoted into the
+ * structured field so older clients keep working without the blob and column drifting apart.
+ * Every mutation emits a {@code vehicle.care-preference.updated} fact for CRM consumers.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class VehiclePreferencesServiceImpl implements VehiclePreferencesService {
 
+    /** Legacy blob key promoted into the structured column by the V4 migration (#1175). */
+    static final String LEGACY_INTERVAL_KEY = "serviceIntervalMonths";
+
+    private static final int MIN_INTERVAL_MONTHS = 1;
+    private static final int MAX_INTERVAL_MONTHS = 120;
+
     private final VehicleCarePreferenceRepository preferencesRepository;
     private final VehicleRecordRepository vehicleRepository;
+    private final CarePreferenceEventPublisher carePreferenceEventPublisher;
 
     /**
      * Gets preferences for a vehicle. Returns empty Optional if not found.
@@ -56,13 +70,19 @@ public class VehiclePreferencesServiceImpl implements VehiclePreferencesService 
             throw new IllegalArgumentException("Preferences map cannot be null (use empty map instead)");
         }
 
+        Integer legacyInterval = extractLegacyInterval(request.getPreferences());
+        Integer serviceIntervalMonths = request.getServiceIntervalMonths() != null
+                ? (Integer) validateInterval(request.getServiceIntervalMonths())
+                : legacyInterval;
+
         var existing = preferencesRepository.findByVehicle_VehicleId(request.getVehicleId());
 
         VehicleCarePreference preference;
         if (existing.isPresent()) {
-            // Update existing
+            // Update existing; PUT is a full replace, so a null interval clears the override.
             preference = existing.get();
             preference.setPreferences(request.getPreferences());
+            preference.setServiceIntervalMonths(serviceIntervalMonths);
             if (request.getServiceNotes() != null) {
                 preference.setServiceNotes(request.getServiceNotes());
             }
@@ -75,6 +95,7 @@ public class VehiclePreferencesServiceImpl implements VehiclePreferencesService 
             preference = VehicleCarePreference.builder()
                     .vehicle(vehicleRepository.getReferenceById(request.getVehicleId()))
                     .preferences(request.getPreferences())
+                    .serviceIntervalMonths(serviceIntervalMonths)
                     .serviceNotes(request.getServiceNotes())
                     .createdByUserId(request.getCreatedByUserId())
                     .updatedByUserId(request.getUpdatedByUserId())
@@ -83,6 +104,7 @@ public class VehiclePreferencesServiceImpl implements VehiclePreferencesService 
         }
 
         var saved = preferencesRepository.save(preference);
+        carePreferenceEventPublisher.publishCarePreferenceUpserted(saved);
         log.info("Saved preferences: id={}, vehicleId={}", saved.getId(), saved.getVehicleId());
 
         return saved;
@@ -94,23 +116,36 @@ public class VehiclePreferencesServiceImpl implements VehiclePreferencesService 
     @Override
     @Transactional
     public VehicleCarePreference mergePreferences(
-            @NonNull UUID vehicleId, @NonNull Map<String, Object> partialPreferences, UUID updatedByUserId) {
+            @NonNull UUID vehicleId,
+            @NonNull Map<String, Object> partialPreferences,
+            Integer serviceIntervalMonths,
+            UUID updatedByUserId) {
 
         log.info("Merging preferences for vehicleId={}, keys={}", vehicleId, partialPreferences.keySet());
 
         var existing = getPreferences(vehicleId)
                 .orElseThrow(() -> new EntityNotFoundException("No preferences found for vehicle: " + vehicleId));
 
+        Integer legacyInterval = extractLegacyInterval(partialPreferences);
+        Integer effectiveInterval =
+                serviceIntervalMonths != null ? (Integer) validateInterval(serviceIntervalMonths) : legacyInterval;
+
         // Merge new values into existing preferences
         var currentPreferences = existing.getPreferences();
         currentPreferences.putAll(partialPreferences);
+        // The legacy key never survives in the blob — the structured column is the single source.
+        currentPreferences.remove(LEGACY_INTERVAL_KEY);
 
         existing.setPreferences(currentPreferences);
+        if (effectiveInterval != null) {
+            existing.setServiceIntervalMonths(effectiveInterval);
+        }
         if (updatedByUserId != null) {
             existing.setUpdatedByUserId(updatedByUserId);
         }
 
         var saved = preferencesRepository.save(existing);
+        carePreferenceEventPublisher.publishCarePreferenceUpserted(saved);
         log.info("Merged preferences: id={}, vehicleId={}", saved.getId(), saved.getVehicleId());
 
         return saved;
@@ -126,7 +161,43 @@ public class VehiclePreferencesServiceImpl implements VehiclePreferencesService 
 
         preferencesRepository.findByVehicle_VehicleId(vehicleId).ifPresent(preference -> {
             preferencesRepository.delete(preference);
+            carePreferenceEventPublisher.publishCarePreferenceDeleted(vehicleId);
             log.info("Deleted preferences: id={}", preference.getId());
         });
+    }
+
+    /**
+     * Removes the legacy {@code serviceIntervalMonths} key from the given map and returns its
+     * validated value, or null when absent. Rejects non-numeric or out-of-range values so a bad
+     * blob write cannot silently drop the interval (#1175).
+     */
+    private static @Nullable Integer extractLegacyInterval(Map<String, Object> preferences) {
+        Object raw = preferences.remove(LEGACY_INTERVAL_KEY);
+        if (raw == null) {
+            return null;
+        }
+        int value;
+        if (raw instanceof Number number) {
+            double asDouble = number.doubleValue();
+            value = number.intValue();
+            if (asDouble != value) {
+                throw new IllegalArgumentException(LEGACY_INTERVAL_KEY + " must be a whole number but was: " + raw);
+            }
+        } else {
+            try {
+                value = Integer.parseInt(raw.toString().trim());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(LEGACY_INTERVAL_KEY + " must be a whole number but was: " + raw);
+            }
+        }
+        return validateInterval(value);
+    }
+
+    private static int validateInterval(int serviceIntervalMonths) {
+        if (serviceIntervalMonths < MIN_INTERVAL_MONTHS || serviceIntervalMonths > MAX_INTERVAL_MONTHS) {
+            throw new IllegalArgumentException("serviceIntervalMonths must be between " + MIN_INTERVAL_MONTHS + " and "
+                    + MAX_INTERVAL_MONTHS + " but was: " + serviceIntervalMonths);
+        }
+        return serviceIntervalMonths;
     }
 }

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/service/VehiclePreferencesServiceImpl.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/service/VehiclePreferencesServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.vehicle.internal.service;
 
+import com.positivity.domainevents.vehicle.VehicleCarePreferenceUpdatedV1;
 import com.positivity.vehicle.internal.config.CarePreferenceEventPublisher;
 import com.positivity.vehicle.internal.dto.UpsertPreferencesRequest;
 import com.positivity.vehicle.internal.entity.VehicleCarePreference;
@@ -35,8 +36,8 @@ public class VehiclePreferencesServiceImpl implements VehiclePreferencesService 
     /** Legacy blob key promoted into the structured column by the V4 migration (#1175). */
     static final String LEGACY_INTERVAL_KEY = "serviceIntervalMonths";
 
-    private static final int MIN_INTERVAL_MONTHS = 1;
-    private static final int MAX_INTERVAL_MONTHS = 120;
+    private static final int MIN_INTERVAL_MONTHS = VehicleCarePreferenceUpdatedV1.MIN_SERVICE_INTERVAL_MONTHS;
+    private static final int MAX_INTERVAL_MONTHS = VehicleCarePreferenceUpdatedV1.MAX_SERVICE_INTERVAL_MONTHS;
 
     private final VehicleCarePreferenceRepository preferencesRepository;
     private final VehicleRecordRepository vehicleRepository;
@@ -71,8 +72,9 @@ public class VehiclePreferencesServiceImpl implements VehiclePreferencesService 
         }
 
         Integer legacyInterval = extractLegacyInterval(request.getPreferences());
+        // Boxed explicitly so the conditional stays Integer and a null legacyInterval survives.
         Integer serviceIntervalMonths = request.getServiceIntervalMonths() != null
-                ? (Integer) validateInterval(request.getServiceIntervalMonths())
+                ? Integer.valueOf(validateInterval(request.getServiceIntervalMonths()))
                 : legacyInterval;
 
         var existing = preferencesRepository.findByVehicle_VehicleId(request.getVehicleId());
@@ -127,8 +129,9 @@ public class VehiclePreferencesServiceImpl implements VehiclePreferencesService 
                 .orElseThrow(() -> new EntityNotFoundException("No preferences found for vehicle: " + vehicleId));
 
         Integer legacyInterval = extractLegacyInterval(partialPreferences);
-        Integer effectiveInterval =
-                serviceIntervalMonths != null ? (Integer) validateInterval(serviceIntervalMonths) : legacyInterval;
+        Integer effectiveInterval = serviceIntervalMonths != null
+                ? Integer.valueOf(validateInterval(serviceIntervalMonths))
+                : legacyInterval;
 
         // Merge new values into existing preferences
         var currentPreferences = existing.getPreferences();
@@ -172,6 +175,9 @@ public class VehiclePreferencesServiceImpl implements VehiclePreferencesService 
      * blob write cannot silently drop the interval (#1175).
      */
     private static @Nullable Integer extractLegacyInterval(Map<String, Object> preferences) {
+        if (!preferences.containsKey(LEGACY_INTERVAL_KEY)) {
+            return null;
+        }
         Object raw = preferences.remove(LEGACY_INTERVAL_KEY);
         if (raw == null) {
             return null;

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/service/VehiclePreferencesService.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/service/VehiclePreferencesService.java
@@ -19,10 +19,16 @@ public interface VehiclePreferencesService {
     VehicleCarePreference upsertPreferences(UpsertPreferencesRequest request);
 
     /**
-     * Updates specific preference fields without replacing the entire map.
+     * Updates specific preference fields without replacing the entire map. A null
+     * {@code serviceIntervalMonths} leaves the structured interval unchanged (use the upsert to
+     * clear it); a legacy {@code serviceIntervalMonths} key inside {@code partialPreferences} is
+     * promoted into the structured field instead of being stored in the blob (#1175).
      */
     VehicleCarePreference mergePreferences(
-            UUID vehicleId, Map<String, Object> partialPreferences, UUID updatedByUserId);
+            UUID vehicleId,
+            Map<String, Object> partialPreferences,
+            Integer serviceIntervalMonths,
+            UUID updatedByUserId);
 
     /**
      * Deletes preferences for a vehicle.

--- a/pos-vehicle-inventory/src/main/resources/db/migration/V4__add_service_interval_months_to_care_preferences.sql
+++ b/pos-vehicle-inventory/src/main/resources/db/migration/V4__add_service_interval_months_to_care_preferences.sql
@@ -1,0 +1,20 @@
+-- #1175: promote the service interval out of the unstructured JSONB preferences blob into a
+-- structured, validated column so pos-vehicle-inventory can emit it as a
+-- vehicle.care-preference.updated fact for CRM service-due consumers. Null means "no
+-- per-vehicle override" — consumers fall back to their module-wide default interval.
+ALTER TABLE vehicle_care_preferences
+    ADD COLUMN service_interval_months integer;
+
+ALTER TABLE vehicle_care_preferences
+    ADD CONSTRAINT vehicle_care_preferences_service_interval_months_chk
+        CHECK (service_interval_months IS NULL OR service_interval_months BETWEEN 1 AND 120);
+
+-- Backfill from the legacy JSONB key where a row already carries a plausible integer value,
+-- then strip the promoted key so the blob and the structured column cannot drift apart.
+-- Unparseable/out-of-range values are left in the blob untouched (nothing ever read them).
+UPDATE vehicle_care_preferences
+SET service_interval_months = (preferences ->> 'serviceIntervalMonths')::integer,
+    preferences             = preferences - 'serviceIntervalMonths'
+WHERE preferences ? 'serviceIntervalMonths'
+  AND preferences ->> 'serviceIntervalMonths' ~ '^[0-9]{1,3}$'
+  AND (preferences ->> 'serviceIntervalMonths')::integer BETWEEN 1 AND 120;

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/CarePreferenceEventPublisherTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/CarePreferenceEventPublisherTest.java
@@ -1,0 +1,127 @@
+package com.positivity.vehicle.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.vehicle.VehicleCarePreferenceUpdatedV1;
+import com.positivity.vehicle.internal.entity.VehicleCarePreference;
+import com.positivity.vehicle.internal.entity.VehicleRecord;
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Unit tests for {@link CarePreferenceEventPublisher} (#1175).
+ */
+class CarePreferenceEventPublisherTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-12T12:00:00Z"), ZoneOffset.UTC);
+    private static final UUID VEHICLE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    private final EntityManager entityManager = mock(EntityManager.class);
+    private final OutboxEventWriter writer = mock(OutboxEventWriter.class);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<OutboxEventWriter> writerProvider = mock(ObjectProvider.class);
+
+    private CarePreferenceEventPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new CarePreferenceEventPublisher(TEST_CLOCK, entityManager, writerProvider, "vehicle.events.v1");
+    }
+
+    private VehicleRecord vehicleRecord() {
+        return VehicleRecord.builder()
+                .vehicleId(VEHICLE_ID)
+                .accountId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                .vin("1HGBH41JXMN109186")
+                .vinNormalized("1HGBH41JXMN109186")
+                .unitNumber("UNIT-1")
+                .description("2022 Honda Accord")
+                .build();
+    }
+
+    private VehicleCarePreference preference() {
+        return VehicleCarePreference.builder()
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000010"))
+                .vehicle(vehicleRecord())
+                .preferences(Map.of("oilType", "synthetic"))
+                .serviceIntervalMonths(4)
+                .updatedAt(Instant.parse("2026-07-12T11:00:00Z"))
+                .createdByUserId(UUID.fromString("00000000-0000-0000-0000-000000000020"))
+                .updatedByUserId(UUID.fromString("00000000-0000-0000-0000-000000000020"))
+                .version(2L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Queues a vehicle.care-preference.updated envelope keyed by vehicleId with an epoch-millis version")
+    void queuesUpsertEnvelope() {
+        when(writerProvider.getIfAvailable()).thenReturn(writer);
+
+        publisher.publishCarePreferenceUpserted(preference());
+
+        // Auditing must have stamped the row before the payload snapshot is taken.
+        verify(entityManager).flush();
+        ArgumentCaptor<String> topic = ArgumentCaptor.forClass(String.class);
+        @SuppressWarnings("rawtypes")
+        ArgumentCaptor<DomainEventEnvelope> envelope = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(topic.capture(), envelope.capture());
+        assertThat(topic.getValue()).isEqualTo("vehicle.events.v1");
+        assertThat(envelope.getValue().eventType()).isEqualTo(VehicleCarePreferenceUpdatedV1.EVENT_TYPE);
+        assertThat(envelope.getValue().aggregateId()).isEqualTo(VEHICLE_ID);
+        // LWW stamp, not the row's JPA @Version: delete + re-create restarts the row version.
+        assertThat(envelope.getValue().aggregateVersion())
+                .isEqualTo(Instant.parse("2026-07-12T12:00:00Z").toEpochMilli());
+        assertThat(envelope.getValue().sourceService()).isEqualTo("pos-vehicle-inventory");
+        VehicleCarePreferenceUpdatedV1 payload =
+                (VehicleCarePreferenceUpdatedV1) envelope.getValue().payload();
+        assertThat(payload.vehicleId()).isEqualTo(VEHICLE_ID);
+        assertThat(payload.serviceIntervalMonths()).isEqualTo(4);
+        assertThat(payload.deleted()).isFalse();
+        assertThat(payload.updatedAt()).isEqualTo(Instant.parse("2026-07-12T11:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("Delete queues a tombstone with a null interval")
+    void queuesDeleteTombstone() {
+        when(writerProvider.getIfAvailable()).thenReturn(writer);
+
+        publisher.publishCarePreferenceDeleted(VEHICLE_ID);
+
+        @SuppressWarnings("rawtypes")
+        ArgumentCaptor<DomainEventEnvelope> envelope = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(writer).publish(any(), envelope.capture());
+        assertThat(envelope.getValue().aggregateId()).isEqualTo(VEHICLE_ID);
+        VehicleCarePreferenceUpdatedV1 payload =
+                (VehicleCarePreferenceUpdatedV1) envelope.getValue().payload();
+        assertThat(payload.deleted()).isTrue();
+        assertThat(payload.serviceIntervalMonths()).isNull();
+    }
+
+    @Test
+    @DisplayName("No-op when the Kafka feature flag is off (writer bean absent)")
+    void noopWithoutWriter() {
+        when(writerProvider.getIfAvailable()).thenReturn(null);
+
+        publisher.publishCarePreferenceUpserted(preference());
+        publisher.publishCarePreferenceDeleted(VEHICLE_ID);
+
+        verify(entityManager, never()).flush();
+        verify(writer, never()).publish(any(), any());
+    }
+}

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/service/VehiclePreferencesServiceImplTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/service/VehiclePreferencesServiceImplTest.java
@@ -1,0 +1,199 @@
+package com.positivity.vehicle.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.vehicle.internal.config.CarePreferenceEventPublisher;
+import com.positivity.vehicle.internal.dto.UpsertPreferencesRequest;
+import com.positivity.vehicle.internal.entity.VehicleCarePreference;
+import com.positivity.vehicle.internal.entity.VehicleRecord;
+import com.positivity.vehicle.internal.repository.VehicleCarePreferenceRepository;
+import com.positivity.vehicle.internal.repository.VehicleRecordRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link VehiclePreferencesServiceImpl} — structured service interval and fact
+ * emission (#1175).
+ */
+class VehiclePreferencesServiceImplTest {
+
+    private static final UUID VEHICLE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+    private final VehicleCarePreferenceRepository preferencesRepository = mock(VehicleCarePreferenceRepository.class);
+    private final VehicleRecordRepository vehicleRepository = mock(VehicleRecordRepository.class);
+    private final CarePreferenceEventPublisher publisher = mock(CarePreferenceEventPublisher.class);
+
+    private VehiclePreferencesServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new VehiclePreferencesServiceImpl(preferencesRepository, vehicleRepository, publisher);
+        when(preferencesRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private UpsertPreferencesRequest request(Map<String, Object> preferences, Integer serviceIntervalMonths) {
+        return new UpsertPreferencesRequest(VEHICLE_ID, preferences, serviceIntervalMonths, null, USER_ID, USER_ID);
+    }
+
+    private VehicleRecord vehicleRecord() {
+        return VehicleRecord.builder()
+                .vehicleId(VEHICLE_ID)
+                .accountId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
+                .vin("1HGBH41JXMN109186")
+                .vinNormalized("1HGBH41JXMN109186")
+                .unitNumber("UNIT-1")
+                .description("2022 Honda Accord")
+                .build();
+    }
+
+    private VehicleCarePreference existing(Integer serviceIntervalMonths) {
+        return VehicleCarePreference.builder()
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000010"))
+                .vehicle(vehicleRecord())
+                .preferences(new HashMap<>(Map.of("oilType", "synthetic")))
+                .serviceIntervalMonths(serviceIntervalMonths)
+                .createdByUserId(USER_ID)
+                .updatedByUserId(USER_ID)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Upsert stores the structured interval and emits the care-preference fact")
+    void upsertStoresIntervalAndEmits() {
+        when(vehicleRepository.existsById(VEHICLE_ID)).thenReturn(true);
+        when(vehicleRepository.getReferenceById(VEHICLE_ID)).thenReturn(vehicleRecord());
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.empty());
+
+        VehicleCarePreference saved = service.upsertPreferences(request(new HashMap<>(), 4));
+
+        assertThat(saved.getServiceIntervalMonths()).isEqualTo(4);
+        verify(publisher).publishCarePreferenceUpserted(saved);
+    }
+
+    @Test
+    @DisplayName("Upsert with a null interval clears the per-vehicle override (PUT is a full replace)")
+    void upsertNullIntervalClears() {
+        when(vehicleRepository.existsById(VEHICLE_ID)).thenReturn(true);
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.of(existing(4)));
+
+        VehicleCarePreference saved = service.upsertPreferences(request(new HashMap<>(), null));
+
+        assertThat(saved.getServiceIntervalMonths()).isNull();
+        verify(publisher).publishCarePreferenceUpserted(saved);
+    }
+
+    @Test
+    @DisplayName("Legacy serviceIntervalMonths blob key is promoted into the structured field, not stored")
+    void upsertPromotesLegacyBlobKey() {
+        when(vehicleRepository.existsById(VEHICLE_ID)).thenReturn(true);
+        when(vehicleRepository.getReferenceById(VEHICLE_ID)).thenReturn(vehicleRecord());
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.empty());
+        Map<String, Object> blob = new HashMap<>(Map.of("serviceIntervalMonths", 9, "oilType", "synthetic"));
+
+        VehicleCarePreference saved = service.upsertPreferences(request(blob, null));
+
+        assertThat(saved.getServiceIntervalMonths()).isEqualTo(9);
+        assertThat(saved.getPreferences()).doesNotContainKey("serviceIntervalMonths");
+        assertThat(saved.getPreferences()).containsEntry("oilType", "synthetic");
+    }
+
+    @Test
+    @DisplayName("An explicit structured interval wins over the legacy blob key")
+    void explicitIntervalWinsOverLegacyKey() {
+        when(vehicleRepository.existsById(VEHICLE_ID)).thenReturn(true);
+        when(vehicleRepository.getReferenceById(VEHICLE_ID)).thenReturn(vehicleRecord());
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.empty());
+        Map<String, Object> blob = new HashMap<>(Map.of("serviceIntervalMonths", 9));
+
+        VehicleCarePreference saved = service.upsertPreferences(request(blob, 3));
+
+        assertThat(saved.getServiceIntervalMonths()).isEqualTo(3);
+        assertThat(saved.getPreferences()).doesNotContainKey("serviceIntervalMonths");
+    }
+
+    @Test
+    @DisplayName("A non-numeric or out-of-range legacy blob value is rejected, not silently dropped")
+    void rejectsInvalidLegacyBlobValue() {
+        when(vehicleRepository.existsById(VEHICLE_ID)).thenReturn(true);
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.upsertPreferences(
+                        request(new HashMap<>(Map.of("serviceIntervalMonths", "soon")), null)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                        service.upsertPreferences(request(new HashMap<>(Map.of("serviceIntervalMonths", 0)), null)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                        service.upsertPreferences(request(new HashMap<>(Map.of("serviceIntervalMonths", 121)), null)))
+                .isInstanceOf(IllegalArgumentException.class);
+        verify(publisher, never()).publishCarePreferenceUpserted(any());
+    }
+
+    @Test
+    @DisplayName("Merge with a null interval leaves the stored interval unchanged")
+    void mergeNullIntervalLeavesUnchanged() {
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.of(existing(4)));
+
+        VehicleCarePreference saved =
+                service.mergePreferences(VEHICLE_ID, new HashMap<>(Map.of("washPreference", "hand")), null, USER_ID);
+
+        assertThat(saved.getServiceIntervalMonths()).isEqualTo(4);
+        assertThat(saved.getPreferences()).containsEntry("washPreference", "hand");
+        verify(publisher).publishCarePreferenceUpserted(saved);
+    }
+
+    @Test
+    @DisplayName("Merge updates the interval from the structured field or the legacy blob key")
+    void mergeUpdatesInterval() {
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.of(existing(4)));
+
+        VehicleCarePreference saved = service.mergePreferences(VEHICLE_ID, new HashMap<>(), 7, USER_ID);
+        assertThat(saved.getServiceIntervalMonths()).isEqualTo(7);
+
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.of(existing(4)));
+        VehicleCarePreference viaLegacy =
+                service.mergePreferences(VEHICLE_ID, new HashMap<>(Map.of("serviceIntervalMonths", 12)), null, USER_ID);
+        assertThat(viaLegacy.getServiceIntervalMonths()).isEqualTo(12);
+        assertThat(viaLegacy.getPreferences()).doesNotContainKey("serviceIntervalMonths");
+    }
+
+    @Test
+    @DisplayName("Delete emits the tombstone fact; a delete of nothing emits nothing")
+    void deleteEmitsTombstone() {
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.of(existing(4)));
+        service.deletePreferences(VEHICLE_ID);
+        verify(publisher).publishCarePreferenceDeleted(VEHICLE_ID);
+
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.empty());
+        service.deletePreferences(VEHICLE_ID);
+        // still exactly one emission from the first call
+        verify(publisher).publishCarePreferenceDeleted(VEHICLE_ID);
+    }
+
+    @Test
+    @DisplayName("Emission happens via the publisher only after a successful save")
+    void emitsAfterSave() {
+        when(vehicleRepository.existsById(VEHICLE_ID)).thenReturn(true);
+        when(vehicleRepository.getReferenceById(VEHICLE_ID)).thenReturn(vehicleRecord());
+        when(preferencesRepository.findByVehicle_VehicleId(VEHICLE_ID)).thenReturn(Optional.empty());
+
+        service.upsertPreferences(request(new HashMap<>(), null));
+
+        ArgumentCaptor<VehicleCarePreference> captor = ArgumentCaptor.forClass(VehicleCarePreference.class);
+        verify(preferencesRepository).save(captor.capture());
+        verify(publisher).publishCarePreferenceUpserted(captor.getValue());
+    }
+}


### PR DESCRIPTION

## Capability &amp; Traceability
- Capability: n/a (no cap id on the story)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1175
- Domain: `domain:crm` (pos-vehicle-inventory → pos-customer)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/vehicle/.business-rules/BACKEND_CONTRACT_GUIDE.md` — new additive event contract `vehicle.care-preference.updated` v1 on `vehicle.events.v1` (`VehicleCarePreferenceUpdatedV1` in `pos-domain-events`), plus additive nullable `serviceIntervalMonths` on the care-preference REST DTOs
- Durion contract PR (if applicable): none

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller (`VehiclePreferencesController`: `serviceIntervalMonths` on upsert/merge DTOs, `@Min(1)`/`@Max(120)`, `@Valid` added to the PATCH body)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — module `openapi.yaml`/`openapi.json` updated by hand to match the annotations (the generator boots the app, unavailable in this environment); the aggregate spec was not regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — not done here; additive nullable field only

## Scope
- What changed:
  - **pos-domain-events**: new `VehicleCarePreferenceUpdatedV1` payload record (`vehicle.care-preference.updated`, schema v1, interval bounds 1–120 enforced in the contract). Event type uses a hyphen — `DomainEventEnvelope` rejects underscores, so the story&#39;s literal `care_preference` spelling is not representable.
  - **pos-vehicle-inventory** (producer): V4 migration promotes the service interval out of the JSONB blob into a structured `service_interval_months` column (nullable = &#34;use CRM default&#34;, CHECK 1–120, backfill from the legacy blob key, promoted key stripped from the blob). Entity/DTOs/mapper/controller carry the field; a legacy `serviceIntervalMonths` key sent inside the preferences map by older clients is promoted on write instead of being stored; a PATCH may update only the interval (null `partialPreferences` is normalized). `CarePreferenceEventPublisher` emits the fact on upsert/merge/delete through the existing ADR-0044 transactional outbox on `vehicle.events.v1`, so the existing `ManifestPublisher` reconciliation and command-topic replay cover the new fact type with no manifest code changes. Deletes ride the same event type as a tombstone (`deleted=true`). The envelope `aggregateVersion` is a last-writer-wins epoch-millis stamp rather than the JPA `@Version`, because a care-preference row can be hard-deleted and re-created (which restarts the row version at 0 and would wedge a `&gt;=` guard).
  - **pos-customer** (consumer): V28 creates the `ext_vehicle_care_preference` replica keyed by `vehicle_id`; `VehicleEventsListener` now dispatches both fact types, applies care-preference facts with an LWW `&gt;` stale guard (people-contact precedent), and lands deletes as versioned tombstones (interval null, version advanced). The listener now records **every** parsed eventId in `processed_events`, including ignored event types — previously unknown types were dropped unrecorded, which would have made the vehicle manifest reconciliation report false drift (and fire replays) every window once a second fact type shared the topic. `SegmentResolutionService` groups last service per (party, vehicle) via a new `findLastServiceByPartyAndVehicle` projection and judges each scope against its effective interval (replica override where present, else `pos.customer.crm.service-due-months`); `monthsSinceLastService` stays the max across scopes, and the batch query count is unchanged. `ServiceDueReminderJob` queries candidates at the loosest interval in effect (min of overrides and the default), filters each candidate against one batched replica load (no N+1), and computes `dueDate` from the per-vehicle interval. Non-positive replica values are treated as corrupt and fall back to the default. The now-unused party-level `findLastServiceByParty` projection was removed.
  - **CI** (`.github/workflows/ci.yml`): the PR-only build-cache pilot skipped the install goal on cache hits, so the selective test reactor failed dependency resolution on shared libs (`pos-shared-dtos`, then `pos-tax-common` via an `-amd` dependent — the `-am` band-aid from 7d44c4b52 cannot cover dependents&#39; own upstreams). The install step now passes `-Dmaven.build.cache.alwaysRunPlugins=maven-install-plugin:install` so restored artifacts still land in `~/.m2` without being rebuilt.
- Why: both CRM service-due consumers (`service.due` segment attribute, #1144, and `SERVICE_DUE_REMINDER` generation, #1153) could only use the module-wide interval because `VehicleCarePreference` stored preferences as an unstructured blob and emitted nothing. This is the per-vehicle feed those code paths were annotated as waiting for. Closes #1175.

## Tests
- [x] Unit tests added/updated
  - `VehicleCarePreferenceUpdatedV1Test` (contract round-trip + invariants, incl. 1–120 bounds)
  - `CarePreferenceEventPublisherTest`, `VehiclePreferencesServiceImplTest` (emission, legacy-key promotion, validation, tombstone)
  - `VehicleEventsListenerTest` (care-preference upsert/tombstone/LWW guard, ignored-type eventIds now recorded)
  - `ServiceDueReminderJobTest` (loosest-cutoff widening, per-vehicle dueDate, looser-interval deferral, vehicle-less default)
  - `SegmentResolutionServiceTest` (new; first direct coverage of `serviceDue`)
- [x] Integration tests added/updated — `ServiceHistoryRepositoryTest` (H2 `@SpringBootTest`) covers the new per-(party, vehicle) projection. `FlywayMigrationIT` (Testcontainers) will validate V4/V28 in CI; it could not run in this environment.
- [ ] Provider behavioral contract tests added/updated — n/a (no such suite for this contract)
- How to run: `./mvnw -pl pos-domain-events,pos-vehicle-inventory,pos-customer test` and `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test` (both green locally, plus Spotless/Checkstyle/SpotBugs via `package`)

## Risk &amp; Rollback
- Risk level: Medium — two Flyway migrations (one with a JSONB backfill), a new event type on a shared topic, and changed reminder cutoff arithmetic. Mitigations: the fact pipeline is behind the existing `pos.vehicle-inventory.kafka.enabled` / `pos.customer.kafka.enabled` flags (both default off); vehicles without a structured interval behave exactly as today; replayed/duplicate facts are inert via `processed_events` + the LWW guard + deterministic reminder keys.
- Rollback plan: revert the commit. V4/V28 are additive (new column/table); the V4 backfill moves the legacy blob key into the column, so a post-rollback restore of that key would need a manual copy back into `preferences` if any rows carried it. With the revert deployed, consumers ignore the already-published care-preference facts (unknown-type path) — but note that a reverted listener also stops recording those eventIds, so vehicle manifest windows containing them will flag drift until the feed is restored.

## Checklist
- [ ] Branch name matches `cap/` — branch is `claude/issue-1175-tet9cd` (session-designated branch; no cap id on the story)
- [ ] PR title starts with `[CAP:]` — no cap id on the story; title mirrors the issue&#39;s `[CRM]` tag
- [x] Links to parent + child issues are present (child #1175; the story has no parent link)
- [x] Contract guide updated (when contract semantics changed) — additive-only change documented above; javadoc on the payload record is the contract source in `pos-domain-events` (see BACKEND_CONTRACT_GUIDE.md reference above)
- [x] Required CI checks passing — full-reactor run green on 2345d25dc; all three Copilot review comments addressed in 6c3c8c840

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gpCdeH2gLj8cqzXuXHaMQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gpCdeH2gLj8cqzXuXHaMQ)_