### PR TITLE
feat(pos-catalog): CUSTOMER_TIER candidate-book selection in the reference role (#1234)

### DIFF
--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -49,6 +49,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Successfully retrieved product
@@ -79,6 +80,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -128,12 +130,14 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: uomId
         in: path
         description: Product UoM ID
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -176,12 +180,14 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: uomId
         in: path
         description: Product UoM ID
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '204':
           description: Product UoM deleted
@@ -205,6 +211,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -247,11 +254,13 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: msrpId
         in: path
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -308,6 +317,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Successfully retrieved lifecycle state
@@ -341,6 +351,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -399,6 +410,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Conversion found
@@ -429,6 +441,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -471,6 +484,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '204':
           description: Conversion deactivated
@@ -493,6 +507,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Found
@@ -523,6 +538,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -559,6 +575,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '204':
           description: Deleted
@@ -582,6 +599,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Price book returned
@@ -612,6 +630,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -649,11 +668,13 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: ruleId
         in: path
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -690,11 +711,13 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: ruleId
         in: path
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '204':
           description: Rule deactivated
@@ -716,6 +739,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -756,6 +780,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Successfully retrieved catalog
@@ -786,6 +811,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         description: Updated catalog object
         content:
@@ -829,6 +855,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '204':
           description: Catalog deleted successfully
@@ -858,6 +885,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -906,6 +934,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '204':
           description: Catalog item deleted successfully
@@ -967,6 +996,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Product UoMs listed
@@ -1001,6 +1031,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -1050,6 +1081,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Replacements listed
@@ -1079,6 +1111,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -1124,6 +1157,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: MSRP records returned
@@ -1148,6 +1182,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -1333,6 +1368,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -1418,6 +1454,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -1469,6 +1506,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -1580,6 +1618,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Rule list returned
@@ -1604,6 +1643,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
         content:
           application/json:
@@ -1632,8 +1672,8 @@ paths:
     post:
       tags:
       - Price Book API
-      summary: Resolve effective product price
-      description: Calculates the effective price for a product using applicable price books and rules.
+      summary: Resolve reference/list product price
+      description: 'Resolves the reference/list price for a product using applicable price books and rules. Candidate book precedence: explicit priceBookId, then active LOCATION book, then active CUSTOMER_TIER book (customerTierId), then COMPANY_DEFAULT. The result is catalog reference data (ADR-0054) — transactional sell prices are resolved by pos-price, never by this endpoint.'
       operationId: resolvePrice
       requestBody:
         content:
@@ -1766,6 +1806,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Substitute parts returned
@@ -1798,6 +1839,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: asOf
         in: query
         required: false
@@ -1836,12 +1878,14 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: location_id
         in: query
         description: Location/store ID for location-specific data
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Successfully retrieved product details (may be partial if some services unavailable)
@@ -1885,6 +1929,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Substitution group found
@@ -1915,6 +1960,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '204':
           description: Substitution group deleted
@@ -1938,6 +1984,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Successfully retrieved service
@@ -2099,12 +2146,14 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: productId
         in: path
         description: Product ID
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Effective price returned
@@ -2136,6 +2185,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Successfully retrieved non-inventory product
@@ -2216,6 +2266,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Found
@@ -2241,6 +2292,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Found
@@ -2292,12 +2344,14 @@ paths:
         required: false
         schema:
           type: string
+          format: uuid
       - name: supplierId
         in: query
         description: Filter by supplier ID
         required: false
         schema:
           type: string
+          format: uuid
       - name: pageable
         in: query
         required: true
@@ -2353,12 +2407,14 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: productId
         in: path
         description: Product ID to remove
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Member removed
@@ -2988,6 +3044,7 @@ components:
           type: number
           description: Multiplier to convert one unit of the source UOM into the target UOM
           example: 12
+          minimum: 0
       required:
       - conversionFactor
     UomConversionDto:
@@ -3013,7 +3070,6 @@ components:
           example: 12
         active:
           type: boolean
-          default: false
           description: Whether this conversion is currently active
           example: true
         createdAt:
@@ -3058,6 +3114,7 @@ components:
           type: number
           description: Per-unit cost for this quantity range
           example: 5.0
+          minimum: 0
       required:
       - minQuantity
       - unitCost
@@ -3150,7 +3207,6 @@ components:
           example: 0196cf6f-c8dd-7ee0-93e7-f48a5698a535
         isDefault:
           type: boolean
-          default: false
           description: Whether this is the default price book for the scope
           example: false
         status:
@@ -3386,6 +3442,7 @@ components:
         newCost:
           type: number
           description: New standard cost
+          minimum: 0
         reasonCode:
           type: string
           description: Reason code for manual change
@@ -3728,6 +3785,7 @@ components:
           type: number
           description: Multiplier to convert one unit of the source UOM into the target UOM
           example: 12
+          minimum: 0
         createdBy:
           type: string
           description: Identifier of the user creating the conversion
@@ -4058,9 +4116,14 @@ components:
           format: uuid
           description: Identifier of the location used to scope price book selection
           example: 01960003-0000-7000-8000-000000000001
+        customerTierId:
+          type: string
+          format: uuid
+          description: Identifier of the customer tier used to select a CUSTOMER_TIER reference price book (matches the book's scopeId). Selects tier list/reference prices only — transactional customer-tier discounting is owned by pos-price (ADR-0054)
+          example: 0196cf6f-c8dd-7ee0-93e7-f48a5698a536
         customerTier:
           type: string
-          description: Customer tier used to scope price book selection
+          description: Customer tier label matched against rule-level CUSTOMER_TIER conditions within the selected price book
           example: GOLD
         currency:
           type: string
@@ -4075,7 +4138,7 @@ components:
       - productId
     ResolvePriceResponseDto:
       type: object
-      description: Resolved price result for a product in a given context
+      description: Resolved reference/list price for a product in a given context. This is catalog reference data (list/MSRP role per ADR-0054), never a transactional sell price — transactional quoting is owned by pos-price
       properties:
         resolvedAmount:
           type: string
@@ -4222,7 +4285,6 @@ components:
           example: 01960003-0000-7000-8000-000000000001
         success:
           type: boolean
-          default: false
           description: Whether this record was ingested successfully
           example: true
         errorCode:
@@ -4685,12 +4747,12 @@ components:
     Page:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -4703,13 +4765,13 @@ components:
           $ref: '#/components/schemas/SortObject'
         pageable:
           $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:
@@ -4722,10 +4784,10 @@ components:
           $ref: '#/components/schemas/SortObject'
         paged:
           type: boolean
-        pageSize:
+        pageNumber:
           type: integer
           format: int32
-        pageNumber:
+        pageSize:
           type: integer
           format: int32
         unpaged:
@@ -4742,12 +4804,12 @@ components:
     PageSupplierItemCostDto:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -4762,13 +4824,13 @@ components:
           $ref: '#/components/schemas/SortObject'
         pageable:
           $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
   securitySchemes:

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -4099,7 +4099,7 @@ components:
       - scopeId
     ResolvePriceRequestDto:
       type: object
-      description: Request to resolve the effective price for a product in a given context
+      description: Request to resolve the reference/list price for a product in a given context (catalog reference role per ADR-0054; transactional sell prices are resolved by pos-price)
       properties:
         productId:
           type: string
@@ -4119,7 +4119,7 @@ components:
         customerTierId:
           type: string
           format: uuid
-          description: Identifier of the customer tier used to select a CUSTOMER_TIER reference price book (matches the book's scopeId). Selects tier list/reference prices only — transactional customer-tier discounting is owned by pos-price (ADR-0054)
+          description: Identifier of the customer tier used to select a CUSTOMER_TIER reference price book (matches the scopeId of the book). Selects tier list/reference prices only — transactional customer-tier discounting is owned by pos-price (ADR-0054)
           example: 0196cf6f-c8dd-7ee0-93e7-f48a5698a536
         customerTier:
           type: string
@@ -4780,8 +4780,6 @@ components:
         offset:
           type: integer
           format: int64
-        sort:
-          $ref: '#/components/schemas/SortObject'
         paged:
           type: boolean
         pageNumber:
@@ -4790,6 +4788,8 @@ components:
         pageSize:
           type: integer
           format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
         unpaged:
           type: boolean
     SortObject:

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/PriceBookController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/PriceBookController.java
@@ -171,8 +171,12 @@ public class PriceBookController {
             scopes = {"catalog:price_book:read"})
     @PostMapping("/resolve-price")
     @Operation(
-            summary = "Resolve effective product price",
-            description = "Calculates the effective price for a product using applicable price books and rules.")
+            summary = "Resolve reference/list product price",
+            description = "Resolves the reference/list price for a product using applicable price books and"
+                    + " rules. Candidate book precedence: explicit priceBookId, then active LOCATION book,"
+                    + " then active CUSTOMER_TIER book (customerTierId), then COMPANY_DEFAULT. The result is"
+                    + " catalog reference data (ADR-0054) — transactional sell prices are resolved by"
+                    + " pos-price, never by this endpoint.")
     @ApiResponse(
             responseCode = "200",
             description = "Resolved price returned",

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ResolvePriceRequestDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ResolvePriceRequestDto.java
@@ -10,7 +10,9 @@ import java.util.UUID;
 import lombok.Data;
 
 @Data
-@Schema(description = "Request to resolve the effective price for a product in a given context")
+@Schema(
+        description = "Request to resolve the reference/list price for a product in a given context"
+                + " (catalog reference role per ADR-0054; transactional sell prices are resolved by pos-price)")
 public class ResolvePriceRequestDto {
 
     @NotNull
@@ -34,7 +36,7 @@ public class ResolvePriceRequestDto {
 
     @Schema(
             description = "Identifier of the customer tier used to select a CUSTOMER_TIER reference price book"
-                    + " (matches the book's scopeId). Selects tier list/reference prices only — transactional"
+                    + " (matches the scopeId of the book). Selects tier list/reference prices only — transactional"
                     + " customer-tier discounting is owned by pos-price (ADR-0054)",
             example = "0196cf6f-c8dd-7ee0-93e7-f48a5698a536",
             requiredMode = NOT_REQUIRED)

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ResolvePriceRequestDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ResolvePriceRequestDto.java
@@ -33,7 +33,16 @@ public class ResolvePriceRequestDto {
     private UUID locationId;
 
     @Schema(
-            description = "Customer tier used to scope price book selection",
+            description = "Identifier of the customer tier used to select a CUSTOMER_TIER reference price book"
+                    + " (matches the book's scopeId). Selects tier list/reference prices only — transactional"
+                    + " customer-tier discounting is owned by pos-price (ADR-0054)",
+            example = "0196cf6f-c8dd-7ee0-93e7-f48a5698a536",
+            requiredMode = NOT_REQUIRED)
+    private UUID customerTierId;
+
+    @Schema(
+            description = "Customer tier label matched against rule-level CUSTOMER_TIER conditions"
+                    + " within the selected price book",
             example = "GOLD",
             requiredMode = NOT_REQUIRED)
     private String customerTier;

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ResolvePriceResponseDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ResolvePriceResponseDto.java
@@ -8,7 +8,10 @@ import java.util.UUID;
 import lombok.Data;
 
 @Data
-@Schema(description = "Resolved price result for a product in a given context")
+@Schema(
+        description = "Resolved reference/list price for a product in a given context. This is catalog"
+                + " reference data (list/MSRP role per ADR-0054), never a transactional sell price —"
+                + " transactional quoting is owned by pos-price")
 public class ResolvePriceResponseDto {
 
     public enum ResolvePriceSource {

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/PriceBookServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/PriceBookServiceImpl.java
@@ -369,6 +369,15 @@ public class PriceBookServiceImpl implements PriceBookService {
         return taxonomyNodeIds.contains(targetId);
     }
 
+    /**
+     * Candidate price book resolution selects exactly one book in precedence order: explicit
+     * priceBookId → active LOCATION book (locationId) → active CUSTOMER_TIER book (customerTierId)
+     * → COMPANY_DEFAULT (isDefault=true). A supplied context whose book is missing or inactive
+     * falls through to the next step. CUSTOMER_TIER books define reference/list prices for a tier
+     * and are never a discount mechanism — transactional customer-tier discounting is owned
+     * exclusively by pos-price and is applied on top of, never in competition with, the catalog
+     * reference price (ADR-0054 §3).
+     */
     private List<UUID> resolveCandidatePriceBookIds(ResolvePriceRequestDto request) {
         if (request.getPriceBookId() != null) {
             return List.of(requirePriceBook(request.getPriceBookId()).getPriceBookId());
@@ -379,6 +388,14 @@ public class PriceBookServiceImpl implements PriceBookService {
                     PriceBookScope.LOCATION, request.getLocationId(), PriceBookStatus.ACTIVE);
             if (locationBook.isPresent()) {
                 return List.of(locationBook.get().getPriceBookId());
+            }
+        }
+
+        if (request.getCustomerTierId() != null) {
+            var tierBook = priceBookRepository.findByScopeAndScopeIdAndStatus(
+                    PriceBookScope.CUSTOMER_TIER, request.getCustomerTierId(), PriceBookStatus.ACTIVE);
+            if (tierBook.isPresent()) {
+                return List.of(tierBook.get().getPriceBookId());
             }
         }
 

--- a/pos-catalog/src/test/java/com/positivity/catalog/contract/PriceBookContractBehaviorIT.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/contract/PriceBookContractBehaviorIT.java
@@ -305,6 +305,106 @@ class PriceBookContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(jsonPath("$.resolvedAmount").value("88.8800"));
     }
 
+    @Test
+    @DisplayName("ADR-0054-010: Resolve reference price from CUSTOMER_TIER book when customerTierId supplied")
+    void resolveFromCustomerTierBook() throws Exception {
+        UUID productId = createProductAndReturnId("ADR0054 Tier Product A");
+        UUID tierId = UUID.randomUUID();
+        String tierBookId = createPriceBook("ADR0054 Tier Book A", "CUSTOMER_TIER", tierId.toString(), false);
+        addGlobalRule(tierBookId, "77.7700", 10);
+
+        mockMvc.perform(withAuth(post("/v1/products/price-books/resolve-price")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "productId", productId.toString(),
+                                "customerTierId", tierId.toString(),
+                                "asOf", LocalDate.now(TEST_CLOCK).toString())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.source").value("PRICE_BOOK_RULE"))
+                .andExpect(jsonPath("$.resolvedAmount").value("77.7700"));
+    }
+
+    @Test
+    @DisplayName("ADR-0054-011: Active LOCATION book takes precedence over CUSTOMER_TIER book")
+    void locationBookBeatsCustomerTierBook() throws Exception {
+        UUID productId = createProductAndReturnId("ADR0054 Tier Product B");
+        UUID tierId = UUID.randomUUID();
+        UUID locationId = UUID.randomUUID();
+        String tierBookId = createPriceBook("ADR0054 Tier Book B", "CUSTOMER_TIER", tierId.toString(), false);
+        addGlobalRule(tierBookId, "66.6600", 10);
+        String locationBookId = createPriceBook("ADR0054 Location Book B", "LOCATION", locationId.toString(), false);
+        addGlobalRule(locationBookId, "55.5500", 10);
+
+        mockMvc.perform(withAuth(post("/v1/products/price-books/resolve-price")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "productId", productId.toString(),
+                                "locationId", locationId.toString(),
+                                "customerTierId", tierId.toString(),
+                                "asOf", LocalDate.now(TEST_CLOCK).toString())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.source").value("PRICE_BOOK_RULE"))
+                .andExpect(jsonPath("$.resolvedAmount").value("55.5500"));
+    }
+
+    @Test
+    @DisplayName("ADR-0054-012: Missing CUSTOMER_TIER book falls through to company default")
+    void missingTierBookFallsThroughToCompanyDefault() throws Exception {
+        UUID productId = createProductAndReturnId("ADR0054 Tier Product C");
+        String defaultBookId = createPriceBook("ADR0054 Default Book C", "COMPANY_DEFAULT", null, true);
+        addGlobalRule(defaultBookId, "44.4400", 10);
+
+        mockMvc.perform(withAuth(post("/v1/products/price-books/resolve-price")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "productId", productId.toString(),
+                                "customerTierId", UUID.randomUUID().toString(),
+                                "asOf", LocalDate.now(TEST_CLOCK).toString())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.source").value("PRICE_BOOK_RULE"))
+                .andExpect(jsonPath("$.resolvedAmount").value("44.4400"));
+    }
+
+    @Test
+    @DisplayName("ADR-0054-013: Without customerTierId an active CUSTOMER_TIER book is never selected")
+    void absentTierContextIgnoresTierBooks() throws Exception {
+        UUID productId = createProductAndReturnId("ADR0054 Tier Product D");
+        UUID tierId = UUID.randomUUID();
+        String tierBookId = createPriceBook("ADR0054 Tier Book D", "CUSTOMER_TIER", tierId.toString(), false);
+        addGlobalRule(tierBookId, "33.3300", 10);
+        String defaultBookId = createPriceBook("ADR0054 Default Book D", "COMPANY_DEFAULT", null, true);
+        addGlobalRule(defaultBookId, "22.2200", 10);
+
+        mockMvc.perform(withAuth(post("/v1/products/price-books/resolve-price")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "productId", productId.toString(),
+                                "asOf", LocalDate.now(TEST_CLOCK).toString())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.source").value("PRICE_BOOK_RULE"))
+                .andExpect(jsonPath("$.resolvedAmount").value("22.2200"));
+    }
+
+    private void addGlobalRule(String priceBookId, String usdAmount, int priority) throws Exception {
+        mockMvc.perform(withAuth(post("/v1/products/price-books/{priceBookId}/rules", priceBookId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "targetType",
+                                "GLOBAL",
+                                "pricingLogic",
+                                "{\"amounts\":{\"USD\":\"" + usdAmount + "\"},\"defaultCurrency\":\"USD\"}",
+                                "conditionType",
+                                "NONE",
+                                "priority",
+                                priority,
+                                "effectiveStartAt",
+                                OffsetDateTime.now(ZoneOffset.UTC).minusDays(1).toString(),
+                                "createdByUserId",
+                                UUID.fromString("00000000-0000-0000-0000-000000000001")
+                                        .toString()))))
+                .andExpect(status().isCreated());
+    }
+
     private String createPriceBook(String name, String scope, String scopeId, boolean isDefault) throws Exception {
         var payload = new java.util.HashMap<String, Object>();
         payload.put("name", name);


### PR DESCRIPTION
## Capability & Traceability
- Capability: ADR-0054 §3 — CUSTOMER_TIER candidate-book selection (no `cap:` id assigned to issue #1234; parent decision louisburroughs/durion#382)
- Parent STORY (durion): louisburroughs/durion#382 (ADR-0054, decided 2026-08-10)
- Child issue: louisburroughs/durion-positivity-backend#1234 — Closes #1234
- Domain: `domain:product` (also labeled `domain:pricing`)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/product/.business-rules/BACKEND_CONTRACT_GUIDE.md` → candidate-book precedence + reference-vs-discount boundary entry (added on branch `docs/adr-0054-boundary-guides`)
- Durion contract PR: https://github.com/louisburroughs/durion/pull/385

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller (`PriceBookController`, `ResolvePriceRequestDto`/`ResolvePriceResponseDto` descriptions)
- [x] `openapi.yaml` regenerated (`pos-catalog/openapi.yaml`; gateway aggregate not touched in this PR)
- [x] Angular SDK regenerated (`durion-positivity-sdk-angular`) — companion PR: https://github.com/louisburroughs/durion-positivity-sdk-angular/pull/31

## Scope
- What changed:
  - Implements ADR-0054 §3 per issue #1234; parent decision louisburroughs/durion#382.
  - The candidate price book resolver (`PriceBookServiceImpl`) now selects an active `CUSTOMER_TIER` book via the new optional `customerTierId` (UUID) request field. Precedence was decided in refinement with the Product & Catalog domain agent and is documented in the resolver javadoc and the contract guide: explicit `priceBookId` → active LOCATION book → active CUSTOMER_TIER book → COMPANY_DEFAULT. A missing or inactive tier book falls through (never fails); resolution without tier context is byte-for-byte today's behavior.
  - `customerTierId` selects the book by `scopeId`; the existing `customerTier` string still matches rule-level CUSTOMER_TIER conditions inside the selected book. Rule precedence within a book is unchanged (SKU → category → global, priority desc, effective-start desc, rule UUID tie-break).
  - Reference-role boundary stated in DTO/OpenAPI descriptions and resolve-price operation docs: results are catalog reference/list data (ADR-0054), never a transactional sell price; pos-price customer-tier discounts remain the applied transactional mechanism.
  - Contract chain honored: `pos-catalog/openapi.yaml` regenerated; Angular SDK regenerated in companion PR https://github.com/louisburroughs/durion-positivity-sdk-angular/pull/31; the durion product contract guide gained the precedence + reference-vs-discount entry on branch `docs/adr-0054-boundary-guides` (https://github.com/louisburroughs/durion/pull/385).
- Why: The `CUSTOMER_TIER` book scope existed in the model but was unreachable — the resolver never selected it. ADR-0054 §3 ruled it a feature to finish (not dead code) within pos-catalog's narrowed reference/list-pricing role, so tier-specific reference prices (e.g. contract or program list prices per customer tier) can resolve while transactional quoting remains exclusively pos-price's.

## Tests
- [ ] Unit tests added/updated (no new unit tests; existing 42 unit tests pass unchanged)
- [x] Integration tests added/updated
- [x] Provider behavioral contract tests added/updated
- How to run: `./mvnw -pl pos-catalog -am verify`
  - 4 new contract IT cases in `PriceBookContractBehaviorIT`: tier-book selection, LOCATION-over-tier precedence, missing-tier-book fall-through to company default, and absent-tier-context regression proving tier books are never selected without `customerTierId`.
  - Full pos-catalog verify green: 42 unit + 94 IT (11 price-book), checkstyle/spotbugs/spotless.

## Risk & Rollback
- Risk level: Low
- Rollback plan: Revert the single commit (3e6c55fc0). The change is additive — `customerTierId` is optional, and resolution without tier context is proven byte-for-byte identical to today's behavior by the regression IT — so reverting restores the prior contract with no data or schema impact (no Flyway migrations in this PR).

## Checklist
- [ ] Branch name matches `cap/<cap-id>` (branch is `feat/adr-0054-customer-tier-books` per issue #1234; no `cap:` id assigned)
- [ ] PR title starts with `[CAP:<cap-id>]` (no `cap:` id assigned; title follows the story's conventional-commit naming)
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — https://github.com/louisburroughs/durion/pull/385
- [ ] Required CI checks passing (pending on this PR)
