### PR TITLE
[MCP] Configurable RAG similarity floors + eval column selector for the bge-m3 cutover (#1194)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -830,6 +830,10 @@ services:
       MCP_RAG_MAX_SEGMENT_SIZE: ${MCP_RAG_MAX_SEGMENT_SIZE:-2000}
       MCP_RAG_MAX_OVERLAP_SIZE: ${MCP_RAG_MAX_OVERLAP_SIZE:-200}
       MCP_RAG_LEXICAL_ENABLED: ${MCP_RAG_LEXICAL_ENABLED:-true}
+      MCP_RAG_EMBEDDING_COLUMN: ${MCP_RAG_EMBEDDING_COLUMN:-embedding}
+      MCP_RAG_DIMENSION: ${MCP_RAG_DIMENSION:-768}
+      MCP_RAG_MIN_SCORE: ${MCP_RAG_MIN_SCORE:-0.6}
+      MCP_RAG_TIER2_MIN_SCORE: ${MCP_RAG_TIER2_MIN_SCORE:-0.55}
       # Origin of the frontend SSR server that serves /sitemap.json (NOT the API gateway).
       # Must be listed here to be passed into the container; values come from the
       # docker compose process environment and/or the .env file during ${...} substitution.

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -100,6 +100,9 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
     private final @Nullable TieredChatModelResolver tieredChatModelResolver;
     private final boolean tieringEnabled;
     private final Clock clock;
+    // #1194: dense-retrieval similarity floors — calibrated per embedding model (see application.yml).
+    private final double ragMinScore;
+    private final double ragTier2MinScore;
 
     private final int memoryMaxMessages;
     private final int rateLimitPerSession;
@@ -129,7 +132,9 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
             @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
             @Value("${mcp.agent.memory-max-messages:100}") int memoryMaxMessages,
-            @Value("${pos.nlti.rate-limit.per-session:100}") int rateLimitPerSession) {
+            @Value("${pos.nlti.rate-limit.per-session:100}") int rateLimitPerSession,
+            @Value("${mcp.rag.min-score:0.6}") double ragMinScore,
+            @Value("${mcp.rag.tier2-min-score:0.55}") double ragTier2MinScore) {
         this.chatModel = chatModel;
         this.embeddingModel = embeddingModel;
         this.embeddingStore = embeddingStore;
@@ -151,6 +156,8 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         this.tieredChatModelResolver = tieredChatModelResolver;
         this.tieringEnabled = tieringEnabled;
         this.clock = clock;
+        this.ragMinScore = ragMinScore;
+        this.ragTier2MinScore = ragTier2MinScore;
         this.memoryMaxMessages = memoryMaxMessages;
         this.rateLimitPerSession = rateLimitPerSession;
         this.requestCountCache = Caffeine.newBuilder()
@@ -351,9 +358,9 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         String promptName = SystemPromptDefaults.promptNameForRagScope(ragScope);
 
         // 2. Tier 2 retrieval pipeline: semantic + expanded + hybrid + re-ranking.
-        QueryDocumentRetriever semanticRetriever = scopedContentRetrieverFactory.create(ragScope, 10, 0.6);
+        QueryDocumentRetriever semanticRetriever = scopedContentRetrieverFactory.create(ragScope, 10, ragMinScore);
         QueryDocumentRetriever broadSemanticRetriever =
-                scopedContentRetrieverFactory.create(ragScope, TIER2_RETRIEVAL_CANDIDATES, 0.55);
+                scopedContentRetrieverFactory.create(ragScope, TIER2_RETRIEVAL_CANDIDATES, ragTier2MinScore);
         QueryDocumentRetriever expandedRetriever = new QueryExpansionContentRetriever(
                 broadSemanticRetriever, TIER2_EXPANDED_QUERY_LIMIT, TIER2_RETRIEVAL_CANDIDATES);
         // #784: dense + query-expansion, plus the lexical (FTS) source when enabled. RRF fusion when

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -105,6 +105,12 @@ public class StreamingSessionAgentManager
 
     private final Clock clock;
 
+    // #1194: dense-retrieval similarity floors — calibrated per embedding model (see application.yml).
+
+    private final double ragMinScore;
+
+    private final double ragTier2MinScore;
+
     private final int memoryMaxMessages;
     private final int rateLimitPerSession;
 
@@ -129,7 +135,9 @@ public class StreamingSessionAgentManager
             @Value("${mcp.agent.cache-ttl-minutes:30}") int cacheTtlMinutes,
             @Value("${mcp.agent.max-cached-agents:500}") int maxCachedAgents,
             @Value("${mcp.agent.memory-max-messages:100}") int memoryMaxMessages,
-            @Value("${pos.nlti.rate-limit.per-session:100}") int rateLimitPerSession) {
+            @Value("${pos.nlti.rate-limit.per-session:100}") int rateLimitPerSession,
+            @Value("${mcp.rag.min-score:0.6}") double ragMinScore,
+            @Value("${mcp.rag.tier2-min-score:0.55}") double ragTier2MinScore) {
         this.streamingChatModel = streamingChatModel;
         this.toolRegistry = toolRegistry;
         this.sharedOrchestrationSupport = sharedOrchestrationSupport;
@@ -147,6 +155,8 @@ public class StreamingSessionAgentManager
         this.tieredChatModelResolver = tieredChatModelResolver;
         this.tieringEnabled = tieringEnabled;
         this.clock = clock;
+        this.ragMinScore = ragMinScore;
+        this.ragTier2MinScore = ragTier2MinScore;
         this.memoryMaxMessages = memoryMaxMessages;
         this.rateLimitPerSession = rateLimitPerSession;
         int sanitizedMaxCachedAgents = Math.max(1, maxCachedAgents);
@@ -460,9 +470,9 @@ public class StreamingSessionAgentManager
         long startNanos = System.nanoTime();
         String ragScope = toolRegistry.resolveRagScopeForTools(tools);
         String promptName = SystemPromptDefaults.promptNameForRagScope(ragScope);
-        QueryDocumentRetriever semanticRetriever = scopedContentRetrieverFactory.create(ragScope, 10, 0.6);
+        QueryDocumentRetriever semanticRetriever = scopedContentRetrieverFactory.create(ragScope, 10, ragMinScore);
         QueryDocumentRetriever broadSemanticRetriever =
-                scopedContentRetrieverFactory.create(ragScope, TIER2_RETRIEVAL_CANDIDATES, 0.55);
+                scopedContentRetrieverFactory.create(ragScope, TIER2_RETRIEVAL_CANDIDATES, ragTier2MinScore);
         QueryDocumentRetriever expandedRetriever = new QueryExpansionContentRetriever(
                 broadSemanticRetriever, TIER2_EXPANDED_QUERY_LIMIT, TIER2_RETRIEVAL_CANDIDATES);
         // #784: dense + query-expansion, plus the lexical (FTS) source when enabled. RRF fusion when

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -51,6 +51,13 @@ mcp:
     # only after the alpha re-embed is validated — see docs/gate5-rag-hybrid-design.md.
     embedding-column: ${MCP_RAG_EMBEDDING_COLUMN:embedding}
     dimension: ${MCP_RAG_DIMENSION:768}
+    # #1194: dense-retrieval cosine-similarity floors (primary retriever / tier-2 wide
+    # retriever), calibrated per embedding model. The defaults fit nomic-embed-text (768).
+    # bge-m3 similarities sit ~0.10-0.15 lower on the same corpus, so flip these together with
+    # the column/dimension/model trio (~0.45/0.40 per the alpha floor sweep — see
+    # docs/gate5-rag-hybrid-design.md G5.4).
+    min-score: ${MCP_RAG_MIN_SCORE:0.6}
+    tier2-min-score: ${MCP_RAG_TIER2_MIN_SCORE:0.55}
     index-type: ivfflat
     hybrid:
       # Exact identifiers (VINs, SKUs, permission/event codes) routinely score below the dense

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/CachedAgentOpenApiPermissionLeakageTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/CachedAgentOpenApiPermissionLeakageTest.java
@@ -310,7 +310,9 @@ class CachedAgentOpenApiPermissionLeakageTest {
                 30,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
     }
 
     /** Names of the OpenAPI-discovered tool callbacks attached to the prompt's tool-calling options. */

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -202,7 +202,9 @@ class SessionAgentManagerTest {
                 30,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
         clearInvocations(toolRegistry);
         clearInvocations(toolRegistryService);
         clearInvocations(toolSelectionEngine);
@@ -410,7 +412,9 @@ class SessionAgentManagerTest {
                 0,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
         clearInvocations(toolRegistry);
 
         expiringManager.getOrCreateAgent("user-1", "ROLE_CASHIER");
@@ -479,7 +483,9 @@ class SessionAgentManagerTest {
                 30,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
     }
 
     private ToolSelectionEngine realToolSelectionEngine() {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTieringTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTieringTest.java
@@ -295,7 +295,9 @@ class SessionAgentManagerTieringTest {
                 30,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
     }
 
     private static CurrentUserContext userContext(String username) {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -198,7 +198,9 @@ class StreamingSessionAgentManagerTest {
                 30,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
         clearInvocations(toolRegistry);
         clearInvocations(toolSelectionEngine);
         clearInvocations(scopedContentRetrieverFactory);
@@ -397,7 +399,9 @@ class StreamingSessionAgentManagerTest {
                 30,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
 
         ArgumentCaptor<List<Object>> fallbackToolsCaptor = listCaptor();
         verify(sharedSupportSpy, atLeastOnce()).mergeTools(argThat(Collection::isEmpty), fallbackToolsCaptor.capture());
@@ -406,6 +410,42 @@ class StreamingSessionAgentManagerTest {
                         .containsExactly(exaWebSearchTool, inventoryFacadeTool, orderFacadeTool));
         verify(scopedContentRetrieverFactory, atLeastOnce()).create("master", 10, 0.6);
         verify(scopedContentRetrieverFactory, atLeastOnce()).create("master", 20, 0.55);
+    }
+
+    @Test
+    @DisplayName("#1194: configured similarity floors propagate to the dense retrievers")
+    void constructor_customRagFloors_propagateToRetrieverFactory() {
+        SharedOrchestrationSupport sharedSupportSpy = spy(new SharedOrchestrationSupport());
+        when(toolRegistry.resolveDomainTools("ROLE_CASHIER")).thenReturn(new ArrayList<>());
+        when(toolRegistry.preloadableRoleIdentifiers()).thenReturn(Set.of("ROLE_CASHIER"));
+
+        new StreamingSessionAgentManager(
+                streamingChatModel,
+                toolRegistry,
+                sharedSupportSpy,
+                toolSelectionEngine,
+                scopedContentRetrieverFactory,
+                rolePromptResolver,
+                simpleChatFastPath,
+                null,
+                telemetryEmitter,
+                null, // openApiToolProvider
+                null, // requestScopedUserContext
+                null, // roleDefaultPermissionsClient
+                workflowStateService,
+                null, // nltiRouter
+                null, // tieredChatModelResolver
+                true, // tieringEnabled (no-op without a router)
+                FIXED_CLOCK,
+                30,
+                500,
+                50,
+                100,
+                0.42,
+                0.37);
+
+        verify(scopedContentRetrieverFactory, atLeastOnce()).create("master", 10, 0.42);
+        verify(scopedContentRetrieverFactory, atLeastOnce()).create("master", 20, 0.37);
     }
 
     @Test
@@ -466,7 +506,9 @@ class StreamingSessionAgentManagerTest {
                 0,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
         clearInvocations(toolRegistry);
 
         expiringManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "show inventory stock");
@@ -516,7 +558,9 @@ class StreamingSessionAgentManagerTest {
                 30,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
     }
 
     private ToolSelectionEngine realToolSelectionEngine() {
@@ -582,7 +626,9 @@ class StreamingSessionAgentManagerTest {
                 30,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
 
         Flux<String> result =
                 providerManager.streamChat(userContext("user-1", USER_ID, "ROLE_CASHIER"), "show open invoices");

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTieringTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTieringTest.java
@@ -197,7 +197,9 @@ class StreamingSessionAgentManagerTieringTest {
                 30,
                 500,
                 50,
-                100);
+                100,
+                0.6,
+                0.55);
     }
 
     private static CurrentUserContext userContext(String username) {

--- a/scripts/eval_live.py
+++ b/scripts/eval_live.py
@@ -99,7 +99,7 @@ MODEL = cfg("OLLAMA_EMBEDDING_MODEL", default="nomic-embed-text")
 # `embedding` column). Set EVAL_EMBEDDING_COLUMN=embedding_1024 (together with
 # OLLAMA_EMBEDDING_MODEL=bge-m3) to validate the 1024-dim bge-m3 path against the dual-column
 # data BEFORE flipping the live config. Allowlisted because the name is interpolated into SQL.
-EMB_COL = os.environ.get("EVAL_EMBEDDING_COLUMN", "embedding")
+EMB_COL = cfg("EVAL_EMBEDDING_COLUMN", default="embedding")
 if EMB_COL not in ("embedding", "embedding_1024"):
     sys.exit(f"Invalid EVAL_EMBEDDING_COLUMN '{EMB_COL}' (expected 'embedding' or 'embedding_1024')")
 

--- a/scripts/eval_live.py
+++ b/scripts/eval_live.py
@@ -95,6 +95,13 @@ DB_USER = cfg("POS_MCP_DB_USER", "SPRING_DATASOURCE_USERNAME", "POSTGRES_USER")
 DB_PASS = cfg("POS_MCP_DB_PASSWORD", "SPRING_DATASOURCE_PASSWORD", "POSTGRES_PASSWORD")
 OLLAMA = cfg("OLLAMA_EMBEDDING_BASE_URL", default="http://localhost:11434").rstrip("/")
 MODEL = cfg("OLLAMA_EMBEDDING_MODEL", default="nomic-embed-text")
+# #1194: which pgvector column the eval reads. Default preserves historical behavior (the 768
+# `embedding` column). Set EVAL_EMBEDDING_COLUMN=embedding_1024 (together with
+# OLLAMA_EMBEDDING_MODEL=bge-m3) to validate the 1024-dim bge-m3 path against the dual-column
+# data BEFORE flipping the live config. Allowlisted because the name is interpolated into SQL.
+EMB_COL = os.environ.get("EVAL_EMBEDDING_COLUMN", "embedding")
+if EMB_COL not in ("embedding", "embedding_1024"):
+    sys.exit(f"Invalid EVAL_EMBEDDING_COLUMN '{EMB_COL}' (expected 'embedding' or 'embedding_1024')")
 
 
 def embed(text):
@@ -153,18 +160,18 @@ def main():
     con = pg8000.native.Connection(
         user=DB_USER, password=DB_PASS, host=DB_HOST, port=DB_PORT, database=DB_NAME
     )
-    print(f"DB={DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME}  embed={OLLAMA} ({MODEL})\n")
+    print(f"DB={DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME}  embed={OLLAMA} ({MODEL})  column={EMB_COL}\n")
 
     def ann_facade(query_vec, perms, workflow, limit):
         rows = con.run(
-            """
+            f"""
             SELECT t.name FROM mcp_tool t
             JOIN mcp_tool_workflow tw ON t.id = tw.tool_id
             JOIN mcp_workflow_state ws ON tw.workflow_state_id = ws.id
-            WHERE t.enabled = true AND t.source <> 'openapi' AND t.embedding IS NOT NULL
+            WHERE t.enabled = true AND t.source <> 'openapi' AND t.{EMB_COL} IS NOT NULL
               AND ws.name = :wf
               AND t.id IN (SELECT tool_id FROM mcp_tool_permission WHERE permission_code = ANY(:perms))
-            ORDER BY t.embedding <=> CAST(:q AS vector), t.id
+            ORDER BY t.{EMB_COL} <=> CAST(:q AS vector), t.id
             LIMIT :k
             """,
             wf=workflow, perms=list(perms), q=vec_literal(query_vec), k=limit,
@@ -184,26 +191,26 @@ def main():
         opts in to reproduce the live dense path that produced the verified misses."""
         if master_all_scopes and scope == "master":
             rows = con.run(
-                """
+                f"""
                 SELECT metadata->>'document_id'        AS document_id,
                        metadata->>'required_permissions' AS required_permissions
                 FROM mcp_document_embedding
-                WHERE embedding IS NOT NULL
-                  AND (1 - (embedding <=> CAST(:q AS vector))) >= :min_score
-                ORDER BY embedding <=> CAST(:q AS vector), id
+                WHERE {EMB_COL} IS NOT NULL
+                  AND (1 - ({EMB_COL} <=> CAST(:q AS vector))) >= :min_score
+                ORDER BY {EMB_COL} <=> CAST(:q AS vector), id
                 LIMIT :limit
                 """,
                 q=vec_literal(query_vec), min_score=min_score, limit=max(want * 10, 50),
             )
         else:
             rows = con.run(
-                """
+                f"""
                 SELECT metadata->>'document_id'        AS document_id,
                        metadata->>'required_permissions' AS required_permissions
                 FROM mcp_document_embedding
-                WHERE metadata->>'rag_scope' = :scope AND embedding IS NOT NULL
-                  AND (1 - (embedding <=> CAST(:q AS vector))) >= :min_score
-                ORDER BY embedding <=> CAST(:q AS vector), id
+                WHERE metadata->>'rag_scope' = :scope AND {EMB_COL} IS NOT NULL
+                  AND (1 - ({EMB_COL} <=> CAST(:q AS vector))) >= :min_score
+                ORDER BY {EMB_COL} <=> CAST(:q AS vector), id
                 LIMIT :limit
                 """,
                 scope=scope, q=vec_literal(query_vec), min_score=min_score, limit=max(want * 10, 50),
@@ -394,15 +401,15 @@ def main():
             `ORDER BY embedding <=> constant` is the exact operator-ordering pattern pgvector
             indexes match — same convention as every other ANN query in this script."""
             rows = con.run(
-                """
-                SELECT t.name, 1 - (t.embedding <=> CAST(:q AS vector)) AS sim
+                f"""
+                SELECT t.name, 1 - (t.{EMB_COL} <=> CAST(:q AS vector)) AS sim
                 FROM mcp_tool t
                 JOIN mcp_tool_workflow tw ON t.id = tw.tool_id
                 JOIN mcp_workflow_state ws ON tw.workflow_state_id = ws.id
-                WHERE t.enabled = true AND t.source <> 'openapi' AND t.embedding IS NOT NULL
+                WHERE t.enabled = true AND t.source <> 'openapi' AND t.{EMB_COL} IS NOT NULL
                   AND ws.name = :wf
                   AND t.id IN (SELECT tool_id FROM mcp_tool_permission WHERE permission_code = ANY(:perms))
-                ORDER BY t.embedding <=> CAST(:q AS vector), t.id
+                ORDER BY t.{EMB_COL} <=> CAST(:q AS vector), t.id
                 LIMIT :k
                 """,
                 wf=workflow, perms=list(perms), q=vec_literal(query_vec), k=limit,
@@ -461,10 +468,10 @@ def main():
     # ---- #779: permission gating (openapi tool) ---------------------------
     gating = {"status": "skipped"}
     row = con.run(
-        """
+        f"""
         SELECT t.name, t.description, MIN(tp.permission_code) AS perm
         FROM mcp_tool t JOIN mcp_tool_permission tp ON tp.tool_id = t.id
-        WHERE t.source = 'openapi' AND t.embedding IS NOT NULL
+        WHERE t.source = 'openapi' AND t.{EMB_COL} IS NOT NULL
         GROUP BY t.id, t.name, t.description
         HAVING COUNT(*) = 1 AND MIN(tp.permission_code) <> 'AUTHENTICATED'
         LIMIT 1
@@ -476,11 +483,11 @@ def main():
 
         def openapi_hit(perms):
             r = con.run(
-                """
+                f"""
                 SELECT t.name FROM mcp_tool t
-                WHERE t.source = 'openapi' AND t.embedding IS NOT NULL
+                WHERE t.source = 'openapi' AND t.{EMB_COL} IS NOT NULL
                   AND t.id IN (SELECT tool_id FROM mcp_tool_permission WHERE permission_code = ANY(:perms))
-                ORDER BY t.embedding <=> CAST(:q AS vector), t.id
+                ORDER BY t.{EMB_COL} <=> CAST(:q AS vector), t.id
                 LIMIT :k
                 """,
                 perms=list(perms), q=qv, k=max(K, 10),


### PR DESCRIPTION
# Configurable RAG similarity floors + eval column selector for the bge-m3 cutover

## Capability & Traceability
- Child issue: louisburroughs/durion-positivity-backend#1194
- Domain: `domain:mcp`

## Contract References
- No API/event contract change — internal retrieval configuration and eval tooling only (no controllers, DTOs, or `openapi.yaml`; reference for the contract-sync check: BACKEND_CONTRACT_GUIDE.md not applicable).

## Scope
- What changed:
  - `SessionAgentManager` / `StreamingSessionAgentManager`: the dense-retrieval cosine-similarity floors (primary 0.6, tier-2 wide 0.55) move from hardcoded literals to `mcp.rag.min-score` / `mcp.rag.tier2-min-score` (`MCP_RAG_MIN_SCORE` / `MCP_RAG_TIER2_MIN_SCORE`), defaults unchanged.
  - `docker-compose.yml`: passes the two floor vars plus `MCP_RAG_EMBEDDING_COLUMN` and `MCP_RAG_DIMENSION` (previously unmapped) into pos-mcp-server, so the G5.4 alpha flip is fully env-file-driven.
  - `scripts/eval_live.py`: allowlisted `EVAL_EMBEDDING_COLUMN` selector (default `embedding`, unchanged) so the 1024 data can be validated pre-flip; active column echoed in the run header.
- Why: the #1194 cutover stopped at the G5.4 step-2 no-regression gate ([evidence on #1194](https://github.com/louisburroughs/durion-positivity-backend/issues/1194#issuecomment-5229531591)). bge-m3 similarities sit ~0.10–0.15 lower than nomic-embed-text on the same corpus: recall@k collapsed 0.8431 → 0.6078 at the fixed floors while rank-based metrics were flat-to-better (hit@5 0.76 both, MRR 0.7222 → 0.7333). The alpha floor sweep recovered recall monotonically (0.45 → 0.8235, **0.40 → 0.8627**, 0.35 → 0.9216) with zero forbidden leaks at every floor — the floors are embedding-model calibration values and must flip with the column/dimension/model trio.

## Tests
- [x] Unit tests added/updated
- New `constructor_customRagFloors_propagateToRetrieverFactory` (StreamingSessionAgentManagerTest) asserts custom floors reach the retriever factory on the primary and tier-2 paths; the existing prebuild test pins the 0.6/0.55 defaults. Constructor call sites updated across the five orchestration test classes.
- How to run: `./mvnw -pl pos-mcp-server test` — full module suite green: **643/643**.

## Risk & Rollback
- Risk level: Low — defaults identical to the previous literals; behavior changes only when the new env vars are set. Compose additions default to current values.
- Rollback plan: revert; or set the env vars to 0.6/0.55 (equivalent to revert at runtime).

## Post-merge (cutover plan)
Redeploy alpha, then flip as a five-value change: `MCP_RAG_EMBEDDING_COLUMN=embedding_1024`, `MCP_RAG_DIMENSION=1024`, `OLLAMA_EMBEDDING_MODEL=bge-m3`, `MCP_RAG_MIN_SCORE=0.45`, `MCP_RAG_TIER2_MIN_SCORE=0.40` → re-validate (step 2) → #1179 `--baseline 3` re-baseline → #1180 probe. `embedding_1024` is already fully populated on alpha; the 768 snapshot is retained on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhvGmjZPdfRUScvbVbLJzm