### PR TITLE
Fix invalid ghsa element in OWASP suppressions file

### DIFF
--- a/build-tools/owasp-suppressions.xml
+++ b/build-tools/owasp-suppressions.xml
@@ -35,7 +35,7 @@
     <suppress>
         <notes>DOMPurify bundled in swagger-ui; Swagger UI disabled in production; no springdoc 3.x fix available yet.</notes>
         <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
-        <ghsa>GHSA-39q2-94rc-95cp</ghsa>
+        <vulnerabilityName>GHSA-39q2-94rc-95cp</vulnerabilityName>
     </suppress>
 
 </suppressions>


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (follow-up to #1185, nightly OWASP scan)
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:ci`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- n/a — build-tools config only, no controllers/DTOs/events/openapi touched

## Contract Chain (when a Controller changed)
- n/a — no controller changed

## Scope
- What changed: replaced the invalid `<ghsa>` element in `build-tools/owasp-suppressions.xml` with `<vulnerabilityName>`, which is how the dependency-suppression 1.3 schema expresses GHSA advisory suppressions.
- Why: validating the new datafeed-mirror path (dispatch run 31186635337) proved the NVD sync now completes in ~68 seconds, but the scan then failed with `SuppressionParseException` — the schema has no `<ghsa>` element, so the suppression analyzer failed to initialize. This was invisible before because no CI run had ever completed the NVD sync to reach the analysis phase.

## Tests
- [ ] Unit tests added/updated — n/a (config-only)
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run: dispatch the `Backend CI/CD` workflow; the Security Scan job should complete the OWASP check with the suppression file loading cleanly (no `SuppressionParseException` warning in the log).

## Risk & Rollback
- Risk level: Low — one element rename in a suppression file; the scan step is `continue-on-error`.
- Rollback plan: revert the commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, session branch `claude/backend-build-spec-lrbgnf`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a
- [x] Links to parent + child issues are present (n/a)
- [x] Contract guide updated (no contract semantics changed)
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9szbL2WrnjqWwE5wVMHhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9szbL2WrnjqWwE5wVMHhQ)_