### PR TITLE
ci: import JaCoCo coverage with absolute, correctly-scoped report paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,12 +642,33 @@ jobs:
           pattern: jacoco-coverage-*
           path: sonar-coverage
 
+      - name: Report downloaded coverage reports
+        # This job runs `test-compile` only, so the sole source of coverage is the
+        # artifact downloaded above; if it is empty the scan silently reports 0%.
+        # Warn rather than fail: when selective testing skips every module, an empty
+        # artifact is the correct outcome and must not break the gate.
+        run: |
+          count=$(find sonar-coverage -name jacoco.xml 2>/dev/null | wc -l)
+          echo "Downloaded ${count} JaCoCo report(s) for coverage import."
+          if [[ "${count}" -eq 0 ]]; then
+            echo "::warning::No JaCoCo reports downloaded; SonarCloud will report no coverage for this analysis."
+          else
+            find sonar-coverage -name jacoco.xml | sed 's/^/  /'
+          fi
+
       - name: SonarCloud Scan
         # Stopgap: PR-mode analysis currently fails at PR decoration because SonarCloud cannot
         # resolve the pull request via its GitHub App / DevOps-platform binding ("Something went
         # wrong while trying to get the pullrequest with key 'N'"). Until that binding is fixed in
         # SonarCloud, do not let a PR-decoration failure fail this check. The push/main-branch scan
         # (else branch below) stays strict and remains the authoritative quality gate.
+        #
+        # xmlReportPaths must be absolute: the scanner resolves a relative value against each
+        # Maven module's own base directory, so `sonar-coverage/**` only ever matched from the
+        # root module and every other module imported nothing. The per-module
+        # `**/target/site/jacoco/jacoco.xml` entry that used to follow it was dead weight here —
+        # this job runs `test-compile` with -DskipTests, so no module produces a local report and
+        # the downloaded artifact is the only coverage that exists.
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -664,7 +685,7 @@ jobs:
             -Dsonar.projectKey=louisburroughs_durion-positivity-backend \
             -Dsonar.organization=louisburroughs \
             -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.coverage.jacoco.xmlReportPaths=sonar-coverage/**/jacoco.xml,**/target/site/jacoco/jacoco.xml"
+            -Dsonar.coverage.jacoco.xmlReportPaths=${{ github.workspace }}/sonar-coverage/**/jacoco.xml"
 
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
             # Force PR-scoped analysis explicitly to avoid branch-level quality-gate
@@ -728,13 +749,21 @@ jobs:
         # pos-archunit's tests here (-Darchunit.skipTests=true): it has no production code so it
         # adds no coverage, and its rules are enforced at the `test` phase in the per-module
         # unit/integration jobs.
+        #
+        # Coverage import uses `aggregateXmlReportPaths`, not `xmlReportPaths`: the latter is the
+        # per-module property, and the scanner resolves a *relative* value against each Maven
+        # module's own base directory. Every non-root module therefore looked for
+        # `<module>/pos-coverage-aggregate/target/site/jacoco-aggregate/jacoco.xml`, found nothing,
+        # and fell back to its own `target/site/jacoco/jacoco.xml` — losing exactly the
+        # cross-module coverage the aggregate report exists to capture. The path is absolute
+        # (github.workspace) so it resolves identically from every module.
         run: |
           ./mvnw -pl ${{ env.COVERAGE_AGGREGATE_MODULE }} -am -DskipITs -Darchunit.skipTests=true verify -T 1C -B \
             org.sonarsource.scanner.maven:sonar-maven-plugin:${{ env.SONAR_MAVEN_PLUGIN_VERSION }}:sonar \
             -Dsonar.projectKey=louisburroughs_durion-positivity-backend \
             -Dsonar.organization=louisburroughs \
             -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.coverage.jacoco.xmlReportPaths=${{ env.COVERAGE_AGGREGATE_XML_PATH }}
+            -Dsonar.coverage.jacoco.aggregateXmlReportPaths=${{ github.workspace }}/${{ env.COVERAGE_AGGREGATE_XML_PATH }}
 
       - name: Upload aggregate JaCoCo coverage report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,7 +648,11 @@ jobs:
         # Warn rather than fail: when selective testing skips every module, an empty
         # artifact is the correct outcome and must not break the gate.
         run: |
-          count=$(find sonar-coverage -name jacoco.xml 2>/dev/null | wc -l)
+          # The download step is continue-on-error and creates nothing when no artifact
+          # matches, so sonar-coverage may not exist. Without this mkdir, `find` exits 1
+          # and -eo pipefail fails the step — the opposite of the warn-only intent.
+          mkdir -p sonar-coverage
+          count=$(find sonar-coverage -name jacoco.xml | wc -l)
           echo "Downloaded ${count} JaCoCo report(s) for coverage import."
           if [[ "${count}" -eq 0 ]]; then
             echo "::warning::No JaCoCo reports downloaded; SonarCloud will report no coverage for this analysis."


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — CI/build infrastructure fix, not capability work
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:build`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable. This PR touches `.github/workflows/ci.yml` only — no controllers, DTOs,
`*Request`/`*Response` types, events, `openapi.yaml`, or validation/error models change,
so no contract semantics are affected.

## Contract Chain (when a Controller changed)
Not applicable — no controller changed.

## Scope

**What changed:** SonarCloud coverage import in both analysis jobs.

SonarCloud was logging:

```
No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths=
'pos-coverage-aggregate/target/site/jacoco-aggregate/jacoco.xml'.
Using default locations: target/site/jacoco/jacoco.xml, ...
```

**Why:** two independent defects, one per job, sharing a root cause. The scanner resolves a
*relative* report path against each Maven module's own base directory, not against the reactor
root. Both jobs passed relative paths, so only the root module ever resolved them; every other
module silently imported nothing and the build stayed green.

`code-quality-full` (scheduled full analysis):
- Switched to `sonar.coverage.jacoco.aggregateXmlReportPaths`. The property in use was the
  per-module one; a `jacoco:report-aggregate` output must be imported through the aggregate
  property.
- Made the path absolute via `github.workspace`. Modules had been falling back to their own
  `target/site/jacoco/jacoco.xml`, discarding exactly the cross-module coverage that the
  aggregate report exists to capture.

`code-quality` (incremental — the push/PR gate):
- Made the downloaded-artifact path absolute, same reason. `sonar-coverage/**` previously
  matched only from the root module, so this job was likely importing no coverage at all.
- Dropped the trailing `**/target/site/jacoco/jacoco.xml` entry. It was dead weight: this job
  runs `test-compile` with `-DskipTests`, so no module produces a local report and the
  downloaded artifact is the only coverage present in the workspace.

Also added a step that counts and lists the downloaded reports before the scan. It emits a
`::warning::` rather than failing, because when selective testing skips every module an empty
artifact is the correct outcome and must not break the gate. This is the signal that was missing
while coverage import was silently returning nothing.

The aggregate report itself was never the problem — it builds correctly at 8.6 MB / 5404 class
entries. Only the import path was wrong.

Follows up on `40cf20961`, which added the seven missing modules to `pos-coverage-aggregate`
and the drift guard that keeps them there.

## Tests
- [ ] Unit tests added/updated — n/a, CI workflow change
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a

**How to run / what was verified locally:**
- `.github/workflows/ci.yml` parses as valid YAML.
- The new step's shell body passes `bash -n`, and was exercised in both branches: zero reports
  emits the warning; a simulated `sonar-coverage/jacoco-coverage-reactor/<module>/target/site/jacoco/jacoco.xml`
  tree counts and lists them.
- Artifact layout confirmed from the workflow rather than assumed: `build-test` uploads glob
  `**/target/site/jacoco/jacoco.xml` (least-common-ancestor = workspace root), and the download
  step sets no `merge-multiple`, so files land under `sonar-coverage/jacoco-coverage-reactor/`.

**Not verified locally — needs a CI run.** The Sonar-side import cannot be exercised from a
workstation. On merge, confirm:
1. The incremental job's new "Report downloaded coverage reports" step lists ~30 reports.
2. The `No coverage report can be found` warning is gone from the next scheduled full run.
3. Reported coverage on SonarCloud does not drop — if it moves, it should move *up*, since
   cross-module coverage is now imported where it previously was not.

## Risk & Rollback
- Risk level: Low — CI-only change; no production, main-source, or contract code is touched.
  Worst case is that coverage import stays as broken as it already is. The added step cannot
  fail the gate by construction.
- Rollback plan: `git revert` this commit. Coverage reporting returns to its current
  (silently-empty) behaviour; no other job is affected.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — intentionally not followed; no capability id applies
      to this infrastructure fix. Branch is `fix/sonar-coverage-report-paths`.
- [ ] PR title starts with `[CAP:<cap-id>]` — same reason; title uses the `ci:` prefix matching
      the commit.
- [ ] Links to parent + child issues are present — none exist for this fix.
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed.
- [ ] Required CI checks passing — pending on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qf94WzGUfGak57j7xebHT
