### PR TITLE
feat(pos-price): currency-aware quote resolution with company-default fallback (#1239)

### DIFF
--- a/pos-price/openapi.yaml
+++ b/pos-price/openapi.yaml
@@ -1602,7 +1602,7 @@ components:
           - 'null'
           description: Optional ISO 4217 currency code for the quote; defaults to the company default currency (pos.price.default-currency) when omitted. Base price and location override selection are filtered to this currency
           example: USD
-          pattern: '[A-Za-z]{3}'
+          pattern: ^[A-Za-z]{3}$
       required:
       - customerTierId
       - locationId

--- a/pos-price/openapi.yaml
+++ b/pos-price/openapi.yaml
@@ -1596,6 +1596,13 @@ components:
           format: date-time
           description: Optional timestamp for effective pricing lookup; defaults to current time if omitted
           example: 2026-03-05 21:15:00+00:00
+        currency:
+          type:
+          - string
+          - 'null'
+          description: Optional ISO 4217 currency code for the quote; defaults to the company default currency (pos.price.default-currency) when omitted. Base price and location override selection are filtered to this currency
+          example: USD
+          pattern: '[A-Za-z]{3}'
       required:
       - customerTierId
       - locationId

--- a/pos-price/src/main/java/com/positivity/price/internal/dto/PriceQuoteRequest.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/dto/PriceQuoteRequest.java
@@ -3,6 +3,7 @@ package com.positivity.price.internal.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -46,6 +47,15 @@ public class PriceQuoteRequest {
             nullable = true)
     private Instant effectiveTimestamp;
 
+    @Schema(
+            description = "Optional ISO 4217 currency code for the quote; defaults to the company default"
+                    + " currency (pos.price.default-currency) when omitted. Base price and location override"
+                    + " selection are filtered to this currency",
+            example = "USD",
+            nullable = true)
+    @Pattern(regexp = "[A-Za-z]{3}", message = "currency must be a 3-letter ISO code")
+    private String currency;
+
     public UUID getProductId() {
         return productId;
     }
@@ -84,5 +94,13 @@ public class PriceQuoteRequest {
 
     public void setEffectiveTimestamp(Instant effectiveTimestamp) {
         this.effectiveTimestamp = effectiveTimestamp;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
     }
 }

--- a/pos-price/src/main/java/com/positivity/price/internal/dto/PriceQuoteRequest.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/dto/PriceQuoteRequest.java
@@ -53,7 +53,7 @@ public class PriceQuoteRequest {
                     + " selection are filtered to this currency",
             example = "USD",
             nullable = true)
-    @Pattern(regexp = "[A-Za-z]{3}", message = "currency must be a 3-letter ISO code")
+    @Pattern(regexp = "^[A-Za-z]{3}$", message = "currency must be a 3-letter ISO code")
     private String currency;
 
     public UUID getProductId() {

--- a/pos-price/src/main/java/com/positivity/price/internal/exception/BasePriceUnavailableException.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/exception/BasePriceUnavailableException.java
@@ -10,7 +10,7 @@ import java.util.UUID;
  */
 public class BasePriceUnavailableException extends RuntimeException {
 
-    public BasePriceUnavailableException(UUID productId, Instant at) {
-        super("No base price effective for product " + productId + " at " + at);
+    public BasePriceUnavailableException(UUID productId, String currency, Instant at) {
+        super("No base price effective for product " + productId + " (" + currency + ") at " + at);
     }
 }

--- a/pos-price/src/main/java/com/positivity/price/internal/repository/LocationPriceOverrideRepository.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/repository/LocationPriceOverrideRepository.java
@@ -25,6 +25,7 @@ public interface LocationPriceOverrideRepository extends JpaRepository<LocationP
             SELECT l FROM LocationPriceOverride l
             WHERE l.productId = :productId
             AND l.locationId = :locationId
+            AND l.currency = :currency
             AND l.effectiveFrom <= :effectiveAt
             AND (l.effectiveTo IS NULL OR l.effectiveTo > :effectiveAt)
             ORDER BY l.effectiveFrom DESC
@@ -32,11 +33,13 @@ public interface LocationPriceOverrideRepository extends JpaRepository<LocationP
     List<LocationPriceOverride> findActiveAt(
             @Param("productId") UUID productId,
             @Param("locationId") UUID locationId,
+            @Param("currency") String currency,
             @Param("effectiveAt") Instant effectiveAt,
             Pageable pageable);
 
-    default Optional<LocationPriceOverride> findActiveAt(UUID productId, UUID locationId, Instant effectiveAt) {
-        return findActiveAt(productId, locationId, effectiveAt, PageRequest.of(0, 1)).stream()
+    default Optional<LocationPriceOverride> findActiveAt(
+            UUID productId, UUID locationId, String currency, Instant effectiveAt) {
+        return findActiveAt(productId, locationId, currency, effectiveAt, PageRequest.of(0, 1)).stream()
                 .findFirst();
     }
 

--- a/pos-price/src/main/java/com/positivity/price/internal/repository/ProductBasePriceRepository.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/repository/ProductBasePriceRepository.java
@@ -25,15 +25,19 @@ public interface ProductBasePriceRepository extends JpaRepository<ProductBasePri
     @Query("""
             SELECT p FROM ProductBasePrice p
             WHERE p.productId = :productId
+            AND p.currency = :currency
             AND p.effectiveFrom <= :effectiveAt
             AND (p.effectiveTo IS NULL OR p.effectiveTo > :effectiveAt)
             ORDER BY p.effectiveFrom DESC
             """)
     List<ProductBasePrice> findActiveAt(
-            @Param("productId") UUID productId, @Param("effectiveAt") Instant effectiveAt, Pageable pageable);
+            @Param("productId") UUID productId,
+            @Param("currency") String currency,
+            @Param("effectiveAt") Instant effectiveAt,
+            Pageable pageable);
 
-    default Optional<ProductBasePrice> findActiveAt(UUID productId, Instant effectiveAt) {
-        return findActiveAt(productId, effectiveAt, PageRequest.of(0, 1)).stream()
+    default Optional<ProductBasePrice> findActiveAt(UUID productId, String currency, Instant effectiveAt) {
+        return findActiveAt(productId, currency, effectiveAt, PageRequest.of(0, 1)).stream()
                 .findFirst();
     }
 }

--- a/pos-price/src/main/java/com/positivity/price/internal/service/BasePriceServiceImpl.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/service/BasePriceServiceImpl.java
@@ -8,6 +8,7 @@ import com.positivity.price.service.model.BasePriceView;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +29,9 @@ public class BasePriceServiceImpl implements BasePriceService {
             @NonNull BigDecimal msrp,
             @NonNull String currency,
             @NonNull Instant effectiveFrom) {
+        String normalizedCurrency = currency.toUpperCase(Locale.ROOT);
         Optional<ProductBasePrice> latest =
-                repository.findFirstByProductIdAndCurrencyOrderByEffectiveFromDesc(productId, currency);
+                repository.findFirstByProductIdAndCurrencyOrderByEffectiveFromDesc(productId, normalizedCurrency);
 
         if (latest.isPresent()) {
             ProductBasePrice current = latest.get();
@@ -41,7 +43,7 @@ public class BasePriceServiceImpl implements BasePriceService {
             }
             if (!effectiveFrom.isAfter(current.getEffectiveFrom())
                     || (currentEnd != null && effectiveFrom.isBefore(currentEnd))) {
-                throw new BasePriceWindowConflictException(productId, currency, effectiveFrom);
+                throw new BasePriceWindowConflictException(productId, normalizedCurrency, effectiveFrom);
             }
             if (openWindow) {
                 current.setEffectiveTo(effectiveFrom);
@@ -52,7 +54,7 @@ public class BasePriceServiceImpl implements BasePriceService {
         ProductBasePrice appended = new ProductBasePrice();
         appended.setProductId(productId);
         appended.setMsrp(msrp);
-        appended.setCurrency(currency);
+        appended.setCurrency(normalizedCurrency);
         appended.setEffectiveFrom(effectiveFrom);
         appended.setEffectiveTo(null);
         return repository.save(appended).getId();
@@ -70,7 +72,9 @@ public class BasePriceServiceImpl implements BasePriceService {
     @Transactional(readOnly = true)
     public Optional<BasePriceView> getBasePriceAt(
             @NonNull UUID productId, @NonNull String currency, @NonNull Instant at) {
-        return repository.findActiveAt(productId, currency, at).map(BasePriceServiceImpl::toView);
+        return repository
+                .findActiveAt(productId, currency.toUpperCase(Locale.ROOT), at)
+                .map(BasePriceServiceImpl::toView);
     }
 
     private static BasePriceView toView(ProductBasePrice entity) {

--- a/pos-price/src/main/java/com/positivity/price/internal/service/BasePriceServiceImpl.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/service/BasePriceServiceImpl.java
@@ -68,8 +68,9 @@ public class BasePriceServiceImpl implements BasePriceService {
 
     @Override
     @Transactional(readOnly = true)
-    public Optional<BasePriceView> getBasePriceAt(@NonNull UUID productId, @NonNull Instant at) {
-        return repository.findActiveAt(productId, at).map(BasePriceServiceImpl::toView);
+    public Optional<BasePriceView> getBasePriceAt(
+            @NonNull UUID productId, @NonNull String currency, @NonNull Instant at) {
+        return repository.findActiveAt(productId, currency, at).map(BasePriceServiceImpl::toView);
     }
 
     private static BasePriceView toView(ProductBasePrice entity) {

--- a/pos-price/src/main/java/com/positivity/price/internal/service/PriceQuoteServiceImpl.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/service/PriceQuoteServiceImpl.java
@@ -18,8 +18,10 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,16 +37,19 @@ public class PriceQuoteServiceImpl implements PriceQuoteService {
     private final ProductBasePriceRepository productPriceRepository;
     private final LocationPriceOverrideRepository locationOverrideRepository;
     private final CustomerTierPricingRuleRepository customerTierPricingRuleRepository;
+    private final String defaultCurrency;
 
     public PriceQuoteServiceImpl(
             ProductBasePriceRepository productPriceRepository,
             LocationPriceOverrideRepository locationOverrideRepository,
             CustomerTierPricingRuleRepository customerTierPricingRuleRepository,
-            Clock clock) {
+            Clock clock,
+            @Value("${pos.price.default-currency:USD}") String defaultCurrency) {
         this.clock = clock;
         this.productPriceRepository = productPriceRepository;
         this.locationOverrideRepository = locationOverrideRepository;
         this.customerTierPricingRuleRepository = customerTierPricingRuleRepository;
+        this.defaultCurrency = defaultCurrency.toUpperCase(Locale.ROOT);
     }
 
     @Override
@@ -53,10 +58,15 @@ public class PriceQuoteServiceImpl implements PriceQuoteService {
     public PriceQuoteResponse calculatePrice(@NonNull PriceQuoteRequest request) {
         Instant effectiveAt =
                 request.getEffectiveTimestamp() != null ? request.getEffectiveTimestamp() : Instant.now(clock);
+        String quoteCurrency =
+                request.getCurrency() != null && !request.getCurrency().isBlank()
+                        ? request.getCurrency().toUpperCase(Locale.ROOT)
+                        : defaultCurrency;
 
         ProductBasePrice basePrice = productPriceRepository
-                .findActiveAt(request.getProductId(), effectiveAt)
-                .orElseThrow(() -> new BasePriceUnavailableException(request.getProductId(), effectiveAt));
+                .findActiveAt(request.getProductId(), quoteCurrency, effectiveAt)
+                .orElseThrow(
+                        () -> new BasePriceUnavailableException(request.getProductId(), quoteCurrency, effectiveAt));
 
         List<PricingBreakdownEntry> breakdownEntries = new ArrayList<>();
         String currency = basePrice.getCurrency();
@@ -65,8 +75,8 @@ public class PriceQuoteServiceImpl implements PriceQuoteService {
 
         breakdownEntries.add(createBreakdownEntry("BASE_PRICE", "BASE_PRICE", BigDecimal.ZERO, currentPrice, currency));
 
-        Optional<LocationPriceOverride> locationOverride =
-                locationOverrideRepository.findActiveAt(request.getProductId(), request.getLocationId(), effectiveAt);
+        Optional<LocationPriceOverride> locationOverride = locationOverrideRepository.findActiveAt(
+                request.getProductId(), request.getLocationId(), quoteCurrency, effectiveAt);
 
         if (locationOverride.isPresent()) {
             BigDecimal adjustment = locationOverride.get().getOverridePrice().subtract(currentPrice);

--- a/pos-price/src/main/java/com/positivity/price/internal/service/PriceQuoteServiceImpl.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/service/PriceQuoteServiceImpl.java
@@ -59,9 +59,7 @@ public class PriceQuoteServiceImpl implements PriceQuoteService {
         Instant effectiveAt =
                 request.getEffectiveTimestamp() != null ? request.getEffectiveTimestamp() : Instant.now(clock);
         String quoteCurrency =
-                request.getCurrency() != null && !request.getCurrency().isBlank()
-                        ? request.getCurrency().toUpperCase(Locale.ROOT)
-                        : defaultCurrency;
+                request.getCurrency() != null ? request.getCurrency().toUpperCase(Locale.ROOT) : defaultCurrency;
 
         ProductBasePrice basePrice = productPriceRepository
                 .findActiveAt(request.getProductId(), quoteCurrency, effectiveAt)

--- a/pos-price/src/main/java/com/positivity/price/service/BasePriceService.java
+++ b/pos-price/src/main/java/com/positivity/price/service/BasePriceService.java
@@ -50,11 +50,12 @@ public interface BasePriceService {
     List<BasePriceView> getBasePriceHistory(@NonNull UUID productId);
 
     /**
-     * Returns the base-price window covering the given instant, if any.
+     * Returns the base-price window covering the given instant for a currency, if any.
      *
      * @param productId product identifier
+     * @param currency  currency code of the window to select
      * @param at        pricing instant
-     * @return the covering window, or empty when no window covers {@code at}
+     * @return the covering window, or empty when no window covers {@code at} in {@code currency}
      */
-    Optional<BasePriceView> getBasePriceAt(@NonNull UUID productId, @NonNull Instant at);
+    Optional<BasePriceView> getBasePriceAt(@NonNull UUID productId, @NonNull String currency, @NonNull Instant at);
 }

--- a/pos-price/src/main/resources/application.yml
+++ b/pos-price/src/main/resources/application.yml
@@ -62,3 +62,7 @@ springdoc:
     enabled: true
     path: /swagger-ui.html
   default-produces-media-type: application/json
+pos:
+  price:
+    # Company default currency used when a quote request omits `currency` (ADR-0054 / #1239)
+    default-currency: ${POS_PRICE_DEFAULT_CURRENCY:USD}

--- a/pos-price/src/test/java/com/positivity/price/contract/PriceQuoteContractBehaviorIT.java
+++ b/pos-price/src/test/java/com/positivity/price/contract/PriceQuoteContractBehaviorIT.java
@@ -120,6 +120,60 @@ class PriceQuoteContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
     }
 
+    @Test
+    @DisplayName("givenExplicitUsdCurrency_whenPriceQuoteRequested_thenMatchesDefaultCurrencyResolution")
+    void givenExplicitUsdCurrency_whenPriceQuoteRequested_thenMatchesDefaultCurrencyResolution() throws Exception {
+        ObjectNode request = baseValidRequest();
+        request.put("currency", "usd");
+
+        mockMvc.perform(withGatewayAuth(post("/v1/price/quotes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.unitPrice.currency").value("USD"))
+                .andExpect(jsonPath("$.unitPrice.amount").value(85.50));
+    }
+
+    @Test
+    @DisplayName("givenCadCurrency_whenPriceQuoteRequested_thenResolvesCadWindowWithoutUsdOverride")
+    void givenCadCurrency_whenPriceQuoteRequested_thenResolvesCadWindowWithoutUsdOverride() throws Exception {
+        ObjectNode request = baseValidRequest();
+        request.put("currency", "CAD");
+
+        mockMvc.perform(withGatewayAuth(post("/v1/price/quotes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.unitPrice.currency").value("CAD"))
+                .andExpect(jsonPath("$.msrp.amount").value(130.0000))
+                .andExpect(jsonPath("$.unitPrice.amount").value(117.00));
+    }
+
+    @Test
+    @DisplayName("givenCurrencyWithoutWindow_whenPriceQuoteRequested_thenReturns404PriceBaseUnavailable")
+    void givenCurrencyWithoutWindow_whenPriceQuoteRequested_thenReturns404PriceBaseUnavailable() throws Exception {
+        ObjectNode request = baseValidRequest();
+        request.put("currency", "EUR");
+
+        mockMvc.perform(withGatewayAuth(post("/v1/price/quotes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("PRICE_BASE_UNAVAILABLE"));
+    }
+
+    @Test
+    @DisplayName("givenMalformedCurrency_whenPriceQuoteRequested_thenReturns400")
+    void givenMalformedCurrency_whenPriceQuoteRequested_thenReturns400() throws Exception {
+        ObjectNode request = baseValidRequest();
+        request.put("currency", "DOLLARS");
+
+        mockMvc.perform(withGatewayAuth(post("/v1/price/quotes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))))
+                .andExpect(status().isBadRequest());
+    }
+
     private ObjectNode baseValidRequest() {
         ObjectNode request = objectMapper.createObjectNode();
         request.put(

--- a/pos-price/src/test/java/com/positivity/price/repository/BasePriceHistoryRepositoryTest.java
+++ b/pos-price/src/test/java/com/positivity/price/repository/BasePriceHistoryRepositoryTest.java
@@ -92,6 +92,21 @@ class BasePriceHistoryRepositoryTest {
     }
 
     @Test
+    @DisplayName("currency is normalized on write and read: lowercase ingest stores and resolves uppercase")
+    void currencyNormalizedOnWriteAndRead() {
+        UUID productId = UUID.randomUUID();
+        UUID rowId = basePriceService.saveBasePrice(productId, new BigDecimal("100.0000"), "usd", T1);
+
+        BasePriceView stored =
+                basePriceService.getBasePriceAt(productId, "Usd", T2).orElseThrow();
+        assertEquals("USD", stored.currency());
+        assertEquals(rowId, stored.id());
+
+        UUID replayedRowId = basePriceService.saveBasePrice(productId, new BigDecimal("100.0000"), "USD", T1);
+        assertEquals(rowId, replayedRowId);
+    }
+
+    @Test
     @DisplayName("backdated write is rejected and identical re-ingest is an idempotent no-op")
     void backdatedWriteRejectedAndReIngestIsNoOp() {
         UUID productId = UUID.randomUUID();

--- a/pos-price/src/test/java/com/positivity/price/repository/BasePriceHistoryRepositoryTest.java
+++ b/pos-price/src/test/java/com/positivity/price/repository/BasePriceHistoryRepositoryTest.java
@@ -56,14 +56,39 @@ class BasePriceHistoryRepositoryTest {
         basePriceService.saveBasePrice(productId, new BigDecimal("100.0000"), "USD", T1);
         basePriceService.saveBasePrice(productId, new BigDecimal("120.0000"), "USD", T2);
 
-        BasePriceView beforeCutover =
-                basePriceService.getBasePriceAt(productId, T2.minusSeconds(1)).orElseThrow();
-        BasePriceView atCutover = basePriceService.getBasePriceAt(productId, T2).orElseThrow();
+        BasePriceView beforeCutover = basePriceService
+                .getBasePriceAt(productId, "USD", T2.minusSeconds(1))
+                .orElseThrow();
+        BasePriceView atCutover =
+                basePriceService.getBasePriceAt(productId, "USD", T2).orElseThrow();
 
         assertEquals(new BigDecimal("100.0000"), beforeCutover.msrp());
         assertEquals(new BigDecimal("120.0000"), atCutover.msrp());
-        assertTrue(
-                basePriceService.getBasePriceAt(productId, T1.minusSeconds(1)).isEmpty());
+        assertTrue(basePriceService
+                .getBasePriceAt(productId, "USD", T1.minusSeconds(1))
+                .isEmpty());
+    }
+
+    @Test
+    @DisplayName("windows are independent per currency and selected deterministically by currency")
+    void windowsAreIndependentPerCurrency() {
+        UUID productId = UUID.randomUUID();
+        basePriceService.saveBasePrice(productId, new BigDecimal("100.0000"), "USD", T1);
+        basePriceService.saveBasePrice(productId, new BigDecimal("130.0000"), "CAD", T1);
+
+        assertEquals(
+                new BigDecimal("100.0000"),
+                basePriceService
+                        .getBasePriceAt(productId, "USD", T2)
+                        .orElseThrow()
+                        .msrp());
+        assertEquals(
+                new BigDecimal("130.0000"),
+                basePriceService
+                        .getBasePriceAt(productId, "CAD", T2)
+                        .orElseThrow()
+                        .msrp());
+        assertTrue(basePriceService.getBasePriceAt(productId, "EUR", T2).isEmpty());
     }
 
     @Test

--- a/pos-price/src/test/java/com/positivity/price/repository/TemporalPricingRepositoryTest.java
+++ b/pos-price/src/test/java/com/positivity/price/repository/TemporalPricingRepositoryTest.java
@@ -53,11 +53,11 @@ class TemporalPricingRepositoryTest {
         locationPriceOverrideRepository.saveAndFlush(future);
 
         LocationPriceOverride activeBeforeCutover = locationPriceOverrideRepository
-                .findActiveAt(productId, locationId, Instant.parse("2025-05-01T00:00:00Z"))
+                .findActiveAt(productId, locationId, "USD", Instant.parse("2025-05-01T00:00:00Z"))
                 .orElseThrow();
 
         LocationPriceOverride activeAfterCutover = locationPriceOverrideRepository
-                .findActiveAt(productId, locationId, Instant.parse("2025-06-15T00:00:00Z"))
+                .findActiveAt(productId, locationId, "USD", Instant.parse("2025-06-15T00:00:00Z"))
                 .orElseThrow();
 
         assertEquals(new BigDecimal("95.0000"), activeBeforeCutover.getOverridePrice());

--- a/pos-price/src/test/resources/data.sql
+++ b/pos-price/src/test/resources/data.sql
@@ -9,3 +9,6 @@ VALUES ('33333333-3333-3333-3333-333333333000', '11111111-1111-1111-1111-1111111
 
 INSERT INTO product_base_price (id, product_id, msrp, currency, effective_from, effective_to, created_at, updated_at)
 VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa00', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 50.0000, 'USD', TIMESTAMP '2020-01-01 00:00:00', NULL, TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-01 00:00:00');
+
+INSERT INTO product_base_price (id, product_id, msrp, currency, effective_from, effective_to, created_at, updated_at)
+VALUES ('11111111-1111-1111-1111-111111111101', '11111111-1111-1111-1111-111111111111', 130.0000, 'CAD', TIMESTAMP '2020-01-01 00:00:00', NULL, TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-01 00:00:00');


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:none` — direct ADR follow-up (ADR-0054 chain, durion#382; surfaced by review on PR #1237)
- Parent STORY (durion): louisburroughs/durion#382 (ADR-0054 decision record)
- Child issue: louisburroughs/durion-positivity-backend#1239 — Closes #1239
- Domain: `domain:pricing`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/pricing/.business-rules/BACKEND_CONTRACT_GUIDE.md` → Base Price Effective Windows (currency-aware quote resolution)
- Durion contract PR (if applicable): https://github.com/louisburroughs/durion/pull/386

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller (`PriceQuoteRequest` documents optional `currency`)
- [x] `openapi.yaml` regenerated (`pos-price/openapi.yaml`, +`currency` field)
- [x] Angular SDK regenerated (`durion-positivity-sdk-angular`) — companion PR: https://github.com/louisburroughs/durion-positivity-sdk-angular/pull/32

## Scope
- What changed:
  - `PriceQuoteRequest` gains an optional 3-letter `currency` field (bean-validated, case-insensitive, normalized to uppercase). When omitted, the company default currency applies via `pos.price.default-currency` (default `USD`, overridable with env `POS_PRICE_DEFAULT_CURRENCY`; documented in `application.yml`).
  - Base-price and location-override `findActiveAt` lookups now filter by currency, so multi-currency windows resolve deterministically per requested currency. Customer-tier rules are percentage discounts and remain currency-agnostic by design.
  - `BasePriceService.getBasePriceAt` becomes currency-aware.
  - When no window exists in the resolved currency, the existing 404 `PRICE_BASE_UNAVAILABLE` contract from #1233 applies, with the currency named in the message.
  - No migration needed — the schema is already per-currency from #1233 (partial unique index per `(product_id, currency)`).
- Why: Follow-up from #1237 review (issue #1239, ADR-0054 chain). The #1233 schema legitimized one open window per currency, but quote resolution filtered only by product and instant, so multi-currency data would resolve to an arbitrary currency's row. Owner refinement decision recorded on the issue: optional request `currency` + company-default fallback.

## Tests
- [x] Unit tests added/updated — full `pos-price` verify green; `BasePriceHistoryRepositoryTest` gains a per-currency independence test; `TemporalPricingRepositoryTest` updated for currency-aware override lookups
- [x] Integration tests added/updated — 9 quote contract ITs green, including 4 new: explicit USD parity (85.50), CAD resolution without USD override (117.00), EUR-no-window 404 `PRICE_BASE_UNAVAILABLE`, malformed currency 400
- [x] Provider behavioral contract tests added/updated — `PriceQuoteContractBehaviorIT` covers explicit/default/missing/malformed currency behavior
- How to run:
  ```bash
  ./mvnw -pl pos-price -am verify
  ```

## Risk & Rollback
- Risk level: Low — additive optional request field with a company-default fallback; single-currency (USD-only) data keeps identical behavior. No schema change.
- Rollback plan: revert the single commit; the request field is optional so no client is broken, and no migration exists to unwind.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A: no capability; issue-driven branch `feat/1239-currency-aware-quotes`
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A: no capability; ADR-0054 follow-up
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — companion durion PR: https://github.com/louisburroughs/durion/pull/386
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qf94WzGUfGak57j7xebHT
