### PR TITLE
[MCP] Include master-scope docs in domain-scoped RAG retrieval (#1180)

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/rag/LexicalDocumentRetriever.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/rag/LexicalDocumentRetriever.java
@@ -42,10 +42,13 @@ final class LexicalDocumentRetriever implements QueryDocumentRetriever {
     // The tsquery term binds twice: once for the @@ match, once for ts_rank_cd ordering.
     private static final String OR_TSQUERY = "replace(websearch_to_tsquery('english', ?)::text, ' & ', ' | ')::tsquery";
 
+    // #1180: domain scopes also match 'master' — master-scope docs (glossary, capability catalog)
+    // are the global tier and must stay reachable from every domain scope (mirrors the dense path
+    // in ScopedContentRetrieverFactory#create). Permission gating stays downstream.
     private static final String SQL_SCOPED = "SELECT id, content, metadata::text AS metadata\n"
             + "FROM mcp_document_embedding\n"
             + "WHERE content_tsv @@ " + OR_TSQUERY + "\n"
-            + "  AND metadata ->> 'rag_scope' = ?\n"
+            + "  AND metadata ->> 'rag_scope' IN (?, 'master')\n"
             + "ORDER BY ts_rank_cd(content_tsv, " + OR_TSQUERY + ") DESC, id\n"
             + "LIMIT ?";
 

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/rag/ScopedContentRetrieverFactory.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/rag/ScopedContentRetrieverFactory.java
@@ -43,14 +43,23 @@ public class ScopedContentRetrieverFactory {
      * doc scope. A strict {@code rag_scope = 'master'} filter there made every domain doc
      * (order/pricing/tax/…) structurally unreachable, so cross-domain questions retrieved nothing and
      * the assistant refused or fabricated. When the scope resolves to {@code master} we therefore drop
-     * the scope filter and search all scopes; specific domain scopes keep their narrow filter.
-     * Permission-gated docs are still excluded downstream by {@code PermissionAwareMetadataFilter}.
+     * the scope filter and search all scopes.
+     *
+     * <p>#1180: domain scopes include {@code master}-scope docs alongside their own. Master-scope
+     * docs are the global tier — glossary/identifier formats, the capability catalog — relevant in
+     * every domain. A strictly-scoped filter reproduced the #1124 failure shape one level down:
+     * when tool selection resolves a specific domain scope (e.g. the compound invoice question
+     * selects only the admin facade → {@code ragScope=admin}), the master-scope glossary was
+     * structurally unreachable no matter how well it ranked. Permission-gated docs are still
+     * excluded downstream by {@code PermissionAwareMetadataFilter}.
      */
     public @NonNull QueryDocumentRetriever create(@Nullable String ragScope, int maxResults, double minScore) {
         String normalizedScope = RagScope.normalize(ragScope);
         var ragScopeFilter = RagScope.MASTER.equals(normalizedScope)
                 ? null
-                : new FilterExpressionBuilder().eq(RAG_SCOPE, normalizedScope).build();
+                : new FilterExpressionBuilder()
+                        .in(RAG_SCOPE, normalizedScope, RagScope.MASTER)
+                        .build();
         return queryText -> {
             SearchRequest.Builder request =
                     SearchRequest.builder().query(queryText).topK(maxResults).similarityThreshold(minScore);

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/rag/LexicalDocumentRetrieverTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/rag/LexicalDocumentRetrieverTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -12,6 +13,7 @@ import java.sql.ResultSet;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.ai.document.Document;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -28,6 +30,26 @@ class LexicalDocumentRetrieverTest {
 
         assertThat(retriever.retrieve("   ")).isEmpty();
         verifyNoInteractions(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("#1180: a domain scope also matches master-scope docs and binds (query, scope, query, limit)")
+    @SuppressWarnings("unchecked")
+    void domainScope_includesMasterScopeDocs() {
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of());
+
+        new LexicalDocumentRetriever(jdbcTemplate, objectMapper, "admin", 9).retrieve("invoice number format");
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object[]> argsCaptor = ArgumentCaptor.forClass(Object[].class);
+        verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), argsCaptor.capture());
+        // Master-scope docs (glossary/identifier formats) are the global tier and must stay
+        // reachable from every domain-scoped agent — a strict equality filter reproduced the
+        // compound-invoice failure (#1180) whenever tool selection resolved a narrow scope.
+        assertThat(sqlCaptor.getValue()).contains("IN (?, 'master')");
+        assertThat(argsCaptor.getValue()).containsExactly("invoice number format", "admin", "invoice number format", 9);
     }
 
     @Test

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/rag/ScopedContentRetrieverFactoryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/rag/ScopedContentRetrieverFactoryTest.java
@@ -55,9 +55,11 @@ class ScopedContentRetrieverFactoryTest {
         assertThat(request.getQuery()).isEqualTo("stock");
         assertThat(request.getTopK()).isEqualTo(7);
         assertThat(request.getSimilarityThreshold()).isEqualTo(0.42);
+        // #1180: a domain scope includes master-scope docs (glossary/capability tier) alongside
+        // its own — a strict eq filter made them structurally unreachable from domain agents.
         assertThat(request.getFilterExpression())
                 .isEqualTo(new FilterExpressionBuilder()
-                        .eq("rag_scope", "inventory")
+                        .in("rag_scope", "inventory", RagScope.MASTER)
                         .build());
     }
 


### PR DESCRIPTION
# Include master-scope docs in domain-scoped RAG retrieval

## Capability & Traceability
- Child issue: louisburroughs/durion-positivity-backend#1180
- Domain: `domain:mcp`

## Contract References
- No API/event contract change — internal retrieval scope filter only (BACKEND_CONTRACT_GUIDE.md not applicable).

## Scope
- What changed: domain-scoped RAG retrieval now includes `master`-scope docs alongside the domain's own — dense path (`ScopedContentRetrieverFactory`: `rag_scope IN (scope, 'master')` filter) and lexical FTS mirror (`LexicalDocumentRetriever`: `metadata->>'rag_scope' IN (?, 'master')`). Master-scope behavior itself unchanged (still searches all scopes per #1169); `PermissionAwareMetadataFilter` still applies downstream.
- Why: root cause of the last item-4 probe failure, [re-diagnosed live during the bge-m3 cutover](https://github.com/louisburroughs/durion-positivity-backend/issues/1180#issuecomment-5231829008). The compound invoice question's "permission" clause makes tool selection resolve only the admin facade → `ragScope=admin` → scoped retrieval searched admin docs exclusively, so the master-scope `glossary.identifiers` chunk (containing BOTH halves of the answer, dense rank #1 at 0.671) was structurally unreachable regardless of ranking. Same failure shape as #1124 item 4, one level down: any narrowly-scoped agent lost the global glossary/capability tier.

## Tests
- [x] Unit tests added/updated — new dense filter expression pinned in `ScopedContentRetrieverFactoryTest`; new `LexicalDocumentRetrieverTest` case pins the scoped SQL (`IN (?, 'master')`) and bind order; master-scope tests unchanged. Full module suite green: **644/644**.
- How to run: `./mvnw -pl pos-mcp-server -Dtest=ScopedContentRetrieverFactoryTest,LexicalDocumentRetrieverTest test`
- Post-merge live acceptance (#1180): redeploy alpha, re-run the 7-question item-4 probe — expected 7/7 with the invoice answer covering both halves; floored eval must stay green with `rag_forbidden` 0.

## Risk & Rollback
- Risk level: Low — widens each domain scope by the AUTHENTICATED-gated global tier only; permission gating unchanged; master path untouched. Retrieval candidate sets can now contain master docs where domain docs previously filled all slots — the floored eval gate covers regression.
- Rollback plan: revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhvGmjZPdfRUScvbVbLJzm