### PR TITLE
Add lexical dense-miss regression fixtures + recovery gate to the RAG eval suite (#1178)

### DIFF
--- a/pos-mcp-server/src/test/java/com/positivity/mcp/eval/EvalFixtureValidationTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/eval/EvalFixtureValidationTest.java
@@ -91,6 +91,27 @@ class EvalFixtureValidationTest {
     }
 
     @Test
+    @DisplayName("rag-lexical fixtures are structurally valid")
+    void ragLexicalFixturesValid() throws IOException {
+        // #1178: same shape as rag-retrieval (query + actor + expected.doc_ids). This suite feeds the
+        // dense-vs-hybrid diagnostic in eval_live.py (rag_lexical_hybrid_784), so a malformed fixture
+        // would silently drop out of the dense-miss denominator instead of failing loudly.
+        for (Path file : suiteFiles("rag-lexical")) {
+            JsonNode root = parseSuite(file);
+            Set<String> ids = new HashSet<>();
+            for (JsonNode fx : root.get("fixtures")) {
+                String id = requireId(fx, file, ids);
+                requireText(fx, "query", file, id);
+                validateActor(fx.get("actor"), file, id, false);
+                JsonNode expected = required(fx, "expected", file, id);
+                assertThat(expected.has("doc_ids"))
+                        .as("%s[%s]: expected.doc_ids required", file, id)
+                        .isTrue();
+            }
+        }
+    }
+
+    @Test
     @DisplayName("write-safety fixtures are structurally valid")
     void writeSafetyFixturesValid() throws IOException {
         for (Path file : suiteFiles("write-safety")) {

--- a/pos-mcp-server/src/test/resources/eval/README.md
+++ b/pos-mcp-server/src/test/resources/eval/README.md
@@ -8,8 +8,10 @@ eval/
   schema/        JSON Schema for each suite (authoring reference)
   tool-selection/*.json   hit@5 / MRR fixtures
   rag-retrieval/*.json    recall@k fixtures
+  rag-lexical/*.json      dense-vs-hybrid lexical fixtures (#784/#1178) — separate from the dense gate
   write-safety/*.json     write-gate invariant fixtures
   tool-response/*.json    coverage fixtures: realistic-response vs no-tool-available (#1164)
+  gap-harness/            synthetic question set + calibration for scripts/gap_harness (#1125)
   baseline.json           metric baseline snapshot
 ```
 
@@ -29,6 +31,31 @@ eval/
   set or permission seeds change.
 - Baseline metrics (hit@5 / MRR / recall@k): **pending** live backend — captured by `BaselineCaptureIT`
   against a running model + pgvector, not part of the structural CI test.
+
+## Lexical regression suite (#784 / #1178)
+
+`rag-lexical/` is scored by the `rag_lexical_hybrid_784` block of `scripts/eval_live.py` under
+dense-only vs dense+lexical (RRF), mirroring the production hybrid path (`LexicalDocumentRetriever`
+with the #1170 OR-semantics tsquery and the #1169 master-searches-all-scopes rule; dense pass at the
+primary 0.6 floor). Three fixture classes:
+
+- **bare-token** (`glossary-identifiers.json`, `returns-refunds.json`, `codes-catalogs.json`) —
+  exact enum constants, `domain:resource:action` permission codes, and event ids with no semantic
+  hook, per the per-doc fixture spec in `docs/rag-corpus-growth-plan-1124.md`.
+- **dense-miss NL questions** (`dense-miss-questions.json`) — natural-language identifier questions;
+  the VIN and invoice-number entries are live-verified dense misses (#1170) recovered only by the
+  lexical path. These give the suite a non-zero `dense_misses` denominator.
+- Fixtures where dense alone misses feed the **regression gate**: hybrid must recover at least
+  `EVAL_MIN_LEXICAL_RECOVERY` (default 0.5) of them or the eval exits non-zero. Breaking the lexical
+  path (tsquery construction, `content_tsv` loss on re-embed, RRF wiring) turns the suite red;
+  a corpus where dense recalls everything leaves the gate vacuously green. The gated
+  `rag_retrieval.recall_at_k` floor is untouched by all of this.
+
+After changing these fixtures, verify on alpha per
+`docs/rag-corpus-growth-and-flip-threshold-1124.md`: re-run `eval_live.py`, confirm
+`rag_lexical_hybrid_784.dense_misses > 0` and `hybrid_recall_at_k > dense_recall_at_k`, and update
+each fixture's `dense-miss-candidate` tag to `dense-miss` (or adjust the query) based on the
+observed per-fixture detail.
 
 ## Tool-response coverage suite (#1164)
 

--- a/pos-mcp-server/src/test/resources/eval/README.md
+++ b/pos-mcp-server/src/test/resources/eval/README.md
@@ -41,7 +41,7 @@ primary 0.6 floor). Three fixture classes:
 
 - **bare-token** (`glossary-identifiers.json`, `returns-refunds.json`, `codes-catalogs.json`) —
   exact enum constants, `domain:resource:action` permission codes, and event ids with no semantic
-  hook, per the per-doc fixture spec in `docs/rag-corpus-growth-plan-1124.md`.
+  hook, per the per-doc fixture spec in `../../../../docs/rag-corpus-growth-plan-1124.md`.
 - **dense-miss NL questions** (`dense-miss-questions.json`) — natural-language identifier questions;
   the VIN and invoice-number entries are live-verified dense misses (#1170) recovered only by the
   lexical path. These give the suite a non-zero `dense_misses` denominator.
@@ -52,7 +52,7 @@ primary 0.6 floor). Three fixture classes:
   `rag_retrieval.recall_at_k` floor is untouched by all of this.
 
 After changing these fixtures, verify on alpha per
-`docs/rag-corpus-growth-and-flip-threshold-1124.md`: re-run `eval_live.py`, confirm
+`../../../../docs/rag-corpus-growth-and-flip-threshold-1124.md`: re-run `eval_live.py`, confirm
 `rag_lexical_hybrid_784.dense_misses > 0` and `hybrid_recall_at_k > dense_recall_at_k`, and update
 each fixture's `dense-miss-candidate` tag to `dense-miss` (or adjust the query) based on the
 observed per-fixture detail.

--- a/pos-mcp-server/src/test/resources/eval/gap-harness/questions.json
+++ b/pos-mcp-server/src/test/resources/eval/gap-harness/questions.json
@@ -230,6 +230,90 @@
       "topic": "warranty settle-customer-first invariant",
       "tags": ["scope-coverage", "positive"],
       "source": "synthetic"
+    },
+    {
+      "id": "gap-order-cancel-failed-workexec",
+      "query": "what does CANCEL_FAILED_WORKEXEC mean on a sales order and where can it go next",
+      "actor": { "role": "ROLE_USER", "permission_codes": ["order:order:view"] },
+      "rag_scope": "order",
+      "expected_doc_ids": ["order.lifecycle"],
+      "expected_facts": [
+        "CANCEL_FAILED_WORKEXEC is a SalesOrderStatus in the pos-order cancel saga; it transitions only to CANCEL_REQUESTED or CANCEL_REQUIRES_MANUAL_REVIEW.",
+        "CANCEL_REQUESTED can move to WORKORDER_CANCELLED, PAYMENT_REVERSED, CANCELLED, CANCEL_FAILED_WORKEXEC, or CANCEL_FAILED_BILLING; COMPLETED, VOIDED, and CANCELLED are terminal."
+      ],
+      "topic": "sales-order cancel-saga status",
+      "tags": ["exact-code", "bare-enum"],
+      "source": "synthetic"
+    },
+    {
+      "id": "gap-inventory-received-short",
+      "query": "what does receiving line status RECEIVED_SHORT mean and what variance type is created",
+      "actor": { "role": "ROLE_USER", "permission_codes": ["inventory:receiving:view"] },
+      "rag_scope": "inventory",
+      "expected_doc_ids": ["inventory.receiving"],
+      "expected_facts": [
+        "A receiving line with received quantity lower than expected becomes RECEIVED_SHORT and creates a SHORTAGE variance; higher becomes RECEIVED_OVER with an OVERAGE variance; equal becomes RECEIVED.",
+        "Receipt posting writes GOODS_RECEIPT ledger entries, and a receiving session is set COMPLETED only when all lines are in terminal receiving states."
+      ],
+      "topic": "receiving line status and variance",
+      "tags": ["exact-code", "bare-enum"],
+      "source": "synthetic"
+    },
+    {
+      "id": "gap-pricing-allow-with-override",
+      "query": "when does a price restriction evaluation return ALLOW_WITH_OVERRIDE instead of BLOCK",
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
+      "rag_scope": "pricing",
+      "expected_doc_ids": ["pricing.restrictions"],
+      "expected_facts": [
+        "Per evaluated item: no matching rules returns ALLOW; any matching non-overrideable rule returns BLOCK; matching rules that are all overrideable return ALLOW_WITH_OVERRIDE.",
+        "On timeout or exception, the commit contexts CHECKOUT, INVOICE_FINALIZE, and COMMIT_SALE throw RestrictionServiceUnavailableException while non-commit contexts return RESTRICTION_UNKNOWN."
+      ],
+      "topic": "restriction decision semantics",
+      "tags": ["exact-code", "bare-enum"],
+      "source": "synthetic"
+    },
+    {
+      "id": "gap-accounting-je-error-tokens",
+      "query": "which error code is returned when reversing a journal entry that was already reversed or posting into a hard locked period",
+      "actor": { "role": "ROLE_USER", "permission_codes": ["accounting:je:view"] },
+      "rag_scope": "accounting",
+      "expected_doc_ids": ["accounting.journal-entries"],
+      "expected_facts": [
+        "Reversing an already-reversed journal entry fails with JE_ALREADY_REVERSED; period locks surface PERIOD_CLOSED or PERIOD_HARD_LOCKED; the other error tokens are UNBALANCED_ENTRY, ENTRY_ALREADY_POSTED, and JE_NOT_POSTED.",
+        "Only DRAFT entries can be posted and only POSTED entries reversed; entries must balance within BALANCE_TOLERANCE 0.0001 and are numbered JE-{YYYYMM}-{seq} during post/reverse."
+      ],
+      "topic": "journal-entry error tokens",
+      "tags": ["exact-code", "gated"],
+      "source": "synthetic"
+    },
+    {
+      "id": "gap-workorder-promote-event",
+      "query": "which event id and permission gate promoting an estimate to a workorder and what error is returned when the approval has expired",
+      "actor": { "role": "ROLE_USER", "permission_codes": ["workorder:estimate:view"] },
+      "rag_scope": "workorder",
+      "expected_doc_ids": ["workorder.estimate-promotion"],
+      "expected_facts": [
+        "POST /v1/workorders/estimates/{estimateId}/promote is gated by workorder:estimate:promote and emits WORKORDER_ESTIMATE_PROMOTE.",
+        "PromotionValidationServiceImpl gates in order: ESTIMATE_NOT_FOUND, ALREADY_PROMOTED, APPROVAL_INVALID (status must be APPROVED), APPROVAL_EXPIRED, NO_APPROVED_ITEMS; the created workorder lands in DRAFT and an EST- estimate number is swapped to WO- when free."
+      ],
+      "topic": "estimate promotion event and gates",
+      "tags": ["exact-code", "event-id"],
+      "source": "synthetic"
+    },
+    {
+      "id": "gap-order-price-override-approve-perm",
+      "query": "which permission code lets someone approve a price override and is there a dollar limit above their authority",
+      "actor": { "role": "ROLE_USER", "permission_codes": ["order:price_override:view"] },
+      "rag_scope": "order",
+      "expected_doc_ids": ["order.price-override"],
+      "expected_facts": [
+        "Approving a price override is gated by order:price_override:approve (POST /v1/orders/price-overrides/{overrideId}/approve, event ORDER_PRICE_OVERRIDE_APPROVE); approval is required when discountAmount >= 50.0 or discountPercentage > 10.0.",
+        "The threshold is flat, not tiered: any order:price_override:approve holder can approve any amount. Approve allows only PENDING_APPROVAL -> APPROVED and reject only PENDING_APPROVAL -> REJECTED."
+      ],
+      "topic": "price-override approval permission",
+      "tags": ["exact-code", "permission-code"],
+      "source": "synthetic"
     }
   ]
 }

--- a/pos-mcp-server/src/test/resources/eval/rag-lexical/codes-catalogs.json
+++ b/pos-mcp-server/src/test/resources/eval/rag-lexical/codes-catalogs.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": 1,
+  "_comment": "#1178 bare-code lexical fixtures for the #1124 wave docs — the per-doc fixture class the corpus-growth plan (rag-corpus-growth-plan-1124.md §Fixtures item 1) calls for: bare enum constants, domain:resource:action permission codes, and @EmitEvent ids with no semantic hook, targeting the {scope}.codes catalog docs (plus accounting.journal-entries for its unique error tokens). Dense embeddings under-retrieve bare codes against the per-scope cosine floor; Postgres FTS matches them exactly, so these fixtures give the rag_lexical_hybrid_784 block dense-miss headroom inside domain scopes (the dense-miss-questions.json file covers the master-scope NL-question class). Every token is verbatim from the target doc, which is itself source-verified against the owning pos-* module. Actors hold each doc's required_permissions so PermissionAwareMetadataFilter passes.",
+  "fixtures": [
+    {
+      "fixture_id": "rag-lexical-order-codes-cancel-failed-workexec",
+      "query": "CANCEL_FAILED_WORKEXEC",
+      "actor": { "role": "ROLE_SERVICE_ADVISOR", "permission_codes": ["order:order:view"] },
+      "expected": { "doc_ids": ["order.codes"], "k": 5 },
+      "rag_scope": "order",
+      "tags": ["positive", "lexical", "exact-code", "bare-token"],
+      "notes": "Bare SalesOrderStatus cancel-saga constant; verbatim in order.codes (and order.lifecycle). No semantic hook for dense."
+    },
+    {
+      "fixture_id": "rag-lexical-order-codes-override-approve-perm",
+      "query": "order:price_override:approve",
+      "actor": { "role": "ROLE_SERVICE_ADVISOR", "permission_codes": ["order:order:view"] },
+      "expected": { "doc_ids": ["order.codes"], "k": 5 },
+      "rag_scope": "order",
+      "tags": ["positive", "lexical", "permission-code", "bare-token"],
+      "notes": "Bare domain:resource:action permission code; verbatim in order.codes."
+    },
+    {
+      "fixture_id": "rag-lexical-pricing-codes-restriction-decisions",
+      "query": "ALLOW_WITH_OVERRIDE RESTRICTION_UNKNOWN",
+      "actor": { "role": "ROLE_LOCATION_MANAGER", "permission_codes": ["pricing:promotion:view"] },
+      "expected": { "doc_ids": ["pricing.codes"], "k": 5 },
+      "rag_scope": "pricing",
+      "tags": ["positive", "lexical", "exact-code", "bare-token"],
+      "notes": "Bare RestrictionDecision constants; verbatim in pricing.codes."
+    },
+    {
+      "fixture_id": "rag-lexical-inventory-codes-receiving-transfer",
+      "query": "RECEIVED_SHORT LOST_IN_TRANSIT",
+      "actor": { "role": "ROLE_LOCATION_MANAGER", "permission_codes": ["inventory:purchase_order:view"] },
+      "expected": { "doc_ids": ["inventory.codes"], "k": 5 },
+      "rag_scope": "inventory",
+      "tags": ["positive", "lexical", "exact-code", "bare-token"],
+      "notes": "Bare ReceivingLineStatus + TransferShortCloseDisposition constants; verbatim in inventory.codes."
+    },
+    {
+      "fixture_id": "rag-lexical-accounting-codes-manual-je-reasons",
+      "query": "ACCRUAL_ADJUSTMENT ERROR_CORRECTION RECLASSIFICATION",
+      "actor": { "role": "ROLE_ACCOUNTING_ASSOCIATE", "permission_codes": ["accounting:je:view"] },
+      "expected": { "doc_ids": ["accounting.codes"], "k": 5 },
+      "rag_scope": "accounting",
+      "tags": ["positive", "lexical", "exact-code", "bare-token", "gated"],
+      "notes": "Bare ManualJEReasonCode constants; verbatim in accounting.codes. Doc is permission-gated (accounting:je:view), which the actor holds."
+    },
+    {
+      "fixture_id": "rag-lexical-accounting-je-error-tokens",
+      "query": "JE_ALREADY_REVERSED PERIOD_HARD_LOCKED",
+      "actor": { "role": "ROLE_ACCOUNTING_ASSOCIATE", "permission_codes": ["accounting:je:view"] },
+      "expected": { "doc_ids": ["accounting.journal-entries"], "k": 5 },
+      "rag_scope": "accounting",
+      "tags": ["positive", "lexical", "exact-code", "bare-token", "gated"],
+      "notes": "Post/reverse error tokens unique to accounting.journal-entries (not in accounting.codes), so recall pins the specific doc."
+    },
+    {
+      "fixture_id": "rag-lexical-workorder-codes-promotion-errors",
+      "query": "APPROVAL_EXPIRED NO_APPROVED_ITEMS",
+      "actor": { "role": "ROLE_SERVICE_ADVISOR", "permission_codes": ["workorder:estimate:view"] },
+      "expected": { "doc_ids": ["workorder.codes"], "k": 5 },
+      "rag_scope": "workorder",
+      "tags": ["positive", "lexical", "exact-code", "bare-token"],
+      "notes": "Bare PromotionErrorCode constants; verbatim in workorder.codes."
+    },
+    {
+      "fixture_id": "rag-lexical-workorder-codes-promote-event",
+      "query": "WORKORDER_ESTIMATE_PROMOTE",
+      "actor": { "role": "ROLE_SERVICE_ADVISOR", "permission_codes": ["workorder:estimate:view"] },
+      "expected": { "doc_ids": ["workorder.codes"], "k": 5 },
+      "rag_scope": "workorder",
+      "tags": ["positive", "lexical", "event-id", "bare-token"],
+      "notes": "Bare @EmitEvent id; verbatim in workorder.codes (and workorder.estimate-promotion)."
+    },
+    {
+      "fixture_id": "rag-lexical-crm-codes-contact-roles",
+      "query": "PAYMENT_AUTHORIZER PRIMARY_BUSINESS_CONTACT",
+      "actor": { "role": "ROLE_ACCOUNT_MANAGER", "permission_codes": ["crm:party:view"] },
+      "expected": { "doc_ids": ["crm.codes"], "k": 5 },
+      "rag_scope": "customer",
+      "tags": ["positive", "lexical", "exact-code", "bare-token"],
+      "notes": "Bare ContactRole constants; verbatim in crm.codes."
+    }
+  ]
+}

--- a/pos-mcp-server/src/test/resources/eval/rag-lexical/dense-miss-questions.json
+++ b/pos-mcp-server/src/test/resources/eval/rag-lexical/dense-miss-questions.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "_comment": "#1178 dense-miss regression fixtures. Natural-language identifier questions — the exact class that failed live on alpha (#1170): dense similarity for glossary.identifiers lands below the production 0.60 floor, and only the OR-semantics lexical FTS path (#1170) recovers the doc. Unlike the original bare-token fixtures (where dense = hybrid = 1.0 and a lexical breakage stays invisible), these queries make eval_live.py's rag_lexical_hybrid_784 block report hybrid_recall_at_k > dense_recall_at_k, so breaking the lexical path (flag off, tsquery construction, content_tsv loss on re-embed, RRF wiring) turns the suite red. The VIN and invoice-number queries are live-verified dense misses (#1170 alpha diagnosis); the rest are the same query class pending live confirmation per the #1124 runbook. Query texts mirror the gap-harness questions.json entries so harness runs and eval runs stay comparable.",
+  "fixtures": [
+    {
+      "fixture_id": "rag-lexical-densemiss-vin-question",
+      "query": "what is the exact format of a VIN and which characters are not allowed",
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
+      "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
+      "rag_scope": "master",
+      "tags": ["positive", "lexical", "dense-miss", "nl-question"],
+      "notes": "LIVE-VERIFIED dense miss (#1170): glossary.identifiers dense similarity 0.58 < 0.60 floor; with OR-semantics FTS the doc is the top-ranked lexical hit. Mirrors gap-harness question gap-vin-format."
+    },
+    {
+      "fixture_id": "rag-lexical-densemiss-invoice-number-question",
+      "query": "what does an invoice number look like and what permission is needed to read an invoice",
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
+      "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
+      "rag_scope": "master",
+      "tags": ["positive", "lexical", "dense-miss", "nl-question"],
+      "notes": "LIVE-VERIFIED dense miss (#1170): dense does not surface glossary.identifiers; lexical ranks it top-2 on alpha. Mirrors gap-harness question gap-invoice-number-format."
+    },
+    {
+      "fixture_id": "rag-lexical-densemiss-po-number-question",
+      "query": "which service owns purchase order numbers and what do they look like",
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
+      "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
+      "rag_scope": "master",
+      "tags": ["positive", "lexical", "dense-miss-candidate", "nl-question"],
+      "notes": "Same class as the verified VIN/invoice misses (NL question wrapping an identifier topic, answered only by glossary.identifiers). Dense-miss status to be confirmed on alpha per the #1124 runbook. Mirrors gap-harness question gap-po-number-owner."
+    },
+    {
+      "fixture_id": "rag-lexical-densemiss-workorder-number-question",
+      "query": "what is the format of a workorder number and how does it relate to the estimate number",
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
+      "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
+      "rag_scope": "master",
+      "tags": ["positive", "lexical", "dense-miss-candidate", "nl-question"],
+      "notes": "WO-YYYY-NNNN / EST-YYYY-NNNN prefix-swap question. Dense-miss status to be confirmed on alpha. Mirrors gap-harness question gap-workorder-number-format."
+    },
+    {
+      "fixture_id": "rag-lexical-densemiss-gl-code-question",
+      "query": "what is the format of a GL chart-of-accounts code",
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
+      "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
+      "rag_scope": "master",
+      "tags": ["positive", "lexical", "dense-miss-candidate", "nl-question"],
+      "notes": "GL code ^\\d{4}(-\\d{3})?$ question. Dense-miss status to be confirmed on alpha. Mirrors gap-harness question gap-gl-account-code."
+    }
+  ]
+}

--- a/pos-mcp-server/src/test/resources/eval/rag-lexical/glossary-identifiers.json
+++ b/pos-mcp-server/src/test/resources/eval/rag-lexical/glossary-identifiers.json
@@ -5,7 +5,7 @@
     {
       "fixture_id": "rag-lexical-glossary-wo-number",
       "query": "WO-2026-1001 workorder number format",
-      "actor": { "role": "ROLE_STAFF", "permission_codes": [] },
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
       "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
       "rag_scope": "master",
       "tags": ["positive", "lexical", "exact-code"],
@@ -14,7 +14,7 @@
     {
       "fixture_id": "rag-lexical-glossary-est-number",
       "query": "EST-YYYY-NNNN estimate number unique per location",
-      "actor": { "role": "ROLE_STAFF", "permission_codes": [] },
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
       "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
       "rag_scope": "master",
       "tags": ["positive", "lexical", "exact-code"],
@@ -23,7 +23,7 @@
     {
       "fixture_id": "rag-lexical-glossary-sku-constraint",
       "query": "uk_product_sku unique immutable SKU",
-      "actor": { "role": "ROLE_STAFF", "permission_codes": [] },
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
       "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
       "rag_scope": "master",
       "tags": ["positive", "lexical", "exact-identifier"],
@@ -32,7 +32,7 @@
     {
       "fixture_id": "rag-lexical-glossary-vin-pattern",
       "query": "vin_normalized 17 character pattern ^[A-HJ-NPR-Z0-9]{17}$",
-      "actor": { "role": "ROLE_STAFF", "permission_codes": [] },
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
       "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
       "rag_scope": "master",
       "tags": ["positive", "lexical", "exact-identifier"],
@@ -41,7 +41,7 @@
     {
       "fixture_id": "rag-lexical-glossary-gr-receipt",
       "query": "GR- goods receipt number prefix",
-      "actor": { "role": "ROLE_STAFF", "permission_codes": [] },
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
       "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
       "rag_scope": "master",
       "tags": ["positive", "lexical", "exact-code"],
@@ -50,7 +50,7 @@
     {
       "fixture_id": "rag-lexical-glossary-invoice-number",
       "query": "INV- epochMillis invoice number generateInvoiceNumber",
-      "actor": { "role": "ROLE_STAFF", "permission_codes": [] },
+      "actor": { "role": "ROLE_USER", "permission_codes": [] },
       "expected": { "doc_ids": ["glossary.identifiers"], "k": 5 },
       "rag_scope": "master",
       "tags": ["positive", "lexical", "exact-code"],

--- a/scripts/eval_live.py
+++ b/scripts/eval_live.py
@@ -49,6 +49,18 @@ RAG_MIN_SCORE = float(os.environ.get("EVAL_RAG_MIN_SCORE", "0.55"))
 # #784: Reciprocal Rank Fusion constant for the dense+lexical hybrid diagnostic. Matches the
 # application default (HybridRetrievalProperties.rrfK / mcp.rag.hybrid.rrf-k).
 RRF_K = max(1, int(os.environ.get("EVAL_RRF_K", "60")))  # clamp: rank constant must be >= 1
+# #1178: the rag-lexical block scores its DENSE pass at the primary production floor (0.6 —
+# SessionAgentManager's semanticRetriever, ScopedContentRetrieverFactory.create(scope, 10, 0.6)),
+# because that is the path whose live dense misses the dense-miss fixtures encode (#1170: VIN
+# question, glossary.identifiers similarity 0.58 < 0.60). The gated rag-retrieval suite keeps the
+# looser 0.55 RAG_MIN_SCORE above, unchanged.
+LEX_DENSE_MIN_SCORE = float(os.environ.get("EVAL_LEXICAL_DENSE_MIN_SCORE", "0.6"))
+# #1178: regression gate for the lexical path. Of the lexical fixtures where dense alone misses
+# (dense_recall < 1.0), at least this fraction must be improved by hybrid RRF fusion. Applied only
+# when the dense-miss denominator is non-zero, so a corpus where dense recalls everything cannot go
+# red vacuously; a broken lexical path (tsquery construction, content_tsv loss on re-embed, RRF
+# wiring) drives recovery to 0 and turns the suite red. Set to 0 to restore diagnostic-only mode.
+MIN_LEXICAL_RECOVERY = float(os.environ.get("EVAL_MIN_LEXICAL_RECOVERY", "0.5"))
 # #1164: tool-response coverage — cheap realistic-vs-no-tool classifier. A fixture counts as
 # realistic-response when the gated ANN returns a candidate whose cosine similarity clears this
 # floor; empty candidate set or a top hit below the floor is no-tool-available (the model has no
@@ -159,23 +171,43 @@ def main():
         )
         return [r[0] for r in rows]
 
-    def rag_visible_docs(query_vec, scope, caller_perms, want):
+    def rag_visible_docs(query_vec, scope, caller_perms, want, min_score=RAG_MIN_SCORE, master_all_scopes=False):
         """Reproduce the production RAG path: ScopedContentRetrieverFactory (ANN filtered by the
-        rag_scope metadata + a cosine similarity floor RAG_MIN_SCORE) + PermissionAwareMetadataFilter
-        (drop docs whose required_permissions the caller lacks). Returns ordered distinct document_ids
-        (chunks collapsed to their document)."""
-        rows = con.run(
-            """
-            SELECT metadata->>'document_id'        AS document_id,
-                   metadata->>'required_permissions' AS required_permissions
-            FROM mcp_document_embedding
-            WHERE metadata->>'rag_scope' = :scope AND embedding IS NOT NULL
-              AND (1 - (embedding <=> CAST(:q AS vector))) >= :min_score
-            ORDER BY embedding <=> CAST(:q AS vector), id
-            LIMIT :limit
-            """,
-            scope=scope, q=vec_literal(query_vec), min_score=RAG_MIN_SCORE, limit=max(want * 10, 50),
-        )
+        rag_scope metadata + a cosine similarity floor) + PermissionAwareMetadataFilter (drop docs
+        whose required_permissions the caller lacks). Returns ordered distinct document_ids (chunks
+        collapsed to their document).
+
+        With master_all_scopes=True the 'master' scope drops the scope filter and searches every
+        scope, mirroring #1169 (ScopedContentRetrieverFactory#create: master is the catch-all agent,
+        not a literal doc scope). The gated rag-retrieval suite keeps the historical scoped behavior
+        (default False) so its recall@k floor calibration is undisturbed; the #1178 lexical block
+        opts in to reproduce the live dense path that produced the verified misses."""
+        if master_all_scopes and scope == "master":
+            rows = con.run(
+                """
+                SELECT metadata->>'document_id'        AS document_id,
+                       metadata->>'required_permissions' AS required_permissions
+                FROM mcp_document_embedding
+                WHERE embedding IS NOT NULL
+                  AND (1 - (embedding <=> CAST(:q AS vector))) >= :min_score
+                ORDER BY embedding <=> CAST(:q AS vector), id
+                LIMIT :limit
+                """,
+                q=vec_literal(query_vec), min_score=min_score, limit=max(want * 10, 50),
+            )
+        else:
+            rows = con.run(
+                """
+                SELECT metadata->>'document_id'        AS document_id,
+                       metadata->>'required_permissions' AS required_permissions
+                FROM mcp_document_embedding
+                WHERE metadata->>'rag_scope' = :scope AND embedding IS NOT NULL
+                  AND (1 - (embedding <=> CAST(:q AS vector))) >= :min_score
+                ORDER BY embedding <=> CAST(:q AS vector), id
+                LIMIT :limit
+                """,
+                scope=scope, q=vec_literal(query_vec), min_score=min_score, limit=max(want * 10, 50),
+            )
         caller = set(caller_perms) | {"AUTHENTICATED"}  # any authenticated caller holds AUTHENTICATED
         ordered = []
         for document_id, required in rows:
@@ -191,22 +223,34 @@ def main():
 
     def rag_lexical_docs(query_text, scope, caller_perms, want):
         """#784: lexical (Postgres FTS) counterpart of rag_visible_docs — mirrors
-        LexicalDocumentRetriever (websearch_to_tsquery / ts_rank_cd over content_tsv, scope-filtered)
-        plus the same PermissionAwareMetadataFilter. Returns ordered distinct document_ids. Raises if
-        the content_tsv column is absent (migration V28 not applied); the caller treats that as
-        'lexical unavailable' and skips the diagnostic rather than failing."""
-        rows = con.run(
-            """
-            SELECT metadata->>'document_id'          AS document_id,
-                   metadata->>'required_permissions' AS required_permissions
-            FROM mcp_document_embedding
-            WHERE metadata->>'rag_scope' = :scope
-              AND content_tsv @@ websearch_to_tsquery('english', :q)
-            ORDER BY ts_rank_cd(content_tsv, websearch_to_tsquery('english', :q)) DESC, id
-            LIMIT :limit
-            """,
-            scope=scope, q=query_text, limit=max(want * 10, 50),
+        LexicalDocumentRetriever plus the same PermissionAwareMetadataFilter. Returns ordered
+        distinct document_ids. Raises if the content_tsv column is absent (migration V28 not
+        applied); the caller treats that as 'lexical unavailable' and skips the diagnostic rather
+        than failing.
+
+        Kept in lockstep with LexicalDocumentRetriever (#1178 — a drifted mirror is exactly the
+        regression this suite exists to catch):
+        - #1170: websearch_to_tsquery ANDs every term, so an NL question that merely CONTAINS an
+          identifier matched nothing; the parsed tsquery is OR-transformed (its '&' operators swapped
+          for '|' in text form — raw user text still passes only through websearch_to_tsquery, so no
+          injection surface) and ts_rank_cd ranks the OR matches.
+        - #1169: the 'master' scope is the catch-all agent, not a literal doc scope, so it searches
+          all scopes (SQL_ALL_SCOPES); domain scopes keep their narrow filter."""
+        or_tsquery = "replace(websearch_to_tsquery('english', :q)::text, ' & ', ' | ')::tsquery"
+        scope_filter = "" if scope == "master" else "  AND metadata->>'rag_scope' = :scope\n"
+        sql = (
+            "SELECT metadata->>'document_id'          AS document_id,\n"
+            "       metadata->>'required_permissions' AS required_permissions\n"
+            "FROM mcp_document_embedding\n"
+            f"WHERE content_tsv @@ {or_tsquery}\n"
+            f"{scope_filter}"
+            f"ORDER BY ts_rank_cd(content_tsv, {or_tsquery}) DESC, id\n"
+            "LIMIT :limit"
         )
+        params = {"q": query_text, "limit": max(want * 10, 50)}
+        if scope != "master":
+            params["scope"] = scope
+        rows = con.run(sql, **params)
         caller = set(caller_perms) | {"AUTHENTICATED"}
         ordered = []
         for document_id, required in rows:
@@ -278,10 +322,15 @@ def main():
 
     recall_at_k = sum(recalls) / len(recalls) if recalls else 0.0
 
-    # ---- #784: lexical vs hybrid recall on the exact-code suite (diagnostic, NOT gated) ----
-    # Scores the separate 'rag-lexical' suite under dense-only vs dense+lexical(RRF) so the value of
-    # the hybrid path is measurable. Never contributes to threshold failures, and degrades to a
-    # 'skipped' status (rather than aborting the eval) when the FTS column / fixtures are absent.
+    # ---- #784/#1178: lexical vs hybrid recall on the exact-code suite ----
+    # Scores the separate 'rag-lexical' suite under dense-only vs dense+lexical(RRF). The dense pass
+    # runs at the primary production floor (LEX_DENSE_MIN_SCORE=0.6) with master searching all
+    # scopes, reproducing the live path whose verified dense misses (#1170: VIN / invoice-number)
+    # the dense-miss fixtures encode. #1178 adds a regression gate: fixtures where dense alone
+    # misses form the dense_misses denominator, and hybrid must recover at least
+    # MIN_LEXICAL_RECOVERY of them — a silently broken lexical path (tsquery construction,
+    # content_tsv loss on re-embed, RRF wiring, flag off) drives recovery to 0 and turns the suite
+    # red. Degrades to a 'skipped' status (never gated) when the FTS column / fixtures are absent.
     rag_lexical_summary = {"status": "skipped: no rag-lexical fixtures"}
     lexical_fixtures = suite("rag-lexical")
     if lexical_fixtures:
@@ -295,7 +344,8 @@ def main():
                 scope = fx.get("rag_scope", "master")
                 k = fx.get("expected", {}).get("k", K)
                 qvec = embed(fx["query"])
-                dense = rag_visible_docs(qvec, scope, perms, k)[:k]
+                dense = rag_visible_docs(
+                    qvec, scope, perms, k, min_score=LEX_DENSE_MIN_SCORE, master_all_scopes=True)[:k]
                 lexical = rag_lexical_docs(fx["query"], scope, perms, k)
                 hybrid = rrf_fuse([dense, lexical], k=RRF_K, limit=k)
                 dense_r = sum(1 for d in expected_docs if d in dense) / len(expected_docs)
@@ -308,12 +358,19 @@ def main():
                     "hybrid_recall": round(hybrid_r, 4), "dense_top_k": dense, "hybrid_top_k": hybrid,
                 })
             n = len(dense_recalls)
+            dense_miss = [pf for pf in per_fixture if pf["dense_recall"] < 1.0]
+            recovered = [pf for pf in dense_miss if pf["hybrid_recall"] > pf["dense_recall"]]
             rag_lexical_summary = {
                 "status": "scored",
                 "scored": n,
                 "rrf_k": RRF_K,
+                "dense_min_score": LEX_DENSE_MIN_SCORE,
                 "dense_recall_at_k": round(sum(dense_recalls) / n, 4) if n else 0.0,
                 "hybrid_recall_at_k": round(sum(hybrid_recalls) / n, 4) if n else 0.0,
+                "dense_misses": len(dense_miss),
+                "hybrid_recovered": len(recovered),
+                "recovery_rate": round(len(recovered) / len(dense_miss), 4) if dense_miss else None,
+                "dense_miss_fixture_ids": [pf["fixture_id"] for pf in dense_miss],
                 "detail": per_fixture,
             }
         except Exception as e:  # missing content_tsv (V28 not deployed), FTS error, etc.
@@ -470,6 +527,15 @@ def main():
         failures.append(f"recall@k {recall_at_k:.4f} < {floor_recall}")
     if gating.get("status") == "FAIL":
         failures.append("permission_gating_779 FAIL")
+    # #1178: lexical regression gate — only when the dense-miss denominator is non-zero (see
+    # MIN_LEXICAL_RECOVERY above). A skipped lexical block (no fixtures / FTS unavailable) never gates.
+    if rag_lexical_summary.get("status") == "scored" and rag_lexical_summary.get("dense_misses", 0) > 0:
+        recovery = rag_lexical_summary.get("recovery_rate") or 0.0
+        if recovery < MIN_LEXICAL_RECOVERY:
+            failures.append(
+                f"lexical_recovery {recovery:.4f} < {MIN_LEXICAL_RECOVERY} "
+                f"(dense_misses={rag_lexical_summary['dense_misses']}, "
+                f"hybrid_recovered={rag_lexical_summary['hybrid_recovered']})")
 
     result = {
         "tool_selection": {"hit_at_5": round(hit_at_5, 4), "mrr": round(mrr, 4),
@@ -482,6 +548,7 @@ def main():
         "tool_response_coverage": tool_response_summary,
         "permission_gating_779": gating,
         "thresholds": {"min_hit_at_5": floor_hit5, "min_mrr": floor_mrr, "min_recall_at_k": floor_recall,
+                       "min_lexical_recovery": MIN_LEXICAL_RECOVERY,
                        "passed": not failures, "failures": failures},
     }
     out = ROOT / "pos-mcp-server/target/eval/baseline-live-python.json"


### PR DESCRIPTION
The rag-lexical suite could not catch a lexical-path regression: every scored
fixture was a bare token that dense also recalled at rank 1, so dense = hybrid
= 1.0 and a silently broken FTS path (tsquery construction, content_tsv loss on
re-embed, RRF wiring) left the suite green. Encode the live-verified dense
misses from #1170 and gate on hybrid recovery so a lexical break turns the
suite red.

Fixtures (pos-mcp-server/src/test/resources/eval):
- rag-lexical/dense-miss-questions.json: NL identifier questions; the VIN and
  invoice-number entries are the live-verified dense misses from the #1170
  alpha diagnosis (glossary.identifiers dense sim 0.58 < 0.60 floor, recovered
  only by OR-semantics FTS); three same-class candidates pending alpha
  confirmation.
- rag-lexical/codes-catalogs.json: bare enum / permission-code / event-id
  fixtures for the #1124 wave docs ({scope}.codes catalogs +
  accounting.journal-entries), per the per-doc fixture spec in
  rag-corpus-growth-plan-1124.md. All tokens verbatim from the docs.
- gap-harness/questions.json: six new exact-code questions (bare enums,
  domain:resource:action codes, @EmitEvent ids) with source-verified
  expected_facts — the original 16-question set contained no query class that
  could produce a dense miss.
- Normalize ROLE_STAFF -> ROLE_USER in glossary-identifiers.json (not a
  KNOWN_ROLES entry; the suite was previously unvalidated).

Harness (scripts/eval_live.py):
- Sync the lexical mirror with production: OR-transformed websearch_to_tsquery
  (#1170) and master-searches-all-scopes (#1169), matching
  LexicalDocumentRetriever; the drifted AND-semantics mirror would have scored
  every NL fixture 0 on both paths.
- Score the lexical block's dense pass at the primary production floor
  (EVAL_LEXICAL_DENSE_MIN_SCORE=0.6, master all-scopes) — the path whose live
  misses the fixtures encode. The gated rag_retrieval suite keeps its 0.55
  floor and scoped SQL untouched.
- Emit dense_misses / hybrid_recovered / recovery_rate and gate:
  when dense_misses > 0, recovery_rate < EVAL_MIN_LEXICAL_RECOVERY (default
  0.5) fails the eval. Skipped FTS or an all-dense-hit corpus never gates.

Validation:
- New EvalFixtureValidationTest#ragLexicalFixturesValid (the suite had no
  structural check); module validation tests and scripts/tests/test_gap_harness
  pass.

Alpha verification (issue AC, runbook rag-corpus-growth-and-flip-threshold-1124.md)
still to run post-merge: re-embed, eval_live.py, confirm dense_misses > 0 and
hybrid > dense, then promote dense-miss-candidate tags to dense-miss.

Closes #1178

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XPChW7xAEShXEYzPNgUEmu