### PR TITLE
[MCP] Fix spurious 401 when an SSE stream completes without emitting events (#1196 defect 2)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/SecurityConfiguration.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/SecurityConfiguration.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.positivity.security.common.GatewayAuthoritiesFilter;
 import com.positivity.security.common.GatewaySecurityConfig;
+import jakarta.servlet.DispatcherType;
 import java.time.Clock;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -54,7 +55,17 @@ public class SecurityConfiguration {
         http.securityMatcher("/v1/mcp/**", "/v1/nlt/**")
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                // The ASYNC dispatch is container-internal: it only happens after the original
+                // REQUEST dispatch was authenticated and authorized, and a client cannot trigger it
+                // directly. It must be permitted explicitly because GatewayAuthoritiesFilter (an
+                // OncePerRequestFilter) does not run on async dispatches, so re-authorizing there
+                // finds an empty security context — an SSE stream that completed without emitting
+                // any event then surfaced as a spurious 401 from the entry point instead of its
+                // real (empty 200) outcome.
+                .authorizeHttpRequests(auth -> auth.dispatcherTypeMatchers(DispatcherType.ASYNC)
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated())
                 .exceptionHandling(handler -> handler.authenticationEntryPoint(apiErrorEntryPoint))
                 .addFilterBefore(gatewayAuthoritiesFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/StreamingSseAsyncDispatchSecurityTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/controller/StreamingSseAsyncDispatchSecurityTest.java
@@ -1,0 +1,116 @@
+package com.positivity.mcp.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.service.CurrentUserContext;
+import com.positivity.mcp.service.StreamingAgentOrchestrationService;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import reactor.core.publisher.Flux;
+
+/**
+ * Regression test for the async-dispatch 401 found live on alpha (2026-08-08, #1196 session):
+ * an SSE stream that completes without emitting any event leaves the response uncommitted, and the
+ * stream's completion is processed on a container ASYNC dispatch. Spring Security re-authorizes
+ * that dispatch, but {@code GatewayAuthoritiesFilter} (a {@code OncePerRequestFilter}) does not run
+ * on async dispatches — so the re-authorization found an empty security context and
+ * {@code ApiErrorAuthenticationEntryPoint} replaced the real (empty 200) outcome with a spurious
+ * {@code 401 "Authentication is required"}, even though the caller's token was valid and the
+ * request-level authorization had already passed. The fix permits {@code DispatcherType.ASYNC} in
+ * the MCP API security chain (the dispatch is container-internal and unreachable by clients).
+ *
+ * <p>This must run against a REAL servlet container ({@code RANDOM_PORT}): MockMvc's
+ * {@code asyncDispatch} does not reproduce the container's filter-registration dispatcher-type
+ * behavior, so a MockMvc variant passes even without the fix.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"eureka.client.enabled=false", "pos.security.permission-registration.enabled=false"})
+@ActiveProfiles("test")
+class StreamingSseAsyncDispatchSecurityTest {
+
+    @LocalServerPort
+    private int port;
+
+    @MockitoBean
+    private StreamingAgentOrchestrationService streamingSessionAgentManager;
+
+    private final HttpClient httpClient =
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+    private HttpResponse<String> postStream(boolean authenticated) throws Exception {
+        HttpRequest.Builder request = HttpRequest.newBuilder()
+                .uri(URI.create("http://127.0.0.1:" + port + "/v1/mcp/chat/stream"))
+                .timeout(Duration.ofSeconds(30))
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/event-stream")
+                .POST(HttpRequest.BodyPublishers.ofString("{\"message\":\"hello\"}"));
+        if (authenticated) {
+            request.header("X-Authorities", "mcp:chat:stream")
+                    .header("X-User", "stream-user")
+                    .header("Authorization", "Bearer " + unsignedJwtWithUid());
+        }
+        return httpClient.send(request.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    /**
+     * {@code GatewayAuthoritiesFilter} resolves the authenticated userId detail by base64-decoding
+     * the JWT payload's {@code uid} claim (the gateway has already verified the signature in
+     * production), and {@code CurrentUserContextResolver} requires that detail — so the test token
+     * only needs a decodable payload, not a valid signature.
+     */
+    private static String unsignedJwtWithUid() {
+        String payload = "{\"uid\":\"00000000-0000-7000-8000-000000001196\",\"username\":\"stream-user\"}";
+        java.util.Base64.Encoder encoder = java.util.Base64.getUrlEncoder().withoutPadding();
+        return encoder.encodeToString("{\"alg\":\"none\"}".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                + "."
+                + encoder.encodeToString(payload.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                + ".sig";
+    }
+
+    @Test
+    @DisplayName("#1196 defect 2: SSE stream with zero events completes as 200 with an empty body, not 401")
+    void emptyStream_completesAs200_not401() throws Exception {
+        when(streamingSessionAgentManager.streamChat(any(CurrentUserContext.class), any()))
+                .thenReturn(Flux.empty());
+
+        HttpResponse<String> response = postStream(true);
+
+        // Before the fix the async completion dispatch was re-authorized with an empty security
+        // context and this returned 401 {"code":"UNAUTHORIZED",...} despite the valid caller.
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("SSE stream with events still delivers them as 200")
+    void nonEmptyStream_deliversSsePayload() throws Exception {
+        when(streamingSessionAgentManager.streamChat(any(CurrentUserContext.class), any()))
+                .thenReturn(Flux.just("token-1", "token-2"));
+
+        HttpResponse<String> response = postStream(true);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("data:token-1").contains("data:token-2");
+    }
+
+    @Test
+    @DisplayName("Unauthenticated initial request is still rejected up front with the ApiError 401")
+    void unauthenticatedRequest_stillRejectedUpFront() throws Exception {
+        HttpResponse<String> response = postStream(false);
+
+        assertThat(response.statusCode()).isEqualTo(401);
+        assertThat(response.body()).contains("\"code\":\"UNAUTHORIZED\"").contains("Authentication is required");
+    }
+}

--- a/pos-mcp-server/src/test/resources/application-test.yml
+++ b/pos-mcp-server/src/test/resources/application-test.yml
@@ -30,6 +30,11 @@ mcp:
               api-key: ""
 
 pos:
+    # Point the event-type initializer at an unroutable loopback port: the test profile has no
+    # pos-event-receiver, and the docker-internal default hostname adds DNS/connect delays to every
+    # @SpringBootTest boot. Loopback refuses instantly and the initializer swallows the failure.
+    events:
+        base-url: http://127.0.0.1:1
     nlti:
         session:
             ttl-hours: 24


### PR DESCRIPTION
# Fix spurious 401 when an SSE stream completes without emitting events

## Capability & Traceability
- Child issue: louisburroughs/durion-positivity-backend#1196
- Domain: `domain:mcp`

## Contract References
- No API/event contract change: this PR touches the security filter-chain configuration and adds a test under the controller package — no controllers, DTOs, or `openapi.yaml` are modified, so no `BACKEND_CONTRACT_GUIDE.md` entry needs updating (reference included for the contract-sync check, which triggers on the controller-package test file).

## Scope
- What changed: `SecurityConfiguration.mcpApiSecurityFilterChain` now permits `DispatcherType.ASYNC` before `anyRequest().authenticated()`.
- Why: an SSE stream that completes without emitting any event leaves the response uncommitted; the completion is processed on a container ASYNC dispatch, which Spring Security re-authorizes. `GatewayAuthoritiesFilter` is a `OncePerRequestFilter` and does not run on async dispatches, so re-authorization found an empty security context and `ApiErrorAuthenticationEntryPoint` replaced the real (empty 200) outcome with `401 "Authentication is required"` — with a valid token and the request-level authorization already passed. Found live on alpha during the Gate 3 streaming verification (defect 2 in [the #1196 session report](https://github.com/louisburroughs/durion-positivity-backend/issues/1196#issuecomment-5227460823)), where it masked every empty-stream outcome.
- Security note: the ASYNC dispatch is container-internal — a client cannot trigger it directly; it only occurs after the original REQUEST dispatch was authenticated and authorized. Permitting it is the documented Spring Security pattern for async controllers and does not weaken ingress auth (asserted by the up-front-401 test).

## Tests
- [x] Unit tests added/updated
- `StreamingSseAsyncDispatchSecurityTest` — boots the app on a **real servlet container** (`RANDOM_PORT`) and drives real HTTP with gateway-style auth headers: empty stream → 200 empty body (this case returns 401 without the fix — verified); streamed events → 200 with SSE payload; unauthenticated → 401 `ApiError` up front. A real container is required: MockMvc's `asyncDispatch` does not reproduce the container's filter-registration dispatcher-type behavior and passes even without the fix (a MockMvc variant was written and discarded for that reason).
- How to run: `./mvnw -pl pos-mcp-server -Dtest=StreamingSseAsyncDispatchSecurityTest test` (full module suite green: 642/642)

## Risk & Rollback
- Risk level: Low — one dispatcher-type matcher in one service's filter chain; no change to REQUEST-dispatch authentication or authorization.
- Rollback plan: revert the commit; empty SSE streams return to surfacing as spurious 401s.

## Note for other services
The same latent pattern (Spring Security re-authorizing ASYNC dispatches + `GatewayAuthoritiesFilter` skipping them) exists in the shared `gatewaySecurityFilterChain` in `pos-security-common` — it only bites services with async/SSE controllers, which today is pos-mcp-server. Worth a follow-up if other services add SSE endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhvGmjZPdfRUScvbVbLJzm