### PR TITLE
docs: sell-price boundary documentation in pos-price and pos-catalog (ADR-0054) (#1235)

### DIFF
--- a/pos-catalog/README.md
+++ b/pos-catalog/README.md
@@ -1,6 +1,6 @@
 # pos-catalog
 
-Product catalog service for the Durion Positivity ETSMS platform. Manages the product master, price books, unit-of-measure conversions, supplier item costs, MSRP records, location-level price overrides, and product lifecycle transitions.
+Product catalog service for the Durion Positivity ETSMS platform. Manages the product master, unit-of-measure conversions, supplier item costs, product lifecycle transitions, and the platform's **reference pricing data**: price books, MSRP records, and location-level reference price overrides (see the sell-price boundary below — transactional pricing is pos-price's).
 
 ## Sell-Price Boundary (ADR-0054)
 
@@ -37,10 +37,10 @@ Routing rule for new stories: computing **what a customer pays** → pos-price; 
 
 - Maintain product master data (inventory and non-inventory products)
 - Own product stock-attribute contract data for pos-inventory (#1023): per-product UoM conversion sets (purchase/pack UoM → base UoM factor + precision scale), stock tracking level (`NONE`/`LOT`/`SERIAL`), and substitution groups of interchangeable products
-- Manage price books and associated pricing rules
+- Manage price books and associated pricing rules (reference/list role, ADR-0054)
 - Handle unit-of-measure conversions between stocking and selling units
 - Track supplier item costs and MSRP records per product
-- Apply and resolve location-level price overrides
+- Apply and resolve location-level **reference** price overrides (list-price display; never a transactional price source)
 - Control product lifecycle (active, discontinued, archived)
 - Search and filter products with Caffeine-backed caching
 - Support bulk product import via `POST /v1/catalog/bulk-ingest`
@@ -62,7 +62,7 @@ Routing rule for new stories: computing **what a customer pays** → pos-price; 
 - `DELETE /v1/catalog/{catalogId}` — archive a product
 - `GET /v1/catalog/{itemId}/costs` — list item costs
 - `GET /v1/catalog/{itemId}/costs/audit` — cost audit trail
-- `GET /v1/catalog/pricing/effective-price/{locationId}/{productId}` — effective price at a location
+- `GET /v1/catalog/pricing/effective-price/{locationId}/{productId}` — reference price at a location (list/MSRP role, ADR-0054; not a transactional quote)
 - `GET /v1/catalog/{priceBookId}` — retrieve a price book
 - `POST /v1/catalog/bulk-ingest` — bulk import products (auth: `catalog:product:create`)
 - `PUT /v1/products/{productId}/tracking-level` — set stock tracking level (`NONE`/`LOT`/`SERIAL`)

--- a/pos-catalog/README.md
+++ b/pos-catalog/README.md
@@ -2,6 +2,37 @@
 
 Product catalog service for the Durion Positivity ETSMS platform. Manages the product master, price books, unit-of-measure conversions, supplier item costs, MSRP records, location-level price overrides, and product lifecycle transitions.
 
+## Sell-Price Boundary (ADR-0054)
+
+pos-catalog's pricing surface is **list/MSRP reference data only**: price books, MSRP history,
+list prices, and reference series (including PRICAT suggested retail per ADR-0053 §4) are
+displayable and reportable, but **never the source of a transactional price**. Every
+transactional sell-price resolution (quotes, workorder/estimate pricing, checkout) is owned
+exclusively by pos-price. Catalog customer-tier price books define **reference/list prices for a
+tier**; pos-price customer-tier *discounts* are the applied transactional mechanism — the two are
+never competing resolvers.
+
+`supplier_item_cost`'s successor — the append-only supplier price entries of ADR-0053 §2 — is
+**cost input**, also outside sell-price resolution: neither the pos-price quote chain nor the
+catalog price-book resolver reads it.
+
+### Which module owns a price fact?
+
+| Price fact | Owning module | Governing ADR |
+| --- | --- | --- |
+| Transactional sell price (quote, workorder/estimate, checkout) | pos-price | ADR-0054 §1 |
+| Base price (effective-dated, history-retaining) | pos-price | ADR-0054 §4 |
+| Location price override (transactional) | pos-price | ADR-0054 §1 |
+| Customer-tier discount (applied transactional mechanism) | pos-price | ADR-0054 §3 |
+| MSRP / list reference price | pos-catalog | ADR-0054 §1 |
+| Customer-tier reference books (tier list prices) | pos-catalog | ADR-0054 §3 |
+| Supplier cost (PRICAT supplier price entries — cost input, outside sell-price resolution) | pos-catalog | ADR-0053 §2 |
+| Inventory valuation cost | pos-inventory | ADR-0048 |
+| PRICAT suggested retail (reference series) | pos-catalog | ADR-0053 §4 |
+
+Routing rule for new stories: computing **what a customer pays** → pos-price; showing a
+**list/MSRP/reference price** → pos-catalog.
+
 ## Responsibilities
 
 - Maintain product master data (inventory and non-inventory products)

--- a/pos-price/README.md
+++ b/pos-price/README.md
@@ -2,6 +2,40 @@
 
 Pricing engine service for the Durion Positivity ETSMS platform. Manages base prices, promotion offers, restriction rules, eligibility evaluation, pricing snapshots, and price quote calculation.
 
+## Sell-Price Boundary (ADR-0054)
+
+pos-price is the **system of record for transactional sell-price resolution**: every price a
+customer actually pays (quotes, workorder/estimate pricing, checkout) is resolved here and only
+here, via the quote chain **base price → location override → customer-tier discount**. pos-price
+holds **no list/MSRP reference data** — list prices, MSRP history, and reference series (including
+PRICAT suggested retail) are pos-catalog's reference role and are never a transactional price
+source. Customer-tier *discounts* in pos-price are the applied transactional mechanism; pos-catalog
+customer-tier *books* are reference/list data — the two are never competing resolvers.
+
+pos-price is a **utility** module (ADR-0044 §1): it remains synchronously callable by other
+services.
+
+Effective dating uses half-open windows on `Instant`: a base price row is effective for instants
+`t` where `effectiveFrom <= t < effectiveTo`; a null `effectiveTo` means the window is open-ended
+(inclusive start, exclusive end).
+
+### Which module owns a price fact?
+
+| Price fact | Owning module | Governing ADR |
+| --- | --- | --- |
+| Transactional sell price (quote, workorder/estimate, checkout) | pos-price | ADR-0054 §1 |
+| Base price (effective-dated, history-retaining) | pos-price | ADR-0054 §4 |
+| Location price override (transactional) | pos-price | ADR-0054 §1 |
+| Customer-tier discount (applied transactional mechanism) | pos-price | ADR-0054 §3 |
+| MSRP / list reference price | pos-catalog | ADR-0054 §1 |
+| Customer-tier reference books (tier list prices) | pos-catalog | ADR-0054 §3 |
+| Supplier cost (PRICAT supplier price entries — cost input, outside sell-price resolution) | pos-catalog | ADR-0053 §2 |
+| Inventory valuation cost | pos-inventory | ADR-0048 |
+| PRICAT suggested retail (reference series) | pos-catalog | ADR-0053 §4 |
+
+Routing rule for new stories: computing **what a customer pays** → pos-price; showing a
+**list/MSRP/reference price** → pos-catalog.
+
 ## Responsibilities
 
 - Store and resolve base prices per product and effective date


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## Capability & Traceability
- Capability: n/a (documentation-only story; no capability branch)
- Parent STORY (durion): louisburroughs/durion#382 (ADR-0054, decided 2026-08-10)
- Child issue: louisburroughs/durion-positivity-backend#1235
- Domain: `domain:pricing`, `domain:product`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
<!--
  No contract-relevant files change in this PR (READMEs only). Reference kept per template:
-->
- Contract guide entry (durion): n/a — no API/event behavior change; `domains/<domain>/.business-rules/BACKEND_CONTRACT_GUIDE.md` untouched. Domain decision guides updated in the companion durion PR instead.
- Durion contract PR (if applicable): companion docs PR https://github.com/louisburroughs/durion/pull/385 (DECISION-PRICING-019, DECISION-PRODUCT-011 business-rules guide entries)

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
- What changed: Documentation only — adds a "Sell-Price Boundary (ADR-0054)" section to both module READMEs:
  - `pos-price/README.md`: states pos-price is the system of record for transactional sell-price resolution (quote chain); holds no list/MSRP reference data; notes the utility-module classification (ADR-0044 §1); documents half-open effective-window semantics.
  - `pos-catalog/README.md`: replaces the prior "overlap acknowledged" wording — the pricing surface is list/MSRP reference data only, never a transactional price source; ADR-0053 §2 supplier price entries are cost input outside sell-price resolution; clarifies catalog CUSTOMER_TIER books (tier reference prices) vs pos-price tier discounts (applied transactional mechanism).
  - Both READMEs gain an identical "which module owns a price fact" routing table covering: transactional quote, base price, location override, tier discount, MSRP/list reference, tier reference books, supplier cost (ADR-0053), valuation cost (ADR-0048), PRICAT suggested retail.
- Why: ADR-0054 splits sell-price authority between pos-catalog (list/MSRP reference) and pos-price (transactional quoting). Landing the boundary in the READMEs where developers and agents look ensures new pricing stories route to the correct module instead of relying on reviewer memory of the ADR.

Companion durion-repo PR (business-rules guide entries): https://github.com/louisburroughs/durion/pull/385

Closes #1235

## Tests
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run: n/a — documentation only, no code changes.

## Risk & Rollback
- Risk level: Low
- Rollback plan: Revert this commit; README sections are additive documentation with no runtime impact.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, story branch `feat/adr-0054-boundary-docs` per #1235
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability for this docs story
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — n/a here; decision entries land via the companion durion PR
- [ ] Required CI checks passing