### PR TITLE
[MCP] Fix streaming chat 401 against authenticated Ollama backends (#1196 defect 1)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/OllamaChatModelConfiguration.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/OllamaChatModelConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @Profile("!test")
@@ -75,13 +76,19 @@ public class OllamaChatModelConfiguration {
         requestFactory.setReadTimeout(timeoutMillis);
 
         RestClient.Builder restClientBuilder = RestClient.builder().requestFactory(requestFactory);
+        // OllamaApi talks to the backend over the RestClient for blocking calls and over a separate
+        // WebClient for streaming — the API key must be attached to both, or streaming chat 401s
+        // against authenticated backends (e.g. ollama.com) while blocking chat works.
+        WebClient.Builder webClientBuilder = WebClient.builder();
         if (!apiKey.isBlank()) {
             restClientBuilder.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
+            webClientBuilder.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
         }
 
         OllamaApi ollamaApi = OllamaApi.builder()
                 .baseUrl(baseUrl)
                 .restClientBuilder(restClientBuilder)
+                .webClientBuilder(webClientBuilder)
                 .build();
 
         OllamaChatOptions.Builder optionsBuilder =

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/OllamaChatModelConfigurationTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/OllamaChatModelConfigurationTest.java
@@ -1,0 +1,91 @@
+package com.positivity.mcp.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.StreamingChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+
+/**
+ * The chat backend can require authentication (e.g. ollama.com). {@code OllamaApi} talks to it over
+ * a RestClient for blocking calls and a separate WebClient for streaming, so the API key must reach
+ * both clients — a header on only one of them makes the other path 401 against the live backend.
+ * These tests drive each path against a local HTTP server and assert the relayed header.
+ */
+class OllamaChatModelConfigurationTest {
+
+    private static final String NO_HEADER = "<no-authorization-header>";
+
+    private static final String CHAT_RESPONSE = """
+            {"model":"test-model","created_at":"2026-01-01T00:00:00Z",\
+            "message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop"}
+            """;
+
+    private final OllamaChatModelConfiguration configuration = new OllamaChatModelConfiguration();
+    private final ConcurrentLinkedQueue<String> authorizationHeaders = new ConcurrentLinkedQueue<>();
+    private HttpServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/chat", exchange -> {
+            String header = exchange.getRequestHeaders().getFirst("Authorization");
+            authorizationHeaders.add(header == null ? NO_HEADER : header);
+            String request = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            boolean streaming = request.contains("\"stream\":true");
+            byte[] body = CHAT_RESPONSE.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", streaming ? "application/x-ndjson" : "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void streamingChatModel_relaysApiKeyAsBearerHeader() {
+        StreamingChatModel model =
+                configuration.streamingChatModel(baseUrl, "test-model", "secret-key", Duration.ofSeconds(10), "");
+
+        model.stream(new Prompt("hi")).blockLast(Duration.ofSeconds(10));
+
+        assertThat(authorizationHeaders).containsExactly("Bearer secret-key");
+    }
+
+    @Test
+    void chatModel_relaysApiKeyAsBearerHeader() {
+        ChatModel model = configuration.chatModel(baseUrl, "test-model", "secret-key", Duration.ofSeconds(10), "");
+
+        model.call(new Prompt("hi"));
+
+        assertThat(authorizationHeaders).containsExactly("Bearer secret-key");
+    }
+
+    @Test
+    void blankApiKey_sendsNoAuthorizationHeader() {
+        StreamingChatModel model =
+                configuration.streamingChatModel(baseUrl, "test-model", "", Duration.ofSeconds(10), "");
+
+        model.stream(new Prompt("hi")).blockLast(Duration.ofSeconds(10));
+
+        assertThat(authorizationHeaders).containsExactly(NO_HEADER);
+    }
+}


### PR DESCRIPTION
# Fix streaming chat 401 against authenticated Ollama backends

## Capability & Traceability
- Child issue: louisburroughs/durion-positivity-backend#1196
- Domain: `domain:mcp`

## Contract References
- No API/event contract changes — internal model-client configuration only (no controllers, DTOs, or openapi.yaml touched).

## Scope
- What changed: `OllamaChatModelConfiguration.buildChatModel` now mirrors the `OLLAMA_API_KEY` bearer header onto a `WebClient.Builder` passed to `OllamaApi.builder().webClientBuilder(...)`. Previously the header was attached to the RestClient builder only.
- Why: Spring AI's `OllamaApi` uses the RestClient for blocking calls but a separate WebClient for streaming. Against an authenticated backend (alpha uses `https://ollama.com`), blocking chat worked while **every** streaming chat failed with `401 Unauthorized from POST https://ollama.com/api/chat`. Found live on alpha during the Gate 3 streaming verification session (2026-08-08) — defect 1 in [the #1196 session report](https://github.com/louisburroughs/durion-positivity-backend/issues/1196#issuecomment-5227460823). This has blocked the #1196 item 1 streaming openapi-tool live proof.

## Tests
- [x] Unit tests added/updated
- `OllamaChatModelConfigurationTest` — drives the real blocking and streaming clients against a local `com.sun.net.httpserver` endpoint and asserts the relayed `Authorization` header on each path, plus no-header when no key is configured. The streaming case fails without the fix.
- How to run: `./mvnw -pl pos-mcp-server -Dtest=OllamaChatModelConfigurationTest test` (full module suite green: 639/639)

## Risk & Rollback
- Risk level: Low — additive header on the streaming client, identical conditional to the existing blocking-client header; no behavior change when `OLLAMA_API_KEY` is blank (local Ollama).
- Rollback plan: revert the commit; streaming returns to prior (broken-vs-cloud) behavior.

## Post-merge
- Redeploy pos-mcp-server on alpha, then re-run the #1196 item 1 streaming SSE proof against the cloud backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhvGmjZPdfRUScvbVbLJzm